### PR TITLE
[native_assets] Fix macOS host build failure when there are no frameworks to sign.

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -222,6 +222,7 @@ EmbedFrameworks() {
 
     # Iterate through all .frameworks in native assets directory.
     for native_asset in "${native_assets_path}"*.framework; do
+      [ -e "$native_asset" ] || continue # Skip when there are no matches.
       # Codesign the framework inside the app bundle.
       RunCommand codesign --force --verbose --sign "${EXPANDED_CODE_SIGN_IDENTITY}" -- "${xcode_frameworks_dir}/$(basename "$native_asset")"
     done

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -603,13 +603,6 @@ Future<Directory> createTestProjectWithNoCBuild(String packageName, Directory te
 
   final Directory packageDirectory = tempDirectory.childDirectory(packageName);
 
-  // No platform-specific boilerplate files.
-  expect(packageDirectory.childDirectory('android/'), isNot(exists));
-  expect(packageDirectory.childDirectory('ios/'), isNot(exists));
-  expect(packageDirectory.childDirectory('linux/'), isNot(exists));
-  expect(packageDirectory.childDirectory('macos/'), isNot(exists));
-  expect(packageDirectory.childDirectory('windows/'), isNot(exists));
-
   final ProcessResult result2 = await processManager.run(
     <String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -222,6 +222,26 @@ void main() {
       });
     }
 
+    testWithoutContext('flutter build $buildSubcommand succeeds without libraries', () async {
+      await inTempDir((Directory tempDirectory) async {
+        final Directory projectDirectory = await createTestProjectWithNoCBuild(packageName, tempDirectory);
+
+        final ProcessResult result = processManager.runSync(
+          <String>[
+            flutterBin,
+            'build',
+            buildSubcommand,
+            '--debug',
+            if (buildSubcommand == 'ios') '--no-codesign',
+          ],
+          workingDirectory: projectDirectory.path,
+        );
+        if (result.exitCode != 0) {
+          throw Exception('flutter build failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
+        }
+      });
+    });
+
     // This could be an hermetic unit test if the native_assets_builder
     // could mock process runs and file system.
     // https://github.com/dart-lang/native/issues/90.
@@ -561,6 +581,68 @@ Future<Directory> createTestProject(String packageName, Directory tempDirectory)
     workingDirectory: packageDirectory.path,
   );
   expect(result2, const ProcessResultMatcher());
+
+  return packageDirectory;
+}
+
+Future<Directory> createTestProjectWithNoCBuild(String packageName, Directory tempDirectory) async {
+  final ProcessResult result = processManager.runSync(
+    <String>[
+      flutterBin,
+      'create',
+      '--no-pub',
+      packageName,
+    ],
+    workingDirectory: tempDirectory.path,
+  );
+  if (result.exitCode != 0) {
+    throw Exception(
+      'flutter create failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
+    );
+  }
+
+  final Directory packageDirectory = tempDirectory.childDirectory(packageName);
+
+  // No platform-specific boilerplate files.
+  expect(packageDirectory.childDirectory('android/'), isNot(exists));
+  expect(packageDirectory.childDirectory('ios/'), isNot(exists));
+  expect(packageDirectory.childDirectory('linux/'), isNot(exists));
+  expect(packageDirectory.childDirectory('macos/'), isNot(exists));
+  expect(packageDirectory.childDirectory('windows/'), isNot(exists));
+
+  final ProcessResult result2 = await processManager.run(
+    <String>[
+      flutterBin,
+      'pub',
+      'add',
+      'native_assets_cli',
+    ],
+    workingDirectory: packageDirectory.path,
+  );
+  expect(result2, const ProcessResultMatcher());
+
+  await pinDependencies(packageDirectory.childFile('pubspec.yaml'));
+
+  final ProcessResult result3 = await processManager.run(
+    <String>[
+      flutterBin,
+      'pub',
+      'get',
+    ],
+    workingDirectory: packageDirectory.path,
+  );
+  expect(result3, const ProcessResultMatcher());
+
+  // Add build hook that does nothing to the package.
+  final File buildHook = packageDirectory.childDirectory('hook').childFile('build.dart');
+  buildHook.createSync(recursive: true);
+  buildHook.writeAsStringSync('''
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  await build(args, (config, output) async {});
+}
+''');
 
   return packageDirectory;
 }


### PR DESCRIPTION
When the `"${native_assets_path}"*.framework` glob doesn't resolve anything, bash will run the loop once with the original unglobbed value: `/path/to/native/assets/*.framework`. Skip this case to prevent the build from failing when there are no frameworks to sign.

To reproduce this build failure:
1. Enable native assets in the Flutter tool: `flutter config --enable-native-assets`
2. Create a Flutter project with the default template: `flutter create test_native_assets`
3. Add a build hook that does nothing (`hook/build.dart`).
4. Try to build/run the app: `flutter run --debug -d macos`