### PR TITLE
Retry plugin_test_ios in presubmit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4018,7 +4018,7 @@ targets:
       task_name: plugin_test_ios
       # Retry for flakes caused by https://github.com/flutter/flutter/issues/151772
       presubmit_max_attempts: "2"
-      test_timeout_secs: 3600
+      test_timeout_secs: "3600"
     runIf:
       - dev/**
       - packages/flutter_tools/**

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4018,6 +4018,7 @@ targets:
       task_name: plugin_test_ios
       # Retry for flakes caused by https://github.com/flutter/flutter/issues/151772
       presubmit_max_attempts: "2"
+      test_timeout_secs: 3600
     runIf:
       - dev/**
       - packages/flutter_tools/**

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4016,6 +4016,8 @@ targets:
       tags: >
         ["devicelab", "hostonly", "mac"]
       task_name: plugin_test_ios
+      # Retry for flakes caused by https://github.com/flutter/flutter/issues/151772
+      presubmit_max_attempts: "2"
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/151772

This test is flaking frequently in presubmit and blocking engine -> framework rolls as in https://github.com/flutter/flutter/pull/151762 that only contained a Skia roll.