### PR TITLE
Test of PointerSignalResolverExampleApp visibility

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -367,5 +367,4 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/actions/focusable_action_detector.0_test.dart',
   'examples/api/test/widgets/focus_scope/focus_scope.0_test.dart',
   'examples/api/test/widgets/scroll_view/custom_scroll_view.1_test.dart',
-  'examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart',
 };

--- a/examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart
+++ b/examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/gestures/pointer_signal_resolver/pointer_signal_resolver.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Widget visibility and interactions', () {
+    testWidgets('Widgets visibility', (WidgetTester tester) async {
+      // Build the app and trigger a frame
+      await tester.pumpWidget(const example.PointerSignalResolverExampleApp());
+
+      // There is a ColorChanger on the Stack twice
+      expect(
+          find.descendant(
+              of: find.byType(Stack),
+              matching: find.byType(example.ColorChanger)),
+          findsExactly(2));
+
+      // There is one nested ColorChanger inside the other ColorChanger
+      expect(
+          find.descendant(
+              of: find.byType(example.ColorChanger),
+              matching: find.byType(example.ColorChanger)),
+          findsOneWidget);
+
+      // There is a Switch on the Stack
+      expect(
+          find.descendant(
+              of: find.byType(Stack), matching: find.byType(Switch)),
+          findsOneWidget);
+    });
+
+    testWidgets('Widget interactions', (WidgetTester tester) async {
+      // Build the app and trigger a frame
+      await tester.pumpWidget(const example.PointerSignalResolverExampleApp());
+
+      // Verify the Switch is off
+      final Switch switchWidget = tester.widget(find.byType(Switch));
+      expect(switchWidget.value, isFalse);
+
+      // Toggle the Switch
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+
+      // Verify the Switch state has changed
+      final Switch switchedWidget = tester.widget(find.byType(Switch));
+      expect(switchedWidget.value, isTrue);
+    });
+  });
+}

