### PR TITLE
Change flutter_build_with_compilation_error_test to check stdout or stderr

### DIFF
--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -63,14 +63,16 @@ int x = 'String';
           '--no-codesign',
       ], workingDirectory: projectRoot.path);
 
-      expect(
-        result,
-        const ProcessResultMatcher(
-          exitCode: 1,
-          stderrPattern: "A value of type 'String' can't be assigned to a variable of type 'int'.",
-        ),
-      );
+      const String errorMessage = "A value of type 'String' can't be assigned to a variable of type 'int'.";
+
+      // Xcode 16 moved the xcodebuild error details from stderr to stdout.
+      // Check that it's contained in one or the other.
+      final bool matchStdout = result.stdout.toString().contains(errorMessage);
+      final bool matchStderr = result.stderr.toString().contains(errorMessage);
+
+      expect(matchStdout || matchStderr, isTrue);
       expect(result.stderr, isNot(contains("Warning: The 'dart2js' entrypoint script is deprecated")));
+      expect(result.stdout, isNot(contains("Warning: The 'dart2js' entrypoint script is deprecated")));
     });
   }
 }


### PR DESCRIPTION
On Xcode 16 beta 3 stderr is:
```
** BUILD FAILED **
```
stdout is:
```
Writing result bundle at path:
	/var/folders/fm/wjzsj_z95ydgn4khxqgbtqx000mfq2/T/flutter_tools.PeJZlH/flutter_ios_build_temp_dirqmiKld/temporary_xcresult_bundle

error: lib/main.dart:13:11: Error: A value of type 'String' can't be assigned to a variable of type 'int'.
  int x = 'String';
          ^
Target kernel_snapshot_program failed: Exception
Failed to package /Users/m/Projects/test_create.
note: Disabling previews because SWIFT_VERSION is set and SWIFT_OPTIMIZATION_LEVEL=-O, expected -Onone (in target 'Runner' from project 'Runner')
note: Run script build phase 'Thin Binary' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked. (in target 'Runner' from project 'Runner')
note: Run script build phase 'Run Script' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked. (in target 'Runner' from project 'Runner')
```

The tool output of `flutter build ios` shows both:
```
Building com.example.testCreate for device (ios-release)...
Automatically signing iOS for device deployment using specified development team
in Xcode project: S8QB4VV633
Running Xcode build...
Xcode build done.                                           10.1s
Failed to build iOS app
Error output from Xcode build:
↳
    ** BUILD FAILED **


Xcode's output:
↳
    Writing result bundle at path:
    	/var/folders/fm/wjzsj_z95ydgn4khxqgbtqx000mfq2/T/flutter_tools.Dgnlxc/flutt
    	er_ios_build_temp_dirpKTDdk/temporary_xcresult_bundle

    error: lib/main.dart:13:11: Error: A value of type 'String' can't be
    assigned to a variable of type 'int'.
      int x = 'String';
              ^
    Target kernel_snapshot_program failed: Exception
    Failed to package /Users/magder/Projects/test_create.
    note: Disabling previews because SWIFT_VERSION is set and
    SWIFT_OPTIMIZATION_LEVEL=-O, expected -Onone (in target 'Runner' from
    project 'Runner')
    note: Run script build phase 'Run Script' will be run during every build
    because the option to run the script phase "Based on dependency analysis" is
    unchecked. (in target 'Runner' from project 'Runner')
    note: Run script build phase 'Thin Binary' will be run during every build
    because the option to run the script phase "Based on dependency analysis" is
    unchecked. (in target 'Runner' from project 'Runner')

Encountered error while building for device.
```

The point of this test is that you can see the error `int x = 'String';` error in the tool output. https://github.com/flutter/flutter/issues/72608#issuecomment-797473109

I think just updating the test to check stderr or stdout is sufficient without touching the tool behavior.

Fixes https://github.com/flutter/flutter/issues/151553

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
