### PR TITLE
Remove dubious comment

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -208,7 +208,6 @@ class PackageDependencyTracker {
       }
     }
 
-    // prepare a union of all the .packages files
     if (dependencies.hasConflicts) {
       final StringBuffer message = StringBuffer();
       message.writeln(dependencies.generateConflictReport());


### PR DESCRIPTION
Follow-up to https://github.com/flutter/flutter/pull/150349#discussion_r1648050036

I don't see how the code is preparing a union of anything here. I think the comment is just broken.

This comment seems to have appeared in https://github.com/flutter/flutter/pull/6093
It might have been mistakenly copied from [here](https://github.com/flutter/flutter/commit/a0227cab15e230a564fb6316347b8e0ce3d21f6c#diff-a6e4bf25b45ecb000db25d7343a44f018ff5302d4695eaa1277d804d2252c1f5R148) (where it makes a lot more sense).
