### PR TITLE
Fix link in RenderObjectWidget doc comment

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1878,7 +1878,7 @@ abstract class InheritedWidget extends ProxyWidget {
 /// object widgets subclass one of:
 ///
 ///  * [LeafRenderObjectWidget], if the widget has no children.
-///  * [SingleChildRenderObjectElement], if the widget has exactly one child.
+///  * [SingleChildRenderObjectWidget], if the widget has exactly one child.
 ///  * [MultiChildRenderObjectWidget], if the widget takes a list of children.
 ///  * [SlottedMultiChildRenderObjectWidget], if the widget organizes its
 ///    children in different named slots.


### PR DESCRIPTION
Fix a link in the `RenderObjectWidget` doc comment. The comment recommends subclassing `SingleChildRenderObjectElement` where it means to recommend subclassing `SingleChildRenderObjectWidget`.

Fixes #150597.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] [N/A] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] [N/A] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] [N/A] All existing and new tests are passing.