### PR TITLE
Fix invalid URL suggestion for gradle incompatability

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -592,7 +592,7 @@ final GradleHandledError incompatibleJavaAndGradleVersionsHandler = GradleHandle
       "${globals.logger.terminal.warningMark} Your project's Gradle version "
           'is incompatible with the Java version that Flutter is using for Gradle.\n\n'
           'If you recently upgraded Android Studio, consult the migration guide '
-          'at https://flutter.dev/to/to/java-gradle-incompatibility.\n\n'
+          'at https://flutter.dev/to/java-gradle-incompatibility.\n\n'
           'Otherwise, to fix this issue, first, check the Java version used by Flutter by '
           'running `flutter doctor --verbose`.\n\n'
           'Then, update the Gradle version specified in ${gradlePropertiesFile.path} '

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1256,7 +1256,7 @@ Could not compile build file '…/example/android/build.gradle'.
       // Ensure the error notes the incompatible Gradle/AGP/Java versions, links to related resources,
       // and a portion of the path to where to change their gradle version.
       expect(testLogger.statusText, contains('Gradle version is incompatible with the Java version'));
-      expect(testLogger.statusText, contains('flutter.dev/to/to/java-gradle-incompatibility'));
+      expect(testLogger.statusText, contains('flutter.dev/to/java-gradle-incompatibility'));
       expect(testLogger.statusText, contains('gradle-wrapper.properties'));
       expect(testLogger.statusText, contains('https://docs.gradle.org/current/userguide/compatibility.html#java'));
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
 The current URL has 2 /to, but it should only be 1. However, this url redirects to https://docs.flutter.dev/release/breaking-changes/android-java-gradle-migration-guide, so I can change it to that if it's preferred just to go to the final destination - just don't know if it's a redirect for a reason

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

i didn't create an issue as it's a doc change, but if that's a requirement I can do that