### PR TITLE
Update fake_codec.dart to use Future.value instead of SynchronousFuture

### DIFF
--- a/packages/flutter/test/painting/fake_codec.dart
+++ b/packages/flutter/test/painting/fake_codec.dart
@@ -44,8 +44,8 @@ class FakeCodec implements ui.Codec {
   @override
   Future<ui.FrameInfo> getNextFrame() {
     _numFramesAsked += 1;
-    final SynchronousFuture<ui.FrameInfo> result =
-      SynchronousFuture<ui.FrameInfo>(_frameInfos[_nextFrame]);
+    final Future<ui.FrameInfo> result =
+      Future<ui.FrameInfo>.value(_frameInfos[_nextFrame]);
     _nextFrame = (_nextFrame + 1) % _frameCount;
     return result;
   }


### PR DESCRIPTION
Upcoming changes to DDC change the async semantics of code produced by the compiler. The changes will bring the semantics more in line with those of dart2js and fix several bugs in the old semantics. However in landing those changes I experienced a test failure in [obscured_animated_image_test](https://github.com/flutter/flutter/blob/master/packages/flutter/test/widgets/obscured_animated_image_test.dart).

Some debugging uncovered that this is due to the use of `SynchronousFuture` in this `FakeCodec`. The old DDC async semantics forced an async gap when that future was [awaited](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/painting/image_stream.dart#L1064). The new async semantics do not create an async gap here. This changes the render ordering of the widget tree created in the test leading to the test failure.

`Future.value` should be a reasonable substitute here and should achieve what the test was trying to achieve while also preserving the correct render ordering given the new DDC semantics.