### PR TITLE
Add example of goldenFileComparator usage in widget tests

### DIFF
--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -150,8 +150,8 @@ abstract class GoldenFileComparator {
 ///   })  : assert(
 ///         0 <= precisionTolerance || precisionTolerance <= 1,
 ///         'precisionTolerance must be between 0 and 1',
-///       ),
-///       _precisionTolerance = precisionTolerance;
+///         ),
+///         _precisionTolerance = precisionTolerance;
 ///
 ///   /// How much the golden image can differ from the test image.
 ///   ///

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -127,21 +127,23 @@ abstract class GoldenFileComparator {
 /// levels for allowable differences:
 ///
 /// ```dart
-/// testWidgets('matches golden file with a 0.01 tolerance', (WidgetTester tester) async {
-///   final previousGoldenFileComparator = goldenFileComparator;
-///   goldenFileComparator = _TolerantGoldenFileComparator(
-///     Uri.parse('test/my_widget_test.dart'),
-///     precisionTolerance: 0.01,
-///   );
-///   addTearDown(() => goldenFileComparator = previousGoldenFileComparator);
+/// void main() {
+///   testWidgets('matches golden file with a 0.01 tolerance', (WidgetTester tester) async {
+///     final GoldenFileComparator previousGoldenFileComparator = goldenFileComparator;
+///     goldenFileComparator = _TolerantGoldenFileComparator(
+///       Uri.parse('test/my_widget_test.dart'),
+///       precisionTolerance: 0.01,
+///     );
+///     addTearDown(() => goldenFileComparator = previousGoldenFileComparator);
 ///
-///   await tester.pumpWidget(const ColoredBox(color: Color(0xff00ff00)));
+///     await tester.pumpWidget(const ColoredBox(color: Color(0xff00ff00)));
 ///
-///   await expectLater(
-///     find.byType(ColoredBox),
-///     matchesGoldenFile('my_golden.png'),
-///   );
-/// });
+///     await expectLater(
+///       find.byType(ColoredBox),
+///       matchesGoldenFile('my_golden.png'),
+///     );
+///   });
+/// }
 ///
 /// class _TolerantGoldenFileComparator extends LocalFileComparator {
 ///   _TolerantGoldenFileComparator(
@@ -161,18 +163,18 @@ abstract class GoldenFileComparator {
 ///
 ///   @override
 ///   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
-///     final result = await GoldenFileComparator.compareLists(
+///     final ComparisonResult result = await GoldenFileComparator.compareLists(
 ///       imageBytes,
 ///       await getGoldenBytes(golden),
 ///     );
 ///
-///     final passed = result.passed || result.diffPercent <= _precisionTolerance;
+///     final bool passed = result.passed || result.diffPercent <= _precisionTolerance;
 ///     if (passed) {
 ///       result.dispose();
 ///       return true;
 ///     }
 ///
-///     final error = await generateFailureOutput(result, golden, basedir);
+///     final String error = await generateFailureOutput(result, golden, basedir);
 ///     result.dispose();
 ///     throw FlutterError(error);
 ///   }

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -96,7 +96,8 @@ abstract class GoldenFileComparator {
 
   /// Returns a [ComparisonResult] to describe the pixel differential of the
   /// [test] and [master] image bytes provided.
-  static Future<ComparisonResult> compareLists(List<int> test, List<int> master) {
+  static Future<ComparisonResult> compareLists(
+      List<int> test, List<int> master) {
     return goldens.compareLists(test, master);
   }
 }
@@ -120,8 +121,30 @@ abstract class GoldenFileComparator {
 ///
 /// Callers may choose to override the default comparator by setting this to a
 /// custom comparator during test set-up (or using directory-level test
-/// configuration). For example, some projects may wish to install a comparator
-/// with tolerance levels for allowable differences.
+/// configuration).
+///
+/// {@tool snippet}
+/// For example, some projects may wish to install a comparator with tolerance
+/// levels for allowable differences:
+///
+/// ```dart
+/// testWidgets('matches golden file with a 0.01 tolerance', (WidgetTester tester) async {
+///   final previousGoldenFileComparator = goldenFileComparator;
+///   goldenFileComparator = _MyTolerantGoldenFileComparator(
+///     Uri.parse('test/my_widget_test.dart'),
+///     precisionTolerance: 0.01,
+///   );
+///   addTearDown(() => goldenFileComparator = previousGoldenFileComparator);
+///
+///   await tester.pumpWidget(const ColoredBox(color: Color(0xff00ff00)));
+///
+///   await expectLater(
+///     find.byType(ColoredBox),
+///     matchesGoldenFile('my_golden.png'),
+///   );
+/// });
+/// ```
+/// {@end-tool}
 ///
 /// See also:
 ///
@@ -257,7 +280,8 @@ abstract class WebGoldenComparator {
 ///  * [goldenFileComparator], the comparator used when tests are not running on
 ///    a web browser.
 WebGoldenComparator get webGoldenComparator => _webGoldenComparator;
-WebGoldenComparator _webGoldenComparator = const _TrivialWebGoldenComparator._();
+WebGoldenComparator _webGoldenComparator =
+    const _TrivialWebGoldenComparator._();
 set webGoldenComparator(WebGoldenComparator value) {
   _webGoldenComparator = value;
 }

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -129,7 +129,7 @@ abstract class GoldenFileComparator {
 /// ```dart
 /// testWidgets('matches golden file with a 0.01 tolerance', (WidgetTester tester) async {
 ///   final previousGoldenFileComparator = goldenFileComparator;
-///   goldenFileComparator = _MyTolerantGoldenFileComparator(
+///   goldenFileComparator = _TolerantGoldenFileComparator(
 ///     Uri.parse('test/my_widget_test.dart'),
 ///     precisionTolerance: 0.01,
 ///   );
@@ -142,6 +142,37 @@ abstract class GoldenFileComparator {
 ///     matchesGoldenFile('my_golden.png'),
 ///   );
 /// });
+/// 
+/// class _TolerantGoldenFileComparator extends LocalFileComparator {
+///   _TolerantGoldenFileComparator(
+///     super.testFile, {
+///     required double precisionTolerance,
+///   }) : _precisionTolerance = precisionTolerance;
+///
+///   /// How much the golden image can differ from the test image.
+///   ///
+///   /// It is expected to be between 0 and 1. Where 0 is no difference (the same image)
+///   /// and 1 is the maximum difference (completely different images).
+///   final double _precisionTolerance;
+/// 
+///   @override
+///   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+///     final result = await GoldenFileComparator.compareLists(
+///       imageBytes,
+///       await getGoldenBytes(golden),
+///     );
+///
+///     final passed = result.passed || result.diffPercent <= _precisionTolerance;
+///     if (passed) {
+///       result.dispose();
+///       return true;
+///     }
+///
+///     final error = await generateFailureOutput(result, golden, basedir);
+///     result.dispose();
+///     throw FlutterError(error);
+///   }
+/// }
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -147,7 +147,8 @@ abstract class GoldenFileComparator {
 ///   _TolerantGoldenFileComparator(
 ///     super.testFile, {
 ///     required double precisionTolerance,
-///   }) : _precisionTolerance = precisionTolerance;
+///   }) : assert(precisionTolerance <= 1 || precisionTolerance  0),
+            _precisionTolerance = precisionTolerance;
 ///
 ///   /// How much the golden image can differ from the test image.
 ///   ///

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -96,8 +96,7 @@ abstract class GoldenFileComparator {
 
   /// Returns a [ComparisonResult] to describe the pixel differential of the
   /// [test] and [master] image bytes provided.
-  static Future<ComparisonResult> compareLists(
-      List<int> test, List<int> master) {
+  static Future<ComparisonResult> compareLists(List<int> test, List<int> master) {
     return goldens.compareLists(test, master);
   }
 }
@@ -280,8 +279,7 @@ abstract class WebGoldenComparator {
 ///  * [goldenFileComparator], the comparator used when tests are not running on
 ///    a web browser.
 WebGoldenComparator get webGoldenComparator => _webGoldenComparator;
-WebGoldenComparator _webGoldenComparator =
-    const _TrivialWebGoldenComparator._();
+WebGoldenComparator _webGoldenComparator = const _TrivialWebGoldenComparator._();
 set webGoldenComparator(WebGoldenComparator value) {
   _webGoldenComparator = value;
 }

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -148,7 +148,7 @@ abstract class GoldenFileComparator {
 ///     super.testFile, {
 ///     required double precisionTolerance,
 ///   })  : assert(
-///         0 <= precisionTolerance || precisionTolerance <= 1,
+///         0 <= precisionTolerance && precisionTolerance <= 1,
 ///         'precisionTolerance must be between 0 and 1',
 ///         ),
 ///         _precisionTolerance = precisionTolerance;

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -147,8 +147,11 @@ abstract class GoldenFileComparator {
 ///   _TolerantGoldenFileComparator(
 ///     super.testFile, {
 ///     required double precisionTolerance,
-///   }) : assert(precisionTolerance <= 1 || precisionTolerance  0),
-            _precisionTolerance = precisionTolerance;
+///   })  : assert(
+///         0 <= precisionTolerance || precisionTolerance <= 1,
+///         'precisionTolerance must be between 0 and 1',
+///       ),
+///       _precisionTolerance = precisionTolerance;
 ///
 ///   /// How much the golden image can differ from the test image.
 ///   ///

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -142,7 +142,7 @@ abstract class GoldenFileComparator {
 ///     matchesGoldenFile('my_golden.png'),
 ///   );
 /// });
-/// 
+///
 /// class _TolerantGoldenFileComparator extends LocalFileComparator {
 ///   _TolerantGoldenFileComparator(
 ///     super.testFile, {
@@ -154,7 +154,7 @@ abstract class GoldenFileComparator {
 ///   /// It is expected to be between 0 and 1. Where 0 is no difference (the same image)
 ///   /// and 1 is the maximum difference (completely different images).
 ///   final double _precisionTolerance;
-/// 
+///
 ///   @override
 ///   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
 ///     final result = await GoldenFileComparator.compareLists(


### PR DESCRIPTION
As from #76337, precisely https://github.com/flutter/flutter/issues/76337#issuecomment-795486138 and https://github.com/flutter/flutter/issues/76337#issuecomment-2172941109. There is missing documentation with an example on how the [`goldenFileComparator`](https://api.flutter.dev/flutter/flutter_test/goldenFileComparator.html) can be used.

This change updates the documentation by providing an additional code snippet to the example that was already stated by the documentation. 

Follows the effort made by #76337 and https://github.com/flutter/flutter/pull/150343.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
