### PR TITLE
tool/build/web: move source-maps CLI flag to "general" web section

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -65,6 +65,12 @@ class BuildWebCommand extends BuildSubCommand {
       defaultsTo: '${WebCompilerConfig.kDefaultOptimizationLevel}',
       allowed: const <String>['0', '1', '2', '3', '4'],
     );
+    argParser.addFlag(
+      'source-maps',
+      help: 'Generate a sourcemap file. These can be used by browsers '
+            'to view and debug the original source code of a compiled and minified Dart '
+            'application.'
+    );
 
     //
     // JavaScript compilation options
@@ -74,12 +80,6 @@ class BuildWebCommand extends BuildSubCommand {
       negatable: false,
       help: 'Disable dynamic generation of code in the generated output. '
             'This is necessary to satisfy CSP restrictions (see http://www.w3.org/TR/CSP/).'
-    );
-    argParser.addFlag(
-      'source-maps',
-      help: 'Generate a sourcemap file. These can be used by browsers '
-            'to view and debug the original source code of a compiled and minified Dart '
-            'application.'
     );
     argParser.addOption('dart2js-optimization',
       help: 'Sets the optimization level used for Dart compilation to JavaScript. '


### PR DESCRIPTION
...now that wasm supports source maps (see https://github.com/flutter/flutter/pull/151643)
