### PR TITLE
Show the `ValueIndicator` when the user typing the keyboard 

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -37,7 +37,8 @@ import 'theme.dart';
 ///
 /// Since the value indicator is painted on the Overlay; this method paints the
 /// value indicator in a [RenderBox] that appears in the [Overlay].
-typedef PaintValueIndicator = void Function(PaintingContext context, Offset offset);
+typedef PaintValueIndicator = void Function(
+    PaintingContext context, Offset offset);
 
 enum _SliderType { material, adaptive }
 
@@ -196,13 +197,15 @@ class Slider extends StatefulWidget {
     this.focusNode,
     this.autofocus = false,
     this.allowedInteraction,
-  }) : _sliderType = _SliderType.material,
-       assert(min <= max),
-       assert(value >= min && value <= max,
-         'Value $value is not between minimum $min and maximum $max'),
-       assert(secondaryTrackValue == null || (secondaryTrackValue >= min && secondaryTrackValue <= max),
-         'SecondaryValue $secondaryTrackValue is not between $min and $max'),
-       assert(divisions == null || divisions > 0);
+  })  : _sliderType = _SliderType.material,
+        assert(min <= max),
+        assert(value >= min && value <= max,
+            'Value $value is not between minimum $min and maximum $max'),
+        assert(
+            secondaryTrackValue == null ||
+                (secondaryTrackValue >= min && secondaryTrackValue <= max),
+            'SecondaryValue $secondaryTrackValue is not between $min and $max'),
+        assert(divisions == null || divisions > 0);
 
   /// Creates an adaptive [Slider] based on the target platform, following
   /// Material design's
@@ -237,13 +240,15 @@ class Slider extends StatefulWidget {
     this.focusNode,
     this.autofocus = false,
     this.allowedInteraction,
-  }) : _sliderType = _SliderType.adaptive,
-       assert(min <= max),
-       assert(value >= min && value <= max,
-         'Value $value is not between minimum $min and maximum $max'),
-       assert(secondaryTrackValue == null || (secondaryTrackValue >= min && secondaryTrackValue <= max),
-         'SecondaryValue $secondaryTrackValue is not between $min and $max'),
-       assert(divisions == null || divisions > 0);
+  })  : _sliderType = _SliderType.adaptive,
+        assert(min <= max),
+        assert(value >= min && value <= max,
+            'Value $value is not between minimum $min and maximum $max'),
+        assert(
+            secondaryTrackValue == null ||
+                (secondaryTrackValue >= min && secondaryTrackValue <= max),
+            'SecondaryValue $secondaryTrackValue is not between $min and $max'),
+        assert(divisions == null || divisions > 0);
 
   /// The currently selected value for this slider.
   ///
@@ -550,7 +555,7 @@ class Slider extends StatefulWidget {
   /// Defaults to [SliderInteraction.tapAndSlide].
   final SliderInteraction? allowedInteraction;
 
-  final _SliderType _sliderType ;
+  final _SliderType _sliderType;
 
   @override
   State<Slider> createState() => _SliderState();
@@ -560,9 +565,13 @@ class Slider extends StatefulWidget {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('value', value));
     properties.add(DoubleProperty('secondaryTrackValue', secondaryTrackValue));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChanged', onChanged, ifNull: 'disabled'));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('onChangeStart', onChangeStart));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('onChangeEnd', onChangeEnd));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>(
+        'onChanged', onChanged,
+        ifNull: 'disabled'));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has(
+        'onChangeStart', onChangeStart));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has(
+        'onChangeEnd', onChangeEnd));
     properties.add(DoubleProperty('min', min));
     properties.add(DoubleProperty('max', max));
     properties.add(IntProperty('divisions', divisions));
@@ -570,15 +579,18 @@ class Slider extends StatefulWidget {
     properties.add(ColorProperty('activeColor', activeColor));
     properties.add(ColorProperty('inactiveColor', inactiveColor));
     properties.add(ColorProperty('secondaryActiveColor', secondaryActiveColor));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('semanticFormatterCallback', semanticFormatterCallback));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has(
+        'semanticFormatterCallback', semanticFormatterCallback));
     properties.add(ObjectFlagProperty<FocusNode>.has('focusNode', focusNode));
-    properties.add(FlagProperty('autofocus', value: autofocus, ifTrue: 'autofocus'));
+    properties
+        .add(FlagProperty('autofocus', value: autofocus, ifTrue: 'autofocus'));
   }
 }
 
 class _SliderState extends State<Slider> with TickerProviderStateMixin {
   static const Duration enableAnimationDuration = Duration(milliseconds: 75);
-  static const Duration valueIndicatorAnimationDuration = Duration(milliseconds: 100);
+  static const Duration valueIndicatorAnimationDuration =
+      Duration(milliseconds: 100);
 
   // Animation controller that is run when the overlay (a.k.a radial reaction)
   // is shown in response to user interaction.
@@ -596,7 +608,8 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   final GlobalKey _renderObjectKey = GlobalKey();
 
   // Keyboard mapping for a focused slider.
-  static const Map<ShortcutActivator, Intent> _traditionalNavShortcutMap = <ShortcutActivator, Intent>{
+  static const Map<ShortcutActivator, Intent> _traditionalNavShortcutMap =
+      <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.arrowUp): _AdjustSliderIntent.up(),
     SingleActivator(LogicalKeyboardKey.arrowDown): _AdjustSliderIntent.down(),
     SingleActivator(LogicalKeyboardKey.arrowLeft): _AdjustSliderIntent.left(),
@@ -605,7 +618,8 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
   // Keyboard mapping for a focused slider when using directional navigation.
   // The vertical inputs are not handled to allow navigating out of the slider.
-  static const Map<ShortcutActivator, Intent> _directionalNavShortcutMap = <ShortcutActivator, Intent>{
+  static const Map<ShortcutActivator, Intent> _directionalNavShortcutMap =
+      <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.arrowLeft): _AdjustSliderIntent.left(),
     SingleActivator(LogicalKeyboardKey.arrowRight): _AdjustSliderIntent.right(),
   };
@@ -696,29 +710,36 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   }
 
   void _actionHandler(_AdjustSliderIntent intent) {
-    final TextDirection directionality = Directionality.of(_renderObjectKey.currentContext!);
+    final TextDirection directionality =
+        Directionality.of(_renderObjectKey.currentContext!);
     final bool shouldIncrease = switch (intent.type) {
-      _SliderAdjustmentType.up    => true,
-      _SliderAdjustmentType.down  => false,
-      _SliderAdjustmentType.left  => directionality == TextDirection.rtl,
+      _SliderAdjustmentType.up => true,
+      _SliderAdjustmentType.down => false,
+      _SliderAdjustmentType.left => directionality == TextDirection.rtl,
       _SliderAdjustmentType.right => directionality == TextDirection.ltr,
     };
 
-    final _RenderSlider slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
-    return shouldIncrease ? slider.increaseAction() : slider.decreaseAction();
+    final _RenderSlider slider =
+        _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
+    // TODO: slider._startInteraction();
+    shouldIncrease ? slider.increaseAction() : slider.decreaseAction();
   }
 
   bool _focused = false;
   void _handleFocusHighlightChanged(bool focused) {
     if (focused != _focused) {
-      setState(() { _focused = focused; });
+      setState(() {
+        _focused = focused;
+      });
     }
   }
 
   bool _hovering = false;
   void _handleHoverChanged(bool hovering) {
     if (hovering != _hovering) {
-      setState(() { _hovering = hovering; });
+      setState(() {
+        _hovering = hovering;
+      });
     }
   }
 
@@ -750,7 +771,9 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   double _unlerp(double value) {
     assert(value <= widget.max);
     assert(value >= widget.min);
-    return widget.max > widget.min ? (value - widget.min) / (widget.max - widget.min) : 0.0;
+    return widget.max > widget.min
+        ? (value - widget.min) / (widget.max - widget.min)
+        : 0.0;
   }
 
   @override
@@ -762,26 +785,29 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       case _SliderType.material:
         return _buildMaterialSlider(context);
 
