### PR TITLE
Add Spaced list for spacing widgets

### DIFF
--- a/packages/flutter/lib/rendering.dart
+++ b/packages/flutter/lib/rendering.dart
@@ -77,6 +77,7 @@ export 'src/rendering/sliver_multi_box_adaptor.dart';
 export 'src/rendering/sliver_padding.dart';
 export 'src/rendering/sliver_persistent_header.dart';
 export 'src/rendering/sliver_tree.dart';
+export 'src/rendering/spaced.dart';
 export 'src/rendering/stack.dart';
 export 'src/rendering/table.dart';
 export 'src/rendering/table_border.dart';

--- a/packages/flutter/lib/src/rendering/spaced.dart
+++ b/packages/flutter/lib/src/rendering/spaced.dart
@@ -1,0 +1,62 @@
+import 'dart:collection';
+
+import 'package:flutter/widgets.dart';
+
+class Spaced with ListMixin<Widget> {
+  Spaced.vertical({
+    required double space,
+    required List<Widget> children,
+  }) : _children = createSpacedList(
+          direction: Axis.vertical,
+          space: space,
+          children: children,
+        );
+
+  Spaced.horizontal({
+    required double space,
+    required List<Widget> children,
+  }) : _children = createSpacedList(
+          direction: Axis.horizontal,
+          space: space,
+          children: children,
+        );
+
+  @override
+  int get length => _children.length;
+
+  @override
+  set length(int newLength) {
+    throw StateError('The length of the spaced list can not be modified');
+  }
+
+  final List<Widget> _children;
+
+  @visibleForTesting
+  static List<Widget> createSpacedList({
+    required List<Widget> children,
+    required double space,
+    required Axis direction,
+  }) {
+    final SizedBox sizedBox = direction == Axis.vertical
+        ? SizedBox(height: space)
+        : SizedBox(width: space);
+
+    return children
+        .expand((Widget widget) => [sizedBox, widget])
+        .skip(1)
+        .toList();
+  }
+
+  @override
+  Widget operator [](int index) => _children[index];
+
+  @override
+  void operator []=(int index, Widget value) {
+    throw StateError('The spaced list can not be modified');
+  }
+
+  @override
+  void add(Widget element) {
+    throw StateError('The spaced list can not be modified');
+  }
+}


### PR DESCRIPTION
Closes [#55378](https://github.com/flutter/flutter/issues/55378)

This is a first draft to show my idea for `Spaced`, a list that will add spaces around widgets, so we can avoid changing `Row/Column/Flex`. If I get the "go ahead" I will add docs and tests.

You can test it with the following code:

```dart
import 'package:flutter/rendering.dart';
import 'package:flutter/widgets.dart';

void main() => runApp(
      Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: Spaced.vertical(
            space: 64,
            children: [
              const Text('Hello', textDirection: TextDirection.ltr),
              const Text('world', textDirection: TextDirection.ltr),
              const Text('!', textDirection: TextDirection.ltr),
            ],
          ),
        ),
      ),
    );
```

<img width="200" alt="image" src="https://github.com/user-attachments/assets/ce273904-90ab-4573-ae6a-99b63624bbd2">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/49644228-65b5-4605-9a19-c273e6326c40">

@Hixie @Piinks @justinmc

PS: I think the interface could be even simpler if we could merge the [`gap`](https://pub.dev/packages/gap) package into the framework, as a `Gap` can automatically determine if it should be horizontal or vertical.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
