### PR TITLE
Introduce caching mechanism during compile semantics tree

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4752,21 +4752,6 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     // Parent data changes may result in node formation changes.
     markNeedsBuild();
     parentData = newParentData;
-
-    final Set<SemanticsTag>? tags = newParentData.tagsForChildren;
-    if (tags != null) {
-      assert(tags.isNotEmpty);
-      configProvider.updateConfig((SemanticsConfiguration config) {
-        tags.forEach(config.addTagForChildren);
-      });
-    }
-
-    final bool effectiveBlocksUserAction = newParentData.blocksUserActions || configProvider.original.isBlockingUserActions;
-    if (effectiveBlocksUserAction != configProvider.effective.isBlockingUserActions) {
-      configProvider.updateConfig((SemanticsConfiguration config) {
-        config.isBlockingUserActions = effectiveBlocksUserAction;
-      });
-    }
     updateChildren();
   }
 
@@ -4789,6 +4774,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     final bool hasChildConfigurationsDelegate = childConfigurationsDelegate != null;
     final Map<SemanticsConfiguration, _SemanticsFragment> configToFragment = <SemanticsConfiguration, _SemanticsFragment>{};
     final List<_SemanticsFragment> children = <_SemanticsFragment>[];
+    final bool blocksUserAction = (parentData?.blocksUserActions ?? false) || configProvider.effective.isBlockingUserActions;
     siblingMergeGroups.clear();
     _childrenAndElevationAdjustments.clear();
     mergeUp.clear();
@@ -4796,7 +4782,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       assert(!childSemantics.renderObject._needsLayout);
       final _SemanticsParentData childParentData = _SemanticsParentData(
         mergeIntoParent: (parentData?.mergeIntoParent ?? false) || configProvider.effective.isMergingSemanticsOfDescendants,
-        blocksUserActions: (parentData?.blocksUserActions ?? false) || configProvider.effective.isBlockingUserActions,
+        blocksUserActions: blocksUserAction,
         explicitChildNodes: explicitChildNodesForChildren,
         tagsForChildren: tagsForChildren,
       );
@@ -4863,6 +4849,20 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
           siblingMergeGroups.addAll(childSemantics.siblingMergeGroups);
         }
       }
+    }
+
+    final Set<SemanticsTag>? tags = parentData?.tagsForChildren;
+    if (tags != null) {
+      assert(tags.isNotEmpty);
+      configProvider.updateConfig((SemanticsConfiguration config) {
+        tags.forEach(config.addTagForChildren);
+      });
+    }
+
+    if (blocksUserAction != configProvider.effective.isBlockingUserActions) {
+      configProvider.updateConfig((SemanticsConfiguration config) {
+        config.isBlockingUserActions = blocksUserAction;
+      });
     }
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4764,7 +4764,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     final bool effectiveBlocksUserAction = newParentData.blocksUserActions || configProvider.original.isBlockingUserActions;
     if (effectiveBlocksUserAction != configProvider.effective.isBlockingUserActions) {
       configProvider.updateConfig((SemanticsConfiguration config) {
-        config.isBlockingUserActions = newParentData.blocksUserActions || configProvider.original.isBlockingUserActions;
+        config.isBlockingUserActions = effectiveBlocksUserAction;
       });
     }
     updateChildren();
@@ -4836,6 +4836,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       }
     }
 
+    mergeUp.addAll(children);
     if (contributesToSemanticsTree) {
       _marksConflictsInMergeGroup(mergeUp, isMergeUp: true);
       siblingMergeGroups.forEach(_marksConflictsInMergeGroup);
@@ -4846,6 +4847,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       configProvider.absorbAll(mergeUpConfigs);
       // merge up fragments below this object will not be visible to parent
       // because they are either absorbed or will form a semantics node.
+      mergeUp.clear();
       mergeUp.add(this);
       for (final _RenderObjectSemantics childSemantics in children.whereType<_RenderObjectSemantics>()) {
         assert(childSemantics.contributesToSemanticsTree);
@@ -4861,8 +4863,6 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
           siblingMergeGroups.addAll(childSemantics.siblingMergeGroups);
         }
       }
-    } else {
-      mergeUp.addAll(children);
     }
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4592,22 +4592,22 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
   SemanticsNode? cachedSemanticsNode;
 
   /// The semantics nodes produced by this render object.
