### PR TITLE
Adding `@docImport`s to the `animation` library

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/widgets.dart';
+library;
 
 import 'package:flutter/foundation.dart';
 

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/widgets.dart';
+/// @docImport 'package:flutter_test/flutter_test.dart';
+library;
 
 import 'dart:ui' as ui show lerpDouble;
 

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 /// @docImport 'package:flutter/widgets.dart';
-/// @docImport 'package:flutter_test/flutter_test.dart';
 library;
 
 import 'dart:ui' as ui show lerpDouble;

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+library;
+
 import 'package:flutter/foundation.dart';
 
 import 'curves.dart';

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/widgets.dart';
+library;
 
 import 'dart:math' as math;
 

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+library;
+
 import 'dart:math' as math;
 import 'dart:ui';
 

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+library;
+
 import 'dart:ui' show Color, Rect, Size;
 
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/150800.

I turned on the `comment_references` lint and looked at what needed fixing inside of the `animation` library.

There are a couple of places where for some reason adding a docImport didn't fix the `comment_references` warning:

- [ ] All the references in the doc on the `library` statement of the animations library (no doc import helps), example: https://github.com/flutter/flutter/blob/65e6bde4b13a680cbc0e9032c39e299aab882280/packages/flutter/lib/animation.dart#L12
- [ ] The docImport of `package:flutter/material.dart` is for some reason unable to resolve `[Easing.legacy]`: https://github.com/flutter/flutter/blob/65e6bde4b13a680cbc0e9032c39e299aab882280/packages/flutter/lib/src/animation/curves.dart#L1831
- [ ] The docImport of `package:flutter/widgets.dart` is for some reason unable to resolve `[State]` and `[AnimationController]` in https://github.com/flutter/flutter/blob/65e6bde4b13a680cbc0e9032c39e299aab882280/packages/flutter/lib/src/animation/animations.dart#L50 https://github.com/flutter/flutter/blob/65e6bde4b13a680cbc0e9032c39e299aab882280/packages/flutter/lib/src/animation/animations.dart#L410