### PR TITLE
fix: Dropdown menu trying to access highlight element which doesn't exist when search and filters both are enabled

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -613,14 +613,30 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       .toList();
   }
 
+  bool _shouldUpdateCurrentHighlight(List<DropdownMenuEntry<T>> entries) {
+    final String searchText = _localTextEditingController!.value.text.toLowerCase();
+    if (searchText.isEmpty) {
+      return true;
+    }
+
+    // When `entries` are filtered by filter algorithm, currentHighlight may exceed the valid range of `entries` and should be updated.
+    if (currentHighlight == null || currentHighlight! >= entries.length) {
+      return true;
+    }
+
+    if (entries[currentHighlight!].label.toLowerCase().contains(searchText)) {
+      return false;
+    }
+
+    return true;
+  }
+
   int? search(List<DropdownMenuEntry<T>> entries, TextEditingController textEditingController) {
     final String searchText = textEditingController.value.text.toLowerCase();
     if (searchText.isEmpty) {
       return null;
     }
-    if (currentHighlight != null && entries[currentHighlight!].label.toLowerCase().contains(searchText)) {
-      return currentHighlight;
-    }
+
     final int index = entries.indexWhere((DropdownMenuEntry<T> entry) => entry.label.toLowerCase().contains(searchText));
 
     return index != -1 ? index : null;
@@ -796,7 +812,10 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       if (widget.searchCallback != null) {
         currentHighlight = widget.searchCallback!(filteredEntries, _localTextEditingController!.text);
       } else {
-        currentHighlight = search(filteredEntries, _localTextEditingController!);
+        final bool shouldUpdateCurrentHighlight = _shouldUpdateCurrentHighlight(filteredEntries);
+        if (shouldUpdateCurrentHighlight) {
+          currentHighlight = search(filteredEntries, _localTextEditingController!);
+        }
       }
       if (currentHighlight != null) {
         scrollToHighlight();

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1292,6 +1292,29 @@ void main() {
 
   }, variant: TargetPlatformVariant.desktop());
 
+  // Regression test for https://github.com/flutter/flutter/issues/151878.
+  testWidgets('Searching for non matching item does not crash',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DropdownMenu<TestMenu>(
+          enableFilter: true,
+          requestFocusOnTap: true,
+          dropdownMenuEntries: menuChildren,
+        ),
+      ),
+    ));
+
+    // Open the menu.
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
+    await tester.enterText(find.byType(TextField).first, 'Me');
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, 'Meu');
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/147253.
   testWidgets('Default search prioritises the current highlight on desktop platforms',
       (WidgetTester tester) async {


### PR DESCRIPTION
DropdownMenu throws RangeError when both filter and search are enabled because when we search for elements, we have some highlighted element, but if there is no element to highlight it tries to access 0th element is the filtered entries, but entries are empty.

Fixes #151878 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.