### PR TITLE
Updates mark needs semantics update logic for overlay portal

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1831,6 +1831,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   ///
   /// [OverlayPortal] overrides this field to change how it forms its
   /// semantics sub-tree.
+  @visibleForOverriding
   RenderObject? get semanticsParent => _parent;
 
   /// Called by subclasses when they decide a render object is a child.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1825,7 +1825,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   RenderObject? get parent => _parent;
   RenderObject? _parent;
 
-  /// The semantics parent of this render object in the render tree.
+  /// The semantics parent of this render object in the semantics tree.
   ///
   /// This is typically the same as [parent].
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3586,7 +3586,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
 
   /// Whether the semantics of this render object is dirty and await the update.
   ///
-  /// Always return false in release mode.
+  /// Always returns false in release mode.
   bool get debugNeedsSemanticsUpdate {
     if (kReleaseMode) {
       return false;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1825,6 +1825,14 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   RenderObject? get parent => _parent;
   RenderObject? _parent;
 
+  /// The semantics parent of this render object in the render tree.
+  ///
+  /// This is typically the same as [parent].
+  ///
+  /// [OverlayPortal] overrides this field to change how it forms its
+  /// semantics sub-tree.
+  RenderObject? get semanticsParent => _parent;
+
   /// Called by subclasses when they decide a render object is a child.
   ///
   /// Only for use by subclasses when changing their child lists. Calling this
@@ -3576,6 +3584,15 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   /// object, for accessibility purposes.
   Rect get semanticBounds;
 
+  /// Whether the semantics of this render object is dirty and await the update.
+  ///
+  /// Always return false in release mode.
+  bool get debugNeedsSemanticsUpdate {
+    if (kReleaseMode) {
+      return false;
+    }
+    return _needsSemanticsUpdate;
+  }
   bool _needsSemanticsUpdate = true;
   SemanticsNode? _semantics;
 
@@ -3641,10 +3658,11 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
     // node, thus marking this semantics boundary dirty is not enough, it needs
     // to find the first parent semantics boundary that does not have any
     // possible sibling node.
-    while (node.parent != null && (mayProduceSiblingNodes || !isEffectiveSemanticsBoundary)) {
+    while (node.semanticsParent != null && (mayProduceSiblingNodes || !isEffectiveSemanticsBoundary)) {
       if (node != this && node._needsSemanticsUpdate) {
         break;
       }
+
       node._needsSemanticsUpdate = true;
       // Since this node is a semantics boundary, the produced sibling nodes will
       // be attached to the parent semantics boundary. Thus, these sibling nodes
@@ -3653,7 +3671,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
         mayProduceSiblingNodes = false;
       }
 
-      node = node.parent!;
+      node = node.semanticsParent!;
       isEffectiveSemanticsBoundary = node._semanticsConfiguration.isSemanticBoundary;
       if (isEffectiveSemanticsBoundary && node._semantics == null) {
         // We have reached a semantics boundary that doesn't own a semantics node.
@@ -3675,7 +3693,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
     if (!node._needsSemanticsUpdate) {
       node._needsSemanticsUpdate = true;
       if (owner != null) {
-        assert(node._semanticsConfiguration.isSemanticBoundary || node.parent == null);
+        assert(node._semanticsConfiguration.isSemanticBoundary || node.semanticsParent == null);
         owner!._nodesNeedingSemantics.add(node);
         owner!.requestVisualUpdate();
       }
@@ -3684,7 +3702,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
 
   /// Updates the semantic information of the render object.
   void _updateSemantics() {
-    assert(_semanticsConfiguration.isSemanticBoundary || parent == null);
+    assert(_semanticsConfiguration.isSemanticBoundary || semanticsParent == null);
     if (_needsLayout) {
       // There's not enough information in this subtree to compute semantics.
       // The subtree is probably being kept alive by a viewport but not laid out.
@@ -3735,7 +3753,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
     final bool blockChildInteractions = blockUserActions || config.isBlockingUserActions;
     final bool childrenMergeIntoParent = mergeIntoParent || config.isMergingSemanticsOfDescendants;
     final List<SemanticsConfiguration> childConfigurations = <SemanticsConfiguration>[];
-    final bool explicitChildNode = config.explicitChildNodes || parent == null;
+    final bool explicitChildNode = config.explicitChildNodes || semanticsParent == null;
     final ChildSemanticsConfigurationsDelegate? childConfigurationsDelegate = config.childConfigurationsDelegate;
     final Map<SemanticsConfiguration, _InterestingSemanticsFragment> configToFragment = <SemanticsConfiguration, _InterestingSemanticsFragment>{};
     final List<_InterestingSemanticsFragment> mergeUpFragments = <_InterestingSemanticsFragment>[];
@@ -3816,7 +3834,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
     _needsSemanticsUpdate = false;
 
     final _SemanticsFragment result;
-    if (parent == null) {
+    if (semanticsParent == null) {
       assert(!config.hasBeenAnnotated);
       assert(!mergeIntoParent);
       assert(siblingMergeFragmentGroups.isEmpty);

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -2152,6 +2152,7 @@ class _OverlayPortalElement extends RenderObjectElement {
     if (slot != null) {
       renderObject._deferredLayoutChild = child as _RenderDeferredLayoutBox;
       slot._addChild(child);
+      renderObject.markNeedsSemanticsUpdate();
     } else {
       renderObject.child = child;
     }
@@ -2163,6 +2164,7 @@ class _OverlayPortalElement extends RenderObjectElement {
   void moveRenderObjectChild(_RenderDeferredLayoutBox child, _OverlayEntryLocation oldSlot, _OverlayEntryLocation newSlot) {
     assert(newSlot._debugIsLocationValid());
     newSlot._moveChild(child, oldSlot);
+    renderObject.markNeedsSemanticsUpdate();
   }
 
   @override
@@ -2269,6 +2271,9 @@ final class _RenderDeferredLayoutBox extends RenderProxyBox with _RenderTheaterM
     _needsLayout = true;
     super.markNeedsLayout();
   }
+
+  @override
+  RenderObject? get semanticsParent => _layoutSurrogate;
 
   @override
   double? computeDryBaseline(BoxConstraints constraints, TextBaseline baseline) {


### PR DESCRIPTION
OverlayPortal attaches its overlaychild's renderobject to overlay directly while keeps its semantics tree under overlayportal.

This become a problem when the `overlaychild` markNeedsSemanticsUpdate that it propagate upward the rendering tree.

This means instead of marking dirty upward to the OverlayPortal, it directly mark Overlay dirty instead and skip `OverlayPortal`.

Currently this does not pose an issue other than unnecessary rebuilds, but it become a problem when I try to optimize the semantics tree compilation https://github.com/flutter/flutter/pull/150394.

After the optimization it won't rebuild semantics node unless it is marked dirty. Since the OverlayPortal widget does not get marked dirty, it won't update the subtree.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
