### PR TITLE
Explain that predictive back doesn't work with WillPopScope

### DIFF
--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -16,14 +16,14 @@ import 'routes.dart';
 ///  * [Form], which provides an `onWillPop` callback that enables the form
 ///    to veto a `pop` initiated by the app's back button.
 @Deprecated(
-  "Use PopScope instead. Android's predictive back feature will not work with WillPopScope. "
+  'Use PopScope instead. The Android predictive back feature will not work with WillPopScope. '
   'This feature was deprecated after v3.12.0-1.0.pre.',
 )
 class WillPopScope extends StatefulWidget {
   /// Creates a widget that registers a callback to veto attempts by the user to
   /// dismiss the enclosing [ModalRoute].
   @Deprecated(
-    "Use PopScope instead. Android's predictive back feature will not work with WillPopScope. "
+    'Use PopScope instead. The Android predictive back feature will not work with WillPopScope. '
     'This feature was deprecated after v3.12.0-1.0.pre.',
   )
   const WillPopScope({

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -16,14 +16,14 @@ import 'routes.dart';
 ///  * [Form], which provides an `onWillPop` callback that enables the form
 ///    to veto a `pop` initiated by the app's back button.
 @Deprecated(
-  'Use PopScope instead. '
+  "Use PopScope instead. Android's predictive back feature will not work with WillPopScope. "
   'This feature was deprecated after v3.12.0-1.0.pre.',
 )
 class WillPopScope extends StatefulWidget {
   /// Creates a widget that registers a callback to veto attempts by the user to
   /// dismiss the enclosing [ModalRoute].
   @Deprecated(
-    'Use PopScope instead. '
+    "Use PopScope instead. Android's predictive back feature will not work with WillPopScope. "
     'This feature was deprecated after v3.12.0-1.0.pre.',
   )
   const WillPopScope({


### PR DESCRIPTION
Clearly explains that WillPopScope will break predictive back support.

Came up in https://github.com/flutter/flutter/pull/152057#pullrequestreview-2191560087.