### PR TITLE
Update Material token to the latest 4.1.0

### DIFF
--- a/dev/tools/gen_defaults/data/badge.json
+++ b/dev/tools/gen_defaults/data/badge.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.badge.color": "error",
   "md.comp.badge.large.color": "error",

--- a/dev/tools/gen_defaults/data/banner.json
+++ b/dev/tools/gen_defaults/data/banner.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.banner.container.color": "surfaceContainerLow",
   "md.comp.banner.container.elevation": "md.sys.elevation.level1",

--- a/dev/tools/gen_defaults/data/bottom_app_bar.json
+++ b/dev/tools/gen_defaults/data/bottom_app_bar.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.bottom-app-bar.container.color": "surfaceContainer",
   "md.comp.bottom-app-bar.container.elevation": "md.sys.elevation.level2",

--- a/dev/tools/gen_defaults/data/button_elevated.json
+++ b/dev/tools/gen_defaults/data/button_elevated.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.elevated-button.container.color": "surfaceContainerLow",
   "md.comp.elevated-button.container.elevation": "md.sys.elevation.level1",

--- a/dev/tools/gen_defaults/data/button_filled.json
+++ b/dev/tools/gen_defaults/data/button_filled.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.filled-button.container.color": "primary",
   "md.comp.filled-button.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/button_filled_tonal.json
+++ b/dev/tools/gen_defaults/data/button_filled_tonal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.filled-tonal-button.container.color": "secondaryContainer",
   "md.comp.filled-tonal-button.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/button_outlined.json
+++ b/dev/tools/gen_defaults/data/button_outlined.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.outlined-button.container.height": 40.0,
   "md.comp.outlined-button.container.shape": "md.sys.shape.corner.full",

--- a/dev/tools/gen_defaults/data/button_text.json
+++ b/dev/tools/gen_defaults/data/button_text.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.text-button.container.height": 40.0,
   "md.comp.text-button.container.shape": "md.sys.shape.corner.full",

--- a/dev/tools/gen_defaults/data/card_elevated.json
+++ b/dev/tools/gen_defaults/data/card_elevated.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.elevated-card.container.color": "surfaceContainerLow",
   "md.comp.elevated-card.container.elevation": "md.sys.elevation.level1",

--- a/dev/tools/gen_defaults/data/card_filled.json
+++ b/dev/tools/gen_defaults/data/card_filled.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.filled-card.container.color": "surfaceContainerHighest",
   "md.comp.filled-card.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/card_outlined.json
+++ b/dev/tools/gen_defaults/data/card_outlined.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.outlined-card.container.color": "surface",
   "md.comp.outlined-card.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/carousel_item.json
+++ b/dev/tools/gen_defaults/data/carousel_item.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.carousel-item.container.color": "surface",
   "md.comp.carousel-item.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/checkbox.json
+++ b/dev/tools/gen_defaults/data/checkbox.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.checkbox.container.size": 18.0,
   "md.comp.checkbox.error.focus.state-layer.color": "error",

--- a/dev/tools/gen_defaults/data/chip_assist.json
+++ b/dev/tools/gen_defaults/data/chip_assist.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.assist-chip.container.height": 32.0,
   "md.comp.assist-chip.container.shape": "md.sys.shape.corner.small",

--- a/dev/tools/gen_defaults/data/chip_filter.json
+++ b/dev/tools/gen_defaults/data/chip_filter.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.filter-chip.container.height": 32.0,
   "md.comp.filter-chip.container.shape": "md.sys.shape.corner.small",

--- a/dev/tools/gen_defaults/data/chip_input.json
+++ b/dev/tools/gen_defaults/data/chip_input.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.input-chip.container.elevation": "md.sys.elevation.level0",
   "md.comp.input-chip.container.height": 32.0,

--- a/dev/tools/gen_defaults/data/chip_suggestion.json
+++ b/dev/tools/gen_defaults/data/chip_suggestion.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.suggestion-chip.container.height": 32.0,
   "md.comp.suggestion-chip.container.shape": "md.sys.shape.corner.small",

--- a/dev/tools/gen_defaults/data/color_dark.json
+++ b/dev/tools/gen_defaults/data/color_dark.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.sys.color.background": "md.ref.palette.neutral6",
   "md.sys.color.error": "md.ref.palette.error80",

--- a/dev/tools/gen_defaults/data/color_light.json
+++ b/dev/tools/gen_defaults/data/color_light.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.sys.color.background": "md.ref.palette.neutral98",
   "md.sys.color.error": "md.ref.palette.error40",

