### PR TITLE
Fix teardown of a FocusScopeNode in material/app_test

### DIFF
--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -58,6 +58,7 @@ void main() {
 
   testWidgets('Can place app inside FocusScope', (WidgetTester tester) async {
     final FocusScopeNode focusScopeNode = FocusScopeNode();
+    addTearDown(focusScopeNode.dispose);
 
     await tester.pumpWidget(FocusScope(
       autofocus: true,
@@ -68,7 +69,6 @@ void main() {
     ));
 
     expect(find.text('Home'), findsOneWidget);
-    focusScopeNode.dispose();
   });
 
   testWidgets('Can show grid without losing sync', (WidgetTester tester) async {


### PR DESCRIPTION
This test suite had been failing when run with --test-randomize-ordering-seed=20240701