### PR TITLE
✨ : Animation controller now has ability to repeat animation 'n' no. of times.

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -1000,8 +1000,7 @@ class _RepeatingSimulation extends Simulation {
   /// If [reverse] is true, the duration of a full cycle is doubled.
   late final int _effectiveRepeatCount = repeatCount! * (reverse ? 2 : 1);
 
-  late final double _exitTimeInSeconds =
-      (_effectiveRepeatCount * _periodInSeconds) - _initialT;
+  late final double _exitTimeInSeconds = (_effectiveRepeatCount * _periodInSeconds) - _initialT;
 
   @override
   double x(double timeInSeconds) {
@@ -1025,7 +1024,7 @@ class _RepeatingSimulation extends Simulation {
 
   @override
   bool isDone(double timeInSeconds) {
-    // if [totalTimeInSeconds] elapsed the [exitTimeInSeconds] && repeatCount is not null,
+    // if [timeInSeconds] elapsed the [_exitTimeInSeconds] && repeatCount is not null,
     // consider marking the simulation as "DONE"
     return repeatCount != null && (timeInSeconds >= _exitTimeInSeconds);
   }

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -997,19 +997,11 @@ class _RepeatingSimulation extends Simulation {
   final double _periodInSeconds;
   final double _initialT;
 
-  double get _calculateSimulationExitTime {
-    // if reverse simulation is [true], then we shall double the repeat times
-    // else, use the given value
-    final int effectiveRepeatTimes = repeatCount! * (reverse ? 2 : 1);
+  /// If [reverse] is true, the duration of a full cycle is doubled.
+  late final int _effectiveRepeatCount = repeatCount! * (reverse ? 2 : 1);
 
-    // [exitTimeInSeconds] is the time in seconds which will help
-    // to determine when to complete the simulation. [Fixed to 3 decimal points]
-    return double.parse(
-      (effectiveRepeatTimes * _periodInSeconds).toStringAsFixed(3),
-    );
-  }
-
-  late final double _exitTimeInSeconds = _calculateSimulationExitTime;
+  late final double _exitTimeInSeconds =
+      (_effectiveRepeatCount * _periodInSeconds) - _initialT;
 
   @override
   double x(double timeInSeconds) {
@@ -1033,18 +1025,8 @@ class _RepeatingSimulation extends Simulation {
 
   @override
   bool isDone(double timeInSeconds) {
-    if (repeatCount == null) {
-      // if repeat count is null it is to be consider as repeated simulation
-      return false;
-    }
-
-    // total simulation elapsed time [Fixed to 3 decimal points]
-    final double totalTimeInSeconds = double.parse(
-      (timeInSeconds + _initialT).toStringAsFixed(3),
-    );
-
-    // if [totalTimeInSeconds] elapsed the [exitTimeInSeconds],
+    // if [totalTimeInSeconds] elapsed the [exitTimeInSeconds] && repeatCount is not null,
     // consider marking the simulation as "DONE"
-    return totalTimeInSeconds >= _exitTimeInSeconds;
+    return repeatCount != null && (timeInSeconds >= _exitTimeInSeconds);
   }
 }

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -707,11 +707,12 @@ class AnimationController extends Animation<double>
   /// provided, [duration] will be used instead, which has to be set before [repeat] is
   /// called either in the constructor or later by using the [duration] setter.
   ///
-  /// With [repeatTimes] set as valid value, animation will be executed by given times.
-  /// If value not given, infinite animation shall be simulated.
+  /// If a value is passed to [repeatCount], the animation will perform that many
+  /// iterations before stopping. Otherwise, the animation repeats indefinitely.
   ///
-  /// Returns a [TickerFuture] that never completes. The [TickerFuture.orCancel] future
-  /// completes with an error when the animation is stopped (e.g. with [stop]).
+  /// Returns a [TickerFuture] that never completes, unless a [repeatCount] is specified.
+  /// The [TickerFuture.orCancel] future completes with an error when the animation is
+  /// stopped (e.g. with [stop]).
   ///
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
@@ -721,7 +722,7 @@ class AnimationController extends Animation<double>
     double? max,
     bool reverse = false,
     Duration? period,
-    int? repeatTimes,
+    int? repeatCount,
   }) {
     min ??= lowerBound;
     max ??= upperBound;
@@ -739,9 +740,9 @@ class AnimationController extends Animation<double>
     }());
     assert(max >= min);
     assert(max <= upperBound && min >= lowerBound);
-    assert(repeatTimes == null || repeatTimes > 0, 'Repeat times shall be greater than zero if not null');
+    assert(repeatCount == null || repeatCount > 0, 'Repeat times shall be greater than zero if not null');
     stop();
-    return _startSimulation(_RepeatingSimulation(_value, min, max, reverse, period!, _directionSetter, repeatTimes,));
+    return _startSimulation(_RepeatingSimulation(_value, min, max, reverse, period!, _directionSetter, repeatCount));
   }
 
   void _directionSetter(_AnimationDirection direction) {
@@ -975,11 +976,11 @@ class _RepeatingSimulation extends Simulation {
     this.max,
     this.reverse,
     Duration period,
-    this.directionSetter, [
-    this.repeatTimes,
-  ])  : assert(
-          repeatTimes == null || repeatTimes > 0,
-          'Repeat times shall be greater than zero if not null',
+    this.directionSetter,
+    this.repeatCount,
+  )  : assert(
+          repeatCount == null || repeatCount > 0,
+          'Repeat count shall be greater than zero if not null',
         ),
         _periodInSeconds = period.inMicroseconds / Duration.microsecondsPerSecond,
         _initialT = (max == min) ? 0.0 : ((clampDouble(initialValue, min, max) - min) / (max - min)) * (period.inMicroseconds / Duration.microsecondsPerSecond) {
@@ -990,11 +991,25 @@ class _RepeatingSimulation extends Simulation {
   final double min;
   final double max;
   final bool reverse;
-  final int? repeatTimes;
+  final int? repeatCount;
   final _DirectionSetter directionSetter;
 
   final double _periodInSeconds;
   final double _initialT;
+
+  double get _calculateSimulationExitTime {
+    // if reverse simulation is [true], then we shall double the repeat times
+    // else, use the given value
+    final int effectiveRepeatTimes = repeatCount! * (reverse ? 2 : 1);
+
+    // [exitTimeInSeconds] is the time in seconds which will help
+    // to determine when to complete the simulation. [Fixed to 3 decimal points]
+    return double.parse(
+      (effectiveRepeatTimes * _periodInSeconds).toStringAsFixed(3),
+    );
+  }
+
+  late final double _exitTimeInSeconds = _calculateSimulationExitTime;
 
   @override
   double x(double timeInSeconds) {
@@ -1018,8 +1033,8 @@ class _RepeatingSimulation extends Simulation {
 
   @override
   bool isDone(double timeInSeconds) {
-    if (repeatTimes == null) {
-      // if repeat times is null it is to be consider as repeated simulation
+    if (repeatCount == null) {
+      // if repeat count is null it is to be consider as repeated simulation
       return false;
     }
 
@@ -1028,18 +1043,8 @@ class _RepeatingSimulation extends Simulation {
       (timeInSeconds + _initialT).toStringAsFixed(3),
     );
 
-    // if reverse simulation is [true], then we shall double the repeat times
-    // else, use the given value
-    final int effectiveRepeatTimes = repeatTimes! * (reverse ? 2 : 1);
-
-    // [exitTimeInSeconds] is the time in seconds which will help
-    // to determine when to complete the simulation. [Fixed to 3 decimal points]
-    final double exitTimeInSeconds = double.parse(
-      (effectiveRepeatTimes * _periodInSeconds).toStringAsFixed(3),
-    );
-
     // if [totalTimeInSeconds] elapsed the [exitTimeInSeconds],
     // consider marking the simulation as "DONE"
-    return totalTimeInSeconds >= exitTimeInSeconds;
+    return totalTimeInSeconds >= _exitTimeInSeconds;
   }
 }

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -707,10 +707,10 @@ class AnimationController extends Animation<double>
   /// provided, [duration] will be used instead, which has to be set before [repeat] is
   /// called either in the constructor or later by using the [duration] setter.
   ///
-  /// If a value is passed to [repeatCount], the animation will perform that many
+  /// If a value is passed to [count], the animation will perform that many
   /// iterations before stopping. Otherwise, the animation repeats indefinitely.
   ///
-  /// Returns a [TickerFuture] that never completes, unless a [repeatCount] is specified.
+  /// Returns a [TickerFuture] that never completes, unless a [count] is specified.
   /// The [TickerFuture.orCancel] future completes with an error when the animation is
   /// stopped (e.g. with [stop]).
   ///
@@ -722,7 +722,7 @@ class AnimationController extends Animation<double>
     double? max,
     bool reverse = false,
     Duration? period,
-    int? repeatCount,
+    int? count,
   }) {
     min ??= lowerBound;
     max ??= upperBound;
@@ -740,9 +740,9 @@ class AnimationController extends Animation<double>
     }());
     assert(max >= min);
     assert(max <= upperBound && min >= lowerBound);
-    assert(repeatCount == null || repeatCount > 0, 'Repeat times shall be greater than zero if not null');
+    assert(count == null || count > 0, 'Count shall be greater than zero if not null');
     stop();
-    return _startSimulation(_RepeatingSimulation(_value, min, max, reverse, period!, _directionSetter, repeatCount));
+    return _startSimulation(_RepeatingSimulation(_value, min, max, reverse, period!, _directionSetter, count));
   }
 
   void _directionSetter(_AnimationDirection direction) {
@@ -977,10 +977,10 @@ class _RepeatingSimulation extends Simulation {
     this.reverse,
     Duration period,
     this.directionSetter,
-    this.repeatCount,
+    this.count,
   )  : assert(
-          repeatCount == null || repeatCount > 0,
-          'Repeat count shall be greater than zero if not null',
+          count == null || count > 0,
+          'Count shall be greater than zero if not null',
         ),
         _periodInSeconds = period.inMicroseconds / Duration.microsecondsPerSecond,
         _initialT = (max == min) ? 0.0 : ((clampDouble(initialValue, min, max) - min) / (max - min)) * (period.inMicroseconds / Duration.microsecondsPerSecond) {
@@ -991,16 +991,13 @@ class _RepeatingSimulation extends Simulation {
   final double min;
   final double max;
   final bool reverse;
-  final int? repeatCount;
+  final int? count;
   final _DirectionSetter directionSetter;
 
   final double _periodInSeconds;
   final double _initialT;
 
-  /// If [reverse] is true, the duration of a full cycle is doubled.
-  late final int _effectiveRepeatCount = repeatCount! * (reverse ? 2 : 1);
-
-  late final double _exitTimeInSeconds = (_effectiveRepeatCount * _periodInSeconds) - _initialT;
+  late final double _exitTimeInSeconds = (count! * _periodInSeconds) - _initialT;
 
   @override
   double x(double timeInSeconds) {
@@ -1024,8 +1021,8 @@ class _RepeatingSimulation extends Simulation {
 
   @override
   bool isDone(double timeInSeconds) {
-    // if [timeInSeconds] elapsed the [_exitTimeInSeconds] && repeatCount is not null,
+    // if [timeInSeconds] elapsed the [_exitTimeInSeconds] && [count] is not null,
     // consider marking the simulation as "DONE"
-    return repeatCount != null && (timeInSeconds >= _exitTimeInSeconds);
+    return count != null && (timeInSeconds >= _exitTimeInSeconds);
   }
 }

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -1227,6 +1227,107 @@ void main() {
     );
   });
 
+  group('repeatTimes tests for repeated animation', () {
+    test(
+      'calling repeat by setting repeatTimes as zero shall throw Assertion',
+      () {
+        final AnimationController controller = AnimationController(
+          duration: const Duration(milliseconds: 100),
+          value: 0.0,
+          vsync: const TestVSync(),
+        );
+
+        expect(controller.value, 0.0);
+        expect(
+          () => controller.repeat(reverse: true, repeatTimes: 0),
+          throwsAssertionError,
+        );
+      },
+    );
+
+    test(
+      'calling repeat by setting repeatTimes as negative shall throw Assertion',
+      () {
+        final AnimationController controller = AnimationController(
+          duration: const Duration(milliseconds: 100),
+          value: 0.0,
+          vsync: const TestVSync(),
+        );
+
+        expect(controller.value, 0.0);
+        expect(
+          () => controller.repeat(reverse: true, repeatTimes: -1),
+          throwsAssertionError,
+        );
+      },
+    );
+
+    test(
+      'calling repeat by setting repeatTimes as valid with reverse as false, shall run animation accordingly',
+      () {
+        final AnimationController controller = AnimationController(
+          duration: const Duration(milliseconds: 100),
+          value: 0.0,
+          vsync: const TestVSync(),
+        );
+
+        expect(controller.value, 0.0);
+        controller.repeat(repeatTimes: 1);
+        tick(Duration.zero);
+        tick(const Duration(milliseconds: 25));
+        expect(controller.value, 0.25);
+        tick(const Duration(milliseconds: 50));
+        expect(controller.value, 0.5);
+        tick(const Duration(milliseconds: 99));
+        expect(controller.value, 0.99);
+        tick(const Duration(milliseconds: 100));
+        expect(controller.value, 0);
+
+        controller.reset();
+
+        expect(controller.value, 0.0);
+        controller.repeat(repeatTimes: 2);
+        tick(Duration.zero);
+        tick(const Duration(milliseconds: 25));
+        expect(controller.value, 0.25);
+        tick(const Duration(milliseconds: 50));
+        expect(controller.value, 0.5);
+        tick(const Duration(milliseconds: 200));
+        expect(controller.value, 0);
+
+        controller.reset();
+        controller.dispose();
+      },
+    );
+
+    test(
+      'calling repeat by setting repeatTimes as valid with reverse as true, shall run animation accordingly',
+      () {
+        final AnimationController controller = AnimationController(
+          duration: const Duration(milliseconds: 100),
+          value: 0.0,
+          vsync: const TestVSync(),
+        );
+
+        expect(controller.value, 0.0);
+        controller.repeat(reverse: true, repeatTimes: 2);
+        tick(Duration.zero);
+        tick(const Duration(milliseconds: 25));
+        expect(controller.value, 0.25);
+        tick(const Duration(milliseconds: 50));
+        expect(controller.value, 0.5);
+        tick(const Duration(milliseconds: 99));
+        expect(controller.value, 0.99);
+        tick(const Duration(milliseconds: 100));
+        expect(controller.value, 1);
+        tick(const Duration(milliseconds: 60));
+        expect(double.parse(controller.value.toStringAsFixed(1)), 0.6);
+
+        controller.reset();
+        controller.dispose();
+      },
+    );
+  });
 }
 
 class TestSimulation extends Simulation {

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -1227,9 +1227,9 @@ void main() {
     );
   });
 
-  group('repeatTimes tests for repeated animation', () {
+  group('repeatCount tests for repeated animation', () {
     test(
-      'calling repeat by setting repeatTimes as zero shall throw Assertion',
+      'calling repeat by setting repeatCount as zero shall throw Assertion',
       () {
         final AnimationController controller = AnimationController(
           duration: const Duration(milliseconds: 100),
@@ -1239,14 +1239,14 @@ void main() {
 
         expect(controller.value, 0.0);
         expect(
-          () => controller.repeat(reverse: true, repeatTimes: 0),
+          () => controller.repeat(reverse: true, repeatCount: 0),
           throwsAssertionError,
         );
       },
     );
 
     test(
-      'calling repeat by setting repeatTimes as negative shall throw Assertion',
+      'calling repeat by setting repeatCount as negative shall throw Assertion',
       () {
         final AnimationController controller = AnimationController(
           duration: const Duration(milliseconds: 100),
@@ -1256,14 +1256,14 @@ void main() {
 
         expect(controller.value, 0.0);
         expect(
-          () => controller.repeat(reverse: true, repeatTimes: -1),
+          () => controller.repeat(reverse: true, repeatCount: -1),
           throwsAssertionError,
         );
       },
     );
 
     test(
-      'calling repeat by setting repeatTimes as valid with reverse as false, shall run animation accordingly',
+      'calling repeat by setting repeatCount as valid with reverse as false, shall run animation accordingly',
       () {
         final AnimationController controller = AnimationController(
           duration: const Duration(milliseconds: 100),
@@ -1272,7 +1272,7 @@ void main() {
         );
 
         expect(controller.value, 0.0);
-        controller.repeat(repeatTimes: 1);
+        controller.repeat(repeatCount: 1);
         tick(Duration.zero);
         tick(const Duration(milliseconds: 25));
         expect(controller.value, 0.25);
@@ -1286,7 +1286,7 @@ void main() {
         controller.reset();
 
         expect(controller.value, 0.0);
-        controller.repeat(repeatTimes: 2);
+        controller.repeat(repeatCount: 2);
         tick(Duration.zero);
         tick(const Duration(milliseconds: 25));
         expect(controller.value, 0.25);
@@ -1301,7 +1301,7 @@ void main() {
     );
 
     test(
-      'calling repeat by setting repeatTimes as valid with reverse as true, shall run animation accordingly',
+      'calling repeat by setting repeatCount as valid with reverse as true, shall run animation accordingly',
       () {
         final AnimationController controller = AnimationController(
           duration: const Duration(milliseconds: 100),
@@ -1310,7 +1310,7 @@ void main() {
         );
 
         expect(controller.value, 0.0);
-        controller.repeat(reverse: true, repeatTimes: 2);
+        controller.repeat(reverse: true, repeatCount: 2);
         tick(Duration.zero);
         tick(const Duration(milliseconds: 25));
         expect(controller.value, 0.25);

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -1227,9 +1227,9 @@ void main() {
     );
   });
 
-  group('repeatCount tests for repeated animation', () {
+  group('count tests for repeated animation', () {
     test(
-      'calling repeat by setting repeatCount as zero shall throw Assertion',
+      'calling repeat by setting count as zero shall throw Assertion',
       () {
         final AnimationController controller = AnimationController(
           duration: const Duration(milliseconds: 100),
@@ -1239,14 +1239,14 @@ void main() {
 
         expect(controller.value, 0.0);
         expect(
-          () => controller.repeat(reverse: true, repeatCount: 0),
+          () => controller.repeat(reverse: true, count: 0),
           throwsAssertionError,
         );
       },
     );
 
     test(
-      'calling repeat by setting repeatCount as negative shall throw Assertion',
+      'calling repeat by setting count as negative shall throw Assertion',
       () {
         final AnimationController controller = AnimationController(
           duration: const Duration(milliseconds: 100),
@@ -1256,14 +1256,14 @@ void main() {
 
         expect(controller.value, 0.0);
         expect(
-          () => controller.repeat(reverse: true, repeatCount: -1),
+          () => controller.repeat(reverse: true, count: -1),
           throwsAssertionError,
         );
       },
     );
 
     test(
-      'calling repeat by setting repeatCount as valid with reverse as false, shall run animation accordingly',
+      'calling repeat by setting count as valid with reverse as false, shall run animation accordingly',
       () {
         final AnimationController controller = AnimationController(
           duration: const Duration(milliseconds: 100),
@@ -1272,7 +1272,7 @@ void main() {
         );
 
         expect(controller.value, 0.0);
-        controller.repeat(repeatCount: 1);
+        controller.repeat(count: 1);
         tick(Duration.zero);
         tick(const Duration(milliseconds: 25));
         expect(controller.value, 0.25);
@@ -1286,7 +1286,7 @@ void main() {
         controller.reset();
 
         expect(controller.value, 0.0);
-        controller.repeat(repeatCount: 2);
+        controller.repeat(count: 2);
         tick(Duration.zero);
         tick(const Duration(milliseconds: 25));
         expect(controller.value, 0.25);
@@ -1301,7 +1301,7 @@ void main() {
     );
 
     test(
-      'calling repeat by setting repeatCount as valid with reverse as true, shall run animation accordingly',
+      'calling repeat by setting count as valid with reverse as true, shall run animation accordingly',
       () {
         final AnimationController controller = AnimationController(
           duration: const Duration(milliseconds: 100),
@@ -1310,7 +1310,7 @@ void main() {
         );
 
         expect(controller.value, 0.0);
-        controller.repeat(reverse: true, repeatCount: 2);
+        controller.repeat(reverse: true, count: 4);
         tick(Duration.zero);
         tick(const Duration(milliseconds: 25));
         expect(controller.value, 0.25);


### PR DESCRIPTION
Right now animation controller does not have any way by which user can repeat animation with specific no. of times. Adding the changes in existing `repeat` method in which users can specific no. of times they want to repeat the animation. If not specified, it would simulate infinitely. [Existing repeat behaviour]

This PR fixes : https://github.com/flutter/flutter/issues/53262

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
