### PR TITLE
Add borderRadius property to PopupMenuButton

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1196,6 +1196,7 @@ class PopupMenuButton<T> extends StatefulWidget {
     this.padding = const EdgeInsets.all(8.0),
     this.menuPadding,
     this.child,
+    this.borderRadius,
     this.splashRadius,
     this.icon,
     this.iconSize,
@@ -1291,6 +1292,9 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// If provided, [child] is the widget used for this button
   /// and the button will utilize an [InkWell] for taps.
   final Widget? child;
+
+  /// If [child] is provided, this property is used for the child's [InkWell].
+  final BorderRadius? borderRadius;
 
   /// If provided, the [icon] is used for this button
   /// and the button will behave like an [IconButton].
@@ -1527,6 +1531,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
       return Tooltip(
         message: widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
         child: InkWell(
+          borderRadius: widget.borderRadius,
           onTap: widget.enabled ? showButtonMenu : null,
           canRequestFocus: _canRequestFocus,
           radius: widget.splashRadius,

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1293,7 +1293,9 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// and the button will utilize an [InkWell] for taps.
   final Widget? child;
 
-  /// If [child] is provided, this property is used for the child's [InkWell].
+  /// The border radius for the [InkWell] that wraps the [child].
+  ///
+  /// Defaults to null, which indicates no border radius should be applied.
   final BorderRadius? borderRadius;
 
   /// If provided, the [icon] is used for this button

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -4243,7 +4243,7 @@ void main() {
     expect(iconText.text.style?.color, Colors.red);
   });
 
-  testWidgets("Popup menu child's InkWell borderRadius",
+  testWidgets("Popup menu child's InkWell borderRadius", (WidgetTester tester) async {
       (WidgetTester tester) async {
     const double radius = 20;
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -4242,6 +4242,59 @@ void main() {
     ));
     expect(iconText.text.style?.color, Colors.red);
   });
+
+  testWidgets("Popup menu child's InkWell borderRadius",
+      (WidgetTester tester) async {
+    const double radius = 20;
+
+    Widget buildPopupMenu({required BorderRadius? borderRadius}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PopupMenuButton<String>(
+              borderRadius: borderRadius,
+              itemBuilder: (_) => <PopupMenuEntry<String>>[
+                const PopupMenuItem<String>(
+                  value: 'value',
+                  child: Text('Item 0'),
+                ),
+              ],
+              child: Ink(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(radius),
+                ),
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text('Pop up menu'),
+                    Icon(Icons.arrow_drop_down),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Popup menu with default null borderRadius.
+    await tester.pumpWidget(buildPopupMenu(borderRadius: null));
+
+    await tester.pumpAndSettle();
+
+    InkWell inkWell = tester.widget<InkWell>(find.byType(InkWell).last);
+    expect(inkWell.borderRadius, null);
+
+    // Popup menu with fixed borderRadius.
+    await tester.pumpWidget(
+        buildPopupMenu(borderRadius: BorderRadius.circular(radius)));
+
+    await tester.pumpAndSettle();
+
+    inkWell = tester.widget<InkWell>(find.byType(InkWell).last);
+    expect(inkWell.borderRadius, BorderRadius.circular(radius));
+  });
 }
 
 Matcher overlaps(Rect other) => OverlapsMatcher(other);

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -4244,8 +4244,7 @@ void main() {
   });
 
   testWidgets("Popup menu child's InkWell borderRadius", (WidgetTester tester) async {
-      (WidgetTester tester) async {
-    const double radius = 20;
+    final BorderRadius borderRadius = BorderRadius.circular(20);
 
     Widget buildPopupMenu({required BorderRadius? borderRadius}) {
       return MaterialApp(
@@ -4259,18 +4258,12 @@ void main() {
                   child: Text('Item 0'),
                 ),
               ],
-              child: Ink(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(radius),
-                ),
-                child: const Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Text('Pop up menu'),
-                    Icon(Icons.arrow_drop_down),
-                  ],
-                ),
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Text('Pop up menu'),
+                  Icon(Icons.arrow_drop_down),
+                ],
               ),
             ),
           ),
@@ -4280,20 +4273,17 @@ void main() {
 
     // Popup menu with default null borderRadius.
     await tester.pumpWidget(buildPopupMenu(borderRadius: null));
-
     await tester.pumpAndSettle();
 
-    InkWell inkWell = tester.widget<InkWell>(find.byType(InkWell).last);
+    InkWell inkWell = tester.widget<InkWell>(find.byType(InkWell));
     expect(inkWell.borderRadius, isNull);
 
     // Popup menu with fixed borderRadius.
-    await tester.pumpWidget(
-        buildPopupMenu(borderRadius: BorderRadius.circular(radius)));
-
+    await tester.pumpWidget(buildPopupMenu(borderRadius: borderRadius));
     await tester.pumpAndSettle();
 
-    inkWell = tester.widget<InkWell>(find.byType(InkWell).last);
-    expect(inkWell.borderRadius, BorderRadius.circular(radius));
+    inkWell = tester.widget<InkWell>(find.byType(InkWell));
+    expect(inkWell.borderRadius, borderRadius);
   });
 }
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -4284,7 +4284,7 @@ void main() {
     await tester.pumpAndSettle();
 
     InkWell inkWell = tester.widget<InkWell>(find.byType(InkWell).last);
-    expect(inkWell.borderRadius, null);
+    expect(inkWell.borderRadius, isNull);
 
     // Popup menu with fixed borderRadius.
     await tester.pumpWidget(


### PR DESCRIPTION
This PR is adding borderRadius property to PopupMenuButton. PopupMenuButton has a child wrapped in an InkWell widget where as of right now you can't customize it's border radius resulting in wrong splash effect when the child has border radius.

Fixes: #151227 


https://github.com/flutter/flutter/assets/20647774/93feb0a4-c4ff-4059-bde2-e59c4d35e2b6

