### PR TITLE
Add `shouldTriggerDismiss` callback parameter to the `Dismissible` widget

### DIFF
--- a/examples/api/lib/widgets/dismissible/dismissible.1.dart
+++ b/examples/api/lib/widgets/dismissible/dismissible.1.dart
@@ -35,49 +35,74 @@ class _DismissibleExampleAppState extends State<DismissibleExampleApp> {
   }
 }
 
-class DismissibleExample extends StatelessWidget {
+class DismissibleExample extends StatefulWidget {
   const DismissibleExample({super.key});
+
+  @override
+  State<DismissibleExample> createState() => _DismissibleExampleState();
+}
+
+class _DismissibleExampleState extends State<DismissibleExample> {
+  late List<_Dismissible> dismissibleWidgets = <_Dismissible>[
+    _Dismissible(
+      index: 0,
+      title: 'Default behavior',
+      description: '`shouldDismiss: null`',
+      onDismissed: _dismissItem,
+    ),
+    _Dismissible(
+      index: 1,
+      title: 'Default behavior',
+      description: '`shouldDismiss: (_) => null`',
+      shouldDismiss: (_) => null,
+      onDismissed: _dismissItem,
+    ),
+    _Dismissible(
+      index: 2,
+      title: 'Never dismiss',
+      description: '`shouldDismiss: (_) => false`',
+      shouldDismiss: (_) => false,
+      onDismissed: _dismissItem,
+    ),
+    _Dismissible(
+      index: 3,
+      title: 'Always dismiss',
+      description: '`shouldDismiss: (_) => true`',
+      shouldDismiss: (_) => true,
+      onDismissed: _dismissItem,
+    ),
+    _Dismissible(
+      index: 4,
+      title: 'Only accept if threshold is reached (Disable flinging)',
+      shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
+      onDismissed: _dismissItem,
+    ),
+    _Dismissible(
+      index: 5,
+      title: 'Accept dismiss before threshold',
+      description: '`details.progress >= 0.2`',
+      shouldDismiss: (AcceptDismissDetails details) {
+        if (details.progress >= 0.2) {
+          return true;
+        }
+        return null;
+      },
+      onDismissed: _dismissItem,
+    ),
+  ];
 
   @override
   Widget build(BuildContext context) {
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 16),
-      children: <Widget>[
-        const _Dismissible(
-          title: 'Default behavior',
-          description: '`shouldDismiss: null`',
-        ),
-        _Dismissible(
-          title: 'Default behavior',
-          description: '`shouldDismiss: (_) => null`',
-          shouldDismiss: (_) => null,
-        ),
-        _Dismissible(
-          title: 'Never dismiss',
-          description: '`shouldDismiss: (_) => false`',
-          shouldDismiss: (_) => false,
-        ),
-        _Dismissible(
-          title: 'Always dismiss',
-          description: '`shouldDismiss: (_) => true`',
-          shouldDismiss: (_) => true,
-        ),
-        _Dismissible(
-          title: 'Only accept if threshold is reached (Disable flinging)',
-          shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
-        ),
-        _Dismissible(
-          title: 'Accept dismiss before threshold',
-          description: '`details.progress >= 0.1`',
-          shouldDismiss: (AcceptDismissDetails details) {
-            if (details.progress >= 0.1) {
-              return true;
-            }
-            return null;
-          },
-        ),
-      ],
+      children: dismissibleWidgets,
     );
+  }
+
+  void _dismissItem(_Dismissible dismissedItem) {
+    setState(() {
+      dismissibleWidgets = dismissibleWidgets.where((_Dismissible item) => item != dismissedItem).toList();
+    });
   }
 }
 
@@ -87,15 +112,19 @@ class DismissibleExample extends StatelessWidget {
 /// Change background color to red when the item is reached based on
 /// [DismissUpdateDetails.reached] value of [Dismissible.onUpdate] events.
 class _Dismissible extends StatefulWidget {
-  const _Dismissible({
+  _Dismissible({
+    required this.index,
     required this.title,
+    required this.onDismissed,
     this.description,
     this.shouldDismiss,
-  });
+  }) : super(key: ValueKey<int>(index));
 
+  final int index;
   final String title;
   final String? description;
   final AcceptDismissCallback? shouldDismiss;
+  final ValueChanged<_Dismissible> onDismissed;
 
   @override
   State<_Dismissible> createState() => _DismissibleState();
@@ -103,12 +132,11 @@ class _Dismissible extends StatefulWidget {
 
 class _DismissibleState extends State<_Dismissible> {
   bool reached = false;
-  final UniqueKey _key = UniqueKey();
 
   @override
   Widget build(BuildContext context) {
     return Dismissible(
-      key: _key,
+      key: Key('dismissible-${widget.index}'),
       background: ColoredBox(
         color: reached ? Colors.red : Colors.blue,
       ),
@@ -122,6 +150,7 @@ class _DismissibleState extends State<_Dismissible> {
         title: Text(widget.title),
         subtitle: widget.description != null ? Text(widget.description!) : null,
       ),
+      onDismissed: (_) => widget.onDismissed(widget),
     );
   }
 }

--- a/examples/api/lib/widgets/dismissible/dismissible.1.dart
+++ b/examples/api/lib/widgets/dismissible/dismissible.1.dart
@@ -64,7 +64,7 @@ class DismissibleExample extends StatelessWidget {
         ),
         _Dismissible(
           title: 'Only accept if threshold is reached (Disable flinging)',
-          shouldDismiss: (AcceptDismissDetails details) => details.reached,
+          shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
         ),
         _Dismissible(
           title: 'Accept dismiss before threshold',

--- a/examples/api/lib/widgets/dismissible/dismissible.1.dart
+++ b/examples/api/lib/widgets/dismissible/dismissible.1.dart
@@ -1,0 +1,127 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [Dismissible] using [Dismissible.shouldDismiss].
+
+void main() => runApp(const DismissibleExampleApp());
+
+class DismissibleExampleApp extends StatefulWidget {
+  const DismissibleExampleApp({super.key});
+
+  @override
+  State<DismissibleExampleApp> createState() => _DismissibleExampleAppState();
+}
+
+class _DismissibleExampleAppState extends State<DismissibleExampleApp> {
+  UniqueKey _refreshKey = UniqueKey();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => setState(() {
+            _refreshKey = UniqueKey();
+          }),
+          child: const Icon(Icons.refresh),
+        ),
+        appBar: AppBar(title: const Text('Dismissible Sample - shouldDismiss')),
+        body: DismissibleExample(key: _refreshKey),
+      ),
+    );
+  }
+}
+
+class DismissibleExample extends StatelessWidget {
+  const DismissibleExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      children: <Widget>[
+        const _Dismissible(
+          title: 'Default behavior',
+          description: '`shouldDismiss: null`',
+        ),
+        _Dismissible(
+          title: 'Default behavior',
+          description: '`shouldDismiss: (_) => null`',
+          shouldDismiss: (_) => null,
+        ),
+        _Dismissible(
+          title: 'Never dismiss',
+          description: '`shouldDismiss: (_) => false`',
+          shouldDismiss: (_) => false,
+        ),
+        _Dismissible(
+          title: 'Always dismiss',
+          description: '`shouldDismiss: (_) => true`',
+          shouldDismiss: (_) => true,
+        ),
+        _Dismissible(
+          title: 'Only accept if threshold is reached (Disable flinging)',
+          shouldDismiss: (AcceptDismissDetails details) => details.reached,
+        ),
+        _Dismissible(
+          title: 'Accept dismiss before threshold',
+          description: '`details.progress >= 0.1`',
+          shouldDismiss: (AcceptDismissDetails details) {
+            if (details.progress >= 0.1) {
+              return true;
+            }
+            return null;
+          },
+        ),
+      ],
+    );
+  }
+}
+
+/// A [Dismissible] widget used to demonstrates the behavior of the [shouldDismiss]
+/// parameter.
+///
+/// Change background color to red when the item is reached based on
+/// [DismissUpdateDetails.reached] value of [Dismissible.onUpdate] events.
+class _Dismissible extends StatefulWidget {
+  const _Dismissible({
+    required this.title,
+    this.description,
+    this.shouldDismiss,
+  });
+
+  final String title;
+  final String? description;
+  final AcceptDismissCallback? shouldDismiss;
+
+  @override
+  State<_Dismissible> createState() => _DismissibleState();
+}
+
+class _DismissibleState extends State<_Dismissible> {
+  bool reached = false;
+  final UniqueKey _key = UniqueKey();
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: _key,
+      background: ColoredBox(
+        color: reached ? Colors.red : Colors.blue,
+      ),
+      onUpdate: (DismissUpdateDetails details) {
+        setState(() {
+          reached = details.reached;
+        });
+      },
+      shouldDismiss: widget.shouldDismiss,
+      child: ListTile(
+        title: Text(widget.title),
+        subtitle: widget.description != null ? Text(widget.description!) : null,
+      ),
+    );
+  }
+}

