### PR TITLE
Fix: Flicker when reorderable list doesn't change its position

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -871,7 +871,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
     // Find the new index for inserting the item being dragged.
     int newIndex = _insertIndex!;
     for (final _ReorderableItemState item in _items.values) {
-      if (item.index == _dragIndex! || !item.mounted) {
+      if ((_reverse && item.index == _dragIndex!) || !item.mounted) {
         continue;
       }
 
@@ -902,7 +902,13 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
           newIndex = item.index;
         }
       } else {
-        if (itemStart <= proxyItemStart && proxyItemStart <= itemMiddle) {
+        if (item.index == _dragIndex!) {
+          // If end of the proxy is not in ending half of item,
+          // we don't process, because it's original dragged item.
+          if (itemMiddle <= proxyItemEnd && proxyItemEnd <= itemEnd) {
+            newIndex = _dragIndex!;
+          }
+        } else if (itemStart <= proxyItemStart && proxyItemStart <= itemMiddle) {
           // The start of the proxy is in the beginning half of the item, so
           // we should swap the item with the gap and we are done looking for
           // the new index.


### PR DESCRIPTION
Fix: Flicker when no update in index of dragged item


Resolves #150843

This PR ensures that even if we move dragged item anywhere in list and comeback to initial position, we smoothly adjust to that position.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
