### PR TITLE
More docimports for animation library

### DIFF
--- a/packages/flutter/lib/animation.dart
+++ b/packages/flutter/lib/animation.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+///
 /// The Flutter animation system.
 ///
 /// To use, import `package:flutter/animation.dart`.

--- a/packages/flutter/lib/animation.dart
+++ b/packages/flutter/lib/animation.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// The Flutter animation system.
 ///
 /// To use, import `package:flutter/animation.dart`.
@@ -160,6 +158,8 @@
 ///    implicitly animate changes to their properties.
 ///  * [AnimatedWidget] and its subclasses, which are [Widget]s that take an
 ///    explicit [Animation] to animate their properties.
+///
+/// @docImport 'package:flutter/material.dart';
 library animation;
 
 // AnimationController can throw TickerCanceled


### PR DESCRIPTION
docimports for references in doc comments on library statements now work!

Part of https://github.com/flutter/flutter/issues/150800