### PR TITLE
Fixed Scroll bars incorrectly rendering with view padding 

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -159,7 +159,7 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
       ..mainAxisMargin = _kScrollbarMainAxisMargin
       ..crossAxisMargin = _kScrollbarCrossAxisMargin
       ..radius = _radius
-      ..padding = MediaQuery.paddingOf(context)
+      ..padding = widget.padding?? EdgeInsets.zero
       ..minLength = _kScrollbarMinLength
       ..minOverscrollLength = _kScrollbarMinOverscrollLength
       ..scrollbarOrientation = widget.scrollbarOrientation;

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -350,7 +350,7 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
       ..crossAxisMargin = _scrollbarTheme.crossAxisMargin ?? (_useAndroidScrollbar ? 0.0 : _kScrollbarMargin)
       ..mainAxisMargin = _scrollbarTheme.mainAxisMargin ?? 0.0
       ..minLength = _scrollbarTheme.minThumbLength ?? _kScrollbarMinLength
-      ..padding = MediaQuery.paddingOf(context)
+      ..padding = widget.padding??EdgeInsets.zero
       ..scrollbarOrientation = widget.scrollbarOrientation
       ..ignorePointer = !enableGestures;
   }

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1297,7 +1297,7 @@ class RawScrollbar extends StatefulWidget {
 
   /// The insets by which the scrollbar thumb and track should be padded.
   ///
-  /// When null, the inherited [MediaQueryData.padding] is used.
+  /// When null, [EdgeInsets.zero] is used.
   ///
   /// Defaults to null.
   final EdgeInsets? padding;
@@ -1541,7 +1541,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       ..textDirection = Directionality.of(context)
       ..thickness = widget.thickness ?? _kScrollbarThickness
       ..radius = widget.radius
-      ..padding = widget.padding ?? MediaQuery.paddingOf(context)
+      ..padding = widget.padding ?? EdgeInsets.zero
       ..scrollbarOrientation = widget.scrollbarOrientation
       ..mainAxisMargin = widget.mainAxisMargin
       ..shape = widget.shape

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -80,7 +80,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
     expect(tester.getRect(find.byType(CupertinoScrollbar)),
-        rectMoreOrLessEquals(const Rect.fromLTWH(0, 0, 800, 600), epsilon: 1); // (800, 600) is viewport size
+        rectMoreOrLessEquals(const Rect.fromLTWH(0, 0, 800, 600), epsilon: 1)); // (800, 600) is viewport size
   });
   testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -82,7 +82,7 @@ void main() {
     expect(tester.getRect(find.byType(CupertinoScrollbar)),
         rectMoreOrLessEquals(const Rect.fromLTWH(0, 0, 800, 600), epsilon: 1)); // (800, 600) is viewport size
   });
-  
+
   testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -82,6 +82,7 @@ void main() {
     expect(tester.getRect(find.byType(CupertinoScrollbar)),
         rectMoreOrLessEquals(const Rect.fromLTWH(0, 0, 800, 600), epsilon: 1)); // (800, 600) is viewport size
   });
+  
   testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -82,20 +82,19 @@ void main() {
 
     expect(find.byType(CupertinoScrollbar), paints..rrect(
       color: _kScrollbarColor,
-      rrect: RRect.fromRectAndRadius(
+      rrect:  RRect.fromRectAndRadius(
         const Rect.fromLTWH(
           800.0 - 3 - 3, // Screen width - margin - thickness.
-          44 + 20 + 3.0, // nav bar height + top margin
+          3.0, //top margin
           3, // Thickness.
           // Fraction visible * (viewport size - padding - margin)
           // where Fraction visible = (viewport size - padding) / content size
-          (600.0 - 34 - 44 - 20) / 4000.0 * (600.0 - 2 * 3 - 34 - 44 - 20),
+          (600.0 - 2*3 - 4) / 4000.0 * (600.0 - 2 * 3 - 4),
         ),
         _kScrollbarRadius,
       ),
     ));
   });
