### PR TITLE
Docimports for foundation

### DIFF
--- a/packages/flutter/lib/src/foundation/_bitfield_io.dart
+++ b/packages/flutter/lib/src/foundation/_bitfield_io.dart
@@ -7,7 +7,7 @@ import 'bitfield.dart' as bitfield;
 /// The dart:io implementation of [bitfield.kMaxUnsignedSMI].
 const int kMaxUnsignedSMI = 0x3FFFFFFFFFFFFFFF; // ignore: avoid_js_rounded_ints, (VM-only code)
 
-/// The dart:io implementation of [bitfield.Bitfield].
+/// The dart:io implementation of [bitfield.BitField].
 class BitField<T extends dynamic> implements bitfield.BitField<T> {
   /// The dart:io implementation of [bitfield.Bitfield()].
   BitField(this._length)

--- a/packages/flutter/lib/src/foundation/_bitfield_web.dart
+++ b/packages/flutter/lib/src/foundation/_bitfield_web.dart
@@ -13,9 +13,9 @@ import 'bitfield.dart' as bitfield;
 /// does not have to guarantee efficiency.
 const int kMaxUnsignedSMI = -1;
 
-/// The web implementation of [bitfield.Bitfield].
+/// The web implementation of [bitfield.BitField].
 class BitField<T extends dynamic> implements bitfield.BitField<T> {
-  /// The web implementation of [bitfield.Bitfield].
+  /// The web implementation of [bitfield.BitField].
   // Can remove when we have metaclasses.
   // ignore: avoid_unused_constructor_parameters
   BitField(int length);

--- a/packages/flutter/lib/src/foundation/_isolates_io.dart
+++ b/packages/flutter/lib/src/foundation/_isolates_io.dart
@@ -10,7 +10,7 @@ import 'isolates.dart' as isolates;
 
 export 'isolates.dart' show ComputeCallback;
 
-/// The dart:io implementation of [isolate.compute].
+/// The dart:io implementation of [isolates.compute].
 @pragma('vm:prefer-inline')
 Future<R> compute<M, R>(isolates.ComputeCallback<M, R> callback, M message, {String? debugLabel}) async {
   debugLabel ??= kReleaseMode ? 'compute' : callback.toString();

--- a/packages/flutter/lib/src/foundation/_isolates_web.dart
+++ b/packages/flutter/lib/src/foundation/_isolates_web.dart
@@ -6,7 +6,7 @@ import 'isolates.dart' as isolates;
 
 export 'isolates.dart' show ComputeCallback;
 
-/// The web implementation of [isolate.compute].
+/// The web implementation of [isolates.compute].
 @pragma('dart2js:tryInline')
 Future<R> compute<M, R>(isolates.ComputeCallback<M, R> callback, M message, { String? debugLabel }) async {
   // To avoid blocking the UI immediately for an expensive function call, we

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/widgets.dart';
+library;
+
 import 'package:meta/meta.dart';
 
 import 'basic_types.dart';

--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'dart:ui';
+library;
+
 import 'dart:collection';
 
 // COMMON SIGNATURES

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -2,6 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'dart:convert';
+/// @docImport 'dart:ui';
+///
+/// @docImport 'package:flutter/rendering.dart';
+/// @docImport 'package:flutter/scheduler.dart';
+/// @docImport 'package:flutter/services.dart';
+/// @docImport 'package:flutter/widgets.dart';
+library;
+
 import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:developer' as developer;

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/animation.dart';
+/// @docImport 'package:flutter/widgets.dart';
+library;
+
 import 'dart:ui' show VoidCallback;
 
 import 'package:meta/meta.dart';
@@ -150,7 +154,7 @@ mixin class ChangeNotifier implements Listenable {
   /// If true, the event [ObjectCreated] for this instance was dispatched to
   /// [FlutterMemoryAllocations].
   ///
-  /// As [ChangedNotifier] is used as mixin, it does not have constructor,
+  /// As [ChangeNotifier] is used as mixin, it does not have constructor,
   /// so we use [addListener] to dispatch the event.
   bool _creationDispatched = false;
 

--- a/packages/flutter/lib/src/foundation/collections.dart
+++ b/packages/flutter/lib/src/foundation/collections.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:collection/collection.dart';
+library;
+
 // TODO(ianh): These should be on the Set and List classes themselves.
 
 /// Compares two sets for element-by-element equality.

--- a/packages/flutter/lib/src/foundation/constants.dart
+++ b/packages/flutter/lib/src/foundation/constants.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'platform.dart';
+library;
+
 /// A constant that is true if the application was compiled in release mode.
 ///
 /// More specifically, this is a constant that is true if the application was

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -2,6 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'dart:developer';
+///
+/// @docImport 'package:flutter/foundation.dart';
+/// @docImport 'package:flutter/rendering.dart';
+/// @docImport 'package:flutter/widgets.dart';
+library;
+
 import 'dart:ui' as ui show Brightness;
 
 import 'assertions.dart';

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 /// @docImport 'dart:developer';
+///
+/// @docImport 'package:flutter/rendering.dart';
+/// @docImport 'package:flutter/widgets.dart';
 library;
 
 import 'dart:math' as math;

--- a/packages/flutter/lib/src/foundation/isolates.dart
+++ b/packages/flutter/lib/src/foundation/isolates.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'dart:developer';
 /// @docImport 'dart:isolate';
+///
+/// @docImport 'package:flutter/scheduler.dart';
 library;
 
 import 'dart:async';

--- a/packages/flutter/lib/src/foundation/key.dart
+++ b/packages/flutter/lib/src/foundation/key.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/semantics.dart';
+/// @docImport 'package:flutter/widgets.dart';
+library;
+
 import 'package:meta/meta.dart';
 
 import 'diagnostics.dart';

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/foundation.dart';
+/// @docImport 'package:flutter/material.dart';
+/// @docImport 'package:flutter/scheduler.dart';
+library;
+
 import 'dart:async';
 
 import 'package:meta/meta.dart' show visibleForTesting;

--- a/packages/flutter/lib/src/foundation/persistent_hash_map.dart
+++ b/packages/flutter/lib/src/foundation/persistent_hash_map.dart
@@ -116,7 +116,8 @@ class _FullNode extends _TrieNode {
 /// Instead of storing the full array of outgoing edges this node uses a
 /// compressed representation:
 ///
-///   * [_CompressedNode.occupied] has a bit set for indices which are occupied.
+///   * [_CompressedNode.occupiedIndices] has a bit set for indices which are
+///     occupied.
 ///   * furthermore, each occupied index can either be a `(key, value)` pair
 ///     representing an actual key/value mapping or a `(null, trieNode)` pair
 ///     representing a descendant node.

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+library;
+
 import '_platform_io.dart'
   if (dart.library.js_util) '_platform_web.dart' as platform;
 import 'assertions.dart';

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -6,6 +6,9 @@
 // calling "print" is sort of a non-starter here...
 // ignore_for_file: avoid_print
 
+/// @docImport 'package:flutter/widgets.dart';
+library;
+
 import 'dart:async';
 import 'dart:collection';
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/150800

Things I couldn't get to work:

- [ ] references to library names, example: https://github.com/flutter/flutter/blob/b79aabff265dce997152a4ec181337ccffe779ee/packages/flutter/lib/src/foundation/binding.dart#L57
- [ ] references to things in pkg:flutter_test (known issue, because of g3)
- [ ] (many) references in doc comments on enum values, example: https://github.com/flutter/flutter/blob/b79aabff265dce997152a4ec181337ccffe779ee/packages/flutter/lib/src/foundation/diagnostics.dart#L139