-      case _SliderType.adaptive: {
-        final ThemeData theme = Theme.of(context);
-        switch (theme.platform) {
-          case TargetPlatform.android:
-          case TargetPlatform.fuchsia:
-          case TargetPlatform.linux:
-          case TargetPlatform.windows:
-            return _buildMaterialSlider(context);
-          case TargetPlatform.iOS:
-          case TargetPlatform.macOS:
-            return _buildCupertinoSlider(context);
+      case _SliderType.adaptive:
+        {
+          final ThemeData theme = Theme.of(context);
+          switch (theme.platform) {
+            case TargetPlatform.android:
+            case TargetPlatform.fuchsia:
+            case TargetPlatform.linux:
+            case TargetPlatform.windows:
+              return _buildMaterialSlider(context);
+            case TargetPlatform.iOS:
+            case TargetPlatform.macOS:
+              return _buildCupertinoSlider(context);
+          }
         }
-      }
     }
   }
 
   Widget _buildMaterialSlider(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     SliderThemeData sliderTheme = SliderTheme.of(context);
-    final SliderThemeData defaults = theme.useMaterial3 ? _SliderDefaultsM3(context) : _SliderDefaultsM2(context);
+    final SliderThemeData defaults = theme.useMaterial3
+        ? _SliderDefaultsM3(context)
+        : _SliderDefaultsM2(context);
 
     // If the widget has active or inactive colors specified, then we plug them
     // in to the slider theme as best we can. If the developer wants more
@@ -794,9 +820,12 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     const SliderTickMarkShape defaultTickMarkShape = RoundSliderTickMarkShape();
     const SliderComponentShape defaultOverlayShape = RoundSliderOverlayShape();
     const SliderComponentShape defaultThumbShape = RoundSliderThumbShape();
-    final SliderComponentShape defaultValueIndicatorShape = defaults.valueIndicatorShape!;
-    const ShowValueIndicator defaultShowValueIndicator = ShowValueIndicator.onlyForDiscrete;
-    const SliderInteraction defaultAllowedInteraction = SliderInteraction.tapAndSlide;
+    final SliderComponentShape defaultValueIndicatorShape =
+        defaults.valueIndicatorShape!;
+    const ShowValueIndicator defaultShowValueIndicator =
+        ShowValueIndicator.onlyForDiscrete;
+    const SliderInteraction defaultAllowedInteraction =
+        SliderInteraction.tapAndSlide;
 
     final Set<MaterialState> states = <MaterialState>{
       if (!_enabled) MaterialState.disabled,
@@ -809,40 +838,70 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     // (which can be defined by activeColor) if the
     // RectangularSliderValueIndicatorShape is used. In all other cases, the
     // value indicator is assumed to be the same as the active color.
-    final SliderComponentShape valueIndicatorShape = sliderTheme.valueIndicatorShape ?? defaultValueIndicatorShape;
+    final SliderComponentShape valueIndicatorShape =
+        sliderTheme.valueIndicatorShape ?? defaultValueIndicatorShape;
     final Color valueIndicatorColor;
     if (valueIndicatorShape is RectangularSliderValueIndicatorShape) {
-      valueIndicatorColor = sliderTheme.valueIndicatorColor ?? Color.alphaBlend(theme.colorScheme.onSurface.withOpacity(0.60), theme.colorScheme.surface.withOpacity(0.90));
+      valueIndicatorColor = sliderTheme.valueIndicatorColor ??
+          Color.alphaBlend(theme.colorScheme.onSurface.withOpacity(0.60),
+              theme.colorScheme.surface.withOpacity(0.90));
     } else {
-      valueIndicatorColor = widget.activeColor ?? sliderTheme.valueIndicatorColor ?? theme.colorScheme.primary;
+      valueIndicatorColor = widget.activeColor ??
+          sliderTheme.valueIndicatorColor ??
+          theme.colorScheme.primary;
     }
 
     Color? effectiveOverlayColor() {
-      return widget.overlayColor?.resolve(states)
-        ?? widget.activeColor?.withOpacity(0.12)
-        ?? MaterialStateProperty.resolveAs<Color?>(sliderTheme.overlayColor, states)
-        ?? MaterialStateProperty.resolveAs<Color?>(defaults.overlayColor, states);
+      return widget.overlayColor?.resolve(states) ??
+          widget.activeColor?.withOpacity(0.12) ??
+          MaterialStateProperty.resolveAs<Color?>(
+              sliderTheme.overlayColor, states) ??
+          MaterialStateProperty.resolveAs<Color?>(
+              defaults.overlayColor, states);
     }
 
-    TextStyle valueIndicatorTextStyle = sliderTheme.valueIndicatorTextStyle ?? defaults.valueIndicatorTextStyle!;
+    TextStyle valueIndicatorTextStyle = sliderTheme.valueIndicatorTextStyle ??
+        defaults.valueIndicatorTextStyle!;
     if (MediaQuery.boldTextOf(context)) {
-      valueIndicatorTextStyle = valueIndicatorTextStyle.merge(const TextStyle(fontWeight: FontWeight.bold));
+      valueIndicatorTextStyle = valueIndicatorTextStyle
+          .merge(const TextStyle(fontWeight: FontWeight.bold));
     }
 
     sliderTheme = sliderTheme.copyWith(
       trackHeight: sliderTheme.trackHeight ?? defaults.trackHeight,
-      activeTrackColor: widget.activeColor ?? sliderTheme.activeTrackColor ?? defaults.activeTrackColor,
-      inactiveTrackColor: widget.inactiveColor ?? sliderTheme.inactiveTrackColor ?? defaults.inactiveTrackColor,
-      secondaryActiveTrackColor: widget.secondaryActiveColor ?? sliderTheme.secondaryActiveTrackColor ?? defaults.secondaryActiveTrackColor,
-      disabledActiveTrackColor: sliderTheme.disabledActiveTrackColor ?? defaults.disabledActiveTrackColor,
-      disabledInactiveTrackColor: sliderTheme.disabledInactiveTrackColor ?? defaults.disabledInactiveTrackColor,
-      disabledSecondaryActiveTrackColor: sliderTheme.disabledSecondaryActiveTrackColor ?? defaults.disabledSecondaryActiveTrackColor,
-      activeTickMarkColor: widget.inactiveColor ?? sliderTheme.activeTickMarkColor ?? defaults.activeTickMarkColor,
-      inactiveTickMarkColor: widget.activeColor ?? sliderTheme.inactiveTickMarkColor ?? defaults.inactiveTickMarkColor,
-      disabledActiveTickMarkColor: sliderTheme.disabledActiveTickMarkColor ?? defaults.disabledActiveTickMarkColor,
-      disabledInactiveTickMarkColor: sliderTheme.disabledInactiveTickMarkColor ?? defaults.disabledInactiveTickMarkColor,
-      thumbColor: widget.thumbColor ?? widget.activeColor ?? sliderTheme.thumbColor ?? defaults.thumbColor,
-      disabledThumbColor: sliderTheme.disabledThumbColor ?? defaults.disabledThumbColor,
+      activeTrackColor: widget.activeColor ??
+          sliderTheme.activeTrackColor ??
+          defaults.activeTrackColor,
+      inactiveTrackColor: widget.inactiveColor ??
+          sliderTheme.inactiveTrackColor ??
+          defaults.inactiveTrackColor,
+      secondaryActiveTrackColor: widget.secondaryActiveColor ??
+          sliderTheme.secondaryActiveTrackColor ??
+          defaults.secondaryActiveTrackColor,
+      disabledActiveTrackColor: sliderTheme.disabledActiveTrackColor ??
+          defaults.disabledActiveTrackColor,
+      disabledInactiveTrackColor: sliderTheme.disabledInactiveTrackColor ??
+          defaults.disabledInactiveTrackColor,
+      disabledSecondaryActiveTrackColor:
+          sliderTheme.disabledSecondaryActiveTrackColor ??
+              defaults.disabledSecondaryActiveTrackColor,
+      activeTickMarkColor: widget.inactiveColor ??
+          sliderTheme.activeTickMarkColor ??
+          defaults.activeTickMarkColor,
+      inactiveTickMarkColor: widget.activeColor ??
+          sliderTheme.inactiveTickMarkColor ??
+          defaults.inactiveTickMarkColor,
+      disabledActiveTickMarkColor: sliderTheme.disabledActiveTickMarkColor ??
+          defaults.disabledActiveTickMarkColor,
+      disabledInactiveTickMarkColor:
+          sliderTheme.disabledInactiveTickMarkColor ??
+              defaults.disabledInactiveTickMarkColor,
+      thumbColor: widget.thumbColor ??
+          widget.activeColor ??
+          sliderTheme.thumbColor ??
+          defaults.thumbColor,
+      disabledThumbColor:
+          sliderTheme.disabledThumbColor ?? defaults.disabledThumbColor,
       overlayColor: effectiveOverlayColor(),
       valueIndicatorColor: valueIndicatorColor,
       trackShape: sliderTheme.trackShape ?? defaultTrackShape,
@@ -850,15 +909,19 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       thumbShape: sliderTheme.thumbShape ?? defaultThumbShape,
       overlayShape: sliderTheme.overlayShape ?? defaultOverlayShape,
       valueIndicatorShape: valueIndicatorShape,
-      showValueIndicator: sliderTheme.showValueIndicator ?? defaultShowValueIndicator,
+      showValueIndicator:
+          sliderTheme.showValueIndicator ?? defaultShowValueIndicator,
       valueIndicatorTextStyle: valueIndicatorTextStyle,
     );
-    final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
-      ?? sliderTheme.mouseCursor?.resolve(states)
-      ?? MaterialStateMouseCursor.clickable.resolve(states);
-    final SliderInteraction effectiveAllowedInteraction = widget.allowedInteraction
-      ?? sliderTheme.allowedInteraction
-      ?? defaultAllowedInteraction;
+    final MouseCursor effectiveMouseCursor =
+        MaterialStateProperty.resolveAs<MouseCursor?>(
+                widget.mouseCursor, states) ??
+            sliderTheme.mouseCursor?.resolve(states) ??
+            MaterialStateMouseCursor.clickable.resolve(states);
+    final SliderInteraction effectiveAllowedInteraction =
+        widget.allowedInteraction ??
+            sliderTheme.allowedInteraction ??
+            defaultAllowedInteraction;
 
     // This size is used as the max bounds for the painting of the value
     // indicators It must be kept in sync with the function with the same name
@@ -882,21 +945,25 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         };
     }
 
-    final Map<ShortcutActivator, Intent> shortcutMap = switch (MediaQuery.navigationModeOf(context)) {
+    final Map<ShortcutActivator, Intent> shortcutMap =
+        switch (MediaQuery.navigationModeOf(context)) {
       NavigationMode.directional => _directionalNavShortcutMap,
       NavigationMode.traditional => _traditionalNavShortcutMap,
     };
 
-    final double fontSize = sliderTheme.valueIndicatorTextStyle?.fontSize ?? kDefaultFontSize;
-    final double fontSizeToScale = fontSize == 0.0 ? kDefaultFontSize : fontSize;
+    final double fontSize =
+        sliderTheme.valueIndicatorTextStyle?.fontSize ?? kDefaultFontSize;
+    final double fontSizeToScale =
+        fontSize == 0.0 ? kDefaultFontSize : fontSize;
     final TextScaler textScaler = theme.useMaterial3
-      // TODO(tahatesser): This is an eye-balled value.
-      // This needs to be updated when accessibility
-      // guidelines are available on the material specs page
-      // https://m3.material.io/components/sliders/accessibility.
-      ? MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3)
-      : MediaQuery.textScalerOf(context);
-    final double effectiveTextScale = textScaler.scale(fontSizeToScale) / fontSizeToScale;
+        // TODO(tahatesser): This is an eye-balled value.
+        // This needs to be updated when accessibility
+        // guidelines are available on the material specs page
+        // https://m3.material.io/components/sliders/accessibility.
+        ? MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3)
+        : MediaQuery.textScalerOf(context);
+    final double effectiveTextScale =
+        textScaler.scale(fontSizeToScale) / fontSizeToScale;
 
     return Semantics(
       container: true,
@@ -916,13 +983,17 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
           child: _SliderRenderObjectWidget(
             key: _renderObjectKey,
             value: _convert(widget.value),
-            secondaryTrackValue: (widget.secondaryTrackValue != null) ? _convert(widget.secondaryTrackValue!) : null,
+            secondaryTrackValue: (widget.secondaryTrackValue != null)
+                ? _convert(widget.secondaryTrackValue!)
+                : null,
             divisions: widget.divisions,
             label: widget.label,
             sliderTheme: sliderTheme,
             textScaleFactor: effectiveTextScale,
             screenSize: screenSize(),
-            onChanged: (widget.onChanged != null) && (widget.max > widget.min) ? _handleChanged : null,
+            onChanged: (widget.onChanged != null) && (widget.max > widget.min)
+                ? _handleChanged
+                : null,
             onChangeStart: _handleDragStart,
             onChangeEnd: _handleDragEnd,
             state: this,
@@ -955,6 +1026,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       ),
     );
   }
+
   final LayerLink _layerLink = LayerLink();
 
   OverlayEntry? overlayEntry;
@@ -1083,8 +1155,9 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     required bool hovering,
     required DeviceGestureSettings gestureSettings,
     required SliderInteraction allowedInteraction,
-  }) : assert(value >= 0.0 && value <= 1.0),
-        assert(secondaryTrackValue == null || (secondaryTrackValue >= 0.0 && secondaryTrackValue <= 1.0)),
+  })  : assert(value >= 0.0 && value <= 1.0),
+        assert(secondaryTrackValue == null ||
+            (secondaryTrackValue >= 0.0 && secondaryTrackValue <= 1.0)),
         _platform = platform,
         _semanticFormatterCallback = semanticFormatterCallback,
         _label = label,
@@ -1122,12 +1195,12 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       parent: _state.valueIndicatorController,
       curve: Curves.fastOutSlowIn,
     )..addStatusListener((AnimationStatus status) {
-      if (status.isDismissed) {
-        _state.overlayEntry?.remove();
-        _state.overlayEntry?.dispose();
-        _state.overlayEntry = null;
-      }
-    });
+        if (status.isDismissed) {
+          _state.overlayEntry?.remove();
+          _state.overlayEntry?.dispose();
+          _state.overlayEntry = null;
+        }
+      });
     _enableAnimation = CurvedAnimation(
       parent: _state.enableController,
       curve: Curves.easeInOut,
@@ -1142,13 +1215,16 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // Compute the largest width and height needed to paint the slider shapes,
   // other than the track shape. It is assumed that these shapes are vertically
   // centered on the track.
-  double get _maxSliderPartWidth => _sliderPartSizes.map((Size size) => size.width).reduce(math.max);
-  double get _maxSliderPartHeight => _sliderPartSizes.map((Size size) => size.height).reduce(math.max);
+  double get _maxSliderPartWidth =>
+      _sliderPartSizes.map((Size size) => size.width).reduce(math.max);
+  double get _maxSliderPartHeight =>
+      _sliderPartSizes.map((Size size) => size.height).reduce(math.max);
   List<Size> get _sliderPartSizes => <Size>[
-    _sliderTheme.overlayShape!.getPreferredSize(isInteractive, isDiscrete),
-    _sliderTheme.thumbShape!.getPreferredSize(isInteractive, isDiscrete),
-    _sliderTheme.tickMarkShape!.getPreferredSize(isEnabled: isInteractive, sliderTheme: sliderTheme),
-  ];
+        _sliderTheme.overlayShape!.getPreferredSize(isInteractive, isDiscrete),
+        _sliderTheme.thumbShape!.getPreferredSize(isInteractive, isDiscrete),
+        _sliderTheme.tickMarkShape!.getPreferredSize(
+            isEnabled: isInteractive, sliderTheme: sliderTheme),
+      ];
   double get _minPreferredTrackHeight => _sliderTheme.trackHeight!;
 
   final _SliderState _state;
