### PR TITLE
Add an example for CupertinoPopupSurface

### DIFF
--- a/examples/api/lib/cupertino/dialog/cupertino_popup_surface.0.dart
+++ b/examples/api/lib/cupertino/dialog/cupertino_popup_surface.0.dart
@@ -1,0 +1,105 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+
+/// Flutter code sample for [CupertinoPopupSurface].
+
+void main() => runApp(const PopupSurfaceApp());
+
+class PopupSurfaceApp extends StatelessWidget {
+  const PopupSurfaceApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      home: PopupSurfaceExample(),
+    );
+  }
+}
+
+class PopupSurfaceExample extends StatefulWidget {
+  const PopupSurfaceExample({super.key});
+
+  @override
+  State<PopupSurfaceExample> createState() => _PopupSurfaceExampleState();
+}
+
+class _PopupSurfaceExampleState extends State<PopupSurfaceExample> {
+  bool _shouldPaintSurface = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                const Text('Paint surface'),
+                const SizedBox(width: 16.0),
+                CupertinoSwitch(
+                  value: _shouldPaintSurface,
+                  onChanged: (bool value) => setState(() => _shouldPaintSurface = value),
+                ),
+              ],
+            ),
+            CupertinoButton(
+              onPressed: () => _showPopupSurface(context),
+              child: const Text('Show popup'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showPopupSurface(BuildContext context) {
+    showCupertinoModalPopup<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return CupertinoPopupSurface(
+          isSurfacePainted: _shouldPaintSurface,
+          child: Container(
+            height: 240,
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              children: <Widget>[
+                Expanded(
+                  child: Container(
+                    alignment: Alignment.center,
+                    decoration: _shouldPaintSurface
+                        ? null
+                        : BoxDecoration(
+                            color: CupertinoTheme.of(context).scaffoldBackgroundColor,
+                            borderRadius: BorderRadius.circular(8.0),
+                          ),
+                    child: const Text('This is a popup surface.'),
+                  ),
+                ),
+                const SizedBox(height: 8.0),
+                SizedBox(
+                  width: double.infinity,
+                  child: CupertinoButton(
+                    color: _shouldPaintSurface
+                        ? null
+                        : CupertinoTheme.of(context).scaffoldBackgroundColor,
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text(
+                      'Close',
+                      style: TextStyle(color: CupertinoColors.systemBlue),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/examples/api/test/cupertino/dialog/cupertino_popup_surface.0_test.dart
+++ b/examples/api/test/cupertino/dialog/cupertino_popup_surface.0_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_api_samples/cupertino/dialog/cupertino_popup_surface.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('CupertinoPopupSurface displays expected widgets in init state',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const example.PopupSurfaceApp());
+
+    final Finder cupertinoButton = find.byType(CupertinoButton);
+    expect(cupertinoButton, findsOneWidget);
+
+    final Finder cupertinoSwitch = find.byType(CupertinoSwitch);
+    expect(cupertinoSwitch, findsOneWidget);
+  });
+
+  testWidgets('CupertinoPopupSurface is displayed with painted surface',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const example.PopupSurfaceApp());
+
+    // CupertinoSwitch is toggled on by default.
+    expect(tester.widget<CupertinoSwitch>(find.byType(CupertinoSwitch)).value, isTrue);
+
+    // Tap on the CupertinoButton to show the CupertinoPopupSurface.
+    await tester.tap(find.byType(CupertinoButton));
+    await tester.pumpAndSettle();
+
+    // Make sure CupertinoPopupSurface is showing.
+    final Finder cupertinoPopupSurface = find.byType(CupertinoPopupSurface);
+    expect(cupertinoPopupSurface, findsOneWidget);
+
+    // Confirm that CupertinoPopupSurface is painted with a ColoredBox.
+    final Finder coloredBox = find.descendant(
+      of: cupertinoPopupSurface,
+      matching: find.byType(ColoredBox),
+    );
+    expect(coloredBox, findsOneWidget);
+  });
+
+  testWidgets('CupertinoPopupSurface is displayed without painted surface',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const example.PopupSurfaceApp());
+
+    // Toggling off CupertinoSwitch and confirm its state.
+    final Finder cupertinoSwitch = find.byType(CupertinoSwitch);
+    await tester.tap(cupertinoSwitch);
+    await tester.pumpAndSettle();
+    expect(tester.widget<CupertinoSwitch>(cupertinoSwitch).value, isFalse);
+
+    // Tap on the CupertinoButton to show the CupertinoPopupSurface.
+    await tester.tap(find.byType(CupertinoButton));
+    await tester.pumpAndSettle();
+
+    // Make sure CupertinoPopupSurface is showing.
+    final Finder cupertinoPopupSurface = find.byType(CupertinoPopupSurface);
+    expect(cupertinoPopupSurface, findsOneWidget);
+
+    // Confirm that CupertinoPopupSurface is not painted with a ColoredBox.
+    final Finder coloredBox = find.descendant(
+      of: cupertinoPopupSurface,
+      matching: find.byType(ColoredBox),
+    );
+    expect(coloredBox, findsNothing);
+  });
+}

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -401,8 +401,8 @@ class _CupertinoAlertDialogState extends State<CupertinoAlertDialog> {
 /// rectangle without any color (similar to iOS's volume control popup).
 ///
 /// {@tool dartpad}
-/// This sample shows how to use a [CupertinoPopupSurface].
-/// The [CupertinoPopupSurface] shows a model popup from the bottom of the screen.
+/// This sample shows how to use a [CupertinoPopupSurface]. The [CupertinoPopupSurface]
+/// shows a model popup from the bottom of the screen.
 /// Toggling the switch to configure its surface color.
 ///
 /// ** See code in examples/api/lib/cupertino/dialog/cupertino_popup_surface.0.dart **

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -402,7 +402,7 @@ class _CupertinoAlertDialogState extends State<CupertinoAlertDialog> {
 ///
 /// {@tool dartpad}
 /// This sample shows how to use a [CupertinoPopupSurface].
-///	The [CupertinoPopupSurface] shows a model popup from the bottom of the screen.
+/// The [CupertinoPopupSurface] shows a model popup from the bottom of the screen.
 /// Toggling the switch to configure its surface color.
 ///
 /// ** See code in examples/api/lib/cupertino/dialog/cupertino_popup_surface.0.dart **

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -400,6 +400,14 @@ class _CupertinoAlertDialogState extends State<CupertinoAlertDialog> {
 /// Additionally, the white paint can be disabled to render a blurred rounded
 /// rectangle without any color (similar to iOS's volume control popup).
 ///
+/// {@tool dartpad}
+/// This sample shows how to use a [CupertinoPopupSurface].
+///	The [CupertinoPopupSurface] shows a model popup from the bottom of the screen.
+/// Toggling the switch to configure its surface color.
+///
+/// ** See code in examples/api/lib/cupertino/dialog/cupertino_popup_surface.0.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [CupertinoAlertDialog], which is a dialog with a title, content, and


### PR DESCRIPTION
### Demo

https://github.com/flutter/flutter/assets/104349824/61cd4c96-e01e-4fad-b270-acd7bb55d995

### Related issue

Fixes https://github.com/flutter/flutter/issues/150353

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
