### PR TITLE
Revert "Make `CupertinoRadio`'s `mouseCursor` a `WidgetStateProperty`"

### DIFF
--- a/packages/flutter/lib/src/cupertino/radio.dart
+++ b/packages/flutter/lib/src/cupertino/radio.dart
@@ -132,20 +132,24 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
-  /// Resolves in the following states:
+  /// If [mouseCursor] is a [WidgetStateMouseCursor],
+  /// [WidgetStateMouseCursor.resolve] is used for the following [WidgetState]s:
   ///
   ///  * [WidgetState.selected].
+  ///  * [WidgetState.hovered].
   ///  * [WidgetState.focused].
   ///  * [WidgetState.disabled].
   ///
-  /// Defaults to [defaultMouseCursor].
+  /// If null, then [SystemMouseCursors.basic] is used when this radio button is disabled.
+  /// When this radio button is enabled, [SystemMouseCursors.click] is used on Web, and
+  /// [SystemMouseCursors.basic] is used on other platforms.
   ///
   /// See also:
   ///
   ///  * [WidgetStateMouseCursor], a [MouseCursor] that implements
   ///    `WidgetStateProperty` which is used in APIs that need to accept
-  ///    either a [MouseCursor] or a [WidgetStateProperty].
-  final WidgetStateProperty<MouseCursor>? mouseCursor;
+  ///    either a [MouseCursor] or a [WidgetStateProperty<MouseCursor>].
+  final MouseCursor? mouseCursor;
 
   /// Set to true if this radio button is allowed to be returned to an
   /// indeterminate state by selecting it again when selected.
@@ -206,18 +210,6 @@ class CupertinoRadio<T> extends StatefulWidget {
 
   bool get _selected => value == groupValue;
 
-  /// The default [mouseCursor] of a [CupertinoRadio].
-  ///
-  /// If [onChanged] is null, indicating the radio button is disabled,
-  /// [SystemMouseCursors.basic] is used. Otherwise, [SystemMouseCursors.click]
-  /// is used on Web, and [SystemMouseCursors.basic] is used on other platforms.
-  static WidgetStateProperty<MouseCursor> defaultMouseCursor(Function? onChanged) {
-    final MouseCursor mouseCursor = (onChanged != null && kIsWeb)
-      ? SystemMouseCursors.click
-      : SystemMouseCursors.basic;
-    return WidgetStateProperty.all<MouseCursor>(mouseCursor);
-  }
-
   @override
   State<CupertinoRadio<T>> createState() => _CupertinoRadioState<T>();
 }
@@ -277,6 +269,15 @@ class _CupertinoRadioState<T> extends State<CupertinoRadio<T>> with TickerProvid
 
     final Color effectiveFillColor = widget.fillColor ?? CupertinoColors.white;
 
+    final WidgetStateProperty<MouseCursor> effectiveMouseCursor =
+      WidgetStateProperty.resolveWith<MouseCursor>((Set<WidgetState> states) {
+        return WidgetStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
+          ?? (states.contains(WidgetState.disabled)
+              ? SystemMouseCursors.basic
+              : kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic
+            );
+      });
+
     final bool? accessibilitySelected;
     // Apple devices also use `selected` to annotate radio button's semantics
     // state.
@@ -296,7 +297,7 @@ class _CupertinoRadioState<T> extends State<CupertinoRadio<T>> with TickerProvid
       checked: widget._selected,
       selected: accessibilitySelected,
       child: buildToggleable(
-        mouseCursor: widget.mouseCursor ?? CupertinoRadio.defaultMouseCursor(widget.onChanged),
+        mouseCursor: effectiveMouseCursor,
         focusNode: widget.focusNode,
         autofocus: widget.autofocus,
         onFocusChange: onFocusChange,

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -455,11 +455,7 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
               value: widget.value,
               groupValue: widget.groupValue,
               onChanged: widget.onChanged,
-              mouseCursor: widget.mouseCursor == null
-                ? CupertinoRadio.defaultMouseCursor(widget.onChanged)
-                : WidgetStateProperty.resolveWith((Set<MaterialState> states) {
-                    return WidgetStateProperty.resolveAs<MouseCursor>(widget.mouseCursor!, states);
-                  }),
+              mouseCursor: widget.mouseCursor,
               toggleable: widget.toggleable,
               activeColor: widget.activeColor,
               focusColor: widget.focusColor,

--- a/packages/flutter/test/cupertino/radio_test.dart
+++ b/packages/flutter/test/cupertino/radio_test.dart
@@ -441,7 +441,7 @@ void main() {
           value: 1,
           groupValue: 1,
           onChanged: (int? i) { },
-          mouseCursor: WidgetStateProperty.all(SystemMouseCursors.forbidden),
+          mouseCursor: SystemMouseCursors.forbidden,
         ),
       ),
     ));
