### PR TITLE
Added SliverFloatingHeader.snapMode

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver_floating_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_floating_header.dart
@@ -20,11 +20,11 @@ import 'ticker_provider.dart';
 /// content move in sync. If the header is partially visible when the
 /// scroll gesture ends, [SliverFloatingHeader.snapMode] specifies if
 /// the header should [FloatingHeaderSnapMode.overlay] the scrollable's
-/// content as it expands untill it's completely visible, or if the
+/// content as it expands until it's completely visible, or if the
 /// content should scroll out of the way as the header expands.
 enum FloatingHeaderSnapMode {
   /// At the end of a user scroll gesture, the [SliverFloatingHeader] will
-  /// expand over the scrollable's content
+  /// expand over the scrollable's content.
   overlay,
 
   /// At the end of a user scroll gesture, the [SliverFloatingHeader] will
@@ -301,7 +301,7 @@ class _RenderSliverFloatingHeader extends RenderSliverSingleBoxAdapter {
 
     child?.layout(constraints.asBoxConstraints(), parentUsesSize: true);
     final double paintExtent = childExtent - effectiveScrollOffset;
-    final double layoutExtent = switch(snapMode ?? FloatingHeaderSnapMode.overlay) {
+    final double layoutExtent = switch (snapMode ?? FloatingHeaderSnapMode.overlay) {
       FloatingHeaderSnapMode.overlay => childExtent - constraints.scrollOffset,
       FloatingHeaderSnapMode.scroll => paintExtent,
     };

--- a/packages/flutter/lib/src/widgets/sliver_floating_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_floating_header.dart
@@ -75,7 +75,7 @@ class SliverFloatingHeader extends StatefulWidget {
   /// Specifies how a partially visible [SliverFloatingHeader] animates
   /// into a view when a user scroll gesture ends.
   ///
-  /// The default is [FloatingHeaderSnapMode.scroll]. This parameter doesn't
+  /// The default is [FloatingHeaderSnapMode.overlay]. This parameter doesn't
   /// modify an animation in progress, just subsequent animations.
   final FloatingHeaderSnapMode? snapMode;
 

--- a/packages/flutter/test/widgets/sliver_floating_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_floating_header_test.dart
@@ -273,13 +273,18 @@ void main() {
       expect(getHeaderRect(), const Rect.fromLTRB(0, 0, 800, 200));
       expect(getItem0Y(), 200);
 
+      // Scrolling in this direction will move more than 200 because
+      // timedDrag() concludes with a fling and there's room for a
+      // 200+ scroll.
       await scroll(const Offset(0, -200));
       await tester.pumpAndSettle();
       expect(find.text('header'), findsNothing);
       final double item0StartY = getItem0Y();
       expect(item0StartY, lessThan(0));
 
-      // Trigger the appearance of the floating header.
+      // Trigger the appearance of the floating header. There's no
+      // fling component to the scroll in this case because the scroll
+      // offset is small.
       await scroll(const Offset(0, 25));
       await tester.pumpAndSettle();
 
@@ -287,7 +292,7 @@ void main() {
       // the snapMode is overlay.
       expect(getItem0Y(), item0StartY + 25);
 
-      // Return the header and item0 to their initial layout
+      // Return the header and item0 to their initial layout.
       await scroll(const Offset(0, 200));
       await tester.pumpAndSettle();
       expect(getHeaderRect(), const Rect.fromLTRB(0, 0, 800, 200));
@@ -311,7 +316,7 @@ void main() {
       await scroll(const Offset(0, 25));
       await tester.pumpAndSettle();
 
-      // Item0 has moved as far as the scroll (25) plus the heaight of
+      // Item0 has moved as far as the scroll (25) plus the height of
       // the header (200) because the snapMode is scroll and the
       // entire header had to snap in.
       expect(getItem0Y(), item0StartY + 200 + 25);

--- a/packages/flutter/test/widgets/sliver_floating_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_floating_header_test.dart
@@ -260,7 +260,7 @@ void main() {
     }
 
     Rect getHeaderRect() => tester.getRect(find.text('header'));
-    double getItem0Top() => tester.getRect(find.text('item 0')).topLeft.dy;
+    double getItem0Y() => tester.getRect(find.text('item 0')).topLeft.dy;
 
     Future<void> scroll(Offset offset) async {
       return tester.timedDrag(find.byType(CustomScrollView), offset, const Duration(milliseconds: 500));
@@ -271,12 +271,12 @@ void main() {
       await tester.pumpWidget(buildFrame(FloatingHeaderSnapMode.overlay));
       await tester.pumpAndSettle();
       expect(getHeaderRect(), const Rect.fromLTRB(0, 0, 800, 200));
-      expect(getItem0Top(), 200);
+      expect(getItem0Y(), 200);
 
       await scroll(const Offset(0, -200));
       await tester.pumpAndSettle();
       expect(find.text('header'), findsNothing);
-      final double item0StartY = getItem0Top();
+      final double item0StartY = getItem0Y();
       expect(item0StartY, lessThan(0));
 
       // Trigger the appearance of the floating header.
@@ -284,14 +284,14 @@ void main() {
       await tester.pumpAndSettle();
 
       // Item0 has only moved as far as the scroll because
-      // the snapMode is overlay
-      expect(getItem0Top(), item0StartY + 25);
+      // the snapMode is overlay.
+      expect(getItem0Y(), item0StartY + 25);
 
       // Return the header and item0 to their initial layout
       await scroll(const Offset(0, 200));
       await tester.pumpAndSettle();
       expect(getHeaderRect(), const Rect.fromLTRB(0, 0, 800, 200));
-      expect(getItem0Top(), 200);
+      expect(getItem0Y(), 200);
     }
 
     // FloatingHeaderSnapMode.scroll
@@ -299,21 +299,22 @@ void main() {
       await tester.pumpWidget(buildFrame(FloatingHeaderSnapMode.scroll));
       await tester.pumpAndSettle();
       expect(getHeaderRect(), const Rect.fromLTRB(0, 0, 800, 200));
-      expect(getItem0Top(), 200);
+      expect(getItem0Y(), 200);
 
       await scroll(const Offset(0, -200));
       await tester.pumpAndSettle();
       expect(find.text('header'), findsNothing);
-      final double item0StartY = getItem0Top();
+      final double item0StartY = getItem0Y();
       expect(item0StartY, lessThan(0));
 
       // Trigger the appearance of the floating header.
       await scroll(const Offset(0, 25));
       await tester.pumpAndSettle();
 
-      // Item0 has only moved as far as the scroll (25) plus
-      // the heaight of the (header) because the snapMode is scroll.
-      expect(getItem0Top(), item0StartY + 200 + 25);
+      // Item0 has moved as far as the scroll (25) plus the heaight of
+      // the header (200) because the snapMode is scroll and the
+      // entire header had to snap in.
+      expect(getItem0Y(), item0StartY + 200 + 25);
     }
   });
 }


### PR DESCRIPTION
When a user scroll gesture ends, Material Design floating headers snap into place by animating as far as needed and overlaying the underlying scrollable content. For example Gmail's search header works this way.  Other apps handle the snap animation by scrolling content out of the way. Instagram for example.

Added `SliverFloatingHeader.snapMode`, whose value can be `FloatingHeaderSnapMode.overlay` (the default) or `FloatingHeaderSnapMode.scroll`, so that developers can choose the snap animation style they want.

| FloatingHeaderSnapMode.overlay | FloatingHeaderSnapMode.scroll |
| --- | --- |
| <video src="https://github.com/flutter/flutter/assets/1377460/05c82ddf-05a6-4431-9b1e-88b901feea68" /> | <video src="https://github.com/flutter/flutter/assets/1377460/fedc34de-0b55-4f0d-976f-2df1965c90bc" /> |





