### PR TITLE
[CP] Make `CupertinoRadio`'s `mouseCursor` a `WidgetStateProperty` (#151910)

### DIFF
--- a/packages/flutter/lib/src/cupertino/radio.dart
+++ b/packages/flutter/lib/src/cupertino/radio.dart
@@ -121,6 +121,24 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// ```
   final ValueChanged<T?>? onChanged;
 
+  /// The cursor for a mouse pointer when it enters or is hovering over the
+  /// widget.
+  ///
+  /// Resolves in the following states:
+  ///
+  ///  * [WidgetState.selected].
+  ///  * [WidgetState.focused].
+  ///  * [WidgetState.disabled].
+  ///
+  /// Defaults to [defaultMouseCursor].
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetStateMouseCursor], a [MouseCursor] that implements
+  ///    `WidgetStateProperty` which is used in APIs that need to accept
+  ///    either a [MouseCursor] or a [WidgetStateProperty].
+  final WidgetStateProperty<MouseCursor>? mouseCursor;
+
   /// Set to true if this radio button is allowed to be returned to an
   /// indeterminate state by selecting it again when selected.
   ///
@@ -179,6 +197,18 @@ class CupertinoRadio<T> extends StatefulWidget {
   final bool autofocus;
 
   bool get _selected => value == groupValue;
+
+  /// The default [mouseCursor] of a [CupertinoRadio].
+  ///
+  /// If [onChanged] is null, indicating the radio button is disabled,
+  /// [SystemMouseCursors.basic] is used. Otherwise, [SystemMouseCursors.click]
+  /// is used on Web, and [SystemMouseCursors.basic] is used on other platforms.
+  static WidgetStateProperty<MouseCursor> defaultMouseCursor(Function? onChanged) {
+    final MouseCursor mouseCursor = (onChanged != null && kIsWeb)
+      ? SystemMouseCursors.click
+      : SystemMouseCursors.basic;
+    return WidgetStateProperty.all<MouseCursor>(mouseCursor);
+  }
 
   @override
   State<CupertinoRadio<T>> createState() => _CupertinoRadioState<T>();
@@ -258,6 +288,7 @@ class _CupertinoRadioState<T> extends State<CupertinoRadio<T>> with TickerProvid
       checked: widget._selected,
       selected: accessibilitySelected,
       child: buildToggleable(
+        mouseCursor: widget.mouseCursor ?? CupertinoRadio.defaultMouseCursor(widget.onChanged),
         focusNode: widget.focusNode,
         autofocus: widget.autofocus,
         onFocusChange: onFocusChange,

--- a/packages/flutter/lib/src/cupertino/radio.dart
+++ b/packages/flutter/lib/src/cupertino/radio.dart
@@ -71,6 +71,7 @@ class CupertinoRadio<T> extends StatefulWidget {
     required this.value,
     required this.groupValue,
     required this.onChanged,
+    this.mouseCursor,
     this.toggleable = false,
     this.activeColor,
     this.inactiveColor,

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -447,6 +447,11 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
               value: widget.value,
               groupValue: widget.groupValue,
               onChanged: widget.onChanged,
+              mouseCursor: widget.mouseCursor == null
+                ? CupertinoRadio.defaultMouseCursor(widget.onChanged)
+                : WidgetStateProperty.resolveWith((Set<MaterialState> states) {
+                    return WidgetStateProperty.resolveAs<MouseCursor>(widget.mouseCursor!, states);
+                  }),
               toggleable: widget.toggleable,
               activeColor: widget.activeColor,
               focusColor: widget.focusColor,

--- a/packages/flutter/test/cupertino/radio_test.dart
+++ b/packages/flutter/test/cupertino/radio_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -1855,6 +1855,46 @@ void main() {
     }
   });
 
+  testWidgets('Radio.adaptive respects Radio.mouseCursor', (WidgetTester tester) async {
+    Widget buildApp({required TargetPlatform platform, MouseCursor? mouseCursor}) {
+      return MaterialApp(
+        theme: ThemeData(platform: platform),
+        home: Material(
+          child: Radio<int>.adaptive(
+            value: 1,
+            groupValue: 1,
+            onChanged: (int? i) {},
+            mouseCursor: mouseCursor,
+          ),
+        ),
+      );
+    }
+
+    for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.iOS, TargetPlatform.macOS ]) {
+      await tester.pumpWidget(buildApp(platform: platform));
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+
+      // Test default mouse cursor.
+      await gesture.addPointer(location: tester.getCenter(find.byType(CupertinoRadio<int>)));
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(find.byType(CupertinoRadio<int>)));
+      expect(
+        RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+        kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,
+      );
+
+      // Test mouse cursor can be configured.
+      await tester.pumpWidget(buildApp(platform: platform, mouseCursor: SystemMouseCursors.forbidden));
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
+
+      // Test Radio.adaptive can resolve a WidgetStateMouseCursor.
+      await tester.pumpWidget(buildApp(platform: platform, mouseCursor: const _SelectedGrabMouseCursor()));
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.grab);
+
+      await gesture.removePointer();
+    }
+  });
+
   testWidgets('Material2 - Radio default overlayColor and fillColor resolves pressed state', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Radio');
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
@@ -1988,4 +2028,19 @@ void main() {
     );
     focusNode.dispose();
   });
+}
+
+class _SelectedGrabMouseCursor extends WidgetStateMouseCursor {
+  const _SelectedGrabMouseCursor();
+
+  @override
+  MouseCursor resolve(Set<WidgetState> states) {
+    if (states.contains(WidgetState.selected)) {
+      return SystemMouseCursors.grab;
+    }
+    return SystemMouseCursors.basic;
+  }
+
+  @override
+  String get debugDescription => '_SelectedGrabMouseCursor()';
 }


### PR DESCRIPTION
CP of https://github.com/flutter/flutter/pull/151910 to beta.

This PR changes `mouseCursor` to be of type `WidgetStateProperty<MouseCursor>`.
