### PR TITLE
Reland Add tests for form_text_field.1.dart (#150481) (#150696)

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -325,7 +325,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/flexible_space_bar/flexible_space_bar.0_test.dart',
   'examples/api/test/material/chip/deletable_chip_attributes.on_deleted.0_test.dart',
   'examples/api/test/material/expansion_panel/expansion_panel_list.expansion_panel_list_radio.0_test.dart',
-  'examples/api/test/material/text_form_field/text_form_field.1_test.dart',
   'examples/api/test/material/scrollbar/scrollbar.1_test.dart',
   'examples/api/test/material/search_anchor/search_anchor.0_test.dart',
   'examples/api/test/material/search_anchor/search_anchor.1_test.dart',

--- a/examples/api/test/material/text_form_field/text_form_field.1_test.dart
+++ b/examples/api/test/material/text_form_field/text_form_field.1_test.dart
@@ -1,0 +1,58 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_api_samples/material/text_form_field/text_form_field.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Pressing space should focus the next field', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.TextFormFieldExampleApp());
+    final Finder textFormField = find.byType(TextFormField);
+
+    expect(textFormField, findsExactly(5));
+
+    final Finder editableText = find.byType(EditableText);
+    expect(editableText, findsExactly(5));
+
+    List<bool> getFocuses() {
+      return editableText.evaluate()
+        .map((Element finderResult) => (finderResult.widget as EditableText).focusNode.hasFocus)
+        .toList();
+    }
+
+    expect(getFocuses(), const <bool>[false, false, false, false, false]);
+
+    await tester.tap(textFormField.first);
+    await tester.pump();
+
+    expect(getFocuses(), const <bool>[true, false, false, false, false]);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+
+    expect(getFocuses(), const <bool>[false, true, false, false, false]);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+
+    expect(getFocuses(), const <bool>[false, false, true, false, false]);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+
+    expect(getFocuses(), const <bool>[false, false, false, true, false]);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+
+    expect(getFocuses(), const <bool>[false, false, false, false, true]);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+
+    expect(getFocuses(), const <bool>[true, false, false, false, false]);
+  });
+}


### PR DESCRIPTION
This reverts commit 70e9b4185e3d539c04abb73240d8830c93290470.

Relands https://github.com/flutter/flutter/pull/150481

Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/material/text_form_field/text_form_field.1.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes

