### PR TITLE
[CP] Fix TextPainter's caret position calculation for text containing full-width

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -343,14 +343,14 @@ class _TextLayout {
     final int lastLineIndex = _paragraph.numberOfLines - 1;
     assert(lastLineIndex >= 0);
     final ui.LineMetrics lineMetrics = _paragraph.getLineMetricsAt(lastLineIndex)!;
-    // SkParagraph currently treats " " and "\t" as white spaces. Trailing white
-    // spaces don't contribute to the line width and thus require special handling
+    // Trailing white spaces don't contribute to the line width and thus require special handling
     // when they're present.
     // Luckily they have the same bidi embedding level as the paragraph as per
     // https://unicode.org/reports/tr9/#L1, so we can anchor the caret to the
     // last logical trailing space.
     final bool hasTrailingSpaces = switch (rawString.codeUnitAt(rawString.length - 1)) {
       0x9 ||        // horizontal tab
+      0x3000 ||     // ideographic space
       0x20 => true, // space
       _ => false,
     };

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -144,6 +144,19 @@ void main() {
       painter.layout();
       caretOffset = painter.getOffsetForCaret(ui.TextPosition(offset: text.length), ui.Rect.zero);
       expect(caretOffset.dx, painter.width);
+
+      // Test with trailing full-width space
+      const String textWithFullWidthSpace = 'A\u{3000}';
+      checkCaretOffsetsLtr(textWithFullWidthSpace);
+      painter.text = const TextSpan(text: textWithFullWidthSpace);
+      painter.layout();
+      caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 0), ui.Rect.zero);
+      expect(caretOffset.dx, 0);
+      caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 1), ui.Rect.zero);
+      expect(caretOffset.dx, painter.width / 2);
+      caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: textWithFullWidthSpace.length), ui.Rect.zero);
+      expect(caretOffset.dx, painter.width);
+
       painter.dispose();
     });
 


### PR DESCRIPTION
Cherry pick request of https://github.com/flutter/flutter/pull/149698 to stable.

Fixes the logic for caret position calculation when full-width spaces are present in the text.