@@ -1166,10 +1242,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // are relative to the sliders origin. Therefore, the offset is passed as
   // (0,0).
   Rect get _trackRect => _sliderTheme.trackShape!.getPreferredRect(
-    parentBox: this,
-    sliderTheme: _sliderTheme,
-    isDiscrete: false,
-  );
+        parentBox: this,
+        sliderTheme: _sliderTheme,
+        isDiscrete: false,
+      );
 
   bool get isInteractive => onChanged != null;
 
@@ -1191,9 +1267,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       // get to the new location.
       final double distance = (_value - _state.positionController.value).abs();
       _state.positionController.duration = distance != 0.0
-        ? _positionAnimationDuration * (1.0 / distance)
-        : Duration.zero;
-      _state.positionController.animateTo(convertedValue, curve: Curves.easeInOut);
+          ? _positionAnimationDuration * (1.0 / distance)
+          : Duration.zero;
+      _state.positionController
+          .animateTo(convertedValue, curve: Curves.easeInOut);
     } else {
       _state.positionController.value = convertedValue;
     }
@@ -1228,7 +1305,8 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   SemanticFormatterCallback? _semanticFormatterCallback;
-  SemanticFormatterCallback? get semanticFormatterCallback => _semanticFormatterCallback;
+  SemanticFormatterCallback? get semanticFormatterCallback =>
+      _semanticFormatterCallback;
   set semanticFormatterCallback(SemanticFormatterCallback? value) {
     if (_semanticFormatterCallback == value) {
       return;
@@ -1392,10 +1470,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   bool get showValueIndicator {
     return switch (_sliderTheme.showValueIndicator!) {
-      ShowValueIndicator.onlyForDiscrete   => isDiscrete,
+      ShowValueIndicator.onlyForDiscrete => isDiscrete,
       ShowValueIndicator.onlyForContinuous => !isDiscrete,
       ShowValueIndicator.always => true,
-      ShowValueIndicator.never  => false,
+      ShowValueIndicator.never => false,
     };
   }
 
@@ -1477,7 +1555,8 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   double _getValueFromGlobalPosition(Offset globalPosition) {
-    final double visualPosition = (globalToLocal(globalPosition).dx - _trackRect.left) / _trackRect.width;
+    final double visualPosition =
+        (globalToLocal(globalPosition).dx - _trackRect.left) / _trackRect.width;
     return _getValueFromVisualPosition(visualPosition);
   }
 
@@ -1487,6 +1566,20 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       result = (result * divisions!).round() / divisions!;
     }
     return result;
+  }
+
+  Future<void> _startValueIndicatorTimer() async {
+    _state.valueIndicatorController.forward();
+    _state.interactionTimer?.cancel();
+    final Completer completer = Completer();
+    _state.interactionTimer = Timer(_minimumInteractionTime * timeDilation, () {
+      _state.interactionTimer = null;
+      if (!_active && _state.valueIndicatorController.isCompleted) {
+        _state.valueIndicatorController.reverse();
+      }
+      completer.complete();
+    });
+    return completer.future;
   }
 
   void _startInteraction(Offset globalPosition) {
@@ -1517,14 +1610,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         onChanged!(_discretize(_currentDragValue));
         _state.overlayController.forward();
         if (showValueIndicator) {
-          _state.valueIndicatorController.forward();
-          _state.interactionTimer?.cancel();
-          _state.interactionTimer = Timer(_minimumInteractionTime * timeDilation, () {
-            _state.interactionTimer = null;
-            if (!_active && _state.valueIndicatorController.isCompleted) {
-              _state.valueIndicatorController.reverse();
-            }
-          });
+          _startValueIndicatorTimer();
         }
       }
     }
@@ -1570,7 +1656,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
           final double valueDelta = details.primaryDelta! / _trackRect.width;
           _currentDragValue += switch (textDirection) {
             TextDirection.rtl => -valueDelta,
-            TextDirection.ltr =>  valueDelta,
+            TextDirection.ltr => valueDelta,
           };
           onChanged!(_discretize(_currentDragValue));
         }
@@ -1616,16 +1702,20 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   @override
-  double computeMinIntrinsicWidth(double height) => _minPreferredTrackWidth + _maxSliderPartWidth;
+  double computeMinIntrinsicWidth(double height) =>
+      _minPreferredTrackWidth + _maxSliderPartWidth;
 
   @override
-  double computeMaxIntrinsicWidth(double height) => _minPreferredTrackWidth + _maxSliderPartWidth;
+  double computeMaxIntrinsicWidth(double height) =>
+      _minPreferredTrackWidth + _maxSliderPartWidth;
 
   @override
-  double computeMinIntrinsicHeight(double width) => math.max(_minPreferredTrackHeight, _maxSliderPartHeight);
+  double computeMinIntrinsicHeight(double width) =>
+      math.max(_minPreferredTrackHeight, _maxSliderPartHeight);
 
   @override
-  double computeMaxIntrinsicHeight(double width) => math.max(_minPreferredTrackHeight, _maxSliderPartHeight);
+  double computeMaxIntrinsicHeight(double width) =>
+      math.max(_minPreferredTrackHeight, _maxSliderPartHeight);
 
   @override
   bool get sizedByParent => true;
@@ -1633,8 +1723,12 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     return Size(
-      constraints.hasBoundedWidth ? constraints.maxWidth : _minPreferredTrackWidth + _maxSliderPartWidth,
-      constraints.hasBoundedHeight ? constraints.maxHeight : math.max(_minPreferredTrackHeight, _maxSliderPartHeight),
+      constraints.hasBoundedWidth
+          ? constraints.maxWidth
+          : _minPreferredTrackWidth + _maxSliderPartWidth,
+      constraints.hasBoundedHeight
+          ? constraints.maxHeight
+          : math.max(_minPreferredTrackHeight, _maxSliderPartHeight),
     );
   }
 
@@ -1645,8 +1739,12 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // The visual position is the position of the thumb from 0 to 1 from left
     // to right. In left to right, this is the same as the value, but it is
     // reversed for right to left text.
-    final (double visualPosition, double? secondaryVisualPosition) = switch (textDirection) {
-      TextDirection.rtl when _secondaryTrackValue == null => (1.0 - controllerValue, null),
+    final (double visualPosition, double? secondaryVisualPosition) =
+        switch (textDirection) {
+      TextDirection.rtl when _secondaryTrackValue == null => (
+          1.0 - controllerValue,
+          null
+        ),
       TextDirection.rtl => (1.0 - controllerValue, 1.0 - _secondaryTrackValue!),
       TextDirection.ltr => (controllerValue, _secondaryTrackValue),
     };
@@ -1657,14 +1755,20 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       sliderTheme: _sliderTheme,
       isDiscrete: isDiscrete,
     );
-    final double padding = isDiscrete || _sliderTheme.trackShape!.isRounded ? trackRect.height : 0.0;
+    final double padding = isDiscrete || _sliderTheme.trackShape!.isRounded
+        ? trackRect.height
+        : 0.0;
     final double thumbPosition = isDiscrete
-      ? trackRect.left + visualPosition * (trackRect.width - padding) + padding / 2
-      : trackRect.left + visualPosition * trackRect.width;
+        ? trackRect.left +
+            visualPosition * (trackRect.width - padding) +
+            padding / 2
+        : trackRect.left + visualPosition * trackRect.width;
     // Apply padding to trackRect.left and trackRect.right if the track height is
     // greater than the thumb radius to ensure the thumb is drawn within the track.
