### PR TITLE
Add benchmarks for tracking relayout boundaries

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/layout/relayout_boundary_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/layout/relayout_boundary_bench.dart
@@ -1,0 +1,110 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../common.dart';
+
+late final LiveTestWidgetsFlutterBinding binding;
+late final BenchmarkResultPrinter printer;
+
+Future<void> main() async {
+  assert(false, "Don't run benchmarks in debug mode! Use 'flutter run --release'.");
+  binding = TestWidgetsFlutterBinding.ensureInitialized() as LiveTestWidgetsFlutterBinding;
+  printer = BenchmarkResultPrinter();
+  // Run each benchmark at two sizes, to see how it scales.
+  await measureBoundaryToggle(depth: 2000);
+  await measureBoundaryToggle(depth: 4000);
+  await measureSubtreeReparenting(depth: 2000);
+  await measureSubtreeReparenting(depth: 4000);
+  await measureSubtreeReparentingAccordion(depth: 1000);
+  await measureSubtreeReparentingAccordion(depth: 2000);
+  printer.printToStdout();
+}
+
+const Duration kBenchmarkTime = Duration(seconds: 5);
+const Size kSize = Size.square(100);
+
+Future<void> measureBoundaryToggle({required int depth}) {
+  Widget chain = SizedBox.fromSize(size: kSize);
+  for (int i = 0; i < depth; i++) {
+    chain = SizedBox(child: chain);
+  }
+  chain = Align(child: chain);
+  return measure(
+    name: 'relayout_boundary_toggle_depth$depth',
+    description: 'Relayout boundary toggling on/off, subtree depth $depth',
+    SizedBox.fromSize(size: kSize, child: chain), // relayout boundary
+    SizedBox(child: chain), // not a relayout boundary
+  );
+}
+
+Future<void> measureSubtreeReparenting({required int depth}) {
+  Widget chain = SizedBox.fromSize(size: kSize);
+  for (int i = 0; i < depth; i++) {
+    chain = SizedBox(child: chain);
+  }
+  chain = KeyedSubtree(key: GlobalKey(), child: chain);
+  return measure(
+    name: 'relayout_subtree_reparenting_depth$depth',
+    description: 'Relayout subtree reparenting, depth $depth',
+    chain,
+    SizedBox(child: chain),
+  );
+}
+
+Future<void> measureSubtreeReparentingAccordion({required int depth}) {
+  Widget short = SizedBox.fromSize(size: kSize);
+  Widget long = SizedBox.fromSize(size: kSize);
+  for (int i = 0; i < depth; i++) {
+    final GlobalKey key = GlobalKey(debugLabel: 'height $i');
+    short = SizedBox(key: key, child: short);
+    long = SizedBox(key: key, child: SizedBox(child: long));
+  }
+  return measure(
+    name: 'relayout_subtree_reparenting_accordion_depth$depth',
+    description: 'Relayout subtree reparenting in an accordion, depth $depth',
+    short,
+    long,
+  );
+}
+
+Future<void> measure(Widget child1, Widget child2, {
+  required String name, required String description,
+}) async {
+  final Stopwatch watch = Stopwatch();
+  int iterations = 0;
+  await benchmarkWidgets((WidgetTester tester) async {
+    late StateSetter setState;
+    bool state = false;
+    Widget app = StatefulBuilder(builder: (BuildContext context, StateSetter setter) {
+      setState = setter;
+      return state ? child1 : child2;
+    });
+    app = Align(child: SizedBox.fromSize(size: kSize, child: Align(child: app)));
+
+    binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.onlyPumps;
+    runApp(app);
+    await tester.pump(const Duration(seconds: 1));
+
+    binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.benchmark;
+    while (watch.elapsed < kBenchmarkTime) {
+      watch.start();
+      setState(() {
+        state = !state;
+      });
+      await tester.pumpBenchmark(Duration(milliseconds: iterations * 16));
+      watch.stop();
+      iterations += 1;
+    }
+  });
+
+  printer.addResult(
+    name: name,
+    description: description,
+    value: watch.elapsedMicroseconds / iterations,
+    unit: 'µs per iteration',
+  );
+}

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -69,12 +69,13 @@ TaskFunction createMicrobenchmarkTask({
       ...await runMicrobench('lib/language/compute_bench.dart'),
       ...await runMicrobench('lib/language/sync_star_bench.dart'),
       ...await runMicrobench('lib/language/sync_star_semantics_bench.dart'),
+      ...await runMicrobench('lib/layout/relayout_boundary_bench.dart'),
+      ...await runMicrobench('lib/layout/text_intrinsic_bench.dart'),
       ...await runMicrobench('lib/stocks/animation_bench.dart'),
       ...await runMicrobench('lib/stocks/build_bench_profiled.dart'),
       ...await runMicrobench('lib/stocks/build_bench.dart'),
       ...await runMicrobench('lib/stocks/layout_bench.dart'),
       ...await runMicrobench('lib/ui/image_bench.dart'),
-      ...await runMicrobench('lib/layout/text_intrinsic_bench.dart'),
     };
 
     return TaskResult.success(allResults,


### PR DESCRIPTION
Fixes part of #150524.

As part of #150524, I'll be sending a couple of PRs that simplify and reduce the bookkeeping we do for tracking relayout boundaries. To measure the performance effect of that reduced bookkeeping, I wrote some microbenchmarks that exercise that tracking.

This PR adds the microbenchmarks.  That should give them a clean baseline, before the PRs that change how the bookkeeping works and are meant to change the results of the microbenchmarks.

The "reparenting accordion" benchmark is a bit pathological: it involves N `GlobalKey`s all getting reparented on each frame. It takes quadratic time, and I think we're OK with that. Still, constant-factor improvements and regressions there seem worth knowing about, because real apps may contain smaller versions of the same pattern.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
