### PR TITLE
Use `ErrorHandlingFileSystem.deleteIfExists` when deleting .plugin_symlinks

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -96,7 +96,7 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
       if (entity.existsSync()) {
         throwToolExit(
           'Unable to delete file or directory at "${entity.path}". '
-          'This may be due it and/or the project being in a read-only '
+          'This may be due to the project being in a read-only '
           'volume. Consider relocating the project and trying again.',
         );
       }

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -95,9 +95,9 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
       }
       if (entity.existsSync()) {
         throwToolExit(
-          'The Flutter tool tried to delete the file or directory ${entity.path} but was '
-          "unable to. This may be due to the file and/or project's location on a read-only "
-          'volume. Consider relocating the project and trying again',
+          'Unable to delete file or directory at "${entity.path}". '
+          'This may be due it and/or the project being in a read-only '
+          'volume. Consider relocating the project and trying again.',
         );
       }
     }

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -966,9 +966,9 @@ void handleSymlinkException(FileSystemException e, {
 ///
 /// If [force] is true, the directory will be created only if missing.
 void _createPlatformPluginSymlinks(Directory symlinkDirectory, List<Object?>? platformPlugins, {bool force = false}) {
-  if (force && symlinkDirectory.existsSync()) {
+  if (force) {
     // Start fresh to avoid stale links.
-    symlinkDirectory.deleteSync(recursive: true);
+    ErrorHandlingFileSystem.deleteIfExists(symlinkDirectory, recursive: true);
   }
   symlinkDirectory.createSync(recursive: true);
   if (platformPlugins == null) {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -909,7 +909,7 @@ void main() {
     handler.addError(webCacheDirectory, FileSystemOp.delete, const FileSystemException('', '', OSError('', 2)));
 
     await expectLater(() => webSdk.updateInner(artifactUpdater, fileSystem, FakeOperatingSystemUtils()), throwsToolExit(
-      message: RegExp('The Flutter tool tried to delete the file or directory cache/bin/cache/flutter_web_sdk but was unable to'),
+      message: RegExp('Unable to delete file or directory at "cache/bin/cache/flutter_web_sdk"'),
     ));
   });
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/time.dart';
@@ -1751,6 +1753,75 @@ The Flutter Preview device does not support the following plugins from your pubs
         returnsNormally,
       );
     });
+  });
+
+  testUsingContext('exits tool when deleting .plugin_symlinks fails', () async {
+    final FakeFlutterProject flutterProject = FakeFlutterProject()
+      ..directory = globals.fs.currentDirectory.childDirectory('app');
+    final FakeFlutterManifest flutterManifest = FakeFlutterManifest();
+    final Directory windowsManagedDirectory = flutterProject.directory
+        .childDirectory('windows')
+        .childDirectory('flutter');
+    final FakeWindowsProject windowsProject = FakeWindowsProject()
+      ..managedDirectory = windowsManagedDirectory
+      ..cmakeFile = windowsManagedDirectory.parent.childFile('CMakeLists.txt')
+      ..generatedPluginCmakeFile =
+          windowsManagedDirectory.childFile('generated_plugins.mk')
+      ..pluginSymlinkDirectory = windowsManagedDirectory
+          .childDirectory('ephemeral')
+          .childDirectory('.plugin_symlinks')
+      ..exists = true;
+
+    flutterProject
+      ..manifest = flutterManifest
+      ..flutterPluginsFile =
+          flutterProject.directory.childFile('.flutter-plugins')
+      ..flutterPluginsDependenciesFile =
+          flutterProject.directory.childFile('.flutter-plugins-dependencies')
+      ..windows = windowsProject;
+
+    flutterProject.directory.childFile('.packages').createSync(recursive: true);
+
+    createPluginSymlinks(
+      flutterProject,
+      force: true,
+      featureFlagsOverride: TestFeatureFlags(isWindowsEnabled: true),
+    );
+
+    expect(
+      () => createPluginSymlinks(
+        flutterProject,
+        force: true,
+        featureFlagsOverride: TestFeatureFlags(isWindowsEnabled: true),
+      ),
+      throwsToolExit(
+          message: r'The Flutter tool tried to delete the file or '
+              r'directory C:\app\windows\flutter\ephemeral\.plugin_symlinks but was '
+              r"unable to. This may be due to the file and/or project's location on a "
+              r'read-only volume. Consider relocating the project and trying again'),
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () {
+      final FileExceptionHandler handle = FileExceptionHandler();
+      final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
+        platform: FakePlatform(),
+        delegate: MemoryFileSystem.test(
+          style: FileSystemStyle.windows,
+          opHandle: handle.opHandle,
+        ),
+      );
+      const String symlinkDirectoryPath = r'C:\app\windows\flutter\ephemeral\.plugin_symlinks';
+      handle.addError(
+        fileSystem.directory(symlinkDirectoryPath),
+        FileSystemOp.delete,
+        const PathNotFoundException(
+          symlinkDirectoryPath,
+          OSError('The system cannot find the path specified.', 3),
+        ),
+      );
+      return fileSystem;
+    },
+    ProcessManager: () => FakeProcessManager.empty(),
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -1795,10 +1795,8 @@ The Flutter Preview device does not support the following plugins from your pubs
         featureFlagsOverride: TestFeatureFlags(isWindowsEnabled: true),
       ),
       throwsToolExit(
-          message: r'The Flutter tool tried to delete the file or '
-              r'directory C:\app\windows\flutter\ephemeral\.plugin_symlinks but was '
-              r"unable to. This may be due to the file and/or project's location on a "
-              r'read-only volume. Consider relocating the project and trying again'),
+          message: RegExp('Unable to delete file or directory at '
+              r'"C:\\app\\windows\\flutter\\ephemeral\\\.plugin_symlinks"')),
     );
   }, overrides: <Type, Generator>{
     FileSystem: () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/137168.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