--- a/examples/api/lib/widgets/dismissible/dismissible.1.dart
+++ b/examples/api/lib/widgets/dismissible/dismissible.1.dart
@@ -61,27 +61,39 @@ class _DismissibleExampleState extends State<DismissibleExample> {
     ),
     _Dismissible(
       index: 2,
+      title: 'Default behavior',
+      description: '`shouldTriggerDismiss: (details) => details.reached || details.isFling`',
+      shouldTriggerDismiss: (TriggerDismissDetails details) => details.reached || details.isFling,
+      onDismissed: _dismissItem,
+    ),
+    _Dismissible(
+      index: 3,
       title: 'Never dismiss',
       description: '`shouldTriggerDismiss: (_) => false`',
       shouldTriggerDismiss: (_) => false,
       onDismissed: _dismissItem,
     ),
     _Dismissible(
-      index: 3,
+      index: 4,
       title: 'Always dismiss',
       description: '`shouldTriggerDismiss: (_) => true`',
       shouldTriggerDismiss: (_) => true,
       onDismissed: _dismissItem,
     ),
     _Dismissible(
-      index: 4,
+      index: 5,
       title: 'Only accept if threshold is reached (Disable flinging)',
-      shouldTriggerDismiss: (TriggerDismissDetails details) =>
-          details.reached ? null : false,
+      shouldTriggerDismiss: (TriggerDismissDetails details) => details.reached,
       onDismissed: _dismissItem,
     ),
     _Dismissible(
-      index: 5,
+      index: 6,
+      title: 'Only accept if flung (Disable threshold check)',
+      shouldTriggerDismiss: (TriggerDismissDetails details) => details.isFling,
+      onDismissed: _dismissItem,
+    ),
+    _Dismissible(
+      index: 7,
       title: 'Accept dismiss before threshold',
       description: '`details.progress >= 0.2`',
       shouldTriggerDismiss: (TriggerDismissDetails details) {

--- a/examples/api/lib/widgets/dismissible/dismissible.1.dart
+++ b/examples/api/lib/widgets/dismissible/dismissible.1.dart
@@ -74,7 +74,8 @@ class _DismissibleExampleState extends State<DismissibleExample> {
     _Dismissible(
       index: 4,
       title: 'Only accept if threshold is reached (Disable flinging)',
-      shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
+      shouldDismiss: (AcceptDismissDetails details) =>
+          details.reached ? null : false,
       onDismissed: _dismissItem,
     ),
     _Dismissible(
@@ -101,7 +102,9 @@ class _DismissibleExampleState extends State<DismissibleExample> {
 
   void _dismissItem(_Dismissible dismissedItem) {
     setState(() {
-      dismissibleWidgets = dismissibleWidgets.where((_Dismissible item) => item != dismissedItem).toList();
+      dismissibleWidgets = dismissibleWidgets
+          .where((_Dismissible item) => item != dismissedItem)
+          .toList();
     });
   }
 }

--- a/examples/api/lib/widgets/dismissible/dismissible.1.dart
+++ b/examples/api/lib/widgets/dismissible/dismissible.1.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for [Dismissible] using [Dismissible.shouldDismiss].
+/// Flutter code sample for [Dismissible] using [Dismissible.shouldTriggerDismiss].
 
 void main() => runApp(const DismissibleExampleApp());
 
@@ -28,7 +28,9 @@ class _DismissibleExampleAppState extends State<DismissibleExampleApp> {
           }),
           child: const Icon(Icons.refresh),
         ),
-        appBar: AppBar(title: const Text('Dismissible Sample - shouldDismiss')),
+        appBar: AppBar(
+          title: const Text('Dismissible Sample - shouldTriggerDismiss'),
+        ),
         body: DismissibleExample(key: _refreshKey),
       ),
     );
@@ -47,34 +49,34 @@ class _DismissibleExampleState extends State<DismissibleExample> {
     _Dismissible(
       index: 0,
       title: 'Default behavior',
-      description: '`shouldDismiss: null`',
+      description: '`shouldTriggerDismiss: null`',
       onDismissed: _dismissItem,
     ),
     _Dismissible(
       index: 1,
       title: 'Default behavior',
-      description: '`shouldDismiss: (_) => null`',
-      shouldDismiss: (_) => null,
+      description: '`shouldTriggerDismiss: (_) => null`',
+      shouldTriggerDismiss: (_) => null,
       onDismissed: _dismissItem,
     ),
     _Dismissible(
       index: 2,
       title: 'Never dismiss',
-      description: '`shouldDismiss: (_) => false`',
-      shouldDismiss: (_) => false,
+      description: '`shouldTriggerDismiss: (_) => false`',
+      shouldTriggerDismiss: (_) => false,
       onDismissed: _dismissItem,
     ),
     _Dismissible(
       index: 3,
       title: 'Always dismiss',
-      description: '`shouldDismiss: (_) => true`',
-      shouldDismiss: (_) => true,
+      description: '`shouldTriggerDismiss: (_) => true`',
+      shouldTriggerDismiss: (_) => true,
       onDismissed: _dismissItem,
     ),
     _Dismissible(
       index: 4,
       title: 'Only accept if threshold is reached (Disable flinging)',
-      shouldDismiss: (AcceptDismissDetails details) =>
+      shouldTriggerDismiss: (TriggerDismissDetails details) =>
           details.reached ? null : false,
       onDismissed: _dismissItem,
     ),
@@ -82,7 +84,7 @@ class _DismissibleExampleState extends State<DismissibleExample> {
       index: 5,
       title: 'Accept dismiss before threshold',
       description: '`details.progress >= 0.2`',
-      shouldDismiss: (AcceptDismissDetails details) {
+      shouldTriggerDismiss: (TriggerDismissDetails details) {
         if (details.progress >= 0.2) {
           return true;
         }
@@ -109,7 +111,7 @@ class _DismissibleExampleState extends State<DismissibleExample> {
   }
 }
 
-/// A [Dismissible] widget used to demonstrates the behavior of the [shouldDismiss]
+/// A [Dismissible] widget used to demonstrates the behavior of the [shouldTriggerDismiss]
 /// parameter.
 ///
 /// Change background color to red when the item is reached based on
@@ -120,13 +122,13 @@ class _Dismissible extends StatefulWidget {
     required this.title,
     required this.onDismissed,
     this.description,
-    this.shouldDismiss,
+    this.shouldTriggerDismiss,
   }) : super(key: ValueKey<int>(index));
 
   final int index;
   final String title;
   final String? description;
-  final AcceptDismissCallback? shouldDismiss;
+  final TriggerDismissCallback? shouldTriggerDismiss;
   final ValueChanged<_Dismissible> onDismissed;
 
   @override
@@ -148,7 +150,7 @@ class _DismissibleState extends State<_Dismissible> {
           reached = details.reached;
         });
       },
