### PR TITLE
Allow-list `sh` as a code-snippet type.

### DIFF
--- a/dev/bots/analyze_snippet_code.dart
+++ b/dev/bots/analyze_snippet_code.dart
@@ -677,7 +677,8 @@ class _SnippetChecker {
                        line.contains('```swift') ||
                        line.contains('```glsl') ||
                        line.contains('```json') ||
-                       line.contains('```csv')) {
+                       line.contains('```csv') ||
+                       line.contains('```sh')) {
               inOtherBlock = true;
             } else if (line.startsWith(_uncheckedCodeBlockStartRegex)) {
               // this is an intentionally-unchecked block that doesn't appear in the API docs.


### PR DESCRIPTION
Otherwise I get the following failure on CI:

```txt
packages/flutter_driver/lib/src/native/android.dart:123: Found "```" in code but it did not match RegExp: pattern=^ */// *```dart$ flags= so something is wrong. Line was: "  /// ```sh"
Found 1 snippet code errors.
See the documentation at the top of dev/bots/analyze_snippet_code.dart for details.
```

It seems reasonable to put a reference to a shell command in a Dartdoc comment.