### PR TITLE
Add test for range_slider.0.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -314,7 +314,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/material_state/material_state_outlined_border.0_test.dart',
   'examples/api/test/material/material_state/material_state_property.0_test.dart',
   'examples/api/test/material/selectable_region/selectable_region.0_test.dart',
-  'examples/api/test/material/range_slider/range_slider.0_test.dart',
   'examples/api/test/material/selection_container/selection_container_disabled.0_test.dart',
   'examples/api/test/material/selection_container/selection_container.0_test.dart',
   'examples/api/test/material/color_scheme/dynamic_content_color.0_test.dart',

--- a/examples/api/test/material/range_slider/range_slider.0_test.dart
+++ b/examples/api/test/material/range_slider/range_slider.0_test.dart
@@ -1,0 +1,76 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/range_slider/range_slider.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The range slider should have 5 divisions from 0 to 100', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.RangeSliderExampleApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'RangeSlider Sample'), findsOne);
+    expect(
+      find.byWidgetPredicate((Widget widget) => widget is RangeSlider && widget.values == const RangeValues(40, 80)),
+      findsOne,
+    );
+
+    final Rect rangeSliderRect = tester.getRect(find.byType(RangeSlider));
+
+    final double y = rangeSliderRect.centerRight.dy;
+    final double startX = rangeSliderRect.centerLeft.dx;
+    final double endX = rangeSliderRect.centerRight.dx;
+
+    // Drag the start to 0.
+    final TestGesture drag = await tester.startGesture(Offset(startX + (endX - startX) * 0.4, y));
+    await tester.pump(kPressTimeout);
+    await drag.moveTo(rangeSliderRect.centerLeft);
+    await drag.up();
+    await tester.pump();
+
+    expect(
+      find.byWidgetPredicate((Widget widget) => widget is RangeSlider && widget.values == const RangeValues(0, 80)),
+      findsOne,
+    );
+
+    // Drag the start to 20.
+    await drag.down(rangeSliderRect.centerLeft);
+    await tester.pump(kPressTimeout);
+    await drag.moveTo(Offset(startX + (endX - startX) * 0.2, y));
+    await drag.up();
+    await tester.pump();
+
+    expect(
+      find.byWidgetPredicate((Widget widget) => widget is RangeSlider && widget.values == const RangeValues(20, 80)),
+      findsOne,
+    );
+
+    // Drag the end to 60.
+    await drag.down(Offset(startX + (endX - startX) * 0.8, y));
+    await tester.pump(kPressTimeout);
+    await drag.moveTo(Offset(startX + (endX - startX) * 0.6, y));
+    await drag.up();
+    await tester.pump();
+
+    expect(
+      find.byWidgetPredicate((Widget widget) => widget is RangeSlider && widget.values == const RangeValues(20, 60)),
+      findsOne,
+    );
+
+    // Drag the end to 100.
+    await drag.down(Offset(startX + (endX - startX) * 0.6, y));
+    await tester.pump(kPressTimeout);
+    await drag.moveTo(rangeSliderRect.centerRight);
+    await drag.up();
+    await tester.pump();
+
+    expect(
+      find.byWidgetPredicate((Widget widget) => widget is RangeSlider && widget.values == const RangeValues(20, 100)),
+      findsOne,
+    );
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/material/range_slider/range_slider.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
