### PR TITLE
Reland #151599 (Add button semantics in list tile ) with a flag to control behavior. 

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -469,8 +469,8 @@ class CheckboxListTile extends StatelessWidget {
   /// Whether to add button:true to the semantics if onTap is provided.
   /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
   ///
-  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
-  /// the default value to true.
+  // TODO(hangyujin): Remove this flag after fixing related g3 tests and flipping
+  // the default value to true.
   final bool internalAddSemanticForOnTap;
 
   /// {@macro flutter.material.checkbox.semanticLabel}

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -205,6 +205,7 @@ class CheckboxListTile extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
     this.checkboxSemanticLabel,
+    this.internalAddSemanticForOnTap = false,
   }) : _checkboxType = _CheckboxType.material,
        assert(tristate || value != null),
        assert(!isThreeLine || subtitle != null);
@@ -249,6 +250,7 @@ class CheckboxListTile extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
     this.checkboxSemanticLabel,
+    this.internalAddSemanticForOnTap = false,
   }) : _checkboxType = _CheckboxType.adaptive,
        assert(tristate || value != null),
        assert(!isThreeLine || subtitle != null);
@@ -464,6 +466,13 @@ class CheckboxListTile extends StatelessWidget {
   /// inoperative.
   final bool? enabled;
 
+  /// Whether to add button:true to the semantics if onTap is provided.
+  /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
+  ///
+  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
+  /// the default value to true.
+  final bool internalAddSemanticForOnTap;
+
   /// {@macro flutter.material.checkbox.semanticLabel}
   final String? checkboxSemanticLabel;
 
@@ -567,6 +576,7 @@ class CheckboxListTile extends StatelessWidget {
         focusNode: focusNode,
         onFocusChange: onFocusChange,
         enableFeedback: enableFeedback,
+        internalAddSemanticForOnTap: internalAddSemanticForOnTap,
       ),
     );
   }

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -263,6 +263,7 @@ class ExpansionTile extends StatefulWidget {
     this.enableFeedback = true,
     this.enabled = true,
     this.expansionAnimationStyle,
+    this.internalAddSemanticForOnTap = false,
   }) : assert(
        expandedCrossAxisAlignment != CrossAxisAlignment.baseline,
        'CrossAxisAlignment.baseline is not supported since the expanded children '
@@ -562,6 +563,13 @@ class ExpansionTile extends StatefulWidget {
   /// {@end-tool}
   final AnimationStyle? expansionAnimationStyle;
 
+  /// Whether to add button:true to the semantics if onTap is provided.
+  /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
+  ///
+  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
+  /// the default value to true.
+  final bool internalAddSemanticForOnTap;
+
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();
 }
@@ -753,6 +761,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
                 subtitle: widget.subtitle,
                 trailing: widget.showTrailingIcon ? widget.trailing ?? _buildTrailingIcon(context) : null,
                 minTileHeight: widget.minTileHeight,
+                internalAddSemanticForOnTap: widget.internalAddSemanticForOnTap,
               ),
             ),
           ),

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -566,8 +566,8 @@ class ExpansionTile extends StatefulWidget {
   /// Whether to add button:true to the semantics if onTap is provided.
   /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
   ///
-  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
-  /// the default value to true.
+  // TODO(hangyujin): Remove this flag after fixing related g3 tests and flipping
+  // the default value to true.
   final bool internalAddSemanticForOnTap;
 
   @override

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -410,6 +410,7 @@ class ListTile extends StatelessWidget {
     this.minLeadingWidth,
     this.minTileHeight,
     this.titleAlignment,
+    this.internalAddSemanticForOnTap = false,
   }) : assert(!isThreeLine || subtitle != null);
 
   /// A widget to display before the title.
