### PR TITLE
Fix flaky complex_layout_scroll_perf__memory  & flutter_gallery__memory_nav

### DIFF
--- a/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
+++ b/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
@@ -23,7 +23,7 @@ Future<void> main() async {
   final Completer<void> ready = Completer<void>();
   runApp(GestureDetector(
     onTap: () {
-      debugPrint('Received tap.');
+      debugPrint('==== MEMORY BENCHMARK ==== TAPPED ====');
       ready.complete();
     },
     behavior: HitTestBehavior.opaque,
@@ -32,15 +32,13 @@ Future<void> main() async {
     ),
   ));
   await SchedulerBinding.instance.endOfFrame;
-
-  /// Wait 50ms to allow the raster thread to actually put up the frame. (The
-  /// endOfFrame future ends when we send the data to the engine, before
-  /// the raster thread has had a chance to rasterize, etc.)
-  await Future<void>.delayed(const Duration(milliseconds: 50));
   debugPrint('==== MEMORY BENCHMARK ==== READY ====');
 
   await ready.future; // waits for tap sent by devicelab task
   debugPrint('Continuing...');
+
+  // Wait out any errant taps due to synchronization
+  await Future<void>.delayed(const Duration(milliseconds: 200));
 
   // remove onTap handler, enable pointer events for app
   runApp(GestureDetector(

--- a/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
+++ b/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
@@ -23,7 +23,7 @@ Future<void> main() async {
   final Completer<void> ready = Completer<void>();
   runApp(GestureDetector(
     onTap: () {
-      debugPrint('Received tap.');
+      debugPrint('==== MEMORY BENCHMARK ==== TAPPED ====');
       ready.complete();
     },
     behavior: HitTestBehavior.opaque,
@@ -32,11 +32,6 @@ Future<void> main() async {
     ),
   ));
   await SchedulerBinding.instance.endOfFrame;
-
-  /// Wait 50ms to allow the raster thread to actually put up the frame. (The
-  /// endOfFrame future ends when we send the data to the engine, before
-  /// the raster thread has had a chance to rasterize, etc.)
-  await Future<void>.delayed(const Duration(milliseconds: 50));
   debugPrint('==== MEMORY BENCHMARK ==== READY ====');
 
   await ready.future; // waits for tap sent by devicelab task

--- a/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
+++ b/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
@@ -37,6 +37,9 @@ Future<void> main() async {
   await ready.future; // waits for tap sent by devicelab task
   debugPrint('Continuing...');
 
+  // Wait out any errant taps due to synchronization
+  await Future<void>.delayed(const Duration(milliseconds: 200));
+
   // remove onTap handler, enable pointer events for app
   runApp(GestureDetector(
     child: const IgnorePointer(

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf__memory.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf__memory.dart
@@ -13,5 +13,6 @@ Future<void> main() async {
     '${flutterDirectory.path}/dev/benchmarks/complex_layout',
     'test_memory/scroll_perf.dart',
     'com.yourcompany.complexLayout',
+    requiresTapToStart: true,
   ).run);
 }

--- a/dev/devicelab/bin/tasks/flutter_gallery__memory_nav.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__memory_nav.dart
@@ -11,5 +11,6 @@ Future<void> main() async {
     '${flutterDirectory.path}/dev/integration_tests/flutter_gallery',
     'test_memory/memory_nav.dart',
     'io.flutter.demo.gallery',
+    requiresTapToStart: true,
   ).run);
 }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1968,11 +1968,12 @@ class CompileTest {
 
 /// Measure application memory usage.
 class MemoryTest {
-  MemoryTest(this.project, this.test, this.package);
+  MemoryTest(this.project, this.test, this.package, {this.requiresTapToStart = false});
 
   final String project;
   final String test;
   final String package;
+  final bool requiresTapToStart;
 
   /// Completes when the log line specified in the last call to
   /// [prepareForNextMessage] is seen by `adb logcat`.
@@ -2061,6 +2062,38 @@ class MemoryTest {
     await receivedNextMessage;
   }
 
+  /// Taps the application and looks for acknowldgement.
+  ///
+  /// This is used by several tests to ensure scrolling gestures are installed.
+  Future<void> tapNotification() async {
+    // Keep "tapping" the device till it responds with the string we expect,
+    // or throw an error instead of tying up the infrastructure for 30 minutes.
+    prepareForNextMessage('TAPPED');
+    bool tapped = false;
+    int tapCount = 0;
+    await Future.any(<Future<void>>[
+      () async {
+        while (true) {
+          if (tapped) {
+            break;
+          }
+          tapCount += 1;
+          print('tapping device... [$tapCount]');
+          await device!.tap(100, 100);
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+        }
+      }(),
+      () async {
+        print('awaiting "tapped" message... (timeout: 10 seconds)');
+        try {
+          await receivedNextMessage?.timeout(const Duration(seconds: 10));
+        } finally {
+          tapped = true;
+        }
+      }(),
+    ]);
+  }
+
   /// To change the behavior of the test, override this.
   ///
   /// Make sure to call recordStart() and recordEnd() once each in that order.
@@ -2070,10 +2103,11 @@ class MemoryTest {
   Future<void> useMemory() async {
     await launchApp();
     await recordStart();
+    if (requiresTapToStart) {
+      await tapNotification();
+    }
 
     prepareForNextMessage('DONE');
-    print('tapping device...');
-    await device!.tap(100, 100);
     print('awaiting "done" message...');
     await receivedNextMessage;
 

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -2082,10 +2082,10 @@ class MemoryTest {
           if (tapped) {
             break;
           }
-          i += 1;
-          print('tapping device... [$i]');
+          tapCount += 1;
+          print('tapping device... [$tapCount]');
           await device!.tap(100, 100);
-          await Future<void>.delayed(const Duration(milliseconds: 250));
+          await Future<void>.delayed(const Duration(milliseconds: 100));
         }
       }(),
       () async {

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -2075,7 +2075,7 @@ class MemoryTest {
     // or throw an error instead of tying up the infrastructure for 30 minutes.
     prepareForNextMessage('TAPPED');
     bool tapped = false;
-    int i = 0;
+    int tapCount = 0;
     await Future.any(<Future<void>>[
       () async {
         while (true) {

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -2071,9 +2071,34 @@ class MemoryTest {
     await launchApp();
     await recordStart();
 
+    // Keep "tapping" the device till it responds with the string we expect,
+    // or throw an error instead of tying up the infrastructure for 30 minutes.
+    prepareForNextMessage('TAPPED');
+    bool tapped = false;
+    int i = 0;
+    await Future.any(<Future<void>>[
+      () async {
+        while (true) {
+          if (tapped) {
+            break;
+          }
+          i += 1;
+          print('tapping device... [$i]');
+          await device!.tap(100, 100);
+          await Future<void>.delayed(const Duration(milliseconds: 250));
+        }
+      }(),
+      () async {
+        print('awaiting "tapped" message... (timeout: 10 seconds)');
+        try {
+          await receivedNextMessage?.timeout(const Duration(seconds: 10));
+        } finally {
+          tapped = true;
+        }
+      }(),
+    ]);
+
     prepareForNextMessage('DONE');
-    print('tapping device...');
-    await device!.tap(100, 100);
     print('awaiting "done" message...');
     await receivedNextMessage;
 

--- a/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
+++ b/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
@@ -26,7 +26,7 @@ Future<void> main() async {
   final Completer<void> ready = Completer<void>();
   runApp(GestureDetector(
     onTap: () {
-      debugPrint('Received tap.');
+      debugPrint('==== MEMORY BENCHMARK ==== TAPPED ====');
       ready.complete();
     },
     behavior: HitTestBehavior.opaque,
@@ -35,11 +35,13 @@ Future<void> main() async {
     ),
   ));
   await SchedulerBinding.instance.endOfFrame;
-  await Future<void>.delayed(const Duration(milliseconds: 50));
   debugPrint('==== MEMORY BENCHMARK ==== READY ====');
 
   await ready.future;
   debugPrint('Continuing...');
+
+  // Wait out any errant taps due to synchronization
+  await Future<void>.delayed(const Duration(milliseconds: 200));
 
   // remove onTap handler, enable pointer events for app
   runApp(GestureDetector(

--- a/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
+++ b/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
@@ -26,7 +26,7 @@ Future<void> main() async {
   final Completer<void> ready = Completer<void>();
   runApp(GestureDetector(
     onTap: () {
-      debugPrint('Received tap.');
+      debugPrint('==== MEMORY BENCHMARK ==== TAPPED ====');
       ready.complete();
     },
     behavior: HitTestBehavior.opaque,
@@ -35,7 +35,6 @@ Future<void> main() async {
     ),
   ));
   await SchedulerBinding.instance.endOfFrame;
-  await Future<void>.delayed(const Duration(milliseconds: 50));
   debugPrint('==== MEMORY BENCHMARK ==== READY ====');
 
   await ready.future;

--- a/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
+++ b/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
@@ -40,6 +40,9 @@ Future<void> main() async {
   await ready.future;
   debugPrint('Continuing...');
 
+  // Wait out any errant taps due to synchronization
+  await Future<void>.delayed(const Duration(milliseconds: 200));
+
   // remove onTap handler, enable pointer events for app
   runApp(GestureDetector(
     child: const IgnorePointer(


### PR DESCRIPTION
Initial tap is missing sometimes; either its never delivered or it is
delivered before gesture controller is hooked up.

1: Update MemoryTest to have option `requiresTapToStart` guarding the
   new paths
2: Update the two perf tests that appear to be flaky to output when
   TAPPED is received
3: Update the MemoryTest to keep tapping while waiting for TAPPED

Tested on devicelab:
* setting iterations=1
* removing the timeout before READY
* running tests in a while loop

Before this change, you could get the test to hang often. After this
change you'll see "tapping device... [x]" where x is the counter.

Fixes https://github.com/flutter/flutter/issues/150096