--- a/dev/tools/gen_defaults/data/date_picker_docked.json
+++ b/dev/tools/gen_defaults/data/date_picker_docked.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.date-picker.docked.container.color": "surfaceContainerHigh",
   "md.comp.date-picker.docked.container.elevation": "md.sys.elevation.level3",

--- a/dev/tools/gen_defaults/data/date_picker_input_modal.json
+++ b/dev/tools/gen_defaults/data/date_picker_input_modal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.date-input.modal.container.color": "surfaceContainerHigh",
   "md.comp.date-input.modal.container.elevation": "md.sys.elevation.level3",

--- a/dev/tools/gen_defaults/data/date_picker_modal.json
+++ b/dev/tools/gen_defaults/data/date_picker_modal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.date-picker.modal.container.color": "surfaceContainerHigh",
   "md.comp.date-picker.modal.container.elevation": "md.sys.elevation.level3",

--- a/dev/tools/gen_defaults/data/dialog.json
+++ b/dev/tools/gen_defaults/data/dialog.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.dialog.action.focus.label-text.color": "primary",
   "md.comp.dialog.action.focus.state-layer.color": "primary",

--- a/dev/tools/gen_defaults/data/dialog_fullscreen.json
+++ b/dev/tools/gen_defaults/data/dialog_fullscreen.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.full-screen-dialog.container.color": "surface",
   "md.comp.full-screen-dialog.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/divider.json
+++ b/dev/tools/gen_defaults/data/divider.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.divider.color": "outlineVariant",
   "md.comp.divider.thickness": 1.0

--- a/dev/tools/gen_defaults/data/elevation.json
+++ b/dev/tools/gen_defaults/data/elevation.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.sys.elevation.level0": 0.0,
   "md.sys.elevation.level1": 1.0,

--- a/dev/tools/gen_defaults/data/fab_extended_primary.json
+++ b/dev/tools/gen_defaults/data/fab_extended_primary.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.extended-fab.primary.container.color": "primaryContainer",
   "md.comp.extended-fab.primary.container.elevation": "md.sys.elevation.level3",

--- a/dev/tools/gen_defaults/data/fab_large_primary.json
+++ b/dev/tools/gen_defaults/data/fab_large_primary.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.fab.primary.large.container.color": "primaryContainer",
   "md.comp.fab.primary.large.container.elevation": "md.sys.elevation.level3",

--- a/dev/tools/gen_defaults/data/fab_primary.json
+++ b/dev/tools/gen_defaults/data/fab_primary.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.fab.primary.container.color": "primaryContainer",
   "md.comp.fab.primary.container.elevation": "md.sys.elevation.level3",

--- a/dev/tools/gen_defaults/data/fab_small_primary.json
+++ b/dev/tools/gen_defaults/data/fab_small_primary.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.fab.primary.small.container.color": "primaryContainer",
   "md.comp.fab.primary.small.container.elevation": "md.sys.elevation.level3",

--- a/dev/tools/gen_defaults/data/icon_button.json
+++ b/dev/tools/gen_defaults/data/icon_button.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.icon-button.disabled.icon.color": "onSurface",
   "md.comp.icon-button.disabled.icon.opacity": 0.38,

--- a/dev/tools/gen_defaults/data/icon_button_filled.json
+++ b/dev/tools/gen_defaults/data/icon_button_filled.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.filled-icon-button.container.color": "primary",
   "md.comp.filled-icon-button.container.height": 40.0,

--- a/dev/tools/gen_defaults/data/icon_button_filled_tonal.json
+++ b/dev/tools/gen_defaults/data/icon_button_filled_tonal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.filled-tonal-icon-button.container.color": "secondaryContainer",
   "md.comp.filled-tonal-icon-button.container.height": 40.0,

--- a/dev/tools/gen_defaults/data/icon_button_outlined.json
+++ b/dev/tools/gen_defaults/data/icon_button_outlined.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.outlined-icon-button.container.height": 40.0,
   "md.comp.outlined-icon-button.container.shape": "md.sys.shape.corner.full",

--- a/dev/tools/gen_defaults/data/list.json
+++ b/dev/tools/gen_defaults/data/list.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.list.divider.leading-space": 16.0,
   "md.comp.list.divider.trailing-space": 16.0,

