### PR TITLE
[tool] make `testUsingContext` provide a `Stdio` (with `hasTerminal` unset) override by default

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -469,7 +469,7 @@ void main() {
         Usage: () => usage,
       });
 
-      testUsingContext('passes device target platform to usage', () async {
+      testUsingContext('passes device target platform to analytics', () async {
         final RunCommand command = RunCommand();
         final FakeDevice mockDevice = FakeDevice(sdkNameAndVersion: 'iOS 13')
           ..startAppSuccess = false;
@@ -485,14 +485,6 @@ void main() {
           '--no-hot',
         ]), isNull);
 
-        expect(usage.commands, contains(
-          TestUsageCommand('run', parameters: CustomDimensions.fromMap(<String, String>{
-            'cd3': 'false', 'cd4': 'ios', 'cd22': 'iOS 13',
-            'cd23': 'debug', 'cd18': 'false', 'cd15': 'swift', 'cd31': 'true',
-            'cd57': 'usb',
-            'cd58': 'false',
-          })
-        )));
         expect(
           fakeAnalytics.sentEvents,
           contains(
@@ -522,7 +514,7 @@ void main() {
         analytics.Analytics: () => fakeAnalytics,
       });
 
-      testUsingContext('correctly reports tests to usage', () async {
+      testUsingContext('correctly reports tests to analytics', () async {
         fs.currentDirectory.childDirectory('test').childFile('widget_test.dart').createSync(recursive: true);
         fs.currentDirectory.childDirectory('ios').childFile('AppDelegate.swift').createSync(recursive: true);
         final RunCommand command = RunCommand();
@@ -538,14 +530,6 @@ void main() {
           'test/widget_test.dart',
         ]), isNull);
 
-        expect(usage.commands, contains(
-          TestUsageCommand('run', parameters: CustomDimensions.fromMap(<String, String>{
-            'cd3': 'false', 'cd4': 'ios', 'cd22': 'iOS 13',
-            'cd23': 'debug', 'cd18': 'false', 'cd15': 'swift', 'cd31': 'true',
-            'cd57': 'usb',
-            'cd58': 'true',
-          })),
-        ));
         expect(
           fakeAnalytics.sentEvents,
           contains(

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -126,6 +126,7 @@ void testUsingContext(
           TemplateRenderer: () => const MustacheTemplateRenderer(),
           BuildTargets: () => const BuildTargetsImpl(),
           Analytics: () => const NoOpAnalytics(),
+          Stdio: () => FakeStdio(),
         },
         body: () {
           // To catch all errors thrown by the test, even uncaught async errors, we use a zone.

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -254,7 +254,7 @@ class FakeStdio extends Stdio {
   }
 
   @override
-  bool hasTerminal = true;
+  bool hasTerminal = false;
 
   List<String> get writtenToStdout => _stdout.writes.map<String>(_stdout.encoding.decode).toList();
   List<String> get writtenToStderr => _stderr.writes.map<String>(_stderr.encoding.decode).toList();
@@ -280,6 +280,9 @@ class FakeStdin extends Fake implements Stdin {
 
   @override
   bool lineMode = true;
+
+  @override
+  bool hasTerminal = false;
 
   @override
   Stream<S> transform<S>(StreamTransformer<List<int>, S> transformer) {


### PR DESCRIPTION
While exploring https://github.com/flutter/flutter/issues/107607, I noticed that flutter_tools test results change based on whether `dart test` is run from a terminal or from a process (such as a Dart program). I also ran into this while writing tests for https://github.com/flutter/flutter/pull/150667.

This is due to tests that rely on the global `Stdio` instance, on which the `hasTerminal` property depends on whether the tool is being invoked from a terminal.

Ideally, `testUsingContext` would require any tests that depend on `globals.stdio` to define an override for `Stdio`, but this is not the case. Until a solution to this more general problem is figured out, I think we should have `testUsingContext` always provide a `Stdio` override by default.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
