### PR TITLE
Document that `flutter drive --test-arguments` can opt-in to `dart test`

### DIFF
--- a/dev/bots/suite_runners/run_flutter_driver_android_tests.dart
+++ b/dev/bots/suite_runners/run_flutter_driver_android_tests.dart
@@ -14,7 +14,6 @@ Future<void> runFlutterDriverAndroidTests() async {
     'flutter',
     <String>[
       'drive',
-      '--test-arguments="test --reporter="expanded"'
     ],
     workingDirectory: path.join(
       'dev',

--- a/dev/bots/suite_runners/run_flutter_driver_android_tests.dart
+++ b/dev/bots/suite_runners/run_flutter_driver_android_tests.dart
@@ -14,6 +14,7 @@ Future<void> runFlutterDriverAndroidTests() async {
     'flutter',
     <String>[
       'drive',
+      '--test-arguments="test --reporter="expanded"'
     ],
     workingDirectory: path.join(
       'dev',

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -141,7 +141,7 @@ class DriveCommand extends RunCommandBase {
         help: 'Additional arguments to pass to the Dart VM running The test script.\n\n'
               'This can be used to opt-in to use `dart test` as a runner for the test script, '
               'which allows, among other things, changing the reporter. For example, to opt-in '
-              'to the `expanded` reporter:\n\n'
+              'to the "expanded" reporter:\n\n'
               '    flutter drive --test-arguments="test --reporter expanded"\n\n'
               'Please leave feedback at <https://github.com/flutter/flutter/issues/152409>.',
         )

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -142,7 +142,7 @@ class DriveCommand extends RunCommandBase {
               'This can be used to opt-in to use "dart test" as a runner for the test script, '
               'which allows, among other things, changing the reporter. For example, to opt-in '
               'to the "expanded" reporter:\n\n'
-              '    flutter drive --test-arguments="test --reporter expanded"\n\n'
+              '    --test-arguments="test -rexpanded"\n\n'
               'Please leave feedback at <https://github.com/flutter/flutter/issues/152409>.',
         )
       ..addOption('profile-memory', help: 'Launch devtools and profile application memory, writing '

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -136,8 +136,15 @@ class DriveCommand extends RunCommandBase {
       ..addOption('write-sksl-on-exit',
         help: 'Attempts to write an SkSL file when the drive process is finished '
               'to the provided file, overwriting it if necessary.')
-      ..addMultiOption('test-arguments', help: 'Additional arguments to pass to the '
-          'Dart VM running The test script.')
+      ..addMultiOption(
+        'test-arguments',
+        help: 'Additional arguments to pass to the Dart VM running The test script.\n\n'
+              'This can be used to opt-in to use `dart test` as a runner for the test script, '
+              'which allows, among other things, changing the reporter. For example, to opt-in '
+              'to the `expanded` reporter:\n\n'
+              '    flutter drive --test-arguments="test --reporter expanded"\n\n'
+              'Please leave feedback at <https://github.com/flutter/flutter/issues/152409>.',
+        )
       ..addOption('profile-memory', help: 'Launch devtools and profile application memory, writing '
           'The output data to the file path provided to this argument as JSON.',
           valueHelp: 'profile_memory.json')

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -139,7 +139,7 @@ class DriveCommand extends RunCommandBase {
       ..addMultiOption(
         'test-arguments',
         help: 'Additional arguments to pass to the Dart VM running The test script.\n\n'
-              'This can be used to opt-in to use `dart test` as a runner for the test script, '
+              'This can be used to opt-in to use "dart test" as a runner for the test script, '
               'which allows, among other things, changing the reporter. For example, to opt-in '
               'to the "expanded" reporter:\n\n'
               '    flutter drive --test-arguments="test --reporter expanded"\n\n'

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -141,8 +141,7 @@ class DriveCommand extends RunCommandBase {
         help: 'Additional arguments to pass to the Dart VM running The test script.\n\n'
               'This can be used to opt-in to use "dart test" as a runner for the test script, '
               'which allows, among other things, changing the reporter. For example, to opt-in '
-              'to the "expanded" reporter:\n\n'
-              '    --test-arguments="test -rexpanded"\n\n'
+              'to the "expanded" reporter, pass "test -rexpanded".\n\n'
               'Please leave feedback at <https://github.com/flutter/flutter/issues/152409>.',
         )
       ..addOption('profile-memory', help: 'Launch devtools and profile application memory, writing '

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -141,7 +141,7 @@ class DriveCommand extends RunCommandBase {
         help: 'Additional arguments to pass to the Dart VM running The test script.\n\n'
               'This can be used to opt-in to use "dart test" as a runner for the test script, '
               'which allows, among other things, changing the reporter. For example, to opt-in '
-              'to the "expanded" reporter, pass "test -rexpanded".\n\n'
+              'to the "expanded" reporter, pass both "test" and "--reporter=expanded".\n\n'
               'Please leave feedback at <https://github.com/flutter/flutter/issues/152409>.',
         )
       ..addOption('profile-memory', help: 'Launch devtools and profile application memory, writing '

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -262,7 +262,7 @@ class FlutterDriverService extends DriverService {
     try {
       final int result = await _processUtils.stream(<String>[
         _dartSdkPath,
-        ...arguments, 
+        ...arguments,
         testFile,
       ], environment: <String, String>{
         'VM_SERVICE_URL': _vmServiceUri,

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -262,7 +262,8 @@ class FlutterDriverService extends DriverService {
     try {
       final int result = await _processUtils.stream(<String>[
         _dartSdkPath,
-        ...<String>[...arguments, testFile, '-rexpanded'],
+        ...arguments, 
+        testFile,
       ], environment: <String, String>{
         'VM_SERVICE_URL': _vmServiceUri,
         ...environment,

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -195,7 +195,6 @@ class WebDriverService extends DriverService {
       _dartSdkPath,
       ...arguments,
       testFile,
-      '-rexpanded',
     ], environment: <String, String>{
       'VM_SERVICE_URL': _webUri.toString(),
       ..._additionalDriverEnvironment(webDriver, browserName, androidEmulator),

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -104,7 +104,7 @@ void main() {
     ]);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
-        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test', '-rexpanded'],
+        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test'],
         exitCode: 23,
         environment: <String, String>{
           'FOO': 'BAR',
@@ -129,7 +129,7 @@ void main() {
     ]);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
-        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test', '-rexpanded'],
+        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test'],
         exitCode: 23,
         environment: <String, String>{
           'FOO': 'BAR',
@@ -159,7 +159,7 @@ void main() {
     ]);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
-        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test', '-rexpanded'],
+        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test'],
         exitCode: 23,
         environment: <String, String>{
           'FOO': 'BAR',
@@ -192,7 +192,7 @@ void main() {
     ]);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
-        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test', '-rexpanded'],
+        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test'],
         exitCode: 23,
         environment: <String, String>{
           'FOO': 'BAR',
@@ -223,7 +223,7 @@ void main() {
     ]);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
-        command: <String>['dart', 'foo.test', '-rexpanded'],
+        command: <String>['dart', 'foo.test'],
         exitCode: 11,
         environment: <String, String>{
           'VM_SERVICE_URL': 'http://127.0.0.1:63426/1UasC_ihpXY=/',


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/51135.
Closes https://github.com/flutter/flutter/issues/145499.

Making this the _default_, or better discoverable, is tracked in https://github.com/flutter/flutter/issues/152409.

You'll notice I also removed `-rexpanded`; @jonahwilliams believes that was accidentally copied over from else-where, and never did anything (someone I guess could have parsed it in `void main(...)`, but given https://github.com/flutter/flutter/issues/51135 & https://github.com/flutter/flutter/issues/145499 that seems unlikely.
