### PR TITLE
Emit source maps for wasm in `flutter build web --wasm`

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -363,13 +363,15 @@ class Dart2WasmTarget extends Dart2WebTarget {
       .whereType<File>()
       .where((File file) => switch (file.basename) {
         'main.dart.wasm' || 'main.dart.mjs' => true,
+        'main.dart.wasm.map' => compilerConfig.sourceMaps,
         _ => false,
       });
 
   @override
-  Iterable<String> get buildPatternStems => const <String>[
+  Iterable<String> get buildPatternStems => <String>[
     'main.dart.wasm',
     'main.dart.mjs',
+    if (compilerConfig.sourceMaps) 'main.dart.wasm.map',
   ];
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -146,6 +146,8 @@ class BuildWebCommand extends BuildSubCommand {
         ? null
         : WebRendererMode.values.byName(webRendererString);
 
+    final bool sourceMaps = boolArg('source-maps');
+
     final List<WebCompilerConfig> compilerConfigs;
     if (boolArg(FlutterOptions.kWebWasmFlag)) {
       if (webRenderer != null) {
@@ -162,6 +164,7 @@ class BuildWebCommand extends BuildSubCommand {
         WasmCompilerConfig(
           optimizationLevel: optimizationLevel,
           stripWasm: boolArg('strip-wasm'),
+          sourceMaps: sourceMaps,
         ),
         JsCompilerConfig(
           csp: boolArg('csp'),
@@ -169,7 +172,7 @@ class BuildWebCommand extends BuildSubCommand {
           dumpInfo: boolArg('dump-info'),
           nativeNullAssertions: boolArg('native-null-assertions'),
           noFrequencyBasedMinification: boolArg('no-frequency-based-minification'),
-          sourceMaps: boolArg('source-maps'),
+          sourceMaps: sourceMaps,
         )];
     } else {
       compilerConfigs = <WebCompilerConfig>[JsCompilerConfig(
@@ -178,7 +181,7 @@ class BuildWebCommand extends BuildSubCommand {
         dumpInfo: boolArg('dump-info'),
         nativeNullAssertions: boolArg('native-null-assertions'),
         noFrequencyBasedMinification: boolArg('no-frequency-based-minification'),
-        sourceMaps: boolArg('source-maps'),
+        sourceMaps: sourceMaps,
         renderer: webRenderer ?? WebRendererMode.defaultForJs,
       )];
     }


### PR DESCRIPTION
This will make

* `flutter run` have source maps enabled by default
* `flutter build` have source maps disabled by default

which mirrors what happens already today with the js compilers.

For local development this works quite well - even better than with dart2js (see dart2js issues in [0]).
We do have some follow-up items for source maps in dart2wasm compiler, see [1]

[0] [flutter/flutter/issues/151641](https://github.com/flutter/flutter/issues/151641)
[1] [dart-lang/sdk/issues/56232](https://github.com/dart-lang/sdk/issues/56232)