### PR TITLE
Reduce relayout-boundary tracking to a bool-or-null per RenderObject

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2554,7 +2554,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
         return true;
       }());
 
-      if (relayoutBoundary != _relayoutBoundary) {
+      if (isRelayoutBoundary != _isRelayoutBoundary) {
         _setRelayoutBoundary(relayoutBoundary);
       }
 
@@ -2565,7 +2565,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
     }
     _constraints = constraints;
 
-    if (_relayoutBoundary != null && relayoutBoundary != _relayoutBoundary) {
+    if (_isRelayoutBoundary != null && isRelayoutBoundary != _isRelayoutBoundary) {
       // The local relayout boundary has changed, must notify children in case
       // they also need updating. Otherwise, they will be confused about what
       // their actual relayout boundary is later.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2321,20 +2321,13 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
       assert(_debugRelayoutBoundaryAlreadyMarkedNeedsLayout());
       return;
     }
-    if (_isRelayoutBoundary == null) {
-      _needsLayout = true;
+    _needsLayout = true;
+    if (_isRelayoutBoundary != true) {
+      assert(parent != null || _isRelayoutBoundary == null);
       if (parent != null) {
-        // _relayoutBoundary is cleaned by an ancestor in RenderObject.layout.
-        // Conservatively mark everything dirty until it reaches the closest
-        // known relayout boundary.
         markParentNeedsLayout();
       }
-      return;
-    }
-    if (_isRelayoutBoundary == false) {
-      markParentNeedsLayout();
     } else {
-      _needsLayout = true;
       if (owner != null) {
         assert(() {
           if (debugPrintMarkNeedsLayoutStacks) {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2265,7 +2265,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
       return true;
     }
     RenderObject node = this;
-    while (node != _relayoutBoundary) {
+    while (node._isRelayoutBoundary != true) {
       assert(node._isRelayoutBoundary == false);
       assert(node.parent != null);
       node = node.parent!;
@@ -3944,7 +3944,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
       if (_isRelayoutBoundary == false) {
         int count = 1;
         RenderObject? target = parent;
-        while (target != null && target != _relayoutBoundary) {
+        while (target != null && target._isRelayoutBoundary == false) {
           target = target.parent;
           count += 1;
         }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2187,6 +2187,18 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
 
   /// The nearest relayout boundary enclosing this render object, if known.
   ///
+  /// For discussion, see [_isRelayoutBoundary].
+  ///
+  /// When not null, the relayout boundary is either this render object itself
+  /// or one of its ancestors, and all the render objects in the ancestry chain
+  /// up through that ancestor have the same [_relayoutBoundary].
+  /// Equivalently: when not null, the relayout boundary is either this render
+  /// object itself or the same as that of its parent.  (So [_relayoutBoundary]
+  /// is one of `null`, `this`, or `parent!._relayoutBoundary!`.)
+  RenderObject? _relayoutBoundary;
+
+  /// Whether this render object is a relayout boundary, if known.
+  ///
   /// When a render object is marked as needing layout, its parent may
   /// as a result also need to be marked as needing layout.
   /// For details, see [markNeedsLayout].
@@ -2205,13 +2217,12 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   /// This property can also be null while an ancestor in the tree is
   /// currently doing layout, until this render object itself does layout.
   ///
-  /// When not null, the relayout boundary is either this render object itself
-  /// or one of its ancestors, and all the render objects in the ancestry chain
-  /// up through that ancestor have the same [_relayoutBoundary].
-  /// Equivalently: when not null, the relayout boundary is either this render
-  /// object itself or the same as that of its parent.  (So [_relayoutBoundary]
-  /// is one of `null`, `this`, or `parent!._relayoutBoundary!`.)
-  RenderObject? _relayoutBoundary;
+  /// When [_isRelayoutBoundary] is false, then `parent?._isRelayoutBoundary`
+  /// may be true or false but not null.  As a result, when it's known that
+  /// this render object is not a relayout boundary, that always comes with
+  /// knowledge of some specific ancestor which is the nearest enclosing
+  /// relayout boundary.
+  bool? get _isRelayoutBoundary => _relayoutBoundary == null ? null : _relayoutBoundary == this;
 
   /// Whether [invokeLayoutCallback] for this render object is currently running.
   bool get debugDoingThisLayoutWithCallback => _doingThisLayoutWithCallback;


### PR DESCRIPTION
Fixes part of #150524.

As documented on `_relayoutBoundary` (since e5a35f458 / #150527),
that property has three possible states: it can be null, `this`,
or some ancestor; and in the case of an ancestor, the question of
*which* ancestor is answered by the same property on the parent.

This makes for a lot of redundancy between the `_relayoutBoundary`
values on different render objects in the tree.  All the same
information can be expressed by a `bool?` property on each object
expressing whether the object is itself a relayout boundary;
call it `_isRelayoutBoundary`.

The existing property of type `RenderObject?` does provide a direct
lookup of which ancestor, specifically, is the relayout boundary.
But it turns out that (a) that extra information is never used at all
in release builds; and (b) even in debug builds, it's only used in
conjunction with walking the parent chain up to that ancestor, at
which point the `bool?` values give us all the same information.

This is a pure refactor; all the outward behavior remains the same.
The main immediate win is that it makes the logic simpler, and makes
it simpler to understand by having each render object keep track of
only the data that the logic on that render object will actually use.

As a bonus, this unlocks a small but measurable performance
improvement by letting us reduce the bookkeeping we do on these
values.  That part isn't quite a pure refactor, though, so I'll
leave it for a follow-up PR.

For ease of review, the PR is broken into several commits each with
their own commit message.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