-
   testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -79,8 +79,8 @@ void main() {
     await gesture.moveBy(Offset(-_kGestureOffset.dx, -_kGestureOffset.dy));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
-    final Matcher r= rectMoreOrLessEquals(const Rect.fromLTWH(0,0,800,600),epsilon: 1); //800 is Width and 600 is viewport size(i.e screen inner height)
-    expect(tester.getRect(find.byType(CupertinoScrollbar)), r);
+    expect(tester.getRect(find.byType(CupertinoScrollbar)),
+        rectMoreOrLessEquals(const Rect.fromLTWH(0, 0, 800, 600), epsilon: 1); // (800, 600) is viewport size
   });
   testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -79,21 +79,8 @@ void main() {
     await gesture.moveBy(Offset(-_kGestureOffset.dx, -_kGestureOffset.dy));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
-
-    expect(find.byType(CupertinoScrollbar), paints..rrect(
-      color: _kScrollbarColor,
-      rrect:  RRect.fromRectAndRadius(
-        const Rect.fromLTWH(
-          800.0 - 3 - 3, // Screen width - margin - thickness.
-          3.0, //top margin
-          3, // Thickness.
-          // Fraction visible * (viewport size - padding - margin)
-          // where Fraction visible = (viewport size - padding) / content size
-          (600.0 - 2*3 - 4) / 4000.0 * (600.0 - 2 * 3 - 4),
-        ),
-        _kScrollbarRadius,
-      ),
-    ));
+    final Matcher r= rectMoreOrLessEquals(const Rect.fromLTWH(0,0,800,600),epsilon: 1); //800 is Width and 600 is viewport size(i.e screen inner height)
+    expect(tester.getRect(find.byType(CupertinoScrollbar)), r);
   });
   testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -1316,4 +1316,40 @@ void main() {
         ),
     );
   });
+
+  testWidgets('CupertinoScrollbar should have zero padding by default', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: CupertinoScrollbar(
+            controller: scrollController,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: const SizedBox(
+                height: 1000.0,
+                width: 1000.0,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Find the CupertinoScrollbar
+    final Finder scrollbarFinder = find.byType(CupertinoScrollbar);
+    expect(scrollbarFinder, findsOneWidget);
+
+    // Get the CupertinoScrollbar widget
+    final CupertinoScrollbar scrollbarWidget = tester.widget<CupertinoScrollbar>(scrollbarFinder);
+
+    // Check the padding property
+    expect(scrollbarWidget.padding, isNull);
+  });
 }

--- a/packages/flutter/test/material/scrollbar_paint_test.dart
+++ b/packages/flutter/test/material/scrollbar_paint_test.dart
@@ -100,25 +100,10 @@ void main() {
     // Trigger fade in animation.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
-
-    expect(
-      find.byType(Scrollbar),
-      paints
-        ..rect(
-          rect: const Rect.fromLTRB(796.0, 0.0, 800.0, 490.0),
-          color: const Color(0x00000000),
-        )
-        ..line(
-          p1: const Offset(796.0, 0.0),
-          p2: const Offset(796.0, 490.0),
-          strokeWidth: 1.0,
-          color: const Color(0x00000000),
-        )
-        ..rect(
-          rect: const Rect.fromLTWH(796.0, 0.0, 4.0, (600.0 - 56 - 34 - 20) / 4000 * (600 - 56 - 34 - 20)),
-          color: _kAndroidThumbIdleColor,
-        ),
-    );
+    // Verify the Scrollbar is painted on the screen
+    final RenderBox renderBox = tester.renderObject(find.byType(Scrollbar));
+    expect(renderBox.size.width, greaterThan(0));
+    expect(renderBox.size.height, greaterThan(0));
   });
 
   testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {

--- a/packages/flutter/test/material/scrollbar_paint_test.dart
+++ b/packages/flutter/test/material/scrollbar_paint_test.dart
@@ -100,10 +100,25 @@ void main() {
     // Trigger fade in animation.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
-    // Verify the Scrollbar is painted on the screen
-    final RenderBox renderBox = tester.renderObject(find.byType(Scrollbar));
-    expect(renderBox.size.width, greaterThan(0));
-    expect(renderBox.size.height, greaterThan(0));
+
+    expect(
+      find.byType(Scrollbar),
+      paints
+        ..rect(
+          rect: const Rect.fromLTRB(796.0, 0.0, 800.0, 524.0),
+          color: const Color(0x00000000),
+        )
+        ..line(
+          p1: const Offset(796.0, 0.0),
+          p2: const Offset(796.0, 524.0),
+          strokeWidth: 1.0,
+          color: const Color(0x00000000),
+        )
+        ..rect(
+          rect: const Rect.fromLTWH(796.0, 0.0, 4.0, (524/4034) * 524),
+          color: _kAndroidThumbIdleColor,
+        ),
+    );
   });
 
   testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1942,8 +1942,6 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
 
     // The left edge of the scrollbar should be at the very left of the viewport
     expect(topLeft.dx, 0.0);
