### PR TITLE
performance: Override .elementAt in CachingIterable

### DIFF
--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -182,6 +182,22 @@ class CachingIterable<E> extends IterableBase<E> {
   }
 
   @override
+  E elementAt(int index) {
+    RangeError.checkNotNegative(index, 'index');
+    while (_results.length <= index) {
+      if (!_fillNext()) {
+        throw IndexError.withLength(
+          index,
+          _results.length,
+          indexable: this,
+          name: 'index',
+        );
+      }
+    }
+    return _results[index];
+  }
+
+  @override
   List<E> toList({ bool growable = true }) {
     _precacheEntireList();
     return List<E>.of(_results, growable: growable);

--- a/packages/flutter/test/foundation/caching_iterable_test.dart
+++ b/packages/flutter/test/foundation/caching_iterable_test.dart
@@ -107,4 +107,19 @@ void main() {
     expect(expanded2, equals(<int>[1, 1, 2, 2, 3, 3, 4, 4, 5, 5]));
     expect(yieldCount, equals(5));
   });
+
+  test('The Caching Iterable: elementAt correctness', () {
+    final Iterable<int> integers = CachingIterable<int>(range(1, 5).iterator);
+    expect(yieldCount, equals(0));
+
+    expect(() => integers.elementAt(-1), throwsRangeError);
+
+    expect(integers.elementAt(1), equals(2));
+    expect(integers.elementAt(0), equals(1));
+    expect(integers.elementAt(2), equals(3));
+    expect(integers.elementAt(4), equals(5));
+    expect(integers.elementAt(3), equals(4));
+
+    expect(() => integers.elementAt(5), throwsRangeError);
+  });
 }


### PR DESCRIPTION
Add a more efficient override of `Iterable.elementAt` in `CachingIterable`.

Closes #152476

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).  *I'm not sure if I should add a documentation comment as it would override Iterable.elementAt's documentation, but functionally it's the same.*
- [x] I added new tests to check the change I am making, or this PR is [test-exempt]. *I only added a functional test to check the implementation's correctness, because I can't think of a robust way to test the performance aspect, namely the random access.*
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
