### PR TITLE
feat: Add drag handle size to be configurable based on given size

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -5,6 +5,8 @@
 /// @docImport 'dart:ui';
 library;
 
+import 'dart:math' as math;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -460,8 +462,8 @@ class _DragHandle extends StatelessWidget {
         container: true,
         onTap: onSemanticsTap,
         child: SizedBox(
-          height: kMinInteractiveDimension,
-          width: kMinInteractiveDimension,
+          width: math.max(handleSize.width, kMinInteractiveDimension),
+          height: math.max(handleSize.height, kMinInteractiveDimension),
           child: Center(
             child: Container(
               height: handleSize.height,

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -1281,6 +1281,80 @@ void main() {
     await checkDragHandleAndColors();
   });
 
+  testWidgets('Drag handle interactive area size at minimum possible size', (WidgetTester tester) async {
+    Widget buildScaffold(GlobalKey scaffoldKey, {Size? dragHandleSize}) {
+      return MaterialApp(
+        theme: ThemeData.light().copyWith(
+          bottomSheetTheme:  BottomSheetThemeData(
+            dragHandleSize: dragHandleSize
+          ),
+        ),
+        home: Scaffold(
+          key: scaffoldKey,
+        ),
+      );
+    }
+
+    const Size smallerDragHandleSize = Size(20, 20);
+
+    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+    await tester.pumpWidget(buildScaffold(scaffoldKey, dragHandleSize: smallerDragHandleSize));
+
+    showModalBottomSheet<void>(
+      context: scaffoldKey.currentContext!,
+      showDragHandle: true,
+      builder: (BuildContext context) {
+        return const Text('BottomSheet');
+      },
+    );
+
+    await tester.pump(); // Bottom sheet show animation starts.
+    await tester.pump(const Duration(seconds: 1)); // Animation done.
+
+    final Finder dragHandle = find.bySemanticsLabel('Dismiss');
+    expect(
+      tester.getSize(dragHandle),
+      const Size(kMinInteractiveDimension, kMinInteractiveDimension),
+    );
+  });
+
+  testWidgets('Drag handle interactive area size at given dragHandleSize', (WidgetTester tester) async {
+    Widget buildScaffold(GlobalKey scaffoldKey, {Size? dragHandleSize}) {
+      return MaterialApp(
+        theme: ThemeData.light().copyWith(
+          bottomSheetTheme: BottomSheetThemeData(
+            dragHandleSize: dragHandleSize
+          ),
+        ),
+        home: Scaffold(
+          key: scaffoldKey,
+        ),
+      );
+    }
+
+    const Size extendedDragHandleSize = Size(100, 50);
+
+    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+    await tester.pumpWidget(buildScaffold(scaffoldKey, dragHandleSize: extendedDragHandleSize));
+
+    showModalBottomSheet<void>(
+      context: scaffoldKey.currentContext!,
+      showDragHandle: true,
+      builder: (BuildContext context) {
+        return const Text('BottomSheet');
+      },
+    );
+
+    await tester.pump(); // Bottom sheet show animation starts.
+    await tester.pump(const Duration(seconds: 1)); // Animation done.
+
+    final Finder dragHandle = find.bySemanticsLabel('Dismiss');
+    expect(
+      tester.getSize(dragHandle),
+      extendedDragHandleSize,
+    );
+  });
+
   testWidgets('showModalBottomSheet does not use root Navigator by default', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(


### PR DESCRIPTION
Feat: Drag handle size can now be changed to any given size.
So, In previous behaviour drag handle size was not able to extends beyond 48x48. But some user might want to change it.
In current behaviour,  drag handle size is default to same 48x48 but if drag handle size grows beyond that, we don't restrict it.

Fixes #149170 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.