### PR TITLE
Remove warning when KGP version not detected

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -125,12 +125,8 @@ class DependencyVersionChecker {
             kgpVersion = getKGPVersion(project)
             if (kgpVersion != null) {
                 checkKGPVersion(kgpVersion, project)
-            } else {
-                project.logger.error(
-                    "Warning: unable to detect project KGP version. Skipping " +
-                        "version checking. \nThis may be because you have applied KGP after the Flutter Gradle Plugin."
-                )
             }
+            // KGP is not required, so don't log any warning if we can't find the version.
         }
 
         // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.invocation/-gradle/index.html#-837060600%2FFunctions%2F-1793262594


### PR DESCRIPTION
The Kotlin Gradle plugin isn't actually required. Assume the good case if we can't find the version (that the project doesn't need it).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