@@ -463,25 +463,13 @@ void main() {
     final FocusNode focusNode = FocusNode(debugLabel: 'Radio');
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
 
-    MouseCursor getMouseCursor(Set<WidgetState> states) {
-      if (states.contains(WidgetState.disabled)) {
-        return SystemMouseCursors.forbidden;
-      }
-      if (states.contains(WidgetState.focused)) {
-        return SystemMouseCursors.basic;
-      }
-      return SystemMouseCursors.click;
-    }
-
-    final WidgetStateProperty<MouseCursor> mouseCursor = WidgetStateProperty.resolveWith(getMouseCursor);
-
     await tester.pumpWidget(CupertinoApp(
       home: Center(
         child: CupertinoRadio<int>(
           value: 1,
           groupValue: 1,
           onChanged: (int? i) { },
-          mouseCursor: mouseCursor,
+          mouseCursor: const RadioMouseCursor(),
           focusNode: focusNode
         ),
       ),
@@ -510,13 +498,13 @@ void main() {
     );
 
     // Test disabled case.
-    await tester.pumpWidget(CupertinoApp(
+    await tester.pumpWidget(const CupertinoApp(
       home: Center(
         child: CupertinoRadio<int>(
           value: 1,
           groupValue: 1,
           onChanged: null,
-          mouseCursor: mouseCursor,
+          mouseCursor: RadioMouseCursor(),
         ),
       ),
     ));
@@ -552,4 +540,22 @@ void main() {
       kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic
     );
   });
+}
+
+class RadioMouseCursor extends WidgetStateMouseCursor {
+  const RadioMouseCursor();
+
+  @override
+  MouseCursor resolve(Set<WidgetState> states) {
+    if (states.contains(WidgetState.disabled)) {
+      return SystemMouseCursors.forbidden;
+    }
+    if (states.contains(WidgetState.focused)){
+      return SystemMouseCursors.basic;
+    }
+    return SystemMouseCursors.click;
+  }
+
+  @override
+  String get debugDescription => 'RadioMouseCursor()';
 }

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -1859,46 +1859,6 @@ void main() {
     }
   });
 
-  testWidgets('Radio.adaptive respects Radio.mouseCursor', (WidgetTester tester) async {
-    Widget buildApp({required TargetPlatform platform, MouseCursor? mouseCursor}) {
-      return MaterialApp(
-        theme: ThemeData(platform: platform),
-        home: Material(
-          child: Radio<int>.adaptive(
-            value: 1,
-            groupValue: 1,
-            onChanged: (int? i) {},
-            mouseCursor: mouseCursor,
-          ),
-        ),
-      );
-    }
-
-    for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.iOS, TargetPlatform.macOS ]) {
-      await tester.pumpWidget(buildApp(platform: platform));
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
-
-      // Test default mouse cursor.
-      await gesture.addPointer(location: tester.getCenter(find.byType(CupertinoRadio<int>)));
-      await tester.pump();
-      await gesture.moveTo(tester.getCenter(find.byType(CupertinoRadio<int>)));
-      expect(
-        RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
-        kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,
-      );
-
-      // Test mouse cursor can be configured.
-      await tester.pumpWidget(buildApp(platform: platform, mouseCursor: SystemMouseCursors.forbidden));
-      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
-
-      // Test Radio.adaptive can resolve a WidgetStateMouseCursor.
-      await tester.pumpWidget(buildApp(platform: platform, mouseCursor: const _SelectedGrabMouseCursor()));
-      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.grab);
-
-      await gesture.removePointer();
-    }
-  });
-
   testWidgets('Material2 - Radio default overlayColor and fillColor resolves pressed state', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Radio');
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
@@ -2032,19 +1992,4 @@ void main() {
     );
     focusNode.dispose();
   });
-}
-
-class _SelectedGrabMouseCursor extends WidgetStateMouseCursor {
-  const _SelectedGrabMouseCursor();
-
-  @override
-  MouseCursor resolve(Set<WidgetState> states) {
-    if (states.contains(WidgetState.selected)) {
-      return SystemMouseCursors.grab;
-    }
-    return SystemMouseCursors.basic;
-  }
-
-  @override
-  String get debugDescription => '_SelectedGrabMouseCursor()';
 }


### PR DESCRIPTION
Reverts flutter/flutter#151910, awaiting further discussion on `WidgetStateProperty`.