### PR TITLE
Calendar font factor

### DIFF
--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -331,13 +331,16 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
           child: _buildPicker(),
         ),
         // Put the mode toggle button on top so that it won't be covered up by the _MonthPicker
-        _DatePickerModeToggleButton(
-          mode: _mode,
-          title: _localizations.formatMonthYear(_currentDisplayedMonthDate),
-          onTitlePressed: () => _handleModeChanged(switch (_mode) {
-            DatePickerMode.day => DatePickerMode.year,
-            DatePickerMode.year => DatePickerMode.day,
-          }),
+        MediaQuery.withClampedTextScaling(
+          maxScaleFactor: 2.0,
+          child: _DatePickerModeToggleButton(
+            mode: _mode,
+            title: _localizations.formatMonthYear(_currentDisplayedMonthDate),
+            onTitlePressed: () => _handleModeChanged(switch (_mode) {
+              DatePickerMode.day => DatePickerMode.year,
+              DatePickerMode.year => DatePickerMode.day,
+            }),
+          ),
         ),
       ],
     );
@@ -426,7 +429,6 @@ class _DatePickerModeToggleButtonState extends State<_DatePickerModeToggleButton
                             child: Text(
                               widget.title,
                               overflow: TextOverflow.ellipsis,
-                              textScaleFactor: 2.0,
                               style: textTheme.titleSmall?.copyWith(
                                 color: controlColor,
                               ),
@@ -1002,11 +1004,11 @@ class _DayPickerState extends State<_DayPicker> {
       child: MediaQuery.withClampedTextScaling(
         maxScaleFactor: isLandscapeOrientation ? 1.5 : 2.0,
         child: GridView.custom(
-        physics: const ClampingScrollPhysics(),
-        gridDelegate: _DayPickerGridDelegate(context),
-        childrenDelegate: SliverChildListDelegate(
-          dayItems,
-          addRepaintBoundaries: false,
+          physics: const ClampingScrollPhysics(),
+          gridDelegate: _DayPickerGridDelegate(context),
+          childrenDelegate: SliverChildListDelegate(
+            dayItems,
+            addRepaintBoundaries: false,
           ),
         ),
       ),
@@ -1407,5 +1409,3 @@ class _YearPickerGridDelegate extends SliverGridDelegate {
   @override
   bool shouldRelayout(_YearPickerGridDelegate oldDelegate) => false;
 }
-
-// const _YearPickerGridDelegate _yearPickerGridDelegate = _YearPickerGridDelegate();

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -319,10 +319,14 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
     assert(debugCheckHasDirectionality(context));
+    const double fontSizeToScale = 14.0;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+    final double scaledMaxDayPickerHeight =
+      textScaleFactor > 1.3 ? _maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * 8)) : _maxDayPickerHeight;
     return Stack(
       children: <Widget>[
         SizedBox(
-          height: _subHeaderHeight + _maxDayPickerHeight,
+          height: _subHeaderHeight + scaledMaxDayPickerHeight,
           child: _buildPicker(),
         ),
         // Put the mode toggle button on top so that it won't be covered up by the _MonthPicker
@@ -990,12 +994,15 @@ class _DayPickerState extends State<_DayPicker> {
       padding: const EdgeInsets.symmetric(
         horizontal: _monthPickerHorizontalPadding,
       ),
-      child: GridView.custom(
+      child: MediaQuery.withClampedTextScaling(
+        maxScaleFactor: 2.0,
+        child: GridView.custom(
         physics: const ClampingScrollPhysics(),
-        gridDelegate: _dayPickerGridDelegate,
+        gridDelegate: _DayPickerGridDelegate(context),
         childrenDelegate: SliverChildListDelegate(
           dayItems,
           addRepaintBoundaries: false,
+          ),
         ),
       ),
     );
@@ -1120,14 +1127,20 @@ class _DayState extends State<_Day> {
 }
 
 class _DayPickerGridDelegate extends SliverGridDelegate {
-  const _DayPickerGridDelegate();
+  const _DayPickerGridDelegate(this.context);
+
+  final BuildContext context;
 
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
+    const double fontSizeToScale = 14.0;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+    final double scaledRowHeight =
+      textScaleFactor > 1.3 ? ((textScaleFactor - 1) * 30) + _dayPickerRowHeight : _dayPickerRowHeight;
     const int columnCount = DateTime.daysPerWeek;
     final double tileWidth = constraints.crossAxisExtent / columnCount;
     final double tileHeight = math.min(
-      _dayPickerRowHeight,
+      scaledRowHeight,
       constraints.viewportMainAxisExtent / (_maxDayPickerRowCount + 1),
     );
     return SliverGridRegularTileLayout(
@@ -1143,8 +1156,6 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
   @override
   bool shouldRelayout(_DayPickerGridDelegate oldDelegate) => false;
 }
-
-const _DayPickerGridDelegate _dayPickerGridDelegate = _DayPickerGridDelegate();
 
 /// A scrollable grid of years to allow picking a year.
 ///
@@ -1259,14 +1270,17 @@ class _YearPickerState extends State<YearPicker> {
       );
     }
 
+    const double fontSizeToScale = 14.0;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+
     // Backfill the _YearPicker with disabled years if necessary.
     final int offset = _itemCount < minYears ? (minYears - _itemCount) ~/ 2 : 0;
     final int year = widget.firstDate.year + index - offset;
     final bool isSelected = year == widget.selectedDate?.year;
     final bool isCurrentYear = year == widget.currentDate.year;
     final bool isDisabled = year < widget.firstDate.year || year > widget.lastDate.year;
-    const double decorationHeight = 36.0;
-    const double decorationWidth = 72.0;
+    final double decorationHeight = 36.0 * textScaleFactor;
+    final double decorationWidth = 72.0 * textScaleFactor;
 
     final Set<MaterialState> states = <MaterialState>{
       if (isDisabled) MaterialState.disabled,
@@ -1350,7 +1364,7 @@ class _YearPickerState extends State<YearPicker> {
           child: GridView.builder(
             controller: _scrollController,
             dragStartBehavior: widget.dragStartBehavior,
-            gridDelegate: _yearPickerGridDelegate,
+            gridDelegate: _YearPickerGridDelegate(context),
             itemBuilder: _buildYearItem,
             itemCount: math.max(_itemCount, minYears),
             padding: const EdgeInsets.symmetric(horizontal: _yearPickerPadding),
@@ -1363,18 +1377,24 @@ class _YearPickerState extends State<YearPicker> {
 }
 
 class _YearPickerGridDelegate extends SliverGridDelegate {
-  const _YearPickerGridDelegate();
+  const _YearPickerGridDelegate(this.context);
+
+  final BuildContext context;
 
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
+    const double fontSizeToScale = 14.0;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+    final int scaledYearPickerColumnCount = textScaleFactor > 1.65 ? _yearPickerColumnCount - 1 : _yearPickerColumnCount;
     final double tileWidth =
-      (constraints.crossAxisExtent - (_yearPickerColumnCount - 1) * _yearPickerRowSpacing) / _yearPickerColumnCount;
+      (constraints.crossAxisExtent - (scaledYearPickerColumnCount - 1) * _yearPickerRowSpacing) / scaledYearPickerColumnCount;
+    final double scaledYearPickerRowHeight = textScaleFactor > 1 ? _yearPickerRowHeight + (( textScaleFactor - 1 ) * 9) : _yearPickerRowHeight;
     return SliverGridRegularTileLayout(
       childCrossAxisExtent: tileWidth,
-      childMainAxisExtent: _yearPickerRowHeight,
-      crossAxisCount: _yearPickerColumnCount,
+      childMainAxisExtent: scaledYearPickerRowHeight,
+      crossAxisCount: scaledYearPickerColumnCount,
       crossAxisStride: tileWidth + _yearPickerRowSpacing,
-      mainAxisStride: _yearPickerRowHeight,
+      mainAxisStride: scaledYearPickerRowHeight,
       reverseCrossAxis: axisDirectionIsReversed(constraints.crossAxisDirection),
     );
   }
@@ -1383,4 +1403,4 @@ class _YearPickerGridDelegate extends SliverGridDelegate {
   bool shouldRelayout(_YearPickerGridDelegate oldDelegate) => false;
 }
 
-const _YearPickerGridDelegate _yearPickerGridDelegate = _YearPickerGridDelegate();
+// const _YearPickerGridDelegate _yearPickerGridDelegate = _YearPickerGridDelegate();

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -321,8 +321,11 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
     assert(debugCheckHasDirectionality(context));
     const double fontSizeToScale = 14.0;
     final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+    final Orientation orientation = MediaQuery.orientationOf(context);
+    final bool isLandscapeOrientation = orientation == Orientation.landscape;
+    final double rowHeightScaling = isLandscapeOrientation ? 30 : 8;
     final double scaledMaxDayPickerHeight =
-      textScaleFactor > 1.3 ? _maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * 8)) : _maxDayPickerHeight;
+      textScaleFactor > 1.3 ? _maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * rowHeightScaling)) : _maxDayPickerHeight;
     return Stack(
       children: <Widget>[
         SizedBox(
@@ -955,6 +958,9 @@ class _DayPickerState extends State<_DayPicker> {
     final DatePickerThemeData defaults = DatePickerTheme.defaults(context);
     final TextStyle? weekdayStyle = datePickerTheme.weekdayStyle ?? defaults.weekdayStyle;
 
+    final Orientation orientation = MediaQuery.orientationOf(context);
+    final bool isLandscapeOrientation = orientation == Orientation.landscape;
+
     final int year = widget.displayedMonth.year;
     final int month = widget.displayedMonth.month;
 
@@ -997,7 +1003,7 @@ class _DayPickerState extends State<_DayPicker> {
         horizontal: _monthPickerHorizontalPadding,
       ),
       child: MediaQuery.withClampedTextScaling(
-        maxScaleFactor: 2.0,
+        maxScaleFactor: isLandscapeOrientation ? 1.5 : 2.0,
         child: GridView.custom(
         physics: const ClampingScrollPhysics(),
         gridDelegate: _DayPickerGridDelegate(context),
@@ -1136,11 +1142,10 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
     const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
     final Orientation orientation = MediaQuery.orientationOf(context);
     final bool isLandscapeOrientation = orientation == Orientation.landscape;
-    final double scaledRowHeight = isLandscapeOrientation ?
-      textScaleFactor > 1.3 ? ((textScaleFactor - 1) * 40) + _dayPickerRowHeight : _dayPickerRowHeight :
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+    final double scaledRowHeight =
       textScaleFactor > 1.3 ? ((textScaleFactor - 1) * 30) + _dayPickerRowHeight : _dayPickerRowHeight;
     const int columnCount = DateTime.daysPerWeek;
     final double tileWidth = constraints.crossAxisExtent / columnCount;

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -42,6 +42,25 @@ const double _yearPickerRowSpacing = 8.0;
 const double _subHeaderHeight = 52.0;
 const double _monthNavButtonsWidth = 108.0;
 
+// 3.0 is the maximum scale factor on mobile phones. As of 07/30/24, iOS goes up
+// to a max of 3.0 text sxale factor, and Android goes up to 2.0. This is the
+// default used for non-range date pickers. This default is changed to a lower
+// value at different parts of the date pickers depending on content, and device
+// orientation.
+const double _kMaxTextScaleFactor = 3.0;
+
+const double _kModeToggleButtonMaxScaleFactor = 2.0;
+
+// The max scale factor of the day picker grid. This affects the size of the
+// individual days in calendar view. Due to them filling a majority of the modal,
+// which covers most of the screen, there's a limit in how large they can grow.
+// There is also less room vertically in landscape orientation.
+const double _kDayPickerGridPortraitMaxScaleFactor = 2.0;
+const double _kDayPickerGridLandscapeMaxScaleFactor = 1.5;
+
+// 14 is a common font size used to compute the effective text scale.
+const double _fontSizeToScale = 14.0;
+
 /// Displays a grid of days for a given month and allows the user to select a
 /// date.
 ///
@@ -319,9 +338,11 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
     assert(debugCheckHasDirectionality(context));
-    const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
-    // Scale the height of the picker area up with larger text.
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxTextScaleFactor).scale(_fontSizeToScale) / _fontSizeToScale;
+    // Scale the height of the picker area up with larger text. The size of the
+    // picker has room for larger text, up until a scale facotr of 1.3. After
+    // after which, we increase the height to add room for content to continue
+    // to scale the text size.
     final double scaledMaxDayPickerHeight =
       textScaleFactor > 1.3 ? _maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * 8)) : _maxDayPickerHeight;
     return Stack(
@@ -332,7 +353,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
         ),
         // Put the mode toggle button on top so that it won't be covered up by the _MonthPicker
         MediaQuery.withClampedTextScaling(
-          maxScaleFactor: 2.0,
+          maxScaleFactor: _kModeToggleButtonMaxScaleFactor,
           child: _DatePickerModeToggleButton(
             mode: _mode,
             title: _localizations.formatMonthYear(_currentDisplayedMonthDate),
@@ -1002,7 +1023,9 @@ class _DayPickerState extends State<_DayPicker> {
         horizontal: _monthPickerHorizontalPadding,
       ),
       child: MediaQuery.withClampedTextScaling(
-        maxScaleFactor: isLandscapeOrientation ? 1.5 : 2.0,
+        maxScaleFactor: isLandscapeOrientation ?
+          _kDayPickerGridLandscapeMaxScaleFactor :
+          _kDayPickerGridPortraitMaxScaleFactor,
         child: GridView.custom(
           physics: const ClampingScrollPhysics(),
           gridDelegate: _DayPickerGridDelegate(context),
@@ -1140,8 +1163,7 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
 
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
-    const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(_fontSizeToScale) / _fontSizeToScale;
     final double scaledRowHeight =
       textScaleFactor > 1.3 ? ((textScaleFactor - 1) * 30) + _dayPickerRowHeight : _dayPickerRowHeight;
     const int columnCount = DateTime.daysPerWeek;
@@ -1277,8 +1299,7 @@ class _YearPickerState extends State<YearPicker> {
       );
     }
 
-    const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(_fontSizeToScale) / _fontSizeToScale;
 
     // Backfill the _YearPicker with disabled years if necessary.
     final int offset = _itemCount < minYears ? (minYears - _itemCount) ~/ 2 : 0;
@@ -1390,8 +1411,7 @@ class _YearPickerGridDelegate extends SliverGridDelegate {
 
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
-    const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(_fontSizeToScale) / _fontSizeToScale;
     final int scaledYearPickerColumnCount = textScaleFactor > 1.65 ? _yearPickerColumnCount - 1 : _yearPickerColumnCount;
     final double tileWidth =
       (constraints.crossAxisExtent - (scaledYearPickerColumnCount - 1) * _yearPickerRowSpacing) / scaledYearPickerColumnCount;

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -425,6 +425,8 @@ class _DatePickerModeToggleButtonState extends State<_DatePickerModeToggleButton
                             child: Text(
                               widget.title,
                               overflow: TextOverflow.ellipsis,
+                              // textScaleFactor: 1.6, portrait
+                              textScaleFactor: 2.0, // landscape
                               style: textTheme.titleSmall?.copyWith(
                                 color: controlColor,
                               ),
@@ -1135,7 +1137,10 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
   SliverGridLayout getLayout(SliverConstraints constraints) {
     const double fontSizeToScale = 14.0;
     final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
-    final double scaledRowHeight =
+    final Orientation orientation = MediaQuery.orientationOf(context);
+    final bool isLandscapeOrientation = orientation == Orientation.landscape;
+    final double scaledRowHeight = isLandscapeOrientation ?
+      textScaleFactor > 1.3 ? ((textScaleFactor - 1) * 40) + _dayPickerRowHeight : _dayPickerRowHeight :
       textScaleFactor > 1.3 ? ((textScaleFactor - 1) * 30) + _dayPickerRowHeight : _dayPickerRowHeight;
     const int columnCount = DateTime.daysPerWeek;
     final double tileWidth = constraints.crossAxisExtent / columnCount;

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -321,11 +321,9 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
     assert(debugCheckHasDirectionality(context));
     const double fontSizeToScale = 14.0;
     final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
-    final Orientation orientation = MediaQuery.orientationOf(context);
-    final bool isLandscapeOrientation = orientation == Orientation.landscape;
-    final double rowHeightScaling = isLandscapeOrientation ? 30 : 8;
+    // Scale the height of the picker area up with larger text.
     final double scaledMaxDayPickerHeight =
-      textScaleFactor > 1.3 ? _maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * rowHeightScaling)) : _maxDayPickerHeight;
+      textScaleFactor > 1.3 ? _maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * 8)) : _maxDayPickerHeight;
     return Stack(
       children: <Widget>[
         SizedBox(
@@ -428,8 +426,7 @@ class _DatePickerModeToggleButtonState extends State<_DatePickerModeToggleButton
                             child: Text(
                               widget.title,
                               overflow: TextOverflow.ellipsis,
-                              // textScaleFactor: 1.6, portrait
-                              textScaleFactor: 2.0, // landscape
+                              textScaleFactor: 2.0,
                               style: textTheme.titleSmall?.copyWith(
                                 color: controlColor,
                               ),
@@ -1142,8 +1139,6 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
     const double fontSizeToScale = 14.0;
-    final Orientation orientation = MediaQuery.orientationOf(context);
-    final bool isLandscapeOrientation = orientation == Orientation.landscape;
     final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(fontSizeToScale) / fontSizeToScale;
     final double scaledRowHeight =
       textScaleFactor > 1.3 ? ((textScaleFactor - 1) * 30) + _dayPickerRowHeight : _dayPickerRowHeight;

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -874,7 +874,8 @@ class _DatePickerHeader extends StatelessWidget {
       color: foregroundColor,
     );
     const double fontSizeToScale = 14.0;
-    final double maxHeaderTextScaleFactor = entryModeButton != null ? 1.4 : _kMaxHeaderTextScaleFactor;
+    final double currentScale = MediaQuery.textScalerOf(context).scale(fontSizeToScale) / fontSizeToScale;
+    final double maxHeaderTextScaleFactor = math.min(currentScale, entryModeButton != null ? 1.4 : _kMaxHeaderTextScaleFactor);
     final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: maxHeaderTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
     final double scaledFontSize = MediaQuery.textScalerOf(context).scale(titleStyle?.fontSize ?? 32);
     final double headerScaleFactor = textScaleFactor > 1 ? textScaleFactor  : 1.0;
@@ -884,7 +885,7 @@ class _DatePickerHeader extends StatelessWidget {
       style: helpStyle,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
-      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: orientation ==  Orientation.portrait ? 1.6 : 1.4),
+      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: math.min(textScaleFactor, orientation ==  Orientation.portrait ? 1.6 : 1.4)),
     );
     final Text title = Text(
       titleText,
@@ -894,11 +895,11 @@ class _DatePickerHeader extends StatelessWidget {
         (scaledFontSize > 70 ? 2 : 1) :
         scaledFontSize > 40 ? 3 : 2,
       overflow: TextOverflow.ellipsis,
-      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: maxHeaderTextScaleFactor),
+      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: textScaleFactor),
     );
 
     final double fontScaleAdjustedHeaderHeight =
-      headerScaleFactor > 1.5 ? headerScaleFactor - 0.2 : headerScaleFactor;
+      headerScaleFactor > 1.3 ? headerScaleFactor - 0.2 : 1.0;
 
     switch (orientation) {
       case Orientation.portrait:

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -884,7 +884,9 @@ class _DatePickerHeader extends StatelessWidget {
       titleText,
       semanticsLabel: titleSemanticsLabel ?? titleText,
       style: titleStyle,
-      maxLines: orientation == Orientation.portrait ? scaledFontSize > 70 ? 2 : 1 : scaledFontSize > 40 ? 3 : 2,
+      maxLines: orientation == Orientation.portrait ?
+        (scaledFontSize > 70 ? 2 : 1) :
+        scaledFontSize > 40 ? 3 : 2,
       overflow: TextOverflow.ellipsis,
       textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxHeaderTextScaleFactor),
     );

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -556,7 +556,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
     final Widget actions = ConstrainedBox(
       constraints: const BoxConstraints(minHeight: 52.0),
       child: MediaQuery.withClampedTextScaling(
-        maxScaleFactor: isLandscapeOrientation ? 2.0 : _kMaxTextScaleFactor,
+        maxScaleFactor: isLandscapeOrientation ? 1.6 : _kMaxTextScaleFactor,
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8),
           child: Align(
@@ -878,7 +878,7 @@ class _DatePickerHeader extends StatelessWidget {
       style: helpStyle,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
-      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.6),
+      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: orientation ==  Orientation.portrait ? 1.6 : 1.4),
     );
     final Text title = Text(
       titleText,

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -52,7 +52,8 @@ const Size _inputRangeLandscapeDialogSize = Size(496, 164.0);
 const Duration _dialogSizeAnimationDuration = Duration(milliseconds: 200);
 const double _inputFormPortraitHeight = 98.0;
 const double _inputFormLandscapeHeight = 108.0;
-const double _kMaxTextScaleFactor = 1.3;
+const double _kMaxTextScaleFactor = 3.0;
+const double _kMaxHeaderTextScaleFactor = 2.0;
 
 /// Shows a dialog containing a Material Design date picker.
 ///
@@ -863,27 +864,36 @@ class _DatePickerHeader extends StatelessWidget {
     final TextStyle? helpStyle = (datePickerTheme.headerHelpStyle ?? defaults.headerHelpStyle)?.copyWith(
       color: foregroundColor,
     );
+    const double fontSizeToScale = 14.0;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxHeaderTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
+    final double scaledFontSize = MediaQuery.of(context).textScaler.scale(titleStyle?.fontSize ?? 32);
+    final double headerScaleFactor = textScaleFactor > 1 ? textScaleFactor  : 1.0;
 
     final Text help = Text(
       helpText,
       style: helpStyle,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
+      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.6),
     );
     final Text title = Text(
       titleText,
       semanticsLabel: titleSemanticsLabel ?? titleText,
       style: titleStyle,
-      maxLines: orientation == Orientation.portrait ? 1 : 2,
+      maxLines: orientation == Orientation.portrait ? scaledFontSize > 70 ? 2 : 1 : scaledFontSize > 40 ? 3 : 2,
       overflow: TextOverflow.ellipsis,
+      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxHeaderTextScaleFactor),
     );
+
+    final double fontScaleAdjustedHeaderHeight =
+      orientation == Orientation.portrait ? headerScaleFactor > 1.5 ? headerScaleFactor - 0.1 : headerScaleFactor : headerScaleFactor;
 
     switch (orientation) {
       case Orientation.portrait:
         return Semantics(
           container: true,
           child: SizedBox(
-            height: _datePickerHeaderPortraitHeight,
+            height: _datePickerHeaderPortraitHeight * fontScaleAdjustedHeaderHeight,
             child: Material(
               color: backgroundColor,
               child: Padding(

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -892,7 +892,7 @@ class _DatePickerHeader extends StatelessWidget {
     );
 
     final double fontScaleAdjustedHeaderHeight =
-      orientation == Orientation.portrait ? headerScaleFactor > 1.5 ? headerScaleFactor - 0.2 : headerScaleFactor : headerScaleFactor;
+      headerScaleFactor > 1.5 ? headerScaleFactor - 0.2 : headerScaleFactor;
 
     switch (orientation) {
       case Orientation.portrait:

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -53,7 +53,8 @@ const Duration _dialogSizeAnimationDuration = Duration(milliseconds: 200);
 const double _inputFormPortraitHeight = 98.0;
 const double _inputFormLandscapeHeight = 108.0;
 const double _kMaxTextScaleFactor = 3.0;
-const double _kMaxHeaderTextScaleFactor = 1.8;
+const double _kMaxRangeTextScaleFactor = 1.3;
+const double _kMaxHeaderTextScaleFactor = 1.6;
 
 /// Shows a dialog containing a Material Design date picker.
 ///
@@ -609,23 +610,27 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
             child: Shortcuts(
               shortcuts: _formShortcutMap,
               child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
-                  const Spacer(),
-                  InputDatePickerFormField(
-                    initialDate: _selectedDate.value,
-                    firstDate: widget.firstDate,
-                    lastDate: widget.lastDate,
-                    onDateSubmitted: _handleDateChanged,
-                    onDateSaved: _handleDateChanged,
-                    selectableDayPredicate: widget.selectableDayPredicate,
-                    errorFormatText: widget.errorFormatText,
-                    errorInvalidText: widget.errorInvalidText,
-                    fieldHintText: widget.fieldHintText,
-                    fieldLabelText: widget.fieldLabelText,
-                    keyboardType: widget.keyboardType,
-                    autofocus: true,
+                  Flexible(
+                    child: MediaQuery.withClampedTextScaling(
+                      maxScaleFactor: 2.0,
+                      child: InputDatePickerFormField(
+                        initialDate: _selectedDate.value,
+                        firstDate: widget.firstDate,
+                        lastDate: widget.lastDate,
+                        onDateSubmitted: _handleDateChanged,
+                        onDateSaved: _handleDateChanged,
+                        selectableDayPredicate: widget.selectableDayPredicate,
+                        errorFormatText: widget.errorFormatText,
+                        errorInvalidText: widget.errorInvalidText,
+                        fieldHintText: widget.fieldHintText,
+                        fieldLabelText: widget.fieldLabelText,
+                        keyboardType: widget.keyboardType,
+                        autofocus: true,
+                      ),
+                    ),
                   ),
-                  const Spacer(),
                 ],
               ),
             ),
@@ -869,8 +874,9 @@ class _DatePickerHeader extends StatelessWidget {
       color: foregroundColor,
     );
     const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxHeaderTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
-    final double scaledFontSize = MediaQuery.of(context).textScaler.scale(titleStyle?.fontSize ?? 32);
+    final double maxHeaderTextScaleFactor = entryModeButton != null ? 1.4 : _kMaxHeaderTextScaleFactor;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: maxHeaderTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
+    final double scaledFontSize = MediaQuery.textScalerOf(context).scale(titleStyle?.fontSize ?? 32);
     final double headerScaleFactor = textScaleFactor > 1 ? textScaleFactor  : 1.0;
 
     final Text help = Text(
@@ -888,7 +894,7 @@ class _DatePickerHeader extends StatelessWidget {
         (scaledFontSize > 70 ? 2 : 1) :
         scaledFontSize > 40 ? 3 : 2,
       overflow: TextOverflow.ellipsis,
-      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxHeaderTextScaleFactor),
+      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: maxHeaderTextScaleFactor),
     );
 
     final double fontScaleAdjustedHeaderHeight =
@@ -1628,7 +1634,7 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
         duration: _dialogSizeAnimationDuration,
         curve: Curves.easeIn,
         child: MediaQuery.withClampedTextScaling(
-          maxScaleFactor: _kMaxTextScaleFactor,
+          maxScaleFactor: _kMaxRangeTextScaleFactor,
           child: Builder(builder: (BuildContext context) {
             return contents;
           }),
@@ -2934,7 +2940,7 @@ class _InputDateRangePickerDialog extends StatelessWidget {
 
     // 14 is a common font size used to compute the effective text scale.
     const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxRangeTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
     final Size dialogSize = (useMaterial3 ? _inputPortraitDialogSizeM3 : _inputPortraitDialogSizeM2) * textScaleFactor;
     switch (orientation) {
       case Orientation.portrait:

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -53,7 +53,7 @@ const Duration _dialogSizeAnimationDuration = Duration(milliseconds: 200);
 const double _inputFormPortraitHeight = 98.0;
 const double _inputFormLandscapeHeight = 108.0;
 const double _kMaxTextScaleFactor = 3.0;
-const double _kMaxHeaderTextScaleFactor = 2.0;
+const double _kMaxHeaderTextScaleFactor = 1.8;
 
 /// Shows a dialog containing a Material Design date picker.
 ///
@@ -525,6 +525,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
     final bool useMaterial3 = theme.useMaterial3;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final Orientation orientation = MediaQuery.orientationOf(context);
+    final bool isLandscapeOrientation = orientation == Orientation.landscape;
     final DatePickerThemeData datePickerTheme = DatePickerTheme.of(context);
     final DatePickerThemeData defaults = DatePickerTheme.defaults(context);
     final TextTheme textTheme = theme.textTheme;
@@ -547,35 +548,38 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
           // M3 default is OK.
       }
     } else {
-      headlineStyle = orientation == Orientation.landscape ? textTheme.headlineSmall : textTheme.headlineMedium;
+      headlineStyle = isLandscapeOrientation ? textTheme.headlineSmall : textTheme.headlineMedium;
     }
     final Color? headerForegroundColor = datePickerTheme.headerForegroundColor ?? defaults.headerForegroundColor;
     headlineStyle = headlineStyle?.copyWith(color: headerForegroundColor);
 
     final Widget actions = ConstrainedBox(
       constraints: const BoxConstraints(minHeight: 52.0),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: Align(
-          alignment: AlignmentDirectional.centerEnd,
-          child: OverflowBar(
-            spacing: 8,
-            children: <Widget>[
-              TextButton(
-                style: datePickerTheme.cancelButtonStyle ?? defaults.cancelButtonStyle,
-                onPressed: _handleCancel,
-                child: Text(widget.cancelText ?? (
-                  useMaterial3
-                    ? localizations.cancelButtonLabel
-                    : localizations.cancelButtonLabel.toUpperCase()
-                )),
-              ),
-              TextButton(
-                style: datePickerTheme.confirmButtonStyle ?? defaults.confirmButtonStyle,
-                onPressed: _handleOk,
-                child: Text(widget.confirmText ?? localizations.okButtonLabel),
-              ),
-            ],
+      child: MediaQuery.withClampedTextScaling(
+        maxScaleFactor: isLandscapeOrientation ? 2.0 : _kMaxTextScaleFactor,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Align(
+            alignment: AlignmentDirectional.centerEnd,
+            child: OverflowBar(
+              spacing: 8,
+              children: <Widget>[
+                TextButton(
+                  style: datePickerTheme.cancelButtonStyle ?? defaults.cancelButtonStyle,
+                  onPressed: _handleCancel,
+                  child: Text(widget.cancelText ?? (
+                    useMaterial3
+                      ? localizations.cancelButtonLabel
+                      : localizations.cancelButtonLabel.toUpperCase()
+                  )),
+                ),
+                TextButton(
+                  style: datePickerTheme.confirmButtonStyle ?? defaults.confirmButtonStyle,
+                  onPressed: _handleOk,
+                  child: Text(widget.confirmText ?? localizations.okButtonLabel),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -886,7 +890,7 @@ class _DatePickerHeader extends StatelessWidget {
     );
 
     final double fontScaleAdjustedHeaderHeight =
-      orientation == Orientation.portrait ? headerScaleFactor > 1.5 ? headerScaleFactor - 0.1 : headerScaleFactor : headerScaleFactor;
+      orientation == Orientation.portrait ? headerScaleFactor > 1.5 ? headerScaleFactor - 0.2 : headerScaleFactor : headerScaleFactor;
 
     switch (orientation) {
       case Orientation.portrait:

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -52,9 +52,30 @@ const Size _inputRangeLandscapeDialogSize = Size(496, 164.0);
 const Duration _dialogSizeAnimationDuration = Duration(milliseconds: 200);
 const double _inputFormPortraitHeight = 98.0;
 const double _inputFormLandscapeHeight = 108.0;
+
+// 3.0 is the maximum scale factor on mobile phones. As of 07/30/24, iOS goes up
+// to a max of 3.0 text sxale factor, and Android goes up to 2.0. This is the
+// default used for non-range date pickers. This default is changed to a lower
+// value at different parts of the date pickers depending on content, and device
+// orientation.
 const double _kMaxTextScaleFactor = 3.0;
+
+// The max scale factor for the date range pickers.
 const double _kMaxRangeTextScaleFactor = 1.3;
+
+// The max text scale factor for the header. This is lower than the default as
+// the title text already starts at a large size.
 const double _kMaxHeaderTextScaleFactor = 1.6;
+
+// The entry button shares a line with the header text, so there is less room to
+// scale up.
+const double _kMaxHeaderWithEntryTextScaleFactor = 1.4;
+
+const double _kMaxHelpPortraitTextScaleFactor = 1.6;
+const double _kMaxHelpLandscapeTextScaleFactor = 1.4;
+
+// 14 is a common font size used to compute the effective text scale.
+const double _fontSizeToScale = 14.0;
 
 /// Shows a dialog containing a Material Design date picker.
 ///
@@ -684,9 +705,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
 
     // Constrain the textScaleFactor to the largest supported value to prevent
     // layout issues.
-    // 14 is a common font size used to compute the effective text scale.
-    const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxTextScaleFactor).scale(_fontSizeToScale) / _fontSizeToScale;
     final Size dialogSize = _dialogSize(context) * textScaleFactor;
     final DialogTheme dialogTheme = theme.dialogTheme;
     return Dialog(
@@ -873,10 +892,9 @@ class _DatePickerHeader extends StatelessWidget {
     final TextStyle? helpStyle = (datePickerTheme.headerHelpStyle ?? defaults.headerHelpStyle)?.copyWith(
       color: foregroundColor,
     );
-    const double fontSizeToScale = 14.0;
-    final double currentScale = MediaQuery.textScalerOf(context).scale(fontSizeToScale) / fontSizeToScale;
-    final double maxHeaderTextScaleFactor = math.min(currentScale, entryModeButton != null ? 1.4 : _kMaxHeaderTextScaleFactor);
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: maxHeaderTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
+    final double currentScale = MediaQuery.textScalerOf(context).scale(_fontSizeToScale) / _fontSizeToScale;
+    final double maxHeaderTextScaleFactor = math.min(currentScale, entryModeButton != null ? _kMaxHeaderWithEntryTextScaleFactor : _kMaxHeaderTextScaleFactor);
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: maxHeaderTextScaleFactor).scale(_fontSizeToScale) / _fontSizeToScale;
     final double scaledFontSize = MediaQuery.textScalerOf(context).scale(titleStyle?.fontSize ?? 32);
     final double headerScaleFactor = textScaleFactor > 1 ? textScaleFactor  : 1.0;
 
@@ -885,7 +903,12 @@ class _DatePickerHeader extends StatelessWidget {
       style: helpStyle,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
-      textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: math.min(textScaleFactor, orientation ==  Orientation.portrait ? 1.6 : 1.4)),
+      textScaler: MediaQuery.textScalerOf(context).clamp(
+        maxScaleFactor: math.min(textScaleFactor, orientation ==  Orientation.portrait ?
+          _kMaxHelpPortraitTextScaleFactor :
+          _kMaxHelpLandscapeTextScaleFactor
+        )
+      ),
     );
     final Text title = Text(
       titleText,
@@ -2939,9 +2962,7 @@ class _InputDateRangePickerDialog extends StatelessWidget {
       ),
     );
 
-    // 14 is a common font size used to compute the effective text scale.
-    const double fontSizeToScale = 14.0;
-    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxRangeTextScaleFactor).scale(fontSizeToScale) / fontSizeToScale;
+    final double textScaleFactor = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: _kMaxRangeTextScaleFactor).scale(_fontSizeToScale) / _fontSizeToScale;
     final Size dialogSize = (useMaterial3 ? _inputPortraitDialogSizeM3 : _inputPortraitDialogSizeM2) * textScaleFactor;
     switch (orientation) {
       case Orientation.portrait:

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1316,6 +1316,35 @@ void main() {
         expect(find.text('2017'), findsNothing);
       });
     });
+
+    testWidgets('Calendar dialog contents are visible - textScaler 0.88, 1.0, 2.0',
+      (WidgetTester tester) async {
+        addTearDown(tester.view.reset);
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        final List<double> scales = <double>[0.88, 1.0, 2.0];
+
+        for (final double scale in scales) {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: MediaQuery(
+                data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+                child: Material(
+                  child: DatePickerDialog(
+                    firstDate: DateTime(2001),
+                    lastDate: DateTime(2031, DateTime.december, 31),
+                    initialDate: DateTime(2016, DateTime.january, 15),
+                    initialEntryMode: DatePickerEntryMode.calendarOnly,
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await expectLater(find.byType(Dialog), matchesGoldenFile('date_picker.calendar.contents.visible.$scale.png'));
+        }
+    });
   });
 
   group('Input mode', () {

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1509,6 +1509,7 @@ void main() {
         final List<double> scales = <double>[0.88, 1.0, 2.0];
 
         for (final double scale in scales) {
+          print(scale);
           await tester.pumpWidget(
             MaterialApp(
               home: MediaQuery(

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1509,7 +1509,6 @@ void main() {
         final List<double> scales = <double>[0.88, 1.0, 2.0];
 
         for (final double scale in scales) {
-          print(scale);
           await tester.pumpWidget(
             MaterialApp(
               home: MediaQuery(


### PR DESCRIPTION
Increases the max text can be scaled for the date picker in calendar mode and input mode. Previously the max across the whole widget was 1.3. Due to the size of the widget, this was increased as much as possible with different values used in different places. Testing and screenshots where taken on the iPhone SE 3rd generation simulator, set at max font size, which is a value of 3.0. Android has a lower max font scale value of 2.0, and the iPhone SE is about the smallest phone with a lower pixel density ratio.

Fixes internal issues b/316958515 and b/316959677 
Also fixes #61334

Comparison for calendar mode in portrait and landscape:

| Before    | After |
| -------- | ------- |
| <img width="375" alt="Old-SE-Portrait-DayPicker" src="https://github.com/user-attachments/assets/4dd1735f-f4c7-4a0a-b8d3-e5ea84d2ba3c"> | <img width="376" alt="Screenshot 2024-07-25 at 1 25 41 PM" src="https://github.com/user-attachments/assets/a53d7d68-87ef-4b29-9479-36ef22bd6cc9"> |
| <img width="375" alt="Old-SE-Portrait-YearPicker" src="https://github.com/user-attachments/assets/37c2965d-1ec0-429b-aa4d-37396f90cb74"> | <img width="377" alt="Screenshot 2024-07-25 at 1 26 38 PM" src="https://github.com/user-attachments/assets/2a00d90f-d523-4ff5-a1d7-e1bfafb245d3"> |
| <img width="665" alt="Old-SE-Landscape-DayPicker" src="https://github.com/user-attachments/assets/1cc4cd26-d56a-4f35-88b1-1c13fa460c2f"> | <img width="665" alt="Screenshot 2024-07-25 at 1 25 52 PM" src="https://github.com/user-attachments/assets/729ac66c-d6b9-4a2a-8303-b5c9face0f62"> |
| <img width="664" alt="Old-SE-Landscape-YearPicker" src="https://github.com/user-attachments/assets/f00a9ab8-1925-4c33-bfcc-31020b2858b8"> | <img width="666" alt="Screenshot 2024-07-25 at 1 26 47 PM" src="https://github.com/user-attachments/assets/d6116c20-4862-4e07-8ab4-fb8ecb71bfa5"> |

The title text is smaller when the entry mode button is available:
<img width="374" alt="Screenshot 2024-07-25 at 1 24 52 PM" src="https://github.com/user-attachments/assets/83305c11-97d5-4986-bf51-fe0be71f653e">

Adjustments were made to input mode as well, but they are simpler

<img width="372" alt="Screenshot 2024-07-25 at 1 43 39 PM" src="https://github.com/user-attachments/assets/2440cf6f-160f-4689-978e-d0a3df2db102">
<img width="666" alt="Screenshot 2024-07-25 at 1 43 48 PM" src="https://github.com/user-attachments/assets/e8d8dbf3-c7d8-4668-9245-7b5036165e75">

Date range picker was not adjusted with this PR. It still has a max of 1.3.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
