### PR TITLE
Fixes `flutter build ipa` failure: Command line name "app-store" is deprecated. Use "app-store-connect" 

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -107,10 +107,14 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
       allowed: <String>['app-store', 'app-store-connect', 'ad-hoc', 'release-testing', 'development', 'debugging', 'enterprise'],
       help: 'Specify how the IPA will be distributed.',
       allowedHelp: <String, String>{
-        'app-store': 'Upload to the App Store.',
+        'app-store': 'Upload to the App Store. For XCode <= 15.3.',
+        'app-store-connect': 'Upload to the App Store. For XCode > 15.3',
         'ad-hoc': 'Test on designated devices that do not need to be registered with the Apple developer account. '
-                  'Requires a distribution certificate.',
-        'development': 'Test only on development devices registered with the Apple developer account.',
+                  'Requires a distribution certificate. For XCode <= 15.3.',
+        'release-testing': 'Test on designated devices that do not need to be registered with the Apple developer account. '
+            'Requires a distribution certificate. For XCode > 15.3',
+        'development': 'Test only on development devices registered with the Apple developer account. For XCode <= 15.3.',
+        'debugging': 'Test only on development devices registered with the Apple developer account. For XCode > 15.3.',
         'enterprise': 'Distribute an app registered with the Apple Developer Enterprise Program.',
       },
     );
@@ -600,7 +604,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
         return exportMethodMap[method] ?? method;
       }
     }
-    return '';
+    throwToolExit('Encountered invalid export-method input. Valid inputs include');
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -578,10 +578,13 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     return tempPlist;
   }
 
