### PR TITLE
Add `safeAreaVerticalOffset` for `NavigationBar`

### DIFF
--- a/dev/tools/gen_defaults/lib/navigation_bar_template.dart
+++ b/dev/tools/gen_defaults/lib/navigation_bar_template.dart
@@ -16,6 +16,7 @@ class _${blockName}DefaultsM3 extends NavigationBarThemeData {
   _${blockName}DefaultsM3(this.context)
       : super(
           height: ${getToken("md.comp.navigation-bar.container.height")},
+          safeAreaVerticalOffset: 0.0,
           elevation: ${elevation("md.comp.navigation-bar.container")},
           labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
         );

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -104,6 +104,7 @@ class NavigationBar extends StatelessWidget {
     this.indicatorColor,
     this.indicatorShape,
     this.height,
+    this.safeAreaVerticalOffset,
     this.labelBehavior,
     this.overlayColor,
   }) :  assert(destinations.length >= 2),
@@ -203,6 +204,20 @@ class NavigationBar extends StatelessWidget {
   /// is also null, the default is 80.
   final double? height;
 
+  /// The adjustment on the bottom padding of the [SafeArea].
+  ///
+  /// [NavigationBar] respects the [SafeArea], so its height includes its own
+  /// default height plus the bottom padding of the [SafeArea]. To display more
+  /// content in the main body, [NavigationBar.height] can be updated to a smaller
+  /// value, but this may cause an overlap with the bottom [SafeArea], making
+  /// part of the navigation bar untappable. In this case, this property can be
+  /// used to decrease the bottom padding of the [SafeArea] and ensure that the
+  /// navigtation bar remain tappable.
+  ///
+  /// defaults to 0.0. A positive value means more bottom padding in [SafeArea];
+  /// A negative value means less bottom padding in [SafeArea].
+  final double? safeAreaVerticalOffset;
+
   /// Defines how the [destinations]' labels will be laid out and when they'll
   /// be displayed.
   ///
@@ -234,6 +249,11 @@ class NavigationBar extends StatelessWidget {
       ?? navigationBarTheme.labelBehavior
       ?? defaults.labelBehavior!;
 
+    final double bottomPadding = MediaQuery.paddingOf(context).bottom;
+    final double effectiveSafeAreaVerticalOffset = safeAreaVerticalOffset
+      ?? navigationBarTheme.safeAreaVerticalOffset
+      ?? defaults.safeAreaVerticalOffset!;
+
     return Material(
       color: backgroundColor
         ?? navigationBarTheme.backgroundColor
@@ -242,6 +262,8 @@ class NavigationBar extends StatelessWidget {
       shadowColor: shadowColor ?? navigationBarTheme.shadowColor ?? defaults.shadowColor,
       surfaceTintColor: surfaceTintColor ?? navigationBarTheme.surfaceTintColor ?? defaults.surfaceTintColor,
       child: SafeArea(
+        bottom: false,
+        minimum: EdgeInsets.only(bottom: bottomPadding + effectiveSafeAreaVerticalOffset),
         child: SizedBox(
           height: effectiveHeight,
           child: Row(
@@ -1312,6 +1334,7 @@ class _NavigationBarDefaultsM2 extends NavigationBarThemeData {
         _colors = Theme.of(context).colorScheme,
         super(
           height: 80.0,
+          safeAreaVerticalOffset: 0.0,
           elevation: 0.0,
           indicatorShape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16))),
           labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
@@ -1347,6 +1370,7 @@ class _NavigationBarDefaultsM3 extends NavigationBarThemeData {
   _NavigationBarDefaultsM3(this.context)
       : super(
           height: 80.0,
+          safeAreaVerticalOffset: 0.0,
           elevation: 3.0,
           labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
         );

--- a/packages/flutter/lib/src/material/navigation_bar_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_bar_theme.dart
@@ -53,6 +53,7 @@ class NavigationBarThemeData with Diagnosticable {
     this.iconTheme,
     this.labelBehavior,
     this.overlayColor,
+    this.safeAreaVerticalOffset,
   });
 
   /// Overrides the default value of [NavigationBar.height].
@@ -95,6 +96,9 @@ class NavigationBarThemeData with Diagnosticable {
   /// Overrides the default value of [NavigationBar.overlayColor].
   final MaterialStateProperty<Color?>? overlayColor;
 
+  /// Overrides the default value of [NavigationBar.safeAreaVerticalOffset].
+  final double? safeAreaVerticalOffset;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   NavigationBarThemeData copyWith({
@@ -109,6 +113,7 @@ class NavigationBarThemeData with Diagnosticable {
     MaterialStateProperty<IconThemeData?>? iconTheme,
     NavigationDestinationLabelBehavior? labelBehavior,
     MaterialStateProperty<Color?>? overlayColor,
+    double? safeAreaVerticalOffset,
   }) {
     return NavigationBarThemeData(
       height: height ?? this.height,
@@ -122,6 +127,7 @@ class NavigationBarThemeData with Diagnosticable {
       iconTheme: iconTheme ?? this.iconTheme,
       labelBehavior: labelBehavior ?? this.labelBehavior,
       overlayColor: overlayColor ?? this.overlayColor,
+      safeAreaVerticalOffset: safeAreaVerticalOffset ?? this.safeAreaVerticalOffset,
     );
   }
 
@@ -146,6 +152,7 @@ class NavigationBarThemeData with Diagnosticable {
       iconTheme: MaterialStateProperty.lerp<IconThemeData?>(a?.iconTheme, b?.iconTheme, t, IconThemeData.lerp),
       labelBehavior: t < 0.5 ? a?.labelBehavior : b?.labelBehavior,
       overlayColor: MaterialStateProperty.lerp<Color?>(a?.overlayColor, b?.overlayColor, t, Color.lerp),
+      safeAreaVerticalOffset: lerpDouble(a?.safeAreaVerticalOffset, b?.safeAreaVerticalOffset, t),
     );
   }
 
@@ -162,6 +169,7 @@ class NavigationBarThemeData with Diagnosticable {
     iconTheme,
     labelBehavior,
     overlayColor,
+    safeAreaVerticalOffset,
   );
 
   @override
@@ -183,7 +191,8 @@ class NavigationBarThemeData with Diagnosticable {
       && other.labelTextStyle == labelTextStyle
       && other.iconTheme == iconTheme
       && other.labelBehavior == labelBehavior
-      && other.overlayColor == overlayColor;
+      && other.overlayColor == overlayColor
+      && other.safeAreaVerticalOffset == safeAreaVerticalOffset;
   }
 
   @override
@@ -200,6 +209,7 @@ class NavigationBarThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<MaterialStateProperty<IconThemeData?>>('iconTheme', iconTheme, defaultValue: null));
     properties.add(DiagnosticsProperty<NavigationDestinationLabelBehavior>('labelBehavior', labelBehavior, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('overlayColor', overlayColor, defaultValue: null));
+    properties.add(DoubleProperty('safeAreaVerticalOffset', safeAreaVerticalOffset, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -1228,7 +1228,6 @@ void main() {
       )
     );
 
-
     expect(tester.getSize(find.byType(NavigationBar)).height, 80.0 + 34.0 - 12.0);
     expect(
       tester.getSize(find.descendant(
@@ -1260,7 +1259,6 @@ void main() {
       )
     );
 
-
     expect(tester.getSize(find.byType(NavigationBar)).height, 56.0 + 34.0 - 12.0);
     expect(
       tester.getSize(find.descendant(
@@ -1274,7 +1272,6 @@ void main() {
     safeArea = tester.widget<SafeArea>(findSafeArea);
     expect(safeArea.minimum.bottom, 34.0 - 12.0);
   });
-
 
   group('Material 2', () {
     // These tests are only relevant for Material 2. Once Material 2

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -1180,6 +1180,102 @@ void main() {
     );
   });
 
+  testWidgets('safeAreaVerticalOffset changes the height of the safe area', (WidgetTester tester) async {
+    Widget buildNavigationBar({double? safeAreaVerticalOffset, double? height}) {
+      return MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: NavigationBar(
+          height: height,
+          safeAreaVerticalOffset: safeAreaVerticalOffset,
+          destinations: const <Widget>[
+            NavigationDestination(
+              icon: IconWithRandomColor(icon: Icons.ac_unit),
+              label: 'AC',
+            ),
+            NavigationDestination(
+              icon: IconWithRandomColor(icon: Icons.access_alarm),
+              label: 'Alarm',
+            ),
+          ])
+        ),
+      );
+    }
+
+    // Default height of the nav bar should be the safe area height(34.0) + the default bar height(80.0)
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(bottom: 34.0),
+        ),
+        child: buildNavigationBar(),
+      )
+    );
+
+    expect(tester.getSize(find.byType(NavigationBar)).height, 80.0 + 34.0);
+
+    // With safeAreaVerticalOffset setting to -12, the bar itset has height of 80.0,
+    // and the overall bar height is 80.0 + 34.0 - 12.0.
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(bottom: 34.0),
+        ),
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return buildNavigationBar(safeAreaVerticalOffset: -12.0);
+          }
+        ),
+      )
+    );
+
+
+    expect(tester.getSize(find.byType(NavigationBar)).height, 80.0 + 34.0 - 12.0);
+    expect(
+      tester.getSize(find.descendant(
+        of: find.byType(NavigationBar),
+        matching: find.descendant(of: find.byType(SafeArea), matching: find.byType(SizedBox).first),
+      )).height,
+      80.0,
+    );
+
+    Finder findSafeArea = find.byType(SafeArea);
+    SafeArea safeArea = tester.widget<SafeArea>(findSafeArea);
+    expect(safeArea.minimum.bottom, 34.0 - 12.0);
+
+    // With safeAreaVerticalOffset setting to -12 and the bar itset setting to 56.0,
+    // and the overall bar height is 56.0 + 34.0 - 12.0.
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(bottom: 34.0),
+        ),
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return buildNavigationBar(
+              height: 56.0,
+              safeAreaVerticalOffset: -12.0
+            );
+          }
+        ),
+      )
+    );
+
+
+    expect(tester.getSize(find.byType(NavigationBar)).height, 56.0 + 34.0 - 12.0);
+    expect(
+      tester.getSize(find.descendant(
+        of: find.byType(NavigationBar),
+        matching: find.descendant(of: find.byType(SafeArea), matching: find.byType(SizedBox).first),
+      )).height,
+      56.0,
+    );
+
+    findSafeArea = find.byType(SafeArea);
+    safeArea = tester.widget<SafeArea>(findSafeArea);
+    expect(safeArea.minimum.bottom, 34.0 - 12.0);
+  });
+
+
   group('Material 2', () {
     // These tests are only relevant for Material 2. Once Material 2
     // support is deprecated and the APIs are removed, these tests


### PR DESCRIPTION
This PR is to add a new property `safeAreaVerticalOffset` so the bottom padding of the safe area in the navigation bar can be adjusted to generate a `NavigationBar` with a smaller overall height and make sure the nav bar can be tappable.

When we change `NavigationBar.height` to a smaller value, there might be an overlap with the `SafeArea` and it will cause partial of the nav bar not to be tappable. This PR helps to fix the issue by making the bottom padding of the safe area adjustable.

Fixes: b/349044954

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
