### PR TITLE
Add tests for selection_area.0.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -322,7 +322,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/search_anchor/search_anchor.0_test.dart',
   'examples/api/test/material/search_anchor/search_anchor.1_test.dart',
   'examples/api/test/material/search_anchor/search_anchor.2_test.dart',
-  'examples/api/test/material/selection_area/selection_area.0_test.dart',
   'examples/api/test/material/scaffold/scaffold_messenger.of.0_test.dart',
   'examples/api/test/material/scaffold/scaffold_messenger.0_test.dart',
   'examples/api/test/material/scaffold/scaffold_state.show_bottom_sheet.0_test.dart',

--- a/examples/api/test/material/selection_area/selection_area.0_test.dart
+++ b/examples/api/test/material/selection_area/selection_area.0_test.dart
@@ -1,0 +1,89 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_api_samples/material/selection_area/selection_area.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+
+  Future<void> sendKeyCombination(
+    WidgetTester tester,
+    SingleActivator activator,
+  ) async {
+    final List<LogicalKeyboardKey> modifiers = <LogicalKeyboardKey>[
+      if (activator.control) LogicalKeyboardKey.control,
+      if (activator.meta) LogicalKeyboardKey.meta,
+    ];
+    for (final LogicalKeyboardKey modifier in modifiers) {
+      await tester.sendKeyDownEvent(modifier);
+    }
+    await tester.sendKeyDownEvent(activator.trigger);
+    await tester.sendKeyUpEvent(activator.trigger);
+    await tester.pump();
+    for (final LogicalKeyboardKey modifier in modifiers.reversed) {
+      await tester.sendKeyUpEvent(modifier);
+    }
+  }
+
+  testWidgets('Mouse hovering over selectable Text uses SystemMouseCursor.text', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SelectionAreaExampleApp(),
+    );
+
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: tester.getCenter(find.widgetWithText(AppBar, 'SelectionArea Sample')));
+
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+
+    for (int i = 1; i <= 3; i++) {
+      await gesture.moveTo(tester.getCenter(find.text('Row $i')));
+      await tester.pump();
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+    }
+  });
+
+  testWidgets('can select all non-Apple', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SelectionAreaExampleApp(),
+    );
+    await tester.tapAt(tester.getCenter(find.widgetWithText(AppBar, 'SelectionArea Sample'))); // Put the focus to the title.
+    await tester.pump();
+
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, control: true));
+    await tester.pump();
+
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('SelectionArea Sample'), matching: find.byType(RichText)));
+    expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 'SelectionArea Sample'.length));
+    for (int i = 1; i <= 3; i++) {
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Row $i'), matching: find.byType(RichText)));
+      expect(paragraph.selections[0], TextSelection(baseOffset: 0, extentOffset: 'Row $i'.length));
+    }
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android, TargetPlatform.windows, TargetPlatform.linux, TargetPlatform.fuchsia}));
+
+  testWidgets('can select all - Apple', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SelectionAreaExampleApp(),
+    );
+    await tester.tapAt(tester.getCenter(find.widgetWithText(AppBar, 'SelectionArea Sample'))); // Put the focus to the title.
+    await tester.pump();
+
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, meta: true));
+    await tester.pump();
+
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('SelectionArea Sample'), matching: find.byType(RichText)));
+    expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 'SelectionArea Sample'.length));
+    for (int i = 1; i <= 3; i++) {
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Row $i'), matching: find.byType(RichText)));
+      expect(paragraph.selections[0], TextSelection(baseOffset: 0, extentOffset: 'Row $i'.length));
+    }
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS, TargetPlatform.macOS}));
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/material/selection_area/selection_area.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
