### PR TITLE
[tool] handle any `PathNotFoundException` resulting from a recursive create op where a parent directory was deleted during creation

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -191,10 +191,10 @@ void main() {
         xcodeProjectInterpreter.isInstalled = false;
 
         final File file = fileSystem.file('file')..createSync();
-        exceptionHandler.addError(
+        exceptionHandler.setHandler(
           file,
           FileSystemOp.delete,
-          const FileSystemException('Deletion failed'),
+          () => throw const FileSystemException('Deletion failed'),
         );
 
         final CleanCommand command = CleanCommand();
@@ -212,7 +212,11 @@ void main() {
         final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
         final File throwingFile = fileSystem.file('bad')
           ..createSync();
-        handler.addError(throwingFile, FileSystemOp.delete, const FileSystemException('OS error: Access Denied'));
+        handler.setHandler(
+          throwingFile,
+          FileSystemOp.delete,
+          () => throw const FileSystemException('OS error: Access Denied'),
+        );
 
         xcodeProjectInterpreter.isInstalled = false;
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -179,11 +179,11 @@ void main() {
     group('Windows', () {
       late FakePlatform windowsPlatform;
       late MemoryFileSystem fileSystem;
-      late FileExceptionHandler exceptionHandler;
+      late MutableFileSystemOpHandle exceptionHandler;
 
       setUp(() {
         windowsPlatform = FakePlatform(operatingSystem: 'windows');
-        exceptionHandler = FileExceptionHandler();
+        exceptionHandler = MutableFileSystemOpHandle();
         fileSystem = MemoryFileSystem.test(opHandle: exceptionHandler.opHandle);
       });
 
@@ -208,7 +208,7 @@ void main() {
       });
 
       testUsingContext('$CleanCommand handles missing delete permissions', () async {
-        final FileExceptionHandler handler = FileExceptionHandler();
+        final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
         final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
         final File throwingFile = fileSystem.file('bad')
           ..createSync();

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -179,11 +179,11 @@ void main() {
     group('Windows', () {
       late FakePlatform windowsPlatform;
       late MemoryFileSystem fileSystem;
-      late MutableFileSystemOpHandle exceptionHandler;
+      late FileExceptionHandler exceptionHandler;
 
       setUp(() {
         windowsPlatform = FakePlatform(operatingSystem: 'windows');
-        exceptionHandler = MutableFileSystemOpHandle();
+        exceptionHandler = FileExceptionHandler();
         fileSystem = MemoryFileSystem.test(opHandle: exceptionHandler.opHandle);
       });
 
@@ -191,7 +191,7 @@ void main() {
         xcodeProjectInterpreter.isInstalled = false;
 
         final File file = fileSystem.file('file')..createSync();
-        exceptionHandler.setHandler(
+        exceptionHandler.addError(
           file,
           FileSystemOp.delete,
           () => throw const FileSystemException('Deletion failed'),
@@ -208,11 +208,11 @@ void main() {
       });
 
       testUsingContext('$CleanCommand handles missing delete permissions', () async {
-        final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
+        final FileExceptionHandler handler = FileExceptionHandler();
         final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
         final File throwingFile = fileSystem.file('bad')
           ..createSync();
-        handler.setHandler(
+        handler.addError(
           throwingFile,
           FileSystemOp.delete,
           () => throw const FileSystemException('OS error: Access Denied'),

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -499,7 +499,7 @@ void main() {
 
   testWithoutContext('ArtifactUpdater will tool exit if deleting the existing artifacts fails with 32 on windows', () async {
     const int kSharingViolation = 32;
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
+    final FileExceptionHandler handler = FileExceptionHandler();
     final FakeOperatingSystemUtils operatingSystemUtils = FakeOperatingSystemUtils();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final BufferLogger logger = BufferLogger.test();
@@ -519,7 +519,7 @@ void main() {
       .childDirectory('test')
       ..createSync(recursive: true);
 
-    handler.setHandler(
+    handler.addError(
       errorDirectory,
       FileSystemOp.delete,
       () => throw const FileSystemException(

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -499,7 +499,7 @@ void main() {
 
   testWithoutContext('ArtifactUpdater will tool exit if deleting the existing artifacts fails with 32 on windows', () async {
     const int kSharingViolation = 32;
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final FakeOperatingSystemUtils operatingSystemUtils = FakeOperatingSystemUtils();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final BufferLogger logger = BufferLogger.test();

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -518,7 +518,13 @@ void main() {
       .childDirectory('out')
       .childDirectory('test')
       ..createSync(recursive: true);
-    handler.addError(errorDirectory, FileSystemOp.delete, const FileSystemException('', '', OSError('', kSharingViolation)));
+
+    handler.setHandler(
+      errorDirectory,
+      FileSystemOp.delete,
+      () => throw const FileSystemException(
+          '', '', OSError('', kSharingViolation)),
+    );
 
     await expectLater(() async => artifactUpdater.downloadZippedTarball(
       'test message',

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -618,7 +618,7 @@ flutter:
   });
 
   testUsingContext('Failed directory delete shows message', () async {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
 
     final Directory directory = fileSystem.directory('foo')

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -623,7 +623,11 @@ flutter:
 
     final Directory directory = fileSystem.directory('foo')
       ..createSync();
-    handler.addError(directory, FileSystemOp.delete, const FileSystemException('Expected Error Text'));
+    handler.setHandler(
+      directory,
+      FileSystemOp.delete,
+      () => throw const FileSystemException('Expected Error Text'),
+    );
 
     await writeBundle(
       directory,

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -618,12 +618,12 @@ flutter:
   });
 
   testUsingContext('Failed directory delete shows message', () async {
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
+    final FileExceptionHandler handler = FileExceptionHandler();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
 
     final Directory directory = fileSystem.directory('foo')
       ..createSync();
-    handler.setHandler(
+    handler.addError(
       directory,
       FileSystemOp.delete,
       () => throw const FileSystemException('Expected Error Text'),

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -60,14 +60,14 @@ void main() {
   });
 
   testWithoutContext('deleteIfExists throws tool exit if file exists on read-only volume', () {
-    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
+    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
     final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
       delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
       platform: linuxPlatform,
     );
     final File file = fileSystem.file('file')..createSync();
 
-    exceptionHandler.setHandler(
+    exceptionHandler.addError(
       file,
       FileSystemOp.delete,
       () => throw FileSystemException('', file.path, const OSError('', 2)),
@@ -78,14 +78,14 @@ void main() {
 
   testWithoutContext('deleteIfExists does not tool exit if file exists on read-only '
     'volume and it is run under noExitOnFailure', () {
-    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
+    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
     final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
       delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
       platform: linuxPlatform,
     );
     final File file = fileSystem.file('file')..createSync();
 
-    exceptionHandler.setHandler(
+    exceptionHandler.addError(
       file,
       FileSystemOp.delete,
       () => throw FileSystemException('', file.path, const OSError('', 2)),
@@ -99,7 +99,7 @@ void main() {
   });
 
   testWithoutContext('deleteIfExists throws tool exit if the path is not found on Windows', () {
-    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
+    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
     final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
       delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
       platform: windowsPlatform,
@@ -107,7 +107,7 @@ void main() {
     final File file = fileSystem.file(fileSystem.path.join('directory', 'file'))
       ..createSync(recursive: true);
 
-    exceptionHandler.setHandler(
+    exceptionHandler.addError(
       file,
       FileSystemOp.delete,
       () => throw FileSystemException('', file.path, const OSError('', 2)),
@@ -123,10 +123,10 @@ void main() {
     const int kFatalDeviceHardwareError =  483;
     const int kDeviceDoesNotExist = 433;
 
-    late MutableFileSystemOpHandle opHandle;
+    late FileExceptionHandler opHandle;
 
     setUp(() {
-      opHandle = MutableFileSystemOpHandle();
+      opHandle = FileExceptionHandler();
     });
 
     testWithoutContext('bypasses error handling when noExitOnFailure is used', () {
@@ -136,7 +136,7 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException(
@@ -165,19 +165,19 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException(
             '', file.path, const OSError('', kUserPermissionDenied)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.open,
         () => throw FileSystemException(
             '', file.path, const OSError('', kUserPermissionDenied)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.create,
         () => throw FileSystemException(
@@ -206,7 +206,7 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException('', file.path, const OSError('', kDeviceFull)),
@@ -230,7 +230,7 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException(
@@ -255,19 +255,19 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException(
             '', file.path, const OSError('', kFatalDeviceHardwareError)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.open,
         () => throw FileSystemException(
             '', file.path, const OSError('', kFatalDeviceHardwareError)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.create,
         () => throw FileSystemException(
@@ -297,17 +297,17 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.open,
         () => throw FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.create,
         () => throw FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
@@ -336,7 +336,7 @@ void main() {
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      opHandle.setTempHandler(
+      opHandle.addTempError(
         FileSystemOp.create,
         (String path) => throw FileSystemException(
             '', directory.path, const OSError('', kDeviceFull)),
@@ -356,7 +356,7 @@ void main() {
       );
       final Directory directory = fileSystem.directory('directory');
 
-      opHandle.setHandler(
+      opHandle.addError(
         directory,
         FileSystemOp.create,
         () => throw FileSystemException(
@@ -377,7 +377,7 @@ void main() {
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      opHandle.setHandler(
+      opHandle.addError(
         directory,
         FileSystemOp.exists,
         () => throw FileSystemException(
@@ -396,7 +396,7 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.read,
         () => throw FileSystemException(
@@ -432,7 +432,7 @@ void main() {
       final File file = parentDirectory.childFile('file');
 
       // Simulates the parent directory being deleted/moved as soon it was created.
-      opHandle.setHandler(file, FileSystemOp.create, () {
+      opHandle.addError(file, FileSystemOp.create, () {
         parentDirectory.deleteSync();
       });
 
@@ -449,10 +449,10 @@ void main() {
     const int enospc = 28;
     const int eacces = 13;
 
-    late MutableFileSystemOpHandle opHandle;
+    late FileExceptionHandler opHandle;
 
     setUp(() {
-      opHandle = MutableFileSystemOpHandle();
+      opHandle = FileExceptionHandler();
     });
 
     testWithoutContext('when access is denied', () async {
@@ -463,22 +463,22 @@ void main() {
       final Directory directory = fileSystem.directory('dir')..createSync();
       final File file = directory.childFile('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.create,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.read,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.delete,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
@@ -520,13 +520,13 @@ void main() {
       final Directory parent = fileSystem.directory('parent')..createSync();
       final Directory directory = parent.childDirectory('childDir');
 
-      opHandle.setHandler(
+      opHandle.addError(
         directory,
         FileSystemOp.create,
         () => throw FileSystemException(
             '', directory.path, const OSError('', eperm)),
       );
-      opHandle.setHandler(
+      opHandle.addError(
         directory,
         FileSystemOp.delete,
         () => throw FileSystemException(
@@ -569,7 +569,7 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException('', file.path, const OSError('', enospc)),
@@ -595,7 +595,7 @@ void main() {
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      opHandle.setTempHandler(
+      opHandle.addTempError(
         FileSystemOp.create,
         (String path) => throw FileSystemException('', path, const OSError('', enospc)),
       );
@@ -616,7 +616,7 @@ void main() {
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      opHandle.setHandler(
+      opHandle.addError(
         directory,
         FileSystemOp.exists,
         () => throw FileSystemException('', directory.path, const OSError('', eacces)),
@@ -643,7 +643,7 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      opHandle.setHandler(
+      opHandle.addError(
         file,
         FileSystemOp.read,
         () => throw FileSystemException(
@@ -659,10 +659,10 @@ void main() {
     const int eperm = 1;
     const int enospc = 28;
     const int eacces = 13;
-    late MutableFileSystemOpHandle exceptionHandler;
+    late FileExceptionHandler exceptionHandler;
 
     setUp(() {
-      exceptionHandler = MutableFileSystemOpHandle();
+      exceptionHandler = FileExceptionHandler();
     });
 
     testWithoutContext('when access is denied', () async {
@@ -673,22 +673,22 @@ void main() {
       final Directory directory = fileSystem.directory('dir')..createSync();
       final File file = directory.childFile('file');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         file,
         FileSystemOp.create,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         file,
         FileSystemOp.read,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         file,
         FileSystemOp.delete,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
@@ -730,12 +730,12 @@ void main() {
       final Directory parent = fileSystem.directory('parent')..createSync();
       final Directory directory = parent.childDirectory('childDir');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         directory,
         FileSystemOp.create,
         () => throw FileSystemException('', directory.path, const OSError('', eperm)),
       );
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         directory,
         FileSystemOp.delete,
         () => throw FileSystemException('', directory.path, const OSError('', eperm)),
@@ -776,7 +776,7 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         file,
         FileSystemOp.write,
         () => throw FileSystemException('', file.path, const OSError('', enospc)),
@@ -802,7 +802,7 @@ void main() {
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      exceptionHandler.setTempHandler(
+      exceptionHandler.addTempError(
         FileSystemOp.create,
         (String path) => throw FileSystemException('', path, const OSError('', enospc)),
       );
@@ -822,7 +822,7 @@ void main() {
 
       final Directory directory = fileSystem.directory('directory');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         directory,
         FileSystemOp.exists,
         () => throw FileSystemException(
@@ -841,7 +841,7 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         file,
         FileSystemOp.read,
         () => throw FileSystemException('', file.path, const OSError('', eacces)),
@@ -927,7 +927,7 @@ void main() {
   });
 
   testWithoutContext("ErrorHandlingFileSystem.systemTempDirectory wraps delegates filesystem's systemTempDirectory", () {
-    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
+    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
 
     final MemoryFileSystem delegate = MemoryFileSystem.test(
       style: FileSystemStyle.windows,
@@ -945,7 +945,7 @@ void main() {
     final File tempFile = delegate.systemTempDirectory.childFile('hello')
       ..createSync(recursive: true);
 
-    exceptionHandler.setHandler(
+    exceptionHandler.addError(
       tempFile,
       FileSystemOp.write,
       () => throw FileSystemException(
@@ -1270,11 +1270,11 @@ Please ensure that the SDK and/or project is installed in a location that has re
 
   group('CopySync' , () {
     const int eaccess = 13;
-    late MutableFileSystemOpHandle exceptionHandler;
+    late FileExceptionHandler exceptionHandler;
     late ErrorHandlingFileSystem fileSystem;
 
     setUp(() {
-      exceptionHandler = MutableFileSystemOpHandle();
+      exceptionHandler = FileExceptionHandler();
       fileSystem = ErrorHandlingFileSystem(
         delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
         platform: linuxPlatform,
@@ -1284,7 +1284,7 @@ Please ensure that the SDK and/or project is installed in a location that has re
     testWithoutContext('copySync handles error if openSync on source file fails', () {
       final File source = fileSystem.file('source');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         source,
         FileSystemOp.open,
         () => throw FileSystemException('', source.path, const OSError('', eaccess)),
@@ -1302,7 +1302,7 @@ Please ensure that the SDK and/or project is installed in a location that has re
       fileSystem.file('source').createSync();
       final File dest = fileSystem.file('dest');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         dest,
         FileSystemOp.create,
         () => throw FileSystemException('', dest.path, const OSError('', eaccess)),
@@ -1319,7 +1319,7 @@ Please ensure that the SDK and/or project is installed in a location that has re
       fileSystem.file('source').createSync();
       final File dest = fileSystem.file('dest');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         dest,
         FileSystemOp.open,
         () => throw FileSystemException('', dest.path, const OSError('', eaccess)),
@@ -1344,7 +1344,7 @@ Please ensure that the SDK and/or project is installed in a location that has re
       fileSystem.file('source').writeAsBytesSync(expectedBytes);
       final File dest = fileSystem.file('dest');
 
-      exceptionHandler.setHandler(
+      exceptionHandler.addError(
         dest,
         FileSystemOp.copy,
         () => throw FileSystemException('', dest.path, const OSError('', eaccess)),

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -70,7 +70,7 @@ void main() {
     exceptionHandler.setHandler(
       file,
       FileSystemOp.delete,
-      () => FileSystemException('', file.path, const OSError('', 2)),
+      () => throw FileSystemException('', file.path, const OSError('', 2)),
     );
 
     expect(() => ErrorHandlingFileSystem.deleteIfExists(file), throwsToolExit());
@@ -110,7 +110,7 @@ void main() {
     exceptionHandler.setHandler(
       file,
       FileSystemOp.delete,
-      () => FileSystemException('', file.path, const OSError('', 2)),
+      () => throw FileSystemException('', file.path, const OSError('', 2)),
     );
 
     expect(() => ErrorHandlingFileSystem.deleteIfExists(file), throwsToolExit());
@@ -209,7 +209,7 @@ void main() {
       opHandle.setHandler(
         file,
         FileSystemOp.write,
-        () => FileSystemException('', file.path, const OSError('', kDeviceFull)),
+        () => throw FileSystemException('', file.path, const OSError('', kDeviceFull)),
       );
 
       const String expectedMessage = 'The target device is full';
@@ -359,7 +359,7 @@ void main() {
       opHandle.setHandler(
         directory,
         FileSystemOp.create,
-        () => FileSystemException(
+        () => throw FileSystemException(
             '', directory.path, const OSError('', kUserPermissionDenied)),
       );
 
@@ -656,17 +656,17 @@ void main() {
       exceptionHandler.setHandler(
         file,
         FileSystemOp.write,
-        () => FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
       exceptionHandler.setHandler(
         file,
         FileSystemOp.read,
-        () => FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
       exceptionHandler.setHandler(
         file,
         FileSystemOp.delete,
-        () => FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
       const String writeMessage =
           'Flutter failed to write to a file at "dir/file".\n'
@@ -713,7 +713,7 @@ void main() {
       exceptionHandler.setHandler(
         directory,
         FileSystemOp.delete,
-        () => FileSystemException('', directory.path, const OSError('', eperm)),
+        () => throw FileSystemException('', directory.path, const OSError('', eperm)),
       );
 
       const String createMessage =

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -417,6 +417,31 @@ void main() {
       expect(() => fileSystem.currentDirectory,
              throwsToolExit(message: 'The flutter tool cannot access the file or directory'));
     });
+
+    // TODOadd this test for Linux/macOS
+    testWithoutContext('When creating a file with recursive:true and a PathNotFoundException is thrown on a parent directory', () async {
+      final FileSystem delegate = MemoryFileSystem.test(
+        opHandle: opHandle.opHandle,
+        style: FileSystemStyle.windows,
+      );
+      final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
+        delegate: delegate,
+        platform: windowsPlatform,
+      );
+      final Directory parentDirectory = fileSystem.directory('parent');
+      final File file = parentDirectory.childFile('file');
+
+      // Simulates the parent directory being deleted/moved as soon it was created.
+      opHandle.setHandler(file, FileSystemOp.create, () {
+        parentDirectory.deleteSync();
+      });
+
+      expect(file, isNot(exists));
+      expect(
+        () => file.createSync(recursive: true),
+        throwsToolExit(message: 'TODO write a message here'), // TODO
+      );
+    });
   });
 
   group('throws ToolExit on Linux', () {

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -60,7 +60,7 @@ void main() {
   });
 
   testWithoutContext('deleteIfExists throws tool exit if file exists on read-only volume', () {
-    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
+    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
     final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
       delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
       platform: linuxPlatform,
@@ -78,7 +78,7 @@ void main() {
 
   testWithoutContext('deleteIfExists does not tool exit if file exists on read-only '
     'volume and it is run under noExitOnFailure', () {
-    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
+    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
     final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
       delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
       platform: linuxPlatform,
@@ -99,7 +99,7 @@ void main() {
   });
 
   testWithoutContext('deleteIfExists throws tool exit if the path is not found on Windows', () {
-    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
+    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
     final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
       delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
       platform: windowsPlatform,
@@ -123,10 +123,10 @@ void main() {
     const int kFatalDeviceHardwareError =  483;
     const int kDeviceDoesNotExist = 433;
 
-    late FileExceptionHandler exceptionHandler;
+    late MutableFileSystemOpHandle exceptionHandler;
 
     setUp(() {
-      exceptionHandler = FileExceptionHandler();
+      exceptionHandler = MutableFileSystemOpHandle();
     });
 
     testWithoutContext('bypasses error handling when noExitOnFailure is used', () {
@@ -412,10 +412,10 @@ void main() {
     const int enospc = 28;
     const int eacces = 13;
 
-    late FileExceptionHandler exceptionHandler;
+    late MutableFileSystemOpHandle exceptionHandler;
 
     setUp(() {
-      exceptionHandler = FileExceptionHandler();
+      exceptionHandler = MutableFileSystemOpHandle();
     });
 
     testWithoutContext('when access is denied', () async {
@@ -618,10 +618,10 @@ void main() {
     const int eperm = 1;
     const int enospc = 28;
     const int eacces = 13;
-    late FileExceptionHandler exceptionHandler;
+    late MutableFileSystemOpHandle exceptionHandler;
 
     setUp(() {
-      exceptionHandler = FileExceptionHandler();
+      exceptionHandler = MutableFileSystemOpHandle();
     });
 
     testWithoutContext('when access is denied', () async {
@@ -885,7 +885,7 @@ void main() {
   });
 
   testWithoutContext("ErrorHandlingFileSystem.systemTempDirectory wraps delegates filesystem's systemTempDirectory", () {
-    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
+    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
 
     final MemoryFileSystem delegate = MemoryFileSystem.test(
       style: FileSystemStyle.windows,
@@ -1228,11 +1228,11 @@ Please ensure that the SDK and/or project is installed in a location that has re
 
   group('CopySync' , () {
     const int eaccess = 13;
-    late FileExceptionHandler exceptionHandler;
+    late MutableFileSystemOpHandle exceptionHandler;
     late ErrorHandlingFileSystem fileSystem;
 
     setUp(() {
-      exceptionHandler = FileExceptionHandler();
+      exceptionHandler = MutableFileSystemOpHandle();
       fileSystem = ErrorHandlingFileSystem(
         delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
         platform: linuxPlatform,

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -67,10 +67,10 @@ void main() {
     );
     final File file = fileSystem.file('file')..createSync();
 
-    exceptionHandler.addError(
+    exceptionHandler.setHandler(
       file,
       FileSystemOp.delete,
-      FileSystemException('', file.path, const OSError('', 2)),
+      () => FileSystemException('', file.path, const OSError('', 2)),
     );
 
     expect(() => ErrorHandlingFileSystem.deleteIfExists(file), throwsToolExit());
@@ -85,10 +85,10 @@ void main() {
     );
     final File file = fileSystem.file('file')..createSync();
 
-    exceptionHandler.addError(
+    exceptionHandler.setHandler(
       file,
       FileSystemOp.delete,
-      FileSystemException('', file.path, const OSError('', 2)),
+      () => throw FileSystemException('', file.path, const OSError('', 2)),
     );
 
     expect(() {
@@ -107,10 +107,10 @@ void main() {
     final File file = fileSystem.file(fileSystem.path.join('directory', 'file'))
       ..createSync(recursive: true);
 
-    exceptionHandler.addError(
+    exceptionHandler.setHandler(
       file,
       FileSystemOp.delete,
-      FileSystemException('', file.path, const OSError('', 2)),
+      () => FileSystemException('', file.path, const OSError('', 2)),
     );
 
     expect(() => ErrorHandlingFileSystem.deleteIfExists(file), throwsToolExit());
@@ -123,23 +123,24 @@ void main() {
     const int kFatalDeviceHardwareError =  483;
     const int kDeviceDoesNotExist = 433;
 
-    late MutableFileSystemOpHandle exceptionHandler;
+    late MutableFileSystemOpHandle opHandle;
 
     setUp(() {
-      exceptionHandler = MutableFileSystemOpHandle();
+      opHandle = MutableFileSystemOpHandle();
     });
 
     testWithoutContext('bypasses error handling when noExitOnFailure is used', () {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', kUserPermissionDenied)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kUserPermissionDenied)),
       );
       final Matcher throwsNonToolExit = throwsA(isNot(isA<ToolExit>()));
       expect(() => ErrorHandlingFileSystem.noExitOnFailure(
@@ -159,25 +160,28 @@ void main() {
 
     testWithoutContext('when access is denied', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', kUserPermissionDenied)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kUserPermissionDenied)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.open,
-        FileSystemException('', file.path, const OSError('', kUserPermissionDenied)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kUserPermissionDenied)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.create,
-        FileSystemException('', file.path, const OSError('', kUserPermissionDenied)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kUserPermissionDenied)),
       );
 
       const String expectedMessage = 'The flutter tool cannot access the file';
@@ -197,15 +201,15 @@ void main() {
 
     testWithoutContext('when writing to a full device', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', kDeviceFull)),
+        () => FileSystemException('', file.path, const OSError('', kDeviceFull)),
       );
 
       const String expectedMessage = 'The target device is full';
@@ -221,15 +225,16 @@ void main() {
 
     testWithoutContext('when the file is being used by another program', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', kUserMappedSectionOpened)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kUserMappedSectionOpened)),
       );
 
       const String expectedMessage = 'The file is being used by another program';
@@ -245,25 +250,28 @@ void main() {
 
     testWithoutContext('when the device driver has a fatal error', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', kFatalDeviceHardwareError)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kFatalDeviceHardwareError)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.open,
-        FileSystemException('', file.path, const OSError('', kFatalDeviceHardwareError)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kFatalDeviceHardwareError)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.create,
-        FileSystemException('', file.path, const OSError('', kFatalDeviceHardwareError)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kFatalDeviceHardwareError)),
       );
 
       const String expectedMessage = 'There is a problem with the device driver '
@@ -284,25 +292,25 @@ void main() {
 
     testWithoutContext('when the device does not exist', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
+        () => throw FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.open,
-        FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
+        () => throw FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.create,
-        FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
+        () => throw FileSystemException('', file.path, const OSError('', kDeviceDoesNotExist)),
       );
 
       const String expectedMessage = 'The device was not found.';
@@ -322,15 +330,16 @@ void main() {
 
     testWithoutContext('when creating a temporary dir on a full device', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      exceptionHandler.addTempError(
+      opHandle.setTempHandler(
         FileSystemOp.create,
-        FileSystemException('', directory.path, const OSError('', kDeviceFull)),
+        (String path) => throw FileSystemException(
+            '', directory.path, const OSError('', kDeviceFull)),
       );
 
       const String expectedMessage = 'The target device is full';
@@ -342,15 +351,16 @@ void main() {
 
     testWithoutContext('when creating a directory with permission issues', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final Directory directory = fileSystem.directory('directory');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         directory,
         FileSystemOp.create,
-        FileSystemException('', directory.path, const OSError('', kUserPermissionDenied)),
+        () => FileSystemException(
+            '', directory.path, const OSError('', kUserPermissionDenied)),
       );
 
       const String expectedMessage = 'Flutter failed to create a directory at';
@@ -360,17 +370,18 @@ void main() {
 
     testWithoutContext('when checking for directory existence with permission issues', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
 
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         directory,
         FileSystemOp.exists,
-        FileSystemException('', directory.path, const OSError('', kDeviceFull)),
+        () => throw FileSystemException(
+            '', directory.path, const OSError('', kDeviceFull)),
       );
 
       const String expectedMessage = 'Flutter failed to check for directory existence at';
@@ -380,15 +391,16 @@ void main() {
 
     testWithoutContext('When reading from a file without permission', () {
        final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: windowsPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.read,
-        FileSystemException('', file.path, const OSError('', kUserPermissionDenied)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kUserPermissionDenied)),
       );
 
       const String expectedMessage = 'Flutter failed to read a file at';
@@ -412,40 +424,41 @@ void main() {
     const int enospc = 28;
     const int eacces = 13;
 
-    late MutableFileSystemOpHandle exceptionHandler;
+    late MutableFileSystemOpHandle opHandle;
 
     setUp(() {
-      exceptionHandler = MutableFileSystemOpHandle();
+      opHandle = MutableFileSystemOpHandle();
     });
 
     testWithoutContext('when access is denied', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: linuxPlatform,
       );
       final Directory directory = fileSystem.directory('dir')..createSync();
       final File file = directory.childFile('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.create,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.read,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.delete,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
+
       const String writeMessage =
           'Flutter failed to write to a file at "dir/file".\n'
           'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
@@ -476,21 +489,23 @@ void main() {
 
     testWithoutContext('when access is denied for directories', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: linuxPlatform,
       );
       final Directory parent = fileSystem.directory('parent')..createSync();
       final Directory directory = parent.childDirectory('childDir');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         directory,
         FileSystemOp.create,
-        FileSystemException('', directory.path, const OSError('', eperm)),
+        () => throw FileSystemException(
+            '', directory.path, const OSError('', eperm)),
       );
-      exceptionHandler.addError(
+      opHandle.setHandler(
         directory,
         FileSystemOp.delete,
-        FileSystemException('', directory.path, const OSError('', eperm)),
+        () => throw FileSystemException(
+            '', directory.path, const OSError('', eperm)),
       );
 
       const String createMessage =
@@ -524,15 +539,15 @@ void main() {
 
     testWithoutContext('when writing to a full device', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: linuxPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', enospc)),
+        () => throw FileSystemException('', file.path, const OSError('', enospc)),
       );
 
       const String expectedMessage = 'The target device is full';
@@ -548,16 +563,16 @@ void main() {
 
     testWithoutContext('when creating a temporary dir on a full device', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: linuxPlatform,
       );
 
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      exceptionHandler.addTempError(
+      opHandle.setTempHandler(
         FileSystemOp.create,
-        FileSystemException('', directory.path, const OSError('', enospc)),
+        (String path) => throw FileSystemException('', path, const OSError('', enospc)),
       );
 
       const String expectedMessage = 'The target device is full';
@@ -569,17 +584,17 @@ void main() {
 
     testWithoutContext('when checking for directory existence with permission issues', () async {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: linuxPlatform,
       );
 
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         directory,
         FileSystemOp.exists,
-        FileSystemException('', directory.path, const OSError('', eacces)),
+        () => throw FileSystemException('', directory.path, const OSError('', eacces)),
       );
 
       const String expectedMessage = 'Flutter failed to check for directory existence at';
@@ -598,15 +613,16 @@ void main() {
 
     testWithoutContext('Rethrows os error $kSystemCodeCannotFindFile', () {
        final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
-        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        delegate: MemoryFileSystem.test(opHandle: opHandle.opHandle),
         platform: linuxPlatform,
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      opHandle.setHandler(
         file,
         FileSystemOp.read,
-        FileSystemException('', file.path, const OSError('', kSystemCodeCannotFindFile)),
+        () => throw FileSystemException(
+            '', file.path, const OSError('', kSystemCodeCannotFindFile)),
       );
 
       // Error is not caught by other operations.
@@ -632,25 +648,25 @@ void main() {
       final Directory directory = fileSystem.directory('dir')..createSync();
       final File file = directory.childFile('file');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         file,
         FileSystemOp.create,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         file,
         FileSystemOp.read,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => FileSystemException('', file.path, const OSError('', eacces)),
       );
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         file,
         FileSystemOp.delete,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => FileSystemException('', file.path, const OSError('', eacces)),
       );
       const String writeMessage =
           'Flutter failed to write to a file at "dir/file".\n'
@@ -689,15 +705,15 @@ void main() {
       final Directory parent = fileSystem.directory('parent')..createSync();
       final Directory directory = parent.childDirectory('childDir');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         directory,
         FileSystemOp.create,
-        FileSystemException('', directory.path, const OSError('', eperm)),
+        () => throw FileSystemException('', directory.path, const OSError('', eperm)),
       );
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         directory,
         FileSystemOp.delete,
-        FileSystemException('', directory.path, const OSError('', eperm)),
+        () => FileSystemException('', directory.path, const OSError('', eperm)),
       );
 
       const String createMessage =
@@ -735,10 +751,10 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         file,
         FileSystemOp.write,
-        FileSystemException('', file.path, const OSError('', enospc)),
+        () => throw FileSystemException('', file.path, const OSError('', enospc)),
       );
 
       const String expectedMessage = 'The target device is full';
@@ -761,9 +777,9 @@ void main() {
       final Directory directory = fileSystem.directory('directory')
         ..createSync();
 
-      exceptionHandler.addTempError(
+      exceptionHandler.setTempHandler(
         FileSystemOp.create,
-        FileSystemException('', directory.path, const OSError('', enospc)),
+        (String path) => throw FileSystemException('', path, const OSError('', enospc)),
       );
 
       const String expectedMessage = 'The target device is full';
@@ -781,10 +797,11 @@ void main() {
 
       final Directory directory = fileSystem.directory('directory');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         directory,
         FileSystemOp.exists,
-        FileSystemException('', directory.path, const OSError('', eacces)),
+        () => throw FileSystemException(
+            '', directory.path, const OSError('', eacces)),
       );
 
       const String expectedMessage = 'Flutter failed to check for directory existence at';
@@ -799,10 +816,10 @@ void main() {
       );
       final File file = fileSystem.file('file');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         file,
         FileSystemOp.read,
-        FileSystemException('', file.path, const OSError('', eacces)),
+        () => throw FileSystemException('', file.path, const OSError('', eacces)),
       );
 
       const String expectedMessage = 'Flutter failed to read a file at';
@@ -903,10 +920,10 @@ void main() {
     final File tempFile = delegate.systemTempDirectory.childFile('hello')
       ..createSync(recursive: true);
 
-    exceptionHandler.addError(
+    exceptionHandler.setHandler(
       tempFile,
       FileSystemOp.write,
-      FileSystemException(
+      () => throw FileSystemException(
         'Oh no!',
         tempFile.path,
         const OSError('Access denied ):', 5),
@@ -1242,10 +1259,10 @@ Please ensure that the SDK and/or project is installed in a location that has re
     testWithoutContext('copySync handles error if openSync on source file fails', () {
       final File source = fileSystem.file('source');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         source,
         FileSystemOp.open,
-        FileSystemException('', source.path, const OSError('', eaccess)),
+        () => throw FileSystemException('', source.path, const OSError('', eaccess)),
       );
 
       const String expectedMessage =
@@ -1260,10 +1277,10 @@ Please ensure that the SDK and/or project is installed in a location that has re
       fileSystem.file('source').createSync();
       final File dest = fileSystem.file('dest');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         dest,
         FileSystemOp.create,
-        FileSystemException('', dest.path, const OSError('', eaccess)),
+        () => throw FileSystemException('', dest.path, const OSError('', eaccess)),
       );
 
       const String expectedMessage =
@@ -1277,10 +1294,10 @@ Please ensure that the SDK and/or project is installed in a location that has re
       fileSystem.file('source').createSync();
       final File dest = fileSystem.file('dest');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         dest,
         FileSystemOp.open,
-        FileSystemException('', dest.path, const OSError('', eaccess)),
+        () => throw FileSystemException('', dest.path, const OSError('', eaccess)),
       );
 
       expect(dest, isNot(exists));
@@ -1302,10 +1319,10 @@ Please ensure that the SDK and/or project is installed in a location that has re
       fileSystem.file('source').writeAsBytesSync(expectedBytes);
       final File dest = fileSystem.file('dest');
 
-      exceptionHandler.addError(
+      exceptionHandler.setHandler(
         dest,
         FileSystemOp.copy,
-        FileSystemException('', dest.path, const OSError('', eaccess)),
+        () => throw FileSystemException('', dest.path, const OSError('', eaccess)),
       );
 
       fileSystem.file('source').copySync('dest');

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -514,7 +514,7 @@ void main() {
     });
 
     testWithoutContext('Linux name when reading "/etc/os-release" fails', () async {
-      final FileExceptionHandler handler = FileExceptionHandler();
+      final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
       final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
 
       fileSystem.directory('/etc').createSync();
@@ -592,7 +592,7 @@ void main() {
 
   testWithoutContext('If unzip fails, include stderr in exception text', () {
     const String exceptionMessage = 'Something really bad happened.';
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
 
     fakeProcessManager.addCommand(

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -514,13 +514,17 @@ void main() {
     });
 
     testWithoutContext('Linux name when reading "/etc/os-release" fails', () async {
-      final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
-      final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+      final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+      final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
 
       fileSystem.directory('/etc').createSync();
       final File osRelease = fileSystem.file('/etc/os-release');
 
-      handler.addError(osRelease, FileSystemOp.read, const FileSystemException());
+      fileSystemOpHandle.setHandler(
+        osRelease,
+        FileSystemOp.read,
+        () => throw const FileSystemException(),
+      );
 
       final OperatingSystemUtils utils = OperatingSystemUtils(
         fileSystem: fileSystem,
@@ -592,8 +596,8 @@ void main() {
 
   testWithoutContext('If unzip fails, include stderr in exception text', () {
     const String exceptionMessage = 'Something really bad happened.';
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
-    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
 
     fakeProcessManager.addCommand(
       const FakeCommand(command: <String>[
@@ -610,7 +614,11 @@ void main() {
       ..createSync();
     final File bar = fileSystem.file('bar.zip')
       ..createSync();
-    handler.addError(bar, FileSystemOp.read, const FileSystemException(exceptionMessage));
+    fileSystemOpHandle.setHandler(
+      bar,
+      FileSystemOp.read,
+      () => throw const FileSystemException(exceptionMessage),
+    );
 
     final OperatingSystemUtils osUtils = OperatingSystemUtils(
       fileSystem: fileSystem,

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -514,13 +514,13 @@ void main() {
     });
 
     testWithoutContext('Linux name when reading "/etc/os-release" fails', () async {
-      final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+      final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
       final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
 
       fileSystem.directory('/etc').createSync();
       final File osRelease = fileSystem.file('/etc/os-release');
 
-      fileSystemOpHandle.setHandler(
+      fileSystemOpHandle.addError(
         osRelease,
         FileSystemOp.read,
         () => throw const FileSystemException(),
@@ -596,7 +596,7 @@ void main() {
 
   testWithoutContext('If unzip fails, include stderr in exception text', () {
     const String exceptionMessage = 'Something really bad happened.';
-    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
 
     fakeProcessManager.addCommand(
@@ -614,7 +614,7 @@ void main() {
       ..createSync();
     final File bar = fileSystem.file('bar.zip')
       ..createSync();
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       bar,
       FileSystemOp.read,
       () => throw const FileSystemException(exceptionMessage),

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -153,7 +153,7 @@ void main() {
   });
 
   testWithoutContext('FileStore handles failure to persist file cache', () async {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final BufferLogger logger = BufferLogger.test();
 
@@ -173,7 +173,7 @@ void main() {
   });
 
   testWithoutContext('FileStore handles failure to restore file cache', () async {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final BufferLogger logger = BufferLogger.test();
 

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -153,13 +153,13 @@ void main() {
   });
 
   testWithoutContext('FileStore handles failure to persist file cache', () async {
-    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final BufferLogger logger = BufferLogger.test();
 
     final File cacheFile = fileSystem.file('foo')
       ..createSync();
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       cacheFile,
       FileSystemOp.write,
       () => throw const FileSystemException('Out of space!'),
@@ -177,13 +177,13 @@ void main() {
   });
 
   testWithoutContext('FileStore handles failure to restore file cache', () async {
-    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final BufferLogger logger = BufferLogger.test();
 
     final File cacheFile = fileSystem.file('foo')
       ..createSync();
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       cacheFile,
       FileSystemOp.read,
       () => throw const FileSystemException('Out of space!'),

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -153,13 +153,17 @@ void main() {
   });
 
   testWithoutContext('FileStore handles failure to persist file cache', () async {
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
-    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final BufferLogger logger = BufferLogger.test();
 
     final File cacheFile = fileSystem.file('foo')
       ..createSync();
-    handler.addError(cacheFile, FileSystemOp.write, const FileSystemException('Out of space!'));
+    fileSystemOpHandle.setHandler(
+      cacheFile,
+      FileSystemOp.write,
+      () => throw const FileSystemException('Out of space!'),
+    );
 
     final FileStore fileCache = FileStore(
       cacheFile: cacheFile,
@@ -173,13 +177,17 @@ void main() {
   });
 
   testWithoutContext('FileStore handles failure to restore file cache', () async {
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
-    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final BufferLogger logger = BufferLogger.test();
 
     final File cacheFile = fileSystem.file('foo')
       ..createSync();
-    handler.addError(cacheFile, FileSystemOp.read, const FileSystemException('Out of space!'));
+    fileSystemOpHandle.setHandler(
+      cacheFile,
+      FileSystemOp.read,
+      () => throw const FileSystemException('Out of space!'),
+    );
 
     final FileStore fileCache = FileStore(
       cacheFile: cacheFile,

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -891,7 +891,7 @@ void main() {
   });
 
   testWithoutContext('FlutterWebSdk uses tryToDelete to handle directory edge cases', () async {
-    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final Cache cache = Cache.test(processManager: FakeProcessManager.any(), fileSystem: fileSystem);
     final Directory webCacheDirectory = cache.getWebSdkDirectory();
@@ -903,7 +903,7 @@ void main() {
       location.childFile('foo').createSync();
     };
     webCacheDirectory.childFile('bar').createSync(recursive: true);
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       webCacheDirectory,
       FileSystemOp.delete,
       () => throw const FileSystemException('', '', OSError('', 2)),
@@ -915,7 +915,7 @@ void main() {
   });
 
   testWithoutContext('LegacyCanvasKitRemover removes old canvaskit artifacts if they exist', () async {
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
+    final FileExceptionHandler handler = FileExceptionHandler();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final Cache cache = Cache.test(processManager: FakeProcessManager.any(), fileSystem: fileSystem);
     final File canvasKitWasm = fileSystem.file(fileSystem.path.join(
@@ -940,7 +940,7 @@ void main() {
   });
 
   testWithoutContext('Cache handles exception thrown if stamp file cannot be parsed', () {
-    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final Logger logger = BufferLogger.test();
     final FakeCache cache = FakeCache(
@@ -955,7 +955,7 @@ void main() {
     expect(cache.getStampFor('foo'), null);
 
     file.createSync();
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       file,
       FileSystemOp.read,
       () => throw const FileSystemException(),

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -891,7 +891,7 @@ void main() {
   });
 
   testWithoutContext('FlutterWebSdk uses tryToDelete to handle directory edge cases', () async {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final Cache cache = Cache.test(processManager: FakeProcessManager.any(), fileSystem: fileSystem);
     final Directory webCacheDirectory = cache.getWebSdkDirectory();
@@ -911,7 +911,7 @@ void main() {
   });
 
   testWithoutContext('LegacyCanvasKitRemover removes old canvaskit artifacts if they exist', () async {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final Cache cache = Cache.test(processManager: FakeProcessManager.any(), fileSystem: fileSystem);
     final File canvasKitWasm = fileSystem.file(fileSystem.path.join(
@@ -936,7 +936,7 @@ void main() {
   });
 
   testWithoutContext('Cache handles exception thrown if stamp file cannot be parsed', () {
-    final FileExceptionHandler exceptionHandler = FileExceptionHandler();
+    final MutableFileSystemOpHandle exceptionHandler = MutableFileSystemOpHandle();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: exceptionHandler.opHandle);
     final Logger logger = BufferLogger.test();
     final FakeCache cache = FakeCache(

--- a/packages/flutter_tools/test/general.shard/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/config_test.dart
@@ -133,12 +133,12 @@ void main() {
   testWithoutContext('Config.createForTesting does not error when failing to delete a file', () {
     final BufferLogger bufferLogger = BufferLogger.test();
 
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
+    final FileExceptionHandler handler = FileExceptionHandler();
     final MemoryFileSystem fs = MemoryFileSystem.test(opHandle: handler.opHandle);
     final File file = fs.file('testfile')
         // We write invalid JSON so that we test catching a `FormatException`
         ..writeAsStringSync('{"This is not valid JSON"');
-    handler.setHandler(
+    handler.addError(
       file,
       FileSystemOp.delete,
       () => throw const FileSystemException(

--- a/packages/flutter_tools/test/general.shard/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/config_test.dart
@@ -133,7 +133,7 @@ void main() {
   testWithoutContext('Config.createForTesting does not error when failing to delete a file', () {
     final BufferLogger bufferLogger = BufferLogger.test();
 
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final MemoryFileSystem fs = MemoryFileSystem.test(opHandle: handler.opHandle);
     final File file = fs.file('testfile')
         // We write invalid JSON so that we test catching a `FormatException`

--- a/packages/flutter_tools/test/general.shard/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/config_test.dart
@@ -138,10 +138,10 @@ void main() {
     final File file = fs.file('testfile')
         // We write invalid JSON so that we test catching a `FormatException`
         ..writeAsStringSync('{"This is not valid JSON"');
-    handler.addError(
+    handler.setHandler(
       file,
       FileSystemOp.delete,
-      const FileSystemException(
+      () => throw const FileSystemException(
         "Cannot delete file, path = 'testfile' (OS Error: No such file or directory, errno = 2)",
       ),
     );

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -289,7 +289,7 @@ library funstuff;
   });
 
   testWithoutContext('Returns null safe error if reading the file throws a FileSystemException', () {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     setUpLanguageVersion(fileSystem);
     final File errorFile = fileSystem.file('foo');

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -289,11 +289,11 @@ library funstuff;
   });
 
   testWithoutContext('Returns null safe error if reading the file throws a FileSystemException', () {
-    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     setUpLanguageVersion(fileSystem);
     final File errorFile = fileSystem.file('foo');
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       errorFile,
       FileSystemOp.read,
       () => throw const FileSystemException(),

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -289,11 +289,15 @@ library funstuff;
   });
 
   testWithoutContext('Returns null safe error if reading the file throws a FileSystemException', () {
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
-    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     setUpLanguageVersion(fileSystem);
     final File errorFile = fileSystem.file('foo');
-    handler.addError(errorFile, FileSystemOp.read, const FileSystemException());
+    fileSystemOpHandle.setHandler(
+      errorFile,
+      FileSystemOp.read,
+      () => throw const FileSystemException(),
+    );
 
     final Package package = Package(
       'foo',

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -435,11 +435,11 @@ void main() {
   });
 
   testWithoutContext('Local DevFSWriter turns FileSystemException into DevFSException', () async {
-    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final LocalDevFSWriter writer = LocalDevFSWriter(fileSystem: fileSystem);
     final File file = fileSystem.file('foo');
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       file,
       FileSystemOp.read,
       () => throw const FileSystemException('foo'),

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -435,11 +435,15 @@ void main() {
   });
 
   testWithoutContext('Local DevFSWriter turns FileSystemException into DevFSException', () async {
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
-    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final LocalDevFSWriter writer = LocalDevFSWriter(fileSystem: fileSystem);
     final File file = fileSystem.file('foo');
-    handler.addError(file, FileSystemOp.read, const FileSystemException('foo'));
+    fileSystemOpHandle.setHandler(
+      file,
+      FileSystemOp.read,
+      () => throw const FileSystemException('foo'),
+    );
 
     await expectLater(() async => writer.write(<Uri, DevFSContent>{
       Uri.parse('goodbye'): DevFSFileContent(file),

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -435,7 +435,7 @@ void main() {
   });
 
   testWithoutContext('Local DevFSWriter turns FileSystemException into DevFSException', () async {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final LocalDevFSWriter writer = LocalDevFSWriter(fileSystem: fileSystem);
     final File file = fileSystem.file('foo');

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
@@ -568,7 +568,7 @@ void createIntellijDartPluginJar(String pluginJarPath, FileSystem fileSystem) {
 }
 
 // TODO(fujino): this should use the MemoryFileSystem and a
-// FileExceptionHandler, blocked by https://github.com/google/file.dart/issues/227.
+//  MutableFileSystemOpHandle, blocked by https://github.com/google/file.dart/issues/227.
 class _ThrowingFileSystem extends Fake implements FileSystem {
   _ThrowingFileSystem(this._exception);
 

--- a/packages/flutter_tools/test/general.shard/template_test.dart
+++ b/packages/flutter_tools/test/general.shard/template_test.dart
@@ -17,7 +17,7 @@ import '../src/context.dart';
 
 void main() {
   testWithoutContext('Template constructor throws ToolExit when source directory is missing', () {
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
+    final FileExceptionHandler handler = FileExceptionHandler();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
 
     expect(() => Template(
@@ -30,7 +30,7 @@ void main() {
   });
 
   testWithoutContext('Template.render throws ToolExit when FileSystem exception is raised', () {
-    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final FileExceptionHandler fileSystemOpHandle = FileExceptionHandler();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final Template template = Template(
       fileSystem.directory('examples')..createSync(recursive: true),
@@ -40,7 +40,7 @@ void main() {
       templateRenderer: FakeTemplateRenderer(),
     );
     final Directory directory = fileSystem.directory('foo');
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       directory,
       FileSystemOp.create,
       () => throw const FileSystemException(),

--- a/packages/flutter_tools/test/general.shard/template_test.dart
+++ b/packages/flutter_tools/test/general.shard/template_test.dart
@@ -30,8 +30,8 @@ void main() {
   });
 
   testWithoutContext('Template.render throws ToolExit when FileSystem exception is raised', () {
-    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
-    final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+    final MutableFileSystemOpHandle fileSystemOpHandle = MutableFileSystemOpHandle();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     final Template template = Template(
       fileSystem.directory('examples')..createSync(recursive: true),
       fileSystem.currentDirectory,
@@ -40,7 +40,11 @@ void main() {
       templateRenderer: FakeTemplateRenderer(),
     );
     final Directory directory = fileSystem.directory('foo');
-    handler.addError(directory, FileSystemOp.create, const FileSystemException());
+    fileSystemOpHandle.setHandler(
+      directory,
+      FileSystemOp.create,
+      () => throw const FileSystemException(),
+    );
 
     expect(() => template.render(directory, <String, Object>{}),
       throwsToolExit());

--- a/packages/flutter_tools/test/general.shard/template_test.dart
+++ b/packages/flutter_tools/test/general.shard/template_test.dart
@@ -17,7 +17,7 @@ import '../src/context.dart';
 
 void main() {
   testWithoutContext('Template constructor throws ToolExit when source directory is missing', () {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
 
     expect(() => Template(
@@ -30,7 +30,7 @@ void main() {
   });
 
   testWithoutContext('Template.render throws ToolExit when FileSystem exception is raised', () {
-    final FileExceptionHandler handler = FileExceptionHandler();
+    final MutableFileSystemOpHandle handler = MutableFileSystemOpHandle();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
     final Template template = Template(
       fileSystem.directory('examples')..createSync(recursive: true),

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -265,7 +265,7 @@ class _NoContext implements AppContext {
 ///
 /// ```dart
 /// void main() {
-///   var handler = FileExceptionHandler();
+///   var handler = MutableFileSystemOpHandle();
 ///   var fs = MemoryFileSystem(opHandle: handler.opHandle);
 ///
 ///   var file = fs.file('foo')..createSync();
@@ -274,7 +274,7 @@ class _NoContext implements AppContext {
 ///   expect(() => file.writeAsStringSync('A'), throwsA(isA<FileSystemException>()));
 /// }
 /// ```
-class FileExceptionHandler {
+class MutableFileSystemOpHandle {
   final Map<String, Map<FileSystemOp, FileSystemException>> _contextErrors = <String, Map<FileSystemOp, FileSystemException>>{};
   final Map<FileSystemOp, FileSystemException> _tempErrors = <FileSystemOp, FileSystemException>{};
   static final RegExp _tempDirectoryEnd = RegExp('rand[0-9]+');

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -287,7 +287,7 @@ class MutableFileSystemOpHandle {
   void setHandler(
     FileSystemEntity entity,
     FileSystemOp operation,
-    void Function() handler,
+    Null Function() handler,
   ) {
     final String path = entity.path;
     _handlers[path] ??= <FileSystemOp, void Function()>{};
@@ -297,7 +297,6 @@ class MutableFileSystemOpHandle {
   void removeHandler(
     FileSystemEntity entity,
     FileSystemOp operation,
-    void Function() handler,
   ) {
     final String path = entity.path;
     _handlers[path] ??= <FileSystemOp, void Function()>{};

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -275,7 +275,7 @@ class _NoContext implements AppContext {
 ///   expect(() => file.writeAsStringSync('A'), throwsA(isA<FileSystemException>()));
 /// }
 /// ```
-class MutableFileSystemOpHandle {
+class FileExceptionHandler {
   final Map<FileSystemOp, void Function(String path)> _tempHandlers = <FileSystemOp, void Function(String)>{};
 
   final Map<String, Map<FileSystemOp, void Function()>> _handlers = <String, Map<FileSystemOp, void Function()>>{};
@@ -284,7 +284,7 @@ class MutableFileSystemOpHandle {
 
   /// Sets the handler that will be called when file system performs the
   /// [operation] on the [entity].
-  void setHandler(
+  void addError(
     FileSystemEntity entity,
     FileSystemOp operation,
     Null Function() handler,
@@ -294,7 +294,7 @@ class MutableFileSystemOpHandle {
     _handlers[path]![operation] = handler;
   }
 
-  void removeHandler(
+  void removeError(
     FileSystemEntity entity,
     FileSystemOp operation,
   ) {
@@ -303,7 +303,7 @@ class MutableFileSystemOpHandle {
     _handlers[path]!.remove(operation);
   }
 
-  void setTempHandler(FileSystemOp operation, void Function(String path) handler) {
+  void addTempError(FileSystemOp operation, void Function(String path) handler) {
     _tempHandlers[operation] = handler;
   }
 

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -41,7 +41,7 @@ const List<String> kCodeCache = <String>[
 const String kDevtoolsStderr = '\n\nDevTools listening\n\n';
 
 void main() {
-  late MutableFileSystemOpHandle exceptionHandler;
+  late MutableFileSystemOpHandle fileSystemOpHandle;
   late ChromiumLauncher chromeLauncher;
   late FileSystem fileSystem;
   late Platform platform;
@@ -50,12 +50,12 @@ void main() {
   late BufferLogger testLogger;
 
   setUp(() {
-    exceptionHandler = MutableFileSystemOpHandle();
+    fileSystemOpHandle = MutableFileSystemOpHandle();
     operatingSystemUtils = FakeOperatingSystemUtils();
     platform = FakePlatform(operatingSystem: 'macos', environment: <String, String>{
       kChromeEnvironment: 'example_chrome',
     });
-    fileSystem = MemoryFileSystem.test(opHandle: exceptionHandler.opHandle);
+    fileSystem = MemoryFileSystem.test(opHandle: fileSystemOpHandle.opHandle);
     processManager = FakeProcessManager.empty();
     chromeLauncher = ChromiumLauncher(
       fileSystem: fileSystem,
@@ -312,10 +312,10 @@ void main() {
       .createSync(recursive: true);
     final File file = fileSystem.file('$directoryPrefix/Local Storage/foo')
       ..createSync(recursive: true);
-    exceptionHandler.addError(
+    fileSystemOpHandle.setHandler(
       file,
       FileSystemOp.read,
-      const FileSystemException(),
+      () => throw const FileSystemException(),
     );
 
     await chrome.close(); // does not exit with error.
@@ -326,10 +326,10 @@ void main() {
     final BufferLogger logger = BufferLogger.test();
     final File file = fileSystem.file('/Default/foo')
       ..createSync(recursive: true);
-    exceptionHandler.addError(
+    fileSystemOpHandle.setHandler(
       file,
       FileSystemOp.read,
-      const FileSystemException(),
+      () => throw const FileSystemException(),
     );
     chromeLauncher = ChromiumLauncher(
       fileSystem: fileSystem,

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -41,7 +41,7 @@ const List<String> kCodeCache = <String>[
 const String kDevtoolsStderr = '\n\nDevTools listening\n\n';
 
 void main() {
-  late FileExceptionHandler exceptionHandler;
+  late MutableFileSystemOpHandle exceptionHandler;
   late ChromiumLauncher chromeLauncher;
   late FileSystem fileSystem;
   late Platform platform;
@@ -50,7 +50,7 @@ void main() {
   late BufferLogger testLogger;
 
   setUp(() {
-    exceptionHandler = FileExceptionHandler();
+    exceptionHandler = MutableFileSystemOpHandle();
     operatingSystemUtils = FakeOperatingSystemUtils();
     platform = FakePlatform(operatingSystem: 'macos', environment: <String, String>{
       kChromeEnvironment: 'example_chrome',

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -41,7 +41,7 @@ const List<String> kCodeCache = <String>[
 const String kDevtoolsStderr = '\n\nDevTools listening\n\n';
 
 void main() {
-  late MutableFileSystemOpHandle fileSystemOpHandle;
+  late FileExceptionHandler fileSystemOpHandle;
   late ChromiumLauncher chromeLauncher;
   late FileSystem fileSystem;
   late Platform platform;
@@ -50,7 +50,7 @@ void main() {
   late BufferLogger testLogger;
 
   setUp(() {
-    fileSystemOpHandle = MutableFileSystemOpHandle();
+    fileSystemOpHandle = FileExceptionHandler();
     operatingSystemUtils = FakeOperatingSystemUtils();
     platform = FakePlatform(operatingSystem: 'macos', environment: <String, String>{
       kChromeEnvironment: 'example_chrome',
@@ -312,7 +312,7 @@ void main() {
       .createSync(recursive: true);
     final File file = fileSystem.file('$directoryPrefix/Local Storage/foo')
       ..createSync(recursive: true);
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       file,
       FileSystemOp.read,
       () => throw const FileSystemException(),
@@ -326,7 +326,7 @@ void main() {
     final BufferLogger logger = BufferLogger.test();
     final File file = fileSystem.file('/Default/foo')
       ..createSync(recursive: true);
-    fileSystemOpHandle.setHandler(
+    fileSystemOpHandle.addError(
       file,
       FileSystemOp.read,
       () => throw const FileSystemException(),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/142537.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
