### PR TITLE
Force regeneration of platform-specific manifests before running performance tests

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1324,6 +1324,10 @@ class PerfTest {
       final String? localEngineSrcPath = localEngineSrcPathFromEnv;
 
       if (createPlatforms.isNotEmpty) {
+        // Ensure that the platform-specific manifests are freshly created and
+        // do not contain any settings from previous runs.
+        await exec('git', <String>['clean', '-f', testDirectory]);
+
         await flutter('create', options: <String>[
           '--platforms',
           createPlatforms.join(','),


### PR DESCRIPTION
Some performance tests run "flutter create" to generate platform-specific project configuration files for the test app.  These files may be further patched by the test script to apply settings such as the Impeller backend.

The manifests need to be deleted and recreated on each run so that settings applied by previous runs will not be used by the current run.