### PR TITLE
migration & enhancement for `Axis` / `AxisDirection`

### DIFF
--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -93,7 +93,20 @@ enum Axis {
   horizontal,
 
   /// Up and down.
-  vertical,
+  vertical;
+
+  /// Returns the opposite of the given [Axis].
+  ///
+  /// Specifically, returns [Axis.horizontal] for [Axis.vertical], and
+  /// vice versa.
+  ///
+  /// See also:
+  ///
+  ///  * [AxisDirection.flipped], which does the same thing for [AxisDirection] values.
+  Axis get flipped => switch (this) {
+    horizontal => vertical,
+    vertical => horizontal,
+  };
 }
 
 /// A direction in which boxes flow vertically.
@@ -145,7 +158,7 @@ enum VerticalDirection {
 ///   * [CustomScrollView.anchor], the relative position of the zero scroll
 ///     offset in a viewport and inflection point for [AxisDirection]s of the
 ///     same cardinal [Axis].
-///   * [axisDirectionIsReversed], which returns whether traveling along the
+///   * [AxisDirection.isReversed], which returns whether traveling along the
 ///     given axis direction visits coordinates along that axis in numerically
 ///     decreasing order.
 enum AxisDirection {
@@ -160,7 +173,7 @@ enum AxisDirection {
   ///
   /// See also:
   ///
-  ///   * [axisDirectionIsReversed], which returns whether traveling along the
+  ///   * [AxisDirection.isReversed], which returns whether traveling along the
   ///     given axis direction visits coordinates along that axis in numerically
   ///     decreasing order.
   up,
@@ -177,7 +190,7 @@ enum AxisDirection {
   ///
   /// See also:
   ///
-  ///   * [axisDirectionIsReversed], which returns whether traveling along the
+  ///   * [AxisDirection.isReversed], which returns whether traveling along the
   ///     given axis direction visits coordinates along that axis in numerically
   ///     decreasing order.
   right,
@@ -194,7 +207,7 @@ enum AxisDirection {
   ///
   /// See also:
   ///
-  ///   * [axisDirectionIsReversed], which returns whether traveling along the
+  ///   * [AxisDirection.isReversed], which returns whether traveling along the
   ///     given axis direction visits coordinates along that axis in numerically
   ///     decreasing order.
   down,
@@ -212,10 +225,46 @@ enum AxisDirection {
   ///
   /// See also:
   ///
-  ///   * [axisDirectionIsReversed], which returns whether traveling along the
+  ///   * [AxisDirection.isReversed], which returns whether traveling along the
   ///     given axis direction visits coordinates along that axis in numerically
   ///     decreasing order.
-  left,
+  left;
+
+  /// Returns the [Axis] that contains the given [AxisDirection].
+  ///
+  /// Specifically, returns [Axis.vertical] for [AxisDirection.up] and
+  /// [AxisDirection.down] and returns [Axis.horizontal] for [AxisDirection.left]
+  /// and [AxisDirection.right].
+  Axis get axis => switch (this) {
+    left || right => Axis.horizontal,
+    up   || down  => Axis.vertical,
+  };
+
+  /// Returns the opposite of the given [AxisDirection].
+  ///
+  /// Specifically, returns [AxisDirection.up] for [AxisDirection.down] (and
+  /// vice versa), as well as [AxisDirection.left] for [AxisDirection.right] (and
+  /// vice versa).
+  ///
+  /// See also:
+  ///
+  ///  * [Axis.flipped], which does the same thing for [Axis] values.
+  AxisDirection get flipped => switch (this) {
+    up    => AxisDirection.down,
+    right => AxisDirection.left,
+    down  => AxisDirection.up,
+    left  => AxisDirection.right,
+  };
+
+  /// Returns whether traveling along the given axis direction visits coordinates
+  /// along that axis in numerically decreasing order.
+  ///
+  /// Specifically, returns true for [AxisDirection.up] and [AxisDirection.left]
+  /// and false for [AxisDirection.down] and [AxisDirection.right].
+  bool get isReversed => switch (this) {
+    up   || left  => true,
+    down || right => false,
+  };
 }
 
 // LAZY CACHING ITERATOR

--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 /// @docImport 'dart:ui';
+///
+/// @docImport 'package:flutter/material.dart';
+/// @docImport 'package:flutter/rendering.dart';
 library;
 
 import 'dart:collection';
@@ -67,6 +70,153 @@ typedef AsyncValueSetter<T> = Future<void> Function(T value);
 ///  * [ValueGetter], a synchronous version of this signature.
 ///  * [AsyncValueSetter], the setter equivalent of this signature.
 typedef AsyncValueGetter<T> = Future<T> Function();
+
+/// The two cardinal directions in two dimensions.
+///
+/// The axis is always relative to the current coordinate space. This means, for
+/// example, that a [horizontal] axis might actually be diagonally from top
+/// right to bottom left, due to some local [Transform] applied to the scene.
+///
+/// See also:
+///
+///  * [AxisDirection], which is a directional version of this enum (with values
+///    like left and right, rather than just horizontal).
+///  * [TextDirection], which disambiguates between left-to-right horizontal
+///    content and right-to-left horizontal content.
+enum Axis {
+  /// Left and right.
+  ///
+  /// See also:
+  ///
+  ///  * [TextDirection], which disambiguates between left-to-right horizontal
+  ///    content and right-to-left horizontal content.
+  horizontal,
+
+  /// Up and down.
+  vertical,
+}
+
+/// A direction in which boxes flow vertically.
+///
+/// This is used by the flex algorithm (e.g. [Column]) to decide in which
+/// direction to draw boxes.
+///
+/// This is also used to disambiguate `start` and `end` values (e.g.
+/// [MainAxisAlignment.start] or [CrossAxisAlignment.end]).
+///
+/// See also:
+///
+///  * [TextDirection], which controls the same thing but horizontally.
+enum VerticalDirection {
+  /// Boxes should start at the bottom and be stacked vertically towards the top.
+  ///
+  /// The "start" is at the bottom, the "end" is at the top.
+  up,
+
+  /// Boxes should start at the top and be stacked vertically towards the bottom.
+  ///
+  /// The "start" is at the top, the "end" is at the bottom.
+  down,
+}
+
+/// A direction along either the horizontal or vertical [Axis] in which the
+/// origin, or zero position, is determined.
+///
+/// This value relates to the direction in which the scroll offset increases
+/// from the origin. This value does not represent the direction of user input
+/// that may be modifying the scroll offset, such as from a drag. For the
+/// active scrolling direction, see [ScrollDirection].
+///
+/// {@tool dartpad}
+/// This sample shows a [CustomScrollView], with [Radio] buttons in the
+/// [AppBar.bottom] that change the [AxisDirection] to illustrate different
+/// configurations.
+///
+/// ** See code in examples/api/lib/painting/axis_direction/axis_direction.0.dart **
+/// {@end-tool}
+///
+/// See also:
+///
+///   * [ScrollDirection], the direction of active scrolling, relative to the positive
+///     scroll offset axis given by an [AxisDirection] and a [GrowthDirection].
+///   * [GrowthDirection], the direction in which slivers and their content are
+///     ordered, relative to the scroll offset axis as specified by
+///     [AxisDirection].
+///   * [CustomScrollView.anchor], the relative position of the zero scroll
+///     offset in a viewport and inflection point for [AxisDirection]s of the
+///     same cardinal [Axis].
+///   * [axisDirectionIsReversed], which returns whether traveling along the
+///     given axis direction visits coordinates along that axis in numerically
+///     decreasing order.
+enum AxisDirection {
+  /// A direction in the [Axis.vertical] where zero is at the bottom and
+  /// positive values are above it: `⇈`
+  ///
+  /// Alphabetical content with a [GrowthDirection.forward] would have the A at
+  /// the bottom and the Z at the top.
+  ///
+  /// For example, the behavior of a [ListView] with [ListView.reverse] set to
+  /// true would have this axis direction.
+  ///
+  /// See also:
+  ///
+  ///   * [axisDirectionIsReversed], which returns whether traveling along the
+  ///     given axis direction visits coordinates along that axis in numerically
+  ///     decreasing order.
+  up,
+
+  /// A direction in the [Axis.horizontal] where zero is on the left and
+  /// positive values are to the right of it: `⇉`
+  ///
+  /// Alphabetical content with a [GrowthDirection.forward] would have the A on
+  /// the left and the Z on the right. This is the ordinary reading order for a
+  /// horizontal set of tabs in an English application, for example.
+  ///
+  /// For example, the behavior of a [ListView] with [ListView.scrollDirection]
+  /// set to [Axis.horizontal] would have this axis direction.
+  ///
+  /// See also:
+  ///
+  ///   * [axisDirectionIsReversed], which returns whether traveling along the
+  ///     given axis direction visits coordinates along that axis in numerically
+  ///     decreasing order.
+  right,
+
+  /// A direction in the [Axis.vertical] where zero is at the top and positive
+  /// values are below it: `⇊`
+  ///
+  /// Alphabetical content with a [GrowthDirection.forward] would have the A at
+  /// the top and the Z at the bottom. This is the ordinary reading order for a
+  /// vertical list.
+  ///
+  /// For example, the default behavior of a [ListView] would have this axis
+  /// direction.
+  ///
+  /// See also:
+  ///
+  ///   * [axisDirectionIsReversed], which returns whether traveling along the
+  ///     given axis direction visits coordinates along that axis in numerically
+  ///     decreasing order.
+  down,
+
+  /// A direction in the [Axis.horizontal] where zero is to the right and
+  /// positive values are to the left of it: `⇇`
+  ///
+  /// Alphabetical content with a [GrowthDirection.forward] would have the A at
+  /// the right and the Z at the left. This is the ordinary reading order for a
+  /// horizontal set of tabs in a Hebrew application, for example.
+  ///
+  /// For example, the behavior of a [ListView] with [ListView.scrollDirection]
+  /// set to [Axis.horizontal] and [ListView.reverse] set to true would have
+  /// this axis direction.
+  ///
+  /// See also:
+  ///
+  ///   * [axisDirectionIsReversed], which returns whether traveling along the
+  ///     given axis direction visits coordinates along that axis in numerically
+  ///     decreasing order.
+  left,
+}
 
 // LAZY CACHING ITERATOR
 

--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -122,6 +122,11 @@ enum RenderComparison {
 /// See also:
 ///
 ///  * [flipAxisDirection], which does the same thing for [AxisDirection] values.
+@Deprecated(
+  'Use the ".flipped" getter instead. '
+  "The getter's behavior is identical to this function and is less verbose. "
+  'This feature was deprecated after v3.23.0-0.1.pre.',
+)
 Axis flipAxis(Axis direction) {
   return switch (direction) {
     Axis.horizontal => Axis.vertical,
@@ -134,6 +139,11 @@ Axis flipAxis(Axis direction) {
 /// Specifically, returns [Axis.vertical] for [AxisDirection.up] and
 /// [AxisDirection.down] and returns [Axis.horizontal] for [AxisDirection.left]
 /// and [AxisDirection.right].
+@Deprecated(
+  'Use the ".axis" getter instead. '
+  "The getter's behavior is identical to this function and is less verbose. "
+  'This feature was deprecated after v3.23.0-0.1.pre.',
+)
 Axis axisDirectionToAxis(AxisDirection axisDirection) {
   return switch (axisDirection) {
     AxisDirection.up   || AxisDirection.down  => Axis.vertical,
@@ -161,6 +171,11 @@ AxisDirection textDirectionToAxisDirection(TextDirection textDirection) {
 /// See also:
 ///
 ///  * [flipAxis], which does the same thing for [Axis] values.
+@Deprecated(
+  'Use the ".flipped" getter instead. '
+  "The getter's behavior is identical to this function and is less verbose. "
+  'This feature was deprecated after v3.23.0-0.1.pre.',
+)
 AxisDirection flipAxisDirection(AxisDirection axisDirection) {
   return switch (axisDirection) {
     AxisDirection.up    => AxisDirection.down,
@@ -175,6 +190,11 @@ AxisDirection flipAxisDirection(AxisDirection axisDirection) {
 ///
 /// Specifically, returns true for [AxisDirection.up] and [AxisDirection.left]
 /// and false for [AxisDirection.down] and [AxisDirection.right].
+@Deprecated(
+  'Use the ".isReversed" getter instead. '
+  "The getter's behavior is identical to this function and is less verbose. "
+  'This feature was deprecated after v3.23.0-0.1.pre.',
+)
 bool axisDirectionIsReversed(AxisDirection axisDirection) {
   return switch (axisDirection) {
     AxisDirection.up   || AxisDirection.left  => true,

--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -10,6 +10,7 @@
 library;
 
 import 'dart:ui' show TextDirection;
+import 'package:flutter/foundation.dart' show Axis, AxisDirection;
 
 export 'dart:ui' show
   BlendMode,
@@ -57,7 +58,7 @@ export 'dart:ui' show
   hashList,
   hashValues;
 
-export 'package:flutter/foundation.dart' show VoidCallback;
+export 'package:flutter/foundation.dart' show Axis, AxisDirection, VerticalDirection, VoidCallback;
 
 // Intentionally not exported:
 //  - Image, instantiateImageCodec, decodeImageFromList:
@@ -113,31 +114,6 @@ enum RenderComparison {
   layout,
 }
 
-/// The two cardinal directions in two dimensions.
-///
-/// The axis is always relative to the current coordinate space. This means, for
-/// example, that a [horizontal] axis might actually be diagonally from top
-/// right to bottom left, due to some local [Transform] applied to the scene.
-///
-/// See also:
-///
-///  * [AxisDirection], which is a directional version of this enum (with values
-///    like left and right, rather than just horizontal).
-///  * [TextDirection], which disambiguates between left-to-right horizontal
-///    content and right-to-left horizontal content.
-enum Axis {
-  /// Left and right.
-  ///
-  /// See also:
-  ///
-  ///  * [TextDirection], which disambiguates between left-to-right horizontal
-  ///    content and right-to-left horizontal content.
-  horizontal,
-
-  /// Up and down.
-  vertical,
-}
-
 /// Returns the opposite of the given [Axis].
 ///
 /// Specifically, returns [Axis.horizontal] for [Axis.vertical], and
@@ -151,128 +127,6 @@ Axis flipAxis(Axis direction) {
     Axis.horizontal => Axis.vertical,
     Axis.vertical => Axis.horizontal,
   };
-}
-
-/// A direction in which boxes flow vertically.
-///
-/// This is used by the flex algorithm (e.g. [Column]) to decide in which
-/// direction to draw boxes.
-///
-/// This is also used to disambiguate `start` and `end` values (e.g.
-/// [MainAxisAlignment.start] or [CrossAxisAlignment.end]).
-///
-/// See also:
-///
-///  * [TextDirection], which controls the same thing but horizontally.
-enum VerticalDirection {
-  /// Boxes should start at the bottom and be stacked vertically towards the top.
-  ///
-  /// The "start" is at the bottom, the "end" is at the top.
-  up,
-
-  /// Boxes should start at the top and be stacked vertically towards the bottom.
-  ///
-  /// The "start" is at the top, the "end" is at the bottom.
-  down,
-}
-
-/// A direction along either the horizontal or vertical [Axis] in which the
-/// origin, or zero position, is determined.
-///
-/// This value relates to the direction in which the scroll offset increases
-/// from the origin. This value does not represent the direction of user input
-/// that may be modifying the scroll offset, such as from a drag. For the
-/// active scrolling direction, see [ScrollDirection].
-///
-/// {@tool dartpad}
-/// This sample shows a [CustomScrollView], with [Radio] buttons in the
-/// [AppBar.bottom] that change the [AxisDirection] to illustrate different
-/// configurations.
-///
-/// ** See code in examples/api/lib/painting/axis_direction/axis_direction.0.dart **
-/// {@end-tool}
-///
-/// See also:
-///
-///   * [ScrollDirection], the direction of active scrolling, relative to the positive
-///     scroll offset axis given by an [AxisDirection] and a [GrowthDirection].
-///   * [GrowthDirection], the direction in which slivers and their content are
-///     ordered, relative to the scroll offset axis as specified by
-///     [AxisDirection].
-///   * [CustomScrollView.anchor], the relative position of the zero scroll
-///     offset in a viewport and inflection point for [AxisDirection]s of the
-///     same cardinal [Axis].
-///   * [axisDirectionIsReversed], which returns whether traveling along the
-///     given axis direction visits coordinates along that axis in numerically
-///     decreasing order.
-enum AxisDirection {
-  /// A direction in the [Axis.vertical] where zero is at the bottom and
-  /// positive values are above it: `⇈`
-  ///
-  /// Alphabetical content with a [GrowthDirection.forward] would have the A at
-  /// the bottom and the Z at the top.
-  ///
-  /// For example, the behavior of a [ListView] with [ListView.reverse] set to
-  /// true would have this axis direction.
-  ///
-  /// See also:
-  ///
-  ///   * [axisDirectionIsReversed], which returns whether traveling along the
-  ///     given axis direction visits coordinates along that axis in numerically
-  ///     decreasing order.
-  up,
-
-  /// A direction in the [Axis.horizontal] where zero is on the left and
-  /// positive values are to the right of it: `⇉`
-  ///
-  /// Alphabetical content with a [GrowthDirection.forward] would have the A on
-  /// the left and the Z on the right. This is the ordinary reading order for a
-  /// horizontal set of tabs in an English application, for example.
-  ///
-  /// For example, the behavior of a [ListView] with [ListView.scrollDirection]
-  /// set to [Axis.horizontal] would have this axis direction.
-  ///
-  /// See also:
-  ///
-  ///   * [axisDirectionIsReversed], which returns whether traveling along the
-  ///     given axis direction visits coordinates along that axis in numerically
-  ///     decreasing order.
-  right,
-
-  /// A direction in the [Axis.vertical] where zero is at the top and positive
-  /// values are below it: `⇊`
-  ///
-  /// Alphabetical content with a [GrowthDirection.forward] would have the A at
-  /// the top and the Z at the bottom. This is the ordinary reading order for a
-  /// vertical list.
-  ///
-  /// For example, the default behavior of a [ListView] would have this axis
-  /// direction.
-  ///
-  /// See also:
-  ///
-  ///   * [axisDirectionIsReversed], which returns whether traveling along the
-  ///     given axis direction visits coordinates along that axis in numerically
-  ///     decreasing order.
-  down,
-
-  /// A direction in the [Axis.horizontal] where zero is to the right and
-  /// positive values are to the left of it: `⇇`
-  ///
-  /// Alphabetical content with a [GrowthDirection.forward] would have the A at
-  /// the right and the Z at the left. This is the ordinary reading order for a
-  /// horizontal set of tabs in a Hebrew application, for example.
-  ///
-  /// For example, the behavior of a [ListView] with [ListView.scrollDirection]
-  /// set to [Axis.horizontal] and [ListView.reverse] set to true would have
-  /// this axis direction.
-  ///
-  /// See also:
-  ///
-  ///   * [axisDirectionIsReversed], which returns whether traveling along the
-  ///     given axis direction visits coordinates along that axis in numerically
-  ///     decreasing order.
-  left,
 }
 
 /// Returns the [Axis] that contains the given [AxisDirection].

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
 
 import 'actions.dart';

--- a/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/painting.dart';
 
 import 'framework.dart';
 import 'scroll_configuration.dart';

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/painting.dart' show AxisDirection;
 import 'package:flutter/physics.dart';
 
 import 'binding.dart' show WidgetsBinding;


### PR DESCRIPTION
This is a small change, but it still might be difficult to review.

Related:
- #151446
- #147799

<br>

## Motivation

### Dependency conflict

Currently, **package:flutter/painting.dart** depends on **package:flutter/gestures.dart**, so anything within the **gestures** library cannot use something declared in **painting** (since that would create a dependency loop).

This resulted in a less-than-ideal situation: the `DragGestureRecognizer` needs to use an `Axis` value for its `primaryDragAxis` field and its `getSumDelta()` method, but it isn't allowed to import the `Axis` enum.

So instead, the enum was copied into the file and given a private name. All methods that use this enum have to be private as well: if someone needs a version of `PanGestureRecognizer` with a slight change to the distance required to accept the gesture, they need to copy the entire `DragGestureRecognizer` interface and re-implement each abstract method before tweaking to the desired behavior.

### Enum enhancements

`Axis` and `AxisDirection` were given a few helper methods before enhanced enum features were added to Dart. This provides an opportunity for a satisfying refactor:

```dart
// before
if (axisDirectionToAxis(intent.direction) == axisDirectionToAxis(state.direction)) {
  // ...
}


// after
if (intent.direction.axis == state.direction.axis) {
  // ...
}
```

```dart
// before
Flex(
  direction: flipAxis(axisDirectionToAxis(direction)),
  // ...
);


// after
Flex(
  direction: direction.axis.flipped,
  // ...
);
```

It's much easier for me to understand the process of "convert the `AxisDirection` to an `Axis`, and then flip it" when it isn't a nested function call that's read from right-to-left.

<br>

## Summary of changes

### Migration

Since [**painting/basic_types.dart**](https://github.com/flutter/flutter/blob/82b63ff27d7a15581837c84ca9304d3023934545/packages/flutter/lib/src/painting/basic_types.dart#L60) is already exporting a type from the **foundation** package, the migration was more-or-less trivial: enums in that file were moved into [**foundation/basic_types.dart**](https://github.com/flutter/flutter/blob/ec8b062161b4ee5efb12ee0a77cad3b4c4e78de5/packages/flutter/lib/src/foundation/basic_types.dart).

### Deprecation

`Axis` and `AxisDirection` were given a `.flipped` getter that corresponds to `flipAxis()` and `flipAxisDirection()` respectively.

`AxisDirection` also has `.axis` and `.isReversed` that corresponds to `axisDirectionToAxis()` & `axisDirectionIsReversed()`.

<br>

I also added `@Deprecated()` to the functions being replaced; unfortunately at this point we can't implement a [data-driven fix](https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md#replacedby) for a "function → getter" migration. Perhaps instead of deprecating now, we could do something similar to `WidgetStateProperty.all`:

https://github.com/flutter/flutter/blob/fbb12c2c6120e75d4081aa501bff656354a28094/packages/flutter/lib/src/widgets/widget_state.dart#L552-L555