-    final Size thumbSize = _sliderTheme.thumbShape!.getPreferredSize(isInteractive, isDiscrete);
-    final double thumbPadding = (padding > thumbSize.width / 2 ? padding / 2 : 0);
+    final Size thumbSize =
+        _sliderTheme.thumbShape!.getPreferredSize(isInteractive, isDiscrete);
+    final double thumbPadding =
+        (padding > thumbSize.width / 2 ? padding / 2 : 0);
     final Offset thumbCenter = Offset(
       clampDouble(
         thumbPosition,
@@ -1674,10 +1778,15 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       trackRect.center.dy,
     );
     if (isInteractive) {
-      final Size overlaySize = sliderTheme.overlayShape!.getPreferredSize(isInteractive, false);
-      overlayRect = Rect.fromCircle(center: thumbCenter, radius: overlaySize.width / 2.0);
+      final Size overlaySize =
+          sliderTheme.overlayShape!.getPreferredSize(isInteractive, false);
+      overlayRect =
+          Rect.fromCircle(center: thumbCenter, radius: overlaySize.width / 2.0);
     }
-    final Offset? secondaryOffset = (secondaryVisualPosition != null) ? Offset(trackRect.left + secondaryVisualPosition * trackRect.width, trackRect.center.dy) : null;
+    final Offset? secondaryOffset = (secondaryVisualPosition != null)
+        ? Offset(trackRect.left + secondaryVisualPosition * trackRect.width,
+            trackRect.center.dy)
+        : null;
 
     _sliderTheme.trackShape!.paint(
       context,
@@ -1710,10 +1819,12 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (isDiscrete) {
-      final double tickMarkWidth = _sliderTheme.tickMarkShape!.getPreferredSize(
-        isEnabled: isInteractive,
-        sliderTheme: _sliderTheme,
-      ).width;
+      final double tickMarkWidth = _sliderTheme.tickMarkShape!
+          .getPreferredSize(
+            isEnabled: isInteractive,
+            sliderTheme: _sliderTheme,
+          )
+          .width;
       final double adjustedTrackWidth = trackRect.width - padding;
       // If the tick marks would be too dense, don't bother painting them.
       if (adjustedTrackWidth / divisions! >= 3.0 * tickMarkWidth) {
@@ -1722,7 +1833,8 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
           final double value = i / divisions!;
           // The ticks are mapped to be within the track, so the tick mark width
           // must be subtracted from the track width.
-          final double dx = trackRect.left + value * adjustedTrackWidth + padding / 2;
+          final double dx =
+              trackRect.left + value * adjustedTrackWidth + padding / 2;
           final Offset tickMarkOffset = Offset(dx, dy);
           _sliderTheme.tickMarkShape!.paint(
             context,
@@ -1738,7 +1850,9 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       }
     }
 
-    if (isInteractive && label != null && !_valueIndicatorAnimation.isDismissed) {
+    if (isInteractive &&
+        label != null &&
+        !_valueIndicatorAnimation.isDismissed) {
       if (showValueIndicator) {
         _state.paintValueIndicator = (PaintingContext context, Offset offset) {
           if (attached && _labelPainter.text != null) {
@@ -1801,23 +1915,36 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (semanticFormatterCallback != null) {
       config.value = semanticFormatterCallback!(_state._lerp(value));
-      config.increasedValue = semanticFormatterCallback!(_state._lerp(clampDouble(value + _semanticActionUnit, 0.0, 1.0)));
-      config.decreasedValue = semanticFormatterCallback!(_state._lerp(clampDouble(value - _semanticActionUnit, 0.0, 1.0)));
+      config.increasedValue = semanticFormatterCallback!(
+          _state._lerp(clampDouble(value + _semanticActionUnit, 0.0, 1.0)));
+      config.decreasedValue = semanticFormatterCallback!(
+          _state._lerp(clampDouble(value - _semanticActionUnit, 0.0, 1.0)));
     } else {
       config.value = '${(value * 100).round()}%';
-      config.increasedValue = '${(clampDouble(value + _semanticActionUnit, 0.0, 1.0) * 100).round()}%';
-      config.decreasedValue = '${(clampDouble(value - _semanticActionUnit, 0.0, 1.0) * 100).round()}%';
+      config.increasedValue =
+          '${(clampDouble(value + _semanticActionUnit, 0.0, 1.0) * 100).round()}%';
+      config.decreasedValue =
+          '${(clampDouble(value - _semanticActionUnit, 0.0, 1.0) * 100).round()}%';
     }
   }
 
-  double get _semanticActionUnit => divisions != null ? 1.0 / divisions! : _adjustmentUnit;
+  double get _semanticActionUnit =>
+      divisions != null ? 1.0 / divisions! : _adjustmentUnit;
 
   void increaseAction() {
+    _state.showValueIndicator();
     if (isInteractive) {
       onChangeStart!(currentValue);
       final double increase = increaseValue();
       onChanged!(increase);
-      onChangeEnd!(increase);
+      _state.overlayController.forward();
+      if (showValueIndicator) {
+        _startValueIndicatorTimer().then((_) async {
+          onChangeEnd!(increase);
+        });
+      } else {
+        onChangeEnd!(increase);
+      }
     }
   }
 
@@ -1826,7 +1953,14 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       onChangeStart!(currentValue);
       final double decrease = decreaseValue();
       onChanged!(decrease);
-      onChangeEnd!(decrease);
+      _state.overlayController.forward();
+      if (showValueIndicator) {
+        _startValueIndicatorTimer().then((_) {
+          onChangeEnd!(decrease);
+        });
+      } else {
+        onChangeEnd!(decrease);
+      }
     }
   }
 
@@ -1879,13 +2013,16 @@ class _ValueIndicatorRenderObjectWidget extends LeafRenderObjectWidget {
       state: state,
     );
   }
+
   @override
-  void updateRenderObject(BuildContext context, _RenderValueIndicator renderObject) {
+  void updateRenderObject(
+      BuildContext context, _RenderValueIndicator renderObject) {
     renderObject._state = state;
   }
 }
 
-class _RenderValueIndicator extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
+class _RenderValueIndicator extends RenderBox
+    with RelayoutWhenSystemFontsChangeMixin {
   _RenderValueIndicator({
     required _SliderState state,
   }) : _state = state {
@@ -1933,8 +2070,8 @@ class _RenderValueIndicator extends RenderBox with RelayoutWhenSystemFontsChange
 
 class _SliderDefaultsM2 extends SliderThemeData {
   _SliderDefaultsM2(this.context)
-    : _colors = Theme.of(context).colorScheme,
-      super(trackHeight: 4.0);
+      : _colors = Theme.of(context).colorScheme,
+        super(trackHeight: 4.0);
 
   final BuildContext context;
   final ColorScheme _colors;
@@ -1955,7 +2092,8 @@ class _SliderDefaultsM2 extends SliderThemeData {
   Color? get disabledInactiveTrackColor => _colors.onSurface.withOpacity(0.12);
 
   @override
-  Color? get disabledSecondaryActiveTrackColor => _colors.onSurface.withOpacity(0.12);
+  Color? get disabledSecondaryActiveTrackColor =>
+      _colors.onSurface.withOpacity(0.12);
 
   @override
   Color? get activeTickMarkColor => _colors.onPrimary.withOpacity(0.54);
@@ -1967,24 +2105,28 @@ class _SliderDefaultsM2 extends SliderThemeData {
   Color? get disabledActiveTickMarkColor => _colors.onPrimary.withOpacity(0.12);
 
   @override
-  Color? get disabledInactiveTickMarkColor => _colors.onSurface.withOpacity(0.12);
+  Color? get disabledInactiveTickMarkColor =>
+      _colors.onSurface.withOpacity(0.12);
 
   @override
   Color? get thumbColor => _colors.primary;
 
   @override
-  Color? get disabledThumbColor => Color.alphaBlend(_colors.onSurface.withOpacity(.38), _colors.surface);
+  Color? get disabledThumbColor =>
+      Color.alphaBlend(_colors.onSurface.withOpacity(.38), _colors.surface);
 
   @override
   Color? get overlayColor => _colors.primary.withOpacity(0.12);
 
   @override
-  TextStyle? get valueIndicatorTextStyle => Theme.of(context).textTheme.bodyLarge!.copyWith(
-    color: _colors.onPrimary,
-  );
+  TextStyle? get valueIndicatorTextStyle =>
+      Theme.of(context).textTheme.bodyLarge!.copyWith(
+            color: _colors.onPrimary,
+          );
 
   @override
-  SliderComponentShape? get valueIndicatorShape => const RectangularSliderValueIndicatorShape();
+  SliderComponentShape? get valueIndicatorShape =>
+      const RectangularSliderValueIndicatorShape();
 }
 
 // TODO(quncheng): Update M3 defaults to match the latest specs.
@@ -1996,8 +2138,7 @@ class _SliderDefaultsM2 extends SliderThemeData {
 //   dev/tools/gen_defaults/bin/gen_defaults.dart.
 
 class _SliderDefaultsM3 extends SliderThemeData {
-  _SliderDefaultsM3(this.context)
-    : super(trackHeight: 4.0);
+  _SliderDefaultsM3(this.context) : super(trackHeight: 4.0);
 
   final BuildContext context;
   late final ColorScheme _colors = Theme.of(context).colorScheme;
@@ -2018,48 +2159,55 @@ class _SliderDefaultsM3 extends SliderThemeData {
   Color? get disabledInactiveTrackColor => _colors.onSurface.withOpacity(0.12);
 
   @override
-  Color? get disabledSecondaryActiveTrackColor => _colors.onSurface.withOpacity(0.12);
+  Color? get disabledSecondaryActiveTrackColor =>
+      _colors.onSurface.withOpacity(0.12);
 
   @override
   Color? get activeTickMarkColor => _colors.onPrimary.withOpacity(0.38);
 
   @override
-  Color? get inactiveTickMarkColor => _colors.onSurfaceVariant.withOpacity(0.38);
+  Color? get inactiveTickMarkColor =>
+      _colors.onSurfaceVariant.withOpacity(0.38);
 
   @override
   Color? get disabledActiveTickMarkColor => _colors.onSurface.withOpacity(0.38);
 
   @override
-  Color? get disabledInactiveTickMarkColor => _colors.onSurface.withOpacity(0.38);
+  Color? get disabledInactiveTickMarkColor =>
+      _colors.onSurface.withOpacity(0.38);
 
   @override
   Color? get thumbColor => _colors.primary;
 
   @override
-  Color? get disabledThumbColor => Color.alphaBlend(_colors.onSurface.withOpacity(0.38), _colors.surface);
+  Color? get disabledThumbColor =>
+      Color.alphaBlend(_colors.onSurface.withOpacity(0.38), _colors.surface);
 
   @override
-  Color? get overlayColor => MaterialStateColor.resolveWith((Set<MaterialState> states) {
-    if (states.contains(MaterialState.dragged)) {
-      return _colors.primary.withOpacity(0.1);
-    }
-    if (states.contains(MaterialState.hovered)) {
-      return _colors.primary.withOpacity(0.08);
-    }
-    if (states.contains(MaterialState.focused)) {
-      return _colors.primary.withOpacity(0.1);
-    }
+  Color? get overlayColor =>
+      MaterialStateColor.resolveWith((Set<MaterialState> states) {
+        if (states.contains(MaterialState.dragged)) {
+          return _colors.primary.withOpacity(0.1);
+        }
+        if (states.contains(MaterialState.hovered)) {
+          return _colors.primary.withOpacity(0.08);
+        }
+        if (states.contains(MaterialState.focused)) {
+          return _colors.primary.withOpacity(0.1);
+        }
 
-    return Colors.transparent;
-  });
-
-  @override
-  TextStyle? get valueIndicatorTextStyle => Theme.of(context).textTheme.labelMedium!.copyWith(
-    color: _colors.onPrimary,
-  );
+        return Colors.transparent;
+      });
 
   @override
-  SliderComponentShape? get valueIndicatorShape => const DropSliderValueIndicatorShape();
+  TextStyle? get valueIndicatorTextStyle =>
+      Theme.of(context).textTheme.labelMedium!.copyWith(
+            color: _colors.onPrimary,
+          );
+
+  @override
+  SliderComponentShape? get valueIndicatorShape =>
+      const DropSliderValueIndicatorShape();
 }
 
 // END GENERATED TOKEN PROPERTIES - Slider

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -37,8 +37,7 @@ import 'theme.dart';
 ///
 /// Since the value indicator is painted on the Overlay; this method paints the
 /// value indicator in a [RenderBox] that appears in the [Overlay].
-typedef PaintValueIndicator = void Function(
-    PaintingContext context, Offset offset);
+typedef PaintValueIndicator = void Function(PaintingContext context, Offset offset);
 
 enum _SliderType { material, adaptive }
 
@@ -198,14 +197,12 @@ class Slider extends StatefulWidget {
     this.autofocus = false,
     this.allowedInteraction,
   })  : _sliderType = _SliderType.material,
-        assert(min <= max),
-        assert(value >= min && value <= max,
-            'Value $value is not between minimum $min and maximum $max'),
-        assert(
-            secondaryTrackValue == null ||
-                (secondaryTrackValue >= min && secondaryTrackValue <= max),
-            'SecondaryValue $secondaryTrackValue is not between $min and $max'),
-        assert(divisions == null || divisions > 0);
+       assert(min <= max),
+       assert(value >= min && value <= max,
+         'Value $value is not between minimum $min and maximum $max'),
+       assert(secondaryTrackValue == null || (secondaryTrackValue >= min && secondaryTrackValue <= max),
+         'SecondaryValue $secondaryTrackValue is not between $min and $max'),
+       assert(divisions == null || divisions > 0);
 
   /// Creates an adaptive [Slider] based on the target platform, following
   /// Material design's
@@ -241,14 +238,12 @@ class Slider extends StatefulWidget {
     this.autofocus = false,
     this.allowedInteraction,
   })  : _sliderType = _SliderType.adaptive,
-        assert(min <= max),
-        assert(value >= min && value <= max,
-            'Value $value is not between minimum $min and maximum $max'),
-        assert(
-            secondaryTrackValue == null ||
-                (secondaryTrackValue >= min && secondaryTrackValue <= max),
-            'SecondaryValue $secondaryTrackValue is not between $min and $max'),
-        assert(divisions == null || divisions > 0);
+       assert(min <= max),
+       assert(value >= min && value <= max,
+         'Value $value is not between minimum $min and maximum $max'),
+       assert(secondaryTrackValue == null || (secondaryTrackValue >= min && secondaryTrackValue <= max),
+         'SecondaryValue $secondaryTrackValue is not between $min and $max'),
+       assert(divisions == null || divisions > 0);
 
   /// The currently selected value for this slider.
   ///
@@ -565,13 +560,9 @@ class Slider extends StatefulWidget {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('value', value));
     properties.add(DoubleProperty('secondaryTrackValue', secondaryTrackValue));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>(
-        'onChanged', onChanged,
-        ifNull: 'disabled'));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>.has(
-        'onChangeStart', onChangeStart));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>.has(
-        'onChangeEnd', onChangeEnd));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChanged', onChanged, ifNull: 'disabled'));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('onChangeStart', onChangeStart));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('onChangeEnd', onChangeEnd));
     properties.add(DoubleProperty('min', min));
     properties.add(DoubleProperty('max', max));
     properties.add(IntProperty('divisions', divisions));
@@ -579,18 +570,15 @@ class Slider extends StatefulWidget {
     properties.add(ColorProperty('activeColor', activeColor));
     properties.add(ColorProperty('inactiveColor', inactiveColor));
     properties.add(ColorProperty('secondaryActiveColor', secondaryActiveColor));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>.has(
-        'semanticFormatterCallback', semanticFormatterCallback));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('semanticFormatterCallback', semanticFormatterCallback));
     properties.add(ObjectFlagProperty<FocusNode>.has('focusNode', focusNode));
-    properties
-        .add(FlagProperty('autofocus', value: autofocus, ifTrue: 'autofocus'));
+    properties.add(FlagProperty('autofocus', value: autofocus, ifTrue: 'autofocus'));
   }
 }
 
 class _SliderState extends State<Slider> with TickerProviderStateMixin {
   static const Duration enableAnimationDuration = Duration(milliseconds: 75);
-  static const Duration valueIndicatorAnimationDuration =
-      Duration(milliseconds: 100);
+  static const Duration valueIndicatorAnimationDuration = Duration(milliseconds: 100);
 
   // Animation controller that is run when the overlay (a.k.a radial reaction)
   // is shown in response to user interaction.
@@ -608,8 +596,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   final GlobalKey _renderObjectKey = GlobalKey();
 
   // Keyboard mapping for a focused slider.
-  static const Map<ShortcutActivator, Intent> _traditionalNavShortcutMap =
-      <ShortcutActivator, Intent>{
+  static const Map<ShortcutActivator, Intent> _traditionalNavShortcutMap = <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.arrowUp): _AdjustSliderIntent.up(),
     SingleActivator(LogicalKeyboardKey.arrowDown): _AdjustSliderIntent.down(),
     SingleActivator(LogicalKeyboardKey.arrowLeft): _AdjustSliderIntent.left(),
@@ -618,8 +605,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
   // Keyboard mapping for a focused slider when using directional navigation.
   // The vertical inputs are not handled to allow navigating out of the slider.
-  static const Map<ShortcutActivator, Intent> _directionalNavShortcutMap =
-      <ShortcutActivator, Intent>{
+  static const Map<ShortcutActivator, Intent> _directionalNavShortcutMap = <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.arrowLeft): _AdjustSliderIntent.left(),
     SingleActivator(LogicalKeyboardKey.arrowRight): _AdjustSliderIntent.right(),
   };
@@ -710,17 +696,15 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   }
 
   void _actionHandler(_AdjustSliderIntent intent) {
-    final TextDirection directionality =
-        Directionality.of(_renderObjectKey.currentContext!);
+    final TextDirection directionality = Directionality.of(_renderObjectKey.currentContext!);
     final bool shouldIncrease = switch (intent.type) {
-      _SliderAdjustmentType.up => true,
-      _SliderAdjustmentType.down => false,
-      _SliderAdjustmentType.left => directionality == TextDirection.rtl,
+      _SliderAdjustmentType.up    => true,
+      _SliderAdjustmentType.down  => false,
+      _SliderAdjustmentType.left  => directionality == TextDirection.rtl,
       _SliderAdjustmentType.right => directionality == TextDirection.ltr,
     };
 
-    final _RenderSlider slider =
-        _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
+    final _RenderSlider slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
 
     shouldIncrease ? slider.increaseAction() : slider.decreaseAction();
   }
@@ -771,9 +755,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   double _unlerp(double value) {
     assert(value <= widget.max);
     assert(value >= widget.min);
-    return widget.max > widget.min
-        ? (value - widget.min) / (widget.max - widget.min)
-        : 0.0;
+    return widget.max > widget.min ? (value - widget.min) / (widget.max - widget.min) : 0.0;
   }
 
   @override
@@ -785,18 +767,17 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       case _SliderType.material:
         return _buildMaterialSlider(context);
 
-      case _SliderType.adaptive:
-        {
-          final ThemeData theme = Theme.of(context);
-          switch (theme.platform) {
-            case TargetPlatform.android:
-            case TargetPlatform.fuchsia:
-            case TargetPlatform.linux:
-            case TargetPlatform.windows:
-              return _buildMaterialSlider(context);
-            case TargetPlatform.iOS:
-            case TargetPlatform.macOS:
-              return _buildCupertinoSlider(context);
+      case _SliderType.adaptive: {
+        final ThemeData theme = Theme.of(context);
+        switch (theme.platform) {
+          case TargetPlatform.android:
+          case TargetPlatform.fuchsia:
+          case TargetPlatform.linux:
+          case TargetPlatform.windows:
+            return _buildMaterialSlider(context);
+          case TargetPlatform.iOS:
+          case TargetPlatform.macOS:
+            return _buildCupertinoSlider(context);
           }
         }
     }
@@ -805,9 +786,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   Widget _buildMaterialSlider(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     SliderThemeData sliderTheme = SliderTheme.of(context);
-    final SliderThemeData defaults = theme.useMaterial3
-        ? _SliderDefaultsM3(context)
-        : _SliderDefaultsM2(context);
+    final SliderThemeData defaults = theme.useMaterial3 ? _SliderDefaultsM3(context) : _SliderDefaultsM2(context);
 
     // If the widget has active or inactive colors specified, then we plug them
     // in to the slider theme as best we can. If the developer wants more
@@ -820,12 +799,9 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     const SliderTickMarkShape defaultTickMarkShape = RoundSliderTickMarkShape();
     const SliderComponentShape defaultOverlayShape = RoundSliderOverlayShape();
     const SliderComponentShape defaultThumbShape = RoundSliderThumbShape();
-    final SliderComponentShape defaultValueIndicatorShape =
-        defaults.valueIndicatorShape!;
-    const ShowValueIndicator defaultShowValueIndicator =
-        ShowValueIndicator.onlyForDiscrete;
-    const SliderInteraction defaultAllowedInteraction =
-        SliderInteraction.tapAndSlide;
+    final SliderComponentShape defaultValueIndicatorShape = defaults.valueIndicatorShape!;
+    const ShowValueIndicator defaultShowValueIndicator = ShowValueIndicator.onlyForDiscrete;
+    const SliderInteraction defaultAllowedInteraction = SliderInteraction.tapAndSlide;
 
     final Set<MaterialState> states = <MaterialState>{
       if (!_enabled) MaterialState.disabled,
@@ -838,13 +814,10 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     // (which can be defined by activeColor) if the
     // RectangularSliderValueIndicatorShape is used. In all other cases, the
     // value indicator is assumed to be the same as the active color.
-    final SliderComponentShape valueIndicatorShape =
-        sliderTheme.valueIndicatorShape ?? defaultValueIndicatorShape;
+    final SliderComponentShape valueIndicatorShape = sliderTheme.valueIndicatorShape ?? defaultValueIndicatorShape;
     final Color valueIndicatorColor;
     if (valueIndicatorShape is RectangularSliderValueIndicatorShape) {
-      valueIndicatorColor = sliderTheme.valueIndicatorColor ??
-          Color.alphaBlend(theme.colorScheme.onSurface.withOpacity(0.60),
-              theme.colorScheme.surface.withOpacity(0.90));
+      valueIndicatorColor = sliderTheme.valueIndicatorColor ?? Color.alphaBlend(theme.colorScheme.onSurface.withOpacity(0.60), theme.colorScheme.surface.withOpacity(0.90));
     } else {
       valueIndicatorColor = widget.activeColor ??
           sliderTheme.valueIndicatorColor ??
@@ -852,12 +825,10 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     }
 
     Color? effectiveOverlayColor() {
-      return widget.overlayColor?.resolve(states) ??
-          widget.activeColor?.withOpacity(0.12) ??
-          MaterialStateProperty.resolveAs<Color?>(
-              sliderTheme.overlayColor, states) ??
-          MaterialStateProperty.resolveAs<Color?>(
-              defaults.overlayColor, states);
+      return widget.overlayColor?.resolve(states)
+        ?? widget.activeColor?.withOpacity(0.12)
+        ?? MaterialStateProperty.resolveAs<Color?>(sliderTheme.overlayColor, states)
+        ?? MaterialStateProperty.resolveAs<Color?>(defaults.overlayColor, states);
     }
 
     TextStyle valueIndicatorTextStyle = sliderTheme.valueIndicatorTextStyle ??
@@ -869,39 +840,18 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
     sliderTheme = sliderTheme.copyWith(
       trackHeight: sliderTheme.trackHeight ?? defaults.trackHeight,
-      activeTrackColor: widget.activeColor ??
-          sliderTheme.activeTrackColor ??
-          defaults.activeTrackColor,
-      inactiveTrackColor: widget.inactiveColor ??
-          sliderTheme.inactiveTrackColor ??
-          defaults.inactiveTrackColor,
-      secondaryActiveTrackColor: widget.secondaryActiveColor ??
-          sliderTheme.secondaryActiveTrackColor ??
-          defaults.secondaryActiveTrackColor,
-      disabledActiveTrackColor: sliderTheme.disabledActiveTrackColor ??
-          defaults.disabledActiveTrackColor,
-      disabledInactiveTrackColor: sliderTheme.disabledInactiveTrackColor ??
-          defaults.disabledInactiveTrackColor,
-      disabledSecondaryActiveTrackColor:
-          sliderTheme.disabledSecondaryActiveTrackColor ??
-              defaults.disabledSecondaryActiveTrackColor,
-      activeTickMarkColor: widget.inactiveColor ??
-          sliderTheme.activeTickMarkColor ??
-          defaults.activeTickMarkColor,
-      inactiveTickMarkColor: widget.activeColor ??
-          sliderTheme.inactiveTickMarkColor ??
-          defaults.inactiveTickMarkColor,
-      disabledActiveTickMarkColor: sliderTheme.disabledActiveTickMarkColor ??
-          defaults.disabledActiveTickMarkColor,
-      disabledInactiveTickMarkColor:
-          sliderTheme.disabledInactiveTickMarkColor ??
-              defaults.disabledInactiveTickMarkColor,
-      thumbColor: widget.thumbColor ??
-          widget.activeColor ??
-          sliderTheme.thumbColor ??
-          defaults.thumbColor,
-      disabledThumbColor:
-          sliderTheme.disabledThumbColor ?? defaults.disabledThumbColor,
+      activeTrackColor: widget.activeColor ?? sliderTheme.activeTrackColor ?? defaults.activeTrackColor,
+      inactiveTrackColor: widget.inactiveColor ?? sliderTheme.inactiveTrackColor ?? defaults.inactiveTrackColor,
+      secondaryActiveTrackColor: widget.secondaryActiveColor ?? sliderTheme.secondaryActiveTrackColor ?? defaults.secondaryActiveTrackColor,
+      disabledActiveTrackColor: sliderTheme.disabledActiveTrackColor ?? defaults.disabledActiveTrackColor,
+      disabledInactiveTrackColor: sliderTheme.disabledInactiveTrackColor ?? defaults.disabledInactiveTrackColor,
+      disabledSecondaryActiveTrackColor: sliderTheme.disabledSecondaryActiveTrackColor ?? defaults.disabledSecondaryActiveTrackColor,
+      activeTickMarkColor: widget.inactiveColor ?? sliderTheme.activeTickMarkColor ?? defaults.activeTickMarkColor,
+      inactiveTickMarkColor: widget.activeColor ?? sliderTheme.inactiveTickMarkColor ?? defaults.inactiveTickMarkColor,
+      disabledActiveTickMarkColor: sliderTheme.disabledActiveTickMarkColor ?? defaults.disabledActiveTickMarkColor,
+      disabledInactiveTickMarkColor: sliderTheme.disabledInactiveTickMarkColor ?? defaults.disabledInactiveTickMarkColor,
+      thumbColor: widget.thumbColor ?? widget.activeColor ?? sliderTheme.thumbColor ?? defaults.thumbColor,
+      disabledThumbColor: sliderTheme.disabledThumbColor ?? defaults.disabledThumbColor,
       overlayColor: effectiveOverlayColor(),
       valueIndicatorColor: valueIndicatorColor,
       trackShape: sliderTheme.trackShape ?? defaultTrackShape,
@@ -909,19 +859,15 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       thumbShape: sliderTheme.thumbShape ?? defaultThumbShape,
       overlayShape: sliderTheme.overlayShape ?? defaultOverlayShape,
       valueIndicatorShape: valueIndicatorShape,
-      showValueIndicator:
-          sliderTheme.showValueIndicator ?? defaultShowValueIndicator,
+      showValueIndicator: sliderTheme.showValueIndicator ?? defaultShowValueIndicator,
       valueIndicatorTextStyle: valueIndicatorTextStyle,
     );
-    final MouseCursor effectiveMouseCursor =
-        MaterialStateProperty.resolveAs<MouseCursor?>(
-                widget.mouseCursor, states) ??
-            sliderTheme.mouseCursor?.resolve(states) ??
-            MaterialStateMouseCursor.clickable.resolve(states);
-    final SliderInteraction effectiveAllowedInteraction =
-        widget.allowedInteraction ??
-            sliderTheme.allowedInteraction ??
-            defaultAllowedInteraction;
+    final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
+      ?? sliderTheme.mouseCursor?.resolve(states)
+      ?? MaterialStateMouseCursor.clickable.resolve(states);
+    final SliderInteraction effectiveAllowedInteraction = widget.allowedInteraction
+      ?? sliderTheme.allowedInteraction
+      ?? defaultAllowedInteraction;
 
     // This size is used as the max bounds for the painting of the value
     // indicators It must be kept in sync with the function with the same name
@@ -951,10 +897,8 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       NavigationMode.traditional => _traditionalNavShortcutMap,
     };
 
-    final double fontSize =
-        sliderTheme.valueIndicatorTextStyle?.fontSize ?? kDefaultFontSize;
-    final double fontSizeToScale =
-        fontSize == 0.0 ? kDefaultFontSize : fontSize;
+    final double fontSize = sliderTheme.valueIndicatorTextStyle?.fontSize ?? kDefaultFontSize;
+    final double fontSizeToScale = fontSize == 0.0 ? kDefaultFontSize : fontSize;
     final TextScaler textScaler = theme.useMaterial3
         // TODO(tahatesser): This is an eye-balled value.
         // This needs to be updated when accessibility
@@ -983,17 +927,13 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
           child: _SliderRenderObjectWidget(
             key: _renderObjectKey,
             value: _convert(widget.value),
-            secondaryTrackValue: (widget.secondaryTrackValue != null)
-                ? _convert(widget.secondaryTrackValue!)
-                : null,
+            secondaryTrackValue: (widget.secondaryTrackValue != null) ? _convert(widget.secondaryTrackValue!) : null,
             divisions: widget.divisions,
             label: widget.label,
             sliderTheme: sliderTheme,
             textScaleFactor: effectiveTextScale,
             screenSize: screenSize(),
-            onChanged: (widget.onChanged != null) && (widget.max > widget.min)
-                ? _handleChanged
-                : null,
+            onChanged: (widget.onChanged != null) && (widget.max > widget.min) ? _handleChanged : null,
             onChangeStart: _handleDragStart,
             onChangeEnd: _handleDragEnd,
             state: this,
@@ -1156,8 +1096,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     required DeviceGestureSettings gestureSettings,
     required SliderInteraction allowedInteraction,
   })  : assert(value >= 0.0 && value <= 1.0),
-        assert(secondaryTrackValue == null ||
-            (secondaryTrackValue >= 0.0 && secondaryTrackValue <= 1.0)),
+        assert(secondaryTrackValue == null || (secondaryTrackValue >= 0.0 && secondaryTrackValue <= 1.0)),
         _platform = platform,
         _semanticFormatterCallback = semanticFormatterCallback,
         _label = label,
@@ -1268,9 +1207,8 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       final double distance = (_value - _state.positionController.value).abs();
       _state.positionController.duration = distance != 0.0
           ? _positionAnimationDuration * (1.0 / distance)
-          : Duration.zero;
-      _state.positionController
-          .animateTo(convertedValue, curve: Curves.easeInOut);
+        : Duration.zero;
+      _state.positionController.animateTo(convertedValue, curve: Curves.easeInOut);
     } else {
       _state.positionController.value = convertedValue;
     }
@@ -1305,8 +1243,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   SemanticFormatterCallback? _semanticFormatterCallback;
-  SemanticFormatterCallback? get semanticFormatterCallback =>
-      _semanticFormatterCallback;
+  SemanticFormatterCallback? get semanticFormatterCallback => _semanticFormatterCallback;
   set semanticFormatterCallback(SemanticFormatterCallback? value) {
     if (_semanticFormatterCallback == value) {
       return;
@@ -1473,10 +1410,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   bool get showValueIndicator {
     return switch (_sliderTheme.showValueIndicator!) {
-      ShowValueIndicator.onlyForDiscrete => isDiscrete,
+      ShowValueIndicator.onlyForDiscrete   => isDiscrete,
       ShowValueIndicator.onlyForContinuous => !isDiscrete,
       ShowValueIndicator.always => true,
-      ShowValueIndicator.never => false,
+      ShowValueIndicator.never  => false,
     };
   }
 
@@ -1558,8 +1495,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   double _getValueFromGlobalPosition(Offset globalPosition) {
-    final double visualPosition =
-        (globalToLocal(globalPosition).dx - _trackRect.left) / _trackRect.width;
+    final double visualPosition = (globalToLocal(globalPosition).dx - _trackRect.left) / _trackRect.width;
     return _getValueFromVisualPosition(visualPosition);
   }
 
@@ -1570,11 +1506,11 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
     return result;
   }
-
+  
   Future<void> _startValueIndicatorTimer() async {
     _state.valueIndicatorController.forward();
     _state.interactionTimer?.cancel();
-    final Completer completer = Completer();
+    final Completer<void> completer = Completer<void>();
     _state.interactionTimer = Timer(_minimumInteractionTime * timeDilation, () {
       _state.interactionTimer = null;
       if (!_active && _state.valueIndicatorController.isCompleted) {
@@ -1705,20 +1641,16 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   @override
-  double computeMinIntrinsicWidth(double height) =>
-      _minPreferredTrackWidth + _maxSliderPartWidth;
+  double computeMinIntrinsicWidth(double height) => _minPreferredTrackWidth + _maxSliderPartWidth;
 
   @override
-  double computeMaxIntrinsicWidth(double height) =>
-      _minPreferredTrackWidth + _maxSliderPartWidth;
+  double computeMaxIntrinsicWidth(double height) => _minPreferredTrackWidth + _maxSliderPartWidth;
 
   @override
-  double computeMinIntrinsicHeight(double width) =>
-      math.max(_minPreferredTrackHeight, _maxSliderPartHeight);
+  double computeMinIntrinsicHeight(double width) => math.max(_minPreferredTrackHeight, _maxSliderPartHeight);
 
   @override
-  double computeMaxIntrinsicHeight(double width) =>
-      math.max(_minPreferredTrackHeight, _maxSliderPartHeight);
+  double computeMaxIntrinsicHeight(double width) => math.max(_minPreferredTrackHeight, _maxSliderPartHeight);
 
   @override
   bool get sizedByParent => true;
@@ -1726,12 +1658,8 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     return Size(
-      constraints.hasBoundedWidth
-          ? constraints.maxWidth
-          : _minPreferredTrackWidth + _maxSliderPartWidth,
-      constraints.hasBoundedHeight
-          ? constraints.maxHeight
-          : math.max(_minPreferredTrackHeight, _maxSliderPartHeight),
+      constraints.hasBoundedWidth ? constraints.maxWidth : _minPreferredTrackWidth + _maxSliderPartWidth,
+      constraints.hasBoundedHeight ? constraints.maxHeight : math.max(_minPreferredTrackHeight, _maxSliderPartHeight),
     );
   }
 
@@ -1742,12 +1670,8 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // The visual position is the position of the thumb from 0 to 1 from left
     // to right. In left to right, this is the same as the value, but it is
     // reversed for right to left text.
-    final (double visualPosition, double? secondaryVisualPosition) =
-        switch (textDirection) {
-      TextDirection.rtl when _secondaryTrackValue == null => (
-          1.0 - controllerValue,
-          null
-        ),
+    final (double visualPosition, double? secondaryVisualPosition) = switch (textDirection) {
+      TextDirection.rtl when _secondaryTrackValue == null => (1.0 - controllerValue, null),
       TextDirection.rtl => (1.0 - controllerValue, 1.0 - _secondaryTrackValue!),
       TextDirection.ltr => (controllerValue, _secondaryTrackValue),
     };
@@ -1758,20 +1682,14 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       sliderTheme: _sliderTheme,
       isDiscrete: isDiscrete,
     );
-    final double padding = isDiscrete || _sliderTheme.trackShape!.isRounded
-        ? trackRect.height
-        : 0.0;
+    final double padding = isDiscrete || _sliderTheme.trackShape!.isRounded ? trackRect.height : 0.0;
     final double thumbPosition = isDiscrete
-        ? trackRect.left +
-            visualPosition * (trackRect.width - padding) +
-            padding / 2
-        : trackRect.left + visualPosition * trackRect.width;
+      ? trackRect.left + visualPosition * (trackRect.width - padding) + padding / 2
+      : trackRect.left + visualPosition * trackRect.width;
     // Apply padding to trackRect.left and trackRect.right if the track height is
     // greater than the thumb radius to ensure the thumb is drawn within the track.
-    final Size thumbSize =
-        _sliderTheme.thumbShape!.getPreferredSize(isInteractive, isDiscrete);
-    final double thumbPadding =
-        (padding > thumbSize.width / 2 ? padding / 2 : 0);
+    final Size thumbSize = _sliderTheme.thumbShape!.getPreferredSize(isInteractive, isDiscrete);
+    final double thumbPadding = (padding > thumbSize.width / 2 ? padding / 2 : 0);
     final Offset thumbCenter = Offset(
       clampDouble(
         thumbPosition,
@@ -1781,10 +1699,8 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       trackRect.center.dy,
     );
     if (isInteractive) {
-      final Size overlaySize =
-          sliderTheme.overlayShape!.getPreferredSize(isInteractive, false);
-      overlayRect =
-          Rect.fromCircle(center: thumbCenter, radius: overlaySize.width / 2.0);
+      final Size overlaySize = sliderTheme.overlayShape!.getPreferredSize(isInteractive, false);
+      overlayRect = Rect.fromCircle(center: thumbCenter, radius: overlaySize.width / 2.0);
     }
     final Offset? secondaryOffset = (secondaryVisualPosition != null)
         ? Offset(trackRect.left + secondaryVisualPosition * trackRect.width,
@@ -1822,12 +1738,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (isDiscrete) {
-      final double tickMarkWidth = _sliderTheme.tickMarkShape!
-          .getPreferredSize(
-            isEnabled: isInteractive,
-            sliderTheme: _sliderTheme,
-          )
-          .width;
+      final double tickMarkWidth = _sliderTheme.tickMarkShape!.getPreferredSize(
+        isEnabled: isInteractive,
+        sliderTheme: _sliderTheme,
+      ).width;
       final double adjustedTrackWidth = trackRect.width - padding;
       // If the tick marks would be too dense, don't bother painting them.
       if (adjustedTrackWidth / divisions! >= 3.0 * tickMarkWidth) {
@@ -1836,8 +1750,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
           final double value = i / divisions!;
           // The ticks are mapped to be within the track, so the tick mark width
           // must be subtracted from the track width.
-          final double dx =
-              trackRect.left + value * adjustedTrackWidth + padding / 2;
+          final double dx = trackRect.left + value * adjustedTrackWidth + padding / 2;
           final Offset tickMarkOffset = Offset(dx, dy);
           _sliderTheme.tickMarkShape!.paint(
             context,
@@ -1853,9 +1766,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       }
     }
 
-    if (isInteractive &&
-        label != null &&
-        !_valueIndicatorAnimation.isDismissed) {
+    if (isInteractive && label != null && !_valueIndicatorAnimation.isDismissed) {
       if (showValueIndicator) {
         _state.paintValueIndicator = (PaintingContext context, Offset offset) {
           if (attached && _labelPainter.text != null) {
@@ -1918,21 +1829,16 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (semanticFormatterCallback != null) {
       config.value = semanticFormatterCallback!(_state._lerp(value));
-      config.increasedValue = semanticFormatterCallback!(
-          _state._lerp(clampDouble(value + _semanticActionUnit, 0.0, 1.0)));
-      config.decreasedValue = semanticFormatterCallback!(
-          _state._lerp(clampDouble(value - _semanticActionUnit, 0.0, 1.0)));
+      config.increasedValue = semanticFormatterCallback!(_state._lerp(clampDouble(value + _semanticActionUnit, 0.0, 1.0)));
+      config.decreasedValue = semanticFormatterCallback!(_state._lerp(clampDouble(value - _semanticActionUnit, 0.0, 1.0)));
     } else {
       config.value = '${(value * 100).round()}%';
-      config.increasedValue =
-          '${(clampDouble(value + _semanticActionUnit, 0.0, 1.0) * 100).round()}%';
-      config.decreasedValue =
-          '${(clampDouble(value - _semanticActionUnit, 0.0, 1.0) * 100).round()}%';
+      config.increasedValue = '${(clampDouble(value + _semanticActionUnit, 0.0, 1.0) * 100).round()}%';
+      config.decreasedValue = '${(clampDouble(value - _semanticActionUnit, 0.0, 1.0) * 100).round()}%';
     }
   }
 
-  double get _semanticActionUnit =>
-      divisions != null ? 1.0 / divisions! : _adjustmentUnit;
+  double get _semanticActionUnit => divisions != null ? 1.0 / divisions! : _adjustmentUnit;
 
   void increaseAction() {
     _state.showValueIndicator();
@@ -2006,14 +1912,12 @@ class _ValueIndicatorRenderObjectWidget extends LeafRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(
-      BuildContext context, _RenderValueIndicator renderObject) {
+  void updateRenderObject(BuildContext context, _RenderValueIndicator renderObject) {
     renderObject._state = state;
   }
 }
 
-class _RenderValueIndicator extends RenderBox
-    with RelayoutWhenSystemFontsChangeMixin {
+class _RenderValueIndicator extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   _RenderValueIndicator({
     required _SliderState state,
   }) : _state = state {
@@ -2083,8 +1987,7 @@ class _SliderDefaultsM2 extends SliderThemeData {
   Color? get disabledInactiveTrackColor => _colors.onSurface.withOpacity(0.12);
 
   @override
-  Color? get disabledSecondaryActiveTrackColor =>
-      _colors.onSurface.withOpacity(0.12);
+  Color? get disabledSecondaryActiveTrackColor => _colors.onSurface.withOpacity(0.12);
 
   @override
   Color? get activeTickMarkColor => _colors.onPrimary.withOpacity(0.54);
@@ -2096,15 +1999,13 @@ class _SliderDefaultsM2 extends SliderThemeData {
   Color? get disabledActiveTickMarkColor => _colors.onPrimary.withOpacity(0.12);
 
   @override
-  Color? get disabledInactiveTickMarkColor =>
-      _colors.onSurface.withOpacity(0.12);
+  Color? get disabledInactiveTickMarkColor => _colors.onSurface.withOpacity(0.12);
 
   @override
   Color? get thumbColor => _colors.primary;
 
   @override
-  Color? get disabledThumbColor =>
-      Color.alphaBlend(_colors.onSurface.withOpacity(.38), _colors.surface);
+  Color? get disabledThumbColor => Color.alphaBlend(_colors.onSurface.withOpacity(.38), _colors.surface);
 
   @override
   Color? get overlayColor => _colors.primary.withOpacity(0.12);
@@ -2150,8 +2051,7 @@ class _SliderDefaultsM3 extends SliderThemeData {
   Color? get disabledInactiveTrackColor => _colors.onSurface.withOpacity(0.12);
 
   @override
-  Color? get disabledSecondaryActiveTrackColor =>
-      _colors.onSurface.withOpacity(0.12);
+  Color? get disabledSecondaryActiveTrackColor => _colors.onSurface.withOpacity(0.12);
 
   @override
   Color? get activeTickMarkColor => _colors.onPrimary.withOpacity(0.38);
@@ -2171,34 +2071,30 @@ class _SliderDefaultsM3 extends SliderThemeData {
   Color? get thumbColor => _colors.primary;
 
   @override
-  Color? get disabledThumbColor =>
-      Color.alphaBlend(_colors.onSurface.withOpacity(0.38), _colors.surface);
+  Color? get disabledThumbColor => Color.alphaBlend(_colors.onSurface.withOpacity(0.38), _colors.surface);
 
   @override
-  Color? get overlayColor =>
-      MaterialStateColor.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.dragged)) {
-          return _colors.primary.withOpacity(0.1);
-        }
-        if (states.contains(MaterialState.hovered)) {
-          return _colors.primary.withOpacity(0.08);
-        }
-        if (states.contains(MaterialState.focused)) {
-          return _colors.primary.withOpacity(0.1);
-        }
+  Color? get overlayColor => MaterialStateColor.resolveWith((Set<MaterialState> states) {
+    if (states.contains(MaterialState.dragged)) {
+      return _colors.primary.withOpacity(0.1);
+    }
+    if (states.contains(MaterialState.hovered)) {
+      return _colors.primary.withOpacity(0.08);
+    }
+    if (states.contains(MaterialState.focused)) {
+      return _colors.primary.withOpacity(0.1);
+    }
 
-        return Colors.transparent;
-      });
+    return Colors.transparent;
+  });
 
   @override
-  TextStyle? get valueIndicatorTextStyle =>
-      Theme.of(context).textTheme.labelMedium!.copyWith(
+  TextStyle? get valueIndicatorTextStyle => Theme.of(context).textTheme.labelMedium!.copyWith(
             color: _colors.onPrimary,
           );
 
   @override
-  SliderComponentShape? get valueIndicatorShape =>
-      const DropSliderValueIndicatorShape();
+  SliderComponentShape? get valueIndicatorShape => const DropSliderValueIndicatorShape();
 }
 
 // END GENERATED TOKEN PROPERTIES - Slider

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -237,7 +237,7 @@ class Slider extends StatefulWidget {
     this.focusNode,
     this.autofocus = false,
     this.allowedInteraction,
-  })  : _sliderType = _SliderType.adaptive,
+  }) : _sliderType = _SliderType.adaptive,
        assert(min <= max),
        assert(value >= min && value <= max,
          'Value $value is not between minimum $min and maximum $max'),
@@ -819,9 +819,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     if (valueIndicatorShape is RectangularSliderValueIndicatorShape) {
       valueIndicatorColor = sliderTheme.valueIndicatorColor ?? Color.alphaBlend(theme.colorScheme.onSurface.withOpacity(0.60), theme.colorScheme.surface.withOpacity(0.90));
     } else {
-      valueIndicatorColor = widget.activeColor ??
-          sliderTheme.valueIndicatorColor ??
-          theme.colorScheme.primary;
+      valueIndicatorColor = widget.activeColor ?? sliderTheme.valueIndicatorColor ?? theme.colorScheme.primary;
     }
 
     Color? effectiveOverlayColor() {
@@ -831,8 +829,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         ?? MaterialStateProperty.resolveAs<Color?>(defaults.overlayColor, states);
     }
 
-    TextStyle valueIndicatorTextStyle = sliderTheme.valueIndicatorTextStyle ??
-        defaults.valueIndicatorTextStyle!;
+    TextStyle valueIndicatorTextStyle = sliderTheme.valueIndicatorTextStyle ?? defaults.valueIndicatorTextStyle!;
     if (MediaQuery.boldTextOf(context)) {
       valueIndicatorTextStyle = valueIndicatorTextStyle
           .merge(const TextStyle(fontWeight: FontWeight.bold));
@@ -891,8 +888,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         };
     }
 
-    final Map<ShortcutActivator, Intent> shortcutMap =
-        switch (MediaQuery.navigationModeOf(context)) {
+    final Map<ShortcutActivator, Intent> shortcutMap = switch (MediaQuery.navigationModeOf(context)) {
       NavigationMode.directional => _directionalNavShortcutMap,
       NavigationMode.traditional => _traditionalNavShortcutMap,
     };
@@ -900,14 +896,13 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     final double fontSize = sliderTheme.valueIndicatorTextStyle?.fontSize ?? kDefaultFontSize;
     final double fontSizeToScale = fontSize == 0.0 ? kDefaultFontSize : fontSize;
     final TextScaler textScaler = theme.useMaterial3
-        // TODO(tahatesser): This is an eye-balled value.
-        // This needs to be updated when accessibility
-        // guidelines are available on the material specs page
-        // https://m3.material.io/components/sliders/accessibility.
-        ? MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3)
-        : MediaQuery.textScalerOf(context);
-    final double effectiveTextScale =
-        textScaler.scale(fontSizeToScale) / fontSizeToScale;
+      // TODO(tahatesser): This is an eye-balled value.
+      // This needs to be updated when accessibility
+      // guidelines are available on the material specs page
+      // https://m3.material.io/components/sliders/accessibility.
+      ? MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3)
+      : MediaQuery.textScalerOf(context);
+    final double effectiveTextScale = textScaler.scale(fontSizeToScale) / fontSizeToScale;
 
     return Semantics(
       container: true,
@@ -1095,7 +1090,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     required bool hovering,
     required DeviceGestureSettings gestureSettings,
     required SliderInteraction allowedInteraction,
-  })  : assert(value >= 0.0 && value <= 1.0),
+  }) : assert(value >= 0.0 && value <= 1.0),
         assert(secondaryTrackValue == null || (secondaryTrackValue >= 0.0 && secondaryTrackValue <= 1.0)),
         _platform = platform,
         _semanticFormatterCallback = semanticFormatterCallback,
@@ -1134,12 +1129,12 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       parent: _state.valueIndicatorController,
       curve: Curves.fastOutSlowIn,
     )..addStatusListener((AnimationStatus status) {
-        if (status.isDismissed) {
-          _state.overlayEntry?.remove();
-          _state.overlayEntry?.dispose();
-          _state.overlayEntry = null;
-        }
-      });
+      if (status.isDismissed) {
+        _state.overlayEntry?.remove();
+        _state.overlayEntry?.dispose();
+        _state.overlayEntry = null;
+      }
+    });
     _enableAnimation = CurvedAnimation(
       parent: _state.enableController,
       curve: Curves.easeInOut,
@@ -1154,16 +1149,14 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // Compute the largest width and height needed to paint the slider shapes,
   // other than the track shape. It is assumed that these shapes are vertically
   // centered on the track.
-  double get _maxSliderPartWidth =>
-      _sliderPartSizes.map((Size size) => size.width).reduce(math.max);
-  double get _maxSliderPartHeight =>
-      _sliderPartSizes.map((Size size) => size.height).reduce(math.max);
+  double get _maxSliderPartWidth => _sliderPartSizes.map((Size size) => size.width).reduce(math.max);
+  double get _maxSliderPartHeight => _sliderPartSizes.map((Size size) => size.height).reduce(math.max);
   List<Size> get _sliderPartSizes => <Size>[
-        _sliderTheme.overlayShape!.getPreferredSize(isInteractive, isDiscrete),
-        _sliderTheme.thumbShape!.getPreferredSize(isInteractive, isDiscrete),
-        _sliderTheme.tickMarkShape!.getPreferredSize(
-            isEnabled: isInteractive, sliderTheme: sliderTheme),
-      ];
+    _sliderTheme.overlayShape!.getPreferredSize(isInteractive, isDiscrete),
+    _sliderTheme.thumbShape!.getPreferredSize(isInteractive, isDiscrete),
+    _sliderTheme.tickMarkShape!.getPreferredSize(
+        isEnabled: isInteractive, sliderTheme: sliderTheme),
+  ];
   double get _minPreferredTrackHeight => _sliderTheme.trackHeight!;
 
   final _SliderState _state;
@@ -1181,10 +1174,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // are relative to the sliders origin. Therefore, the offset is passed as
   // (0,0).
   Rect get _trackRect => _sliderTheme.trackShape!.getPreferredRect(
-        parentBox: this,
-        sliderTheme: _sliderTheme,
-        isDiscrete: false,
-      );
+    parentBox: this,
+    sliderTheme: _sliderTheme,
+    isDiscrete: false,
+  );
 
   bool get isInteractive => onChanged != null;
 
@@ -1206,7 +1199,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       // get to the new location.
       final double distance = (_value - _state.positionController.value).abs();
       _state.positionController.duration = distance != 0.0
-          ? _positionAnimationDuration * (1.0 / distance)
+        ? _positionAnimationDuration * (1.0 / distance)
         : Duration.zero;
       _state.positionController.animateTo(convertedValue, curve: Curves.easeInOut);
     } else {
@@ -1595,7 +1588,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
           final double valueDelta = details.primaryDelta! / _trackRect.width;
           _currentDragValue += switch (textDirection) {
             TextDirection.rtl => -valueDelta,
-            TextDirection.ltr => valueDelta,
+            TextDirection.ltr =>  valueDelta,
           };
           onChanged!(_discretize(_currentDragValue));
         }
@@ -1702,10 +1695,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       final Size overlaySize = sliderTheme.overlayShape!.getPreferredSize(isInteractive, false);
       overlayRect = Rect.fromCircle(center: thumbCenter, radius: overlaySize.width / 2.0);
     }
-    final Offset? secondaryOffset = (secondaryVisualPosition != null)
-        ? Offset(trackRect.left + secondaryVisualPosition * trackRect.width,
-            trackRect.center.dy)
-        : null;
+    final Offset? secondaryOffset = (secondaryVisualPosition != null) ? Offset(trackRect.left + secondaryVisualPosition * trackRect.width, trackRect.center.dy) : null;
 
     _sliderTheme.trackShape!.paint(
       context,
@@ -1965,8 +1955,8 @@ class _RenderValueIndicator extends RenderBox with RelayoutWhenSystemFontsChange
 
 class _SliderDefaultsM2 extends SliderThemeData {
   _SliderDefaultsM2(this.context)
-      : _colors = Theme.of(context).colorScheme,
-        super(trackHeight: 4.0);
+    : _colors = Theme.of(context).colorScheme,
+      super(trackHeight: 4.0);
 
   final BuildContext context;
   final ColorScheme _colors;
@@ -2011,14 +2001,12 @@ class _SliderDefaultsM2 extends SliderThemeData {
   Color? get overlayColor => _colors.primary.withOpacity(0.12);
 
   @override
-  TextStyle? get valueIndicatorTextStyle =>
-      Theme.of(context).textTheme.bodyLarge!.copyWith(
-            color: _colors.onPrimary,
-          );
+  TextStyle? get valueIndicatorTextStyle => Theme.of(context).textTheme.labelMedium!.copyWith(
+    color: _colors.onPrimary,
+  );
 
   @override
-  SliderComponentShape? get valueIndicatorShape =>
-      const RectangularSliderValueIndicatorShape();
+  SliderComponentShape? get valueIndicatorShape => const RectangularSliderValueIndicatorShape();
 }
 
 // TODO(quncheng): Update M3 defaults to match the latest specs.
@@ -2057,15 +2045,13 @@ class _SliderDefaultsM3 extends SliderThemeData {
   Color? get activeTickMarkColor => _colors.onPrimary.withOpacity(0.38);
 
   @override
-  Color? get inactiveTickMarkColor =>
-      _colors.onSurfaceVariant.withOpacity(0.38);
+  Color? get inactiveTickMarkColor => _colors.onSurfaceVariant.withOpacity(0.38);
 
   @override
   Color? get disabledActiveTickMarkColor => _colors.onSurface.withOpacity(0.38);
 
   @override
-  Color? get disabledInactiveTickMarkColor =>
-      _colors.onSurface.withOpacity(0.38);
+  Color? get disabledInactiveTickMarkColor => _colors.onSurface.withOpacity(0.38);
 
   @override
   Color? get thumbColor => _colors.primary;

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -721,7 +721,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
     final _RenderSlider slider =
         _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
-    // TODO: slider._startInteraction();
+
     shouldIncrease ? slider.increaseAction() : slider.decreaseAction();
   }
 
@@ -1446,7 +1446,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (focused) {
       _state.overlayController.forward();
       if (showValueIndicator) {
-        _state.valueIndicatorController.forward();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _state.showValueIndicator();
+          _state.valueIndicatorController.forward();
+        });
       }
     } else {
       _state.overlayController.reverse();
@@ -1938,13 +1941,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       final double increase = increaseValue();
       onChanged!(increase);
       _state.overlayController.forward();
-      if (showValueIndicator) {
-        _startValueIndicatorTimer().then((_) async {
-          onChangeEnd!(increase);
-        });
-      } else {
-        onChangeEnd!(increase);
-      }
+      onChangeEnd!(increase);
     }
   }
 
