### PR TITLE
Update deprecation policy

### DIFF
--- a/docs/contributing/Tree-hygiene.md
+++ b/docs/contributing/Tree-hygiene.md
@@ -458,9 +458,10 @@ When adding a deprecation notice to the framework, a flutter fix should be inclu
 
 When deprecating features, be aware that *you* will not by default be informed when the Flutter code itself uses the deprecated feature (there is a `deprecated_member_use_from_same_package: ignore` line in the root `analysis_options.yaml` file). To find places where the old feature is used, rename its declaration and see where the compiler complains. (You can't just comment out the "ignore" in the `analysis_options.yaml` file because it's hiding hundreds of other warnings...)
 
-Deprecations are removed in a consistent "first-in-first-out" fashion. The lifetime for a Flutter deprecation is 1 year after reaching the stable channel, or after 4 stable releases, whichever is longer. Deprecations are still subject to the policy described on the [breaking changes page](https://flutter.dev/docs/release/breaking-changes) of the website. Where possible, prepare the dart fix tools and write appropriate migrations guides.
-
-This policy is currently enforced for `package:flutter`, `package:flutter_driver`, and `package:flutter_test`.
+Removing deprecated APIs from the framework are not currently planned. In the past, deprecations were removed after a set
+amount of time. This is not currently in practice. If and when we do resume removing deprecated APIs, it will be announced
+across several channels like the [flutter-announce group](https://groups.google.com/g/flutter-announce), and the
+[Discord](../contributing/Chat.md).
 
 ## Skipped Tests
 


### PR DESCRIPTION
We are pausing our cadence of removing deprecated API from the framework until we can create a new policy.
The last couple of cycles we noticed customers having more difficult migrations, and it being harder to remove the APIs in the scheduled time period. So we need to reevaluate the policy and update it.

This is the policy working as intended. Signals like flutter/tests provide feedback on how we are affecting users - so that for folks that contributed!

Related to https://github.com/flutter/website/pull/10839


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
