### PR TITLE
fix(Flutter A11y Assessments Web App): pages missing heading level 1 in flutter web app

### DIFF
--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -85,8 +85,8 @@ class HomePageState extends State<HomePage> {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child:const Text('Accessibility Assessments'),
-          )
+          child: const Text('Accessibility Assessments'),
+          ),
         ),
       body: Center(
         child: ListView(

--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -81,7 +81,13 @@ class HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Accessibility Assessments')),
+      appBar: AppBar(
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child:const Text('Accessibility Assessments'),
+          )
+        ),
       body: Center(
         child: ListView(
           controller: scrollController,

--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -47,11 +47,7 @@ class _MainWidgetState extends State<_MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('AutoComplete')
-        ),
+        title: const Text('AutoComplete')
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -47,7 +47,11 @@ class _MainWidgetState extends State<_MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('AutoComplete'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('AutoComplete')
+        ),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -31,7 +31,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Badge'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Badge')
+        ),
       ),
       body: const Center(
         child: Badge(

--- a/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
@@ -29,7 +29,13 @@ class _MainWidgetState extends State<_MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('CheckBoxListTile')),
+      appBar: AppBar(
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('CheckBoxListTile'),
+        ),
+      ),
       body: ListView(
         children: <Widget>[
           CheckboxListTile(

--- a/dev/a11y_assessments/lib/use_cases/date_picker.dart
+++ b/dev/a11y_assessments/lib/use_cases/date_picker.dart
@@ -32,7 +32,11 @@ class _MainWidgetState extends State<_MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('DatePicker'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('DatePicker'),
+        ),
       ),
       body: Center(
         child: TextButton(

--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -25,7 +25,11 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Dialog'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Dialog'),
+        ),
       ),
       body: Center(
         child: TextButton(

--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -60,7 +60,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('MaterialBanner'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('MaterialBanner'),
+        ),
       ),
       body: Center(
         child: ElevatedButton(

--- a/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
@@ -33,7 +33,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('NavigationBar'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('NavigationBar'),
+        ),
       ),
       bottomNavigationBar: NavigationBar(
         onDestinationSelected: (int index) {

--- a/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
@@ -37,7 +37,13 @@ class _MainWidgetState extends State<_MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Radio button')),
+      appBar: AppBar(
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Radio button'),
+        ),
+      ),
       body: ListView(
         children: <Widget>[
           RadioListTile<SingingCharacter>(

--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -33,7 +33,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Slider'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Slider'),
+        ),
       ),
       body: Center(
         child: Slider(

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -33,7 +33,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextButton'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('TextButton'),
+        ),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -26,7 +26,11 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextField'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('TextField'),
+        ),
       ),
       body: ListView(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -26,7 +26,11 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextField password'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('TextField password'),
+        ),
       ),
       body: ListView(
         children: const <Widget>[

--- a/dev/a11y_assessments/test/accessibility_guideline_test.dart
+++ b/dev/a11y_assessments/test/accessibility_guideline_test.dart
@@ -23,6 +23,7 @@ void main() {
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(pageHasHeadingOneGuideline));
     });
   }
 }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -983,6 +983,10 @@ class _AppBarState extends State<AppBar> {
             TargetPlatform.iOS || TargetPlatform.macOS => null,
           },
           header: true,
+          // Set default AppBar header title to h1 to satisfy
+          // accessibility guidelines of having at least 1 h1
+          // per page.
+          headingLevel: 1,
           child: title,
         );
       }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1413,6 +1413,68 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('AppBar sets title to headingLevel = 1 (h1) by default.', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: AppBar(
+            leading: const Text('Leading'),
+            title: Semantics(
+              child: const Text('Title')
+            ),
+            actions: const <Widget>[
+              Text('Action 1'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      TestSemantics.root(
+        children: <TestSemantics>[
+          TestSemantics(
+            children: <TestSemantics>[
+              TestSemantics(
+                children: <TestSemantics>[
+                  TestSemantics(
+                    flags: <SemanticsFlag>[SemanticsFlag.isHeader],
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            label: 'Leading',
+                            textDirection: TextDirection.ltr,
+                          ),
+                          TestSemantics(
+                            label: 'Title',
+                            headingLevel: 1,
+                            textDirection: TextDirection.ltr,
+                          ),
+                          TestSemantics(
+                            label: 'Action 1',
+                            textDirection: TextDirection.ltr,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+      ignoreId: true,
+    ));
+
+    semantics.dispose();
+  });
+
   testWidgets('Material3 - AppBar draws a light system bar for a dark background', (WidgetTester tester) async {
     final ThemeData darkTheme = ThemeData.dark(useMaterial3: true);
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -730,6 +730,44 @@ Map<Color, int> _colorsWithinRect(
   });
 }
 
+/// A guideline which enforces that all pages have a h1 tag present.
+///
+/// See also:
+///  * [AccessibilityGuideline], which provides a general overview of
+///    accessibility guidelines and how to use them.
+@visibleForTesting
+class PageHasHeadingOneGuideline extends AccessibilityGuideline {
+  const PageHasHeadingOneGuideline._();
+
+  @override
+  String get description => 'Pages should have a semantic header with headingLevel: 1.';
+
+  @override
+  FutureOr<Evaluation> evaluate(WidgetTester tester) {
+    Evaluation result = const Evaluation.pass();
+
+    for (final RenderView view in tester.binding.renderViews) {
+      result += _traverse(view.owner!.semanticsOwner!.rootSemanticsNode!);
+    }
+
+    return result;
+  }
+
+  Evaluation _traverse(SemanticsNode node) {
+    Evaluation result = const Evaluation.pass();
+    node.visitChildren((SemanticsNode child) {
+      result += _traverse(child);
+      return true;
+    });
+    final SemanticsData data = node.getSemanticsData();
+    if (!!data.hasFlag(ui.SemanticsFlag.isHeader)) {
+      expect(data.headingLevel, 1);
+    }
+    
+    return result;
+  }
+}
+
 /// A guideline which requires tappable semantic nodes a minimum size of
 /// 48 by 48.
 ///
@@ -780,3 +818,10 @@ const AccessibilityGuideline textContrastGuideline = MinimumTextContrastGuidelin
 ///  * [AccessibilityGuideline], which provides a general overview of
 ///    accessibility guidelines and how to use them.
 const AccessibilityGuideline labeledTapTargetGuideline = LabeledTapTargetGuideline._();
+
+/// A guideline which enforces that all nodes with a tap or long press action
+/// also have a label.
+///
+///  * [AccessibilityGuideline], which provides a general overview of
+///    accessibility guidelines and how to use them.
+const AccessibilityGuideline pageHasHeadingOneGuideline = PageHasHeadingOneGuideline._();


### PR DESCRIPTION
Adds Semantic Widget to wrap the contents of each page's AppBar title attribute and adds `header: true` and `headingLevel: 1` as Semantic attributes so the content of the title is compiled as an h1 tag to meet accessibility guidelines that each page must have a h1 tag present.

[Before Screenshot - Accessibility Assessments Home Page](https://screenshot.googleplex.com/4i9LuiGwvLnEcZ8)
[Before Screenshot - Checkbox List Title -- note: each use case page is missing an h1](https://screenshot.googleplex.com/3qQjfqvAMTehRsm)
[After Screenshot - Accessibility Assessments Home Page](https://screenshot.googleplex.com/APSJJXBmwNBP35m)
[After Screenshot - Checkbox List Title-- note: change is similar across each Accessibility use case page](https://screenshot.googleplex.com/6EGgZnTusEgeN5L)

Fixes b/338035526

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
