### PR TITLE
docs: Fix typo in data driven fixes test folder section

### DIFF
--- a/docs/contributing/Data-driven-Fixes.md
+++ b/docs/contributing/Data-driven-Fixes.md
@@ -499,7 +499,7 @@ An abbreviated URI is the portion of the URI following the name of the package c
 
 ### test folder
 
-A _test folder_ contains dart files and their curresponding golden master `.expect` files that are used to test the data in the [data file](#data-file). These files are located in a folder (conventionally named `test_fixes`) in the package directory. See the [Testing](#testing) section for more documentation.
+A _test folder_ contains dart files and their corresponding golden master `.expect` files that are used to test the data in the [data file](#data-file). These files are located in a folder (conventionally named `test_fixes`) in the package directory. See the [Testing](#testing) section for more documentation.
 
 You might find it useful to include a `README.md` file that has a link to this documentation for easy reference.
 


### PR DESCRIPTION
Previously we were having `corresponding` written as `curresponding`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.