### PR TITLE
[CP-stable] Update `FocusManager` platform check to include iOS

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1521,18 +1521,28 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
     if (kFlutterMemoryAllocationsEnabled) {
       ChangeNotifier.maybeDispatchObjectCreation(this);
     }
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
-      // It appears that some Android keyboard implementations can cause
-      // app lifecycle state changes: adding this listener would cause the
-      // text field to unfocus as the user is trying to type.
-      //
-      // Until this is resolved, we won't be adding the listener to Android apps.
-      // https://github.com/flutter/flutter/pull/142930#issuecomment-1981750069
+    if (_respondToWindowFocus) {
       _appLifecycleListener = _AppLifecycleListener(_appLifecycleChange);
       WidgetsBinding.instance.addObserver(_appLifecycleListener!);
     }
     rootScope._manager = this;
   }
+
+  /// It appears that some Android keyboard implementations can cause
+  /// app lifecycle state changes: adding the app lifecycle listener would
+  /// cause the text field to unfocus as the user is trying to type.
+  ///
+  /// Additionally, on iOS, input fields aren't automatically populated
+  /// with relevant data when using autofill.
+  ///
+  /// Until these are resolved, we won't be adding the listener to mobile platforms.
+  /// https://github.com/flutter/flutter/issues/148475#issuecomment-2118407411
+  /// https://github.com/flutter/flutter/pull/142930#issuecomment-1981750069
+  bool get _respondToWindowFocus => kIsWeb || switch (defaultTargetPlatform) {
+    TargetPlatform.android || TargetPlatform.iOS => false,
+    TargetPlatform.fuchsia || TargetPlatform.linux => true,
+    TargetPlatform.windows || TargetPlatform.macOS => true,
+  };
 
   /// Registers global input event handlers that are needed to manage focus.
   ///

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -354,44 +354,39 @@ void main() {
       logs.clear();
     }, variant: KeySimulatorTransitModeVariant.all());
 
-    testWidgets('FocusManager ignores app lifecycle changes on Android.', (WidgetTester tester) async {
-      final bool shouldRespond = kIsWeb || defaultTargetPlatform != TargetPlatform.android;
-      if (shouldRespond) {
-        return;
-      }
+    testWidgets(
+      'FocusManager ignores app lifecycle changes on Android and iOS.',
+      (WidgetTester tester) async {
+        Future<void> setAppLifecycleState(AppLifecycleState state) async {
+          final ByteData? message = const StringCodec().encodeMessage(state.toString());
+          await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .handlePlatformMessage('flutter/lifecycle', message, (_) {});
+        }
 
-      Future<void> setAppLifecycleState(AppLifecycleState state) async {
-        final ByteData? message = const StringCodec().encodeMessage(state.toString());
-        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .handlePlatformMessage('flutter/lifecycle', message, (_) {});
-      }
+        final BuildContext context = await setupWidget(tester);
+        final FocusScopeNode scope = FocusScopeNode(debugLabel: 'Scope');
+        addTearDown(scope.dispose);
+        final FocusAttachment scopeAttachment = scope.attach(context);
+        final FocusNode focusNode = FocusNode(debugLabel: 'Focus Node');
+        addTearDown(focusNode.dispose);
+        final FocusAttachment focusNodeAttachment = focusNode.attach(context);
+        scopeAttachment.reparent(parent: tester.binding.focusManager.rootScope);
+        focusNodeAttachment.reparent(parent: scope);
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(focusNode.hasPrimaryFocus, isTrue);
 
-      final BuildContext context = await setupWidget(tester);
-      final FocusScopeNode scope = FocusScopeNode(debugLabel: 'Scope');
-      addTearDown(scope.dispose);
-      final FocusAttachment scopeAttachment = scope.attach(context);
-      final FocusNode focusNode = FocusNode(debugLabel: 'Focus Node');
-      addTearDown(focusNode.dispose);
-      final FocusAttachment focusNodeAttachment = focusNode.attach(context);
-      scopeAttachment.reparent(parent: tester.binding.focusManager.rootScope);
-      focusNodeAttachment.reparent(parent: scope);
-      focusNode.requestFocus();
-      await tester.pump();
-      expect(focusNode.hasPrimaryFocus, isTrue);
+        await setAppLifecycleState(AppLifecycleState.paused);
+        expect(focusNode.hasPrimaryFocus, isTrue);
 
-      await setAppLifecycleState(AppLifecycleState.paused);
-      expect(focusNode.hasPrimaryFocus, isTrue);
-
-      await setAppLifecycleState(AppLifecycleState.resumed);
-      expect(focusNode.hasPrimaryFocus, isTrue);
-    });
+        await setAppLifecycleState(AppLifecycleState.resumed);
+        expect(focusNode.hasPrimaryFocus, isTrue);
+      },
+      skip: kIsWeb, // [intended]
+      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android, TargetPlatform.iOS}),
+    );
 
     testWidgets('FocusManager responds to app lifecycle changes.', (WidgetTester tester) async {
-      final bool shouldRespond = kIsWeb || defaultTargetPlatform != TargetPlatform.android;
-      if (!shouldRespond) {
-        return;
-      }
-
       Future<void> setAppLifecycleState(AppLifecycleState state) async {
         final ByteData? message = const StringCodec().encodeMessage(state.toString());
         await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger


### PR DESCRIPTION
<details> <summary><h3>Cherry-pick template (click to expand)</h3></summary>

### Issue Link:
- https://github.com/flutter/flutter/issues/148475

### Changelog Description:
On iOS, selecting an email/password autofill suggestion should populate the input fields.

### Impact Description:
In iOS apps, selecting an autofill suggestion does not populate the input fields.

### Workaround:
No

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

This essentially reverses https://github.com/flutter/flutter/pull/142930 on non-desktop platforms.

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
Code sample and instructions at https://github.com/flutter/flutter/issues/148475#issuecomment-2116866676

</details>

<br>

The reason why #148612 was reverted (and why this cherry-pick PR needed to be created manually) is a kind of interesting story:
- May 18: created a PR https://github.com/flutter/flutter/pull/148612
- May 20: a different PR was merged https://github.com/flutter/flutter/pull/148067
- May 23: the PR from May 18 was merged (everything was green on that branch since it didn't include May 20 changes)

Tests on master started failing, so it was [reverted shortly thereafter](https://github.com/flutter/flutter/pull/148978), and then [relanded that same day](https://github.com/flutter/flutter/pull/148984).

This was one of those uncommon (and unfortunate) cases when 2 people edited a file at the same time in a way that caused tests to fail without any merge conflicts popping up.

Now that this change has been around for a while without breakages, I feel pretty good about applying the cherry-pick.

<br><br>

**Update:** current plan is to cherry-pick the platform check once #151618 is merged!

**Final update:** the current stable Flutter release includes this change 🙂