### PR TITLE
Pass --no-dds to some integration tests driven by flutter drive

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -478,6 +478,10 @@ List<String> _flutterCommandArgs(String command, List<String> options) {
         '5',
       ],
 
+    // DDS should be disabled for flutter drive in CI.
+    // See https://github.com/flutter/flutter/issues/152684.
+    if (command == 'drive') '--no-dds',
+
     if (command == 'drive' && hostAgent.dumpDirectory != null) ...<String>[
       '--screenshot',
       hostAgent.dumpDirectory!.path,

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -134,7 +134,6 @@ class GalleryTransitionTest {
           : '${testFile}_test');
       section('DRIVE START');
       await flutter('drive', options: <String>[
-        '--no-dds',
         '--profile',
         if (enableImpeller != null && enableImpeller!) '--enable-impeller',
         if (enableImpeller != null && !enableImpeller!) '--no-enable-impeller',

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1395,7 +1395,6 @@ class PerfTest {
             '--local-engine-src-path',
             localEngineSrcPath
           ],
-          '--no-dds',
           '--no-android-gradle-daemon',
           '-v',
           '--verbose-system-logs',


### PR DESCRIPTION
As in https://github.com/flutter/flutter/pull/152696, It's not clear that DDS initialization is necessary for any of these tests.

In particular, from the comments on the tool flag:
```
            'It may be necessary to disable this when attaching to an application with '
            'an existing DDS instance (e.g., attaching to an application currently '
            'connected to by "flutter run"), or when running certain tests.\n'
            'Disabling this feature may degrade IDE functionality if a DDS instance is '
            'not already connected to the target application.'
```

These tests are unlikely to need IDE functionality. I have initially modified the Linux_android_emu tests in the ci.yaml so that they run in presubmit to verify that this change is safe. Many other postsubmit-only tests that will now be passed `--no-dds` require physical devices, and if there is an issue in post-submit, this change will need to be reverted.