### PR TITLE
[CP] Fix Linux numpad shortcuts on web

### DIFF
--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -529,7 +529,20 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
 
   Map<ShortcutActivator, Intent>? _getDisablingShortcut() {
     if (kIsWeb) {
-      return _webDisablingTextShortcuts;
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.linux:
+          return <ShortcutActivator, Intent>{
+            ..._webDisablingTextShortcuts,
+            for (final ShortcutActivator activator in _linuxNumpadShortcuts.keys)
+              activator as SingleActivator: const DoNothingAndStopPropagationTextIntent(),
+          };
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.windows:
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          return _webDisablingTextShortcuts;
+      }
     }
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:


### PR DESCRIPTION
Cherry pick request of https://github.com/flutter/flutter/pull/148988 to stable.

Fixes an issue on Web+Linux that prevents users from inputting data using the numpad.