### PR TITLE
Remove bringup from platform_views_scroll_perf_bottom_ad_banner__timeline_summary

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4837,7 +4837,6 @@ targets:
   - name: Mac_ios platform_views_scroll_perf_bottom_ad_banner__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
This benchmark is passing in post-submit.  Remove bringup so skiaperf metrics can be collected.

https://ci.chromium.org/ui/p/flutter/builders/staging/Mac_ios%20platform_views_scroll_perf_bottom_ad_banner__timeline_summary/93/overview

Note there have been infra failures https://github.com/flutter/flutter/issues/151592 but I don't expect to see the same when this moves off the staging pool.