### PR TITLE
Make `CupertinoDialogAction` not tappable when disabled

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -2113,7 +2113,9 @@ class _PressableActionButtonState extends State<_PressableActionButton> {
   @override
   Widget build(BuildContext context) {
     return _ActionButtonParentDataWidget(
-      isPressed: _isPressed,
+      isPressed: widget.child is CupertinoDialogAction
+        ? (widget.child as CupertinoDialogAction).enabled && _isPressed
+        : _isPressed,
       child: MergeSemantics(
         // TODO(mattcarroll): Button press dynamics need overhaul for iOS:
         // https://github.com/flutter/flutter/issues/19786

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -854,15 +854,18 @@ void main() {
           return CupertinoAlertDialog(
             title: const Text('The Title'),
             content: const Text('The message'),
-            actions: const <Widget>[
+            actions: <Widget>[
               CupertinoDialogAction(
-                child: Text('Option 1'),
+                child: const Text('Option 1'),
+                onPressed: (){ },
               ),
               CupertinoDialogAction(
-                child: Text('Option 2'),
+                child: const Text('Option 2'),
+                onPressed: (){ },
               ),
               CupertinoDialogAction(
-                child: Text('Option 3'),
+                child: const Text('Option 3'),
+                onPressed: (){ },
               ),
             ],
             scrollController: scrollController,
@@ -897,9 +900,9 @@ void main() {
     );
 
     // Before pressing the button, verify following expectations:
-    // - Background includes the button that will be pressed
-    // - Background excludes the divider above and below the button that will be pressed
-    // - Pressed button background does NOT include the button that will be pressed
+    // - Background includes the button.
+    // - Background excludes the divider above and below the button.
+    // - Pressed button background does NOT include the button.
     expect(actionsSectionBox, paints
       ..path(
         color: normalButtonBackgroundColor,
@@ -921,12 +924,12 @@ void main() {
 
     // Press down on the button.
     final TestGesture gesture = await tester.press(find.widgetWithText(CupertinoDialogAction, 'Option 2'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     // While pressing the button, verify following expectations:
-    // - Background excludes the pressed button
-    // - Background includes the divider above and below the pressed button
-    // - Pressed button background includes the pressed
+    // - Background excludes the pressed button.
+    // - Background includes the divider above and below the pressed button.
+    // - Pressed button background includes the button.
     expect(actionsSectionBox, paints
       ..path(
         color: normalButtonBackgroundColor,
@@ -954,6 +957,102 @@ void main() {
 
     // We must explicitly cause an "up" gesture to avoid a crash.
     // TODO(mattcarroll): remove this call, https://github.com/flutter/flutter/issues/19540
+    await gesture.up();
+  });
+
+  testWidgets('Disabled button does not change appearance on press', (WidgetTester tester) async {
+    const Color normalButtonBackgroundColor = Color(0xCCF2F2F2);
+    const Color pressedButtonBackgroundColor = Color(0xFFE1E1E1);
+    const double dividerThickness = 0.3;
+
+    await tester.pumpWidget(
+      createAppWithButtonThatLaunchesDialog(
+        dialogBuilder: (BuildContext context) {
+          return const CupertinoAlertDialog(
+            title: Text('The Title'),
+            content: Text('The message'),
+            actions: <Widget>[
+              CupertinoDialogAction(
+                child: Text('Option 1'),
+              ),
+              CupertinoDialogAction(
+                child: Text('Option 2'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+
+    await tester.tap(find.text('Go'));
+    await tester.pump();
+
+    final RenderBox firstButtonBox = findActionButtonRenderBoxByTitle(tester, 'Option 1');
+    final RenderBox secondButtonBox = findActionButtonRenderBoxByTitle(tester, 'Option 2');
+    final RenderBox actionsSectionBox = findScrollableActionsSectionRenderBox(tester);
+
+    final Offset pressedButtonCenter = Offset(
+      secondButtonBox.size.width / 2.0,
+      firstButtonBox.size.height + dividerThickness + (secondButtonBox.size.height / 2.0),
+    );
+    final Offset topDividerCenter = Offset(
+      secondButtonBox.size.width / 2.0,
+      firstButtonBox.size.height + (0.5 * dividerThickness),
+    );
+    final Offset bottomDividerCenter = Offset(
+      secondButtonBox.size.width / 2.0,
+      firstButtonBox.size.height +
+          dividerThickness +
+          secondButtonBox.size.height +
+          (0.5 * dividerThickness),
+    );
+
+    // Before pressing the button, verify the following expectations:
+    // - Background includes the button.
+    // - Background excludes the divider above and below the button.
+    // - Pressed button background does NOT include the button.
+    expect(actionsSectionBox, paints
+      ..path(
+        color: normalButtonBackgroundColor,
+        includes: <Offset>[
+          pressedButtonCenter,
+        ],
+        excludes: <Offset>[
+          topDividerCenter,
+          bottomDividerCenter,
+        ],
+      )
+      ..path(
+        color: pressedButtonBackgroundColor,
+        excludes: <Offset>[
+          pressedButtonCenter,
+        ],
+      ),
+    );
+
+    // Press down on the button.
+    final TestGesture gesture = await tester.press(find.widgetWithText(CupertinoDialogAction, 'Option 2'));
+    await tester.pumpAndSettle();
+
+    // While pressing the button, verify that the background remains the same.
+    expect(actionsSectionBox, paints
+      ..path(
+        color: normalButtonBackgroundColor,
+        includes: <Offset>[
+          pressedButtonCenter,
+        ],
+        excludes: <Offset>[
+          topDividerCenter,
+          bottomDividerCenter,
+        ],
+      )
+      ..path(
+        color: pressedButtonBackgroundColor,
+        excludes: <Offset>[
+          pressedButtonCenter,
+        ],
+      ),
+    );
     await gesture.up();
   });
 


### PR DESCRIPTION
Currently, when `CupertinoAlertDialog` has an action (typically a `CupertinoDialogAction`, although can be any widget type) that is disabled, tapping on the action button still makes it change opacity, thus looking tappable:

https://github.com/flutter/flutter/assets/77553258/89410b92-f224-45b0-9023-51124de82298

While there is a dedicated class for `CupertinoAlertDialog` actions (`CupertinoDialogAction` button), actions can be any widget type.

Solving this issue is tricky because the actions are decoupled from the dialog box background. For example, if a `CupertinoDialogAction` is disabled, it's text will be shown at a lower opacity, as in the video recording above. However, the box/background behind it (which changes its opacity on tap) currently has no way of knowing that the action contained within is disabled.

There are two ways I see to fix this problem:

### Option A
Do not allow the action button box/background to be pressed if the action is a `CupertinoDialogAction` that is disabled:

```dart
      isPressed: widget.child is CupertinoDialogAction
        ? (widget.child as CupertinoDialogAction).enabled && _isPressed
        : _isPressed,
```

But Flutter is strongly against this pattern of programming, as a solution should not be conditional on the type of the child widget.

### Option B
Do not allow the action button box/background to be pressed if the action has an `onPressed` property set to null:

```dart
   bool canBePressed;
   try {
     canBePressed = (widget.child as dynamic).onChanged != null;
   } catch(_){
     canBePressed = true;
   }
...
isPressed: canBePressed && _isPressed,
```

but not only does the use of `try...catch` and `dynamic` feel problematic, but if the user makes a custom widget that does not mean the action is disabled if `onPressed` is set to null, this behavior will feel erroneous.

Considering `CupertinoDialogAction` is the recommended action to be used in `CupertinoAlertDialog`, and it has a child property itself that can serve as a wrapper for any custom widgets, should Option A be the recommended way to go? Or are there any alternatives/refactoring that give a better solution? Open to any ideas.

Note: 'action' and 'widget' are used interchangeably.

### Desired Result:

https://github.com/flutter/flutter/assets/77553258/c94b5492-f3ff-43e2-a8f2-55a9538b026a


Issue to fix: #107371 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
