### PR TITLE
Fix CarouselView rebuild

### DIFF
--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -1340,7 +1340,7 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
     if (_itemExtent == value) {
       return;
     }
-    if (hasPixels) {
+    if (hasPixels && _itemExtent != null) {
       final double leadingItem = getItemFromPixels(pixels, viewportDimension);
       final double newPixel = getPixelsFromItem(leadingItem, flexWeights, value);
       forcePixels(newPixel);

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1150,7 +1150,7 @@ void main() {
     expect(tester.getRect(getItem(5)).width, difference);
   });
 
-  testWidgets('Updating Carousel does not cause exception', (WidgetTester tester) async {
+  testWidgets('Updating CarouselView does not cause exception', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/152787
     bool isLight = true;
     await tester.pumpWidget(

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1190,6 +1190,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // No exception.
+    expect(tester.takeException(), isNull);
   });
 }
 

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1149,6 +1149,48 @@ void main() {
     expect(getItem(5), findsOneWidget);
     expect(tester.getRect(getItem(5)).width, difference);
   });
+
+  testWidgets('Updating Carousel does not cause exception', (WidgetTester tester) async {
+    bool isLight = true;
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return MaterialApp(
+            theme: Theme.of(context).copyWith(
+              brightness: isLight ? Brightness.light : Brightness.dark,
+            ),
+            home: Scaffold(
+              appBar: AppBar(
+                actions: <Widget>[
+                  Switch(
+                    value: isLight,
+                    onChanged: (bool value) {
+                      setState(() {
+                        isLight = value;
+                      });
+                    }
+                  )
+                ],
+              ),
+              body: CarouselView(
+                itemExtent: 100,
+                children: List<Widget>.generate(10, (int index) {
+                  return Center(
+                    child: Text('Item $index'),
+                  );
+                }),
+              ),
+            ),
+          );
+        }
+      )
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // No exception.
+  });
 }
 
 Finder getItem(int index) {

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1151,6 +1151,7 @@ void main() {
   });
 
   testWidgets('Updating Carousel does not cause exception', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/152787
     bool isLight = true;
     await tester.pumpWidget(
       StatefulBuilder(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/152787

Originally, when we want to update `itemExtent`, we didn't check if the old itemExtent is null but `getItemFromPixels()` needs that information.
https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/carousel.dart#L1343-L1347
Then in `getItemFromPixels()`, it goes to the else statement which assert `flexWeights` is not null, then the exception happens.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
