### PR TITLE
docimports for semantics

### DIFF
--- a/packages/flutter/lib/semantics.dart
+++ b/packages/flutter/lib/semantics.dart
@@ -11,6 +11,8 @@
 ///
 /// The [SemanticsNode] hierarchy represents the semantic structure of the UI
 /// and is used by the platform-specific accessibility services.
+///
+/// @docImport 'src/semantics/semantics.dart';
 library semantics;
 
 export 'dart:ui' show LocaleStringAttribute, SpellOutStringAttribute;

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/widgets.dart';
+///
+/// @docImport 'semantics.dart';
+library;
+
 import 'dart:ui' as ui show AccessibilityFeatures, SemanticsActionEvent, SemanticsUpdateBuilder;
 
 import 'package:flutter/foundation.dart';
@@ -128,13 +133,13 @@ mixin SemanticsBinding on BindingBase {
   ///
   /// Bindings that mixin the [SemanticsBinding] must implement this method and
   /// perform the given `action` on the [SemanticsNode] specified by
-  /// [SemanticsActionEvent.nodeId].
+  /// [ui.SemanticsActionEvent.nodeId].
   ///
   /// See [dart:ui.PlatformDispatcher.onSemanticsActionEvent].
   @protected
   void performSemanticsAction(ui.SemanticsActionEvent action);
 
-  /// The currently active set of [AccessibilityFeatures].
+  /// The currently active set of [ui.AccessibilityFeatures].
   ///
   /// This is set when the binding is first initialized and updated whenever a
   /// flag is changed.

--- a/packages/flutter/lib/src/semantics/debug.dart
+++ b/packages/flutter/lib/src/semantics/debug.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'binding.dart';
+library;
 
 /// Overrides the setting of [SemanticsBinding.disableAnimations] for debugging
 /// and testing.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'dart:ui';
+///
+/// @docImport 'package:flutter/material.dart';
+/// @docImport 'package:flutter/rendering.dart';
+library;
+
 import 'dart:math' as math;
 import 'dart:ui' show Offset, Rect, SemanticsAction, SemanticsFlag, SemanticsUpdate, SemanticsUpdateBuilder, StringAttribute, TextDirection;
 
@@ -3717,7 +3723,7 @@ class SemanticsConfiguration {
   ///
   /// See also:
   ///
-  ///  * [addAction] to add an action.
+  ///  * [_addAction] to add an action.
   final Map<SemanticsAction, SemanticsActionHandler> _actions = <SemanticsAction, SemanticsActionHandler>{};
 
   int get _effectiveActionsAsBits => isBlockingUserActions ? _actionsAsBits & _kUnblockedUserActions : _actionsAsBits;

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/services.dart';
+/// @docImport 'package:flutter/widgets.dart';
+library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/widgets.dart';
+library;
+
 import 'dart:ui' show TextDirection;
 
 import 'package:flutter/services.dart' show SystemChannels;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/150800

Issues encountered:

- [ ] `comment_references` thinks this is an (invalid) reference; it's not a reference at all: https://github.com/flutter/flutter/blob/44622dac46a954b38111fc6ec1de6e2c74065de3/packages/flutter/lib/src/semantics/semantics.dart#L2424-L2425