### PR TITLE
Fix bad pattern matching in DDS exception parsing

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -125,13 +125,12 @@ class DartDevelopmentServiceException implements Exception {
         case {
           'error_code': final int errorCode,
           'message': final String message,
-          'uri': final String? uri
         }) {
       return switch (errorCode) {
         existingDdsInstanceError =>
           DartDevelopmentServiceException.existingDdsInstance(
             message,
-            ddsUri: Uri.parse(uri!),
+            ddsUri: Uri.parse(json['uri']! as String),
           ),
         failedToStartError => DartDevelopmentServiceException.failedToStart(),
         connectionError =>

--- a/packages/flutter_tools/test/general.shard/base/dds_exception_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/dds_exception_test.dart
@@ -49,7 +49,6 @@ void main() {
     test('parses failed to start error', () {
       final DartDevelopmentServiceException expected =
           DartDevelopmentServiceException.failedToStart();
-
       final DartDevelopmentServiceException actual =
           DartDevelopmentServiceException.fromJson(
         <String, Object>{

--- a/packages/flutter_tools/test/general.shard/base/dds_exception_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/dds_exception_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/dds.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  group('DartDevelopmentServiceException.fromJSON', () {
+    test('parses existing DDS instance error', () {
+      final DartDevelopmentServiceException actual =
+          DartDevelopmentServiceException.fromJson(
+        <String, Object>{
+          'error_code':
+              DartDevelopmentServiceException.existingDdsInstanceError,
+          'message': 'Foo',
+          'uri': 'http://localhost',
+        },
+      );
+      final DartDevelopmentServiceException expected =
+          DartDevelopmentServiceException.existingDdsInstance(
+        'Foo',
+        ddsUri: Uri.parse('http://localhost'),
+      );
+      expect(actual.errorCode, expected.errorCode);
+      expect(actual.message, expected.message);
+      expect(actual, isA<ExistingDartDevelopmentServiceException>());
+      expect(
+        (actual as ExistingDartDevelopmentServiceException).ddsUri,
+        (expected as ExistingDartDevelopmentServiceException).ddsUri,
+      );
+    });
+
+    test('parses connection issue error', () {
+      final DartDevelopmentServiceException actual =
+          DartDevelopmentServiceException.fromJson(
+        <String, Object>{
+          'error_code': DartDevelopmentServiceException.connectionError,
+          'message': 'Foo',
+        },
+      );
+      final DartDevelopmentServiceException expected =
+          DartDevelopmentServiceException.connectionIssue('Foo');
+      expect(actual.errorCode, expected.errorCode);
+      expect(actual.message, expected.message);
+    });
+
+    test('parses failed to start error', () {
+      final DartDevelopmentServiceException expected =
+          DartDevelopmentServiceException.failedToStart();
+
+      final DartDevelopmentServiceException actual =
+          DartDevelopmentServiceException.fromJson(
+        <String, Object>{
+          'error_code': DartDevelopmentServiceException.failedToStartError,
+          'message': expected.message,
+        },
+      );
+      expect(actual.errorCode, expected.errorCode);
+      expect(actual.message, expected.message);
+    });
+  });
+}


### PR DESCRIPTION
Nullable types for values in map patterns require the key to be present. Since the 'uri' key is not always present in DDS exception responses, this was causing us to fall back to throwing a StateError.

Fixes https://github.com/flutter/flutter/issues/152684