### PR TITLE
Remove CODEOWNERS trailing whitespace

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,6 @@
 /packages/flutter_tools/templates/module/ios/ @jmagman
 /packages/flutter_tools/templates/**/Podfile* @jmagman
 
-# In the process of moving to flutter/engine, so ask matan if 
+# In the process of moving to flutter/engine, so ask matan if
 # modifying anything here (https://github.com/flutter/flutter/issues/150869).
 /docs/engine/** @matanlurey


### PR DESCRIPTION
New analyze error in an unrelated PR 
```
╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════
║ /b/s/w/ir/x/w/flutter/CODEOWNERS:13: trailing U+0020 space character
╚═══════════════════════════════════════════════════════════════════════════════
```
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8744032390138579057/+/u/run_test.dart_for_analyze_shard_and_subshard_None/stdout

On this commit 
https://github.com/flutter/flutter/commit/2537b49e4ee1b636b81762be9bd9687941db99ae

Why wasn't this found in presubmit?