### PR TITLE
Add 'direction' allow to 'SegmentedButton' vertically

### DIFF
--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -1134,9 +1134,8 @@ class _RenderSegmentedButton<T> extends RenderBox
           final Offset bottom = Offset(dividerPos, borderRect.bottom);
           context.canvas.drawLine(top, bottom, divider.toPaint());
         } else if (direction == Axis.vertical) {
-          final topPosition = childRect.top;
-          final Offset start = Offset(borderRect.left, topPosition);
-          final Offset end = Offset(borderRect.right, topPosition);
+          final Offset start = Offset(borderRect.left, childRect.top);
+          final Offset end = Offset(borderRect.right, childRect.top);
           context.canvas.drawLine(start, end, divider.toPaint());
         }
       }

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -134,6 +134,7 @@ class SegmentedButton<T> extends StatefulWidget {
     this.style,
     this.showSelectedIcon = true,
     this.selectedIcon,
+    this.direction = Axis.horizontal,
   })  : assert(segments.length > 0),
         assert(selected.length > 0 || emptySelectionAllowed),
         assert(selected.length < 2 || multiSelectionEnabled);
@@ -146,6 +147,11 @@ class SegmentedButton<T> extends StatefulWidget {
   /// If you need more than five options, consider using [FilterChip] or
   /// [ChoiceChip] widgets.
   final List<ButtonSegment<T>> segments;
+
+  /// How the [segments] get aligned, by default its [Axis.horizontal]
+  /// if [Axis.vertical] the segments buttons will aligned in the "y" axis
+  /// and the first item in [segments] will be on the top.
+  final Axis direction;
 
   /// The set of [ButtonSegment.value]s that indicate which [segments] are
   /// selected.
@@ -285,20 +291,30 @@ class SegmentedButton<T> extends StatefulWidget {
     InteractiveInkFeatureFactory? splashFactory,
   }) {
     final MaterialStateProperty<Color?>? foregroundColorProp =
-      (foregroundColor == null && disabledForegroundColor == null && selectedForegroundColor == null)
-        ? null
-        : _SegmentButtonDefaultColor(foregroundColor, disabledForegroundColor, selectedForegroundColor);
+        (foregroundColor == null &&
+                disabledForegroundColor == null &&
+                selectedForegroundColor == null)
+            ? null
+            : _SegmentButtonDefaultColor(foregroundColor,
+                disabledForegroundColor, selectedForegroundColor);
     final MaterialStateProperty<Color?>? backgroundColorProp =
-      (backgroundColor == null && disabledBackgroundColor == null && selectedBackgroundColor == null)
-        ? null
-        : _SegmentButtonDefaultColor(backgroundColor, disabledBackgroundColor, selectedBackgroundColor);
-    final MaterialStateProperty<Color?>? overlayColorProp = (foregroundColor == null &&
-      selectedForegroundColor == null && overlayColor == null)
-        ? null
-        : switch (overlayColor) {
-            (final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
-            _ => _SegmentedButtonDefaultsM3.resolveStateColor(foregroundColor, selectedForegroundColor, overlayColor),
-          };
+        (backgroundColor == null &&
+                disabledBackgroundColor == null &&
+                selectedBackgroundColor == null)
+            ? null
+            : _SegmentButtonDefaultColor(backgroundColor,
+                disabledBackgroundColor, selectedBackgroundColor);
+    final MaterialStateProperty<Color?>? overlayColorProp =
+        (foregroundColor == null &&
+                selectedForegroundColor == null &&
+                overlayColor == null)
+            ? null
+            : switch (overlayColor) {
+                (final Color overlayColor) when overlayColor.value == 0 =>
+                  const MaterialStatePropertyAll<Color?>(Colors.transparent),
+                _ => _SegmentedButtonDefaultsM3.resolveStateColor(
+                    foregroundColor, selectedForegroundColor, overlayColor),
+              };
     return TextButton.styleFrom(
       textStyle: textStyle,
       shadowColor: shadowColor,
@@ -393,13 +409,15 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
 
   /// Controllers for the [ButtonSegment]s.
   @visibleForTesting
-  final Map<ButtonSegment<T>, MaterialStatesController> statesControllers = <ButtonSegment<T>, MaterialStatesController>{};
+  final Map<ButtonSegment<T>, MaterialStatesController> statesControllers =
+      <ButtonSegment<T>, MaterialStatesController>{};
 
   @override
   void didUpdateWidget(covariant SegmentedButton<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget != widget) {
-      statesControllers.removeWhere((ButtonSegment<T> segment, MaterialStatesController controller) {
+      statesControllers.removeWhere(
+          (ButtonSegment<T> segment, MaterialStatesController controller) {
         if (widget.segments.contains(segment)) {
           return false;
         } else {
@@ -414,16 +432,19 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
     if (!_enabled) {
       return;
     }
-    final bool onlySelectedSegment = widget.selected.length == 1 && widget.selected.contains(segmentValue);
-    final bool validChange = widget.emptySelectionAllowed || !onlySelectedSegment;
+    final bool onlySelectedSegment =
+        widget.selected.length == 1 && widget.selected.contains(segmentValue);
+    final bool validChange =
+        widget.emptySelectionAllowed || !onlySelectedSegment;
     if (validChange) {
-      final bool toggle = widget.multiSelectionEnabled || (widget.emptySelectionAllowed && onlySelectedSegment);
+      final bool toggle = widget.multiSelectionEnabled ||
+          (widget.emptySelectionAllowed && onlySelectedSegment);
       final Set<T> pressedSegment = <T>{segmentValue};
       late final Set<T> updatedSelection;
       if (toggle) {
         updatedSelection = widget.selected.contains(segmentValue)
-          ? widget.selected.difference(pressedSegment)
-          : widget.selected.union(pressedSegment);
+            ? widget.selected.difference(pressedSegment)
+            : widget.selected.union(pressedSegment);
       } else {
         updatedSelection = pressedSegment;
       }
@@ -436,23 +457,30 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
   @override
   Widget build(BuildContext context) {
     final SegmentedButtonThemeData theme = SegmentedButtonTheme.of(context);
-    final SegmentedButtonThemeData defaults = _SegmentedButtonDefaultsM3(context);
-    final TextDirection direction = Directionality.of(context);
+    final SegmentedButtonThemeData defaults =
+        _SegmentedButtonDefaultsM3(context);
+    final TextDirection textDirection = Directionality.of(context);
 
     const Set<MaterialState> enabledState = <MaterialState>{};
-    const Set<MaterialState> disabledState = <MaterialState>{ MaterialState.disabled };
-    final Set<MaterialState> currentState = _enabled ? enabledState : disabledState;
+    const Set<MaterialState> disabledState = <MaterialState>{
+      MaterialState.disabled
+    };
+    final Set<MaterialState> currentState =
+        _enabled ? enabledState : disabledState;
 
     P? effectiveValue<P>(P? Function(ButtonStyle? style) getProperty) {
-      late final P? widgetValue  = getProperty(widget.style);
-      late final P? themeValue   = getProperty(theme.style);
+      late final P? widgetValue = getProperty(widget.style);
+      late final P? themeValue = getProperty(theme.style);
       late final P? defaultValue = getProperty(defaults.style);
       return widgetValue ?? themeValue ?? defaultValue;
     }
 
-    P? resolve<P>(MaterialStateProperty<P>? Function(ButtonStyle? style) getProperty, [Set<MaterialState>? states]) {
+    P? resolve<P>(
+        MaterialStateProperty<P>? Function(ButtonStyle? style) getProperty,
+        [Set<MaterialState>? states]) {
       return effectiveValue(
-        (ButtonStyle? style) => getProperty(style)?.resolve(states ?? currentState),
+        (ButtonStyle? style) =>
+            getProperty(style)?.resolve(states ?? currentState),
       );
     }
 
@@ -467,7 +495,8 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
         padding: style?.padding,
         iconColor: style?.iconColor,
         iconSize: style?.iconSize,
-        shape: const MaterialStatePropertyAll<OutlinedBorder>(RoundedRectangleBorder()),
+        shape: const MaterialStatePropertyAll<OutlinedBorder>(
+            RoundedRectangleBorder()),
         mouseCursor: style?.mouseCursor,
         visualDensity: style?.visualDensity,
         tapTargetSize: style?.tapTargetSize,
@@ -479,43 +508,50 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
     }
 
     final ButtonStyle segmentStyle = segmentStyleFor(widget.style);
-    final ButtonStyle segmentThemeStyle = segmentStyleFor(theme.style).merge(segmentStyleFor(defaults.style));
+    final ButtonStyle segmentThemeStyle =
+        segmentStyleFor(theme.style).merge(segmentStyleFor(defaults.style));
     final Widget? selectedIcon = widget.showSelectedIcon
-      ? widget.selectedIcon ?? theme.selectedIcon ?? defaults.selectedIcon
-      : null;
+        ? widget.selectedIcon ?? theme.selectedIcon ?? defaults.selectedIcon
+        : null;
 
     Widget buttonFor(ButtonSegment<T> segment) {
-      final Widget label = segment.label ?? segment.icon ?? const SizedBox.shrink();
+      final Widget label =
+          segment.label ?? segment.icon ?? const SizedBox.shrink();
       final bool segmentSelected = widget.selected.contains(segment.value);
       final Widget? icon = (segmentSelected && widget.showSelectedIcon)
-        ? selectedIcon
-        : segment.label != null
-          ? segment.icon
-          : null;
-      final MaterialStatesController controller = statesControllers.putIfAbsent(segment, () => MaterialStatesController());
+          ? selectedIcon
+          : segment.label != null
+              ? segment.icon
+              : null;
+      final MaterialStatesController controller = statesControllers.putIfAbsent(
+          segment, () => MaterialStatesController());
       controller.update(MaterialState.selected, segmentSelected);
 
       final Widget button = icon != null
-        ? TextButton.icon(
-            style: segmentStyle,
-            statesController: controller,
-            onPressed: (_enabled && segment.enabled) ? () => _handleOnPressed(segment.value) : null,
-            icon: icon,
-            label: label,
-          )
-        : TextButton(
-            style: segmentStyle,
-            statesController: controller,
-            onPressed: (_enabled && segment.enabled) ? () => _handleOnPressed(segment.value) : null,
-            child: label,
-          );
+          ? TextButton.icon(
+              style: segmentStyle,
+              statesController: controller,
+              onPressed: (_enabled && segment.enabled)
+                  ? () => _handleOnPressed(segment.value)
+                  : null,
+              icon: icon,
+              label: label,
+            )
+          : TextButton(
+              style: segmentStyle,
+              statesController: controller,
+              onPressed: (_enabled && segment.enabled)
+                  ? () => _handleOnPressed(segment.value)
+                  : null,
+              child: label,
+            );
 
       final Widget buttonWithTooltip = segment.tooltip != null
-        ? Tooltip(
-            message: segment.tooltip,
-            child: button,
-          )
-        : button;
+          ? Tooltip(
+              message: segment.tooltip,
+              child: button,
+            )
+          : button;
 
       return MergeSemantics(
         child: Semantics(
@@ -526,35 +562,63 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
       );
     }
 
-    final OutlinedBorder resolvedEnabledBorder = resolve<OutlinedBorder?>((ButtonStyle? style) => style?.shape, disabledState) ?? const RoundedRectangleBorder();
-    final OutlinedBorder resolvedDisabledBorder = resolve<OutlinedBorder?>((ButtonStyle? style) => style?.shape, disabledState)?? const RoundedRectangleBorder();
-    final BorderSide enabledSide = resolve<BorderSide?>((ButtonStyle? style) => style?.side, enabledState) ?? BorderSide.none;
-    final BorderSide disabledSide = resolve<BorderSide?>((ButtonStyle? style) => style?.side, disabledState) ?? BorderSide.none;
-    final OutlinedBorder enabledBorder = resolvedEnabledBorder.copyWith(side: enabledSide);
-    final OutlinedBorder disabledBorder = resolvedDisabledBorder.copyWith(side: disabledSide);
-    final VisualDensity resolvedVisualDensity = segmentStyle.visualDensity ?? segmentThemeStyle.visualDensity ?? Theme.of(context).visualDensity;
-    final EdgeInsetsGeometry resolvedPadding = resolve<EdgeInsetsGeometry?>((ButtonStyle? style) => style?.padding, enabledState) ?? EdgeInsets.zero;
-    final MaterialTapTargetSize resolvedTapTargetSize = segmentStyle.tapTargetSize ?? segmentThemeStyle.tapTargetSize ?? Theme.of(context).materialTapTargetSize;
-    final double fontSize = resolve<TextStyle?>((ButtonStyle? style) => style?.textStyle, enabledState)?.fontSize ?? 20.0;
+    final OutlinedBorder resolvedEnabledBorder = resolve<OutlinedBorder?>(
+            (ButtonStyle? style) => style?.shape, disabledState) ??
+        const RoundedRectangleBorder();
+    final OutlinedBorder resolvedDisabledBorder = resolve<OutlinedBorder?>(
+            (ButtonStyle? style) => style?.shape, disabledState) ??
+        const RoundedRectangleBorder();
+    final BorderSide enabledSide = resolve<BorderSide?>(
+            (ButtonStyle? style) => style?.side, enabledState) ??
+        BorderSide.none;
+    final BorderSide disabledSide = resolve<BorderSide?>(
+            (ButtonStyle? style) => style?.side, disabledState) ??
+        BorderSide.none;
+    final OutlinedBorder enabledBorder =
+        resolvedEnabledBorder.copyWith(side: enabledSide);
+    final OutlinedBorder disabledBorder =
+        resolvedDisabledBorder.copyWith(side: disabledSide);
+    final VisualDensity resolvedVisualDensity = segmentStyle.visualDensity ??
+        segmentThemeStyle.visualDensity ??
+        Theme.of(context).visualDensity;
+    final EdgeInsetsGeometry resolvedPadding = resolve<EdgeInsetsGeometry?>(
+            (ButtonStyle? style) => style?.padding, enabledState) ??
+        EdgeInsets.zero;
+    final MaterialTapTargetSize resolvedTapTargetSize =
+        segmentStyle.tapTargetSize ??
+            segmentThemeStyle.tapTargetSize ??
+            Theme.of(context).materialTapTargetSize;
+    final double fontSize = resolve<TextStyle?>(
+                (ButtonStyle? style) => style?.textStyle, enabledState)
+            ?.fontSize ??
+        20.0;
 
     final List<Widget> buttons = widget.segments.map(buttonFor).toList();
 
     final Offset densityAdjustment = resolvedVisualDensity.baseSizeAdjustment;
     const double textButtonMinHeight = 40.0;
 
-    final double adjustButtonMinHeight = textButtonMinHeight + densityAdjustment.dy;
-    final double effectiveVerticalPadding = resolvedPadding.vertical + densityAdjustment.dy * 2;
-    final double effectedButtonHeight = max(fontSize + effectiveVerticalPadding, adjustButtonMinHeight);
+    final double adjustButtonMinHeight =
+        textButtonMinHeight + densityAdjustment.dy;
+    final double effectiveVerticalPadding =
+        resolvedPadding.vertical + densityAdjustment.dy * 2;
+    final double effectedButtonHeight =
+        max(fontSize + effectiveVerticalPadding, adjustButtonMinHeight);
     final double tapTargetVerticalPadding = switch (resolvedTapTargetSize) {
       MaterialTapTargetSize.shrinkWrap => 0.0,
-      MaterialTapTargetSize.padded => max(0, kMinInteractiveDimension + densityAdjustment.dy - effectedButtonHeight)
+      MaterialTapTargetSize.padded => max(
+          0,
+          kMinInteractiveDimension +
+              densityAdjustment.dy -
+              effectedButtonHeight)
     };
 
     return Material(
       type: MaterialType.transparency,
       elevation: resolve<double?>((ButtonStyle? style) => style?.elevation)!,
       shadowColor: resolve<Color?>((ButtonStyle? style) => style?.shadowColor),
-      surfaceTintColor: resolve<Color?>((ButtonStyle? style) => style?.surfaceTintColor),
+      surfaceTintColor:
+          resolve<Color?>((ButtonStyle? style) => style?.surfaceTintColor),
       child: TextButtonTheme(
         data: TextButtonThemeData(style: segmentThemeStyle),
         child: Padding(
@@ -564,7 +628,32 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
             segments: widget.segments,
             enabledBorder: _enabled ? enabledBorder : disabledBorder,
             disabledBorder: disabledBorder,
-            direction: direction,
+            direction: widget.direction,
+            textDirection: textDirection,
+            isExpanded: widget.expandedInsets != null,
+            children: buttons,
+          ),
+        ),
+      ),
+    );
+
+    return Material(
+      type: MaterialType.transparency,
+      elevation: resolve<double?>((ButtonStyle? style) => style?.elevation)!,
+      shadowColor: resolve<Color?>((ButtonStyle? style) => style?.shadowColor),
+      surfaceTintColor:
+          resolve<Color?>((ButtonStyle? style) => style?.surfaceTintColor),
+      child: TextButtonTheme(
+        data: TextButtonThemeData(style: segmentThemeStyle),
+        child: Padding(
+          padding: widget.expandedInsets ?? EdgeInsets.zero,
+          child: _SegmentedButtonRenderWidget<T>(
+            tapTargetVerticalPadding: tapTargetVerticalPadding,
+            segments: widget.segments,
+            enabledBorder: _enabled ? enabledBorder : disabledBorder,
+            disabledBorder: disabledBorder,
+            direction: widget.direction,
+            textDirection: textDirection,
             isExpanded: widget.expandedInsets != null,
             children: buttons,
           ),
@@ -575,7 +664,8 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
 
   @override
   void dispose() {
-    for (final MaterialStatesController controller in statesControllers.values) {
+    for (final MaterialStatesController controller
+        in statesControllers.values) {
       controller.dispose();
     }
     super.dispose();
@@ -583,7 +673,8 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
 }
 
 @immutable
-class _SegmentButtonDefaultColor extends MaterialStateProperty<Color?> with Diagnosticable {
+class _SegmentButtonDefaultColor extends MaterialStateProperty<Color?>
+    with Diagnosticable {
   _SegmentButtonDefaultColor(this.color, this.disabled, this.selected);
 
   final Color? color;
@@ -609,6 +700,7 @@ class _SegmentedButtonRenderWidget<T> extends MultiChildRenderObjectWidget {
     required this.enabledBorder,
     required this.disabledBorder,
     required this.direction,
+    required this.textDirection,
     required this.tapTargetVerticalPadding,
     required this.isExpanded,
     required super.children,
@@ -617,41 +709,48 @@ class _SegmentedButtonRenderWidget<T> extends MultiChildRenderObjectWidget {
   final List<ButtonSegment<T>> segments;
   final OutlinedBorder enabledBorder;
   final OutlinedBorder disabledBorder;
-  final TextDirection direction;
+  final Axis direction;
+  final TextDirection textDirection;
   final double tapTargetVerticalPadding;
   final bool isExpanded;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
     return _RenderSegmentedButton<T>(
-      segments: segments,
-      enabledBorder: enabledBorder,
-      disabledBorder: disabledBorder,
-      textDirection: direction,
-      tapTargetVerticalPadding: tapTargetVerticalPadding,
-      isExpanded: isExpanded,
-    );
+        segments: segments,
+        enabledBorder: enabledBorder,
+        disabledBorder: disabledBorder,
+        textDirection: textDirection,
+        tapTargetVerticalPadding: tapTargetVerticalPadding,
+        isExpanded: isExpanded,
+        direction: direction);
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderSegmentedButton<T> renderObject) {
+  void updateRenderObject(
+      BuildContext context, _RenderSegmentedButton<T> renderObject) {
     renderObject
       ..segments = segments
       ..enabledBorder = enabledBorder
       ..disabledBorder = disabledBorder
-      ..textDirection = direction;
+      ..direction = direction
+      ..textDirection = textDirection;
   }
 }
 
-class _SegmentedButtonContainerBoxParentData extends ContainerBoxParentData<RenderBox> {
+class _SegmentedButtonContainerBoxParentData
+    extends ContainerBoxParentData<RenderBox> {
   RRect? surroundingRect;
 }
 
 typedef _NextChild = RenderBox? Function(RenderBox child);
 
-class _RenderSegmentedButton<T> extends RenderBox with
-     ContainerRenderObjectMixin<RenderBox, ContainerBoxParentData<RenderBox>>,
-     RenderBoxContainerDefaultsMixin<RenderBox, ContainerBoxParentData<RenderBox>> {
+class _RenderSegmentedButton<T> extends RenderBox
+    with
+        ContainerRenderObjectMixin<RenderBox,
+            ContainerBoxParentData<RenderBox>>,
+        RenderBoxContainerDefaultsMixin<RenderBox,
+            ContainerBoxParentData<RenderBox>> {
   _RenderSegmentedButton({
     required List<ButtonSegment<T>> segments,
     required OutlinedBorder enabledBorder,
@@ -659,12 +758,14 @@ class _RenderSegmentedButton<T> extends RenderBox with
     required TextDirection textDirection,
     required double tapTargetVerticalPadding,
     required bool isExpanded,
-  }) : _segments = segments,
-       _enabledBorder = enabledBorder,
-       _disabledBorder = disabledBorder,
-       _textDirection = textDirection,
-       _tapTargetVerticalPadding = tapTargetVerticalPadding,
-       _isExpanded = isExpanded;
+    required Axis direction,
+  })  : _segments = segments,
+        _enabledBorder = enabledBorder,
+        _disabledBorder = disabledBorder,
+        _textDirection = textDirection,
+        _direction = direction,
+        _tapTargetVerticalPadding = tapTargetVerticalPadding,
+        _isExpanded = isExpanded;
 
   List<ButtonSegment<T>> get segments => _segments;
   List<ButtonSegment<T>> _segments;
@@ -706,6 +807,16 @@ class _RenderSegmentedButton<T> extends RenderBox with
     markNeedsLayout();
   }
 
+  Axis get direction => _direction;
+  Axis _direction;
+  set direction(Axis value) {
+    if (value == _direction) {
+      return;
+    }
+    _direction = value;
+    markNeedsLayout();
+  }
+
   double get tapTargetVerticalPadding => _tapTargetVerticalPadding;
   double _tapTargetVerticalPadding;
   set tapTargetVerticalPadding(double value) {
@@ -731,7 +842,8 @@ class _RenderSegmentedButton<T> extends RenderBox with
     RenderBox? child = firstChild;
     double minWidth = 0.0;
     while (child != null) {
-      final _SegmentedButtonContainerBoxParentData childParentData = child.parentData! as _SegmentedButtonContainerBoxParentData;
+      final _SegmentedButtonContainerBoxParentData childParentData =
+          child.parentData! as _SegmentedButtonContainerBoxParentData;
       final double childWidth = child.getMinIntrinsicWidth(height);
       minWidth = math.max(minWidth, childWidth);
       child = childParentData.nextSibling;
@@ -744,7 +856,8 @@ class _RenderSegmentedButton<T> extends RenderBox with
     RenderBox? child = firstChild;
     double maxWidth = 0.0;
     while (child != null) {
-      final _SegmentedButtonContainerBoxParentData childParentData = child.parentData! as _SegmentedButtonContainerBoxParentData;
+      final _SegmentedButtonContainerBoxParentData childParentData =
+          child.parentData! as _SegmentedButtonContainerBoxParentData;
       final double childWidth = child.getMaxIntrinsicWidth(height);
       maxWidth = math.max(maxWidth, childWidth);
       child = childParentData.nextSibling;
@@ -757,7 +870,8 @@ class _RenderSegmentedButton<T> extends RenderBox with
     RenderBox? child = firstChild;
     double minHeight = 0.0;
     while (child != null) {
-      final _SegmentedButtonContainerBoxParentData childParentData = child.parentData! as _SegmentedButtonContainerBoxParentData;
+      final _SegmentedButtonContainerBoxParentData childParentData =
+          child.parentData! as _SegmentedButtonContainerBoxParentData;
       final double childHeight = child.getMinIntrinsicHeight(width);
       minHeight = math.max(minHeight, childHeight);
       child = childParentData.nextSibling;
@@ -770,7 +884,8 @@ class _RenderSegmentedButton<T> extends RenderBox with
     RenderBox? child = firstChild;
     double maxHeight = 0.0;
     while (child != null) {
-      final _SegmentedButtonContainerBoxParentData childParentData = child.parentData! as _SegmentedButtonContainerBoxParentData;
+      final _SegmentedButtonContainerBoxParentData childParentData =
+          child.parentData! as _SegmentedButtonContainerBoxParentData;
       final double childHeight = child.getMaxIntrinsicHeight(width);
       maxHeight = math.max(maxHeight, childHeight);
       child = childParentData.nextSibling;
@@ -790,22 +905,47 @@ class _RenderSegmentedButton<T> extends RenderBox with
     }
   }
 
-  void _layoutRects(_NextChild nextChild, RenderBox? leftChild, RenderBox? rightChild) {
+  void _layoutRects(
+      _NextChild nextChild, RenderBox? leftChild, RenderBox? rightChild) {
     RenderBox? child = leftChild;
     double start = 0.0;
+
     while (child != null) {
-      final _SegmentedButtonContainerBoxParentData childParentData = child.parentData! as _SegmentedButtonContainerBoxParentData;
-      final Offset childOffset = Offset(start, 0.0);
+      final _SegmentedButtonContainerBoxParentData childParentData =
+          child.parentData! as _SegmentedButtonContainerBoxParentData;
+      late final Offset childOffset;
+      if (direction == Axis.vertical) {
+        childOffset = Offset(0.0, start);
+      } else {
+        childOffset = Offset(start, 0.0);
+      }
       childParentData.offset = childOffset;
-      final Rect childRect = Rect.fromLTWH(start, 0.0, child.size.width, child.size.height);
+      late final Rect childRect;
+      if (direction == Axis.vertical) {
+        childRect = Rect.fromLTWH(0.0, childParentData.offset.dy,
+            child.size.width, child.size.height);
+      } else {
+        childRect =
+            Rect.fromLTWH(start, 0.0, child.size.width, child.size.height);
+      }
       final RRect rChildRect = RRect.fromRectAndCorners(childRect);
       childParentData.surroundingRect = rChildRect;
-      start += child.size.width;
+      if (direction == Axis.vertical) {
+        start += child.size.height;
+      } else {
+        start += child.size.width;
+      }
       child = nextChild(child);
     }
   }
 
   Size _calculateChildSize(BoxConstraints constraints) {
+    return direction == Axis.horizontal
+        ? _calculateHorizontalChildSize(constraints)
+        : _calculateVerticalChildSize(constraints);
+  }
+
+  Size _calculateHorizontalChildSize(BoxConstraints constraints) {
     double maxHeight = 0;
     RenderBox? child = firstChild;
     double childWidth;
@@ -814,7 +954,8 @@ class _RenderSegmentedButton<T> extends RenderBox with
     } else {
       childWidth = constraints.minWidth / childCount;
       while (child != null) {
-        childWidth = math.max(childWidth, child.getMaxIntrinsicWidth(double.infinity));
+        childWidth =
+            math.max(childWidth, child.getMaxIntrinsicWidth(double.infinity));
         child = childAfter(child);
       }
       childWidth = math.min(childWidth, constraints.maxWidth / childCount);
@@ -828,8 +969,37 @@ class _RenderSegmentedButton<T> extends RenderBox with
     return Size(childWidth, maxHeight);
   }
 
+  Size _calculateVerticalChildSize(BoxConstraints constraints) {
+    double maxWidth = 0;
+    RenderBox? child = firstChild;
+    double childHeight;
+    if (_isExpanded) {
+      childHeight = constraints.maxWidth / childCount;
+    } else {
+      childHeight = constraints.minWidth / childCount;
+      while (child != null) {
+        childHeight =
+            math.max(childHeight, child.getMaxIntrinsicHeight(double.infinity));
+        child = childAfter(child);
+      }
+      childHeight = math.min(childHeight, constraints.maxWidth / childCount);
+    }
+    child = firstChild;
+    while (child != null) {
+      final double boxHeight = child.getMaxIntrinsicWidth(maxWidth);
+      maxWidth = math.max(maxWidth, boxHeight);
+      child = childAfter(child);
+    }
+    return Size(maxWidth, childHeight);
+  }
+
   Size _computeOverallSizeFromChildSize(Size childSize) {
-    return constraints.constrain(Size(childSize.width * childCount, childSize.height));
+    if (direction == Axis.vertical) {
+      return constraints
+          .constrain(Size(childSize.width, childSize.height * childCount));
+    }
+    return constraints
+        .constrain(Size(childSize.width * childCount, childSize.height));
   }
 
   @override
@@ -839,13 +1009,17 @@ class _RenderSegmentedButton<T> extends RenderBox with
   }
 
   @override
-  double? computeDryBaseline(covariant BoxConstraints constraints, TextBaseline baseline) {
+  double? computeDryBaseline(
+      covariant BoxConstraints constraints, TextBaseline baseline) {
     final Size childSize = _calculateChildSize(constraints);
     final BoxConstraints childConstraints = BoxConstraints.tight(childSize);
 
     BaselineOffset baselineOffset = BaselineOffset.noBaseline;
-    for (RenderBox? child = firstChild; child != null; child = childAfter(child)) {
-      baselineOffset = baselineOffset.minOf(BaselineOffset(child.getDryBaseline(childConstraints, baseline)));
+    for (RenderBox? child = firstChild;
+        child != null;
+        child = childAfter(child)) {
+      baselineOffset = baselineOffset.minOf(
+          BaselineOffset(child.getDryBaseline(childConstraints, baseline)));
     }
     return baselineOffset.offset;
   }
@@ -886,9 +1060,10 @@ class _RenderSegmentedButton<T> extends RenderBox with
 
   @override
   void paint(PaintingContext context, Offset offset) {
-
-    final Rect borderRect = (offset + Offset(0, tapTargetVerticalPadding / 2)) & (Size(size.width, size.height - tapTargetVerticalPadding));
-    final Path borderClipPath = enabledBorder.getInnerPath(borderRect, textDirection: textDirection);
+    final Rect borderRect = (offset + Offset(0, tapTargetVerticalPadding / 2)) &
+        (Size(size.width, size.height - tapTargetVerticalPadding));
+    final Path borderClipPath =
+        enabledBorder.getInnerPath(borderRect, textDirection: textDirection);
     RenderBox? child = firstChild;
     RenderBox? previousChild;
     int index = 0;
@@ -896,10 +1071,14 @@ class _RenderSegmentedButton<T> extends RenderBox with
     Path? disabledClipPath;
 
     while (child != null) {
-      final _SegmentedButtonContainerBoxParentData childParentData = child.parentData! as _SegmentedButtonContainerBoxParentData;
-      final Rect childRect = childParentData.surroundingRect!.outerRect.shift(offset);
+      final _SegmentedButtonContainerBoxParentData childParentData =
+          child.parentData! as _SegmentedButtonContainerBoxParentData;
+      final Rect childRect =
+          childParentData.surroundingRect!.outerRect.shift(offset);
 
-      context.canvas..save()..clipPath(borderClipPath);
+      context.canvas
+        ..save()
+        ..clipPath(borderClipPath);
       context.paintChild(child, childParentData.offset + offset);
       context.canvas.restore();
 
@@ -907,36 +1086,59 @@ class _RenderSegmentedButton<T> extends RenderBox with
       final double segmentLeft;
       final double segmentRight;
       final double dividerPos;
-      final double borderOutset = math.max(enabledBorder.side.strokeOutset, disabledBorder.side.strokeOutset);
+      final double borderOutset = math.max(
+          enabledBorder.side.strokeOutset, disabledBorder.side.strokeOutset);
+
       switch (textDirection) {
         case TextDirection.rtl:
-          segmentLeft = child == lastChild ? borderRect.left - borderOutset : childRect.left;
-          segmentRight = child == firstChild ? borderRect.right + borderOutset : childRect.right;
+          segmentLeft = child == lastChild
+              ? borderRect.left - borderOutset
+              : childRect.left;
+          segmentRight = child == firstChild
+              ? borderRect.right + borderOutset
+              : childRect.right;
           dividerPos = segmentRight;
         case TextDirection.ltr:
-          segmentLeft = child == firstChild ? borderRect.left - borderOutset : childRect.left;
-          segmentRight = child == lastChild ? borderRect.right + borderOutset : childRect.right;
+          segmentLeft = child == firstChild
+              ? borderRect.left - borderOutset
+              : childRect.left;
+          segmentRight = child == lastChild
+              ? borderRect.right + borderOutset
+              : childRect.right;
           dividerPos = segmentLeft;
       }
+
       final Rect segmentClipRect = Rect.fromLTRB(
-        segmentLeft, borderRect.top - borderOutset,
-        segmentRight, borderRect.bottom + borderOutset);
+          segmentLeft,
+          borderRect.top - borderOutset,
+          segmentRight,
+          borderRect.top + borderOutset);
 
       // Add the clip rect to the appropriate border clip path
       if (segments[index].enabled) {
         enabledClipPath = (enabledClipPath ?? Path())..addRect(segmentClipRect);
       } else {
-        disabledClipPath = (disabledClipPath ?? Path())..addRect(segmentClipRect);
+        disabledClipPath = (disabledClipPath ?? Path())
+          ..addRect(segmentClipRect);
       }
 
       // Paint the divider between this segment and the previous one.
       if (previousChild != null) {
-        final BorderSide divider = segments[index - 1].enabled || segments[index].enabled
-          ? enabledBorder.side.copyWith(strokeAlign: 0.0)
-          : disabledBorder.side.copyWith(strokeAlign: 0.0);
-        final Offset top = Offset(dividerPos, borderRect.top);
-        final Offset bottom = Offset(dividerPos, borderRect.bottom);
-        context.canvas.drawLine(top, bottom, divider.toPaint());
+        final BorderSide divider =
+            segments[index - 1].enabled || segments[index].enabled
+                ? enabledBorder.side.copyWith(strokeAlign: 0.0)
+                : disabledBorder.side.copyWith(strokeAlign: 0.0);
+
+        if (direction == Axis.horizontal) {
+          final Offset top = Offset(dividerPos, borderRect.top);
+          final Offset bottom = Offset(dividerPos, borderRect.bottom);
+          context.canvas.drawLine(top, bottom, divider.toPaint());
+        } else if (direction == Axis.vertical) {
+          final topPosition = childRect.top;
+          final Offset start = Offset(borderRect.left, topPosition);
+          final Offset end = Offset(borderRect.right, topPosition);
+          context.canvas.drawLine(start, end, divider.toPaint());
+        }
       }
 
       previousChild = child;
@@ -947,25 +1149,35 @@ class _RenderSegmentedButton<T> extends RenderBox with
     // Paint the outer border for both disabled and enabled clip rect if needed.
     if (disabledClipPath == null) {
       // Just paint the enabled border with no clip.
-      enabledBorder.paint(context.canvas, borderRect, textDirection: textDirection);
+      enabledBorder.paint(context.canvas, borderRect,
+          textDirection: textDirection);
     } else if (enabledClipPath == null) {
       // Just paint the disabled border with no.
-      disabledBorder.paint(context.canvas, borderRect, textDirection: textDirection);
+      disabledBorder.paint(context.canvas, borderRect,
+          textDirection: textDirection);
     } else {
       // Paint both of them clipped appropriately for the children segments.
-      context.canvas..save()..clipPath(enabledClipPath);
-      enabledBorder.paint(context.canvas, borderRect, textDirection: textDirection);
-      context.canvas..restore()..save()..clipPath(disabledClipPath);
-      disabledBorder.paint(context.canvas, borderRect, textDirection: textDirection);
+      context.canvas
+        ..save()
+        ..clipPath(enabledClipPath);
+      enabledBorder.paint(context.canvas, borderRect,
+          textDirection: textDirection);
+      context.canvas
+        ..restore()
+        ..save()
+        ..clipPath(disabledClipPath);
+      disabledBorder.paint(context.canvas, borderRect,
+          textDirection: textDirection);
       context.canvas.restore();
     }
   }
 
   @override
-  bool hitTestChildren(BoxHitTestResult result, { required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
     RenderBox? child = lastChild;
     while (child != null) {
-      final _SegmentedButtonContainerBoxParentData childParentData = child.parentData! as _SegmentedButtonContainerBoxParentData;
+      final _SegmentedButtonContainerBoxParentData childParentData =
+          child.parentData! as _SegmentedButtonContainerBoxParentData;
       if (childParentData.surroundingRect!.contains(position)) {
         return result.addWithPaintOffset(
           offset: childParentData.offset,
@@ -994,10 +1206,13 @@ class _SegmentedButtonDefaultsM3 extends SegmentedButtonThemeData {
   final BuildContext context;
   late final ThemeData _theme = Theme.of(context);
   late final ColorScheme _colors = _theme.colorScheme;
-  @override ButtonStyle? get style {
+  @override
+  ButtonStyle? get style {
     return ButtonStyle(
-      textStyle: MaterialStatePropertyAll<TextStyle?>(Theme.of(context).textTheme.labelLarge),
-      backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      textStyle: MaterialStatePropertyAll<TextStyle?>(
+          Theme.of(context).textTheme.labelLarge),
+      backgroundColor:
+          MaterialStateProperty.resolveWith((Set<MaterialState> states) {
         if (states.contains(MaterialState.disabled)) {
           return null;
         }
@@ -1006,7 +1221,8 @@ class _SegmentedButtonDefaultsM3 extends SegmentedButtonThemeData {
         }
         return null;
       }),
-      foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      foregroundColor:
+          MaterialStateProperty.resolveWith((Set<MaterialState> states) {
         if (states.contains(MaterialState.disabled)) {
           return _colors.onSurface.withOpacity(0.38);
         }
@@ -1034,7 +1250,8 @@ class _SegmentedButtonDefaultsM3 extends SegmentedButtonThemeData {
           return _colors.onSurface;
         }
       }),
-      overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      overlayColor:
+          MaterialStateProperty.resolveWith((Set<MaterialState> states) {
         if (states.contains(MaterialState.selected)) {
           if (states.contains(MaterialState.pressed)) {
             return _colors.onSecondaryContainer.withOpacity(0.1);
@@ -1058,7 +1275,8 @@ class _SegmentedButtonDefaultsM3 extends SegmentedButtonThemeData {
         }
         return null;
       }),
-      surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.transparent),
+      surfaceTintColor:
+          const MaterialStatePropertyAll<Color>(Colors.transparent),
       elevation: const MaterialStatePropertyAll<double>(0),
       iconSize: const MaterialStatePropertyAll<double?>(18.0),
       side: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
@@ -1071,10 +1289,12 @@ class _SegmentedButtonDefaultsM3 extends SegmentedButtonThemeData {
       minimumSize: const MaterialStatePropertyAll<Size?>(Size.fromHeight(40.0)),
     );
   }
+
   @override
   Widget? get selectedIcon => const Icon(Icons.check);
 
-  static MaterialStateProperty<Color?> resolveStateColor(Color? unselectedColor, Color? selectedColor, Color? overlayColor){
+  static MaterialStateProperty<Color?> resolveStateColor(
+      Color? unselectedColor, Color? selectedColor, Color? overlayColor) {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.selected)) {
         if (states.contains(MaterialState.pressed)) {

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -23,10 +23,12 @@ Widget boilerplate({required Widget child}) {
 
 void main() {
   RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    return tester.allRenderObjects.firstWhere((RenderObject object) =>
+        object.runtimeType.toString() == '_RenderInkFeatures');
   }
 
-  testWidgets('SegmentsButton when compositing does not crash', (WidgetTester tester) async {
+  testWidgets('SegmentsButton when compositing does not crash',
+      (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/135747
     // If the render object holds on to a stale canvas reference, this will
     // throw an exception.
@@ -57,7 +59,8 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('SegmentedButton releases state controllers for deleted segments', (WidgetTester tester) async {
+  testWidgets('SegmentedButton releases state controllers for deleted segments',
+      (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     final Key key = UniqueKey();
 
@@ -98,13 +101,16 @@ void main() {
       ),
     );
 
-    final SegmentedButtonState<int> state = tester.state(find.byType(SegmentedButton<int>));
+    final SegmentedButtonState<int> state =
+        tester.state(find.byType(SegmentedButton<int>));
     expect(state.statesControllers, hasLength(2));
     expect(state.statesControllers.keys.first.value, 2);
     expect(state.statesControllers.keys.last.value, 3);
   });
 
-  testWidgets('SegmentedButton is built with Material of type MaterialType.transparency', (WidgetTester tester) async {
+  testWidgets(
+      'SegmentedButton is built with Material of type MaterialType.transparency',
+      (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     await tester.pumpWidget(
       MaterialApp(
@@ -118,7 +124,7 @@ void main() {
                 ButtonSegment<int>(value: 3, label: Text('3'), enabled: false),
               ],
               selected: const <int>{2},
-              onSelectionChanged: (Set<int> selected) { },
+              onSelectionChanged: (Set<int> selected) {},
             ),
           ),
         ),
@@ -127,13 +133,16 @@ void main() {
 
     // Expect SegmentedButton to be built with type MaterialType.transparency.
     final Finder text = find.text('1');
-    final Finder parent = find.ancestor(of: text, matching: find.byType(Material)).first;
-    final Finder parentMaterial = find.ancestor(of: parent, matching: find.byType(Material)).first;
+    final Finder parent =
+        find.ancestor(of: text, matching: find.byType(Material)).first;
+    final Finder parentMaterial =
+        find.ancestor(of: parent, matching: find.byType(Material)).first;
     final Material material = tester.widget<Material>(parentMaterial);
     expect(material.type, MaterialType.transparency);
   });
 
-  testWidgets('SegmentedButton supports exclusive choice by default', (WidgetTester tester) async {
+  testWidgets('SegmentedButton supports exclusive choice by default',
+      (WidgetTester tester) async {
     int callbackCount = 0;
     int selectedSegment = 2;
 
@@ -183,7 +192,8 @@ void main() {
     expect(selectedSegment, 3);
   });
 
-  testWidgets('SegmentedButton supports multiple selected segments', (WidgetTester tester) async {
+  testWidgets('SegmentedButton supports multiple selected segments',
+      (WidgetTester tester) async {
     int callbackCount = 0;
     Set<int> selection = <int>{1};
 
@@ -238,7 +248,8 @@ void main() {
     expect(selection, <int>{2, 3});
   });
 
-  testWidgets('SegmentedButton allows for empty selection', (WidgetTester tester) async {
+  testWidgets('SegmentedButton allows for empty selection',
+      (WidgetTester tester) async {
     int callbackCount = 0;
     int? selectedSegment = 1;
 
@@ -263,7 +274,7 @@ void main() {
     }
 
     await tester.pumpWidget(frameWithSelection(selectedSegment));
-    expect(selectedSegment,1);
+    expect(selectedSegment, 1);
     expect(callbackCount, 0);
 
     // Tap on segment 1 should deselect it and make the selection empty.
@@ -291,7 +302,8 @@ void main() {
     expect(selectedSegment, 3);
   });
 
-  testWidgets('SegmentedButton shows checkboxes for selected segments', (WidgetTester tester) async {
+  testWidgets('SegmentedButton shows checkboxes for selected segments',
+      (WidgetTester tester) async {
     Widget frameWithSelection(int selected) {
       return Material(
         child: boilerplate(
@@ -310,9 +322,7 @@ void main() {
 
     Finder textHasIcon(String text, IconData icon) {
       return find.descendant(
-        of: find.widgetWithText(Row, text),
-        matching: find.byIcon(icon)
-      );
+          of: find.widgetWithText(Row, text), matching: find.byIcon(icon));
     }
 
     await tester.pumpWidget(frameWithSelection(1));
@@ -328,15 +338,20 @@ void main() {
     expect(find.byIcon(Icons.check), findsOneWidget);
   });
 
-  testWidgets('SegmentedButton shows selected checkboxes in place of icon if it has a label as well', (WidgetTester tester) async {
+  testWidgets(
+      'SegmentedButton shows selected checkboxes in place of icon if it has a label as well',
+      (WidgetTester tester) async {
     Widget frameWithSelection(int selected) {
       return Material(
         child: boilerplate(
           child: SegmentedButton<int>(
             segments: const <ButtonSegment<int>>[
-              ButtonSegment<int>(value: 1, icon: Icon(Icons.add), label: Text('1')),
-              ButtonSegment<int>(value: 2, icon: Icon(Icons.add_a_photo), label: Text('2')),
-              ButtonSegment<int>(value: 3, icon: Icon(Icons.add_alarm), label: Text('3')),
+              ButtonSegment<int>(
+                  value: 1, icon: Icon(Icons.add), label: Text('1')),
+              ButtonSegment<int>(
+                  value: 2, icon: Icon(Icons.add_a_photo), label: Text('2')),
+              ButtonSegment<int>(
+                  value: 3, icon: Icon(Icons.add_alarm), label: Text('3')),
             ],
             selected: <int>{selected},
             onSelectionChanged: (Set<int> selected) {},
@@ -347,9 +362,7 @@ void main() {
 
     Finder textHasIcon(String text, IconData icon) {
       return find.descendant(
-        of: find.widgetWithText(Row, text),
-        matching: find.byIcon(icon)
-      );
+          of: find.widgetWithText(Row, text), matching: find.byIcon(icon));
     }
 
     await tester.pumpWidget(frameWithSelection(1));
@@ -371,7 +384,9 @@ void main() {
     expect(find.byIcon(Icons.add_alarm), findsNothing);
   });
 
-  testWidgets('SegmentedButton shows selected checkboxes next to icon if there is no label', (WidgetTester tester) async {
+  testWidgets(
+      'SegmentedButton shows selected checkboxes next to icon if there is no label',
+      (WidgetTester tester) async {
     Widget frameWithSelection(int selected) {
       return Material(
         child: boilerplate(
@@ -390,9 +405,7 @@ void main() {
 
     Finder rowWithIcons(IconData icon1, IconData icon2) {
       return find.descendant(
-        of: find.widgetWithIcon(Row, icon1),
-        matching: find.byIcon(icon2)
-      );
+          of: find.widgetWithIcon(Row, icon1), matching: find.byIcon(icon2));
     }
 
     await tester.pumpWidget(frameWithSelection(1));
@@ -409,10 +422,10 @@ void main() {
     expect(rowWithIcons(Icons.add, Icons.check), findsNothing);
     expect(rowWithIcons(Icons.add_a_photo, Icons.check), findsNothing);
     expect(rowWithIcons(Icons.add_alarm, Icons.check), findsOneWidget);
-
   });
 
-  testWidgets('SegmentedButtons have correct semantics', (WidgetTester tester) async {
+  testWidgets('SegmentedButtons have correct semantics',
+      (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
@@ -492,8 +505,8 @@ void main() {
     semantics.dispose();
   });
 
-
-  testWidgets('Multi-select SegmentedButtons have correct semantics', (WidgetTester tester) async {
+  testWidgets('Multi-select SegmentedButtons have correct semantics',
+      (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
@@ -572,7 +585,9 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('SegmentedButton default overlayColor and foregroundColor resolve pressed state', (WidgetTester tester) async {
+  testWidgets(
+      'SegmentedButton default overlayColor and foregroundColor resolve pressed state',
+      (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
 
     await tester.pumpWidget(
@@ -606,17 +621,23 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
+    expect(getOverlayColor(tester),
+        paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
     expect(material.textStyle?.color, theme.colorScheme.onSurface);
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect()..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)));
+    expect(
+        getOverlayColor(tester),
+        paints
+          ..rect()
+          ..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)));
     expect(material.textStyle?.color, theme.colorScheme.onSurface);
   });
 
-  testWidgets('SegmentedButton has no tooltips by default', (WidgetTester tester) async {
+  testWidgets('SegmentedButton has no tooltips by default',
+      (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     await tester.pumpWidget(
       MaterialApp(
@@ -630,7 +651,7 @@ void main() {
                 ButtonSegment<int>(value: 3, label: Text('3'), enabled: false),
               ],
               selected: const <int>{2},
-              onSelectionChanged: (Set<int> selected) { },
+              onSelectionChanged: (Set<int> selected) {},
             ),
           ),
         ),
@@ -640,7 +661,8 @@ void main() {
     expect(find.byType(Tooltip), findsNothing);
   });
 
-  testWidgets('SegmentedButton has correct tooltips', (WidgetTester tester) async {
+  testWidgets('SegmentedButton has correct tooltips',
+      (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     await tester.pumpWidget(
       MaterialApp(
@@ -659,7 +681,7 @@ void main() {
                 ),
               ],
               selected: const <int>{2},
-              onSelectionChanged: (Set<int> selected) { },
+              onSelectionChanged: (Set<int> selected) {},
             ),
           ),
         ),
@@ -671,9 +693,10 @@ void main() {
     expect(find.byTooltip('t3'), findsOneWidget);
   });
 
-  testWidgets('SegmentedButton.styleFrom is applied to the SegmentedButton', (WidgetTester tester) async {
+  testWidgets('SegmentedButton.styleFrom is applied to the SegmentedButton',
+      (WidgetTester tester) async {
     const Color foregroundColor = Color(0xfffffff0);
-    const Color backgroundColor =  Color(0xfffffff1);
+    const Color backgroundColor = Color(0xfffffff1);
     const Color selectedBackgroundColor = Color(0xfffffff2);
     const Color selectedForegroundColor = Color(0xfffffff3);
     const Color disabledBackgroundColor = Color(0xfffffff4);
@@ -694,7 +717,8 @@ void main() {
       textStyle: const TextStyle(color: Color(0xfffffff8)),
       padding: const EdgeInsets.all(2),
       side: const BorderSide(color: Color(0xfffffff9)),
-      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(3))),
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(3))),
       enabledMouseCursor: enabledMouseCursor,
       disabledMouseCursor: disabledMouseCursor,
       visualDensity: VisualDensity.compact,
@@ -716,7 +740,7 @@ void main() {
               ButtonSegment<int>(value: 3, label: Text('3'), enabled: false),
             ],
             selected: const <int>{2},
-            onSelectionChanged: (Set<int> selected) { },
+            onSelectionChanged: (Set<int> selected) {},
             selectedIcon: const Icon(Icons.alarm),
           ),
         ),
@@ -724,7 +748,8 @@ void main() {
     ));
 
     // Test provided button style is applied to the enabled button segment.
-    ButtonStyle? buttonStyle = tester.widget<TextButton>(find.byType(TextButton).first).style;
+    ButtonStyle? buttonStyle =
+        tester.widget<TextButton>(find.byType(TextButton).first).style;
     expect(buttonStyle?.foregroundColor?.resolve(enabled), foregroundColor);
     expect(buttonStyle?.backgroundColor?.resolve(enabled), backgroundColor);
     expect(buttonStyle?.overlayColor, styleFromStyle.overlayColor);
@@ -741,25 +766,33 @@ void main() {
     expect(buttonStyle?.splashFactory, styleFromStyle.splashFactory);
 
     // Test provided button style is applied selected button segment.
-    buttonStyle = tester.widget<TextButton>(find.byType(TextButton).at(1)).style;
-    expect(buttonStyle?.foregroundColor?.resolve(selected), selectedForegroundColor);
-    expect(buttonStyle?.backgroundColor?.resolve(selected), selectedBackgroundColor);
+    buttonStyle =
+        tester.widget<TextButton>(find.byType(TextButton).at(1)).style;
+    expect(buttonStyle?.foregroundColor?.resolve(selected),
+        selectedForegroundColor);
+    expect(buttonStyle?.backgroundColor?.resolve(selected),
+        selectedBackgroundColor);
     expect(buttonStyle?.mouseCursor?.resolve(enabled), enabledMouseCursor);
 
     // Test provided button style is applied disabled button segment.
     buttonStyle = tester.widget<TextButton>(find.byType(TextButton).last).style;
-    expect(buttonStyle?.foregroundColor?.resolve(disabled), disabledForegroundColor);
-    expect(buttonStyle?.backgroundColor?.resolve(disabled), disabledBackgroundColor);
+    expect(buttonStyle?.foregroundColor?.resolve(disabled),
+        disabledForegroundColor);
+    expect(buttonStyle?.backgroundColor?.resolve(disabled),
+        disabledBackgroundColor);
     expect(buttonStyle?.mouseCursor?.resolve(disabled), disabledMouseCursor);
 
     // Test provided button style is applied to the segmented button material.
-    final Material material = tester.widget<Material>(find.descendant(
-      of: find.byType(SegmentedButton<int>),
-      matching: find.byType(Material),
-    ).first);
+    final Material material = tester.widget<Material>(find
+        .descendant(
+          of: find.byType(SegmentedButton<int>),
+          matching: find.byType(Material),
+        )
+        .first);
     expect(material.elevation, styleFromStyle.elevation?.resolve(enabled));
     expect(material.shadowColor, styleFromStyle.shadowColor?.resolve(enabled));
-    expect(material.surfaceTintColor, styleFromStyle.surfaceTintColor?.resolve(enabled));
+    expect(material.surfaceTintColor,
+        styleFromStyle.surfaceTintColor?.resolve(enabled));
 
     // Test provided button style border is applied to the segmented button border.
     expect(
@@ -774,10 +807,12 @@ void main() {
     await gesture.addPointer();
     await gesture.down(tester.getCenter(find.text('1')));
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: foregroundColor.withOpacity(0.08)));
+    expect(getOverlayColor(tester),
+        paints..rect(color: foregroundColor.withOpacity(0.08)));
   });
 
-  testWidgets('Disabled SegmentedButton has correct states when rebuilding', (WidgetTester tester) async {
+  testWidgets('Disabled SegmentedButton has correct states when rebuilding',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -804,9 +839,13 @@ void main() {
         ),
       ),
     );
-    final Set<MaterialState> states = <MaterialState>{ MaterialState.selected, MaterialState.disabled };
+    final Set<MaterialState> states = <MaterialState>{
+      MaterialState.selected,
+      MaterialState.disabled
+    };
     // Check the initial states.
-    SegmentedButtonState<int> state = tester.state(find.byType(SegmentedButton<int>));
+    SegmentedButtonState<int> state =
+        tester.state(find.byType(SegmentedButton<int>));
     expect(state.statesControllers.values.first.value, states);
     // Trigger a rebuild.
     await tester.tap(find.byType(ElevatedButton));
@@ -816,8 +855,10 @@ void main() {
     expect(state.statesControllers.values.first.value, states);
   });
 
-  testWidgets('Min button hit target height is 48.0 and min (painted) button height is 40 '
-    'by default with standard density and MaterialTapTargetSize.padded', (WidgetTester tester) async {
+  testWidgets(
+      'Min button hit target height is 48.0 and min (painted) button height is 40 '
+      'by default with standard density and MaterialTapTargetSize.padded',
+      (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     await tester.pumpWidget(
       MaterialApp(
@@ -828,10 +869,22 @@ void main() {
               children: <Widget>[
                 SegmentedButton<int>(
                   segments: const <ButtonSegment<int>>[
-                    ButtonSegment<int>(value: 0, label: Text('Day'), icon: Icon(Icons.calendar_view_day)),
-                    ButtonSegment<int>(value: 1, label: Text('Week'), icon: Icon(Icons.calendar_view_week)),
-                    ButtonSegment<int>(value: 2, label: Text('Month'), icon: Icon(Icons.calendar_view_month)),
-                    ButtonSegment<int>(value: 3, label: Text('Year'), icon: Icon(Icons.calendar_today)),
+                    ButtonSegment<int>(
+                        value: 0,
+                        label: Text('Day'),
+                        icon: Icon(Icons.calendar_view_day)),
+                    ButtonSegment<int>(
+                        value: 1,
+                        label: Text('Week'),
+                        icon: Icon(Icons.calendar_view_week)),
+                    ButtonSegment<int>(
+                        value: 2,
+                        label: Text('Month'),
+                        icon: Icon(Icons.calendar_view_month)),
+                    ButtonSegment<int>(
+                        value: 3,
+                        label: Text('Year'),
+                        icon: Icon(Icons.calendar_today)),
                   ],
                   selected: const <int>{0},
                   onSelectionChanged: (Set<int> value) {},
@@ -849,17 +902,19 @@ void main() {
     final Finder button = find.byType(SegmentedButton<int>);
     expect(tester.getSize(button).height, 48.0);
     expect(
-      find.byType(SegmentedButton<int>),
-      paints..rrect(
-        style: PaintingStyle.stroke,
-        strokeWidth: 1.0,
-        // Button border height is button.bottom(43.5) - button.top(4.5) + stoke width(1) = 40.
-        rrect: RRect.fromLTRBR(0.5, 4.5, 497.5, 43.5, const Radius.circular(19.5))
-      )
-    );
+        find.byType(SegmentedButton<int>),
+        paints
+          ..rrect(
+              style: PaintingStyle.stroke,
+              strokeWidth: 1.0,
+              // Button border height is button.bottom(43.5) - button.top(4.5) + stoke width(1) = 40.
+              rrect: RRect.fromLTRBR(
+                  0.5, 4.5, 497.5, 43.5, const Radius.circular(19.5))));
   });
 
-  testWidgets('SegmentedButton expands to fill the available width when expandedInsets is not null', (WidgetTester tester) async {
+  testWidgets(
+      'SegmentedButton expands to fill the available width when expandedInsets is not null',
+      (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: Center(
@@ -868,15 +923,16 @@ void main() {
               ButtonSegment<int>(value: 1, label: Text('Segment 1')),
               ButtonSegment<int>(value: 2, label: Text('Segment 2')),
             ],
-           selected: const <int>{1},
-           expandedInsets: EdgeInsets.zero,
+            selected: const <int>{1},
+            expandedInsets: EdgeInsets.zero,
           ),
         ),
       ),
     ));
 
     // Get the width of the SegmentedButton.
-    final RenderBox box = tester.renderObject(find.byType(SegmentedButton<int>));
+    final RenderBox box =
+        tester.renderObject(find.byType(SegmentedButton<int>));
     final double segmentedButtonWidth = box.size.width;
 
     // Get the width of the parent widget.
@@ -886,7 +942,8 @@ void main() {
     expect(segmentedButtonWidth, equals(screenWidth));
   });
 
-  testWidgets('SegmentedButton does not expand when expandedInsets is null', (WidgetTester tester) async {
+  testWidgets('SegmentedButton does not expand when expandedInsets is null',
+      (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: Center(
@@ -902,7 +959,8 @@ void main() {
     ));
 
     // Get the width of the SegmentedButton.
-    final RenderBox box = tester.renderObject(find.byType(SegmentedButton<int>));
+    final RenderBox box =
+        tester.renderObject(find.byType(SegmentedButton<int>));
     final double segmentedButtonWidth = box.size.width;
 
     // Get the width of the parent widget.
@@ -910,9 +968,13 @@ void main() {
 
     // The width of the SegmentedButton must be less than the width of the parent widget.
     expect(segmentedButtonWidth, lessThan(screenWidth));
-  }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/145527
+  },
+      skip: kIsWeb &&
+          !isCanvasKit); // https://github.com/flutter/flutter/issues/145527
 
-  testWidgets('SegmentedButton.styleFrom overlayColor overrides default overlay color', (WidgetTester tester) async {
+  testWidgets(
+      'SegmentedButton.styleFrom overlayColor overrides default overlay color',
+      (WidgetTester tester) async {
     const Color overlayColor = Color(0xffff0000);
     await tester.pumpWidget(
       MaterialApp(
@@ -946,13 +1008,15 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(getOverlayColor(tester),
+        paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Hovered unselected segment,
     center = tester.getCenter(find.text('Option 2'));
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(getOverlayColor(tester),
+        paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Highlighted unselected segment (pressed).
     center = tester.getCenter(find.text('Option 1'));
@@ -989,15 +1053,18 @@ void main() {
     // Focused unselected segment.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(getOverlayColor(tester),
+        paints..rect(color: overlayColor.withOpacity(0.1)));
 
     // Focused selected segment.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(getOverlayColor(tester),
+        paints..rect(color: overlayColor.withOpacity(0.1)));
   });
 
-  testWidgets('SegmentedButton.styleFrom with transparent overlayColor', (WidgetTester tester) async {
+  testWidgets('SegmentedButton.styleFrom with transparent overlayColor',
+      (WidgetTester tester) async {
     const Color overlayColor = Colors.transparent;
     await tester.pumpWidget(
       MaterialApp(
@@ -1051,7 +1118,8 @@ void main() {
   });
 
   // This is a regression test for https://github.com/flutter/flutter/issues/144990.
-  testWidgets('SegmentedButton clips border path when drawing segments', (WidgetTester tester) async {
+  testWidgets('SegmentedButton clips border path when drawing segments',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -1088,7 +1156,8 @@ void main() {
   });
 
   // This is a regression test for https://github.com/flutter/flutter/issues/144990.
-  testWidgets('SegmentedButton dividers matches border rect size', (WidgetTester tester) async {
+  testWidgets('SegmentedButton dividers matches border rect size',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -1121,9 +1190,50 @@ void main() {
           p2: const Offset(166.8000030517578, tapTargetSize - 4.0),
         ),
     );
-  }, skip: kIsWeb && !isSkiaWeb); // https://github.com/flutter/flutter/issues/99933
+  },
+      skip: kIsWeb &&
+          !isSkiaWeb); // https://github.com/flutter/flutter/issues/99933
+
+  testWidgets('SegmentedButton vertical aligned children',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SegmentedButton<int>(
+              segments: const <ButtonSegment<int>>[
+                ButtonSegment<int>(
+                  value: 0,
+                  label: Text('Option 1'),
+                ),
+                ButtonSegment<int>(
+                  value: 1,
+                  label: Text('Option 1'),
+                ),
+                ButtonSegment<int>(
+                  value: 2,
+                  label: Text('Option 3'),
+                ),
+                ButtonSegment<int>(
+                  value: 3,
+                  label: Text('Option 4'),
+                ),
+              ],
+              onSelectionChanged: (Set<int> selected) {},
+              selected: const <int>{0},
+              direction: Axis.vertical,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder button = find.byType(SegmentedButton<int>);
+    expect(tester.getSize(button).height,
+        greaterThan(tester.getSize(button).width));
+  });
 }
 
 Set<MaterialState> enabled = const <MaterialState>{};
-Set<MaterialState> disabled = const <MaterialState>{ MaterialState.disabled };
-Set<MaterialState> selected = const <MaterialState>{ MaterialState.selected };
+Set<MaterialState> disabled = const <MaterialState>{MaterialState.disabled};
+Set<MaterialState> selected = const <MaterialState>{MaterialState.selected};


### PR DESCRIPTION
This PR add the ability to change buttons of 'SegmentedButton'  directionality (In the vertical and horizontal axis) to be 'vertical' or 'horizontal' instead of just horizontally position by adding "direction" argument.


`direction: Axis.horizontal`
![Simulator Screenshot - iPhone 15 - 2024-06-26 at 13 37 26](https://github.com/flutter/flutter/assets/9139030/4268c820-63c2-4a29-921f-ae739fbe0a7d)

`direction: Axis.vertical`
![Simulator Screenshot - iPhone 15 - 2024-06-26 at 13 43 07](https://github.com/flutter/flutter/assets/9139030/b7428b08-45a9-4a8c-a73b-3b5fb7cde4ce)


Notice: in this example i used:
`style: ButtonStyle(
            shape: MaterialStateProperty.all<RoundedRectangleBorder>(
              const RoundedRectangleBorder(
                borderRadius: BorderRadius.zero,
              ),
            ),
          )
`

To change the `Radius` of the 'SegmentedButton', and the default will be like: 
![Simulator Screenshot - iPhone 15 - 2024-06-26 at 13 51 46](https://github.com/flutter/flutter/assets/9139030/00b628c5-44f4-4eb3-a160-858f790cbee5)
I keep it as it is , cause its not the main purpose of this BR.


*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
Fixes #150416

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
