### PR TITLE
[flutter_tools] remove raster stats CLI option.

### DIFF
--- a/packages/flutter_tools/lib/src/base/command_help.dart
+++ b/packages/flutter_tools/lib/src/base/command_help.dart
@@ -124,11 +124,6 @@ class CommandHelp {
     'WidgetsApp.showWidgetInspectorOverride',
   );
 
-  late final CommandHelpOption j = _makeOption(
-    'j',
-    'Dump frame raster stats for the current frame. (Unsupported for web)',
-  );
-
   late final CommandHelpOption k = _makeOption(
     'k',
     'Toggle CanvasKit rendering.',

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -694,52 +694,6 @@ abstract class ResidentHandlers {
     return true;
   }
 
-  /// Dump frame rasterization metrics for the last rendered frame.
-  ///
-  /// The last frames gets re-painted while recording additional tracing info
-  /// pertaining to the various draw calls issued by the frame. The timings
-  /// recorded here are not indicative of production performance. The intended
-  /// use case is to look at the various layers in proportion to see what
-  /// contributes the most towards raster performance.
-  Future<bool> debugFrameJankMetrics() async {
-    if (!supportsServiceProtocol) {
-      return false;
-    }
-    for (final FlutterDevice? device in flutterDevices) {
-      if (device?.targetPlatform == TargetPlatform.web_javascript) {
-        logger.printWarning('Unable to get jank metrics for web');
-        continue;
-      }
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
-      try {
-        for (final FlutterView view in views) {
-          final Map<String, Object?>? rasterData =
-            await device.vmService!.renderFrameWithRasterStats(
-              viewId: view.id,
-              uiIsolateId: view.uiIsolate!.id,
-            );
-          if (rasterData != null) {
-            final File tempFile = globals.fsUtils.getUniqueFile(
-              globals.fs.currentDirectory,
-              'flutter_jank_metrics',
-              'json',
-            );
-            tempFile.writeAsStringSync(jsonEncode(rasterData), flush: true);
-            logger.printStatus('Wrote jank metrics to ${tempFile.absolute.path}');
-          } else {
-            logger.printWarning('Unable to get jank metrics.');
-          }
-        }
-      } on vm_service.RPCError catch (err) {
-        if (err.code != RPCErrorCodes.kServerError || !err.message.contains('Raster status not supported on Impeller backend')) {
-          rethrow;
-        }
-        logger.printWarning('Unable to get jank metrics for Impeller renderer');
-      }
-    }
-    return true;
-  }
-
   /// Dump the application's current layer tree to the terminal.
   Future<bool> debugDumpLayerTree() async {
     if (!supportsServiceProtocol || !isRunningDebug) {
@@ -1558,7 +1512,6 @@ abstract class ResidentRunner extends ResidentHandlers {
       if (isRunningDebug) {
         commandHelp.g.print();
       }
-      commandHelp.j.print();
     }
   }
 
@@ -1739,9 +1692,6 @@ class TerminalHandler {
         return residentRunner.debugToggleWidgetInspector();
       case 'I':
         return residentRunner.debugToggleInvertOversizedImages();
-      case 'j':
-      case 'J':
-        return residentRunner.debugFrameJankMetrics();
       case 'L':
         return residentRunner.debugDumpLayerTree();
       case 'o':

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -28,7 +28,6 @@ const String kFlushUIThreadTasksMethod = '_flutter.flushUIThreadTasks';
 const String kRunInViewMethod = '_flutter.runInView';
 const String kListViewsMethod = '_flutter.listViews';
 const String kScreenshotSkpMethod = '_flutter.screenshotSkp';
-const String kRenderFrameWithRasterStatsMethod = '_flutter.renderFrameWithRasterStats';
 const String kReloadAssetFonts = '_flutter.reloadAssetFonts';
 
 const String kFlutterToolAlias = 'Flutter Tools';
@@ -591,26 +590,6 @@ class FlutterVmService {
       },
     );
     await onRunnable;
-  }
-
-  /// Renders the last frame with additional raster tracing enabled.
-  ///
-  /// When a frame is rendered using this method it will incur additional cost
-  /// for rasterization which is not reflective of how long the frame takes in
-  /// production. This is primarily intended to be used to identify the layers
-  /// that result in the most raster perf degradation.
-  Future<Map<String, Object?>?> renderFrameWithRasterStats({
-    required String? viewId,
-    required String? uiIsolateId,
-  }) async {
-    final vm_service.Response? response = await callMethodWrapper(
-      kRenderFrameWithRasterStatsMethod,
-      isolateId: uiIsolateId,
-      args: <String, String?>{
-        'viewId': viewId,
-      },
-    );
-    return response?.json;
   }
 
   Future<String> flutterDebugDumpApp({

--- a/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
@@ -113,18 +113,6 @@ final FakeVmServiceRequest listViews = FakeVmServiceRequest(
   },
 );
 
-const FakeVmServiceRequest renderFrameRasterStats = FakeVmServiceRequest(
-  method: kRenderFrameWithRasterStatsMethod,
-  args: <String, Object>{
-    'viewId': 'a',
-    'isolateId': '1',
-  },
-  error: FakeRPCError(
-    code: RPCErrorCodes.kServerError,
-    error: 'Raster status not supported on Impeller backend',
-  ),
-);
-
 const FakeVmServiceRequest setAssetBundlePath = FakeVmServiceRequest(
   method: '_flutter.setAssetBundlePath',
   args: <String, Object>{

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -326,31 +326,6 @@ void main() {
     Usage: () => TestUsage(),
   }));
 
-  testUsingContext('ResidentRunner can handle an RPC exception from debugFrameJankMetrics', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      renderFrameRasterStats,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-
-    final bool result = await residentRunner.debugFrameJankMetrics();
-    expect(result, true);
-    expect((globals.flutterUsage as TestUsage).events, isEmpty);
-    expect(fakeAnalytics.sentEvents, isEmpty);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-    expect((globals.logger as BufferLogger).warningText, contains('Unable to get jank metrics for Impeller renderer'));
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
-
   testUsingContext('ResidentRunner fails its operation if the device initialization is not complete', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
@@ -1335,7 +1310,6 @@ flutter:
           commandHelp.a,
           commandHelp.M,
           commandHelp.g,
-          commandHelp.j,
           commandHelp.hWithDetails,
           commandHelp.c,
           commandHelp.q,

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -179,12 +179,6 @@ void main() {
       await terminalHandler.processTerminalInput('a');
     });
 
-    testWithoutContext('j unsupported jank metrics for web', () async {
-      final TerminalHandler terminalHandler = setUpTerminalHandler(<FakeVmServiceRequest>[], web: true);
-      await terminalHandler.processTerminalInput('j');
-      expect(terminalHandler.logger.warningText.contains('Unable to get jank metrics for web'), true);
-    });
-
     testWithoutContext('a - debugToggleProfileWidgetBuilds without service protocol is skipped', () async {
       final TerminalHandler terminalHandler = setUpTerminalHandler(<FakeVmServiceRequest>[], supportsServiceProtocol: false);
 

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -424,14 +424,6 @@ void main() {
           method: 'getVMTimeline',
           error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
         ),
-        const FakeVmServiceRequest(
-          method: kRenderFrameWithRasterStatsMethod,
-          args: <String, dynamic>{
-            'viewId': '1',
-            'isolateId': '12',
-          },
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
-        ),
       ]
     );
 
@@ -451,10 +443,6 @@ void main() {
 
     final vm_service.Response? timeline = await fakeVmServiceHost.vmService.getTimeline();
     expect(timeline, isNull);
-
-    final Map<String, Object?>? rasterStats =
-      await fakeVmServiceHost.vmService.renderFrameWithRasterStats(viewId: '1', uiIsolateId: '12');
-    expect(rasterStats, isNull);
 
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
@@ -476,35 +464,6 @@ void main() {
       'isolate/123',
     );
     expect(isolate, null);
-
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
-  });
-
-  testWithoutContext('renderWithStats forwards stats correctly', () async {
-    // ignore: always_specify_types
-    const Map<String, dynamic> response = {
-      'type': 'RenderFrameWithRasterStats',
-      'snapshots':<dynamic>[
-        // ignore: always_specify_types
-        {
-          'layer_unique_id':1512,
-          'duration_micros':477,
-          'snapshot':'',
-        },
-      ],
-    };
-    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
-      requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(method: kRenderFrameWithRasterStatsMethod, args: <String, Object>{
-          'isolateId': 'isolate/123',
-          'viewId': 'view/1',
-        }, jsonResponse: response),
-      ]
-    );
-
-    final Map<String, Object?>? rasterStats =
-      await fakeVmServiceHost.vmService.renderFrameWithRasterStats(viewId: 'view/1', uiIsolateId: 'isolate/123');
-    expect(rasterStats, equals(response));
 
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -345,7 +345,6 @@ void main() {
       'a Toggle timeline events for all widget build methods.                    (debugProfileWidgetBuilds)',
       'M Write SkSL shaders to a unique file in the project directory.',
       'g Run source code generators.',
-      'j Dump frame raster stats for the current frame. (Unsupported for web)',
       'h Repeat this help message.',
       'd Detach (terminate "flutter run" but leave application running).',
       'c Clear the screen',


### PR DESCRIPTION
The raster stats feature is being removed from devtools and the engine. Remove the CLI option as well.

Fixes https://github.com/flutter/flutter/issues/144191
Fixes https://github.com/flutter/flutter/issues/132169