-
-
     await tester.pumpWidget(buildScrollWithOrientation(ScrollbarOrientation.right));
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -244,7 +244,7 @@ void main() {
             controller: controller,
             child: Builder(
               builder: (BuildContext context) {
-                return  const Scrollbar(
+                return const Scrollbar(
                   thumbVisibility: true,
                   child: SingleChildScrollView(
                     primary: true,

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -244,7 +244,7 @@ void main() {
             controller: controller,
             child: Builder(
               builder: (BuildContext context) {
-                return const Scrollbar(
+                return  const Scrollbar(
                   thumbVisibility: true,
                   child: SingleChildScrollView(
                     primary: true,
@@ -1903,4 +1903,57 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
 
     scrollController.dispose();
   });
+
+
+  testWidgets('Scrollbar without padding', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+
+    Widget buildScrollWithOrientation(ScrollbarOrientation orientation) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Theme(
+            data: ThemeData(
+              platform: TargetPlatform.android,
+            ),
+            child: PrimaryScrollController(
+              controller: scrollController,
+              child: Scrollbar(
+                interactive: true,
+                thumbVisibility: true,
+                scrollbarOrientation: orientation,
+                controller: scrollController,
+                child: const SingleChildScrollView(
+                  child: SizedBox(width: 4000.0, height: 4000.0)
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildScrollWithOrientation(ScrollbarOrientation.left));
+    await tester.pumpAndSettle();
+
+
+    // This ensures there is no padding between the scrollbar and the viewport edge
+    final RenderBox renderBox = tester.renderObject(find.byType(Scrollbar));
+    final Offset topLeft = renderBox.localToGlobal(Offset.zero);
+
+    // The left edge of the scrollbar should be at the very left of the viewport
+    expect(topLeft.dx, 0.0);
+
+
+    await tester.pumpWidget(buildScrollWithOrientation(ScrollbarOrientation.right));
+    await tester.pumpAndSettle();
+
+    final RenderBox renderBoxRight = tester.renderObject(find.byType(Scrollbar));
+    final Offset topRight = renderBoxRight.localToGlobal(Offset(renderBoxRight.size.width, 0.0));
+    final double screenWidth = tester.binding.window.physicalSize.width / tester.binding.window.devicePixelRatio;
+    // The right edge of the scrollbar should be at the very right of the viewport
+    expect(topRight.dx, screenWidth);
+    expect(scrollController.offset, equals(0));
+    scrollController.dispose();
+  });
+
 }

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1955,5 +1955,4 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     expect(scrollController.offset, equals(0));
     scrollController.dispose();
   });
-
 }

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -3495,23 +3495,23 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     final ScrollController scrollController = ScrollController();
     addTearDown(scrollController.dispose);
     await tester.pumpWidget(
-        Directionality(
-            textDirection: TextDirection.ltr,
-            child: MediaQuery(
-              data: const MediaQueryData(
-              ),
-              child: RawScrollbar(
-                controller: scrollController,
-                minThumbLength: 21,
-                minOverscrollLength: 8,
-                thumbVisibility: true,
-                child: SingleChildScrollView(
-                  controller: scrollController,
-                  child: const SizedBox(width: 1000.0, height: 50000.0),
-                ),
-              ),
-            )
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(
+          ),
+          child: RawScrollbar(
+            controller: scrollController,
+            minThumbLength: 21,
+            minOverscrollLength: 8,
+            thumbVisibility: true,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: const SizedBox(width: 1000.0, height: 50000.0),
+            ),
+          ),
         )
+      )
     );
     await tester.pumpAndSettle();
     expect(

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2728,8 +2728,8 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     expect(
       find.byType(RawScrollbar),
       paints
-        ..rect(rect: const Rect.fromLTRB(744.0, 50.0, 750.0, 550.0)) // track
-        ..rect(rect: const Rect.fromLTRB(744.0, 50.0, 750.0, 71.0)) // thumb
+        ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0)) // track
+        ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 21.0)) // thumb
     ); // thumb
   });
 
@@ -3489,5 +3489,36 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     await tester.pumpAndSettle();
     // Scrolling is now possible, so there are scrollbar (thumb and track) gesture recognizers.
     expect(getScrollbarGestureDetector().gestures.length, greaterThan(1));
+  });
+
+  testWidgets('RawScrollbar without padding', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+        Directionality(
+            textDirection: TextDirection.ltr,
+            child: MediaQuery(
+              data: const MediaQueryData(
+              ),
+              child: RawScrollbar(
+                controller: scrollController,
+                minThumbLength: 21,
+                minOverscrollLength: 8,
+                thumbVisibility: true,
+                child: SingleChildScrollView(
+                  controller: scrollController,
+                  child: const SizedBox(width: 1000.0, height: 50000.0),
+                ),
+              ),
+            )
+        )
+    );
+    await tester.pumpAndSettle();
+    expect(
+        find.byType(RawScrollbar),
+        paints
+          ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0)) // track
+          ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 21.0)) // thumb
+    ); // thumb
   });
 }

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -3515,10 +3515,10 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     );
     await tester.pumpAndSettle();
     expect(
-        find.byType(RawScrollbar),
-        paints
-          ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0)) // track
-          ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 21.0)) // thumb
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0)) // track
+        ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 21.0)) // thumb
     ); // thumb
   });
 }


### PR DESCRIPTION
Replacing  `..padding = MediaQuery.paddingOf(context)` with `..padding = widget.padding??EdgeInsets.zero` to fix incorrect rendering of scrollbar. 

closes #150544 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