-  /// 
+  ///
   /// This is filled after [buildSemantics] is called when
   /// [shouldFormSemanticsNode] is true. In most cases, this only contains one
   /// semantics node equals to [cachedSemanticsNode].
-  /// 
+  ///
   /// If there are [siblingMergeGroups], the nodes produced from the sibling
   /// merge groups are also stored in this list.
   final List<SemanticsNode> semanticsNodes = <SemanticsNode>[];
 
   /// Fragments that will merge up to parent rendering object semantics.
   final List<_SemanticsFragment> mergeUp = <_SemanticsFragment>[];
-  
+
   /// A map that record immediate child [_RenderObjectSemantics]s that will form
   /// semantics nodes with their elevation adjustments.
   final Map<_RenderObjectSemantics, double> _childrenAndElevationAdjustments = <_RenderObjectSemantics, double>{};
-  
+
   /// Merge groups that will form additional sibling nodes.
   final List<List<_SemanticsFragment>> siblingMergeGroups = <List<_SemanticsFragment>>[];
   final Map<SemanticsNode, List<_SemanticsFragment>> _producedSiblingNodesAndOwners = <SemanticsNode, List<_SemanticsFragment>>{};

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1076,14 +1076,14 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
       // TODO(chunhtai): Figure out what to do when text spans are asked to form
       // a semantics node.
       //
-      // this is a workaround to get around cases where text span can't formed
+      // this is a workaround for cases where text span can't formed
       // a semantics node by itself. In `childConfigurationsDelegate`, the
-      // text spans are converted into SemanticsConfigurations to be merge up
-      // This can become a problem if parent has explicit child set to true.
+      // text spans are converted into SemanticsConfigurations to be merge up,
+      // and this can become a problem if parent has explicit child set to true.
+      //
       // Setting the hasBeenAnnotated will force this render object to absorb
       // all the text spans' SemanticsConfigurations.
       if (hasTextSpan) {
-        // Text Span will contribute
         config.hasBeenAnnotated = true;
       }
     } else {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1916,7 +1916,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
   ///  * [elevation], the actual elevation of this [SemanticsNode].
   @Deprecated(
     'This was caches for internal calculation and is no longer needed. '
-    'This feature was deprecated after v3.26.0.'
+    'This feature was deprecated after v3.27.0-0.0.pre-307-gb29f972348.'
   )
   double? elevationAdjustment;
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1916,7 +1916,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
   ///  * [elevation], the actual elevation of this [SemanticsNode].
   @Deprecated(
     'This was caches for internal calculation and is no longer needed. '
-    'This feature was deprecated after v3.27.0-0.0.pre-307-gb29f972348.'
+    'This feature was deprecated after v3.27.0-0.0.pre.'
   )
   double? elevationAdjustment;
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1856,15 +1856,6 @@ class SemanticsNode with DiagnosticableTreeMixin {
     }
   }
 
-  /// Whether is this node is hidden off-screen from parent's bounding box.
-  bool get isHidden => hasFlag(SemanticsFlag.isHidden);
-  set isHidden(bool value) {
-    if (hasFlag(SemanticsFlag.isHidden) != value) {
-      _flags = _flags ^ SemanticsFlag.isHidden.index;
-      _markDirty();
-    }
-  }
-
   /// The semantic clip from an ancestor that was applied to this node.
   ///
   /// Expressed in the coordinate system of the node. May be null if no clip has
