### PR TITLE
Fix flaky sliver tree test

### DIFF
--- a/packages/flutter/test/widgets/sliver_tree_test.dart
+++ b/packages/flutter/test/widgets/sliver_tree_test.dart
@@ -28,6 +28,29 @@ List<TreeSliverNode<String>> simpleNodeSet = <TreeSliverNode<String>>[
 
 void main() {
   group('TreeSliverNode', () {
+    setUp(() {
+      // Reset node conditions for each test.
+      simpleNodeSet = <TreeSliverNode<String>>[
+        TreeSliverNode<String>('Root 0'),
+        TreeSliverNode<String>(
+          'Root 1',
+          expanded: true,
+          children: <TreeSliverNode<String>>[
+            TreeSliverNode<String>('Child 1:0'),
+            TreeSliverNode<String>('Child 1:1'),
+          ],
+        ),
+        TreeSliverNode<String>(
+          'Root 2',
+          children: <TreeSliverNode<String>>[
+            TreeSliverNode<String>('Child 2:0'),
+            TreeSliverNode<String>('Child 2:1'),
+          ],
+        ),
+        TreeSliverNode<String>('Root 3'),
+      ];
+    });
+
     test('getters, toString', () {
       final List<TreeSliverNode<String>> children = <TreeSliverNode<String>>[
         TreeSliverNode<String>('child'),
@@ -123,6 +146,7 @@ void main() {
         TreeSliverNode<String>('Root 3'),
       ];
     });
+
     testWidgets('Can set controller on TreeSliver', (WidgetTester tester) async {
       final TreeSliverController controller = TreeSliverController();
       TreeSliverController? returnedController;
@@ -427,6 +451,26 @@ void main() {
   });
 
   testWidgets('.toggleNodeWith, onNodeToggle', (WidgetTester tester) async {
+    simpleNodeSet = <TreeSliverNode<String>>[
+      TreeSliverNode<String>('Root 0'),
+      TreeSliverNode<String>(
+        'Root 1',
+        expanded: true,
+        children: <TreeSliverNode<String>>[
+          TreeSliverNode<String>('Child 1:0'),
+          TreeSliverNode<String>('Child 1:1'),
+        ],
+      ),
+      TreeSliverNode<String>(
+        'Root 2',
+        children: <TreeSliverNode<String>>[
+          TreeSliverNode<String>('Child 2:0'),
+          TreeSliverNode<String>('Child 2:1'),
+        ],
+      ),
+      TreeSliverNode<String>('Root 3'),
+    ];
+
     final TreeSliverController controller = TreeSliverController();
     // The default node builder wraps the leading icon with toggleNodeWith.
     bool toggled = false;
@@ -516,6 +560,26 @@ void main() {
   });
 
   testWidgets('AnimationStyle is piped through to node builder', (WidgetTester tester) async {
+    simpleNodeSet = <TreeSliverNode<String>>[
+      TreeSliverNode<String>('Root 0'),
+      TreeSliverNode<String>(
+        'Root 1',
+        expanded: true,
+        children: <TreeSliverNode<String>>[
+          TreeSliverNode<String>('Child 1:0'),
+          TreeSliverNode<String>('Child 1:1'),
+        ],
+      ),
+      TreeSliverNode<String>(
+        'Root 2',
+        children: <TreeSliverNode<String>>[
+          TreeSliverNode<String>('Child 2:0'),
+          TreeSliverNode<String>('Child 2:1'),
+        ],
+      ),
+      TreeSliverNode<String>('Root 3'),
+    ];
+
     AnimationStyle? style;
     await tester.pumpWidget(MaterialApp(
       home: CustomScrollView(


### PR DESCRIPTION
The set of nodes being used in the tree test was not being consistently reset at the beginning of every test. The tree is currently broken because today's random seed for test ordering exposed this leak of state from one test to another.

Fixes https://github.com/flutter/flutter/issues/150706

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