--- a/examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart
+++ b/examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart
@@ -2,53 +2,183 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/gestures/pointer_signal_resolver/pointer_signal_resolver.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('Widget visibility and interactions', () {
-    testWidgets('Widgets visibility', (WidgetTester tester) async {
-      // Build the app and trigger a frame
-      await tester.pumpWidget(const example.PointerSignalResolverExampleApp());
+  late final Color initialOuterColor;
+  late final Color initialInnerColor;
 
-      // There is a ColorChanger on the Stack twice
-      expect(
-          find.descendant(
-              of: find.byType(Stack),
-              matching: find.byType(example.ColorChanger)),
-          findsExactly(2));
+  setUpAll(() {
+    initialOuterColor = const HSVColor.fromAHSV(0.2, 120.0, 1, 1).toColor();
+    initialInnerColor = const HSVColor.fromAHSV(1, 60.0, 1, 1).toColor();
+  });
+  testWidgets('Widgets visibility', (WidgetTester tester) async {
+    // Build the app and trigger a frame
+    await tester.pumpWidget(const example.PointerSignalResolverExampleApp());
 
-      // There is one nested ColorChanger inside the other ColorChanger
-      expect(
-          find.descendant(
-              of: find.byType(example.ColorChanger),
-              matching: find.byType(example.ColorChanger)),
-          findsOneWidget);
+    // There is a ColorChanger on the Stack twice
+    expect(
+        find.descendant(
+            of: find.byType(Stack),
+            matching: find.byType(example.ColorChanger)),
+        findsExactly(2));
 
-      // There is a Switch on the Stack
-      expect(
-          find.descendant(
-              of: find.byType(Stack), matching: find.byType(Switch)),
-          findsOneWidget);
-    });
+    // There is one nested ColorChanger inside the other ColorChanger
+    expect(
+        find.descendant(
+            of: find.byType(example.ColorChanger),
+            matching: find.byType(example.ColorChanger)),
+        findsOneWidget);
 
-    testWidgets('Widget interactions', (WidgetTester tester) async {
-      // Build the app and trigger a frame
-      await tester.pumpWidget(const example.PointerSignalResolverExampleApp());
+    // There is a Switch on the Stack
+    expect(
+        find.descendant(of: find.byType(Stack), matching: find.byType(Switch)),
+        findsOneWidget);
 
-      // Verify the Switch is off
-      final Switch switchWidget = tester.widget(find.byType(Switch));
-      expect(switchWidget.value, isFalse);
+    // Verify initial Color of first (outer) BoxDecoration
+    final DecoratedBox outerDecoratedBox = tester.widget(find
+        .descendant(
+          of: find.byType(example.ColorChanger),
+          matching: find.byType(DecoratedBox),
+        )
+        .first);
 
-      // Toggle the Switch
-      await tester.tap(find.byType(Switch));
-      await tester.pumpAndSettle();
+    expect((outerDecoratedBox.decoration as BoxDecoration).color,
+        initialOuterColor);
 
-      // Verify the Switch state has changed
-      final Switch switchedWidget = tester.widget(find.byType(Switch));
-      expect(switchedWidget.value, isTrue);
-    });
+    // Verify initial Color of last (inner) BoxDecoration
+    final DecoratedBox innerDecoratedBox = tester.widget(find
+        .descendant(
+          of: find.byType(example.ColorChanger),
+          matching: find.byType(DecoratedBox),
+        )
+        .last);
+
+    expect((innerDecoratedBox.decoration as BoxDecoration).color,
+        initialInnerColor);
+  });
+
+  testWidgets('Widget interactions - Switch is switching',
+      (WidgetTester tester) async {
+    // Build the app and trigger a frame
+    await tester.pumpWidget(const example.PointerSignalResolverExampleApp());
+
+    // Verify the Switch is off
+    final Switch switchWidget = tester.widget(find.byType(Switch));
+    expect(switchWidget.value, isFalse);
+
+    // Toggle the Switch
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // Verify the Switch state has changed
+    final Switch switchedWidget = tester.widget(find.byType(Switch));
+    expect(switchedWidget.value, isTrue);
+  });
+
+  testWidgets('Mouse scroll changes colors when Switch is off',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const example.PointerSignalResolverExampleApp());
+
+    // Verify the Switch is off
+    final Switch switchWidget = tester.widget(find.byType(Switch));
+    expect(switchWidget.value, isFalse);
+
+    // Simulate pointer signal event
+    final Offset location =
+        tester.getCenter(find.byType(example.ColorChanger).first);
+    final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
+    testPointer.hover(location);
+    await tester.sendEventToBinding(PointerScrollEvent(
+        position: location, scrollDelta: const Offset(0, 10)));
+
+    // Wait for the color to change
+    await tester.pump();
+
+    // Both, inner and outer DecoratedBox, should change when the switch is off
+
+    // Verify initial Color of last (inner) BoxDecoration
+    final DecoratedBox innerDecoratedBox = tester.widget(find
+        .descendant(
+          of: find.byType(example.ColorChanger),
+          matching: find.byType(DecoratedBox),
+        )
+        .last);
+
+    expect(
+        (innerDecoratedBox.decoration as BoxDecoration).color !=
+            initialInnerColor,
+        true);
+
+    // Verify initial Color of first (outer) BoxDecoration
+    final DecoratedBox outerDecoratedBox = tester.widget(find
+        .descendant(
+          of: find.byType(example.ColorChanger),
+          matching: find.byType(DecoratedBox),
+        )
+        .first);
+
+    expect(
+        (outerDecoratedBox.decoration as BoxDecoration).color !=
+            initialOuterColor,
+        true);
+  });
+
+  testWidgets('Mouse scroll changes colors when Switch is on',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const example.PointerSignalResolverExampleApp());
+
+    // Verify the Switch is off
+    final Switch switchWidget = tester.widget(find.byType(Switch));
+    expect(switchWidget.value, isFalse);
+
+    // Toggle the Switch
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // Verify the Switch state has changed
+    final Switch switchedWidget = tester.widget(find.byType(Switch));
+    expect(switchedWidget.value, isTrue);
+
+    // Simulate pointer signal event
+    final Offset location =
+        tester.getCenter(find.byType(example.ColorChanger).first);
+    final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
+    testPointer.hover(location);
+    await tester.sendEventToBinding(PointerScrollEvent(
+        position: location, scrollDelta: const Offset(0, 10)));
+
+    // Wait for the color to change
+    await tester.pump();
+
+    // Verify initial Color of last (inner) BoxDecoration
+    final DecoratedBox innerDecoratedBox = tester.widget(find
+        .descendant(
+          of: find.byType(example.ColorChanger),
+          matching: find.byType(DecoratedBox),
+        )
+        .last);
+
+    // The inner BoxDecoration should always change regardless of the switch status
+    expect(
+        (innerDecoratedBox.decoration as BoxDecoration).color !=
+            initialInnerColor,
+        true);
+
+    // Verify initial Color of first (outer) BoxDecoration
+    final DecoratedBox outerDecoratedBox = tester.widget(find
+        .descendant(
+          of: find.byType(example.ColorChanger),
+          matching: find.byType(DecoratedBox),
+        )
+        .first);
+
+    // Switch disables changes on outer BoxDecoration so the color should be initial
+    expect((outerDecoratedBox.decoration as BoxDecoration).color,
+        initialOuterColor);
   });
 }


### PR DESCRIPTION
Test of PointerSignalResolverExampleApp visibility.

Tests are checking if:
- key Widgets are placed on the Stack
- the Switch exists and changes it's state

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

