### PR TITLE
Fix asset transformation in the presence of resolution-aware asset variants

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -154,7 +154,8 @@ Future<Depfile> copyAssets(
                 );
                 doCopy = false;
                 if (failure != null) {
-                  throwToolExit(failure.message);
+                  throwToolExit('User-defined transformation of asset "${entry.key}" failed.\n'
+                      '${failure.message}');
                 }
               }
             case AssetKind.font:

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -150,6 +150,7 @@ Future<Depfile> copyAssets(
                   outputPath: file.path,
                   workingDirectory: environment.projectDir.path,
                   transformerEntries: entry.value.transformers,
+                  assetKey: entry.key,
                   logger: environment.logger,
                 );
                 doCopy = false;

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -150,7 +150,6 @@ Future<Depfile> copyAssets(
                   outputPath: file.path,
                   workingDirectory: environment.projectDir.path,
                   transformerEntries: entry.value.transformers,
-                  assetKey: entry.key,
                   logger: environment.logger,
                 );
                 doCopy = false;

--- a/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
@@ -61,8 +61,6 @@ final class AssetTransformer {
       final String basename = _fileSystem.path.basename(asset.path);
       final String ext = _fileSystem.path.extension(asset.path);
 
-      // Resolution-aware asset variants can share the same basename/extension,
-      // so we need to insert a unique identifier into the path.
       return tempDirectory.childFile('$basename-transformOutput$transformStep$ext');
     }
 