@@ -738,6 +739,13 @@ class ListTile extends StatelessWidget {
   ///   [ListTileThemeData].
   final ListTileTitleAlignment? titleAlignment;
 
+  /// Whether to add button:true to the semantics if onTap is provided.
+  /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
+  ///
+  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
+  /// the default value to true.
+  final bool internalAddSemanticForOnTap;
+
   /// Add a one pixel border in between each tile. If color isn't specified the
   /// [ThemeData.dividerColor] of the context's [Theme] is used.
   ///
@@ -910,7 +918,7 @@ class ListTile extends StatelessWidget {
       autofocus: autofocus,
       enableFeedback: enableFeedback ?? tileTheme.enableFeedback ?? true,
       child: Semantics(
-        button: onTap != null || onLongPress != null,
+        button: internalAddSemanticForOnTap && (onTap != null || onLongPress != null),
         selected: selected,
         enabled: enabled,
         child: Ink(

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -742,8 +742,8 @@ class ListTile extends StatelessWidget {
   /// Whether to add button:true to the semantics if onTap is provided.
   /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
   ///
-  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
-  /// the default value to true.
+  // TODO(hangyujin): Remove this flag after fixing related g3 tests and flipping
+  // the default value to true.
   final bool internalAddSemanticForOnTap;
 
   /// Add a one pixel border in between each tile. If color isn't specified the

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -910,6 +910,7 @@ class ListTile extends StatelessWidget {
       autofocus: autofocus,
       enableFeedback: enableFeedback ?? tileTheme.enableFeedback ?? true,
       child: Semantics(
+        button: onTap != null || onLongPress != null,
         selected: selected,
         enabled: enabled,
         child: Ink(

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -200,6 +200,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.focusNode,
     this.onFocusChange,
     this.enableFeedback,
+    this.internalAddSemanticForOnTap = false,
   }) : _radioType = _RadioType.material,
        useCupertinoCheckmarkStyle = false,
        assert(!isThreeLine || subtitle != null);
@@ -240,6 +241,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
     this.useCupertinoCheckmarkStyle = false,
+    this.internalAddSemanticForOnTap = false,
   }) : _radioType = _RadioType.adaptive,
        assert(!isThreeLine || subtitle != null);
 
@@ -449,6 +451,13 @@ class RadioListTile<T> extends StatelessWidget {
 
   final _RadioType _radioType;
 
+  /// Whether to add button:true to the semantics if onTap is provided.
+  /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
+  ///
+  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
+  /// the default value to true.
+  final bool internalAddSemanticForOnTap;
+
   /// Whether to use the checkbox style for the [CupertinoRadio] control.
   ///
   /// Only usable under the [RadioListTile.adaptive] constructor. If set to
@@ -546,6 +555,7 @@ class RadioListTile<T> extends StatelessWidget {
         focusNode: focusNode,
         onFocusChange: onFocusChange,
         enableFeedback: enableFeedback,
+        internalAddSemanticForOnTap: internalAddSemanticForOnTap,
       ),
     );
   }

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -454,8 +454,8 @@ class RadioListTile<T> extends StatelessWidget {
   /// Whether to add button:true to the semantics if onTap is provided.
   /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
   ///
-  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
-  /// the default value to true.
+  // TODO(hangyujin): Remove this flag after fixing related g3 tests and flipping
+  // the default value to true.
   final bool internalAddSemanticForOnTap;
 
   /// Whether to use the checkbox style for the [CupertinoRadio] control.

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -209,6 +209,7 @@ class SwitchListTile extends StatelessWidget {
     this.visualDensity,
     this.enableFeedback,
     this.hoverColor,
+    this.internalAddSemanticForOnTap = false,
   }) : _switchListTileType = _SwitchListTileType.material,
        applyCupertinoTheme = false,
        assert(activeThumbImage != null || onActiveThumbImageError == null),
@@ -266,6 +267,7 @@ class SwitchListTile extends StatelessWidget {
     this.visualDensity,
     this.enableFeedback,
     this.hoverColor,
+    this.internalAddSemanticForOnTap = false,
   }) : _switchListTileType = _SwitchListTileType.adaptive,
        assert(!isThreeLine || subtitle != null),
        assert(activeThumbImage != null || onActiveThumbImageError == null),
@@ -517,6 +519,12 @@ class SwitchListTile extends StatelessWidget {
   /// {@macro flutter.cupertino.CupertinoSwitch.applyTheme}
   final bool? applyCupertinoTheme;
 
+  /// Whether to add button:true to the semantics if onTap is provided.
+  /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
+  ///
+  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
+  /// the default value to true.
+  final bool internalAddSemanticForOnTap;
   @override
   Widget build(BuildContext context) {
     final Widget control;
@@ -616,6 +624,7 @@ class SwitchListTile extends StatelessWidget {
         onFocusChange: onFocusChange,
         enableFeedback: enableFeedback,
         hoverColor: hoverColor,
+        internalAddSemanticForOnTap: internalAddSemanticForOnTap,
       ),
     );
   }

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -522,8 +522,8 @@ class SwitchListTile extends StatelessWidget {
   /// Whether to add button:true to the semantics if onTap is provided.
   /// This is a temporary flag to help changing the behavior of ListTile onTap semantics.
   ///
-  /// TODO(hangyujin) Remove this flag after fixing related g3 tests and flipping
-  /// the default value to true.
+  // TODO(hangyujin): Remove this flag after fixing related g3 tests and flipping
+  // the default value to true.
   final bool internalAddSemanticForOnTap;
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -1184,6 +1184,7 @@ void main() {
     ));
 
     expect(tester.getSemantics(find.byType(CheckboxListTile)), matchesSemantics(
+      isButton: true,
       hasCheckedState: true,
       isChecked: true,
       hasEnabledState: true,

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -1180,6 +1180,7 @@ void main() {
         onChanged: (bool? value) { log.add(value); },
         title: const Text('Hello'),
         checkboxSemanticLabel: 'there',
+        internalAddSemanticForOnTap: true,
       ),
     ));
 

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -727,6 +727,7 @@ void main() {
     expect(
       tester.getSemantics(find.byType(ListTile).first),
       matchesSemantics(
+        isButton: true,
         hasTapAction: true,
         hasFocusAction: true,
         hasEnabledState: true,
@@ -742,6 +743,7 @@ void main() {
     expect(
       tester.getSemantics(find.byType(ListTile).last),
       matchesSemantics(
+        isButton: true,
         hasTapAction: true,
         hasFocusAction: true,
         hasEnabledState: true,

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -707,10 +707,12 @@ void main() {
           children: <Widget>[
             ExpansionTile(
               title: Text('First Expansion Tile'),
+              internalAddSemanticForOnTap: true,
             ),
             ExpansionTile(
               initiallyExpanded: true,
               title: Text('Second Expansion Tile'),
+              internalAddSemanticForOnTap: true,
             ),
           ],
         ),

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -304,6 +304,7 @@ void main() {
             ),
             TestSemantics.rootChild(
               flags: <SemanticsFlag>[
+                SemanticsFlag.isButton,
                 SemanticsFlag.hasEnabledState,
                 SemanticsFlag.isEnabled,
                 SemanticsFlag.isFocusable,

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -270,18 +270,22 @@ void main() {
               children: <Widget>[
                 const ListTile(
                   title: Text('one'),
+                  internalAddSemanticForOnTap: true,
                 ),
                 ListTile(
                   title: const Text('two'),
                   onTap: () {},
+                  internalAddSemanticForOnTap: true,
                 ),
                 const ListTile(
                   title: Text('three'),
                   selected: true,
+                  internalAddSemanticForOnTap: true,
                 ),
                 const ListTile(
                   title: Text('four'),
                   enabled: false,
+                  internalAddSemanticForOnTap: true,
                 ),
               ],
             ),

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -393,6 +393,7 @@ void main() {
           groupValue: 2,
           onChanged: (int? i) {},
           title: const Text('Title'),
+          internalAddSemanticForOnTap: true,
         ),
       ),
     );
@@ -430,6 +431,7 @@ void main() {
           groupValue: 2,
           onChanged: (int? i) {},
           title: const Text('Title'),
+          internalAddSemanticForOnTap: true,
         ),
       ),
     );
@@ -468,6 +470,7 @@ void main() {
           groupValue: 2,
           onChanged: null,
           title: Text('Title'),
+          internalAddSemanticForOnTap: true,
         ),
       ),
     );
@@ -504,6 +507,7 @@ void main() {
           groupValue: 2,
           onChanged: null,
           title: Text('Title'),
+          internalAddSemanticForOnTap: true,
         ),
       ),
     );

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -405,6 +405,7 @@ void main() {
             TestSemantics(
               id: 1,
               flags: <SemanticsFlag>[
+                SemanticsFlag.isButton,
                 SemanticsFlag.hasCheckedState,
                 SemanticsFlag.hasEnabledState,
                 SemanticsFlag.isEnabled,
@@ -441,6 +442,7 @@ void main() {
             TestSemantics(
               id: 1,
               flags: <SemanticsFlag>[
+                SemanticsFlag.isButton,
                 SemanticsFlag.hasCheckedState,
                 SemanticsFlag.isChecked,
                 SemanticsFlag.hasEnabledState,

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -744,6 +744,7 @@ void main() {
             return false;
           });
           expect(child, matchesSemantics(
+            isButton: true,
             hasToggledState: true,
             isToggled: true,
             isEnabled: true,

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -707,6 +707,7 @@ void main() {
                     title: const Text('Switch tile'),
                     value: true,
                     onChanged: (bool? newValue) { },
+                    internalAddSemanticForOnTap: true,
                   ),
                 ),
               ),

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -72,6 +72,7 @@ void main() {
           id: 1,
           rect: const Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           flags: <SemanticsFlag>[
+            SemanticsFlag.isButton,
             SemanticsFlag.hasEnabledState,
             SemanticsFlag.hasToggledState,
             SemanticsFlag.isEnabled,
@@ -86,6 +87,7 @@ void main() {
           rect: const Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           transform: Matrix4.translationValues(0.0, 56.0, 0.0),
           flags: <SemanticsFlag>[
+            SemanticsFlag.isButton,
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.hasEnabledState,
             SemanticsFlag.isChecked,
@@ -100,6 +102,7 @@ void main() {
           rect: const Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           transform: Matrix4.translationValues(0.0, 112.0, 0.0),
           flags: <SemanticsFlag>[
+            SemanticsFlag.isButton,
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.hasEnabledState,
             SemanticsFlag.isEnabled,

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -47,12 +47,14 @@ void main() {
             onChanged: (bool value) { },
             title: const Text('AAA'),
             secondary: const Text('aaa'),
+            internalAddSemanticForOnTap: true,
           ),
           CheckboxListTile(
             value: true,
             onChanged: (bool? value) { },
             title: const Text('BBB'),
             secondary: const Text('bbb'),
+            internalAddSemanticForOnTap: true,
           ),
           RadioListTile<bool>(
             value: true,
@@ -60,6 +62,7 @@ void main() {
             onChanged: (bool? value) { },
             title: const Text('CCC'),
             secondary: const Text('ccc'),
+            internalAddSemanticForOnTap: true,
           ),
         ],
       ),


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/151599 was reverted because it was a breaking change to g3
fixes: https://github.com/flutter/flutter/issues/111960

Will reland 151599 in 5 steps 
1. Make changes with an additional parameter ( bool internalAddSemanticForOnTap = false)  
2. Send regular CLs in google3 to pass internalAddSemanticForOnTap: true, and update the tests / text goldens accordingly.
3. Send a PR to flip the default value to true.
4. Send CLs internally to remove internalAddSemanticForOnTap: true.
5. Send another PR to remove the now-redundant internalAddSemanticForOnTap flag.

 (<----This PR is step 1) 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
