### PR TITLE
[devicelab] enable impeller in external texture test.

### DIFF
--- a/dev/devicelab/bin/tasks/external_textures_integration_test.dart
+++ b/dev/devicelab/bin/tasks/external_textures_integration_test.dart
@@ -8,5 +8,5 @@ import 'package:flutter_devicelab/tasks/integration_tests.dart';
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
-  await task(createExternalTexturesFrameRateIntegrationTest(extraOptions: <String>['--no-enable-impeller']));
+  await task(createExternalTexturesFrameRateIntegrationTest());
 }


### PR DESCRIPTION
This will allow us to test impeller with SurfaceTextures. Don't know how to verify if this will work ahead of time without just turning it on...