### PR TITLE
Feat: Add fillColor property for cupertinoCheckbox

### DIFF
--- a/packages/flutter/test/cupertino/checkbox_test.dart
+++ b/packages/flutter/test/cupertino/checkbox_test.dart
@@ -7,6 +7,7 @@
 //   machines.
 @Tags(<String>['reduced-test-set'])
 library;
+import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -573,6 +574,134 @@ void main() {
       find.byType(CupertinoCheckbox),
       matchesGoldenFile('checkbox.disabled_dark_theme.unselected.png'),
     );
+  });
+
+  testWidgets('Checkbox fill color resolves in enabled/disabled states', (WidgetTester tester) async {
+    const Color activeEnabledFillColor = Color(0xFF000001);
+    const Color activeDisabledFillColor = Color(0xFF000002);
+
+    Color getFillColor(Set<WidgetState> states) {
+      if (states.contains(WidgetState.disabled)) {
+        return activeDisabledFillColor;
+      }
+      return activeEnabledFillColor;
+    }
+
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
+
+    Widget buildApp({required bool enabled}) {
+      return CupertinoApp(
+        home: CupertinoCheckbox(
+          value: true,
+          fillColor: fillColor,
+          onChanged: enabled ? (bool? value) { } : null,
+        ),
+      );
+    }
+
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(CupertinoCheckbox));
+    }
+
+    await tester.pumpWidget(buildApp(enabled: true));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: activeEnabledFillColor));
+
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: activeDisabledFillColor));
+  });
+
+  testWidgets('Checkbox fill color take precedence over active/inactive colors', (WidgetTester tester) async {
+    const Color activeEnabledFillColor = Color(0xFF000001);
+    const Color activeDisabledFillColor = Color(0xFF000002);
+    const Color activeColor = Color(0xFF000003);
+    const Color inactiveColor = Color(0xFF000004);
+
+    Color getFillColor(Set<WidgetState> states) {
+      if (states.contains(WidgetState.disabled)) {
+        return activeDisabledFillColor;
+      }
+      return activeEnabledFillColor;
+    }
+
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
+
+    Widget buildApp({required bool enabled}) {
+      return CupertinoApp(
+        home: CupertinoCheckbox(
+          value: true,
+          fillColor: fillColor,
+          activeColor: activeColor,
+          inactiveColor: inactiveColor,
+          onChanged: enabled ? (bool? value) { } : null,
+        ),
+      );
+    }
+
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(CupertinoCheckbox));
+    }
+
+    await tester.pumpWidget(buildApp(enabled: true));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: activeEnabledFillColor));
+
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: activeDisabledFillColor));
+  });
+
+  testWidgets('Checkbox fill color resolves in hovered/focused states', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'checkbox');
+    addTearDown(focusNode.dispose);
+
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    const Color hoveredFillColor = Color(0xFF000001);
+    const Color focusedFillColor = Color(0xFF000002);
+    const Color transparentColor = Color(0x00000000);
+
+    Color getFillColor(Set<WidgetState> states) {
+      if (states.contains(WidgetState.hovered)) {
+        return hoveredFillColor;
+      }
+      if (states.contains(WidgetState.focused)) {
+        return focusedFillColor;
+      }
+      return transparentColor;
+    }
+
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
+
+    Widget buildApp({required bool enabled}) {
+      return CupertinoApp(
+        home: CupertinoCheckbox(
+          focusNode: focusNode,
+          value: enabled,
+          fillColor: fillColor,
+          onChanged: enabled ? (bool? value) { } : null,
+        ),
+      );
+    }
+
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(CupertinoCheckbox));
+    }
+
+    await tester.pumpWidget(buildApp(enabled: true));
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(getCheckboxRenderer(), paints..path(color: focusedFillColor));
+
+    // Start hovering.
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(tester.getCenter(find.byType(CupertinoCheckbox)));
+    await tester.pumpAndSettle();
+
+    expect(getCheckboxRenderer(), paints..path(color: hoveredFillColor));
   });
 
   testWidgets('Checkbox configures focus color', (WidgetTester tester) async {


### PR DESCRIPTION
Feat: Add `fillColor` property for `CupertinoCheckbox`

Required for #151252 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.