-      shouldDismiss: widget.shouldDismiss,
+      shouldTriggerDismiss: widget.shouldTriggerDismiss,
       child: ListTile(
         title: Text(widget.title),
         subtitle: widget.description != null ? Text(widget.description!) : null,

--- a/examples/api/test/widgets/dismissible/dismissible.1_test.dart
+++ b/examples/api/test/widgets/dismissible/dismissible.1_test.dart
@@ -36,7 +36,8 @@ void main() {
     await tester.drag(finder, offset);
   }
 
-  Future<void> testDragBehavior(WidgetTester tester, {
+  Future<void> testDragBehavior(
+    WidgetTester tester, {
     required Key key,
     Matcher expectedBelowThreshold = findsOneWidget,
     Matcher expectedAboveThreshold = findsNothing,
@@ -49,7 +50,7 @@ void main() {
     await dismissHorizontally(
       tester: tester,
       finder: find.byKey(key),
-      dragRatio: 0.3
+      dragRatio: 0.3,
     );
 
     await tester.pumpAndSettle();
@@ -70,15 +71,12 @@ void main() {
   }
 
   group('Test Drag behavior', () {
-
     testWidgets(
-
       '0 - Default begavior - `shouldDismiss: null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(0);
-
         await testDragBehavior(tester, key: key);
       },
     );
@@ -89,7 +87,6 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(1);
-
         await testDragBehavior(tester, key: key);
       },
     );
@@ -100,8 +97,11 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(2);
-
-        await testDragBehavior(tester, key: key, expectedAboveThreshold: findsOneWidget);
+        await testDragBehavior(
+          tester,
+          key: key,
+          expectedAboveThreshold: findsOneWidget,
+        );
       },
     );
 
@@ -111,8 +111,11 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(3);
-
-        await testDragBehavior(tester, key: key, expectedBelowThreshold: findsNothing);
+        await testDragBehavior(
+          tester,
+          key: key,
+          expectedBelowThreshold: findsNothing,
+        );
       },
     );
 
@@ -122,7 +125,6 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(4);
-
         await testDragBehavior(tester, key: key);
       },
     );
@@ -133,8 +135,11 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(5);
-
-        await testDragBehavior(tester, key: key, expectedBelowThreshold: findsNothing);
+        await testDragBehavior(
+          tester,
+          key: key,
+          expectedBelowThreshold: findsNothing,
+        );
       },
     );
   });
@@ -157,7 +162,8 @@ void main() {
     await tester.fling(finder, offset, speed);
   }
 
-  Future<void> testFlingBehavior(WidgetTester tester, {
+  Future<void> testFlingBehavior(
+    WidgetTester tester, {
     required Key key,
     Matcher expectedBelowThreshold = findsOneWidget,
     Matcher expectedAboveThreshold = findsNothing,
@@ -170,7 +176,7 @@ void main() {
     await flingHorizontally(
       tester: tester,
       finder: find.byKey(key),
-      speed: 200
+      speed: 200,
     );
 
     await tester.pumpAndSettle();
@@ -191,14 +197,12 @@ void main() {
   }
 
   group('Test Fling behavior', () {
-
     testWidgets(
       '0 - Default begavior - `shouldDismiss: null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(0);
-
         await testFlingBehavior(tester, key: key);
       },
     );
@@ -209,7 +213,6 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(1);
-
         await testFlingBehavior(tester, key: key);
       },
     );
@@ -220,8 +223,11 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(2);
-
-        await testFlingBehavior(tester, key: key, expectedAboveThreshold: findsOneWidget);
+        await testFlingBehavior(
+          tester,
+          key: key,
+          expectedAboveThreshold: findsOneWidget,
+        );
       },
     );
 
@@ -231,8 +237,11 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(3);
-
-        await testFlingBehavior(tester, key: key, expectedBelowThreshold: findsNothing);
+        await testFlingBehavior(
+          tester,
+          key: key,
+          expectedBelowThreshold: findsNothing,
+        );
       },
     );
 
@@ -242,8 +251,11 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(4);
-
-        await testFlingBehavior(tester, key: key, expectedAboveThreshold: findsOneWidget);
+        await testFlingBehavior(
+          tester,
+          key: key,
+          expectedAboveThreshold: findsOneWidget,
+        );
       },
     );
 
@@ -253,7 +265,6 @@ void main() {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(5);
-
         await testFlingBehavior(tester, key: key);
       },
     );

