### PR TITLE
Stop looking for .packages when analyzing

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -169,41 +169,12 @@ class PackageDependency {
 }
 
 class PackageDependencyTracker {
-  /// Packages whose source is defined in the vended SDK.
-  static const List<String> _vendedSdkPackages = <String>['analyzer', 'front_end', 'kernel'];
-
   // This is a map from package names to objects that track the paths
   // involved (sources and targets).
   Map<String, PackageDependency> packages = <String, PackageDependency>{};
 
   PackageDependency getPackageDependency(String packageName) {
     return packages.putIfAbsent(packageName, () => PackageDependency());
-  }
-
-  /// Read the .packages file in [directory] and add referenced packages to [dependencies].
-  void addDependenciesFromPackagesFileIn(Directory directory) {
-    final String dotPackagesPath = globals.fs.path.join(directory.path, '.packages');
-    final File dotPackages = globals.fs.file(dotPackagesPath);
-    if (dotPackages.existsSync()) {
-      // this directory has opinions about what we should be using
-      final Iterable<String> lines = dotPackages
-        .readAsStringSync()
-        .split('\n')
-        .where((String line) => !line.startsWith(RegExp(r'^ *#')));
-      for (final String line in lines) {
-        final int colon = line.indexOf(':');
-        if (colon > 0) {
-          final String packageName = line.substring(0, colon);
-          final String packagePath = globals.fs.path.fromUri(line.substring(colon+1));
-          // Ensure that we only add `analyzer` and dependent packages defined in the vended SDK (and referred to with a local
-          // globals.fs.path. directive). Analyzer package versions reached via transitive dependencies (e.g., via `test`) are ignored
-          // since they would produce spurious conflicts.
-          if (!_vendedSdkPackages.contains(packageName) || packagePath.startsWith('..')) {
-            add(packageName, globals.fs.path.normalize(globals.fs.path.absolute(directory.path, packagePath)), dotPackagesPath);
-          }
-        }
-      }
-    }
   }
 
   void addCanonicalCase(String packageName, String packagePath, String pubSpecYamlPath) {
@@ -235,7 +206,6 @@ class PackageDependencyTracker {
           throwToolExit('pubspec.yaml is malformed.');
         }
       }
-      dependencies.addDependenciesFromPackagesFileIn(directory);
     }
 
     // prepare a union of all the .packages files


### PR DESCRIPTION
Not sure exactly what this was supposed to do, but pub no longer writes ".packages" and has not done since: https://github.com/dart-lang/pub/pull/3413. So this check would never find a '.packages'.

Not sure if this code was doing anything useful - but it does not seem to have been missed for a couple of years.

This is a warm-up for: https://github.com/flutter/flutter/issues/150196

It was added in https://github.com/flutter/flutter/pull/6093 seemingly without tests of this functionality.