### PR TITLE
[tool] make the `systemTempDirectory` getter on `ErrorHandlingFileSystem` wrap the underlying filesystem's temp directory in a`ErrorHandlingDirectory`

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -115,6 +115,11 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
   }
 
   @override
+  Directory get systemTempDirectory {
+    return directory(delegate.systemTempDirectory);
+  }
+
+  @override
   File file(dynamic path) => ErrorHandlingFile(
     platform: _platform,
     fileSystem: this,

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -866,6 +866,17 @@ void main() {
     });
   });
 
+  testWithoutContext('ErrorHandlingFileSystem.systemTempDirectory wraps systemTempDirectory of delegate', () {
+    final MemoryFileSystem delegate = MemoryFileSystem.test();
+    final FileSystem fs = ErrorHandlingFileSystem(
+      delegate: delegate,
+      platform: const LocalPlatform(),
+    );
+
+    expect(fs.systemTempDirectory, isA<ErrorHandlingDirectory>());
+    expect(fs.systemTempDirectory.path, delegate.systemTempDirectory.path);
+  });
+
   group('ProcessManager on windows throws tool exit', () {
     const int kDeviceFull = 112;
     const int kUserMappedSectionOpened = 1224;

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -866,7 +866,7 @@ void main() {
     });
   });
 
-  testWithoutContext('ErrorHandlingFileSystem.systemTempDirectory wraps systemTempDirectory of delegate', () {
+  testWithoutContext("ErrorHandlingFileSystem.systemTempDirectory wraps delegates filesystem's systemTempDirectory", () {
     final FileExceptionHandler exceptionHandler = FileExceptionHandler();
 
     final MemoryFileSystem delegate = MemoryFileSystem.test(

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -867,14 +867,40 @@ void main() {
   });
 
   testWithoutContext('ErrorHandlingFileSystem.systemTempDirectory wraps systemTempDirectory of delegate', () {
-    final MemoryFileSystem delegate = MemoryFileSystem.test();
+    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
+
+    final MemoryFileSystem delegate = MemoryFileSystem.test(
+      style: FileSystemStyle.windows,
+      opHandle: exceptionHandler.opHandle,
+    );
+
     final FileSystem fs = ErrorHandlingFileSystem(
       delegate: delegate,
-      platform: const LocalPlatform(),
+      platform: FakePlatform(operatingSystem: 'windows'),
     );
 
     expect(fs.systemTempDirectory, isA<ErrorHandlingDirectory>());
     expect(fs.systemTempDirectory.path, delegate.systemTempDirectory.path);
+
+    final File tempFile = delegate.systemTempDirectory.childFile('hello')
+      ..createSync(recursive: true);
+
+    exceptionHandler.addError(
+      tempFile,
+      FileSystemOp.write,
+      FileSystemException(
+        'Oh no!',
+        tempFile.path,
+        const OSError('Access denied ):', 5),
+      ),
+    );
+
+    expect(
+      () => fs.file(tempFile.path).writeAsStringSync('world'),
+      throwsToolExit(message: r'''
+Flutter failed to write to a file at "C:\.tmp_rand0\hello". The flutter tool cannot access the file or directory.
+Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.'''),
+    );
   });
 
   group('ProcessManager on windows throws tool exit', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/150730

If you can think of a more concise title, be my guest.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
