### PR TITLE
[tool] Fix `stdin.flush` calls on processes started by `FakeProcessManager`

### DIFF
--- a/packages/flutter_tools/test/general.shard/fake_process_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/fake_process_manager_test.dart
@@ -174,6 +174,13 @@ void main() {
       expect(stderr, 'stderr'.codeUnits);
       expect(stdout, 'stdout'.codeUnits);
     });
+
+    testWithoutContext('stdin should be flushable (all data written is consumed)', () async {
+      final FakeProcess process = FakeProcess();
+      process.stdin.write('hello');
+      // If nothing is listening to the stdin stream, this test will never complete.
+      await process.stdin.flush();
+    });
   });
 
   group(FakeProcessManager, () {

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -160,8 +160,13 @@ class FakeProcess implements io.Process {
          }
          return exitCode;
        }),
-      _stderr = stderr,
-      stdin = stdin ?? IOSink(StreamController<List<int>>().sink),
+        _stderr = stderr,
+        stdin = stdin ??
+            IOSink(
+              StreamController<List<int>>()
+                ..stream.listen((_) {})
+                ..sink,
+            ),
       _stdout = stdout,
       _completer = completer
   {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/151151

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
