### PR TITLE
fix(flutter/a11y assessments): h1 missing a11y from each page on the web app

### DIFF
--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -77,7 +77,13 @@ class HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Accessibility Assessments')),
+      appBar: AppBar(
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Accessibility Assessments'),
+        ),
+      ),
       body: Center(
         child: ListView(
           controller: scrollController,

--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -78,11 +78,7 @@ class HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('Accessibility Assessments'),
-        ),
+        title: const Text('Accessibility Assessments'),
       ),
       body: Center(
         child: ListView(

--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -78,7 +78,7 @@ class HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Accessibility Assessments'),
+        title: Semantics(headingLevel: 1, child: const Text('Accessibility Assessments')),
       ),
       body: Center(
         child: ListView(

--- a/dev/a11y_assessments/lib/use_cases/action_chip.dart
+++ b/dev/a11y_assessments/lib/use_cases/action_chip.dart
@@ -31,7 +31,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('ActionChip'),
+        title: Semantics(headingLevel:1, child: const Text('ActionChip')),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -50,7 +50,7 @@ class _MainWidgetState extends State<_MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('AutoComplete Demo'),
+        title: Semantics(headingLevel: 1, child: const Text('AutoComplete Demo')),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -45,17 +45,12 @@ class _MainWidgetState extends State<_MainWidget> {
     );
   }
 
-  Widget semanticsH1 = Semantics(
-    header: true,
-    headingLevel: 1,
-    child: const Text('AutoComplete Demo'));
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: semanticsH1,
+        title: const Text('AutoComplete Demo'),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -45,12 +45,17 @@ class _MainWidgetState extends State<_MainWidget> {
     );
   }
 
+  Widget semanticsH1 = Semantics(
+    header: true,
+    headingLevel: 1,
+    child: const Text('AutoComplete Demo'));
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('AutoComplete'),
+        title: semanticsH1,
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -31,7 +31,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Badge Demo'),
+        title: Semantics(headingLevel: 1, child: const Text('Badge Demo')),
       ),
       body: const Center(
         child: Badge(

--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -25,16 +25,18 @@ class MainWidget extends StatefulWidget {
 }
 
 class MainWidgetState extends State<MainWidget> {
+
+  Widget semanticsH1 = Semantics(
+    header: true,
+    headingLevel: 1,
+    child: const Text('Badge Demo'));
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('Badge'),
-        ),
+        title: semanticsH1,
       ),
       body: const Center(
         child: Badge(

--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -26,17 +26,12 @@ class MainWidget extends StatefulWidget {
 
 class MainWidgetState extends State<MainWidget> {
 
-  Widget semanticsH1 = Semantics(
-    header: true,
-    headingLevel: 1,
-    child: const Text('Badge Demo'));
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: semanticsH1,
+        title: const Text('Badge Demo'),
       ),
       body: const Center(
         child: Badge(

--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -30,7 +30,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Badge'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Badge'),
+        ),
       ),
       body: const Center(
         child: Badge(

--- a/dev/a11y_assessments/lib/use_cases/card.dart
+++ b/dev/a11y_assessments/lib/use_cases/card.dart
@@ -31,7 +31,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Card'),
+        title: Semantics(headingLevel: 1, child: const Text('Card')),
       ),
       body: const Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
@@ -29,7 +29,7 @@ class _MainWidgetState extends State<_MainWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('CheckBoxListTile Demo'),
+        title: Semantics(headingLevel: 1, child: const Text('CheckBoxListTile Demo')),
       ),
       body: ListView(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
@@ -28,7 +28,13 @@ class _MainWidgetState extends State<_MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('CheckBoxListTile')),
+      appBar: AppBar(
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('CheckBoxListTile')
+        ),
+      ),
       body: ListView(
         children: <Widget>[
           CheckboxListTile(

--- a/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
@@ -29,11 +29,7 @@ class _MainWidgetState extends State<_MainWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('CheckBoxListTile Demo')
-        ),
+        title: const Text('CheckBoxListTile Demo'),
       ),
       body: ListView(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
@@ -32,7 +32,7 @@ class _MainWidgetState extends State<_MainWidget> {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('CheckBoxListTile')
+          child: const Text('CheckBoxListTile Demo')
         ),
       ),
       body: ListView(

--- a/dev/a11y_assessments/lib/use_cases/date_picker.dart
+++ b/dev/a11y_assessments/lib/use_cases/date_picker.dart
@@ -30,7 +30,11 @@ class _MainWidgetState extends State<_MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('DatePicker'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('DatePicker'),
+        ),
       ),
       body: Center(
         child: TextButton(

--- a/dev/a11y_assessments/lib/use_cases/date_picker.dart
+++ b/dev/a11y_assessments/lib/use_cases/date_picker.dart
@@ -33,7 +33,7 @@ class _MainWidgetState extends State<_MainWidget> {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('DatePicker'),
+          child: const Text('DatePicker Demo'),
         ),
       ),
       body: Center(

--- a/dev/a11y_assessments/lib/use_cases/date_picker.dart
+++ b/dev/a11y_assessments/lib/use_cases/date_picker.dart
@@ -30,7 +30,7 @@ class _MainWidgetState extends State<_MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('DatePicker Demo'),
+        title: Semantics(headingLevel: 1, child: const Text('DatePicker Demo')),
       ),
       body: Center(
         child: TextButton(

--- a/dev/a11y_assessments/lib/use_cases/date_picker.dart
+++ b/dev/a11y_assessments/lib/use_cases/date_picker.dart
@@ -30,11 +30,7 @@ class _MainWidgetState extends State<_MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('DatePicker Demo'),
-        ),
+        title: const Text('DatePicker Demo'),
       ),
       body: Center(
         child: TextButton(

--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -24,7 +24,11 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Dialog'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Dialog'),
+        ),
       ),
       body: Center(
         child: TextButton(

--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -24,7 +24,7 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Dialog Demo'),
+        title: Semantics(headingLevel: 1, child: const Text('Dialog Demo')),
       ),
       body: Center(
         child: TextButton(

--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -27,7 +27,7 @@ class _MainWidget extends StatelessWidget {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('Dialog'),
+          child: const Text('Dialog Demo'),
         ),
       ),
       body: Center(

--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -24,11 +24,7 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('Dialog Demo'),
-        ),
+        title: const Text('Dialog Demo'),
       ),
       body: Center(
         child: TextButton(

--- a/dev/a11y_assessments/lib/use_cases/drawer.dart
+++ b/dev/a11y_assessments/lib/use_cases/drawer.dart
@@ -31,8 +31,8 @@ class _DrawerExampleState extends State<DrawerExample> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Drawer Example'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Semantics(headingLevel: 1, child: const Text('Drawer Demo')),
       ),
       endDrawer: Drawer(
         child: ListView(

--- a/dev/a11y_assessments/lib/use_cases/expansion_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/expansion_tile.dart
@@ -32,7 +32,7 @@ class _ExpansionTileExampleState extends State<ExpansionTileExample> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('ExpansionTile'),
+        title: Semantics(headingLevel: 1, child: const Text('ExpansionTile')),
       ),
       body: Column(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -60,7 +60,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('MaterialBanner'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('MaterialBanner'),
+        ),
       ),
       body: Center(
         child: ElevatedButton(

--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -63,7 +63,7 @@ class MainWidgetState extends State<MainWidget> {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('MaterialBanner'),
+          child: const Text('MaterialBanner Demo'),
         ),
       ),
       body: Center(

--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -60,7 +60,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title:  const Text('MaterialBanner Demo'),
+        title: Semantics(headingLevel: 1, child: const Text('MaterialBanner Demo')),
       ),
       body: Center(
         child: ElevatedButton(

--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -60,11 +60,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('MaterialBanner Demo'),
-        ),
+        title:  const Text('MaterialBanner Demo'),
       ),
       body: Center(
         child: ElevatedButton(

--- a/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
@@ -32,7 +32,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('NavigationBar Demo'),
+        title: Semantics(headingLevel: 1, child: const Text('NavigationBar Demo')),
       ),
       bottomNavigationBar: NavigationBar(
         onDestinationSelected: (int index) {

--- a/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
@@ -32,7 +32,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('NavigationBar'),
+        title: const Text('NavigationBar Demo'),
       ),
       bottomNavigationBar: NavigationBar(
         onDestinationSelected: (int index) {

--- a/dev/a11y_assessments/lib/use_cases/navigation_drawer.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_drawer.dart
@@ -62,8 +62,8 @@ class _NavigationDrawerExampleState extends State<NavigationDrawerExample> {
     return Scaffold(
       key: scaffoldKey,
       appBar: AppBar(
-        title: const Text('Navigation Drawer Example'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Semantics(headingLevel: 1, child: const Text('Navigation Drawer Demo')),
       ),
       body: SafeArea(
         bottom: false,

--- a/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
@@ -37,7 +37,7 @@ class _MainWidgetState extends State<_MainWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Radio button demo')
+        title: Semantics(headingLevel: 1, child: const Text('Radio button demo'))
       ),
       body: ListView(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
@@ -40,7 +40,7 @@ class _MainWidgetState extends State<_MainWidget> {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('Radio button')
+          child: const Text('Radio button demo')
         ),
       ),
       body: ListView(

--- a/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
@@ -36,7 +36,13 @@ class _MainWidgetState extends State<_MainWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Radio button')),
+      appBar: AppBar(
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Radio button')
+        ),
+      ),
       body: ListView(
         children: <Widget>[
           RadioListTile<SingingCharacter>(

--- a/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
@@ -37,11 +37,7 @@ class _MainWidgetState extends State<_MainWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('Radio button demo')
-        ),
+        title: const Text('Radio button demo')
       ),
       body: ListView(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -33,7 +33,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Slider'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('Slider'),
+        ),
       ),
       body: Center(
         child: Semantics(

--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -33,7 +33,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Slider demo'),
+        title: Semantics(headingLevel: 1, child: const Text('Slider demo')),
       ),
       body: Center(
         child: Semantics(

--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -36,7 +36,7 @@ class MainWidgetState extends State<MainWidget> {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('Slider'),
+          child: const Text('Slider demo'),
         ),
       ),
       body: Center(

--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -33,11 +33,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('Slider demo'),
-        ),
+        title: const Text('Slider demo'),
       ),
       body: Center(
         child: Semantics(

--- a/dev/a11y_assessments/lib/use_cases/snack_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/snack_bar.dart
@@ -30,7 +30,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('SnackBar'),
+        title: Semantics(headingLevel: 1, child: const Text('SnackBar')),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/switch_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/switch_list_tile.dart
@@ -32,7 +32,7 @@ class _SwitchListTileExampleState extends State<SwitchListTileExample> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('SwitchListTile'),
+        title: Semantics(headingLevel: 1, child: const Text('SwitchListTile')),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -32,7 +32,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextButton'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('TextButton'),
+        ),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -32,7 +32,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextButton Demo'),
+        title: Semantics(headingLevel: 1, child: const Text('TextButton Demo')),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -35,7 +35,7 @@ class MainWidgetState extends State<MainWidget> {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('TextButton'),
+          child: const Text('TextButton Demo'),
         ),
       ),
       body: Center(

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -32,11 +32,7 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('TextButton Demo'),
-        ),
+        title: const Text('TextButton Demo'),
       ),
       body: Center(
         child: Column(

--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -25,7 +25,11 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextField'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('TextField'),
+        ),
       ),
       body: ListView(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -25,11 +25,7 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('TextField demo'),
-        ),
+        title: const Text('TextField demo'),
       ),
       body: ListView(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -25,7 +25,7 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextField demo'),
+        title: Semantics(headingLevel: 1, child: const Text('TextField demo')),
       ),
       body: ListView(
         children: <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -28,7 +28,7 @@ class _MainWidget extends StatelessWidget {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('TextField'),
+          child: const Text('TextField demo'),
         ),
       ),
       body: ListView(

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -25,7 +25,11 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextField password'),
+        title: Semantics(
+          header: true,
+          headingLevel: 1,
+          child: const Text('TextField password'),
+        ),
       ),
       body: ListView(
         children: const <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -28,7 +28,7 @@ class _MainWidget extends StatelessWidget {
         title: Semantics(
           header: true,
           headingLevel: 1,
-          child: const Text('TextField password'),
+          child: const Text('TextField password demo'),
         ),
       ),
       body: ListView(

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -25,11 +25,7 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(
-          header: true,
-          headingLevel: 1,
-          child: const Text('TextField password demo'),
-        ),
+        title: const Text('TextField password demo'),
       ),
       body: ListView(
         children: const <Widget>[

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -25,7 +25,7 @@ class _MainWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('TextField password demo'),
+        title: Semantics(headingLevel: 1, child: const Text('TextField password demo')),
       ),
       body: ListView(
         children: const <Widget>[

--- a/dev/a11y_assessments/test/auto_complete_test.dart
+++ b/dev/a11y_assessments/test/auto_complete_test.dart
@@ -16,4 +16,13 @@ void main() {
 
     expect(find.text('apple'), findsOneWidget);
   });
+
+  testWidgets('auto complete has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, AutoCompleteUseCase());
+    final Widget semanticsH1 = Semantics(
+      header: true,
+      headingLevel: 1,
+      child: const Text('AutoComplete Demo'));
+    expect(find.byWidget(semanticsH1), findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/auto_complete_test.dart
+++ b/dev/a11y_assessments/test/auto_complete_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:a11y_assessments/use_cases/auto_complete.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_utils.dart';
@@ -19,10 +20,8 @@ void main() {
 
   testWidgets('auto complete has one h1 tag', (WidgetTester tester) async {
     await pumpsUseCase(tester, AutoCompleteUseCase());
-    final Widget semanticsH1 = Semantics(
-      header: true,
-      headingLevel: 1,
-      child: const Text('AutoComplete Demo'));
-    expect(find.byWidget(semanticsH1), findsOne);
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel(RegExp('AutoComplete Demo'));
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
   });
 }

--- a/dev/a11y_assessments/test/auto_complete_test.dart
+++ b/dev/a11y_assessments/test/auto_complete_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:a11y_assessments/use_cases/auto_complete.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_utils.dart';

--- a/dev/a11y_assessments/test/badge_test.dart
+++ b/dev/a11y_assessments/test/badge_test.dart
@@ -13,4 +13,11 @@ void main() {
     expect(find.semantics.byLabel('5 new messages'), findsOne);
     expect(find.semantics.byLabel('Messages'), findsOne);
   });
+
+  testWidgets('badge has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, BadgeUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel(RegExp('Badge Demo'));
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/check_box_list_tile_test.dart
+++ b/dev/a11y_assessments/test/check_box_list_tile_test.dart
@@ -14,4 +14,11 @@ void main() {
     expect(find.text('a check box list title'), findsOneWidget);
     expect(find.text('a disabled check box list title'), findsOneWidget);
   });
+
+  testWidgets('check box list has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, CheckBoxListTile());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel(RegExp('CheckBoxListTile Demo'));
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/date_picker_test.dart
+++ b/dev/a11y_assessments/test/date_picker_test.dart
@@ -17,4 +17,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(DatePickerDialog), findsOneWidget);
   });
+
+  testWidgets('datepicker has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, DatePickerUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('DatePicker Demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/dialog_test.dart
+++ b/dev/a11y_assessments/test/dialog_test.dart
@@ -28,4 +28,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('This is a typical dialog.'), findsNothing);
   });
+
+  testWidgets('dialog has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, DialogUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('Dialog Demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/drawer_test.dart
+++ b/dev/a11y_assessments/test/drawer_test.dart
@@ -20,4 +20,11 @@ void main() {
 
     expect(find.byType(Drawer), findsExactly(1));
   });
+
+  testWidgets('drawer has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, DrawerUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('Drawer Demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/home_page_test.dart
+++ b/dev/a11y_assessments/test/home_page_test.dart
@@ -140,4 +140,11 @@ void main() {
     expect(appScheme.inversePrimary.value,
         MaterialDynamicColors.inversePrimary.getArgb(highContrastScheme));
   });
+
+  testWidgets('a11y assessments home page has one h1 tag', (WidgetTester tester) async {
+    await tester.pumpWidget(const App());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('Accessibility Assessments');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/material_banner_test.dart
+++ b/dev/a11y_assessments/test/material_banner_test.dart
@@ -20,4 +20,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Hello, I am a Material Banner'), findsNothing);
   });
+
+  testWidgets('material banner has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, MaterialBannerUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('MaterialBanner Demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/navigation_bar_test.dart
+++ b/dev/a11y_assessments/test/navigation_bar_test.dart
@@ -20,4 +20,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Page 3'), findsOneWidget);
   });
+
+  testWidgets('navigation bar has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, NavigationBarUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('NavigationBar Demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/navigation_drawer_test.dart
+++ b/dev/a11y_assessments/test/navigation_drawer_test.dart
@@ -20,4 +20,11 @@ void main() {
 
     expect(find.byType(NavigationDrawer), findsExactly(1));
   });
+
+  testWidgets('navigation drawer has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, NavigationDrawerUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('Navigation Drawer Demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/radio_list_tile_test.dart
+++ b/dev/a11y_assessments/test/radio_list_tile_test.dart
@@ -14,4 +14,11 @@ void main() {
     expect(find.text('Lafayette'), findsOneWidget);
     expect(find.text('Jefferson'), findsOneWidget);
   });
+
+  testWidgets('radio button demo page has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, RadioListTileUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('Radio button demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/slider_test.dart
+++ b/dev/a11y_assessments/test/slider_test.dart
@@ -26,4 +26,11 @@ void main() {
         find.bySemanticsLabel('Accessibility Test Slider');
     expect(semanticsWidget, findsOneWidget);
   });
+
+  testWidgets('slider demo page has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, SliderUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('Slider demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/text_button_test.dart
+++ b/dev/a11y_assessments/test/text_button_test.dart
@@ -27,4 +27,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Clicked 2 time(s).'), findsOneWidget);
   });
+
+  testWidgets('text button demo page has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextButtonUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('TextButton Demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/text_field_password_test.dart
+++ b/dev/a11y_assessments/test/text_field_password_test.dart
@@ -50,4 +50,11 @@ void main() {
       expect(textField.decoration?.hintText, isNull);
     }
   });
+
+  testWidgets('text field password demo page has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextFieldPasswordUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('TextField password demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/dev/a11y_assessments/test/text_field_test.dart
+++ b/dev/a11y_assessments/test/text_field_test.dart
@@ -64,4 +64,11 @@ void main() {
         find.bySemanticsLabel(RegExp(textFieldLabel));
     expect(semanticsWidgets, findsExactly(2));
   });
+
+  testWidgets('text field demo page has one h1 tag', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextFieldUseCase());
+    final Finder findHeadingLevelOnes = find.bySemanticsLabel('TextField demo');
+    await tester.pumpAndSettle();
+    expect(findHeadingLevelOnes, findsOne);
+  });
 }

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -946,9 +946,6 @@ class _LargeTitleNavigationBarSliverDelegate
                       duration: _kNavBarTitleFadeDuration,
                       child: Semantics(
                         header: true,
-                        // set default headingLevel: 1 for one h1 element
-                        // per page to meet accessibility guidelines
-                        headingLevel: 1,
                         child: DefaultTextStyle(
                           style: CupertinoTheme.of(context)
                               .textTheme
@@ -1188,9 +1185,7 @@ class _PersistentNavigationBar extends StatelessWidget {
     if (middle != null) {
       middle = DefaultTextStyle(
         style: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
-        // set default headingLevel: 1 for one h1 element
-        // per page to meet accessibility guidelines
-        child: Semantics(header: true, headingLevel: 1, child: middle),
+        child: Semantics(header: true, child: middle),
       );
       // When the middle's visibility can change on the fly like with large title
       // slivers, wrap with animated opacity.

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -946,6 +946,9 @@ class _LargeTitleNavigationBarSliverDelegate
                       duration: _kNavBarTitleFadeDuration,
                       child: Semantics(
                         header: true,
+                        // set default headingLevel: 1 for one h1 element
+                        // per page to meet accessibility guidelines
+                        headingLevel: 1,
                         child: DefaultTextStyle(
                           style: CupertinoTheme.of(context)
                               .textTheme
@@ -1185,7 +1188,9 @@ class _PersistentNavigationBar extends StatelessWidget {
     if (middle != null) {
       middle = DefaultTextStyle(
         style: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
-        child: Semantics(header: true, child: middle),
+        // set default headingLevel: 1 for one h1 element
+        // per page to meet accessibility guidelines
+        child: Semantics(header: true, headingLevel: 1, child: middle),
       );
       // When the middle's visibility can change on the fly like with large title
       // slivers, wrap with animated opacity.

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -991,9 +991,6 @@ class _AppBarState extends State<AppBar> {
             TargetPlatform.iOS || TargetPlatform.macOS => null,
           },
           header: true,
-          // set default headingLevel: 1 for one h1 element
-          // per page to meet accessibility guidelines
-          headingLevel: 1,
           child: title,
         );
       }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -991,6 +991,7 @@ class _AppBarState extends State<AppBar> {
             TargetPlatform.iOS || TargetPlatform.macOS => null,
           },
           header: true,
+          headingLevel: 1,
           child: title,
         );
       }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -991,6 +991,8 @@ class _AppBarState extends State<AppBar> {
             TargetPlatform.iOS || TargetPlatform.macOS => null,
           },
           header: true,
+          // set default headingLevel: 1 for one h1 element
+          // per page to meet accessibility guidelines
           headingLevel: 1,
           child: title,
         );


### PR DESCRIPTION
Adds Semantic Widget to wrap the contents of each page's AppBar title attribute and adds header: true and headingLevel: 1 as Semantic attributes so the content of the title is compiled as an h1 tag to meet accessibility guidelines that each page must have a h1 tag present. Also updates the test cases for the home page and each use case page to check for its respective h1.

[Before Screenshot - Accessibility Assessments Home Page](https://screenshot.googleplex.com/4i9LuiGwvLnEcZ8)
[Before Screenshot - Checkbox List Title -- note: each use case page is missing an h1](https://screenshot.googleplex.com/3qQjfqvAMTehRsm)
[After Screenshot - Accessibility Assessments Home Page](https://screenshot.googleplex.com/APSJJXBmwNBP35m)
[After Screenshot - Checkbox List Title-- note: change is similar across each Accessibility use case page](https://screenshot.googleplex.com/6EGgZnTusEgeN5L)

Fixes b/338035526

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
