### PR TITLE
`toggle()` parameter

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -457,7 +457,7 @@ class AnimationController extends Animation<double>
   AnimationStatus get status => _status;
   late AnimationStatus _status;
 
-  TickerFuture _toggle(String method, bool animateForward, double? from) {
+  TickerFuture _toggle(String method, double? from, {required bool animateForward}) {
     assert(() {
       if (duration == null && (animateForward || reverseDuration == null)) {
         final (String duration, String durationQuotes) = animateForward
@@ -497,7 +497,9 @@ class AnimationController extends Animation<double>
   /// During the animation, [status] is reported as [AnimationStatus.forward],
   /// which switches to [AnimationStatus.completed] when [upperBound] is
   /// reached at the end of the animation.
-  TickerFuture forward({ double? from }) => _toggle('forward', true, from);
+  TickerFuture forward({ double? from }) {
+    return _toggle('forward', from, animateForward: true);
+  }
 
   /// Starts running this animation in reverse (towards the beginning).
   ///
@@ -513,7 +515,9 @@ class AnimationController extends Animation<double>
   /// During the animation, [status] is reported as [AnimationStatus.reverse],
   /// which switches to [AnimationStatus.dismissed] when [lowerBound] is
   /// reached at the end of the animation.
-  TickerFuture reverse({ double? from }) => _toggle('reverse', false, from);
+  TickerFuture reverse({ double? from }) {
+    return _toggle('reverse', from, animateForward: false);
+  }
 
   /// Toggles the direction of this animation.
   ///
@@ -529,7 +533,7 @@ class AnimationController extends Animation<double>
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
   /// derivative future completes with a [TickerCanceled] error.
   TickerFuture toggle({ bool? forward }) {
-    return _toggle('toggle', forward ?? !isForwardOrCompleted, null);
+    return _toggle('toggle', null, animateForward: forward ?? !isForwardOrCompleted);
   }
 
   /// Drives the animation from its current value to the given target, "forward".

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -457,6 +457,32 @@ class AnimationController extends Animation<double>
   AnimationStatus get status => _status;
   late AnimationStatus _status;
 
+  TickerFuture _toggle(String method, bool animateForward, double? from) {
+    assert(() {
+      if (duration == null && (animateForward || reverseDuration == null)) {
+        final (String duration, String durationQuotes) = animateForward
+            ? ('duration', '"duration"')
+            : ('duration or reverseDuration', '"duration" or "reverseDuration"');
+        throw FlutterError(
+          'AnimationController.$method() called with no default $duration.\n'
+          'The $durationQuotes property should be set, either in '
+          'the constructor or later, before calling the $method() function.',
+        );
+      }
+      return true;
+    }());
+    assert(
+      _ticker != null,
+      'AnimationController.$method() called after AnimationController.dispose()\n'
+      'AnimationController methods should not be used after calling dispose.',
+    );
+    _direction = animateForward ? _AnimationDirection.forward : _AnimationDirection.reverse;
+    if (from != null) {
+      value = from;
+    }
+    return _animateToInternal(animateForward ? upperBound : lowerBound);
+  }
+
   /// Starts running this animation forwards (towards the end).
   ///
   /// Returns a [TickerFuture] that completes when the animation is complete.
@@ -471,28 +497,7 @@ class AnimationController extends Animation<double>
   /// During the animation, [status] is reported as [AnimationStatus.forward],
   /// which switches to [AnimationStatus.completed] when [upperBound] is
   /// reached at the end of the animation.
-  TickerFuture forward({ double? from }) {
-    assert(() {
-      if (duration == null) {
-        throw FlutterError(
-          'AnimationController.forward() called with no default duration.\n'
-          'The "duration" property should be set, either in the constructor or later, before '
-          'calling the forward() function.',
-        );
-      }
-      return true;
-    }());
-    assert(
-      _ticker != null,
-      'AnimationController.forward() called after AnimationController.dispose()\n'
-      'AnimationController methods should not be used after calling dispose.',
-    );
-    _direction = _AnimationDirection.forward;
-    if (from != null) {
-      value = from;
-    }
-    return _animateToInternal(upperBound);
-  }
+  TickerFuture forward({ double? from }) => _toggle('forward', true, from);
 
   /// Starts running this animation in reverse (towards the beginning).
   ///
@@ -508,69 +513,23 @@ class AnimationController extends Animation<double>
   /// During the animation, [status] is reported as [AnimationStatus.reverse],
   /// which switches to [AnimationStatus.dismissed] when [lowerBound] is
   /// reached at the end of the animation.
-  TickerFuture reverse({ double? from }) {
-    assert(() {
-      if (duration == null && reverseDuration == null) {
-        throw FlutterError(
-          'AnimationController.reverse() called with no default duration or reverseDuration.\n'
-          'The "duration" or "reverseDuration" property should be set, either in the constructor or later, before '
-          'calling the reverse() function.',
-        );
-      }
-      return true;
-    }());
-    assert(
-      _ticker != null,
-      'AnimationController.reverse() called after AnimationController.dispose()\n'
-      'AnimationController methods should not be used after calling dispose.',
-    );
-    _direction = _AnimationDirection.reverse;
-    if (from != null) {
-      value = from;
-    }
-    return _animateToInternal(lowerBound);
-  }
+  TickerFuture reverse({ double? from }) => _toggle('reverse', false, from);
 
-  /// Toggles the direction of this animation, based on whether it [isForwardOrCompleted].
+  /// Toggles the direction of this animation.
   ///
-  /// Specifically, this function acts the same way as [reverse] if the [status] is
-  /// either [AnimationStatus.forward] or [AnimationStatus.completed], and acts as
-  /// [forward] for [AnimationStatus.reverse] or [AnimationStatus.dismissed].
+  /// The value of `forward` should toggle between `true` and `false`, and
+  /// `toggle()` should be called each time it changes. This function acts
+  /// like `forward()` or `reverse()` based on whether the value passed is
+  /// `true` or `false`, respectively.
   ///
-  /// If [from] is non-null, it will be set as the current [value] before running
-  /// the animation.
+  /// If no argument is provided, the controller changes direction based on
+  /// the current [status].
   ///
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
   /// derivative future completes with a [TickerCanceled] error.
-  TickerFuture toggle({ double? from }) {
-    assert(() {
-      Duration? duration = this.duration;
-      if (isForwardOrCompleted) {
-        duration ??= reverseDuration;
-      }
-      if (duration == null) {
-        throw FlutterError(
-          'AnimationController.toggle() called with no default duration.\n'
-          'The "duration" property should be set, either in the constructor or later, before '
-          'calling the toggle() function.',
-        );
-      }
-      return true;
-    }());
-    assert(
-      _ticker != null,
-      'AnimationController.toggle() called after AnimationController.dispose()\n'
-      'AnimationController methods should not be used after calling dispose.',
-    );
-    _direction = isForwardOrCompleted ? _AnimationDirection.reverse : _AnimationDirection.forward;
-    if (from != null) {
-      value = from;
-    }
-    return _animateToInternal(switch (_direction) {
-      _AnimationDirection.forward => upperBound,
-      _AnimationDirection.reverse => lowerBound,
-    });
+  TickerFuture toggle({ bool? forward }) {
+    return _toggle('toggle', forward ?? !isForwardOrCompleted, null);
   }
 
   /// Drives the animation from its current value to the given target, "forward".

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -288,6 +288,41 @@ void main() {
     controller.dispose();
   });
 
+  test('toggle() with different directions', () {
+    final AnimationController controller = AnimationController(
+      duration: const Duration(milliseconds: 50),
+      reverseDuration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+
+    controller.toggle(forward: true);
+    tick(const Duration(milliseconds: 10));
+    tick(const Duration(milliseconds: 30));
+    expect(controller.value, moreOrLessEquals(0.4));
+    controller.toggle(forward: true);
+    tick(const Duration(milliseconds: 10));
+    tick(const Duration(milliseconds: 60));
+    expect(controller.value, moreOrLessEquals(1.0));
+    tick(const Duration(milliseconds: 90));
+    expect(controller.value, moreOrLessEquals(1.0));
+    controller.stop();
+
+    controller.toggle(forward: false);
+    tick(const Duration(milliseconds: 210));
+    tick(const Duration(milliseconds: 220));
+    expect(controller.value, moreOrLessEquals(0.9));
+    tick(const Duration(milliseconds: 230));
+    expect(controller.value, moreOrLessEquals(0.8));
+    tick(const Duration(milliseconds: 240));
+    expect(controller.value, moreOrLessEquals(0.7));
+    tick(const Duration(milliseconds: 260));
+    expect(controller.value, moreOrLessEquals(0.5));
+    tick(const Duration(milliseconds: 310));
+    expect(controller.value, moreOrLessEquals(0.0));
+    controller.stop();
+    controller.dispose();
+  });
+
   test('toggle() acts correctly based on the animation state', () {
     final AnimationController controller = AnimationController(
       duration: const Duration(milliseconds: 100),


### PR DESCRIPTION
This pull request updates a method I added in #147801 based on the [lazy programming](https://github.com/flutter/flutter/blob/c03f9955fa34ed557635b65b5702b9cf891dfd51/docs/contributing/Style-guide-for-Flutter-repo.md#lazy-programming) philosophy—a function parameter should have a useful application rather than just being there "for completeness".

Instead of passing a `from` argument (i.e. setting the controller's value before toggling), having an ability to toggle based on a boolean value other than `isForwardOrCompleted` made a lot more sense for this method.