--- a/dev/tools/gen_defaults/data/menu.json
+++ b/dev/tools/gen_defaults/data/menu.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.menu.container.color": "surfaceContainer",
   "md.comp.menu.container.elevation": "md.sys.elevation.level2",

--- a/dev/tools/gen_defaults/data/motion.json
+++ b/dev/tools/gen_defaults/data/motion.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.sys.motion.duration.extra-long1Ms": 700.0,
   "md.sys.motion.duration.extra-long2Ms": 800.0,

--- a/dev/tools/gen_defaults/data/navigation_bar.json
+++ b/dev/tools/gen_defaults/data/navigation_bar.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.navigation-bar.active.focus.icon.color": "onSecondaryContainer",
   "md.comp.navigation-bar.active.focus.label-text.color": "onSurface",

--- a/dev/tools/gen_defaults/data/navigation_drawer.json
+++ b/dev/tools/gen_defaults/data/navigation_drawer.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.navigation-drawer.active.focus.icon.color": "onSecondaryContainer",
   "md.comp.navigation-drawer.active.focus.label-text.color": "onSecondaryContainer",

--- a/dev/tools/gen_defaults/data/navigation_rail.json
+++ b/dev/tools/gen_defaults/data/navigation_rail.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.navigation-rail.active.focus.icon.color": "onSecondaryContainer",
   "md.comp.navigation-rail.active.focus.label-text.color": "onSurface",

--- a/dev/tools/gen_defaults/data/navigation_tab_primary.json
+++ b/dev/tools/gen_defaults/data/navigation_tab_primary.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.primary-navigation-tab.active.focus.state-layer.color": "primary",
   "md.comp.primary-navigation-tab.active.focus.state-layer.opacity": "md.sys.state.focus.state-layer-opacity",

--- a/dev/tools/gen_defaults/data/navigation_tab_secondary.json
+++ b/dev/tools/gen_defaults/data/navigation_tab_secondary.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.secondary-navigation-tab.active-indicator.color": "primary",
   "md.comp.secondary-navigation-tab.active-indicator.height": 2.0,

--- a/dev/tools/gen_defaults/data/palette.json
+++ b/dev/tools/gen_defaults/data/palette.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.ref.palette.black": "0xFF000000",
   "md.ref.palette.blue0": "0xFF000000",

--- a/dev/tools/gen_defaults/data/progress_indicator.json
+++ b/dev/tools/gen_defaults/data/progress_indicator.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.progress-indicator.active-indicator.color": "primary",
   "md.comp.progress-indicator.active-indicator.shape": "md.sys.shape.corner.full",

--- a/dev/tools/gen_defaults/data/radio_button.json
+++ b/dev/tools/gen_defaults/data/radio_button.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.radio-button.disabled.selected.icon.color": "onSurface",
   "md.comp.radio-button.disabled.selected.icon.opacity": 0.38,

--- a/dev/tools/gen_defaults/data/search_bar.json
+++ b/dev/tools/gen_defaults/data/search_bar.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.search-bar.avatar.shape": "md.sys.shape.corner.full",
   "md.comp.search-bar.avatar.size": 30.0,

--- a/dev/tools/gen_defaults/data/search_view.json
+++ b/dev/tools/gen_defaults/data/search_view.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.search-view.container.color": "surfaceContainerHigh",
   "md.comp.search-view.container.elevation": "md.sys.elevation.level3",

--- a/dev/tools/gen_defaults/data/segmented_button_outlined.json
+++ b/dev/tools/gen_defaults/data/segmented_button_outlined.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.outlined-segmented-button.container.height": 40.0,
   "md.comp.outlined-segmented-button.disabled.icon.color": "onSurface",

--- a/dev/tools/gen_defaults/data/shape.json
+++ b/dev/tools/gen_defaults/data/shape.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.sys.shape.corner.extra-large": {
     "family": "SHAPE_FAMILY_ROUNDED_CORNERS",

--- a/dev/tools/gen_defaults/data/sheet_bottom.json
+++ b/dev/tools/gen_defaults/data/sheet_bottom.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.sheet.bottom.docked.container.color": "surfaceContainerLow",
   "md.comp.sheet.bottom.docked.container.shape": "md.sys.shape.corner.extra-large.top",

--- a/dev/tools/gen_defaults/data/slider.json
+++ b/dev/tools/gen_defaults/data/slider.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.slider.active.handle.height": 44.0,
   "md.comp.slider.active.handle.leading-space": 6.0,
