### PR TITLE
Fix misunderstanding of properties vs. drone_dimensions in Linux_build_tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -66,8 +66,9 @@ platform_properties:
           {"dependency": "open_jdk", "version": "version:17"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
-      os: Linux
-      device_type: "mokey"
+      os: Ubuntu
+      cores: "8"
+      device_type: none
   linux_android:
     properties:
       dependencies: >-
@@ -2853,6 +2854,8 @@ targets:
         ["devicelab", "android", "linux", "mokey"]
       task_name: flutter_gallery__transition_perf
       artifact: gallery__transition_perf
+      drone_dimensions: >
+        ["device_os=N","os=Linux", "device_type=mokey"]
 
   - name: Linux_build_test flutter_gallery__transition_perf_e2e
     recipe: devicelab/devicelab_drone_build_test
@@ -2864,6 +2867,8 @@ targets:
         ["devicelab", "android", "linux", "mokey"]
       task_name: flutter_gallery__transition_perf_e2e
       artifact: gallery__transition_perf_e2e
+      drone_dimensions: >
+        ["device_os=N","os=Linux", "device_type=mokey"]
 
   - name: Linux_build_test flutter_gallery__transition_perf_hybrid
     recipe: devicelab/devicelab_drone_build_test
@@ -2875,6 +2880,8 @@ targets:
         ["devicelab", "android", "linux", "mokey"]
       task_name: flutter_gallery__transition_perf_hybrid
       artifact: gallery__transition_perf_hybrid
+      drone_dimensions: >
+        ["device_os=N","os=Linux", "device_type=mokey"]
 
   # linux mokey benchmark
   - name: Linux_mokey flutter_gallery__transition_perf_with_semantics


### PR DESCRIPTION
In "build tests", the `properties` of the build specify the configuration of the coordinator, and the `drone_dimensions` specify the configuration of the devicelab bot. This PR should therefore fix the infra errors on the `Linux_build_test` tests caused by my last PR at https://github.com/flutter/flutter/pull/152756. (Unfortunately, a simple revert won't work since the MotoG4s have already been removed from the Linux hosts.)