@@ -1954,13 +1951,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       final double decrease = decreaseValue();
       onChanged!(decrease);
       _state.overlayController.forward();
-      if (showValueIndicator) {
-        _startValueIndicatorTimer().then((_) {
-          onChangeEnd!(decrease);
-        });
-      } else {
-        onChangeEnd!(decrease);
-      }
+      onChangeEnd!(decrease);
     }
   }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -196,7 +196,7 @@ class Slider extends StatefulWidget {
     this.focusNode,
     this.autofocus = false,
     this.allowedInteraction,
-  })  : _sliderType = _SliderType.material,
+  }) : _sliderType = _SliderType.material,
        assert(min <= max),
        assert(value >= min && value <= max,
          'Value $value is not between minimum $min and maximum $max'),
@@ -2001,7 +2001,7 @@ class _SliderDefaultsM2 extends SliderThemeData {
   Color? get overlayColor => _colors.primary.withOpacity(0.12);
 
   @override
-  TextStyle? get valueIndicatorTextStyle => Theme.of(context).textTheme.labelMedium!.copyWith(
+  TextStyle? get valueIndicatorTextStyle => Theme.of(context).textTheme.bodyLarge!.copyWith(
     color: _colors.onPrimary,
   );
 
@@ -2076,8 +2076,8 @@ class _SliderDefaultsM3 extends SliderThemeData {
 
   @override
   TextStyle? get valueIndicatorTextStyle => Theme.of(context).textTheme.labelMedium!.copyWith(
-            color: _colors.onPrimary,
-          );
+    color: _colors.onPrimary,
+  );
 
   @override
   SliderComponentShape? get valueIndicatorShape => const DropSliderValueIndicatorShape();

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -4443,4 +4443,123 @@ void main() {
       await tester.pumpAndSettle();
       expect(valueIndicatorBox, paintsExactlyCountTimes(#drawPath, 1));
   });
+
+  testWidgets('Value indicator appears after pressing the keyboard shortcuts',
+      (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
+
+    double startValue = 0.0;
+    double currentValue = 0.5;
+    double endValue = 0.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+              return Slider(
+                value: currentValue,
+                label: currentValue.toStringAsFixed(1),
+                divisions: 10,
+                onChangeStart: (double newValue) {
+                  setState(() {
+                    startValue = newValue;
+                  });
+                },
+                onChanged: (double newValue) {
+                  setState(() {
+                    currentValue = newValue;
+                  });
+                },
+                onChangeEnd: (double newValue) {
+                  setState(() {
+                    endValue = newValue;
+                  });
+                },
+                autofocus: true,
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Value indicator is visible when focus
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(startValue, 0.5);
+    expect(currentValue, 0.6);
+    expect(endValue, 0.6);
+    RenderBox valueIndicatorBox = tester.renderObject(find.byType(Overlay));
+    expect(
+      valueIndicatorBox,
+      paints
+        ..scale()
+        ..path(color: theme.colorScheme.primary)
+        ..paragraph(),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pumpAndSettle();
+    expect(startValue, 0.6);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
+
+    valueIndicatorBox = tester.renderObject(find.byType(Overlay));
+    expect(
+      find.byType(Overlay),
+      findsOneWidget
+    );
+    expect(
+      valueIndicatorBox,
+      paints
+        ..scale()
+        ..path(color: theme.colorScheme.primary)
+        ..paragraph(),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(startValue, 0.5);
+    expect(currentValue, 0.6);
+    expect(endValue, 0.6);
+
+    valueIndicatorBox = tester.renderObject(find.byType(Overlay));
+    expect(
+      valueIndicatorBox,
+      paints
+        ..scale()
+        ..path(color: theme.colorScheme.primary)
+        ..paragraph(),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(startValue, 0.6);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
+    valueIndicatorBox = tester.renderObject(find.byType(Overlay));
+    expect(
+      valueIndicatorBox,
+      paints
+        ..scale()
+        ..path(color: theme.colorScheme.primary)
+        ..paragraph(),
+    );
+
+    // The indicator will exists until unfocus
+    await tester.pump(const Duration(seconds: 3));
+     valueIndicatorBox = tester.renderObject(find.byType(Overlay));
+    expect(
+      valueIndicatorBox,
+      paints
+        ..scale()
+        ..path(color: theme.colorScheme.primary)
+        ..paragraph(),
+    );
+  });
 }


### PR DESCRIPTION
Based on the issue [#152884](https://github.com/flutter/flutter/issues/152884), using keyboard to change the value of slider will not show the value indicator. I have checked the code that it doesn't have this feature at all. Here is the result of this PR.

It has these behaviors, which may need to be discussed:
1. The indicator which triggered by click / press will still disappear automatically.
2. The indicator which triggered by auto focus, tab key will keep appearing.
3. The indicator which triggered by arrow key won’t keep appearing, until the slider lost focus.


https://github.com/user-attachments/assets/4630f00d-f912-4d7a-b415-e92313a83301

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
Relative issues:
#152884 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


