### PR TITLE
override the version number that is read from pubspec.lock file for all native plugins when generating the local Maven repository.

### DIFF
--- a/packages/flutter_tools/gradle/aar_init_script.gradle
+++ b/packages/flutter_tools/gradle/aar_init_script.gradle
@@ -8,7 +8,24 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.publish.maven.MavenPublication
 
-void configureProject(Project project, String outputDir) {
+initscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.yaml:snakeyaml:2.2+'
+    }
+}
+
+
+ext{
+    pubspecLock = new org.yaml.snakeyaml.Yaml().load(
+            new File(new File(System.getProperty('user.dir')).parentFile, "pubspec.lock").newInputStream()
+    )
+}
+
+void configureProject(Project project, String outputDir, boolean isModuleProject) {
     if (!project.hasProperty("android")) {
         throw new GradleException("Android property not found.")
     }
@@ -22,7 +39,17 @@ void configureProject(Project project, String outputDir) {
     // to resolve dependencies.
     project.version = project.version.replace("-SNAPSHOT", "")
 
-    if (project.hasProperty("buildNumber")) {
+    if (!isModuleProject) {
+        def deps = pubspecLock.packages.find{ it.key == "${project.name}" }
+        if (deps != null && deps.value != null && deps.value.version != null && !(deps.value.version.trim().isEmpty())){
+            def _version = deps.value.version
+            project.version = _version
+        }else {
+        }
+    }
+
+    if ((isModuleProject && project.hasProperty("buildNumber"))
+            || (project.version == null || project.version.trim().isEmpty())) {
         project.version = project.property("buildNumber")
     }
 
@@ -76,7 +103,7 @@ void configurePlugin(Project project, String outputDir) {
         // A plugin doesn't support the Android platform when this property isn't defined in the plugin.
         return
     }
-    configureProject(project, outputDir)
+    configureProject(project, outputDir, false)
 }
 
 String getFlutterRoot(Project project) {
@@ -121,14 +148,14 @@ projectsEvaluated {
     if (rootProject.property("is-plugin").toBoolean()) {
         assert rootProject.hasProperty("output-dir")
         // In plugin projects, the root project is the plugin.
-        configureProject(rootProject, rootProject.property("output-dir"))
+        configureProject(rootProject, rootProject.property("output-dir"), false)
         return
     }
     // The module project is the `:flutter` subproject.
     Project moduleProject = rootProject.subprojects.find { it.name == "flutter" }
     assert moduleProject != null
     assert moduleProject.hasProperty("output-dir")
-    configureProject(moduleProject, moduleProject.property("output-dir"))
+    configureProject(moduleProject, moduleProject.property("output-dir"), true)
 
     // Gets the plugin subprojects.
     Set<Project> modulePlugins = rootProject.subprojects.findAll {

--- a/packages/flutter_tools/test/integration.shard/android_plugin_version_number.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_version_number.dart
@@ -1,0 +1,83 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math';
+
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:yaml/yaml.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+
+  late Directory tempDir;
+
+  setUp(()  {
+    Cache.flutterRoot = getFlutterRoot();
+    tempDir = createResolvedTempDirectorySync('android_plugin_version_number.');
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  test('plugins obtain version number from pubspec.lock.', () async {
+    final String flutterBin = fileSystem.path.join(
+      getFlutterRoot(),
+      'bin',
+      'flutter',
+    );
+    // create flutter module project
+    ProcessResult result = processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'create',
+      '--template=module',
+      'flutter_project'
+    ], workingDirectory: tempDir.path);
+
+    final String projectPath = fileSystem.path.join(tempDir.path, 'flutter_project');
+
+    final File modulePubspec = fileSystem.file(fileSystem.path.join(projectPath, 'pubspec.yaml'));
+    String pubspecContent = modulePubspec.readAsStringSync();
+    pubspecContent = pubspecContent.replaceFirst(
+      'dependencies:',
+      '''
+dependencies:
+  image_picker: ^1.0.0''',
+    );
+    modulePubspec.writeAsStringSync(pubspecContent);
+
+    // Run flutter build apk to build module example project
+    result = processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'build',
+      'aar',
+      '--no-profile',
+      '--no-debug',
+      '--target-platform=android-arm64',
+    ], workingDirectory: projectPath);
+
+    log(result.exitCode);
+
+    final File pubspecLock = fileSystem.file(fileSystem.path.join(projectPath, 'pubspec.lock'));
+
+    var pubspecLockInfo = loadYaml(pubspecLock.readAsStringSync());
+    var imagePickerVersion = pubspecLockInfo['packages']['image_picker_android']['version'];
+
+    // Check outputDir existed
+    final Directory outputDir = fileSystem.directory(fileSystem.path.join(
+        projectPath, 'build', 'host', 'outputs', 'repo'
+        , 'io', 'flutter', 'plugins', 'imagepicker'
+        , 'image_picker_android_release', imagePickerVersion
+    ));
+    expect(outputDir, exists);
+
+  });
+}

--- a/packages/flutter_tools/test/integration.shard/android_plugin_version_number.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_version_number.dart
@@ -41,6 +41,11 @@ void main() {
       'flutter_project'
     ], workingDirectory: tempDir.path);
 
+    if (result.exitCode != 0) {
+      log(result.exitCode);
+      print("Create project from template failed:\n${result.stderr}");
+    }
+
     final String projectPath = fileSystem.path.join(tempDir.path, 'flutter_project');
 
     final File modulePubspec = fileSystem.file(fileSystem.path.join(projectPath, 'pubspec.yaml'));
@@ -49,7 +54,7 @@ void main() {
       'dependencies:',
       '''
 dependencies:
-  image_picker: ^1.0.0''',
+  image_picker_android: any''',
     );
     modulePubspec.writeAsStringSync(pubspecContent);
 
@@ -64,7 +69,10 @@ dependencies:
       '--target-platform=android-arm64',
     ], workingDirectory: projectPath);
 
-    log(result.exitCode);
+    if (result.exitCode != 0) {
+      log(result.exitCode);
+      print("Build aar failed:\n${result.stderr}");
+    }
 
     final File pubspecLock = fileSystem.file(fileSystem.path.join(projectPath, 'pubspec.lock'));
 


### PR DESCRIPTION
Fixed https://github.com/flutter/flutter/issues/152538
override the version number that is read from pubspec.lock file for all native plugins when generating the local Maven repository.
This pull request addresses this issue by obtaining the version number from the pubspec.lock file, which contains the actual version numbers of plugins in pub.dev. When determining the version number that should be used in the AAR file, most plugin's defined versions are set to '1.0' in their respective `android/build.gradle` files. To avoid significant changes, this pull request selects the plugin's version published on Pub server.
I would like to express my gratitude to all reviewers who have contributed to this pull request.

There is no issue linked to this pull request. If necessary, I could create one.

This pull request has no changes in the [flutter/tests] repo. If a test is necessary, I could create one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