--- a/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
@@ -57,16 +57,19 @@ final class AssetTransformer {
 
     final Directory tempDirectory = _fileSystem.systemTempDirectory.createTempSync();
 
-    File newTempFile(int transformStep) {
+    int transformStep = 0;
+    File nextTempFile() {
       final String basename = _fileSystem.path.basename(asset.path);
       final String ext = _fileSystem.path.extension(asset.path);
 
-      return tempDirectory.childFile('$basename-transformOutput$transformStep$ext');
+      final File result = tempDirectory.childFile('$basename-transformOutput$transformStep$ext');
+      transformStep++;
+      return result;
     }
 
-    File tempInputFile = newTempFile(0);
+    File tempInputFile = nextTempFile();
     await asset.copy(tempInputFile.path);
-    File tempOutputFile = newTempFile(1);
+    File tempOutputFile = nextTempFile();
 
     final Stopwatch stopwatch = Stopwatch()..start();
     try {
@@ -89,7 +92,7 @@ final class AssetTransformer {
           await tempOutputFile.copy(outputPath);
         } else {
           tempInputFile = tempOutputFile;
-          tempOutputFile = newTempFile(i+2);
+          tempOutputFile = nextTempFile();
         }
       }
 

--- a/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
@@ -67,7 +67,6 @@ final class AssetTransformer {
     File tempInputFile = newTempFile(0);
     await asset.copy(tempInputFile.path);
     File tempOutputFile = newTempFile(1);
-    ErrorHandlingFileSystem.deleteIfExists(tempOutputFile);
 
     final Stopwatch stopwatch = Stopwatch()..start();
     try {
@@ -91,7 +90,6 @@ final class AssetTransformer {
         } else {
           tempInputFile = tempOutputFile;
           tempOutputFile = newTempFile(i+2);
-          ErrorHandlingFileSystem.deleteIfExists(tempOutputFile);
         }
       }
 
@@ -122,6 +120,11 @@ final class AssetTransformer {
       transformer.package,
       ...transformerArguments,
     ];
+
+    // Delete the output file if it already exists for whatever reason.
+    // With this, we can check for the existence of the file after transformation
+    // to make sure the transformer produced an output file.
+    ErrorHandlingFileSystem.deleteIfExists(output);
 
     logger.printTrace("Transforming asset using command '${command.join(' ')}'");
     final ProcessResult result = await _processManager.run(

--- a/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
@@ -58,12 +58,16 @@ final class AssetTransformer {
     String getTempFilePath(int transformStep) {
       final String basename = _fileSystem.path.basename(asset.path);
       final String ext = _fileSystem.path.extension(asset.path);
+
+      // Resolution-aware asset variants can share the same basename/extension,
+      // so we need to insert a unique identifier into the path.
       return '$basename-transformOutput$transformStep$ext';
     }
 
-    File tempInputFile = _fileSystem.systemTempDirectory.childFile(getTempFilePath(0));
+    final Directory tempDirectory = _fileSystem.systemTempDirectory.createTempSync();
+    File tempInputFile = tempDirectory.childFile(getTempFilePath(0));
     await asset.copy(tempInputFile.path);
-    File tempOutputFile = _fileSystem.systemTempDirectory.childFile(getTempFilePath(1));
+    File tempOutputFile = tempDirectory.childFile(getTempFilePath(1));
     ErrorHandlingFileSystem.deleteIfExists(tempOutputFile);
 
     final Stopwatch stopwatch = Stopwatch()..start();

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -213,7 +213,8 @@ Future<void> writeBundle(
             );
             doCopy = false;
             if (failure != null) {
-              throwToolExit(failure.message);
+              throwToolExit('User-defined transformation of asset "${entry.key}" failed.\n'
+                  '${failure.message}');
             }
             case AssetKind.font:
               break;

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -206,6 +206,7 @@ Future<void> writeBundle(
             }
             final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
               asset: input,
+              assetKey: entry.key,
               outputPath: file.path,
               workingDirectory: projectDir.path,
               transformerEntries: entry.value.transformers,

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -206,7 +206,6 @@ Future<void> writeBundle(
             }
             final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
               asset: input,
-              assetKey: entry.key,
               outputPath: file.path,
               workingDirectory: projectDir.path,
               transformerEntries: entry.value.transformers,

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -677,7 +677,7 @@ class DevFS {
                 return entry.content;
               }
               return _assetTransformer.retransformAsset(
-                assetKey: archivePath,
+                inputAssetKey: archivePath,
                 inputAssetContent: entry.content,
                 transformerEntries: entry.transformers,
                 workingDirectory: rootDirectory.path,

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -677,7 +677,7 @@ class DevFS {
                 return entry.content;
               }
               return _assetTransformer.retransformAsset(
-                inputAssetKey: archivePath,
+                assetKey: archivePath,
                 inputAssetContent: entry.content,
                 transformerEntries: entry.transformers,
                 workingDirectory: rootDirectory.path,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
@@ -31,8 +31,8 @@ void main() {
           artifacts.getArtifactPath(Artifact.engineDartBinary),
           'run',
           'my_copy_transformer',
-          '--input=/.tmp_rand0/asset.txt-transformOutput0.txt',
-          '--output=/.tmp_rand0/asset.txt-transformOutput1.txt',
+          '--input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt',
+          '--output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt',
           '-f',
           '--my_option',
           'my_option_value',
@@ -95,8 +95,8 @@ void main() {
           dartBinaryPath,
           'run',
           'my_copy_transformer',
-          '--input=/.tmp_rand0/asset.txt-transformOutput0.txt',
-          '--output=/.tmp_rand0/asset.txt-transformOutput1.txt',
+          '--input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt',
+          '--output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt',
         ],
         onRun: (List<String> args) {
           final ArgResults parsedArgs = (ArgParser()
@@ -136,10 +136,9 @@ void main() {
     expect(failure, isNotNull);
     expect(failure!.message,
 '''
-User-defined transformation of asset "asset.txt" failed.
 Transformer process terminated with non-zero exit code: 1
 Transformer package: my_copy_transformer
-Full command: $dartBinaryPath run my_copy_transformer --input=/.tmp_rand0/asset.txt-transformOutput0.txt --output=/.tmp_rand0/asset.txt-transformOutput1.txt
+Full command: $dartBinaryPath run my_copy_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt
 stdout:
 Beginning transformation
 stderr:
@@ -162,8 +161,8 @@ Something went wrong''');
           dartBinaryPath,
           'run',
           'my_transformer',
-          '--input=/.tmp_rand0/asset.txt-transformOutput0.txt',
-          '--output=/.tmp_rand0/asset.txt-transformOutput1.txt',
+          '--input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt',
+          '--output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt',
         ],
         onRun: (_) {
           // Do nothing.
@@ -196,11 +195,10 @@ Something went wrong''');
     expect(failure, isNotNull);
     expect(failure!.message,
 '''
-User-defined transformation of asset "asset.txt" failed.
 Asset transformer my_transformer did not produce an output file.
-Input file provided to transformer: "/.tmp_rand0/asset.txt-transformOutput0.txt"
-Expected output file at: "/.tmp_rand0/asset.txt-transformOutput1.txt"
-Full command: $dartBinaryPath run my_transformer --input=/.tmp_rand0/asset.txt-transformOutput0.txt --output=/.tmp_rand0/asset.txt-transformOutput1.txt
+Input file provided to transformer: "/.tmp_rand0/rand0/asset.txt-transformOutput0.txt"
+Expected output file at: "/.tmp_rand0/rand0/asset.txt-transformOutput1.txt"
+Full command: $dartBinaryPath run my_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt
 stdout:
 
 stderr:
@@ -225,8 +223,8 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
           dartBinaryPath,
           'run',
           'my_lowercase_transformer',
-          '--input=/.tmp_rand0/asset.txt-transformOutput0.txt',
-          '--output=/.tmp_rand0/asset.txt-transformOutput1.txt',
+          '--input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt',
+          '--output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt',
         ],
         onRun: (List<String> args) {
           final ArgResults parsedArgs = (ArgParser()
@@ -245,8 +243,8 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
           dartBinaryPath,
           'run',
           'my_distance_from_ascii_a_transformer',
-          '--input=/.tmp_rand0/asset.txt-transformOutput1.txt',
-          '--output=/.tmp_rand0/asset.txt-transformOutput2.txt',
+          '--input=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt',
+          '--output=/.tmp_rand0/rand0/asset.txt-transformOutput2.txt',
         ],
         onRun: (List<String> args) {
           final ArgResults parsedArgs = (ArgParser()
@@ -314,8 +312,8 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
           dartBinaryPath,
           'run',
           'my_lowercase_transformer',
-          '--input=/.tmp_rand0/asset.txt-transformOutput0.txt',
-          '--output=/.tmp_rand0/asset.txt-transformOutput1.txt',
+          '--input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt',
+          '--output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt',
         ],
         onRun: (List<String> args) {
           final ArgResults parsedArgs = (ArgParser()
@@ -334,8 +332,8 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
           dartBinaryPath,
           'run',
           'my_distance_from_ascii_a_transformer',
-          '--input=/.tmp_rand0/asset.txt-transformOutput1.txt',
-          '--output=/.tmp_rand0/asset.txt-transformOutput2.txt',
+          '--input=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt',
+          '--output=/.tmp_rand0/rand0/asset.txt-transformOutput2.txt',
         ],
         onRun: (List<String> args) {
           // Do nothing.
@@ -374,11 +372,10 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
     expect(failure, isNotNull);
     expect(failure!.message,
 '''
-User-defined transformation of asset "asset.txt" failed.
 Asset transformer my_distance_from_ascii_a_transformer did not produce an output file.
-Input file provided to transformer: "/.tmp_rand0/asset.txt-transformOutput1.txt"
-Expected output file at: "/.tmp_rand0/asset.txt-transformOutput2.txt"
-Full command: Artifact.engineDartBinary run my_distance_from_ascii_a_transformer --input=/.tmp_rand0/asset.txt-transformOutput1.txt --output=/.tmp_rand0/asset.txt-transformOutput2.txt
+Input file provided to transformer: "/.tmp_rand0/rand0/asset.txt-transformOutput1.txt"
+Expected output file at: "/.tmp_rand0/rand0/asset.txt-transformOutput2.txt"
+Full command: Artifact.engineDartBinary run my_distance_from_ascii_a_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput2.txt
 stdout:
 
 stderr:

--- a/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
@@ -58,6 +58,7 @@ void main() {
     );
 
     final AssetTransformationFailure? transformationFailure = await transformer.transformAsset(
+      assetKey: 'asset.txt',
       asset: asset,
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
@@ -120,6 +121,7 @@ void main() {
 
     final AssetTransformationFailure? failure = await transformer.transformAsset(
       asset: asset,
+      assetKey: 'asset.txt',
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
       transformerEntries: <AssetTransformerEntry>[
@@ -181,6 +183,7 @@ Something went wrong''');
 
     final AssetTransformationFailure? failure = await transformer.transformAsset(
       asset: asset,
+      assetKey: 'asset.txt',
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
       transformerEntries: <AssetTransformerEntry>[
@@ -277,6 +280,7 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
 
     final AssetTransformationFailure? failure = await transformer.transformAsset(
       asset: asset,
+      assetKey: 'asset.txt',
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
       transformerEntries: <AssetTransformerEntry>[
@@ -356,6 +360,7 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
 
     final AssetTransformationFailure? failure = await transformer.transformAsset(
       asset: asset,
+      assetKey: 'asset.txt',
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
       transformerEntries: <AssetTransformerEntry>[

--- a/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
@@ -58,7 +58,6 @@ void main() {
     );
 
     final AssetTransformationFailure? transformationFailure = await transformer.transformAsset(
-      assetKey: 'asset.txt',
       asset: asset,
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
@@ -121,7 +120,6 @@ void main() {
 
     final AssetTransformationFailure? failure = await transformer.transformAsset(
       asset: asset,
-      assetKey: 'asset.txt',
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
       transformerEntries: <AssetTransformerEntry>[
@@ -183,7 +181,6 @@ Something went wrong''');
 
     final AssetTransformationFailure? failure = await transformer.transformAsset(
       asset: asset,
-      assetKey: 'asset.txt',
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
       transformerEntries: <AssetTransformerEntry>[
@@ -280,7 +277,6 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
 
     final AssetTransformationFailure? failure = await transformer.transformAsset(
       asset: asset,
-      assetKey: 'asset.txt',
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
       transformerEntries: <AssetTransformerEntry>[
@@ -360,7 +356,6 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
 
     final AssetTransformationFailure? failure = await transformer.transformAsset(
       asset: asset,
-      assetKey: 'asset.txt',
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
       transformerEntries: <AssetTransformerEntry>[

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -291,7 +291,7 @@ flutter:
 
       await expectToolExitLater(
         const CopyAssets().build(environment),
-        startsWith('User-defined transformation of asset "/input.txt" failed.\n'),
+        startsWith('User-defined transformation of asset "input.txt" failed.\n'),
       );
       expect(globals.processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator> {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -166,156 +166,244 @@ flutter:
     });
   });
 
-  testUsingContext('transforms assets declared with transformers', () async {
-    Cache.flutterRoot = Cache.defaultFlutterRoot(
-      platform: globals.platform,
-      fileSystem: fileSystem,
-      userMessages: UserMessages(),
-    );
+  group('asset transformation', () {
+    testUsingContext('transforms assets declared with transformers', () async {
+      Cache.flutterRoot = Cache.defaultFlutterRoot(
+        platform: globals.platform,
+        fileSystem: fileSystem,
+        userMessages: UserMessages(),
+      );
 
-    final Environment environment = Environment.test(
-      fileSystem.currentDirectory,
-      processManager: globals.processManager,
-      artifacts: Artifacts.test(),
-      fileSystem: fileSystem,
-      logger: logger,
-      platform: globals.platform,
-      defines: <String, String>{
-        kBuildMode: BuildMode.debug.cliName,
-      },
-    );
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: globals.processManager,
+        artifacts: Artifacts.test(),
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: globals.platform,
+        defines: <String, String>{
+          kBuildMode: BuildMode.debug.cliName,
+        },
+      );
 
-    await fileSystem.file('.packages').create();
+      await fileSystem.file('.packages').create();
 
-    fileSystem.file('pubspec.yaml')
-      ..createSync()
-      ..writeAsStringSync('''
-name: example
-flutter:
-  assets:
-    - path: input.txt
-      transformers:
-        - package: my_capitalizer_transformer
-          args: ["-a", "-b", "--color", "green"]
-''');
+      fileSystem.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync('''
+  name: example
+  flutter:
+    assets:
+      - path: input.txt
+        transformers:
+          - package: my_capitalizer_transformer
+            args: ["-a", "-b", "--color", "green"]
+  ''');
 
-    fileSystem.file('input.txt')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('abc');
+      fileSystem.file('input.txt')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('abc');
 
-    await const CopyAssets().build(environment);
+      await const CopyAssets().build(environment);
 
-    expect(logger.errorText, isEmpty);
-    expect(globals.processManager, hasNoRemainingExpectations);
-    expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/input.txt'), exists);
-  }, overrides: <Type, Generator> {
-    Logger: () => logger,
-    FileSystem: () => fileSystem,
-    Platform: () => FakePlatform(),
-    ProcessManager: () => FakeProcessManager.list(
-      <FakeCommand>[
-        FakeCommand(
-          command: <Pattern>[
-            Artifacts.test().getArtifactPath(Artifact.engineDartBinary),
-            'run',
-            'my_capitalizer_transformer',
-            RegExp('--input=.*'),
-            RegExp('--output=.*'),
-            '-a',
-            '-b',
-            '--color',
-            'green',
-          ],
-          onRun: (List<String> args) {
-            final ArgResults parsedArgs = (ArgParser()
+      expect(logger.errorText, isEmpty);
+      expect(globals.processManager, hasNoRemainingExpectations);
+      expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/input.txt'), exists);
+    }, overrides: <Type, Generator> {
+      Logger: () => logger,
+      FileSystem: () => fileSystem,
+      Platform: () => FakePlatform(),
+      ProcessManager: () => FakeProcessManager.list(
+        <FakeCommand>[
+          FakeCommand(
+            command: <Pattern>[
+              Artifacts.test().getArtifactPath(Artifact.engineDartBinary),
+              'run',
+              'my_capitalizer_transformer',
+              RegExp('--input=.*'),
+              RegExp('--output=.*'),
+              '-a',
+              '-b',
+              '--color',
+              'green',
+            ],
+            onRun: (List<String> args) {
+              final ArgResults parsedArgs = (ArgParser()
+                  ..addOption('input')
+                  ..addOption('output')
+                  ..addOption('color')
+                  ..addFlag('aaa', abbr: 'a')
+                  ..addFlag('bbb', abbr: 'b'))
+                .parse(args);
+
+              expect(parsedArgs['aaa'], true);
+              expect(parsedArgs['bbb'], true);
+              expect(parsedArgs['color'], 'green');
+
+              final File input = fileSystem.file(parsedArgs['input'] as String);
+              expect(input, exists);
+              final String inputContents = input.readAsStringSync();
+              expect(inputContents, 'abc');
+              fileSystem.file(parsedArgs['output'])
+                ..createSync()
+                ..writeAsStringSync(inputContents.toUpperCase());
+            },
+          ),
+        ],
+      ),
+    });
+
+
+    testUsingContext('exits tool if an asset transformation fails', () async {
+      Cache.flutterRoot = Cache.defaultFlutterRoot(
+        platform: globals.platform,
+        fileSystem: fileSystem,
+        userMessages: UserMessages(),
+      );
+
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: globals.processManager,
+        artifacts: Artifacts.test(),
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: globals.platform,
+        defines: <String, String>{
+          kBuildMode: BuildMode.debug.cliName,
+        },
+      );
+
+      await fileSystem.file('.packages').create();
+
+      fileSystem.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync('''
+  name: example
+  flutter:
+    assets:
+      - path: input.txt
+        transformers:
+          - package: my_transformer
+            args: ["-a", "-b", "--color", "green"]
+  ''');
+
+      await fileSystem.file('input.txt').create(recursive: true);
+
+      await expectToolExitLater(
+        const CopyAssets().build(environment),
+        startsWith('User-defined transformation of asset "/input.txt" failed.\n'),
+      );
+      expect(globals.processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator> {
+      Logger: () => logger,
+      FileSystem: () => fileSystem,
+      Platform: () => FakePlatform(),
+      ProcessManager: () => FakeProcessManager.list(
+        <FakeCommand>[
+          FakeCommand(
+            command: <Pattern>[
+              Artifacts.test().getArtifactPath(Artifact.engineDartBinary),
+              'run',
+              'my_transformer',
+              RegExp('--input=.*'),
+              RegExp('--output=.*'),
+              '-a',
+              '-b',
+              '--color',
+              'green',
+            ],
+            exitCode: 1,
+          ),
+        ],
+      ),
+    });
+
+    {
+      final List<String> inputFilePaths = <String>[];
+      final List<String> outputFilePaths = <String>[];
+
+      final FakeCommand transformerCommand = FakeCommand(
+        command: <Pattern>[
+          Artifacts.test().getArtifactPath(Artifact.engineDartBinary),
+          'run',
+          'my_capitalizer_transformer',
+          RegExp('--input=.*'),
+          RegExp('--output=.*'),
+        ],
+        onRun: (List<String> args) {
+          final ArgResults parsedArgs = (ArgParser()
                 ..addOption('input')
-                ..addOption('output')
-                ..addOption('color')
-                ..addFlag('aaa', abbr: 'a')
-                ..addFlag('bbb', abbr: 'b'))
+                ..addOption('output'))
               .parse(args);
 
-            expect(parsedArgs['aaa'], true);
-            expect(parsedArgs['bbb'], true);
-            expect(parsedArgs['color'], 'green');
+          final String input = parsedArgs['input'] as String;
+          final String output = parsedArgs['output'] as String;
 
-            final File input = fileSystem.file(parsedArgs['input'] as String);
-            expect(input, exists);
-            final String inputContents = input.readAsStringSync();
-            expect(inputContents, 'abc');
-            fileSystem.file(parsedArgs['output'])
-              ..createSync()
-              ..writeAsStringSync(inputContents.toUpperCase());
+          inputFilePaths.add(input);
+          outputFilePaths.add(output);
+
+          fileSystem.file(output)
+            ..createSync()
+            ..writeAsStringSync('foo');
+        },
+      );
+      testUsingContext('uses unique paths for temporary files', () async {
+        Cache.flutterRoot = Cache.defaultFlutterRoot(
+          platform: globals.platform,
+          fileSystem: fileSystem,
+          userMessages: UserMessages(),
+        );
+
+        final Environment environment = Environment.test(
+          fileSystem.currentDirectory,
+          processManager: globals.processManager,
+          artifacts: Artifacts.test(),
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: globals.platform,
+          defines: <String, String>{
+            kBuildMode: BuildMode.debug.cliName,
           },
+        );
+
+        await fileSystem.file('.packages').create();
+
+        fileSystem.file('pubspec.yaml')
+          ..createSync()
+          ..writeAsStringSync('''
+    name: example
+    flutter:
+      assets:
+        - path: input.txt
+          transformers:
+            - package: my_capitalizer_transformer
+    ''');
+
+        fileSystem.file('input.txt')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('abc');
+
+        fileSystem.directory('2x').childFile('input.txt')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('def');
+
+        await const CopyAssets().build(environment);
+
+        expect(inputFilePaths.toSet(), hasLength(inputFilePaths.length));
+        expect(outputFilePaths.toSet(), hasLength(outputFilePaths.length));
+      }, overrides: <Type, Generator> {
+        Logger: () => logger,
+        FileSystem: () => fileSystem,
+        Platform: () => FakePlatform(),
+        ProcessManager: () => FakeProcessManager.list(
+          <FakeCommand>[
+            transformerCommand,
+            transformerCommand,
+          ]
         ),
-      ],
-    ),
+      });
+    }
   });
-
-  testUsingContext('exits tool if an asset transformation fails', () async {
-    Cache.flutterRoot = Cache.defaultFlutterRoot(
-      platform: globals.platform,
-      fileSystem: fileSystem,
-      userMessages: UserMessages(),
-    );
-
-    final Environment environment = Environment.test(
-      fileSystem.currentDirectory,
-      processManager: globals.processManager,
-      artifacts: Artifacts.test(),
-      fileSystem: fileSystem,
-      logger: logger,
-      platform: globals.platform,
-      defines: <String, String>{
-        kBuildMode: BuildMode.debug.cliName,
-      },
-    );
-
-    await fileSystem.file('.packages').create();
-
-    fileSystem.file('pubspec.yaml')
-      ..createSync()
-      ..writeAsStringSync('''
-name: example
-flutter:
-  assets:
-    - path: input.txt
-      transformers:
-        - package: my_transformer
-          args: ["-a", "-b", "--color", "green"]
-''');
-
-    await fileSystem.file('input.txt').create(recursive: true);
-
-    await expectToolExitLater(
-      const CopyAssets().build(environment),
-      startsWith('User-defined transformation of asset "/input.txt" failed.\n'),
-    );
-    expect(globals.processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator> {
-    Logger: () => logger,
-    FileSystem: () => fileSystem,
-    Platform: () => FakePlatform(),
-    ProcessManager: () => FakeProcessManager.list(
-      <FakeCommand>[
-        FakeCommand(
-          command: <Pattern>[
-            Artifacts.test().getArtifactPath(Artifact.engineDartBinary),
-            'run',
-            'my_transformer',
-            RegExp('--input=.*'),
-            RegExp('--output=.*'),
-            '-a',
-            '-b',
-            '--color',
-            'green',
-          ],
-          exitCode: 1,
-        ),
-      ],
-    ),
-  });
-
 
   testUsingContext('Throws exception if pubspec contains missing files', () async {
     fileSystem.file('pubspec.yaml')

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -347,6 +347,7 @@ flutter:
             ..writeAsStringSync('foo');
         },
       );
+
       testUsingContext('uses unique paths for temporary files', () async {
         Cache.flutterRoot = Cache.defaultFlutterRoot(
           platform: globals.platform,

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -71,8 +71,8 @@ void main() {
               artifacts.getArtifactPath(Artifact.engineDartBinary),
               'run',
               'increment',
-              '--input=/.tmp_rand0/my-asset.txt-transformOutput0.txt',
-              '--output=/.tmp_rand0/my-asset.txt-transformOutput1.txt'
+              '--input=/.tmp_rand0/rand0/my-asset.txt-transformOutput0.txt',
+              '--output=/.tmp_rand0/rand0/my-asset.txt-transformOutput1.txt'
             ],
             onRun: (List<String> command) {
               final ArgResults argParseResults = (ArgParser()

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -733,8 +733,8 @@ void main() {
               artifacts.getArtifactPath(Artifact.engineDartBinary),
               'run',
               'increment',
-              '--input=/.tmp_rand0/retransformerInput-asset.txt-transformOutput0.txt',
-              '--output=/.tmp_rand0/retransformerInput-asset.txt-transformOutput1.txt',
+              '--input=/.tmp_rand0/rand0/retransformerInput-asset.txt-transformOutput0.txt',
+              '--output=/.tmp_rand0/rand0/retransformerInput-asset.txt-transformOutput1.txt',
             ],
             onRun: (List<String> command) {
               final ArgResults argParseResults = (ArgParser()
@@ -831,8 +831,8 @@ void main() {
               artifacts.getArtifactPath(Artifact.engineDartBinary),
               'run',
               'increment',
-              '--input=/.tmp_rand0/retransformerInput-asset.txt-transformOutput0.txt',
-              '--output=/.tmp_rand0/retransformerInput-asset.txt-transformOutput1.txt',
+              '--input=/.tmp_rand0/rand0/retransformerInput-asset.txt-transformOutput0.txt',
+              '--output=/.tmp_rand0/rand0/retransformerInput-asset.txt-transformOutput1.txt',
             ],
             exitCode: 1,
           ),
@@ -895,10 +895,9 @@ void main() {
       expect(devFSWriter.entries, isNull, reason: 'DevFS should not have written anything since the update failed.');
       expect(
         logger.errorText,
-        'User-defined transformation of asset "/.tmp_rand0/retransformerInput-asset.txt" failed.\n'
         'Transformer process terminated with non-zero exit code: 1\n'
         'Transformer package: increment\n'
-        'Full command: Artifact.engineDartBinary run increment --input=/.tmp_rand0/retransformerInput-asset.txt-transformOutput0.txt --output=/.tmp_rand0/retransformerInput-asset.txt-transformOutput1.txt\n'
+        'Full command: Artifact.engineDartBinary run increment --input=/.tmp_rand0/rand0/retransformerInput-asset.txt-transformOutput0.txt --output=/.tmp_rand0/rand0/retransformerInput-asset.txt-transformOutput1.txt\n'
         'stdout:\n'
         '\n'
         'stderr:\n'


### PR DESCRIPTION
For the necessary background knowledge, see the flutter.dev content on [Resolution-aware image assets](https://docs.flutter.dev/ui/assets/assets-and-images#resolution-aware) and [Conditional bundling of assets based on app flavor](https://docs.flutter.dev/ui/assets/assets-and-images#conditional-bundling-of-assets-based-on-app-flavor) if you don't have a basic understanding of these features.

Fixes https://github.com/flutter/flutter/issues/151813 by using unique temporary directories, per asset file, for transformations. Currently, only a single directory is used and the name of the temporary files was based only on the basename of files. This means that `assets/image.png` and `assets/2x/image.png` would share an output path (`<temp dir path>/image.png`), causing a race. If this quick and rough explanation is a bit confusing, the original issue—#151813—provides a full repro and correct identification of the exact cause of the failure that can occur in the asset transformation process.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