@@ -1991,7 +1982,6 @@ class SemanticsNode with DiagnosticableTreeMixin {
   // CHILDREN
 
   /// Contains the children in inverse hit test order (i.e. paint order).
-  List<SemanticsNode>? get children => _children;
   List<SemanticsNode>? _children;
 
   /// A snapshot of `newChildren` passed to [_replaceChildren] that we keep in
@@ -1999,7 +1989,6 @@ class SemanticsNode with DiagnosticableTreeMixin {
   /// of children.
   late List<SemanticsNode> _debugPreviousSnapshot;
 
-  /// Replace current children.
   void _replaceChildren(List<SemanticsNode> newChildren) {
     assert(!newChildren.any((SemanticsNode child) => child == this));
     assert(() {
@@ -2203,7 +2192,6 @@ class SemanticsNode with DiagnosticableTreeMixin {
     _children?.forEach(_updateChildMergeFlagRecursively);
   }
 
-
   void _adoptChild(SemanticsNode child) {
     assert(child._parent == null);
     assert(() {
@@ -2220,10 +2208,10 @@ class SemanticsNode with DiagnosticableTreeMixin {
     }
     _redepthChild(child);
     // In most cases, child should have up to date `isMergedIntoParent` since
-    // it was set during _SwitchableSemanticsFragment.compileSemanticsNodes.
-    // However, it is still possible that this child was an extra node
-    // introduced in RenderObject.assembleSemanticsNode. We have to make sure
-    // their `isMergedIntoParent` is updated correctly.
+    // it was set during _RenderObjectSemantics.buildSemantics. However, it is
+    // still possible that this child was an extra node introduced in
+    // RenderObject.assembleSemanticsNode. We have to make sure their
+    // `isMergedIntoParent` is updated correctly.
     _updateChildMergeFlagRecursively(child);
   }
 
@@ -4225,7 +4213,6 @@ class SemanticsConfiguration {
   set childConfigurationsDelegate(ChildSemanticsConfigurationsDelegate? value) {
     assert(value != null);
     _childConfigurationsDelegate = value;
-    // hasBeenAnnotated = true;
   }
 
   /// Returns the action handler registered for [action] or null if none was

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -2190,6 +2190,7 @@ class _OverlayPortalElement extends RenderObjectElement {
     assert(renderObject._deferredLayoutChild == child);
     slot._removeChild(child as _RenderDeferredLayoutBox);
     renderObject._deferredLayoutChild = null;
+    renderObject.markNeedsSemanticsUpdate();
   }
 
   @override

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -626,7 +626,6 @@ void main() {
                               label: 'Item 3',
                               textDirection: TextDirection.ltr,
                             ),
-
                           ],
                         ),
                       ],

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -33,7 +33,7 @@ void main() {
       onSemanticsUpdate: (ui.SemanticsUpdate update) {}
     );
     owner.ensureSemantics();
-    renderObject.attach(owner);
+    owner.rootNode = renderObject;
     renderObject.layout(const BoxConstraints.tightForFinite());  // semantics are only calculated if layout information is up to date.
     owner.flushSemantics();
 
@@ -54,7 +54,7 @@ void main() {
     expect(onSemanticsUpdateCallCount, 0);
 
     final TestRenderObject renderObject = TestRenderObject();
-    renderObject.attach(owner);
+    owner.rootNode = renderObject;
     renderObject.layout(const BoxConstraints.tightForFinite());
     owner.flushSemantics();
 

--- a/packages/flutter/test/semantics/traversal_order_test.dart
+++ b/packages/flutter/test/semantics/traversal_order_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';

--- a/packages/flutter/test/semantics/traversal_order_test.dart
+++ b/packages/flutter/test/semantics/traversal_order_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';

--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -669,7 +669,7 @@ void _defineTests() {
       child: paint,
     ));
     expect(_PainterWithSemantics.shouldRebuildSemanticsCallCount, 0);
-    expect(_PainterWithSemantics.buildSemanticsCallCount, 2);
+    expect(_PainterWithSemantics.buildSemanticsCallCount, 1);
     expect(_PainterWithSemantics.semanticsBuilderCallCount, 4);
 
     semanticsTester.dispose();

--- a/packages/flutter/test/widgets/semantics_1_test.dart
+++ b/packages/flutter/test/widgets/semantics_1_test.dart
@@ -210,7 +210,7 @@ void main() {
           rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             TestSemantics(
-              id: 4,
+              id: 2,
               label: 'child1',
               rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: <SemanticsFlag>[SemanticsFlag.hasSelectedState, SemanticsFlag.isSelected],

--- a/packages/flutter/test/widgets/semantics_2_test.dart
+++ b/packages/flutter/test/widgets/semantics_2_test.dart
@@ -149,7 +149,7 @@ void main() {
           rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             TestSemantics(
-              id: 4,
+              id: 2,
               label: 'child1',
               rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: <SemanticsFlag>[SemanticsFlag.hasSelectedState, SemanticsFlag.isSelected],

--- a/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
+++ b/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
@@ -285,7 +285,7 @@ void main() {
     objectWithDelegate.markNeedsSemanticsUpdate();
     await tester.pump();
     // object with delegate rebuilds up to grand parent boundary except the
-    // the inner object since it is not dirty.
+    // inner object since it is not dirty.
     expect(innerObject.hasRebuildSemantics, isFalse);
     expect(boundaryParentObject.hasRebuildSemantics, isTrue);
     expect(grandBoundaryParentObject.hasRebuildSemantics, isTrue);

--- a/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
+++ b/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
@@ -284,8 +284,9 @@ void main() {
 
     objectWithDelegate.markNeedsSemanticsUpdate();
     await tester.pump();
-    // object with delegate rebuilds up to grand parent boundary;
-    expect(innerObject.hasRebuildSemantics, isTrue);
+    // object with delegate rebuilds up to grand parent boundary except the
+    // the inner object since it is not dirty.
+    expect(innerObject.hasRebuildSemantics, isFalse);
     expect(boundaryParentObject.hasRebuildSemantics, isTrue);
     expect(grandBoundaryParentObject.hasRebuildSemantics, isTrue);
     resetBuildState();
@@ -295,7 +296,7 @@ void main() {
     // Render objects in between child delegate and grand boundary parent does
     // not mark the grand boundary parent dirty because it should not change the
     // generated sibling nodes.
-    expect(innerObject.hasRebuildSemantics, isTrue);
+    expect(innerObject.hasRebuildSemantics, isFalse);
     expect(boundaryParentObject.hasRebuildSemantics, isTrue);
     expect(grandBoundaryParentObject.hasRebuildSemantics, isFalse);
   });
@@ -323,6 +324,7 @@ class RenderMarkSemanticsDirtySpy extends RenderProxyBox {
     Iterable<SemanticsNode> children,
   ) {
     hasRebuildSemantics = true;
+    super.assembleSemanticsNode(node, config, children);
   }
 }
 

--- a/packages/flutter/test/widgets/semantics_refactor_regression_test.dart
+++ b/packages/flutter/test/widgets/semantics_refactor_regression_test.dart
@@ -1,0 +1,52 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('finder does not return dirty semantics nodes', (WidgetTester tester) async {
+    final UniqueKey key1 = UniqueKey();
+    final UniqueKey key2 = UniqueKey();
+    const String label = 'label';
+    // not merged
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Semantics(
+          key: key1,
+          label: label,
+          container: true,
+          child: Semantics(
+            key: key2,
+            label: label,
+            container: true,
+            child: const SizedBox(width: 100, height: 100),
+          )
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsLabel(label), findsExactly(2));
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        // key2 widget should merge up to key1, its dirty cached semantics node
+        // should not show up in the finder.
+        child: Semantics(
+            key: key1,
+            container: true,
+            child: Semantics(
+              key: key2,
+              label: label,
+              child: const SizedBox(width: 100, height: 100),
+            )
+        ),
+      ),
+    );
+    expect(find.bySemanticsLabel(label), findsOneWidget);
+  });
+}


### PR DESCRIPTION
toward https://github.com/flutter/flutter/issues/150234

There are two expansive part when updating a semantics subtree.

1. _getSemanticsForParent to get the _SemanticsFragment
2.  _SemanticsFragment.compileChildren to get the actual semantics node.

This pr introduced caching for both steps.

First, this pr make a _RenderObjectSemantics to replace _SemanticsFragment. It will be permanently cached on each RenderObject. It handles any semantics related compilation and move all the properties from RenderObject to this class. RenderObject is only responsible for provide semantics property through describeSemanticsConfiguration and assembleSemanticsNode.

to compile the semantics sub-tree,

1. the root of the RenderOjbect of that subtree will first gather all the other _RenderObjectSemantics in the subtree that contribute to semantics. *(cached as mergeUp, and siblingMergeGroups)*
2. It handles merging and filter out those that won't form a semantics node to form a _RenderObjectSemantics tree that each node in the tree will form semantics nodes. *(cached as _childrenAndElevationAdjustments)*
3. go through the _RenderObjectSemantics tree to create semantics tree. *(cached as semanticsNodes)*

The performance boost comes from caching from all steps. When the markNeedsSemanticsUpdate is called. it will only clear minimum caches from the `_RenderObjectSemantics` so only a small portion will be recalculated.


before
![image](https://github.com/user-attachments/assets/d7f4bb1c-5bce-4d03-92ae-a8ae11647f11)
after
![image](https://github.com/user-attachments/assets/04e4c87c-306d-4848-bf5c-2d7cc236a841)

getsemantics + compileChildren 
530 + 470     ~= 900           before
34 + 187 ~= 200       after

about 78% reduce in compile time
## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
