### PR TITLE
Add test for inherited_notifier.0.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -385,7 +385,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/color_filter/color_filtered.0_test.dart',
   'examples/api/test/widgets/focus_scope/focus_scope.0_test.dart',
   'examples/api/test/widgets/scroll_view/custom_scroll_view.1_test.dart',
-  'examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart',
   'examples/api/test/animation/curves/curve2_d.0_test.dart',
   'examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart',
 };

--- a/examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart
+++ b/examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart
@@ -14,40 +14,47 @@ void main() {
       const example.InheritedNotifierExampleApp(),
     );
 
-    final Iterable<Transform> widgets = tester.widgetList<Transform>(find.ancestor(of: find.text('Whee!'), matching: find.byType(Transform)));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.identity())));
-
-    await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(0.2 * math.pi))));
-
-    await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(0.4 * math.pi))));
-
-    await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(0.6 * math.pi))));
-
-    await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(0.8 * math.pi))));
-
-    await tester.pump(const Duration(seconds: 1));
-    expect(
-      widgets,
-      everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.identity()..storage[0] = -1..storage[5] = -1)),
+    final Iterable<Transform> widgets = tester.widgetList<Transform>(
+      find.ancestor(
+        of: find.text('Whee!'),
+        matching: find.byType(Transform),
+      ),
     );
 
-    await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(1.2 * math.pi))));
+    Matcher transformMatcher(Matrix4 matrix) {
+      return everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', matrix));
+    }
+
+    expect(widgets, transformMatcher(Matrix4.identity()));
 
     await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(1.4 * math.pi))));
+    expect(widgets, transformMatcher(Matrix4.rotationZ(0.2 * math.pi)));
 
     await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(1.6 * math.pi))));
+    expect(widgets, transformMatcher(Matrix4.rotationZ(0.4 * math.pi)));
 
     await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(1.8 * math.pi))));
+    expect(widgets, transformMatcher(Matrix4.rotationZ(0.6 * math.pi)));
 
     await tester.pump(const Duration(seconds: 1));
-    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.identity())));
+    expect(widgets, transformMatcher(Matrix4.rotationZ(0.8 * math.pi)));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, transformMatcher(Matrix4.identity()..storage[0] = -1..storage[5] = -1));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, transformMatcher(Matrix4.rotationZ(1.2 * math.pi)));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, transformMatcher(Matrix4.rotationZ(1.4 * math.pi)));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, transformMatcher(Matrix4.rotationZ(1.6 * math.pi)));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, transformMatcher(Matrix4.rotationZ(1.8 * math.pi)));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, transformMatcher(Matrix4.identity()));
   });
 }

--- a/examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart
+++ b/examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart
@@ -1,0 +1,53 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/inherited_notifier/inherited_notifier.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('It rotate the spinners', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.InheritedNotifierExampleApp(),
+    );
+
+    final Iterable<Transform> widgets = tester.widgetList<Transform>(find.ancestor(of: find.text('Whee!'), matching: find.byType(Transform)));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.identity())));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(0.2 * math.pi))));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(0.4 * math.pi))));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(0.6 * math.pi))));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(0.8 * math.pi))));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(
+      widgets,
+      everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.identity()..storage[0] = -1..storage[5] = -1)),
+    );
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(1.2 * math.pi))));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(1.4 * math.pi))));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(1.6 * math.pi))));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.rotationZ(1.8 * math.pi))));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(widgets, everyElement(isA<Transform>().having((Transform widget) => widget.transform, 'transform', Matrix4.identity())));
+  });
+}

--- a/examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart
+++ b/examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_api_samples/widgets/inherited_notifier/inherited_notifie
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('It rotate the spinners', (WidgetTester tester) async {
+  testWidgets('It rotates the spinners', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.InheritedNotifierExampleApp(),
     );


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/inherited_notifier/inherited_notifier.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
