### PR TITLE
docimports for API samples

### DIFF
--- a/examples/api/lib/material/expansion_panel/expansion_panel_list.expansion_panel_list_radio.0.dart
+++ b/examples/api/lib/material/expansion_panel/expansion_panel_list.expansion_panel_list_radio.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for [ExpansionPanelList.ExpansionPanelList.radio].
+/// Flutter code sample for [ExpansionPanelList.radio].
 
 void main() => runApp(const ExpansionPanelListRadioExampleApp());
 

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for [ReorderableListView.ReorderableListView.builder].
+/// Flutter code sample for [ReorderableListView.builder].
 
 void main() => runApp(const ReorderableApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_alternative.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_alternative.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.alternative].
+/// Flutter code sample for [FontFeature.alternative].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_alternative_fractions.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_alternative_fractions.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.alternativeFractions].
+/// Flutter code sample for [FontFeature.alternativeFractions].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_case_sensitive_forms.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_case_sensitive_forms.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.caseSensitiveForms].
+/// Flutter code sample for [FontFeature.caseSensitiveForms].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_character_variant.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_character_variant.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.characterVariant].
+/// Flutter code sample for [FontFeature.characterVariant].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_contextual_alternates.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_contextual_alternates.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.contextualAlternates].
+/// Flutter code sample for [FontFeature.contextualAlternates].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_denominator.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_denominator.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.denominator].
+/// Flutter code sample for [FontFeature.denominator].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_fractions.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_fractions.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.fractions].
+/// Flutter code sample for [FontFeature.fractions].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_historical_forms.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_historical_forms.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.historicalForms].
+/// Flutter code sample for [FontFeature.historicalForms].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_historical_ligatures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_historical_ligatures.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.historicalLigatures].
+/// Flutter code sample for [FontFeature.historicalLigatures].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_lining_figures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_lining_figures.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.liningFigures].
+/// Flutter code sample for [FontFeature.liningFigures].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_locale_aware.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_locale_aware.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.localeAware].
+/// Flutter code sample for [FontFeature.localeAware].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_notational_forms.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_notational_forms.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.notationalForms].
+/// Flutter code sample for [FontFeature.notationalForms].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_numerators.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_numerators.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.numerators].
+/// Flutter code sample for [FontFeature.numerators].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_oldstyle_figures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_oldstyle_figures.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.oldstyleFigures].
+/// Flutter code sample for [FontFeature.oldstyleFigures].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_ordinal_forms.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_ordinal_forms.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.ordinalForms].
+/// Flutter code sample for [FontFeature.ordinalForms].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_proportional_figures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_proportional_figures.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.proportionalFigures].
+/// Flutter code sample for [FontFeature.proportionalFigures].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_scientific_inferiors.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_scientific_inferiors.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.scientificInferiors].
+/// Flutter code sample for [FontFeature.scientificInferiors].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_slashed_zero.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_slashed_zero.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.slashedZero].
+/// Flutter code sample for [FontFeature.slashedZero].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_stylistic_alternates.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_stylistic_alternates.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.stylisticAlternates].
+/// Flutter code sample for [FontFeature.stylisticAlternates].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_stylistic_set.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_stylistic_set.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.stylisticSet].
+/// Flutter code sample for [FontFeature.stylisticSet].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_stylistic_set.1.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_stylistic_set.1.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.stylisticSet].
+/// Flutter code sample for [FontFeature.stylisticSet].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_subscripts.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_subscripts.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.subscripts].
+/// Flutter code sample for [FontFeature.subscripts].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_superscripts.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_superscripts.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.superscripts].
+/// Flutter code sample for [FontFeature.superscripts].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_swash.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_swash.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// Flutter code sample for [FontFeature.FontFeature.swash].
+/// Flutter code sample for [FontFeature.swash].
 
 void main() => runApp(const ExampleApp());
 

--- a/examples/api/lib/widgets/actions/action.action_overridable.0.dart
+++ b/examples/api/lib/widgets/actions/action.action_overridable.0.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-/// Flutter code sample for [Action.Action.overridable].
+/// Flutter code sample for [Action.overridable].
 
 void main() {
   runApp(


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/150800

Turns out: None of these actually need any docImports. They just had broken references.