### PR TITLE
Add support for inverting CircularNotchedRectangle to be drawn on the…

### DIFF
--- a/packages/flutter/test/painting/notched_shapes_test.dart
+++ b/packages/flutter/test/painting/notched_shapes_test.dart
@@ -47,6 +47,26 @@ void main() {
       expect(pathDoesNotContainCircle(actualPath, guest), isTrue);
     });
 
+    test('inverted guest center above host', () {
+      const CircularNotchedRectangle shape = CircularNotchedRectangle();
+      const Rect host = Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      const Rect guest = Rect.fromLTRB(190.0, 285.0, 210.0, 305.0);
+
+      final Path actualPath = shape.getOuterPath(host, guest, inverted: true);
+
+      expect(pathDoesNotContainCircle(actualPath, guest), isTrue);
+    });
+
+    test('inverted guest center below host', () {
+      const CircularNotchedRectangle shape = CircularNotchedRectangle();
+      const Rect host = Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      const Rect guest = Rect.fromLTRB(190.0, 295.0, 210.0, 315.0);
+
+      final Path actualPath = shape.getOuterPath(host, guest, inverted: true);
+
+      expect(pathDoesNotContainCircle(actualPath, guest), isTrue);
+    });
+
     test('no guest is ok', () {
       const Rect host = Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
       expect(


### PR DESCRIPTION
This PR allows for an optional argument [inverted[ to be passed to the [getOuterPath] method of a CircularNotchedRectangle object in order to invert the notch for situations where it is desired to draw the notch on the bottom of the path. Thus allowing both of the below paths in the below screenshot to be drawn and changes no default behavior. 

![Simulator Screenshot - iPhone 15 - 2024-07-07 at 11 46 12](https://github.com/flutter/flutter/assets/71237742/f0897f15-3a56-4311-b31a-04b8cc6345fd)

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
This adds support for the feature in #151382 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
