### PR TITLE
Move Linux_build_test tests from staging to prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2846,7 +2846,6 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -2859,7 +2858,6 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf_e2e
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -2872,7 +2870,6 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf_hybrid
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
These have been migrated to mokey and have been consistently passing in staging.

