### PR TITLE
Add `TimeOfDay` comparison methods

### DIFF
--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -45,7 +45,7 @@ enum DayPeriod {
 ///  * [DateTime], which represents date and time, and is subject to eras and
 ///    time zones.
 @immutable
-class TimeOfDay {
+class TimeOfDay implements Comparable<TimeOfDay> {
   /// Creates a time of day.
   ///
   /// The [hour] argument must be between 0 and 23, inclusive. The [minute]
@@ -110,6 +110,30 @@ class TimeOfDay {
       this,
       alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context),
     );
+  }
+
+  /// Whether this [TimeOfDay] occurs earlier than [other].
+  bool isBefore(TimeOfDay other) => compareTo(other) < 0;
+
+  /// Whether this [TimeOfDay] occurs later than [other].
+  bool isAfter(TimeOfDay other) => compareTo(other) > 0;
+
+  /// Whether this [TimeOfDay] occurs at the same time [other].
+  bool isAtSameTimeAs(TimeOfDay other) => compareTo(other) == 0;
+
+  /// Compares this [TimeOfDay] object to [other] independent of date.
+  ///
+  /// This means that "00:00" of the next day is still before "23:00" of this
+  /// day.
+  ///
+  /// A [compareTo] function returns:
+  ///  * a negative value if this TimeOfDay [isBefore] [other].
+  ///  * `0` if this DateTime [isAtSameMomentAs] [other], and
+  ///  * a positive value otherwise (when this TimeOfDay [isAfter] [other]).
+  @override
+  int compareTo(TimeOfDay other) {
+    final int hourComparison = hour.compareTo(other.hour);
+    return hourComparison == 0 ? minute.compareTo(other.minute) : hourComparison;
   }
 
   @override

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -114,25 +114,25 @@ class TimeOfDay implements Comparable<TimeOfDay> {
 
   /// Whether this [TimeOfDay] occurs earlier than [other].
   ///
-  /// Does not account for day or sub-minute differences. This means 
+  /// Does not account for day or sub-minute differences. This means
   /// that "00:00" of the next day is still before "23:00" of this day.
   bool isBefore(TimeOfDay other) => compareTo(other) < 0;
 
   /// Whether this [TimeOfDay] occurs later than [other].
   ///
-  /// Does not account for day or sub-minute differences. This means 
+  /// Does not account for day or sub-minute differences. This means
   /// that "00:00" of the next day is still before "23:00" of this day.
   bool isAfter(TimeOfDay other) => compareTo(other) > 0;
 
   /// Whether this [TimeOfDay] occurs at the same time as [other].
   ///
-  /// Does not account for day or sub-minute differences. This means 
+  /// Does not account for day or sub-minute differences. This means
   /// that "00:00" of the next day is still before "23:00" of this day.
   bool isAtSameTimeAs(TimeOfDay other) => compareTo(other) == 0;
 
   /// Compares this [TimeOfDay] object to [other] independent of date.
   ///
-  /// Does not account for day or sub-minute differences. This means 
+  /// Does not account for day or sub-minute differences. This means
   /// that "00:00" of the next day is still before "23:00" of this day.
   ///
   /// A [compareTo] function returns:

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -113,18 +113,27 @@ class TimeOfDay implements Comparable<TimeOfDay> {
   }
 
   /// Whether this [TimeOfDay] occurs earlier than [other].
+  ///
+  /// Does not account for day or sub-minute differences. This means 
+  /// that "00:00" of the next day is still before "23:00" of this day.
   bool isBefore(TimeOfDay other) => compareTo(other) < 0;
 
   /// Whether this [TimeOfDay] occurs later than [other].
+  ///
+  /// Does not account for day or sub-minute differences. This means 
+  /// that "00:00" of the next day is still before "23:00" of this day.
   bool isAfter(TimeOfDay other) => compareTo(other) > 0;
 
   /// Whether this [TimeOfDay] occurs at the same time as [other].
+  ///
+  /// Does not account for day or sub-minute differences. This means 
+  /// that "00:00" of the next day is still before "23:00" of this day.
   bool isAtSameTimeAs(TimeOfDay other) => compareTo(other) == 0;
 
   /// Compares this [TimeOfDay] object to [other] independent of date.
   ///
-  /// This means that "00:00" of the next day is still before "23:00" of this
-  /// day.
+  /// Does not account for day or sub-minute differences. This means 
+  /// that "00:00" of the next day is still before "23:00" of this day.
   ///
   /// A [compareTo] function returns:
   ///  * a negative value if this TimeOfDay [isBefore] [other].

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -118,7 +118,7 @@ class TimeOfDay implements Comparable<TimeOfDay> {
   /// Whether this [TimeOfDay] occurs later than [other].
   bool isAfter(TimeOfDay other) => compareTo(other) > 0;
 
-  /// Whether this [TimeOfDay] occurs at the same time [other].
+  /// Whether this [TimeOfDay] occurs at the same time as [other].
   bool isAtSameTimeAs(TimeOfDay other) => compareTo(other) == 0;
 
   /// Compares this [TimeOfDay] object to [other] independent of date.

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -128,7 +128,7 @@ class TimeOfDay implements Comparable<TimeOfDay> {
   ///
   /// A [compareTo] function returns:
   ///  * a negative value if this TimeOfDay [isBefore] [other].
-  ///  * `0` if this DateTime [isAtSameMomentAs] [other], and
+  ///  * `0` if this DateTime [isAtSameTimeAs] [other], and
   ///  * a positive value otherwise (when this TimeOfDay [isAfter] [other]).
   @override
   int compareTo(TimeOfDay other) {

--- a/packages/flutter/test/material/time_test.dart
+++ b/packages/flutter/test/material/time_test.dart
@@ -167,6 +167,36 @@ void main() {
       expect(notifyLog, isEmpty);
     });
   });
+
+  testWidgets('correctly compares to other TimeOfDays', (WidgetTester tester) async {
+    expect(const TimeOfDay(hour: 0, minute: 0).compareTo(const TimeOfDay(hour: 1, minute: 0)), lessThan(0));
+    expect(const TimeOfDay(hour: 20, minute: 0).compareTo(const TimeOfDay(hour: 20, minute: 1)), lessThan(0));
+    expect(const TimeOfDay(hour: 0, minute: 0).compareTo(const TimeOfDay(hour: 0, minute: 0)), 0);
+    expect(const TimeOfDay(hour: 1, minute: 0).compareTo(const TimeOfDay(hour: 0, minute: 0)), greaterThan(0));
+    expect(const TimeOfDay(hour: 20, minute: 1).compareTo(const TimeOfDay(hour: 20, minute: 0)), greaterThan(0));
+
+    expect(const TimeOfDay(hour: 0, minute: 0).isBefore(const TimeOfDay(hour: 1, minute: 0)), isTrue);
+    expect(const TimeOfDay(hour: 0, minute: 0).isBefore(const TimeOfDay(hour: 23, minute: 0)), isTrue);
+    expect(const TimeOfDay(hour: 0, minute: 0).isBefore(const TimeOfDay(hour: 0, minute: 10)), isTrue);
+    expect(const TimeOfDay(hour: 0, minute: 0).isBefore(const TimeOfDay(hour: 0, minute: 0)), isFalse);
+    expect(const TimeOfDay(hour: 1, minute: 0).isBefore(const TimeOfDay(hour: 0, minute: 0)), isFalse);
+    expect(const TimeOfDay(hour: 23, minute: 0).isBefore(const TimeOfDay(hour: 0, minute: 0)), isFalse);
+    expect(const TimeOfDay(hour: 0, minute: 10).isBefore(const TimeOfDay(hour: 0, minute: 0)), isFalse);
+
+    expect(const TimeOfDay(hour: 0, minute: 0).isAfter(const TimeOfDay(hour: 1, minute: 0)), isFalse);
+    expect(const TimeOfDay(hour: 0, minute: 0).isAfter(const TimeOfDay(hour: 23, minute: 0)), isFalse);
+    expect(const TimeOfDay(hour: 0, minute: 0).isAfter(const TimeOfDay(hour: 0, minute: 10)), isFalse);
+    expect(const TimeOfDay(hour: 0, minute: 0).isAfter(const TimeOfDay(hour: 0, minute: 0)), isFalse);
+    expect(const TimeOfDay(hour: 1, minute: 0).isAfter(const TimeOfDay(hour: 0, minute: 0)), isTrue);
+    expect(const TimeOfDay(hour: 23, minute: 0).isAfter(const TimeOfDay(hour: 0, minute: 0)), isTrue);
+    expect(const TimeOfDay(hour: 0, minute: 10).isAfter(const TimeOfDay(hour: 0, minute: 0)), isTrue);
+
+    expect(const TimeOfDay(hour: 0, minute: 0).isAtSameTimeAs(const TimeOfDay(hour: 1, minute: 0)), isFalse);
+    expect(const TimeOfDay(hour: 0, minute: 0).isAtSameTimeAs(const TimeOfDay(hour: 0, minute: 10)), isFalse);
+    expect(const TimeOfDay(hour: 0, minute: 0).isAtSameTimeAs(const TimeOfDay(hour: 0, minute: 0)), isTrue);
+    expect(const TimeOfDay(hour: 1, minute: 0).isAtSameTimeAs(const TimeOfDay(hour: 0, minute: 0)), isFalse);
+    expect(const TimeOfDay(hour: 0, minute: 10).isAtSameTimeAs(const TimeOfDay(hour: 0, minute: 0)), isFalse);
+  });
 }
 
 class _RestorableWidget extends StatefulWidget {


### PR DESCRIPTION
Implement Comparable for the TimeOfDay class as discussed in #139098. 

Also implements utility methods as `isBefore`, `isAfter` and `isAtSameTimeAs` for convenience and parity with `DateTime` from the dart sdk.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
