### PR TITLE
Fix: A selectable's selection under the active selection should not be cleared on right-click

### DIFF
--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -709,7 +709,7 @@ class SelectionGeometry {
     return other is SelectionGeometry
         && other.startSelectionPoint == startSelectionPoint
         && other.endSelectionPoint == endSelectionPoint
-        && other.selectionRects == selectionRects
+        && listEquals(other.selectionRects, selectionRects)
         && other.status == status
         && other.hasContent == hasContent;
   }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2221,7 +2221,7 @@ void main() {
     );
 
     testWidgets(
-      'right-click mouse on an active selection does not clear the selection in other selectables on apple platforms',
+      'right-click mouse on an active selection does not clear the selection in other selectables on Apple platforms',
       (WidgetTester tester) async {
         // Regression test for https://github.com/flutter/flutter/issues/150268.
         Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};


### PR DESCRIPTION
Fixes #150268

The issue was related to the check for selection geometry here: https://github.com/flutter/flutter/blob/22a5c6cb0a906c219e360ab72da0935aa7a18b93/packages/flutter/lib/src/widgets/selectable_region.dart#L2469-L2476 . Since `otherList == myList` is a reference check this would fail even if the selection rects inside the list contained in SelectionGeometry where the same causing the selectables inside the selection but outside the selectable containing the tapped position to have their selection cleared, use `listEquals` instead.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.