### PR TITLE
Add support for inverting CircularNotchedRectangle to be drawn on the bottom of a path

### DIFF
--- a/packages/flutter/lib/src/painting/notched_shapes.dart
+++ b/packages/flutter/lib/src/painting/notched_shapes.dart
@@ -53,9 +53,12 @@ class CircularNotchedRectangle extends NotchedShape {
   ///
   /// The notch is curve that smoothly connects the host's top edge and
   /// the guest circle.
+  ///
+  /// Parameter [inverted] allows for the inversion of the circular notch
+  /// so that it may be applied to the bottom of a path when set to true.
   // TODO(amirh): add an example diagram here.
   @override
-  Path getOuterPath(Rect host, Rect? guest) {
+  Path getOuterPath(Rect host, Rect? guest, {bool inverted = false}) {
     if (guest == null || !host.overlaps(guest)) {
       return Path()..addRect(host);
     }
@@ -63,6 +66,10 @@ class CircularNotchedRectangle extends NotchedShape {
     // The guest's shape is a circle bounded by the guest rectangle.
     // So the guest's radius is half the guest width.
     final double notchRadius = guest.width / 2.0;
+
+    // The variables [p2yA] and [p2yB] need to be inverted
+    // when the notch is drawn on the bottom of a path.
+    final double invertMultiplier = inverted ? -1.0 : 1.0;
 
     // We build a path for the notch from 3 segments:
     // Segment A - a Bezier curve from the host's top edge to segment B.
@@ -77,13 +84,13 @@ class CircularNotchedRectangle extends NotchedShape {
 
     final double r = notchRadius;
     final double a = -1.0 * r - s2;
-    final double b = host.top - guest.center.dy;
+    final double b = (inverted ? host.bottom : host.top) - guest.center.dy;
 
     final double n2 = math.sqrt(b * b * r * r * (a * a + b * b - r * r));
     final double p2xA = ((a * r * r) - n2) / (a * a + b * b);
     final double p2xB = ((a * r * r) + n2) / (a * a + b * b);
-    final double p2yA = math.sqrt(r * r - p2xA * p2xA);
-    final double p2yB = math.sqrt(r * r - p2xB * p2xB);
+    final double p2yA = math.sqrt(r * r - p2xA * p2xA) * invertMultiplier;
+    final double p2yB = math.sqrt(r * r - p2xB * p2xB) * invertMultiplier;
 
     final List<Offset?> p = List<Offset?>.filled(6, null);
 
@@ -104,20 +111,38 @@ class CircularNotchedRectangle extends NotchedShape {
       p[i] = p[i]! + guest.center;
     }
 
-    return Path()
-      ..moveTo(host.left, host.top)
-      ..lineTo(p[0]!.dx, p[0]!.dy)
-      ..quadraticBezierTo(p[1]!.dx, p[1]!.dy, p[2]!.dx, p[2]!.dy)
-      ..arcToPoint(
-        p[3]!,
-        radius: Radius.circular(notchRadius),
-        clockwise: false,
-      )
-      ..quadraticBezierTo(p[4]!.dx, p[4]!.dy, p[5]!.dx, p[5]!.dy)
-      ..lineTo(host.right, host.top)
-      ..lineTo(host.right, host.bottom)
+    // Use the calculated points to draw out a path object.
+    var path = Path();
+    path.moveTo(host.left, host.top);
+    if (!inverted) {
+      path
+        ..lineTo(p[0]!.dx, p[0]!.dy)
+        ..quadraticBezierTo(p[1]!.dx, p[1]!.dy, p[2]!.dx, p[2]!.dy)
+        ..arcToPoint(
+          p[3]!,
+          radius: Radius.circular(notchRadius),
+          clockwise: false,
+        )
+        ..quadraticBezierTo(p[4]!.dx, p[4]!.dy, p[5]!.dx, p[5]!.dy)
+        ..lineTo(host.right, host.top)
+        ..lineTo(host.right, host.bottom);
+    } else {
+      path
+        ..lineTo(host.right, host.top)
+        ..lineTo(host.right, host.bottom)
+        ..lineTo(p[5]!.dx, p[5]!.dy)
+        ..quadraticBezierTo(p[4]!.dx, p[4]!.dy, p[3]!.dx, p[3]!.dy)
+        ..arcToPoint(
+          p[2]!,
+          radius: Radius.circular(notchRadius),
+          clockwise: false,
+        )
+        ..quadraticBezierTo(p[1]!.dx, p[1]!.dy, p[0]!.dx, p[0]!.dy);
+    }
+    path
       ..lineTo(host.left, host.bottom)
       ..close();
+    return path;
   }
 }
 

--- a/packages/flutter/test/painting/notched_shapes_test.dart
+++ b/packages/flutter/test/painting/notched_shapes_test.dart
@@ -47,6 +47,26 @@ void main() {
       expect(pathDoesNotContainCircle(actualPath, guest), isTrue);
     });
 
+    test('inverted guest center above host', () {
+      const CircularNotchedRectangle shape = CircularNotchedRectangle();
+      const Rect host = Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      const Rect guest = Rect.fromLTRB(190.0, 285.0, 210.0, 305.0);
+
+      final Path actualPath = shape.getOuterPath(host, guest, inverted: true);
+
+      expect(pathDoesNotContainCircle(actualPath, guest), isTrue);
+    });
+
+    test('inverted guest center below host', () {
+      const CircularNotchedRectangle shape = CircularNotchedRectangle();
+      const Rect host = Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      const Rect guest = Rect.fromLTRB(190.0, 295.0, 210.0, 315.0);
+
+      final Path actualPath = shape.getOuterPath(host, guest, inverted: true);
+
+      expect(pathDoesNotContainCircle(actualPath, guest), isTrue);
+    });
+
     test('no guest is ok', () {
       const Rect host = Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
       expect(


### PR DESCRIPTION
This PR allows for an optional argument [inverted[ to be passed to the [getOuterPath] method of a CircularNotchedRectangle object in order to invert the notch for situations where it is desired to draw the notch on the bottom of the path. This allows both of the below paths in the below screenshot to be drawn and changes no default behavior.

![Simulator Screenshot - iPhone 15 - 2024-07-07 at 11 46 12](https://github.com/flutter/flutter/assets/71237742/c0477284-b00f-40b2-802c-84bd92834c71)

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
Adds feature proposed in #151381 


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x ] I signed the [CLA].
- [x ] I listed at least one issue that this PR fixes in the description above.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
