### PR TITLE
fix when filteredEntries isEmpty, thrown rangeError exception(#152079)

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -604,6 +604,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     if (searchText.isEmpty) {
       return null;
     }
+    if (entries.isEmpty) {
+      return null;
+    }
     if (currentHighlight != null && entries[currentHighlight!].label.toLowerCase().contains(searchText)) {
       return currentHighlight;
     }

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2432,6 +2432,32 @@ void main() {
     final TextField textField = tester.widget(find.byType(TextField));
     expect(textField.keyboardType, TextInputType.text);
   });
+
+  testWidgets('When filteredEntries isEmpty, no RangeError exception is thrown', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData();
+    await tester.pumpWidget(MaterialApp(
+      theme: themeData,
+      home: Scaffold(
+        body: DropdownMenu<TestMenu>(
+          requestFocusOnTap: true,
+          enableFilter: true,
+          initialSelection: TestMenu.mainMenu1,
+          dropdownMenuEntries: menuChildren,
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
+
+    await tester.enterText(find
+        .byType(TextField)
+        .first, 'Menu 11');
+    await tester.pumpAndSettle();
+
+    // No exception should be thrown.
+    expect(tester.takeException(), isNull);
+  });
 }
 
 enum TestMenu {


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/152079

Pre-launch Checklist
- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/wiki/Tree-hygiene#overview) and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene) wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo), including [Features we expect every widget to implement](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with ///).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/wiki/Tree-hygiene#tests).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord](https://github.com/flutter/flutter/wiki/Chat).