### PR TITLE
Add ability to clip `Stepper` step content

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -222,7 +222,7 @@ class Stepper extends StatefulWidget {
     this.stepIconHeight,
     this.stepIconWidth,
     this.stepIconMargin,
-    this.clipBehavior,
+    this.clipBehavior = Clip.none,
   })  : assert(0 <= currentStep && currentStep < steps.length),
         assert(stepIconHeight == null || (stepIconHeight >= _kStepSize && stepIconHeight <= _kMaxStepSize),
             'stepIconHeight must be greater than $_kStepSize and less or equal to $_kMaxStepSize'),
@@ -374,7 +374,7 @@ class Stepper extends StatefulWidget {
   /// See also:
   ///
   ///  * [Clip], which explains how to use this property.
-  final Clip? clipBehavior;
+  final Clip clipBehavior;
 
   @override
   State<Stepper> createState() => _StepperState();
@@ -806,7 +806,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
             child: Column(
               children: <Widget>[
                 ClipRect(
-                  clipBehavior: widget.clipBehavior ?? Clip.none,
+                  clipBehavior: widget.clipBehavior,
                   child: widget.steps[index].content,
                 ),
                 _buildVerticalControls(index),
@@ -902,7 +902,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
           maintainState: true,
           visible: i == widget.currentStep,
           child: ClipRect(
-            clipBehavior: widget.clipBehavior ?? Clip.none,
+            clipBehavior: widget.clipBehavior,
             child: widget.steps[i].content,
           ),
         ),

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -222,6 +222,7 @@ class Stepper extends StatefulWidget {
     this.stepIconHeight,
     this.stepIconWidth,
     this.stepIconMargin,
+    this.clipBehavior,
   })  : assert(0 <= currentStep && currentStep < steps.length),
         assert(stepIconHeight == null || (stepIconHeight >= _kStepSize && stepIconHeight <= _kMaxStepSize),
             'stepIconHeight must be greater than $_kStepSize and less or equal to $_kMaxStepSize'),
@@ -365,6 +366,15 @@ class Stepper extends StatefulWidget {
 
   /// Overrides the default step icon margin.
   final EdgeInsets? stepIconMargin;
+
+  /// The [Step.content] will be clipped to this Clip type.
+  ///
+  /// Defaults to [Clip.none].
+  ///
+  /// See also:
+  ///
+  ///  * [Clip], which explains how to use this property.
+  final Clip? clipBehavior;
 
   @override
   State<Stepper> createState() => _StepperState();
@@ -795,7 +805,10 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
             ),
             child: Column(
               children: <Widget>[
-                widget.steps[index].content,
+                ClipRect(
+                  clipBehavior: widget.clipBehavior ?? Clip.none,
+                  child: widget.steps[index].content,
+                ),
                 _buildVerticalControls(index),
               ],
             ),
@@ -888,7 +901,10 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         Visibility(
           maintainState: true,
           visible: i == widget.currentStep,
-          child: widget.steps[i].content,
+          child: ClipRect(
+            clipBehavior: widget.clipBehavior ?? Clip.none,
+            child: widget.steps[i].content,
+          ),
         ),
       );
     }

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -1720,6 +1720,59 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     ));
     expect(lastConnector.width, equals(0.0));
   });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/66007.