--- a/examples/api/test/widgets/dismissible/dismissible.1_test.dart
+++ b/examples/api/test/widgets/dismissible/dismissible.1_test.dart
@@ -72,7 +72,7 @@ void main() {
 
   group('Test Drag behavior', () {
     testWidgets(
-      '0 - Default begavior - `shouldTriggerDismiss: null`',
+      '0 - Default behavior - `shouldTriggerDismiss: null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -82,7 +82,7 @@ void main() {
     );
 
     testWidgets(
-      '1 - Default begavior - `shouldTriggerDismiss: (_) => null`',
+      '1 - Default behavior - `shouldTriggerDismiss: (_) => null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -198,7 +198,7 @@ void main() {
 
   group('Test Fling behavior', () {
     testWidgets(
-      '0 - Default begavior - `shouldTriggerDismiss: null`',
+      '0 - Default behavior - `shouldTriggerDismiss: null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -208,7 +208,7 @@ void main() {
     );
 
     testWidgets(
-      '1 - Default begavior - `shouldTriggerDismiss: (_) => null`',
+      '1 - Default behavior - `shouldTriggerDismiss: (_) => null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 

--- a/examples/api/test/widgets/dismissible/dismissible.1_test.dart
+++ b/examples/api/test/widgets/dismissible/dismissible.1_test.dart
@@ -92,11 +92,21 @@ void main() {
     );
 
     testWidgets(
-      '2 - Never dismiss - `shouldTriggerDismiss: (_) => false`',
+      '2 - Default behavior - `shouldTriggerDismiss: (details) => details.reached || details.isFling`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
         const ValueKey<int> key = ValueKey<int>(2);
+        await testDragBehavior(tester, key: key);
+      },
+    );
+
+    testWidgets(
+      '3 - Never dismiss - `shouldTriggerDismiss: (_) => false`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(3);
         await testDragBehavior(
           tester,
           key: key,
@@ -106,11 +116,11 @@ void main() {
     );
 
     testWidgets(
-      '3 - Always dismiss - `shouldTriggerDismiss: (_) => true`',
+      '4 - Always dismiss - `shouldTriggerDismiss: (_) => true`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
-        const ValueKey<int> key = ValueKey<int>(3);
+        const ValueKey<int> key = ValueKey<int>(4);
         await testDragBehavior(
           tester,
           key: key,
@@ -120,21 +130,35 @@ void main() {
     );
 
     testWidgets(
-      '4 - Only accept if threshold is reached (Disable flinging)',
+      '5 - Only accept if threshold is reached (Disable flinging)',
       (WidgetTester tester) async {
         await initWidget(tester);
 
-        const ValueKey<int> key = ValueKey<int>(4);
+        const ValueKey<int> key = ValueKey<int>(5);
         await testDragBehavior(tester, key: key);
       },
     );
 
     testWidgets(
-      '5 - Accept dismiss before threshold - `details.progress >= 0.2`',
+      '6 - Only accept if flung (Disable threshold check)',
       (WidgetTester tester) async {
         await initWidget(tester);
 
-        const ValueKey<int> key = ValueKey<int>(5);
+        const ValueKey<int> key = ValueKey<int>(6);
+        await testDragBehavior(
+          tester,
+          key: key,
+          expectedAboveThreshold: findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      '7 - Accept dismiss before threshold - `details.progress >= 0.2`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(7);
         await testDragBehavior(
           tester,
           key: key,
@@ -218,11 +242,21 @@ void main() {
     );
 
     testWidgets(
-      '2 - Never dismiss - `shouldTriggerDismiss: (_) => false`',
+      '2 - Default behavior - `shouldTriggerDismiss: (details) => details.reached || details.isFling`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
-        const ValueKey<int> key = ValueKey<int>(2);
+        const ValueKey<int> key = ValueKey<int>(1);
+        await testFlingBehavior(tester, key: key);
+      },
+    );
+
+    testWidgets(
+      '3 - Never dismiss - `shouldTriggerDismiss: (_) => false`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(3);
         await testFlingBehavior(
           tester,
           key: key,
@@ -232,11 +266,11 @@ void main() {
     );
 
     testWidgets(
-      '3 - Always dismiss - `shouldTriggerDismiss: (_) => true`',
+      '4 - Always dismiss - `shouldTriggerDismiss: (_) => true`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
-        const ValueKey<int> key = ValueKey<int>(3);
+        const ValueKey<int> key = ValueKey<int>(4);
         await testFlingBehavior(
           tester,
           key: key,
@@ -246,11 +280,11 @@ void main() {
     );
 
     testWidgets(
-      '4 - Only accept if threshold is reached (Disable flinging)',
+      '5 - Only accept if threshold is reached (Disable flinging)',
       (WidgetTester tester) async {
         await initWidget(tester);
 
-        const ValueKey<int> key = ValueKey<int>(4);
+        const ValueKey<int> key = ValueKey<int>(5);
         await testFlingBehavior(
           tester,
           key: key,
@@ -260,11 +294,21 @@ void main() {
     );
 
     testWidgets(
-      '5 - Accept dismiss before threshold - `details.progress >= 0.2`',
+      '6 - Only accept if flung (Disable threshold check)',
       (WidgetTester tester) async {
         await initWidget(tester);
 
-        const ValueKey<int> key = ValueKey<int>(5);
+        const ValueKey<int> key = ValueKey<int>(6);
+        await testFlingBehavior(tester, key: key);
+      },
+    );
+
+    testWidgets(
+      '7 - Accept dismiss before threshold - `details.progress >= 0.2`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(7);
         await testFlingBehavior(tester, key: key);
       },
     );

--- a/examples/api/test/widgets/dismissible/dismissible.1_test.dart
+++ b/examples/api/test/widgets/dismissible/dismissible.1_test.dart
@@ -69,9 +69,10 @@ void main() {
     expect(find.byKey(key), expectedAboveThreshold);
   }
 
-  group('Test Drag behaviour', () {
+  group('Test Drag behavior', () {
 
     testWidgets(
+
       '0 - Default begavior - `shouldDismiss: null`',
       (WidgetTester tester) async {
         await initWidget(tester);
@@ -189,7 +190,7 @@ void main() {
     expect(find.byKey(key), expectedAboveThreshold);
   }
 
-  group('Test Fling behaviour', () {
+  group('Test Fling behavior', () {
 
     testWidgets(
       '0 - Default begavior - `shouldDismiss: null`',

--- a/examples/api/test/widgets/dismissible/dismissible.1_test.dart
+++ b/examples/api/test/widgets/dismissible/dismissible.1_test.dart
@@ -17,7 +17,7 @@ void main() {
     await tester.tap(fab);
     await tester.pumpAndSettle();
   }
-  
+
   Future<void> dismissHorizontally({
     required WidgetTester tester,
     required Finder finder,

--- a/examples/api/test/widgets/dismissible/dismissible.1_test.dart
+++ b/examples/api/test/widgets/dismissible/dismissible.1_test.dart
@@ -72,7 +72,7 @@ void main() {
 
   group('Test Drag behavior', () {
     testWidgets(
-      '0 - Default begavior - `shouldDismiss: null`',
+      '0 - Default begavior - `shouldTriggerDismiss: null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -82,7 +82,7 @@ void main() {
     );
 
     testWidgets(
-      '1 - Default begavior - `shouldDismiss: (_) => null`',
+      '1 - Default begavior - `shouldTriggerDismiss: (_) => null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -92,7 +92,7 @@ void main() {
     );
 
     testWidgets(
-      '2 - Never dismiss - `shouldDismiss: (_) => false`',
+      '2 - Never dismiss - `shouldTriggerDismiss: (_) => false`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -106,7 +106,7 @@ void main() {
     );
 
     testWidgets(
-      '3 - Always dismiss - `shouldDismiss: (_) => true`',
+      '3 - Always dismiss - `shouldTriggerDismiss: (_) => true`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -198,7 +198,7 @@ void main() {
 
   group('Test Fling behavior', () {
     testWidgets(
-      '0 - Default begavior - `shouldDismiss: null`',
+      '0 - Default begavior - `shouldTriggerDismiss: null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -208,7 +208,7 @@ void main() {
     );
 
     testWidgets(
-      '1 - Default begavior - `shouldDismiss: (_) => null`',
+      '1 - Default begavior - `shouldTriggerDismiss: (_) => null`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -218,7 +218,7 @@ void main() {
     );
 
     testWidgets(
-      '2 - Never dismiss - `shouldDismiss: (_) => false`',
+      '2 - Never dismiss - `shouldTriggerDismiss: (_) => false`',
       (WidgetTester tester) async {
         await initWidget(tester);
 
@@ -232,7 +232,7 @@ void main() {
     );
 
     testWidgets(
-      '3 - Always dismiss - `shouldDismiss: (_) => true`',
+      '3 - Always dismiss - `shouldTriggerDismiss: (_) => true`',
       (WidgetTester tester) async {
         await initWidget(tester);
 

--- a/examples/api/test/widgets/dismissible/dismissible.1_test.dart
+++ b/examples/api/test/widgets/dismissible/dismissible.1_test.dart
@@ -1,0 +1,260 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/dismissible/dismissible.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> initWidget(WidgetTester tester) async {
+    await tester.pumpWidget(const example.DismissibleExampleApp());
+  }
+
+  Future<void> reset(WidgetTester tester) async {
+    final Finder fab = find.byType(FloatingActionButton);
+    await tester.tap(fab);
+    await tester.pumpAndSettle();
+  }
+  
+  Future<void> dismissHorizontally({
+    required WidgetTester tester,
+    required Finder finder,
+    double dragRatio = 0.8,
+    AxisDirection direction = AxisDirection.left,
+  }) async {
+    final double width = (tester.renderObject(finder) as RenderBox).size.width;
+    final double dx = width * dragRatio;
+
+    final Offset offset = switch (direction) {
+      AxisDirection.left => Offset(-dx, 0.0),
+      AxisDirection.right => Offset(dx, 0.0),
+      _ => throw ArgumentError('$direction is not supported'),
+    };
+
+    await tester.drag(finder, offset);
+  }
+
+  Future<void> testDragBehavior(WidgetTester tester, {
+    required Key key,
+    Matcher expectedBelowThreshold = findsOneWidget,
+    Matcher expectedAboveThreshold = findsNothing,
+  }) async {
+    await tester.scrollUntilVisible(find.byKey(key), 100);
+
+    expect(find.byKey(key), findsOneWidget);
+
+    // Drag below the threshold
+    await dismissHorizontally(
+      tester: tester,
+      finder: find.byKey(key),
+      dragRatio: 0.3
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(key), expectedBelowThreshold);
+
+    await reset(tester);
+
+    // Drag above the threshold
+    await dismissHorizontally(
+      tester: tester,
+      finder: find.byKey(key),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(key), expectedAboveThreshold);
+  }
+
+  group('Test Drag behaviour', () {
+
+    testWidgets(
+      '0 - Default begavior - `shouldDismiss: null`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(0);
+
+        await testDragBehavior(tester, key: key);
+      },
+    );
+
+    testWidgets(
+      '1 - Default begavior - `shouldDismiss: (_) => null`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(1);
+
+        await testDragBehavior(tester, key: key);
+      },
+    );
+
+    testWidgets(
+      '2 - Never dismiss - `shouldDismiss: (_) => false`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(2);
+
+        await testDragBehavior(tester, key: key, expectedAboveThreshold: findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '3 - Always dismiss - `shouldDismiss: (_) => true`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(3);
+
+        await testDragBehavior(tester, key: key, expectedBelowThreshold: findsNothing);
+      },
+    );
+
+    testWidgets(
+      '4 - Only accept if threshold is reached (Disable flinging)',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(4);
+
+        await testDragBehavior(tester, key: key);
+      },
+    );
+
+    testWidgets(
+      '5 - Accept dismiss before threshold - `details.progress >= 0.2`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(5);
+
+        await testDragBehavior(tester, key: key, expectedBelowThreshold: findsNothing);
+      },
+    );
+  });
+
+  Future<void> flingHorizontally({
+    required WidgetTester tester,
+    required Finder finder,
+    double speed = 1000,
+    AxisDirection direction = AxisDirection.left,
+  }) async {
+    final double width = (tester.renderObject(finder) as RenderBox).size.width;
+    final double dx = width * 0.1;
+
+    final Offset offset = switch (direction) {
+      AxisDirection.left => Offset(-dx, 0.0),
+      AxisDirection.right => Offset(dx, 0.0),
+      _ => throw ArgumentError('$direction is not supported'),
+    };
+
+    await tester.fling(finder, offset, speed);
+  }
+
+  Future<void> testFlingBehavior(WidgetTester tester, {
+    required Key key,
+    Matcher expectedBelowThreshold = findsOneWidget,
+    Matcher expectedAboveThreshold = findsNothing,
+  }) async {
+    await tester.scrollUntilVisible(find.byKey(key), 100);
+
+    expect(find.byKey(key), findsOneWidget);
+
+    // Fling below fling velocity threshold
+    await flingHorizontally(
+      tester: tester,
+      finder: find.byKey(key),
+      speed: 200
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(key), expectedBelowThreshold);
+
+    await reset(tester);
+
+    // Fling above fling velocity threshold
+    await flingHorizontally(
+      tester: tester,
+      finder: find.byKey(key),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(key), expectedAboveThreshold);
+  }
+
+  group('Test Fling behaviour', () {
+
+    testWidgets(
+      '0 - Default begavior - `shouldDismiss: null`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(0);
+
+        await testFlingBehavior(tester, key: key);
+      },
+    );
+
+    testWidgets(
+      '1 - Default begavior - `shouldDismiss: (_) => null`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(1);
+
+        await testFlingBehavior(tester, key: key);
+      },
+    );
+
+    testWidgets(
+      '2 - Never dismiss - `shouldDismiss: (_) => false`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(2);
+
+        await testFlingBehavior(tester, key: key, expectedAboveThreshold: findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '3 - Always dismiss - `shouldDismiss: (_) => true`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(3);
+
+        await testFlingBehavior(tester, key: key, expectedBelowThreshold: findsNothing);
+      },
+    );
+
+    testWidgets(
+      '4 - Only accept if threshold is reached (Disable flinging)',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(4);
+
+        await testFlingBehavior(tester, key: key, expectedAboveThreshold: findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '5 - Accept dismiss before threshold - `details.progress >= 0.2`',
+      (WidgetTester tester) async {
+        await initWidget(tester);
+
+        const ValueKey<int> key = ValueKey<int>(5);
+
+        await testFlingBehavior(tester, key: key);
+      },
+    );
+  });
+}

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -406,7 +406,10 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     super.dispose();
   }
 
-  bool get _directionIsXAxis => widget.direction.directionIsXAxis;
+  bool get _directionIsXAxis => switch (widget.direction) {
+    DismissDirection.horizontal || DismissDirection.endToStart || DismissDirection.startToEnd => true,
+    DismissDirection.vertical || DismissDirection.up || DismissDirection.down || DismissDirection.none => false
+  };
 
   DismissDirection _extentToDirection(double extent) {
     if (extent == 0.0) {
@@ -787,11 +790,4 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       child: content,
     );
   }
-}
-
-extension on DismissDirection {
-  bool get directionIsXAxis => switch (this) {
-    DismissDirection.horizontal || DismissDirection.endToStart || DismissDirection.startToEnd => true,
-    _ => false
-  };
 }

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -584,11 +584,8 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       _handleMoveCompleted();
       return;
     }
-
     final double flingVelocity = _directionIsXAxis ? details.velocity.pixelsPerSecond.dx : details.velocity.pixelsPerSecond.dy;
-    final _FlingGestureKind flingGesture = _describeFlingGesture(details.velocity);
-
-    switch (flingGesture) {
+    switch (_describeFlingGesture(details.velocity)) {
       case _FlingGestureKind.forward:
         assert(_dragExtent != 0.0);
         assert(!_moveController.isDismissed);

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -518,7 +518,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     }
 
     final double flingVelocity = _directionIsXAxis ? details.velocity.pixelsPerSecond.dx : details.velocity.pixelsPerSecond.dy;
-    final _FlingGestureKind flingGesture = widget.allowFlinging ? _describeFlingGesture(details.velocity) :_FlingGestureKind.none;
+    final _FlingGestureKind flingGesture = widget.allowFlinging ? _describeFlingGesture(details.velocity) : _FlingGestureKind.none;
     switch (flingGesture) {
       case _FlingGestureKind.forward:
         assert(_dragExtent != 0.0);

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -546,10 +546,6 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       return;
     }
     _dragUnderway = false;
-    if (_moveController.isCompleted) {
-      _handleMoveCompleted();
-      return;
-    }
 
     // Use value returned by `widget.shouldDismiss` if a callback is provided
     // If the callback returns null, use the default behavior
@@ -573,6 +569,11 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
         }
         return;
       }
+    }
+
+    if (_moveController.isCompleted) {
+      _handleMoveCompleted();
+      return;
     }
 
     final double flingVelocity = _directionIsXAxis ? details.velocity.pixelsPerSecond.dx : details.velocity.pixelsPerSecond.dy;

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -185,7 +185,7 @@ class Dismissible extends StatefulWidget {
   /// Flinging is treated as being equivalent to dragging almost to 1.0, so
   /// flinging can dismiss an item past any threshold less than 1.0.
   ///
-  /// This defaults to `true`
+  /// Defaults to `true`.
   final bool allowFlinging;
 
   /// Defines the duration for card to dismiss or to come back to original position if not dismissed.

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -322,12 +322,12 @@ class TriggerDismissDetails {
   /// completely outside its parent.
   final double progress;
 
-  /// Distance from the start of the drag to the current position
-  ///
-  /// The drag distance is represented in logical pixels.
+  /// Distance from the start of the drag to the current position,
+  /// represented in logical pixels.
   final double dragExtent;
 
   /// The component of the velocity parallel to the [DismissDirection].
+  ///
   /// A fling away from the center will have a positive value.
   final double velocity;
 }

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -799,7 +799,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
 }
 
 extension on DismissDirection {
-  bool get directionIsXAxis => switch(this) {
+  bool get directionIsXAxis => switch (this) {
     DismissDirection.horizontal || DismissDirection.endToStart || DismissDirection.startToEnd => true,
     _ => false
   };

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -36,10 +36,6 @@ typedef ConfirmDismissCallback = Future<bool?> Function(DismissDirection directi
 /// Signature used by [Dismissible] to give the application an opportunity to
 /// accept or deny a dismiss gesture.
 ///
-/// This callback can be used to deny a dismiss gesture based the [AcceptDismissDetails.progress] value.
-///
-/// Returning `null` will use de default behavior.
-///
 /// Used by [Dismissible.shouldDismiss].
 typedef AcceptDismissCallback = bool? Function(AcceptDismissDetails details);
 
@@ -154,7 +150,20 @@ class Dismissible extends StatefulWidget {
   /// and [onDismissed] callbacks will not run.
   final ConfirmDismissCallback? confirmDismiss;
 
-  /// Gives the app an
+  /// Gives the app the ability to accept or reject a dismiss gesture, overriding
+  /// the default behavior.
+  ///
+  /// Returning `null` will use de default behavior.
+  ///
+  /// {@tool snippet}
+  /// The default flinging effect can be disabled by using:
+  /// ```dart
+  /// Dismissible(
+  ///   ...
+  ///   shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
+  /// )
+  /// ```
+  /// {@end-tool}
   final AcceptDismissCallback? shouldDismiss;
 
   /// Called when the widget changes size (i.e., when contracting before being dismissed).

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -408,10 +408,19 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     super.dispose();
   }
 
-  bool get _directionIsXAxis => switch (widget.direction) {
-    DismissDirection.horizontal || DismissDirection.endToStart || DismissDirection.startToEnd => true,
-    DismissDirection.vertical || DismissDirection.up || DismissDirection.down || DismissDirection.none => false,
-  };
+  bool get _directionIsXAxis {
+    return switch (widget.direction) {
+      DismissDirection.horizontal ||
+      DismissDirection.endToStart ||
+      DismissDirection.startToEnd =>
+        true,
+      DismissDirection.vertical ||
+      DismissDirection.up ||
+      DismissDirection.down ||
+      DismissDirection.none =>
+        false,
+    };
+  }
 
   DismissDirection _extentToDirection(double extent) {
     if (extent == 0.0) {

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -166,9 +166,9 @@ class Dismissible extends StatefulWidget {
   /// The default flinging effect can be disabled by using:
   /// ```dart
   /// Dismissible(
-  ///   key: ValueKey('dismissible-key'),
+  ///   key: const ValueKey<String>('dismissible-key'),
   ///   shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
-  ///   child: ListTile(title: Text('Slide me to dismiss')),
+  ///   child: const ListTile(title: Text('Slide me to dismiss')),
   /// )
   /// ```
   /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -111,6 +111,7 @@ class Dismissible extends StatefulWidget {
     this.direction = DismissDirection.horizontal,
     this.resizeDuration = const Duration(milliseconds: 300),
     this.dismissThresholds = const <DismissDirection, double>{},
+    this.allowFlinging = true,
     this.movementDuration = const Duration(milliseconds: 200),
     this.crossAxisEndOffset = 0.0,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -178,6 +179,14 @@ class Dismissible extends StatefulWidget {
   ///  * [direction], which controls the directions in which the items can
   ///    be dismissed.
   final Map<DismissDirection, double> dismissThresholds;
+
+  /// Controls whether the widget can be dismissed by flinging in the indicated [direction].
+  ///
+  /// Flinging is treated as being equivalent to dragging almost to 1.0, so
+  /// flinging can dismiss an item past any threshold less than 1.0.
+  ///
+  /// This defaults to [true]
+  final bool allowFlinging;
 
   /// Defines the duration for card to dismiss or to come back to original position if not dismissed.
   final Duration movementDuration;
@@ -507,8 +516,10 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       _handleMoveCompleted();
       return;
     }
+
     final double flingVelocity = _directionIsXAxis ? details.velocity.pixelsPerSecond.dx : details.velocity.pixelsPerSecond.dy;
-    switch (_describeFlingGesture(details.velocity)) {
+    final _FlingGestureKind flingGesture = widget.allowFlinging ? _describeFlingGesture(details.velocity) :_FlingGestureKind.none;
+    switch (flingGesture) {
       case _FlingGestureKind.forward:
         assert(_dragExtent != 0.0);
         assert(!_moveController.isDismissed);

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -405,7 +405,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
 
   bool get _directionIsXAxis => switch (widget.direction) {
     DismissDirection.horizontal || DismissDirection.endToStart || DismissDirection.startToEnd => true,
-    DismissDirection.vertical || DismissDirection.up || DismissDirection.down || DismissDirection.none => false
+    DismissDirection.vertical || DismissDirection.up || DismissDirection.down || DismissDirection.none => false,
   };
 
   DismissDirection _extentToDirection(double extent) {

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -33,8 +33,8 @@ typedef DismissDirectionCallback = void Function(DismissDirection direction);
 /// Used by [Dismissible.confirmDismiss].
 typedef ConfirmDismissCallback = Future<bool?> Function(DismissDirection direction);
 
-/// Signature used by [Dismissible] to give the application an opportunity to
-/// accept or deny a dismiss gesture.
+/// Signature used by [Dismissible] to determine whether a user gesture
+/// should qualify as a dismissal.
 ///
 /// Used by [Dismissible.shouldTriggerDismiss].
 typedef TriggerDismissCallback = bool? Function(TriggerDismissDetails details);

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -282,11 +282,11 @@ class DismissUpdateDetails {
   final double progress;
 }
 
-/// Details for [DismissUpdateCallback].
+/// Details for [AcceptDismissCallback].
 ///
 /// See also:
 ///
-///   * [Dismissible.onUpdate], which receives this information.
+///   * [Dismissible.shouldDismiss], which receives this information.
 class AcceptDismissDetails {
   /// Create a new instance of [AcceptDismissDetails].
   const AcceptDismissDetails({

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -613,7 +613,11 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
         }
 
         if (shouldDismiss) {
-          _moveController.forward();
+          if (_moveController.isCompleted) {
+            _handleMoveCompleted();
+          } else {
+            _moveController.forward();
+          }
         } else {
           _moveController.reverse();
         }

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -157,17 +157,22 @@ class Dismissible extends StatefulWidget {
   /// and [onDismissed] callbacks will not run.
   final ConfirmDismissCallback? confirmDismiss;
 
-  /// Gives the app the ability to accept or reject a dismiss gesture, overriding
-  /// the default behavior.
+  /// Whether a drag should be considered as a dismiss gesture.
   ///
-  /// Returning `null` will use de default behavior.
+  /// If `null`, defers to behavior defined in [dismissThresholds].
+  /// (This applies both when the callback returns `null`,
+  /// and when no callback is provided.)
   ///
   /// {@tool snippet}
-  /// The default flinging effect can be disabled by using:
+  /// By default, when the dismiss threshold is not reached, flinging the item
+  /// can still cause it to be dismissed.
+  ///
+  /// This behavior can be prevented with the following [TriggerDismissCallback]:
+  ///
   /// ```dart
   /// Dismissible(
   ///   key: const ValueKey<String>('dismissible-key'),
-  ///   shouldTriggerDismiss: (TriggerDismissDetails details) => details.reached ? null : false,
+  ///   shouldTriggerDismiss: (TriggerDismissDetails details) => details.reached,
   ///   child: const ListTile(title: Text('Slide me to dismiss')),
   /// )
   /// ```

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -315,9 +315,6 @@ class TriggerDismissDetails {
   ///
   /// A value of 0.0 represents the normal position and 1.0 means the child is
   /// completely outside its parent.
-  ///
-  /// This can be used to synchronize other elements to what the dismissible is doing on screen,
-  /// e.g. using this value to set the opacity thereby fading dismissible as it's dragged offscreen.
   final double progress;
 
   /// Distance from the start of the drag to the current position

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -87,6 +87,13 @@ enum DismissDirection {
 /// ** See code in examples/api/lib/widgets/dismissible/dismissible.0.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// In this sample, the [shouldDismiss] callback is used to customize the behavior
+/// of the [Dismissible] widget.
+///
+/// ** See code in examples/api/lib/widgets/dismissible/dismissible.1.dart **
+/// {@end-tool}
+///
 /// Backgrounds can be used to implement the "leave-behind" idiom. If a background
 /// is specified it is stacked behind the Dismissible's child and is exposed when
 /// the child moves.

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -36,7 +36,7 @@ typedef ConfirmDismissCallback = Future<bool?> Function(DismissDirection directi
 /// Signature used by [Dismissible] to give the application an opportunity to
 /// accept or deny a dismiss gesture.
 ///
-/// This callback can be used to deny a dismiss gesture based on the distance and the velocity of the gesture.
+/// This callback can be used to deny a dismiss gesture based the [AcceptDismissDetails.progress] value.
 ///
 /// Returning `null` will use de default behavior.
 ///

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -166,8 +166,9 @@ class Dismissible extends StatefulWidget {
   /// The default flinging effect can be disabled by using:
   /// ```dart
   /// Dismissible(
-  ///   ...
+  ///   key: ValueKey('dismissible-key'),
   ///   shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
+  ///   child: ListTile(title: Text('Slide me to dismiss')),
   /// )
   /// ```
   /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -185,7 +185,7 @@ class Dismissible extends StatefulWidget {
   /// Flinging is treated as being equivalent to dragging almost to 1.0, so
   /// flinging can dismiss an item past any threshold less than 1.0.
   ///
-  /// This defaults to [true]
+  /// This defaults to `true`
   final bool allowFlinging;
 
   /// Defines the duration for card to dismiss or to come back to original position if not dismissed.

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -36,8 +36,8 @@ typedef ConfirmDismissCallback = Future<bool?> Function(DismissDirection directi
 /// Signature used by [Dismissible] to give the application an opportunity to
 /// accept or deny a dismiss gesture.
 ///
-/// Used by [Dismissible.shouldDismiss].
-typedef AcceptDismissCallback = bool? Function(AcceptDismissDetails details);
+/// Used by [Dismissible.shouldTriggerDismiss].
+typedef TriggerDismissCallback = bool? Function(TriggerDismissDetails details);
 
 /// Signature used by [Dismissible] to indicate that the dismissible has been dragged.
 ///
@@ -88,7 +88,7 @@ enum DismissDirection {
 /// {@end-tool}
 ///
 /// {@tool dartpad}
-/// In this sample, the [shouldDismiss] callback is used to customize the behavior
+/// In this sample, the [shouldTriggerDismiss] callback is used to customize the behavior
 /// of the [Dismissible] widget.
 ///
 /// ** See code in examples/api/lib/widgets/dismissible/dismissible.1.dart **
@@ -118,7 +118,7 @@ class Dismissible extends StatefulWidget {
     this.background,
     this.secondaryBackground,
     this.confirmDismiss,
-    this.shouldDismiss,
+    this.shouldTriggerDismiss,
     this.onResize,
     this.onUpdate,
     this.onDismissed,
@@ -167,12 +167,12 @@ class Dismissible extends StatefulWidget {
   /// ```dart
   /// Dismissible(
   ///   key: const ValueKey<String>('dismissible-key'),
-  ///   shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
+  ///   shouldTriggerDismiss: (TriggerDismissDetails details) => details.reached ? null : false,
   ///   child: const ListTile(title: Text('Slide me to dismiss')),
   /// )
   /// ```
   /// {@end-tool}
-  final AcceptDismissCallback? shouldDismiss;
+  final TriggerDismissCallback? shouldTriggerDismiss;
 
   /// Called when the widget changes size (i.e., when contracting before being dismissed).
   final VoidCallback? onResize;
@@ -290,14 +290,14 @@ class DismissUpdateDetails {
   final double progress;
 }
 
-/// Details for [AcceptDismissCallback].
+/// Details for [TriggerDismissCallback].
 ///
 /// See also:
 ///
-///   * [Dismissible.shouldDismiss], which receives this information.
-class AcceptDismissDetails {
-  /// Create a new instance of [AcceptDismissDetails].
-  const AcceptDismissDetails({
+///   * [Dismissible.shouldTriggerDismiss], which receives this information.
+class TriggerDismissDetails {
+  /// Create a new instance of [TriggerDismissDetails].
+  const TriggerDismissDetails({
     this.direction = DismissDirection.horizontal,
     this.reached = false,
     this.progress = 0.0,
@@ -580,10 +580,10 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     }
     _dragUnderway = false;
 
-    // Use value returned by `widget.shouldDismiss` if a callback is provided
+    // Use value returned by `shouldTriggerDismiss` if a callback is provided
     // If the callback returns null, use the default behavior
-    if (widget.shouldDismiss case final AcceptDismissCallback shouldDismissCallback) {
-      final AcceptDismissDetails acceptDismissDetails = AcceptDismissDetails(
+    if (widget.shouldTriggerDismiss case final TriggerDismissCallback shouldDismissCallback) {
+      final TriggerDismissDetails triggerDismissDetails = TriggerDismissDetails(
         direction: _dismissDirection,
         reached: _moveController.value > _dismissThreshold,
         progress: _moveController.value,
@@ -591,7 +591,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
         dragExtent: _dragExtent,
       );
 
-      final bool? shouldDismiss = shouldDismissCallback(acceptDismissDetails);
+      final bool? shouldDismiss = shouldDismissCallback(triggerDismissDetails);
 
       if (shouldDismiss != null) {
         if (_moveController.isDismissed) {

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -513,7 +513,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
   }
 
   void _handleDismissUpdateValueChanged() {
-    if (widget.onUpdate case final DismissUpdateCallback onUpdate) {
+    if (widget.onUpdate != null) {
       final bool oldDismissThresholdReached = _dismissThresholdReached;
       _dismissThresholdReached = _moveController.value > _dismissThreshold;
       final DismissUpdateDetails details = DismissUpdateDetails(
@@ -522,7 +522,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
           previousReached: oldDismissThresholdReached,
           progress: _moveController.value,
       );
-      onUpdate(details);
+      widget.onUpdate!(details);
     }
   }
 
@@ -580,7 +580,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
 
     // Use value returned by `shouldTriggerDismiss` if a callback is provided.
     // If the callback returns null, use the default behavior.
-    if (widget.shouldTriggerDismiss case final TriggerDismissCallback shouldDismissCallback) {
+    if (widget.shouldTriggerDismiss != null) {
       final TriggerDismissDetails triggerDismissDetails = TriggerDismissDetails(
         direction: _dismissDirection,
         reached: _moveController.value > _dismissThreshold,
@@ -589,7 +589,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
         dragExtent: _dragExtent,
       );
 
-      final bool? shouldDismiss = shouldDismissCallback(triggerDismissDetails);
+      final bool? shouldDismiss = widget.shouldTriggerDismiss!(triggerDismissDetails);
 
       if (shouldDismiss != null) {
         if (_moveController.isDismissed) {

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -578,8 +578,8 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
 
     final double flingVelocity = _directionIsXAxis ? details.velocity.pixelsPerSecond.dx : details.velocity.pixelsPerSecond.dy;
 
-    // Use value returned by `shouldTriggerDismiss` if a callback is provided
-    // If the callback returns null, use the default behavior
+    // Use value returned by `shouldTriggerDismiss` if a callback is provided.
+    // If the callback returns null, use the default behavior.
     if (widget.shouldTriggerDismiss case final TriggerDismissCallback shouldDismissCallback) {
       final TriggerDismissDetails triggerDismissDetails = TriggerDismissDetails(
         direction: _dismissDirection,

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -301,7 +301,7 @@ class TriggerDismissDetails {
     this.direction = DismissDirection.horizontal,
     this.reached = false,
     this.progress = 0.0,
-    this.flingVelocity = Velocity.zero,
+    this.velocity = 0.0,
     this.dragExtent = 0.0,
   });
 
@@ -325,18 +325,9 @@ class TriggerDismissDetails {
   /// The drag distance is represented in logical pixels.
   final double dragExtent;
 
-  /// The velocity the pointer was moving when it stopped contacting the screen.
-  ///
-  /// Defaults to [Velocity.zero] if not specified in the constructor.
-  final Velocity flingVelocity;
-
   /// The component of the velocity parallel to the [DismissDirection].
   /// A fling away from the center will have a positive value.
-  double get velocity => (
-    direction.directionIsXAxis
-      ? flingVelocity.pixelsPerSecond.dx
-      : flingVelocity.pixelsPerSecond.dy
-    ).abs();
+  final double velocity;
 }
 
 class _DismissibleClipper extends CustomClipper<Rect> {
@@ -580,6 +571,8 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     }
     _dragUnderway = false;
 
+    final double flingVelocity = _directionIsXAxis ? details.velocity.pixelsPerSecond.dx : details.velocity.pixelsPerSecond.dy;
+
     // Use value returned by `shouldTriggerDismiss` if a callback is provided
     // If the callback returns null, use the default behavior
     if (widget.shouldTriggerDismiss case final TriggerDismissCallback shouldDismissCallback) {
@@ -587,7 +580,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
         direction: _dismissDirection,
         reached: _moveController.value > _dismissThreshold,
         progress: _moveController.value,
-        flingVelocity: details.velocity,
+        velocity: flingVelocity.abs(),
         dragExtent: _dragExtent,
       );
 
@@ -611,8 +604,6 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       _handleMoveCompleted();
       return;
     }
-
-    final double flingVelocity = _directionIsXAxis ? details.velocity.pixelsPerSecond.dx : details.velocity.pixelsPerSecond.dy;
 
     switch (_describeFlingGesture(details.velocity)) {
       case _FlingGestureKind.forward:

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -995,6 +995,21 @@ void main() {
     expect(dismissedItems, <int>[0, 1]);
   });
 
+  testWidgets('`shouldTriggerDismiss` should override thresholds higher than 1', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildTest(
+        startToEndThreshold: 10,
+        shouldTriggerDismiss: (TriggerDismissDetails details) => true,
+      )
+    );
+
+    await checkFlingItemAfterMovement(tester, 0, gestureDirection: AxisDirection.right, mechanism: flingElement);
+    expect(find.text('0'), findsNothing);
+
+    await dismissItem(tester, 1, gestureDirection: AxisDirection.right);
+    expect(find.text('1'), findsNothing);
+  });
+
   testWidgets('Dismissible with null resizeDuration calls onDismissed immediately', (WidgetTester tester) async {
     bool resized = false;
     bool dismissed = false;

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -897,6 +897,7 @@ void main() {
     await dismissItem(tester, 1, gestureDirection: AxisDirection.right);
     expect(find.text('1'), findsOneWidget);
   });
+
   testWidgets('Use `shouldTriggerDismiss` to disable flinging', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildTest(

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -22,7 +22,7 @@ Widget buildTest({
   Axis scrollDirection = Axis.vertical,
   DismissDirection dismissDirection = defaultDismissDirection,
   double? startToEndThreshold,
-  AcceptDismissCallback? shouldDismiss,
+  TriggerDismissCallback? shouldTriggerDismiss,
   TextDirection textDirection = TextDirection.ltr,
   Future<bool?> Function(BuildContext context, DismissDirection direction)? confirmDismiss,
   ScrollController? controller,
@@ -41,7 +41,7 @@ Widget buildTest({
             confirmDismiss: confirmDismiss == null ? null : (DismissDirection direction) {
               return confirmDismiss(context, direction);
             },
-            shouldDismiss: shouldDismiss,
+            shouldTriggerDismiss: shouldTriggerDismiss,
             onDismissed: (DismissDirection direction) {
               setState(() {
                 reportedDismissDirection = direction;
@@ -869,10 +869,10 @@ void main() {
     expect(tester.getTopLeft(find.text('0')), position);
   });
 
-  testWidgets('Default behavior expected when `shouldDismiss` returns `null`', (WidgetTester tester) async {
+  testWidgets('Default behavior expected when `shouldTriggerDismiss` returns `null`', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildTest(
-        shouldDismiss: (AcceptDismissDetails details) => null,
+        shouldTriggerDismiss: (TriggerDismissDetails details) => null,
       )
     );
 
@@ -884,10 +884,10 @@ void main() {
     expect(find.text('1'), findsNothing);
   });
 
-  testWidgets('Value returned by `shouldDismiss` override dismiss gesture validation', (WidgetTester tester) async {
+  testWidgets('Value returned by `shouldTriggerDismiss` override dismiss gesture validation', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildTest(
-        shouldDismiss: (AcceptDismissDetails details) => false,
+        shouldTriggerDismiss: (TriggerDismissDetails details) => false,
       )
     );
 
@@ -897,10 +897,10 @@ void main() {
     await dismissItem(tester, 1, gestureDirection: AxisDirection.right);
     expect(find.text('1'), findsOneWidget);
   });
-  testWidgets('Use `shouldDismiss` to disable flinging', (WidgetTester tester) async {
+  testWidgets('Use `shouldTriggerDismiss` to disable flinging', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildTest(
-        shouldDismiss: (AcceptDismissDetails details) => details.reached ? null : false,
+        shouldTriggerDismiss: (TriggerDismissDetails details) => details.reached ? null : false,
       )
     );
 

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -22,6 +22,7 @@ Widget buildTest({
   Axis scrollDirection = Axis.vertical,
   DismissDirection dismissDirection = defaultDismissDirection,
   double? startToEndThreshold,
+  bool allowFlinging = true,
   TextDirection textDirection = TextDirection.ltr,
   Future<bool?> Function(BuildContext context, DismissDirection direction)? confirmDismiss,
   ScrollController? controller,
@@ -60,6 +61,7 @@ Widget buildTest({
             dismissThresholds: startToEndThreshold == null
                 ? <DismissDirection, double>{}
                 : <DismissDirection, double>{DismissDirection.startToEnd: startToEndThreshold},
+            allowFlinging: allowFlinging,
             crossAxisEndOffset: crossAxisEndOffset,
             child: SizedBox(
               width: 100.0,
@@ -701,6 +703,19 @@ void main() {
     expect(dismissedItems, isEmpty);
 
     await checkFlingItemAfterMovement(tester, 1, gestureDirection: AxisDirection.right);
+    expect(find.text('1'), findsOneWidget);
+    expect(dismissedItems, isEmpty);
+  });
+
+  testWidgets('Flinging is disabled', (WidgetTester tester) async {
+    await tester.pumpWidget(buildTest(allowFlinging: false));
+    expect(dismissedItems, isEmpty);
+
+    await checkFlingItemAfterMovement(tester, 0, gestureDirection: AxisDirection.right, mechanism: flingElement);
+    expect(find.text('0'), findsOneWidget);
+    expect(dismissedItems, isEmpty);
+
+    await checkFlingItemAfterMovement(tester, 1, gestureDirection: AxisDirection.left, mechanism: flingElement);
     expect(find.text('1'), findsOneWidget);
     expect(dismissedItems, isEmpty);
   });

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -869,7 +869,7 @@ void main() {
     expect(tester.getTopLeft(find.text('0')), position);
   });
 
-  testWidgets('`shouldDismiss` returning `null` results in default behavior', (WidgetTester tester) async {
+  testWidgets('Default behavior expected when `shouldDismiss` returns `null`', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildTest(
         shouldDismiss: (AcceptDismissDetails details) => null,


### PR DESCRIPTION
### Description
The default flinging behaviour implemented in the `Dismissible` widget often results in undesired triggering of the dismiss action when used in a scrollable content (e.g. dismissible tiles in a `ListView`)
This PR adds an optional callback parameter `shouldTriggerDismiss` to make it possible to override the default behavior.

The type of the `shouldTriggerDismiss` callback is: `bool? Function(TriggerDismissDetails details)`
When returning `null`, the default behavior is preserved and the widget will check the drag threshold and the flinging gesture.
Returning `true` will trigger the dismiss animation of the widget, even if the threshold is not reached.

The object `details` can be accessed to check for `velocity`, `progress` (relative distance dragged), `dragExtent` (distance dragged in logical pixels) or `reached` (bool value indicating whether the threshold has been reached)

### Linked issue
Closes https://github.com/flutter/flutter/issues/151223