### PR TITLE
Fix missing close bracket in NestedScrollView class docs

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -36,7 +36,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 ///
 /// The most common use case for this widget is a scrollable view with a
 /// flexible [SliverAppBar] containing a [TabBar] in the header (built by
-/// [headerSliverBuilder], and with a [TabBarView] in the [body], such that the
+/// [headerSliverBuilder]), and with a [TabBarView] in the [body], such that the
 /// scrollable view's contents vary based on which tab is visible.
 ///
 /// ## Motivation


### PR DESCRIPTION
The [NestedScrollView class docs](https://api.flutter.dev/flutter/widgets/NestedScrollView-class.html) are currently missing a close bracket in the second paragraph (emphasis below is mine):
> The most common use case for this widget is a scrollable view with a flexible [SliverAppBar](https://api.flutter.dev/flutter/material/SliverAppBar-class.html) containing a [TabBar](https://api.flutter.dev/flutter/material/TabBar-class.html) in the header **(built by [headerSliverBuilder](https://api.flutter.dev/flutter/widgets/NestedScrollView/headerSliverBuilder.html)**, and with a [TabBarView](https://api.flutter.dev/flutter/material/TabBarView-class.html) in the [body](https://api.flutter.dev/flutter/widgets/NestedScrollView/body.html), such that the scrollable view's contents vary based on which tab is visible.

I've simply added the close bracket after "(built by [headerSliverBuilder](https://api.flutter.dev/flutter/widgets/NestedScrollView/headerSliverBuilder.html)" so the paragraph becomes:

> The most common use case for this widget is a scrollable view with a flexible [SliverAppBar](https://api.flutter.dev/flutter/material/SliverAppBar-class.html) containing a [TabBar](https://api.flutter.dev/flutter/material/TabBar-class.html) in the header (built by [headerSliverBuilder](https://api.flutter.dev/flutter/widgets/NestedScrollView/headerSliverBuilder.html)), and with a [TabBarView](https://api.flutter.dev/flutter/material/TabBarView-class.html) in the [body](https://api.flutter.dev/flutter/widgets/NestedScrollView/body.html), such that the scrollable view's contents vary based on which tab is visible.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