+  // As of Xcode 15.4, the old export methods 'app-store', 'ad-hoc', and 'development'
+  // are now deprecated. The new equivalents are 'app-store-connect', 'release-testing',
+  // and 'debugging'.
   String _getVersionAppropriateExportMethod(String method) {
     final Version? currVersion = globals.xcode!.currentVersion;
     if (currVersion != null) {
-      if (currVersion.major >= 15 || (currVersion.major == 14 && currVersion.minor > 3)) {
+      if (currVersion.major >= 16 || (currVersion.major == 15 && currVersion.minor > 3)) {
         final Map<String, String> exportMethodMap = <String, String>{
           'app-store': 'app-store-connect',
           'ad-hoc': 'release-testing',

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -107,10 +107,10 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
       allowed: <String>['app-store', 'ad-hoc', 'development', 'enterprise'],
       help: 'Specify how the IPA will be distributed.',
       allowedHelp: <String, String>{
-        'app-store': 'Upload to the App Store. For XCode <= 15.3.',
+        'app-store': 'Upload to the App Store.',
         'ad-hoc': 'Test on designated devices that do not need to be registered with the Apple developer account. '
-                  'Requires a distribution certificate. For XCode <= 15.3.',
-        'development': 'Test only on development devices registered with the Apple developer account. For XCode <= 15.3.',
+                  'Requires a distribution certificate.',
+        'development': 'Test only on development devices registered with the Apple developer account.',
         'enterprise': 'Distribute an app registered with the Apple Developer Enterprise Program.',
       },
     );

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -104,17 +104,13 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     argParser.addOption(
       'export-method',
       defaultsTo: 'app-store',
-      allowed: <String>['app-store', 'app-store-connect', 'ad-hoc', 'release-testing', 'development', 'debugging', 'enterprise'],
+      allowed: <String>['app-store', 'ad-hoc', 'development', 'enterprise'],
       help: 'Specify how the IPA will be distributed.',
       allowedHelp: <String, String>{
         'app-store': 'Upload to the App Store. For XCode <= 15.3.',
-        'app-store-connect': 'Upload to the App Store. For XCode > 15.3',
         'ad-hoc': 'Test on designated devices that do not need to be registered with the Apple developer account. '
                   'Requires a distribution certificate. For XCode <= 15.3.',
-        'release-testing': 'Test on designated devices that do not need to be registered with the Apple developer account. '
-            'Requires a distribution certificate. For XCode > 15.3',
         'development': 'Test only on development devices registered with the Apple developer account. For XCode <= 15.3.',
-        'debugging': 'Test only on development devices registered with the Apple developer account. For XCode > 15.3.',
         'enterprise': 'Distribute an app registered with the Apple Developer Enterprise Program.',
       },
     );
@@ -589,22 +585,20 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     final Version? currVersion = globals.xcode!.currentVersion;
     if (currVersion != null) {
       if (currVersion.major >= 16 || (currVersion.major == 15 && currVersion.minor > 3)) {
-        final Map<String, String> exportMethodMap = <String, String>{
-          'app-store': 'app-store-connect',
-          'ad-hoc': 'release-testing',
-          'development': 'debugging',
-        };
-        return exportMethodMap[method] ?? method;
-      } else {
-        final Map<String, String> exportMethodMap = <String, String>{
-          'app-store-connect': 'app-store',
-          'release-testing': 'ad-hoc',
-          'debugging': 'development',
-        };
-        return exportMethodMap[method] ?? method;
+        switch (method) {
+          case 'app-store':
+            return 'app-store-connect';
+          case 'ad-hoc':
+            return 'release-testing';
+          case 'development':
+            return 'debugging';
+          default:
+            throwToolExit('Encountered invalid export-method input.');
+        }
       }
+      return method;
     }
-    throwToolExit('Encountered invalid export-method input.');
+    throwToolExit('Xcode version could not be found.');
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -604,7 +604,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
         return exportMethodMap[method] ?? method;
       }
     }
-    throwToolExit('Encountered invalid export-method input. Valid inputs include');
+    throwToolExit('Encountered invalid export-method input.');
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -584,7 +584,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   String _getVersionAppropriateExportMethod(String method) {
     final Version? currVersion = globals.xcode!.currentVersion;
     if (currVersion != null) {
-      if (currVersion.major >= 16 || (currVersion.major == 15 && currVersion.minor > 3)) {
+      if (currVersion >= Version(15, 4, 0)) {
         switch (method) {
           case 'app-store':
             return 'app-store-connect';

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -422,38 +422,7 @@ void main() {
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
-  testUsingContext('ipa build uses new instead of legacy export methods when on XCode versions > 15.3', () async {
-    final BuildCommand command = BuildCommand(
-      artifacts: artifacts,
-      androidSdk: FakeAndroidSdk(),
-      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
-      logger: logger,
-      fileSystem: fileSystem,
-      processUtils: processUtils,
-      osUtils: FakeOperatingSystemUtils(),
-    );
-    fakeProcessManager.addCommands(<FakeCommand>[
-      xattrCommand,
-      setUpFakeXcodeBuildHandler(),
-      exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
-    ]);
-    createMinimalMockProjectFiles();
-    await createTestCommandRunner(command).run(
-        const <String>['build', 'ipa','--export-method', 'ad-hoc', '--no-pub']
-    );
-    expect(logger.statusText, contains('Building release-testing IPA'));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fileSystem,
-    Logger: () => logger,
-    ProcessManager: () => fakeProcessManager,
-    Platform: () => macosPlatform,
-    XcodeProjectInterpreter: () {
-      return FakeXcodeProjectInterpreterWithBuildSettings()
-      ..version = Version(15, 4, null);
-    },
-  });
-
-  testUsingContext('ipa build uses new instead of legacy export methods when on XCode versions > 15.3', () async {
+  testUsingContext('ipa build uses new "debugging" export method when on XCode versions > 15.3', () async {
     final BuildCommand command = BuildCommand(
       artifacts: artifacts,
       androidSdk: FakeAndroidSdk(),
@@ -473,6 +442,37 @@ void main() {
         const <String>['build', 'ipa','--export-method', 'development', '--no-pub']
     );
     expect(logger.statusText, contains('Building debugging IPA'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    Logger: () => logger,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () {
+      return FakeXcodeProjectInterpreterWithBuildSettings()
+      ..version = Version(15, 4, null);
+    },
+  });
+
+  testUsingContext('ipa build uses new "release-testing" export method when on XCode versions > 15.3', () async {
+    final BuildCommand command = BuildCommand(
+      artifacts: artifacts,
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      logger: logger,
+      fileSystem: fileSystem,
+      processUtils: processUtils,
+      osUtils: FakeOperatingSystemUtils(),
+    );
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      setUpFakeXcodeBuildHandler(),
+      exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
+    ]);
+    createMinimalMockProjectFiles();
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'ipa','--export-method', 'ad-hoc', '--no-pub']
+    );
+    expect(logger.statusText, contains('Building release-testing IPA'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     Logger: () => logger,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -449,7 +449,7 @@ void main() {
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () {
       return FakeXcodeProjectInterpreterWithBuildSettings()
-      ..version = Version(14, 4, null);
+      ..version = Version(15, 4, null);
     },
   });
 
@@ -480,7 +480,7 @@ void main() {
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () {
       return FakeXcodeProjectInterpreterWithBuildSettings()
-        ..version = Version(14, 3, null);
+        ..version = Version(15, 3, null);
     },
   });
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -422,7 +422,7 @@ void main() {
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
-  testUsingContext('ipa build uses new instead of legacy export methods when on XCode versions > 14.3', () async {
+  testUsingContext('ipa build uses new instead of legacy export methods when on XCode versions > 15.3', () async {
     final BuildCommand command = BuildCommand(
       artifacts: artifacts,
       androidSdk: FakeAndroidSdk(),
@@ -453,7 +453,7 @@ void main() {
     },
   });
 
-  testUsingContext('ipa build uses legacy instead of new export methods when on XCode versions <= 14.3', () async {
+  testUsingContext('ipa build uses new instead of legacy export methods when on XCode versions > 15.3', () async {
     final BuildCommand command = BuildCommand(
       artifacts: artifacts,
       androidSdk: FakeAndroidSdk(),
@@ -470,9 +470,9 @@ void main() {
     ]);
     createMinimalMockProjectFiles();
     await createTestCommandRunner(command).run(
-        const <String>['build', 'ipa','--export-method', 'debugging', '--no-pub']
+        const <String>['build', 'ipa','--export-method', 'development', '--no-pub']
     );
-    expect(logger.statusText, contains('Building development IPA'));
+    expect(logger.statusText, contains('Building debugging IPA'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     Logger: () => logger,
@@ -480,7 +480,7 @@ void main() {
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () {
       return FakeXcodeProjectInterpreterWithBuildSettings()
-        ..version = Version(15, 3, null);
+        ..version = Version(15, 4, null);
     },
   });
 
@@ -512,37 +512,6 @@ void main() {
     XcodeProjectInterpreter: () {
       return FakeXcodeProjectInterpreterWithBuildSettings()
         ..version = Version(14, null, null);
-    },
-  });
-
-  testUsingContext('ipa build accepts new export methods when on XCode versions > 14.3', () async {
-    final BuildCommand command = BuildCommand(
-      artifacts: artifacts,
-      androidSdk: FakeAndroidSdk(),
-      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
-      logger: logger,
-      fileSystem: fileSystem,
-      processUtils: processUtils,
-      osUtils: FakeOperatingSystemUtils(),
-    );
-    fakeProcessManager.addCommands(<FakeCommand>[
-      xattrCommand,
-      setUpFakeXcodeBuildHandler(),
-      exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
-    ]);
-    createMinimalMockProjectFiles();
-    await createTestCommandRunner(command).run(
-        const <String>['build', 'ipa','--export-method', 'debugging', '--no-pub']
-    );
-    expect(logger.statusText, contains('Building debugging IPA'));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fileSystem,
-    Logger: () => logger,
-    ProcessManager: () => fakeProcessManager,
-    Platform: () => macosPlatform,
-    XcodeProjectInterpreter: () {
-      return FakeXcodeProjectInterpreterWithBuildSettings()
-        ..version = Version(16, 0, null);
     },
   });
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -422,7 +422,7 @@ void main() {
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
-  testUsingContext('ipa build uses new "debugging" export method when on XCode versions > 15.3', () async {
+  testUsingContext('ipa build uses new "debugging" export method when on Xcode versions > 15.3', () async {
     final BuildCommand command = BuildCommand(
       artifacts: artifacts,
       androidSdk: FakeAndroidSdk(),
@@ -453,7 +453,7 @@ void main() {
     },
   });
 
-  testUsingContext('ipa build uses new "release-testing" export method when on XCode versions > 15.3', () async {
+  testUsingContext('ipa build uses new "release-testing" export method when on Xcode versions > 15.3', () async {
     final BuildCommand command = BuildCommand(
       artifacts: artifacts,
       androidSdk: FakeAndroidSdk(),
@@ -484,7 +484,7 @@ void main() {
     },
   });
 
-  testUsingContext('ipa build accepts legacy methods when on XCode versions <= 14.3', () async {
+  testUsingContext('ipa build accepts legacy methods when on Xcode versions <= 15.3', () async {
     final BuildCommand command = BuildCommand(
       artifacts: artifacts,
       androidSdk: FakeAndroidSdk(),

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -454,6 +454,7 @@ void main() {
 ''';
 
     final String actualIpaPlistContents = fileSystem.file(cachedExportOptionsPlist).readAsStringSync();
+
     expect(actualIpaPlistContents, expectedIpaPlistContents);
     expect(logger.statusText, contains('Building debugging IPA'));
   }, overrides: <Type, Generator>{


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/149369

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.