### PR TITLE
Extend the Windows web_tool_tests_1_2 shard timeout to 45 minutes

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5800,6 +5800,7 @@ targets:
       subshard: "1_2"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
This suite typically takes almost 30 minutes on CI, and some recent engine->framework rolls failed because the tests exceeded the current 30 minute timeout.