### PR TITLE
Implementing null-aware logic in `/packages/flutter/`

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -980,7 +980,7 @@ class _PrefixedStringBuilder {
         if (allowWrap && wrapWidth != null) {
           final int wrapStart = _currentLine.length;
           final int wrapEnd = wrapStart + line.length;
-          if (_wrappableRanges.isNotEmpty && _wrappableRanges.last == wrapStart) {
+          if (_wrappableRanges.lastOrNull == wrapStart) {
             // Extend last range.
             _wrappableRanges.last = wrapEnd;
           } else {

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -1849,9 +1849,7 @@ class PointerScrollEvent extends PointerSignalEvent with _PointerEventDescriptio
 
   @override
   void respond({required bool allowPlatformDefault}) {
-    if (_onRespond != null) {
-      _onRespond!(allowPlatformDefault: allowPlatformDefault);
-    }
+    _onRespond?.call(allowPlatformDefault: allowPlatformDefault);
   }
 }
 

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -231,19 +231,16 @@ class VelocityTracker {
     } while (sampleCount < _historySize);
 
     if (sampleCount >= _minSampleSize) {
-      final LeastSquaresSolver xSolver = LeastSquaresSolver(time, x, w);
-      final PolynomialFit? xFit = xSolver.solve(2);
-      if (xFit != null) {
-        final LeastSquaresSolver ySolver = LeastSquaresSolver(time, y, w);
-        final PolynomialFit? yFit = ySolver.solve(2);
-        if (yFit != null) {
-          return VelocityEstimate( // convert from pixels/ms to pixels/s
-            pixelsPerSecond: Offset(xFit.coefficients[1] * 1000, yFit.coefficients[1] * 1000),
-            confidence: xFit.confidence * yFit.confidence,
-            duration: newestSample.time - oldestSample.time,
-            offset: newestSample.point - oldestSample.point,
-          );
-        }
+      late final PolynomialFit? xFit = LeastSquaresSolver(time, x, w).solve(2);
+      late final PolynomialFit? yFit = LeastSquaresSolver(time, y, w).solve(2);
+
+      if (xFit != null && yFit != null) {
+        return VelocityEstimate( // convert from pixels/ms to pixels/s
+          pixelsPerSecond: Offset(xFit.coefficients[1] * 1000, yFit.coefficients[1] * 1000),
+          confidence: xFit.confidence * yFit.confidence,
+          duration: newestSample.time - oldestSample.time,
+          offset: newestSample.point - oldestSample.point,
+        );
       }
     }
 

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -231,6 +231,7 @@ class VelocityTracker {
     } while (sampleCount < _historySize);
 
     if (sampleCount >= _minSampleSize) {
+      // Marking as "late" ensures that yFit isn't evaluated unless it's needed.
       late final PolynomialFit? xFit = LeastSquaresSolver(time, x, w).solve(2);
       late final PolynomialFit? yFit = LeastSquaresSolver(time, y, w).solve(2);
 

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -301,7 +301,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
   }
 
   bool _isSelectable(DateTime date) {
-    return widget.selectableDayPredicate == null || widget.selectableDayPredicate!.call(date);
+    return widget.selectableDayPredicate?.call(date) ?? true;
   }
 
   Widget _buildPicker() {
@@ -766,7 +766,7 @@ class _MonthPickerState extends State<_MonthPicker> {
   }
 
   bool _isSelectable(DateTime date) {
-    return widget.selectableDayPredicate == null || widget.selectableDayPredicate!.call(date);
+    return widget.selectableDayPredicate?.call(date) ?? true;
   }
 
   Widget _buildItems(BuildContext context, int index) {

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -752,7 +752,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
 
     if (widget.enableSearch) {
       if (widget.searchCallback != null) {
-        currentHighlight = widget.searchCallback!.call(filteredEntries, _localTextEditingController!.text);
+        currentHighlight = widget.searchCallback!(filteredEntries, _localTextEditingController!.text);
       } else {
         currentHighlight = search(filteredEntries, _localTextEditingController!);
       }

--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -233,10 +233,7 @@ class InkRipple extends InteractiveInkFeature {
   void paintFeature(Canvas canvas, Matrix4 transform) {
     final int alpha = _fadeInController.isAnimating ? _fadeIn.value : _fadeOut.value;
     final Paint paint = Paint()..color = color.withAlpha(alpha);
-    Rect? rect;
-    if (_clipCallback != null) {
-       rect = _clipCallback();
-    }
+    final Rect? rect = _clipCallback?.call();
     // Splash moves to the center of the reference box.
     final Offset center = Offset.lerp(
       _position,

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1034,13 +1034,10 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 
   void _updateHighlightsAndSplashes() {
     for (final InkHighlight? highlight in _highlights.values) {
-      if (highlight != null) {
-        highlight.customBorder = widget.customBorder;
-      }
+      highlight?.customBorder = widget.customBorder;
     }
-    if (_currentSplash != null) {
-      _currentSplash!.customBorder = widget.customBorder;
-    }
+    _currentSplash?.customBorder = widget.customBorder;
+
     if (_splashes != null && _splashes!.isNotEmpty) {
       for (final InteractiveInkFeature inkFeature in _splashes!) {
         inkFeature.customBorder = widget.customBorder;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -911,7 +911,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   }
 
   static double _minWidth(RenderBox? box, double height) => box?.getMinIntrinsicWidth(height) ?? 0.0;
-  static double _maxWidth(RenderBox? box, double height) => box?.getMaxIntrinsicWidth(height) ?? 0.0 ;
+  static double _maxWidth(RenderBox? box, double height) => box?.getMaxIntrinsicWidth(height) ?? 0.0;
   static double _minHeight(RenderBox? box, double width) => box?.getMinIntrinsicHeight(width) ?? 0.0;
   static Size _boxSize(RenderBox? box) => box?.size ?? Size.zero;
   static double _getBaseline(RenderBox box, BoxConstraints boxConstraints) {

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1212,9 +1212,7 @@ class _MenuItemButtonState extends State<MenuItemButton> {
     if (widget.focusNode == null) {
       _internalFocusNode = FocusNode();
       assert(() {
-        if (_internalFocusNode != null) {
-          _internalFocusNode!.debugLabel = '$MenuItemButton(${widget.child})';
-        }
+        _internalFocusNode?.debugLabel = '$MenuItemButton(${widget.child})';
         return true;
       }());
     }
@@ -1381,11 +1379,11 @@ class CheckboxMenuButton extends StatelessWidget {
       onPressed: onChanged == null ? null : () {
         switch (value) {
           case false:
-            onChanged!.call(true);
+            onChanged!(true);
           case true:
-            onChanged!.call(tristate ? null : false);
+            onChanged!(tristate ? null : false);
           case null:
-            onChanged!.call(false);
+            onChanged!(false);
         }
       },
       onHover: onHover,
@@ -1579,10 +1577,9 @@ class RadioMenuButton<T> extends StatelessWidget {
       key: key,
       onPressed: onChanged == null ? null : () {
         if (toggleable && groupValue == value) {
-          onChanged!.call(null);
-          return;
+          return onChanged!(null);
         }
-        onChanged!.call(value);
+        onChanged!(value);
       },
       onHover: onHover,
       onFocusChange: onFocusChange,
@@ -1880,9 +1877,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
     if (widget.focusNode == null) {
       _internalFocusNode = FocusNode();
       assert(() {
-        if (_internalFocusNode != null) {
-          _internalFocusNode!.debugLabel = '$SubmenuButton(${widget.child})';
-        }
+        _internalFocusNode?.debugLabel = '$SubmenuButton(${widget.child})';
         return true;
       }());
     }
@@ -1914,9 +1909,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
       if (widget.focusNode == null) {
         _internalFocusNode ??= FocusNode();
         assert(() {
-          if (_internalFocusNode != null) {
-            _internalFocusNode!.debugLabel = '$SubmenuButton(${widget.child})';
-          }
+          _internalFocusNode?.debugLabel = '$SubmenuButton(${widget.child})';
           return true;
         }());
       }

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -155,11 +155,7 @@ class NavigationDrawer extends StatelessWidget {
             indicatorColor: indicatorColor,
             indicatorShape: indicatorShape,
             tilePadding: tilePadding,
-            onTap: () {
-              if (onDestinationSelected != null) {
-                onDestinationSelected!(index);
-              }
-            },
+            onTap: () => onDestinationSelected?.call(index),
             child: child,
           );
         });

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -550,7 +550,7 @@ class _DayPeriodControl extends StatelessWidget {
     final int newHour = (selectedTime.hour + TimeOfDay.hoursPerPeriod) % TimeOfDay.hoursPerDay;
     final TimeOfDay newTime = selectedTime.replacing(hour: newHour);
     if (onPeriodChanged != null) {
-      onPeriodChanged!.call(newTime);
+      onPeriodChanged!(newTime);
     } else {
       _TimePickerModel.setSelectedTime(context, newTime);
     }

--- a/packages/flutter/lib/src/painting/flutter_logo.dart
+++ b/packages/flutter/lib/src/painting/flutter_logo.dart
@@ -141,9 +141,9 @@ class FlutterLogoDecoration extends Decoration {
   @override
   FlutterLogoDecoration? lerpFrom(Decoration? a, double t) {
     assert(debugAssertIsValid());
-    if (a == null || a is FlutterLogoDecoration) {
-      assert(a == null || a.debugAssertIsValid());
-      return FlutterLogoDecoration.lerp(a as FlutterLogoDecoration?, this, t);
+    if (a is FlutterLogoDecoration?) {
+      assert(a?.debugAssertIsValid() ?? true);
+      return FlutterLogoDecoration.lerp(a, this, t);
     }
     return super.lerpFrom(a, t) as FlutterLogoDecoration?;
   }
@@ -151,9 +151,9 @@ class FlutterLogoDecoration extends Decoration {
   @override
   FlutterLogoDecoration? lerpTo(Decoration? b, double t) {
     assert(debugAssertIsValid());
-    if (b == null || b is FlutterLogoDecoration) {
-      assert(b == null || b.debugAssertIsValid());
-      return FlutterLogoDecoration.lerp(this, b as FlutterLogoDecoration?, t);
+    if (b is FlutterLogoDecoration?) {
+      assert(b?.debugAssertIsValid() ?? true);
+      return FlutterLogoDecoration.lerp(this, b, t);
     }
     return super.lerpTo(b, t) as FlutterLogoDecoration?;
   }

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -459,16 +459,16 @@ class LinearGradient extends Gradient {
 
   @override
   Gradient? lerpFrom(Gradient? a, double t) {
-    if (a == null || (a is LinearGradient)) {
-      return LinearGradient.lerp(a as LinearGradient?, this, t);
+    if (a is LinearGradient?) {
+      return LinearGradient.lerp(a, this, t);
     }
     return super.lerpFrom(a, t);
   }
 
   @override
   Gradient? lerpTo(Gradient? b, double t) {
-    if (b == null || (b is LinearGradient)) {
-      return LinearGradient.lerp(this, b as LinearGradient?, t);
+    if (b is LinearGradient?) {
+      return LinearGradient.lerp(this, b, t);
     }
     return super.lerpTo(b, t);
   }
@@ -751,16 +751,16 @@ class RadialGradient extends Gradient {
 
   @override
   Gradient? lerpFrom(Gradient? a, double t) {
-    if (a == null || (a is RadialGradient)) {
-      return RadialGradient.lerp(a as RadialGradient?, this, t);
+    if (a is RadialGradient?) {
+      return RadialGradient.lerp(a, this, t);
     }
     return super.lerpFrom(a, t);
   }
 
   @override
   Gradient? lerpTo(Gradient? b, double t) {
-    if (b == null || (b is RadialGradient)) {
-      return RadialGradient.lerp(this, b as RadialGradient?, t);
+    if (b is RadialGradient?) {
+      return RadialGradient.lerp(this, b, t);
     }
     return super.lerpTo(b, t);
   }
@@ -1034,16 +1034,16 @@ class SweepGradient extends Gradient {
 
   @override
   Gradient? lerpFrom(Gradient? a, double t) {
-    if (a == null || (a is SweepGradient)) {
-      return SweepGradient.lerp(a as SweepGradient?, this, t);
+    if (a is SweepGradient?) {
+      return SweepGradient.lerp(a, this, t);
     }
     return super.lerpFrom(a, t);
   }
 
   @override
   Gradient? lerpTo(Gradient? b, double t) {
-    if (b == null || (b is SweepGradient)) {
-      return SweepGradient.lerp(this, b as SweepGradient?, t);
+    if (b is SweepGradient?) {
+      return SweepGradient.lerp(this, b, t);
     }
     return super.lerpTo(b, t);
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3176,8 +3176,8 @@ class RenderMouseRegion extends RenderProxyBoxWithHitTestBehavior implements Mou
   @override
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     assert(debugHandleEvent(event, entry));
-    if (onHover != null && event is PointerHoverEvent) {
-      return onHover!(event);
+    if (event is PointerHoverEvent) {
+      onHover?.call(event);
     }
   }
 

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -282,9 +282,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   void performLayout() {
     assert(_rootTransform != null);
     final bool sizedByChild = !constraints.isTight;
-    if (child != null) {
-      child!.layout(constraints, parentUsesSize: sizedByChild);
-    }
+    child?.layout(constraints, parentUsesSize: sizedByChild);
     _size = sizedByChild && child != null ? child!.size : constraints.smallest;
     assert(size.isFinite);
     assert(constraints.isSatisfiedBy(size));
@@ -301,9 +299,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// coordinate system as that expected by the root [Layer], which will
   /// normally be in physical (device) pixels.
   bool hitTest(HitTestResult result, { required Offset position }) {
-    if (child != null) {
-      child!.hitTest(BoxHitTestResult.wrap(result), position: position);
-    }
+    child?.hitTest(BoxHitTestResult.wrap(result), position: position);
     result.add(HitTestEntry(this));
     return true;
   }

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -219,12 +219,10 @@ abstract class CachingAssetBundle extends AssetBundle {
     loadString(key, cache: false).then<T>(parser).then<void>((T value) {
       synchronousResult = SynchronousFuture<T>(value);
       _structuredDataCache[key] = synchronousResult!;
-      if (completer != null) {
-        // We already returned from the loadStructuredData function, which means
-        // we are in the asynchronous mode. Pass the value to the completer. The
-        // completer's future is what we returned.
-        completer.complete(value);
-      }
+      // We already returned from the loadStructuredData function, which means
+      // we are in the asynchronous mode. Pass the value to the completer. The
+      // completer's future is what we returned.
+      completer?.complete(value);
     }, onError: (Object error, StackTrace stack) {
       assert(completer != null, 'unexpected synchronous failure');
       // Either loading or parsing failed. We must report the error back to the
@@ -267,12 +265,10 @@ abstract class CachingAssetBundle extends AssetBundle {
     load(key).then<T>(parser).then<void>((T value) {
       synchronousResult = SynchronousFuture<T>(value);
       _structuredBinaryDataCache[key] = synchronousResult!;
-      if (completer != null) {
-        // The load and parse operation ran asynchronously. We already returned
-        // from the loadStructuredBinaryData function and therefore the caller
-        // was given the future of the completer.
-        completer.complete(value);
-      }
+      // The load and parse operation ran asynchronously. We already returned
+      // from the loadStructuredBinaryData function and therefore the caller
+      // was given the future of the completer.
+      completer?.complete(value);
     }, onError: (Object error, StackTrace stack) {
       assert(completer != null, 'unexpected synchronous failure');
       // Either loading or parsing failed. We must report the error back to the

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -573,11 +573,11 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
     ByteData? message,
     ui.PlatformMessageResponseCallback? callback,
   ) async {
-    ui.channelBuffers.push(channel, message, (ByteData? data) {
-      if (callback != null) {
-        callback(data);
-      }
-    });
+    ui.channelBuffers.push(
+      channel,
+      message,
+      (ByteData? data) => callback?.call(data),
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -94,13 +94,11 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
         element.innerText = client.getSelectedContent()?.plainText ?? '';
 
         // Programmatically select the dom element in browser.
-        final web.Range range = web.document.createRange();
-        range.selectNode(element);
-        final web.Selection? selection = web.window.getSelection();
-        if (selection != null) {
-          selection.removeAllRanges();
-          selection.addRange(range);
-        }
+        final web.Range range = web.document.createRange()..selectNode(element);
+
+        web.window.getSelection()
+          ?..removeAllRanges()
+           ..addRange(range);
       }
     });
   }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1323,9 +1323,7 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
     final FocusableActionDetector oldTarget = oldWidget ?? widget;
     final bool didShowHoverHighlight = shouldShowHoverHighlight(oldTarget);
     final bool didShowFocusHighlight = shouldShowFocusHighlight(oldTarget);
-    if (task != null) {
-      task();
-    }
+    task?.call();
     final bool doShowHoverHighlight = shouldShowHoverHighlight(widget);
     final bool doShowFocusHighlight = shouldShowFocusHighlight(widget);
     if (didShowFocusHighlight != doShowFocusHighlight) {

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -379,10 +379,8 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
 
   @override
   void dispose() {
-    if (_currentEntry != null) {
-      _currentEntry!.controller.dispose();
-      _currentEntry!.animation.dispose();
-    }
+    _currentEntry?.controller.dispose();
+    _currentEntry?.animation.dispose();
     for (final _ChildEntry entry in _outgoingEntries) {
       entry.controller.dispose();
       entry.animation.dispose();

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2271,10 +2271,7 @@ class LayoutId extends ParentDataWidget<MultiChildLayoutParentData> {
     final MultiChildLayoutParentData parentData = renderObject.parentData! as MultiChildLayoutParentData;
     if (parentData.id != id) {
       parentData.id = id;
-      final RenderObject? targetParent = renderObject.parent;
-      if (targetParent is RenderObject) {
-        targetParent.markNeedsLayout();
-      }
+      renderObject.parent?.markNeedsLayout();
     }
   }
 
@@ -4381,10 +4378,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
     }
 
     if (needsLayout) {
-      final RenderObject? targetParent = renderObject.parent;
-      if (targetParent is RenderObject) {
-        targetParent.markNeedsLayout();
-      }
+      renderObject.parent?.markNeedsLayout();
     }
   }
 
@@ -5250,10 +5244,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
     }
 
     if (needsLayout) {
-      final RenderObject? targetParent = renderObject.parent;
-      if (targetParent is RenderObject) {
-        targetParent.markNeedsLayout();
-      }
+      renderObject.parent?.markNeedsLayout();
     }
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2734,7 +2734,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   static SpellCheckConfiguration _inferSpellCheckConfiguration(SpellCheckConfiguration? configuration) {
     final SpellCheckService? spellCheckService = configuration?.spellCheckService;
     final bool spellCheckAutomaticallyDisabled = configuration == null || configuration == const SpellCheckConfiguration.disabled();
-    final bool spellCheckServiceIsConfigured = spellCheckService != null || spellCheckService == null && WidgetsBinding.instance.platformDispatcher.nativeSpellCheckServiceDefined;
+    final bool spellCheckServiceIsConfigured = spellCheckService != null || WidgetsBinding.instance.platformDispatcher.nativeSpellCheckServiceDefined;
     if (spellCheckAutomaticallyDisabled || !spellCheckServiceIsConfigured) {
       // Only enable spell check if a non-disabled configuration is provided
       // and if that configuration does not specify a spell check service,

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4040,7 +4040,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     }
 
     Object? slotFor(int newChildIndex, Element? previousChild) {
-      return slots?[newChildIndex] ?? IndexedSlot<Element?>(newChildIndex, previousChild);
+      return slots != null
+          ? slots[newChildIndex]
+          : IndexedSlot<Element?>(newChildIndex, previousChild);
     }
 
     // This attempts to diff the new child list (newWidgets) with

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4036,13 +4036,11 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     assert(slots == null || newWidgets.length == slots.length);
 
     Element? replaceWithNullIfForgotten(Element child) {
-      return forgottenChildren != null && forgottenChildren.contains(child) ? null : child;
+      return (forgottenChildren?.contains(child) ?? false) ? null : child;
     }
 
     Object? slotFor(int newChildIndex, Element? previousChild) {
-      return slots != null
-          ? slots[newChildIndex]
-          : IndexedSlot<Element?>(newChildIndex, previousChild);
+      return slots?[newChildIndex] ?? IndexedSlot<Element?>(newChildIndex, previousChild);
     }
 
     // This attempts to diff the new child list (newWidgets) with
@@ -4222,7 +4220,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     _parent = parent;
     _slot = newSlot;
     _lifecycleState = _ElementLifecycle.active;
-    _depth = _parent != null ? _parent!.depth + 1 : 1;
+    _depth = 1 + (_parent?.depth ?? 0);
     if (parent != null) {
       // Only assign ownership if the parent is non-null. If parent is null
       // (the root node), the owner should have already been assigned.
@@ -4601,7 +4599,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   void activate() {
     assert(_lifecycleState == _ElementLifecycle.inactive);
     assert(owner != null);
-    final bool hadDependencies = (_dependencies != null && _dependencies!.isNotEmpty) || _hadUnsatisfiedDependencies;
+    final bool hadDependencies = (_dependencies?.isNotEmpty ?? false) || _hadUnsatisfiedDependencies;
     _lifecycleState = _ElementLifecycle.active;
     // We unregistered our dependencies in deactivate, but never cleared the list.
     // Since we're going to be reused, let's clear our list now.
@@ -4636,7 +4634,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   void deactivate() {
     assert(_lifecycleState == _ElementLifecycle.active);
     assert(_widget != null); // Use the private property to avoid a CastError during hot reload.
-    if (_dependencies != null && _dependencies!.isNotEmpty) {
+    if (_dependencies?.isNotEmpty ?? false) {
       for (final InheritedElement dependency in _dependencies!) {
         dependency.removeDependent(this);
       }
@@ -4896,8 +4894,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   /// Returns `true` if [dependOnInheritedElement] was previously called with [ancestor].
   @protected
-  bool doesDependOnInheritedElement(InheritedElement ancestor) =>
-      _dependencies != null && _dependencies!.contains(ancestor);
+  bool doesDependOnInheritedElement(InheritedElement ancestor) {
+    return _dependencies?.contains(ancestor) ?? false;
+  }
 
   @override
   InheritedWidget dependOnInheritedElement(InheritedElement ancestor, { Object? aspect }) {
@@ -4910,7 +4909,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   @override
   T? dependOnInheritedWidgetOfExactType<T extends InheritedWidget>({Object? aspect}) {
     assert(_debugCheckStateIsActiveForAncestorLookup());
-    final InheritedElement? ancestor = _inheritedElements == null ? null : _inheritedElements![T];
+    final InheritedElement? ancestor = _inheritedElements?[T];
     if (ancestor != null) {
       return dependOnInheritedElement(ancestor, aspect: aspect) as T;
     }
@@ -4926,8 +4925,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   @override
   InheritedElement? getElementForInheritedWidgetOfExactType<T extends InheritedWidget>() {
     assert(_debugCheckStateIsActiveForAncestorLookup());
-    final InheritedElement? ancestor = _inheritedElements == null ? null : _inheritedElements![T];
-    return ancestor;
+    return _inheritedElements?[T];
   }
 
   /// Called in [Element.mount] and [Element.activate] to register this element in

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1701,12 +1701,8 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
       return null;
     }
     return (DragUpdateDetails details) {
-      if (horizontalHandler != null) {
-        horizontalHandler(details);
-      }
-      if (panHandler != null) {
-        panHandler(details);
-      }
+      horizontalHandler?.call(details);
+      panHandler?.call(details);
     };
   }
 
@@ -1736,12 +1732,8 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
       return null;
     }
     return (DragUpdateDetails details) {
-      if (verticalHandler != null) {
-        verticalHandler(details);
-      }
-      if (panHandler != null) {
-        panHandler(details);
-      }
+      verticalHandler?.call(details);
+      panHandler?.call(details);
     };
   }
 }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3749,7 +3749,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     if (!_serializableHistory.hasData) {
       String? initialRoute = widget.initialRoute;
       if (widget.pages.isEmpty) {
-        initialRoute = initialRoute ?? Navigator.defaultRouteName;
+        initialRoute ??= Navigator.defaultRouteName;
       }
       if (initialRoute != null) {
         _history.addAll(

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1842,15 +1842,16 @@ class RenderSliverOverlapAbsorber extends RenderSliver with RenderObjectWithChil
   }
 
   @override
-  bool hitTestChildren(SliverHitTestResult result, { required double mainAxisPosition, required double crossAxisPosition }) {
-    if (child != null) {
-      return child!.hitTest(
-        result,
-        mainAxisPosition: mainAxisPosition,
-        crossAxisPosition: crossAxisPosition,
-      );
-    }
-    return false;
+  bool hitTestChildren(
+    SliverHitTestResult result, {
+    required double mainAxisPosition,
+    required double crossAxisPosition,
+  }) {
+    return child?.hitTest(
+      result,
+      mainAxisPosition: mainAxisPosition,
+      crossAxisPosition: crossAxisPosition,
+    ) ?? false;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1842,16 +1842,15 @@ class RenderSliverOverlapAbsorber extends RenderSliver with RenderObjectWithChil
   }
 
   @override
-  bool hitTestChildren(
-    SliverHitTestResult result, {
-    required double mainAxisPosition,
-    required double crossAxisPosition,
-  }) {
-    return child?.hitTest(
-      result,
-      mainAxisPosition: mainAxisPosition,
-      crossAxisPosition: crossAxisPosition,
-    ) ?? false;
+  bool hitTestChildren(SliverHitTestResult result, { required double mainAxisPosition, required double crossAxisPosition }) {
+    if (child != null) {
+      return child!.hitTest(
+        result,
+        mainAxisPosition: mainAxisPosition,
+        crossAxisPosition: crossAxisPosition,
+      );
+    }
+    return false;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -2131,31 +2131,25 @@ class _OverlayPortalElement extends RenderObjectElement {
   @override
   void activate() {
     super.activate();
-    final Element? overlayChild = _overlayChild;
-    if (overlayChild != null) {
-      final _RenderDeferredLayoutBox? box = overlayChild.renderObject as _RenderDeferredLayoutBox?;
-      if (box != null) {
-        assert(!box.attached);
-        assert(renderObject._deferredLayoutChild == box);
-        // updateChild has not been called at this point so the RenderTheater in
-        // the overlay location could be detached. Adding children to a detached
-        // RenderObject is still allowed however this isn't the most efficient.
-        (overlayChild.slot! as _OverlayEntryLocation)._activate(box);
-      }
+    final _RenderDeferredLayoutBox? box = _overlayChild?.renderObject as _RenderDeferredLayoutBox?;
+    if (box != null) {
+      assert(!box.attached);
+      assert(renderObject._deferredLayoutChild == box);
+      // updateChild has not been called at this point so the RenderTheater in
+      // the overlay location could be detached. Adding children to a detached
+      // RenderObject is still allowed however this isn't the most efficient.
+      (_overlayChild!.slot! as _OverlayEntryLocation)._activate(box);
     }
   }
 
   @override
   void deactivate() {
-    final Element? overlayChild = _overlayChild;
     // Instead of just detaching the render objects, removing them from the
     // render subtree entirely. This is a workaround for the
     // !renderObject.attached assert in the `super.deactivate()` method.
-    if (overlayChild != null) {
-      final _RenderDeferredLayoutBox? box = overlayChild.renderObject as _RenderDeferredLayoutBox?;
-      if (box != null) {
-        (overlayChild.slot! as _OverlayEntryLocation)._deactivate(box);
-      }
+    final _RenderDeferredLayoutBox? box = _overlayChild?.renderObject as _RenderDeferredLayoutBox?;
+    if (box != null) {
+      (_overlayChild!.slot! as _OverlayEntryLocation)._deactivate(box);
     }
     super.deactivate();
   }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -411,9 +411,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> implements PredictiveB
     }
     // Finally, we dispose any previous train hopping animation because it
     // has been successfully updated at this point.
-    if (previousTrainHoppingListenerRemover != null) {
-      previousTrainHoppingListenerRemover();
-    }
+    previousTrainHoppingListenerRemover?.call();
   }
 
   void _setSecondaryAnimation(Animation<double>? animation, [Future<dynamic>? disposed]) {

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -244,9 +244,7 @@ class ScrollController extends ChangeNotifier {
     assert(!_positions.contains(position));
     _positions.add(position);
     position.addListener(notifyListeners);
-    if (onAttach != null) {
-      onAttach!(position);
-    }
+    onAttach?.call(position);
   }
 
   /// Unregister the given position with this controller.
@@ -255,9 +253,7 @@ class ScrollController extends ChangeNotifier {
   /// controller will not manipulate the given position.
   void detach(ScrollPosition position) {
     assert(_positions.contains(position));
-    if (onDetach != null) {
-      onDetach!(position);
-    }
+    onDetach?.call(position);
     position.removeListener(notifyListeners);
     _positions.remove(position);
   }

--- a/packages/flutter/lib/src/widgets/scrollable_helpers.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_helpers.dart
@@ -283,9 +283,7 @@ class EdgeDraggingAutoScroller {
       duration: duration,
       curve: Curves.linear,
     );
-    if (onScrollViewScrolled != null) {
-      onScrollViewScrolled!();
-    }
+    onScrollViewScrolled?.call();
     if (_scrolling) {
       await _scroll();
     }

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -902,22 +902,16 @@ class ShortcutManager with Diagnosticable, ChangeNotifier {
   /// [Action] must be enabled.
   @protected
   KeyEventResult handleKeypress(BuildContext context, KeyEvent event) {
-    final Intent? matchedIntent = _find(event, HardwareKeyboard.instance);
-    if (matchedIntent != null) {
-      final BuildContext? primaryContext = primaryFocus?.context;
-      if (primaryContext != null) {
-        final Action<Intent>? action = Actions.maybeFind<Intent>(
-          primaryContext,
-          intent: matchedIntent,
-        );
-        if (action != null) {
-          final (bool enabled, Object? invokeResult) = Actions.of(primaryContext).invokeActionIfEnabled(
-            action, matchedIntent, primaryContext,
-          );
-          if (enabled) {
-            return action.toKeyEventResult(matchedIntent, invokeResult);
-          }
-        }
+    late final Intent? intent = _find(event, HardwareKeyboard.instance);
+    late final BuildContext? context = primaryFocus?.context;
+    late final Action<Intent>? action = Actions.maybeFind<Intent>(context!, intent: intent);
+
+    if (intent != null && context != null && action != null) {
+      final (bool enabled, Object? invokeResult) =
+          Actions.of(context).invokeActionIfEnabled(action, intent, context);
+
+      if (enabled) {
+        return action.toKeyEventResult(intent, invokeResult);
       }
     }
     return modal ? KeyEventResult.skipRemainingHandlers : KeyEventResult.ignored;
@@ -1419,8 +1413,7 @@ class ShortcutRegistry with ChangeNotifier {
   // registry.
   void _disposeEntry(ShortcutRegistryEntry entry) {
     assert(_debugCheckEntryIsValid(entry));
-    final Map<ShortcutActivator, Intent>? removedShortcut = _registeredShortcuts.remove(entry);
-    if (removedShortcut != null) {
+    if (_registeredShortcuts.remove(entry) != null) {
       _notifyListenersNextFrame();
     }
   }

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -902,6 +902,7 @@ class ShortcutManager with Diagnosticable, ChangeNotifier {
   /// [Action] must be enabled.
   @protected
   KeyEventResult handleKeypress(BuildContext context, KeyEvent event) {
+    // Marking some variables as "late" ensures that they aren't evaluated unless needed.
     late final Intent? intent = _find(event, HardwareKeyboard.instance);
     late final BuildContext? context = primaryFocus?.context;
     late final Action<Intent>? action = Actions.maybeFind<Intent>(context!, intent: intent);

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1459,9 +1459,8 @@ class KeepAlive extends ParentDataWidget<KeepAliveParentDataMixin> {
     if (parentData.keepAlive != keepAlive) {
       // No need to redo layout if it became true.
       parentData.keepAlive = keepAlive;
-      final RenderObject? targetParent = renderObject.parent;
-      if (targetParent is RenderObject && !keepAlive) {
-        targetParent.markNeedsLayout();
+      if (!keepAlive) {
+        renderObject.parent?.markNeedsLayout();
       }
     }
   }
@@ -1556,11 +1555,7 @@ class _SliverZeroFlexParentDataWidget extends ParentDataWidget<SliverPhysicalPar
     }
 
     if (needsLayout) {
-      final RenderObject? targetParent = renderObject.parent;
-      if (targetParent is RenderObject) {
-        targetParent.markNeedsLayout();
-      }
-
+      renderObject.parent?.markNeedsLayout();
     }
   }
 
@@ -1628,10 +1623,7 @@ class SliverCrossAxisExpanded extends ParentDataWidget<SliverPhysicalContainerPa
     }
 
     if (needsLayout) {
-      final RenderObject? targetParent = renderObject.parent;
-      if (targetParent is RenderObject) {
-        targetParent.markNeedsLayout();
-      }
+      renderObject.parent?.markNeedsLayout();
     }
   }
 

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -263,17 +263,13 @@ class _RenderSliverPrototypeExtentList extends RenderSliverFixedExtentBoxAdaptor
   @override
   void attach(PipelineOwner owner) {
     super.attach(owner);
-    if (_child != null) {
-      _child!.attach(owner);
-    }
+    _child?.attach(owner);
   }
 
   @override
   void detach() {
     super.detach();
-    if (_child != null) {
-      _child!.detach();
-    }
+    _child?.detach();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/sliver_tree.dart
+++ b/packages/flutter/lib/src/widgets/sliver_tree.dart
@@ -34,7 +34,7 @@ class TreeSliverNode<T> {
     T content, {
     List<TreeSliverNode<T>>? children,
     bool expanded = false,
-  }) : _expanded = children != null && children.isNotEmpty && expanded,
+  }) : _expanded = (children?.isNotEmpty ?? false) && expanded,
        _content = content,
        _children = children ?? <TreeSliverNode<T>>[];
 

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -420,10 +420,7 @@ class TableCell extends ParentDataWidget<TableCellParentData> {
     final TableCellParentData parentData = renderObject.parentData! as TableCellParentData;
     if (parentData.verticalAlignment != verticalAlignment) {
       parentData.verticalAlignment = verticalAlignment;
-      final RenderObject? targetParent = renderObject.parent;
-      if (targetParent is RenderObject) {
-        targetParent.markNeedsLayout();
-      }
+      renderObject.parent?.markNeedsLayout();
     }
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1537,10 +1537,8 @@ class SelectionOverlay {
       _buildScheduled = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
         _buildScheduled = false;
-        if (_handles != null) {
-          _handles!.start.markNeedsBuild();
-          _handles!.end.markNeedsBuild();
-        }
+        _handles?.start.markNeedsBuild();
+        _handles?.end.markNeedsBuild();
         _toolbar?.markNeedsBuild();
         if (_contextMenuController.isShown) {
           _contextMenuController.markNeedsBuild();

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -239,11 +239,7 @@ mixin SingleTickerProviderStateMixin<T extends StatefulWidget> on State<T> imple
     _updateTicker();
   }
 
-  void _updateTicker() {
-    if (_ticker != null) {
-      _ticker!.muted = !_tickerModeNotifier!.value;
-    }
-  }
+  void _updateTicker() => _ticker?.muted = !_tickerModeNotifier!.value;
 
   void _updateTickerModeNotifier() {
     final ValueListenable<bool> newNotifier = TickerMode.getNotifier(context);

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -740,11 +740,7 @@ class InspectorReferenceData {
 // Production implementation of [WidgetInspectorService].
 class _WidgetInspectorService with WidgetInspectorService {
   _WidgetInspectorService() {
-    selection.addListener(() {
-      if (selectionChangedCallback != null) {
-        selectionChangedCallback!();
-      }
-    });
+    selection.addListener(() => selectionChangedCallback?.call());
   }
 }
 

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
@@ -21,9 +21,7 @@ class TestResampleEventFlutterBinding extends BindingBase with GestureBinding, S
   @override
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     super.handleEvent(event, entry);
-    if (callback != null) {
-      callback?.call(event);
-    }
+    callback?.call(event);
   }
 
   @override

--- a/packages/flutter/test/gestures/locking_test.dart
+++ b/packages/flutter/test/gestures/locking_test.dart
@@ -15,9 +15,7 @@ class TestGestureFlutterBinding extends BindingBase with GestureBinding {
 
   @override
   void handleEvent(PointerEvent event, HitTestEntry entry) {
-    if (callback != null) {
-      callback?.call(event);
-    }
+    callback?.call(event);
     super.handleEvent(event, entry);
   }
 

--- a/packages/flutter/test/gestures/recognizer_test.dart
+++ b/packages/flutter/test/gestures/recognizer_test.dart
@@ -246,17 +246,13 @@ class TestPrimaryPointerGestureRecognizer<T extends PointerEvent> extends Primar
   @override
   void acceptGesture(int pointer) {
     super.acceptGesture(pointer);
-    if (onAcceptGesture != null) {
-      onAcceptGesture!();
-    }
+    onAcceptGesture?.call();
   }
 
   @override
   void rejectGesture(int pointer) {
     super.rejectGesture(pointer);
-    if (onRejectGesture != null) {
-      onRejectGesture!();
-    }
+    onRejectGesture?.call();
   }
 
   @override

--- a/packages/flutter/test/gestures/serial_tap_test.dart
+++ b/packages/flutter/test/gestures/serial_tap_test.dart
@@ -459,9 +459,7 @@ class ReleaseGestureRecognizer extends PrimaryPointerGestureRecognizer {
   void handlePrimaryPointer(PointerEvent event) {
     if (event is PointerUpEvent) {
       resolve(GestureDisposition.accepted);
-      if (onRelease != null) {
-        onRelease!();
-      }
+      onRelease?.call();
     }
   }
 }

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -132,7 +132,7 @@ void main() {
           );
           final Iterable<double> currentRotations = rotationTransitions.map((RotationTransition t) => t.turns.value);
 
-          if (previousRotations != null && previousRotations!.isNotEmpty && currentRotations.isNotEmpty
+          if ((previousRotations?.isNotEmpty ?? false) && currentRotations.isNotEmpty
               && previousRect != null && currentRect != null) {
             final List<double> deltas = <double>[];
             for (final double currentRotation in currentRotations) {
@@ -1615,12 +1615,8 @@ class _GeometryListenerState extends State<_GeometryListener> {
       return;
     }
 
-    if (geometryListenable != null) {
-      geometryListenable!.removeListener(onGeometryChanged);
-    }
-
-    geometryListenable = newListenable;
-    geometryListenable!.addListener(onGeometryChanged);
+    geometryListenable?.removeListener(onGeometryChanged);
+    geometryListenable = newListenable..addListener(onGeometryChanged);
     cache = _GeometryCachePainter(geometryListenable!);
   }
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -3447,12 +3447,8 @@ class _GeometryListenerState extends State<_GeometryListener> {
       return;
     }
 
-    if (geometryListenable != null) {
-      geometryListenable!.removeListener(onGeometryChanged);
-    }
-
-    geometryListenable = newListenable;
-    geometryListenable!.addListener(onGeometryChanged);
+    geometryListenable?.removeListener(onGeometryChanged);
+    geometryListenable = newListenable..addListener(onGeometryChanged);
     cache = _GeometryCachePainter(geometryListenable!);
   }
 

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -68,12 +68,7 @@ class MockCodec implements Codec {
 
 class FakeEventReportingImageStreamCompleter extends ImageStreamCompleter {
   FakeEventReportingImageStreamCompleter({Stream<ImageChunkEvent>? chunkEvents}) {
-    if (chunkEvents != null) {
-      chunkEvents.listen((ImageChunkEvent event) {
-          reportImageChunkEvent(event);
-        },
-      );
-    }
+    chunkEvents?.listen(reportImageChunkEvent);
   }
 }
 

--- a/packages/flutter/test/rendering/mouse_tracker_cursor_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_cursor_test.dart
@@ -56,12 +56,10 @@ void main() {
 
   setUp(() {
     binding.postFrameCallbacks.clear();
-    binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.mouseCursor, (MethodCall call) async {
-      if (methodCallHandler != null) {
-        return methodCallHandler!(call);
-      }
-      return null;
-    });
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.mouseCursor,
+      (MethodCall call) => methodCallHandler?.call(call),
+    );
   });
 
   tearDown(() {

--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -292,7 +292,7 @@ void main() {
       direction: ViewFocusDirection.forward,
     );
 
-    PlatformDispatcher.instance.onViewFocusChange!.call(expectedEvent);
+    PlatformDispatcher.instance.onViewFocusChange!(expectedEvent);
     expect(observer.accumulatedEvents, <ViewFocusEvent>[expectedEvent]);
 
     WidgetsBinding.instance.removeObserver(observer);

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -2063,10 +2063,7 @@ class Inherited extends InheritedWidget {
 
   @override
   InheritedElement createElement() {
-    if (elementCreator != null) {
-      return elementCreator!(this);
-    }
-    return super.createElement();
+    return elementCreator?.call(this) ?? super.createElement();
   }
 }
 

--- a/packages/flutter/test/widgets/linked_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/linked_scroll_view_test.dart
@@ -190,12 +190,8 @@ class LinkedScrollPosition extends ScrollPositionWithSingleContext {
   }
 
   void unlink(LinkedScrollActivity activity) {
-    if (_beforeActivities != null) {
-      _beforeActivities!.remove(activity);
-    }
-    if (_afterActivities != null) {
-      _afterActivities!.remove(activity);
-    }
+    _beforeActivities?.remove(activity);
+    _afterActivities?.remove(activity);
   }
 
   @override

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -372,12 +372,7 @@ class SimpleRouterDelegate extends RouterDelegate<RouteInformation> with ChangeN
   }
 
   @override
-  Future<bool> popRoute() {
-    if (onPopRoute != null) {
-      return onPopRoute!();
-    }
-    return SynchronousFuture<bool>(true);
-  }
+  Future<bool> popRoute() => onPopRoute?.call() ?? SynchronousFuture<bool>(true);
 
   @override
   Widget build(BuildContext context) => builder(context, routeInformation);

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -578,11 +578,8 @@ class SemanticsTester {
       node.visitChildren(visit);
       return true;
     }
-    if (ancestor != null) {
-      visit(ancestor);
-    } else {
-      visit(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
-    }
+    visit(ancestor ?? tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+
     return result;
   }
 

--- a/packages/flutter/test/widgets/widget_inspector_test_utils.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test_utils.dart
@@ -37,18 +37,16 @@ class DispatchedEventKey {
 }
 
 class TestWidgetInspectorService extends Object with WidgetInspectorService {
-    TestWidgetInspectorService() {
-    selection.addListener(() {
-      if (selectionChangedCallback != null) {
-        selectionChangedCallback!();
-      }
-    });
+  TestWidgetInspectorService() {
+    selection.addListener(() => selectionChangedCallback?.call());
   }
+
   final Map<String, ServiceExtensionCallback> extensions = <String, ServiceExtensionCallback>{};
 
   final Map<DispatchedEventKey, List<Map<Object, Object?>>> eventsDispatched =
       <DispatchedEventKey, List<Map<Object, Object?>>>{};
-  final  List<Object?> objectsInspected = <Object?>[];
+
+  final List<Object?> objectsInspected = <Object?>[];
 
   @override
   void registerServiceExtension({

--- a/packages/flutter/test_private/bin/test_private.dart
+++ b/packages/flutter/test_private/bin/test_private.dart
@@ -32,7 +32,7 @@ void _usage() {
 Future<void> main(List<String> args) async {
   // TODO(gspencergoog): Convert to using the args package once it has been
   // converted to be non-nullable by default.
-  if (args.isNotEmpty && args[0] == '--help') {
+  if (args.firstOrNull == '--help') {
     _usage();
     exit(0);
   }


### PR DESCRIPTION
Hopefully soon, [flutter.dev/go/dart-patterns](https://flutter.dev/go/dart-patterns) will have lots of good feedback; in the meantime, I'll focus refactoring efforts on uncontroversial things :)

Previously, I was under the impression that I could solve issue #143803 with [just 1 PR](https://github.com/flutter/flutter/pull/143804).
It turns out that I had overlooked quite a bit!

<br>

```dart
// before
if (chunkEvents != null) {
  chunkEvents.listen((ImageChunkEvent event) {
      reportImageChunkEvent(event);
    },
  );
}


// after
chunkEvents?.listen(reportImageChunkEvent);
```