### PR TITLE
Reland fix InputDecorator hint default text style on M3

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2061,7 +2061,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final TextStyle? style = MaterialStateProperty.resolveAs(decoration.hintStyle, materialState)
       ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.hintStyle, materialState);
 
-    return themeData.textTheme.titleMedium!
+    return (themeData.useMaterial3 ? themeData.textTheme.bodyLarge! : themeData.textTheme.titleMedium!)
       .merge(widget.baseStyle)
       .merge(defaultStyle)
       .merge(style);

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2878,8 +2878,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -2943,8 +2942,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurface.withOpacity(0.38);
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3008,8 +3006,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3073,8 +3070,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3138,8 +3134,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3347,8 +3342,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3460,8 +3454,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3525,8 +3518,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurface.withOpacity(0.38);
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3590,8 +3582,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3655,8 +3646,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3720,8 +3710,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });
@@ -3927,8 +3916,7 @@ void main() {
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           final Color expectedColor = theme.colorScheme.onSurfaceVariant;
-          // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
-          final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
+          final TextStyle expectedStyle = theme.textTheme.bodyLarge!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
         });
       });


### PR DESCRIPTION
## Description

This PR is a partial reland of https://github.com/flutter/flutter/pull/148944 which was reverted in https://github.com/flutter/flutter/pull/149448.
It makes the `InputDecoration.hintText` font style compliant with the M3 spec.

(First part of the reland was merged in https://github.com/flutter/flutter/pull/150278)

## Related Issue

Fixes https://github.com/flutter/flutter/issues/148787.

## Tests

Updates several tests.