### PR TITLE
Add tests for search anchor examples

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -319,8 +319,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/color_scheme/dynamic_content_color.0_test.dart',
   'examples/api/test/material/platform_menu_bar/platform_menu_bar.0_test.dart',
   'examples/api/test/material/flexible_space_bar/flexible_space_bar.0_test.dart',
-  'examples/api/test/material/search_anchor/search_anchor.1_test.dart',
-  'examples/api/test/material/search_anchor/search_anchor.2_test.dart',
   'examples/api/test/material/selection_area/selection_area.0_test.dart',
   'examples/api/test/material/scaffold/scaffold_state.show_bottom_sheet.0_test.dart',
   'examples/api/test/material/scaffold/scaffold_messenger_state.show_material_banner.0_test.dart',

--- a/examples/api/test/material/search_anchor/search_anchor.1_test.dart
+++ b/examples/api/test/material/search_anchor/search_anchor.1_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/search_anchor/search_anchor.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The SearchAnchor should be floating', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.PinnedSearchBarApp());
+
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    for (int i = 0; i < 5; i++) {
+      expect(find.widgetWithText(ListTile, 'Initial list item $i'), findsOne);
+    }
+
+    await tester.tap(find.backButton());
+    await tester.pumpAndSettle();
+    expect(find.byType(SearchBar), findsOne);
+
+    final double searchBarHeight = tester.getSize(find.byType(SearchBar)).height;
+    final TestPointer testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+    testPointer.hover(tester.getCenter(find.byType(CustomScrollView)));
+    await tester.sendEventToBinding(testPointer.scroll(Offset(0.0, 2 * searchBarHeight)));
+    await tester.pump();
+    expect(find.byType(SearchBar), findsNothing);
+
+    await tester.sendEventToBinding(testPointer.scroll(Offset(0.0, -0.5 * searchBarHeight)));
+    await tester.pump();
+    expect(find.byType(SearchBar), findsOne);
+
+    await tester.sendEventToBinding(testPointer.scroll(Offset(0.0, 0.5 * searchBarHeight)));
+    await tester.pump();
+    expect(find.byType(SearchBar), findsNothing);
+  });
+}

--- a/examples/api/test/material/search_anchor/search_anchor.2_test.dart
+++ b/examples/api/test/material/search_anchor/search_anchor.2_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/search_anchor/search_anchor.2.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Suggestion of the search bar can be selected', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.SearchBarApp());
+
+    expect(find.widgetWithText(AppBar, 'Search Anchor Sample'), findsOne);
+    expect(find.text('No item selected'), findsOne);
+
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    for (int i = 0; i < 5; i++) {
+      expect(find.widgetWithText(ListTile, 'item $i'), findsOne);
+    }
+
+    await tester.tap(find.text('item 2'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Selected item: item 2'), findsOne);
+
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(ListTile, 'item 3'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Selected item: item 3'), findsOne);
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/material/search_anchor/search_anchor.1.dart`
- `examples/api/lib/material/search_anchor/search_anchor.2.dart`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
