### PR TITLE
Add test for scaffold_state.show_bottom_sheet.0.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -320,7 +320,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/platform_menu_bar/platform_menu_bar.0_test.dart',
   'examples/api/test/material/flexible_space_bar/flexible_space_bar.0_test.dart',
   'examples/api/test/material/selection_area/selection_area.0_test.dart',
-  'examples/api/test/material/scaffold/scaffold_state.show_bottom_sheet.0_test.dart',
   'examples/api/test/material/scaffold/scaffold_messenger_state.show_material_banner.0_test.dart',
   'examples/api/test/material/scaffold/scaffold_messenger_state.show_snack_bar.0_test.dart',
   'examples/api/test/material/app_bar/sliver_app_bar.2_test.dart',

--- a/examples/api/test/material/scaffold/scaffold_state.show_bottom_sheet.0_test.dart
+++ b/examples/api/test/material/scaffold/scaffold_state.show_bottom_sheet.0_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/scaffold/scaffold_state.show_bottom_sheet.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The button should show a bottom sheet when pressed', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ShowBottomSheetExampleApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'ScaffoldState Sample'), findsOne);
+    await tester.tap(find.widgetWithText(ElevatedButton, 'showBottomSheet'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(BottomSheet, 'BottomSheet'), findsOne);
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Close BottomSheet'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(BottomSheet, 'BottomSheet'), findsNothing);
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/material/scaffold/scaffold_state.show_bottom_sheet.0.dart`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
