### PR TITLE
[flutter_tools] Update the mapping for the Dart SDK internal URI

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -100,9 +100,9 @@ abstract class FlutterBaseDebugAdapter extends DartDebugAdapter<FlutterLaunchReq
     final String flutterRoot = fileSystem.path.join(flutterSdkRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'ui');
     orgDartlangSdkMappings[flutterRoot] = Uri.parse('org-dartlang-sdk:///flutter/lib/ui');
 
-    // The rest of the Dart SDK maps to /third_party/dart/sdk
+    // The rest of the Dart SDK maps to /flutter/third_party/dart/sdk
     final String dartRoot = fileSystem.path.join(flutterSdkRoot, 'bin', 'cache', 'pkg', 'sky_engine');
-    orgDartlangSdkMappings[dartRoot] = Uri.parse('org-dartlang-sdk:///third_party/dart/sdk');
+    orgDartlangSdkMappings[dartRoot] = Uri.parse('org-dartlang-sdk:///flutter/third_party/dart/sdk');
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -737,7 +737,7 @@ void main() {
 
       test('dart:core URI to file path', () async {
         expect(
-          adapter.convertOrgDartlangSdkToPath(Uri.parse('org-dartlang-sdk:///third_party/dart/sdk/lib/core/core.dart')),
+          adapter.convertOrgDartlangSdkToPath(Uri.parse('org-dartlang-sdk:///flutter/third_party/dart/sdk/lib/core/core.dart')),
           Uri.file(fs.path.join(flutterRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'core', 'core.dart')),
         );
       });
@@ -745,7 +745,7 @@ void main() {
       test('dart:core file path to URI', () async {
         expect(
           adapter.convertUriToOrgDartlangSdk(Uri.file(fs.path.join(flutterRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'core', 'core.dart'))),
-          Uri.parse('org-dartlang-sdk:///third_party/dart/sdk/lib/core/core.dart'),
+          Uri.parse('org-dartlang-sdk:///flutter/third_party/dart/sdk/lib/core/core.dart'),
         );
       });
     });

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -586,20 +586,14 @@ The relevant error-causing widget was:
     });
 
     group('can step', () {
-      late BasicProject project;
-      late String breakpointFilePath;
-      late int breakpointLine;
-      late String expectedPrintLibraryPath;
-      setUp(() async {
-        project = BasicProject();
+      test('into SDK sources mapped to local files when debugSdkLibraries=true', () async {
+        final BasicProject project = BasicProject();
         await project.setUpIn(tempDir);
 
-        breakpointFilePath = globals.fs.path.join(project.dir.path, 'lib', 'main.dart');
-        breakpointLine = project.topLevelFunctionBreakpointLine;
-        expectedPrintLibraryPath = globals.fs.path.join('pkg', 'sky_engine', 'lib', 'core', 'print.dart');
-      });
+        final String breakpointFilePath = globals.fs.path.join(project.dir.path, 'lib', 'main.dart');
+        final int breakpointLine = project.topLevelFunctionBreakpointLine;
+        final String expectedPrintLibraryPath = globals.fs.path.join('pkg', 'sky_engine', 'lib', 'core', 'print.dart');
 
-      testWithoutContext('into SDK sources mapped to local files when debugSdkLibraries=true', () async {
         // Launch the app and wait for it to print "topLevelFunction".
         await Future.wait(<Future<void>>[
           dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -430,6 +430,37 @@ extension DapTestClientExtension on DapTestClient {
   Future<Response> continue_(int threadId) =>
       sendRequest(ContinueArguments(threadId: threadId));
 
+  /// Sends a stepIn request for the given thread.
+  ///
+  /// Returns a Future that completes when the server returns a corresponding
+  /// response.
+  Future<Response> stepIn(int threadId) =>
+      sendRequest(StepInArguments(threadId: threadId));
+
+  /// Fetches a stack trace and asserts it was a valid response.
+  Future<StackTraceResponseBody> getValidStack(int threadId,
+      {required int startFrame, required int numFrames}) async {
+    final Response response = await stackTrace(threadId,
+        startFrame: startFrame, numFrames: numFrames);
+    assert(response.success);
+    assert(response.command == 'stackTrace');
+    return StackTraceResponseBody.fromJson(
+        response.body! as Map<String, Object?>);
+  }
+
+  /// Sends a stackTrace request to the server to request the call stack for a
+  /// given thread.
+  ///
+  /// If [startFrame] and/or [numFrames] are supplied, only a slice of the
+  /// frames will be returned.
+  ///
+  /// Returns a Future that completes when the server returns a corresponding
+  /// response.
+  Future<Response> stackTrace(int threadId,
+          {int? startFrame, int? numFrames}) =>
+      sendRequest(StackTraceArguments(
+          threadId: threadId, startFrame: startFrame, levels: numFrames));
+
   /// Clears breakpoints in [file].
   Future<void> clearBreakpoints(String filePath) async {
     await sendRequest(


### PR DESCRIPTION
This changes the mapping for the Dart SDK inside Flutter from `org-dartlang-sdk:///third_party/dart/sdk` to org-dartlang-sdk:///flutter/third_party/dart/sdk`. This URI changed in https://github.com/flutter/engine/pull/51917 but was not caught by tests because they only tested a specific set of mappings and there were no integration tests checking what URIs were actually produced by a running app.

So, this change also adds an integration tests that ensures that a real running app produces URIs that are then correctly mapped.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5164.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
