### PR TITLE
Reduce the depth used in a test that applies finders to deep widget trees

### DIFF
--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -770,11 +770,11 @@ void main() {
         Directionality(
           textDirection: TextDirection.ltr,
           child: _deepWidgetTree(
-            depth: 1000,
+            depth: 500,
             child: Row(
               children: <Widget>[
                 _deepWidgetTree(
-                  depth: 1000,
+                  depth: 500,
                   child: const Column(children: fooBarTexts),
                 ),
               ],


### PR DESCRIPTION
With today's random test order (--test-randomize-ordering-seed=20240629) this test is failing due to stack overflows when run on Windows.