### PR TITLE
Added waitDuration in the InkWell widget to wait before starting the hover animation (Resolves #149812 )

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -328,6 +328,7 @@ class InkResponse extends StatelessWidget {
     this.autofocus = false,
     this.statesController,
     this.hoverDuration,
+    this.waitDuration,
   });
 
   /// The widget below this widget in the tree.
@@ -622,6 +623,10 @@ class InkResponse extends StatelessWidget {
   /// The default is 50ms.
   final Duration? hoverDuration;
 
+  /// The duration to wait before starting the hover animation.
+  /// The default is 0ms.
+  final Duration? waitDuration;
+
   @override
   Widget build(BuildContext context) {
     final _ParentInkResponseState? parentState = _ParentInkResponseProvider.maybeOf(context);
@@ -661,6 +666,7 @@ class InkResponse extends StatelessWidget {
       debugCheckContext: debugCheckContext,
       statesController: statesController,
       hoverDuration: hoverDuration,
+      waitDuration: waitDuration,
       child: child,
     );
   }
@@ -718,6 +724,7 @@ class _InkResponseStateWidget extends StatefulWidget {
     required this.debugCheckContext,
     this.statesController,
     this.hoverDuration,
+    this.waitDuration,
   });
 
   final Widget? child;
@@ -756,6 +763,7 @@ class _InkResponseStateWidget extends StatefulWidget {
   final _CheckContext debugCheckContext;
   final MaterialStatesController? statesController;
   final Duration? hoverDuration;
+  final Duration? waitDuration;
 
   @override
   _InkResponseState createState() => _InkResponseState();
@@ -815,6 +823,8 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 
   static const Duration _activationDuration = Duration(milliseconds: 100);
   Timer? _activationTimer;
+
+  Timer? _hoverTimer;
 
   @override
   void markChildInkResponsePressed(_ParentInkResponseState childState, bool value) {
@@ -1254,12 +1264,20 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   void handleMouseEnter(PointerEnterEvent event) {
     _hovering = true;
     if (enabled) {
-      handleHoverChange();
+      if (widget.waitDuration != null && widget.waitDuration! > Duration.zero) {
+        _hoverTimer?.cancel();
+        _hoverTimer = Timer(widget.waitDuration!, () {
+          handleHoverChange();
+        });
+      } else {
+        handleHoverChange();
+      }
     }
   }
 
   void handleMouseExit(PointerExitEvent event) {
     _hovering = false;
+    _hoverTimer?.cancel();
     // If the exit occurs after we've been disabled, we still
     // want to take down the highlights and run widget.onHover.
     handleHoverChange();
@@ -1464,6 +1482,7 @@ class InkWell extends InkResponse {
     super.autofocus,
     super.statesController,
     super.hoverDuration,
+    super.waitDuration,
   }) : super(
     containedInkWell: true,
     highlightShape: BoxShape.rectangle,

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -174,6 +174,75 @@ void main() {
     expect(inkFeatures, paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff00ff00)));
   });
 
+  testWidgets('InkWell waitDuration test', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: Center(
+          child: InkWell(
+            waitDuration: const Duration(milliseconds: 500),
+            onTap: () {
+              log.add('tap');
+            },
+            onDoubleTap: () {
+              log.add('double-tap');
+            },
+            onLongPress: () {
+              log.add('long-press');
+            },
+            onTapDown: (TapDownDetails details) {
+              log.add('tap-down');
+            },
+            onTapUp: (TapUpDetails details) {
+              log.add('tap-up');
+            },
+            onTapCancel: () {
+              log.add('tap-cancel');
+            },
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byType(InkWell), pointer: 1);
+
+    expect(log, isEmpty);
+
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(log, equals(<String>['tap-down', 'tap-up', 'tap']));
+    log.clear();
+
+    await tester.tap(find.byType(InkWell), pointer: 2);
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.tap(find.byType(InkWell), pointer: 3);
+
+    expect(log, equals(<String>['double-tap']));
+    log.clear();
+
+    await tester.longPress(find.byType(InkWell), pointer: 4);
+
+    expect(log, equals(<String>['tap-down', 'tap-cancel', 'long-press']));
+
+    log.clear();
+    TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(log, equals(<String>['tap-down']));
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(log, equals(<String>['tap-down', 'tap-up', 'tap']));
+
+    log.clear();
+    gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await gesture.cancel();
+    expect(log, equals(<String>['tap-down', 'tap-cancel']));
+});
+
+
   testWidgets('ink well changes color on hover with overlayColor', (WidgetTester tester) async {
     // Same test as 'ink well changes color on hover' except that the
     // hover color is specified with the overlayColor parameter.


### PR DESCRIPTION
This PR introduces a new feature to the `InkWell` widget in Flutter, allowing developers to specify a `waitDuration` before the hover animation is shown. This parameter provides more control over user interactions, which is particularly beneficial for desktop platforms where hover effects are more prevalent.

## Key Benefits:

1. **Performance**: Delaying the hover effect in data-intensive applications can prevent unnecessary background processing.
2. **User Experience**: A delayed hover effect reduces visual noise and distractions for interactive dashboards and gaming interfaces.
3. **Accessibility**: Introducing a delay can help users with motor impairments by preventing accidental hover triggers, making the application more accessible.
4. **Context-Specific Interactions**: In scenarios like educational tools or e-commerce websites, a delayed hover effect ensures that additional information or actions are only shown when the user is genuinely interested.

## Changes:

- Added `waitDuration` property: This property allows developers to set a duration that a pointer must hover over the InkWell widget before the hover animation is triggered.
- Updated `_InkResponseState` class: Modified the state management to incorporate the `waitDuration` functionality, ensuring the hover animation respects the specified delay.

Fixes #149812. 

## Example Usage:
```
InkWell(
  onTap: () {
    // Handle tap
  },
  waitDuration: Duration(milliseconds: 500), // Hover animation will show after 500ms
  child: Container(
    padding: EdgeInsets.all(16.0),
    child: Text('Hover over me!'),
  ),
);
```
## Video:
https://github.com/user-attachments/assets/a8cf46e8-80c5-4d65-9b33-24e48f8847c5

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.