### PR TITLE
Disable DDS and Dart profiling for Android driver tests.

### DIFF
--- a/dev/bots/suite_runners/run_flutter_driver_android_tests.dart
+++ b/dev/bots/suite_runners/run_flutter_driver_android_tests.dart
@@ -44,6 +44,11 @@ Future<void> runFlutterDriverAndroidTests() async {
     'flutter',
     <String>[
       'drive',
+      // There are no reason to enable development flags for this test.
+      // Disable them to work around flakiness issues, and in general just
+      // make less things start up unnecessarily.
+      '--no-dds',
+      '--no-enable-dart-profiling',
       '--test-arguments=test',
       '--test-arguments=--reporter=expanded',
     ],


### PR DESCRIPTION
Work around https://github.com/flutter/flutter/issues/152684, and probably indefinitely if we don't need it.