### PR TITLE
chore: fix typo korean, cutButtonLabel

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ko.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ko.arb
@@ -15,7 +15,7 @@
   "timerPickerMinuteLabelOther": "분",
   "timerPickerSecondLabelOne": "초",
   "timerPickerSecondLabelOther": "초",
-  "cutButtonLabel": "잘라냄",
+  "cutButtonLabel": "잘라내기",
   "copyButtonLabel": "복사",
   "pasteButtonLabel": "붙여넣기",
   "selectAllButtonLabel": "전체 선택",

--- a/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
@@ -7758,7 +7758,7 @@ class CupertinoLocalizationKo extends GlobalCupertinoLocalizations {
   String get copyButtonLabel => '복사';
 
   @override
-  String get cutButtonLabel => '잘라냄';
+  String get cutButtonLabel => '잘라내기';
 
   @override
   String get datePickerDateOrderString => 'ymd';

--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -24330,7 +24330,7 @@ class MaterialLocalizationKo extends GlobalMaterialLocalizations {
   String get currentDateLabel => '오늘';
 
   @override
-  String get cutButtonLabel => '잘라냄';
+  String get cutButtonLabel => '잘라내기';
 
   @override
   String get dateHelpText => 'yyyy.mm.dd';

--- a/packages/flutter_localizations/lib/src/l10n/material_ko.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ko.arb
@@ -24,7 +24,7 @@
   "closeButtonLabel": "닫기",
   "continueButtonLabel": "계속",
   "copyButtonLabel": "복사",
-  "cutButtonLabel": "잘라냄",
+  "cutButtonLabel": "잘라내기",
   "scanTextButtonLabel": "텍스트 스캔",
   "okButtonLabel": "확인",
   "pasteButtonLabel": "붙여넣기",

--- a/packages/flutter_localizations/test/cupertino/translations_test.dart
+++ b/packages/flutter_localizations/test/cupertino/translations_test.dart
@@ -240,6 +240,16 @@ void main() {
     expect(localizations.lookUpButtonLabel, '查询');
   });
 
+  testWidgets('ko-KR translation for cut, copy, paste label in ButtonLabel', (WidgetTester tester) async {
+    const Locale locale = Locale('ko');
+    expect(GlobalCupertinoLocalizations.delegate.isSupported(locale), isTrue);
+    final CupertinoLocalizations localizations = await GlobalCupertinoLocalizations.delegate.load(locale);
+    expect(localizations, isA<CupertinoLocalizationKo>());
+    expect(localizations.cutButtonLabel, '잘라내기');
+    expect(localizations.copyButtonLabel, '복사');
+    expect(localizations.pasteButtonLabel, '붙여넣기');
+  });
+
   testWidgets('localizations.datePickerDayOfMonth uses the current locale for weekdays', (WidgetTester tester) async {
     const Locale locale = Locale('zh');
     expect(GlobalCupertinoLocalizations.delegate.isSupported(locale), isTrue);

--- a/packages/flutter_localizations/test/material/translations_test.dart
+++ b/packages/flutter_localizations/test/material/translations_test.dart
@@ -559,4 +559,14 @@ void main() {
     expect(localizations, isA<MaterialLocalizationZh>());
     expect(localizations.lookUpButtonLabel, '查询');
   });
+
+  testWidgets('zh-CN translation for look up label', (WidgetTester tester) async {
+    const Locale locale = Locale('ko');
+    expect(GlobalCupertinoLocalizations.delegate.isSupported(locale), isTrue);
+    final MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(locale);
+    expect(localizations, isA<MaterialLocalizationKo>());
+    expect(localizations.cutButtonLabel, '잘라내기');
+    expect(localizations.copyButtonLabel, '복사');
+    expect(localizations.pasteButtonLabel, '붙여넣기');
+  });
 }


### PR DESCRIPTION
[Wikipeidia](https://ko.wikipedia.org/wiki/%EC%9E%98%EB%9D%BC%EB%82%B4%EA%B8%B0,_%EB%B3%B5%EC%82%AC,_%EB%B6%99%EC%97%AC%EB%84%A3%EA%B8%B0)
In korea, we use '잘라내기', '복사', '붙여넣기', not '잘라냄', '복사', '붙여넣기'.
![image](https://github.com/flutter/flutter/assets/7384324/34845c96-4e7a-4f95-a44c-19f9917f4a6c)
e.g.) korean translation site, papago 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
