### PR TITLE
Update doc-import to primary configured import, _goldens_io.dart

### DIFF
--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -4,7 +4,7 @@
 
 /// @docImport 'package:flutter/widgets.dart';
 ///
-/// @docImport '_goldens_web.dart';
+/// @docImport '_goldens_io.dart';
 /// @docImport 'binding.dart';
 /// @docImport 'matchers.dart';
 /// @docImport 'widget_tester.dart';


### PR DESCRIPTION
There is a... restriction in dartdoc, such that a library which is `@docImport`ed in one library, must be otherwise regularly imported in some other library. Without this case, dartdoc gets a bit lost about where the doc-imported library is.

Combine this restriction with analyzer's restriction that it doesn't super duper handle configuration imports. Since `_goldens_io.dart` is the "primary" import in all other files, and `_goldens_web.dart` is the "configured" import, we must only doc-import `_goldens_io.dart`.
