### PR TITLE
Fixed [DropdownMenu] providing a focusNode, the text cursor is lost after disabling the widget and enabling it again, fixes #152478

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -814,9 +814,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         final Widget textField = TextField(
           key: _anchorKey,
           enabled: widget.enabled,
+          readOnly: !widget.enabled,
           mouseCursor: effectiveMouseCursor,
           focusNode: widget.focusNode,
-          canRequestFocus: canRequestFocus(),
           enableInteractiveSelection: canRequestFocus(),
           keyboardType: widget.keyboardType,
           textAlign: widget.textAlign,

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -563,7 +563,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   }
 
   bool canRequestFocus() {
-    return widget.focusNode?.canRequestFocus ?? widget.requestFocusOnTap
+    return widget.requestFocusOnTap
       ?? switch (Theme.of(context).platform) {
         TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia => false,
         TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows => true,

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -815,6 +815,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           key: _anchorKey,
           enabled: widget.enabled,
           readOnly: !widget.enabled,
+          canRequestFocus: widget.enabled,
           mouseCursor: effectiveMouseCursor,
           focusNode: widget.focusNode,
           enableInteractiveSelection: canRequestFocus(),

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -815,7 +815,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           key: _anchorKey,
           enabled: widget.enabled,
           readOnly: !widget.enabled,
-          canRequestFocus: widget.enabled,
+          canRequestFocus: widget.enabled && canRequestFocus(),
           mouseCursor: effectiveMouseCursor,
           focusNode: widget.focusNode,
           enableInteractiveSelection: canRequestFocus(),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1467,7 +1467,6 @@ void main() {
             DropdownMenu<TestMenu>(
               requestFocusOnTap: requestFocusOnTap,
               dropdownMenuEntries: menuChildren,
-              controller: TextEditingController(),
             ),
           ],
         ),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2454,6 +2454,46 @@ void main() {
 
     expect(menuAnchor.alignmentOffset, alignmentOffset);
   });
+
+  testWidgets('DropDown Menu TextField is set to read-only when dropdown is disabled', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    final TextEditingController textEditingController = TextEditingController();
+    Widget testWidget(bool isEnabled)=>MaterialApp(
+      home: Scaffold(
+      body: DropdownMenu<String>(
+        controller: textEditingController,
+        focusNode: focusNode,
+        enabled: isEnabled,
+        dropdownMenuEntries: const <DropdownMenuEntry<String>>[
+          DropdownMenuEntry<String>(
+            value: 'Yolk',
+            label: 'Yolk',
+          ),
+          DropdownMenuEntry<String>(
+            value: 'Eggbert',
+            label: 'Eggbert',
+          ),
+        ],
+      ),
+              )
+    );
+    await tester.pumpWidget(testWidget(false));
+    final Finder dropDownMenuFinder =find.byType(DropdownMenu<String>);
+    expect(dropDownMenuFinder,findsOneWidget);
+    await tester.enterText(dropDownMenuFinder, 'Flutter');
+    await tester.pump();
+    expect(find.text('Flutter'), findsNothing);
+
+    await tester.pumpWidget(testWidget(true));
+    final Finder dropDownMenuFinder2 =find.byType(DropdownMenu<String>);
+    expect(dropDownMenuFinder,findsOneWidget);
+    await tester.tap(dropDownMenuFinder2);
+    await tester.pumpAndSettle();
+    await tester.enterText(dropDownMenuFinder2, 'Flutter');
+    await tester.pumpAndSettle();
+    await tester.pumpAndSettle();
+    expect(find.text('Flutter'), findsOneWidget);
+  });
 }
 
 enum TestMenu {


### PR DESCRIPTION
closes #152478  

https://github.com/user-attachments/assets/d5f56486-b67d-4db0-8586-f108440155ff




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