@@ -23,7 +23,6 @@
   "md.comp.slider.focus.active.track.color": "primary",
   "md.comp.slider.focus.handle.width": 2.0,
   "md.comp.slider.focus.inactive.track.color": "secondaryContainer",
-  "md.comp.slider.focus.stop.color": "primary",
   "md.comp.slider.handle.color": "primary",
   "md.comp.slider.handle.height": 44.0,
   "md.comp.slider.handle.shape": "md.sys.shape.corner.full",
@@ -32,7 +31,6 @@
   "md.comp.slider.inactive.track.color": "secondaryContainer",
   "md.comp.slider.inactive.track.height": 16.0,
   "md.comp.slider.inactive.track.shape": "md.sys.shape.corner.full",
-  "md.comp.slider.label.label-text.color": "onInverseSurface",
   "md.comp.slider.pressed.active.track.color": "primary",
   "md.comp.slider.pressed.handle.color": "primary",
   "md.comp.slider.pressed.handle.width": 2.0,

--- a/dev/tools/gen_defaults/data/snackbar.json
+++ b/dev/tools/gen_defaults/data/snackbar.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.snackbar.action.focus.label-text.color": "inversePrimary",
   "md.comp.snackbar.action.focus.state-layer.color": "inversePrimary",

--- a/dev/tools/gen_defaults/data/state.json
+++ b/dev/tools/gen_defaults/data/state.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.sys.state.dragged.state-layer-opacity": 0.16,
   "md.sys.state.focus.state-layer-opacity": 0.1,

--- a/dev/tools/gen_defaults/data/switch.json
+++ b/dev/tools/gen_defaults/data/switch.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.switch.disabled.selected.handle.color": "surface",
   "md.comp.switch.disabled.selected.handle.opacity": 1.0,

--- a/dev/tools/gen_defaults/data/text_field_filled.json
+++ b/dev/tools/gen_defaults/data/text_field_filled.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.filled-text-field.active-indicator.color": "onSurfaceVariant",
   "md.comp.filled-text-field.active-indicator.height": 1.0,

--- a/dev/tools/gen_defaults/data/text_field_outlined.json
+++ b/dev/tools/gen_defaults/data/text_field_outlined.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.outlined-text-field.caret.color": "primary",
   "md.comp.outlined-text-field.container.shape": "md.sys.shape.corner.extra-small",

--- a/dev/tools/gen_defaults/data/text_style.json
+++ b/dev/tools/gen_defaults/data/text_style.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.sys.typescale.body-large.font": "md.ref.typeface.plain",
   "md.sys.typescale.body-large.line-height": 24.0,

--- a/dev/tools/gen_defaults/data/time_picker.json
+++ b/dev/tools/gen_defaults/data/time_picker.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.time-picker.clock-dial.color": "surfaceContainerHighest",
   "md.comp.time-picker.clock-dial.container.size": 256.0,

--- a/dev/tools/gen_defaults/data/top_app_bar_large.json
+++ b/dev/tools/gen_defaults/data/top_app_bar_large.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.top-app-bar.large.container.color": "surface",
   "md.comp.top-app-bar.large.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/top_app_bar_medium.json
+++ b/dev/tools/gen_defaults/data/top_app_bar_medium.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.top-app-bar.medium.container.color": "surface",
   "md.comp.top-app-bar.medium.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/top_app_bar_small.json
+++ b/dev/tools/gen_defaults/data/top_app_bar_small.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.comp.top-app-bar.small.container.color": "surface",
   "md.comp.top-app-bar.small.container.elevation": "md.sys.elevation.level0",

--- a/dev/tools/gen_defaults/data/typeface.json
+++ b/dev/tools/gen_defaults/data/typeface.json
@@ -1,5 +1,5 @@
 {
-  "version": "4_0_0",
+  "version": "v4_1_0",
 
   "md.ref.typeface.brand": "Roboto",
   "md.ref.typeface.plain": "Roboto",

--- a/dev/tools/gen_defaults/generated/used_tokens.csv
+++ b/dev/tools/gen_defaults/generated/used_tokens.csv
@@ -1,4 +1,4 @@
-Versions used, 4_0_0
+Versions used, v4_1_0
 md.comp.assist-chip.container.shape,
 md.comp.assist-chip.disabled.label-text.color,
 md.comp.assist-chip.elevated.container.color,


### PR DESCRIPTION
This PR is to update material tokens to the latest version 4.1.0, which:
* deprecates two tokens in `Slider`
* doesn't impact the material widgets' defaults

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