+  testWidgets('Vertical Stepper steps can be clipped', (WidgetTester tester) async {
+    Widget buildStepper({ required StepperType type, Clip? clipBehavior }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Stepper(
+              clipBehavior: clipBehavior,
+              type: type,
+              steps: const <Step>[
+                Step(
+                  title: Text('step1'),
+                  content: Text('step1 content'),
+                ),
+                Step(
+                  title: Text('step2'),
+                  content: Text('step2 content'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    ClipRect getContentClipRect() {
+      return tester.widget<ClipRect>(find.ancestor(
+        of: find.text('step1 content'),
+        matching: find.byType(ClipRect),
+      ).first);
+    }
+
+    // Test vertical stepper with default clipBehavior.
+    await tester.pumpWidget(buildStepper(type: StepperType.vertical));
+
+    expect(getContentClipRect().clipBehavior, equals(Clip.none));
+
+    // Test vertical stepper with clipBehavior set to Clip.hardEdge.
+    await tester.pumpWidget(buildStepper(type: StepperType.vertical, clipBehavior: Clip.hardEdge));
+
+    expect(getContentClipRect().clipBehavior, equals(Clip.hardEdge));
+
+    // Test horizontal stepper with default clipBehavior.
+    await tester.pumpWidget(buildStepper(type: StepperType.horizontal));
+
+    expect(getContentClipRect().clipBehavior, equals(Clip.none));
+
+    // Test horizontal stepper with clipBehavior set to Clip.hardEdge.
+    await tester.pumpWidget(buildStepper(type: StepperType.horizontal, clipBehavior: Clip.hardEdge));
+
+    expect(getContentClipRect().clipBehavior, equals(Clip.hardEdge));
+  });
 }
 
 class _TappableColorWidget extends StatefulWidget {

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -1722,13 +1722,12 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
   });
 
   // This is a regression test for https://github.com/flutter/flutter/issues/66007.
-  testWidgets('Vertical Stepper steps can be clipped', (WidgetTester tester) async {
-    Widget buildStepper({ required StepperType type, Clip? clipBehavior }) {
+  testWidgets('Default Stepper clipBehavior', (WidgetTester tester) async {
+    Widget buildStepper({ required StepperType type }) {
       return MaterialApp(
         home: Scaffold(
           body: Center(
             child: Stepper(
-              clipBehavior: clipBehavior,
               type: type,
               steps: const <Step>[
                 Step(
@@ -1758,15 +1757,48 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
 
     expect(getContentClipRect().clipBehavior, equals(Clip.none));
 
-    // Test vertical stepper with clipBehavior set to Clip.hardEdge.
-    await tester.pumpWidget(buildStepper(type: StepperType.vertical, clipBehavior: Clip.hardEdge));
-
-    expect(getContentClipRect().clipBehavior, equals(Clip.hardEdge));
-
     // Test horizontal stepper with default clipBehavior.
     await tester.pumpWidget(buildStepper(type: StepperType.horizontal));
 
     expect(getContentClipRect().clipBehavior, equals(Clip.none));
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/66007.
+  testWidgets('Stepper steps can be clipped', (WidgetTester tester) async {
+    Widget buildStepper({ required StepperType type, required Clip clipBehavior }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Stepper(
+              clipBehavior: clipBehavior,
+              type: type,
+              steps: const <Step>[
+                Step(
+                  title: Text('step1'),
+                  content: Text('step1 content'),
+                ),
+                Step(
+                  title: Text('step2'),
+                  content: Text('step2 content'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    ClipRect getContentClipRect() {
+      return tester.widget<ClipRect>(find.ancestor(
+        of: find.text('step1 content'),
+        matching: find.byType(ClipRect),
+      ).first);
+    }
+
+    // Test vertical stepper with clipBehavior set to Clip.hardEdge.
+    await tester.pumpWidget(buildStepper(type: StepperType.vertical, clipBehavior: Clip.hardEdge));
+
+    expect(getContentClipRect().clipBehavior, equals(Clip.hardEdge));
 
     // Test horizontal stepper with clipBehavior set to Clip.hardEdge.
     await tester.pumpWidget(buildStepper(type: StepperType.horizontal, clipBehavior: Clip.hardEdge));


### PR DESCRIPTION
fixes [Dismissible content overlays Stepper interface while dismissing it](https://github.com/flutter/flutter/issues/66007)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatefulWidget {
  const MyApp({super.key});

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  final List<String> items =
      List<String>.generate(20, (int i) => 'Item ${i + 1}');

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: Padding(
          padding: const EdgeInsets.all(20),
          child: DecoratedBox(
            decoration: BoxDecoration(
              border: Border.all(color: Colors.amber, width: 2),
            ),
            child: Padding(
              padding: const EdgeInsets.all(2.0),
              child: Column(
                children: <Widget>[
                  const SizedBox(height: 8.0),
                  Text(
                    'Dismissible Widget - Vertical Stepper Widget',
                    style: Theme.of(context).textTheme.titleLarge,
                  ),
                  Expanded(
                    child: Stepper(
                      clipBehavior: Clip.hardEdge,
                      steps: <Step>[
                        Step(
                          isActive: true,
                          title: const Text('Step 1'),
                          content: ColoredBox(
                            color: Colors.black12,
                            child: ListView.builder(
                              itemCount: items.length,
                              shrinkWrap: true,
                              itemBuilder: (BuildContext context, int index) {
                                final String item = items[index];
                                return Dismissible(
                                  key: Key(item),
                                  onDismissed: (DismissDirection direction) {
                                    setState(() {
                                      items.removeAt(index);
                                    });
                                    ScaffoldMessenger.of(context).showSnackBar(
                                        SnackBar(
                                            content: Text('$item dismissed')));
                                  },
                                  background: Container(color: Colors.red),
                                  child: ListTile(title: Text(item)),
                                );
                              },
                            ),
                          ),
                        ),
                        const Step(
                          title: Text('Step 2'),
                          content: Text('content'),
                        ),
                      ],
                    ),
                  ),
                  const Divider(height: 1),
                  const SizedBox(height: 8.0),
                  Text(
                    'Dismissible Widget - Horizontal Stepper Widget',
                    style: Theme.of(context).textTheme.titleLarge,
                  ),
                  Expanded(
                    child: Stepper(
                      clipBehavior: Clip.hardEdge,
                      type: StepperType.horizontal,
                      elevation: 0.0,
                      steps: <Step>[
                        Step(
                          isActive: true,
                          title: const Text('Step 1'),
                          content: ColoredBox(
                            color: Colors.black12,
                            child: ListView.builder(
                              itemCount: items.length,
                              shrinkWrap: true,
                              itemBuilder: (BuildContext context, int index) {
                                final String item = items[index];
                                return Dismissible(
                                  key: Key(item),
                                  onDismissed: (DismissDirection direction) {
                                    setState(() {
                                      items.removeAt(index);
                                    });
                                    ScaffoldMessenger.of(context).showSnackBar(
                                        SnackBar(
                                            content: Text('$item dismissed')));
                                  },
                                  background: Container(color: Colors.red),
                                  child: ListTile(title: Text(item)),
                                );
                              },
                            ),
                          ),
                        ),
                        const Step(
                          title: Text('Step 2'),
                          content: Text('content'),
                        ),
                      ],
                    ),
                  ),
                ],
              ),
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>

### Without `Stepper` step content clipping

![Group 1](https://github.com/user-attachments/assets/1814ad90-8d43-4e03-9f68-7da47e08c718)

### With `Stepper` step content clipping

![Group 2](https://github.com/user-attachments/assets/652ff597-7e9a-4d35-abc2-80d60cee03f4)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
