### PR TITLE
docImports for flutter_test

### DIFF
--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -51,6 +51,12 @@
 ///  * [debugCheckIntrinsicSizes], which can be set in a
 ///    `flutter_test_config.dart` file to enable deeper [RenderBox]
 ///    tests of the intrinsic APIs automatically while laying out widgets.
+///
+/// @docImport 'package:flutter/rendering.dart';
+///
+/// @docImport 'src/controller.dart';
+/// @docImport 'src/test_compat.dart';
+/// @docImport 'src/widget_tester.dart';
 library flutter_test;
 
 export 'dart:async' show Future;

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -207,7 +207,7 @@ class _MockHttpClient implements HttpClient {
   }
 }
 
-/// A mocked [HttpClientRequest] which always returns a [_MockHttpClientResponse].
+/// A mocked [HttpClientRequest] which always returns a [_MockHttpResponse].
 class _MockHttpRequest implements HttpClientRequest {
   @override
   bool bufferOutput = true;

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'matchers.dart';
+library;
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:math' as math;

--- a/packages/flutter_test/lib/src/_goldens_web.dart
+++ b/packages/flutter_test/lib/src/_goldens_web.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'matchers.dart';
+library;
+
 import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:typed_data';
@@ -42,12 +45,12 @@ Future<ComparisonResult> compareLists(List<int> test, List<int> master) async {
 ///   * [matchesGoldenFile], the function from [flutter_test] that invokes the
 ///    comparator.
 class DefaultWebGoldenComparator extends WebGoldenComparator {
-  /// Creates a new [DefaultWebGoldenComparator] for the specified [testFile].
+  /// Creates a new [DefaultWebGoldenComparator] for the specified [testUri].
   ///
   /// Golden file keys will be interpreted as file paths relative to the
-  /// directory in which [testFile] resides.
+  /// directory in which [testUri] resides.
   ///
-  /// The [testFile] URL must represent a file.
+  /// The [testUri] must represent a file.
   DefaultWebGoldenComparator(this.testUri);
 
   /// The test file currently being executed.

--- a/packages/flutter_test/lib/src/_matchers_io.dart
+++ b/packages/flutter_test/lib/src/_matchers_io.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'matchers.dart';
+library;
+
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 

--- a/packages/flutter_test/lib/src/_matchers_web.dart
+++ b/packages/flutter_test/lib/src/_matchers_web.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'matchers.dart';
+library;
+
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+///
+/// @docImport 'matchers.dart';
+library;
+
 import 'dart:async';
 import 'dart:ui' as ui;
 import 'dart:ui';

--- a/packages/flutter_test/lib/src/animation_sheet.dart
+++ b/packages/flutter_test/lib/src/animation_sheet.dart
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+///
+/// @docImport 'goldens.dart';
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -2,6 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'dart:io';
+///
+/// @docImport 'controller.dart';
+/// @docImport 'test_pointer.dart';
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'dart:async';
 import 'dart:ui' as ui;
 

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -2,6 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/scheduler.dart';
+///
+/// @docImport 'binding.dart';
+/// @docImport 'finders.dart';
+/// @docImport 'matchers.dart';
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';

--- a/packages/flutter_test/lib/src/deprecated.dart
+++ b/packages/flutter_test/lib/src/deprecated.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'test_default_binary_messenger.dart';
+library;
+
 import 'package:flutter/services.dart';
 
 import 'binding.dart';

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+///
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'dart:ui';
 
 import 'package:flutter/material.dart' show Tooltip;

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -2,6 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/widgets.dart';
+///
+/// @docImport '_goldens_web.dart';
+/// @docImport 'binding.dart';
+/// @docImport 'matchers.dart';
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'dart:typed_data';
 import 'dart:ui';
 
@@ -141,7 +149,7 @@ GoldenFileComparator goldenFileComparator = const TrivialComparator._();
 /// fake async constraints that are normally imposed on widget tests (i.e. the
 /// need or the ability to call [WidgetTester.pump] to advance the microtask
 /// queue). Prior to the invocation, the test framework will render only the
-/// [widgets.Element] to be compared on the screen.
+/// [Element] to be compared on the screen.
 ///
 /// See also:
 ///

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:fake_async/fake_async.dart';
+///
+/// @docImport 'widget_tester.dart';
+/// @docImport 'test_compat.dart';
+library;
+
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport '_goldens_io.dart';
+library;
+
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 

--- a/packages/flutter_test/lib/src/mock_canvas.dart
+++ b/packages/flutter_test/lib/src/mock_canvas.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+///
+/// @docImport 'matchers.dart';
+library;
+
 import 'dart:ui' as ui show Image, Paragraph;
 
 import 'package:flutter/foundation.dart';

--- a/packages/flutter_test/lib/src/platform.dart
+++ b/packages/flutter_test/lib/src/platform.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/foundation.dart';
+library;
+
 import 'dart:io';
 
 /// Whether the test is running in a web browser compiled to JavaScript or WebAssembly.

--- a/packages/flutter_test/lib/src/recording_canvas.dart
+++ b/packages/flutter_test/lib/src/recording_canvas.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'mock_canvas.dart';
+library;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 

--- a/packages/flutter_test/lib/src/restoration.dart
+++ b/packages/flutter_test/lib/src/restoration.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 

--- a/packages/flutter_test/lib/src/stack_manipulation.dart
+++ b/packages/flutter_test/lib/src/stack_manipulation.dart
@@ -4,6 +4,9 @@
 
 // See also test_async_utils.dart which has some stack manipulation code.
 
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'package:flutter/foundation.dart';
 
 /// Report call site for `expect()` call. Returns the number of frames that

--- a/packages/flutter_test/lib/src/test_async_utils.dart
+++ b/packages/flutter_test/lib/src/test_async_utils.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:test_api/backend.dart';
+/// @docImport 'package:test_api/scaffolding.dart';
+library;
+
 import 'dart:async';
 
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
@@ -285,7 +289,7 @@ Future<void> _tearDownForTestFile() async {
 
 /// A reporter that prints each test on its own line.
 ///
-/// This is currently used in place of [CompactReporter] by `lib/test.dart`,
+/// This is currently used in place of `CompactReporter` by `lib/test.dart`,
 /// which can't transitively import `dart:io` but still needs access to a runner
 /// so that test files can be run directly. This means that until issue 6943 is
 /// fixed, this must not import `dart:io`.

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'dart:ui';
+///
+/// @docImport 'controller.dart';
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/packages/flutter_test/lib/src/test_vsync.dart
+++ b/packages/flutter_test/lib/src/test_vsync.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/animation.dart';
+library;
+
 import 'package:flutter/scheduler.dart';
 
 /// A [TickerProvider] that creates a standalone ticker.

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:fake_async/fake_async.dart';
+/// @docImport 'package:flutter/material.dart';
+/// @docImport 'package:matcher/matcher.dart';
+/// @docImport 'package:test_api/hooks.dart';
+library;
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter/material.dart';
+///
+/// @docImport 'binding.dart';
+/// @docImport 'widget_tester.dart';
+library;
+
 import 'dart:ui' hide window;
 
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/150800

Issues encountered:

- [ ] cannot reference something from flutter_driver (which is not a dependency of flutter_test), example: https://github.com/flutter/flutter/blob/af913a75b5d28b03f0bfe0ee44f9343ae26ae146/packages/flutter_test/lib/src/controller.dart#L2228
- [ ] (known) cannot reference anything in doc comments for enum values
- [ ] (known) cannot reference library names