### PR TITLE
Fix Linux_android_emu tests late initialization errors

### DIFF
--- a/dev/integration_tests/android_driver_test/test_driver/main_test.dart
+++ b/dev/integration_tests/android_driver_test/test_driver/main_test.dart
@@ -24,8 +24,8 @@ Future<void> _main() async {
   // To generate golden files locally, uncomment the following line.
   // autoUpdateGoldenFiles = true;
 
-  late FlutterDriver flutterDriver;
-  late NativeDriver nativeDriver;
+  FlutterDriver? flutterDriver;
+  NativeDriver? nativeDriver;
 
   setUpAll(() async {
     flutterDriver = await FlutterDriver.connect(
@@ -38,14 +38,14 @@ Future<void> _main() async {
   });
 
   tearDownAll(() async {
-    await nativeDriver.close();
-    await flutterDriver.close();
+    await nativeDriver?.close();
+    await flutterDriver?.close();
   });
 
   test('should screenshot and match a full-screen blue rectangle', () async {
-    await flutterDriver.waitFor(find.byType('DecoratedBox'));
+    await flutterDriver?.waitFor(find.byType('DecoratedBox'));
     await expectLater(
-      nativeDriver.screenshot(),
+      nativeDriver?.screenshot(),
       matchesGoldenFile('android_driver_test.BlueRectangle.png'),
     );
   }, timeout: Timeout.none);

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -6,14 +6,14 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 Future<void> main() async {
-  late FlutterDriver driver;
+  FlutterDriver? driver;
 
   setUpAll(() async {
     driver = await FlutterDriver.connect();
   });
 
   tearDownAll(() {
-    driver.close();
+    driver?.close();
   });
 
   // Each test below must return back to the home page after finishing.
@@ -21,14 +21,14 @@ Future<void> main() async {
   test('MotionEvent recomposition', () async {
     final SerializableFinder motionEventsListTile =
     find.byValueKey('MotionEventsListTile');
-    await driver.tap(motionEventsListTile);
-    await driver.runUnsynchronized(() async {
-      driver.waitFor(find.byValueKey('PlatformView'));
+    await driver?.tap(motionEventsListTile);
+    await driver?.runUnsynchronized(() async {
+      driver?.waitFor(find.byValueKey('PlatformView'));
     });
-    final String errorMessage = await driver.requestData('run test');
+    final String errorMessage = (await driver?.requestData('run test'))!;
     expect(errorMessage, '');
     final SerializableFinder backButton = find.byValueKey('back');
-    await driver.tap(backButton);
+    await driver?.tap(backButton);
   }, timeout: Timeout.none);
 
   group('WindowManager', ()
@@ -36,32 +36,32 @@ Future<void> main() async {
     setUpAll(() async {
       final SerializableFinder wmListTile =
       find.byValueKey('WmIntegrationsListTile');
-      await driver.tap(wmListTile);
+      await driver?.tap(wmListTile);
     });
 
     tearDownAll(() async {
-      await driver.waitFor(find.pageBack());
-      await driver.tap(find.pageBack());
+      await driver?.waitFor(find.pageBack());
+      await driver?.tap(find.pageBack());
     });
 
     test('AlertDialog from platform view context', () async {
       final SerializableFinder showAlertDialog = find.byValueKey(
           'ShowAlertDialog');
-      await driver.waitFor(showAlertDialog);
-      await driver.tap(showAlertDialog);
-      final String status = await driver.getText(find.byValueKey('Status'));
+      await driver?.waitFor(showAlertDialog);
+      await driver?.tap(showAlertDialog);
+      final String status = (await driver?.getText(find.byValueKey('Status')))!;
       expect(status, 'Success');
     }, timeout: Timeout.none);
 
     test('Child windows can handle touches', () async {
       final SerializableFinder addWindow = find.byValueKey('AddWindow');
-      await driver.waitFor(addWindow);
-      await driver.tap(addWindow);
+      await driver?.waitFor(addWindow);
+      await driver?.tap(addWindow);
       final SerializableFinder tapWindow = find.byValueKey('TapWindow');
-      await driver.tap(tapWindow);
-      final String windowClickCount = await driver.getText(
+      await driver?.tap(tapWindow);
+      final String windowClickCount = (await driver?.getText(
         find.byValueKey('WindowClickCount'),
-      );
+      ))!;
       expect(windowClickCount, 'Click count: 1');
     }, timeout: Timeout.none, skip: true); // TODO(garyq): Skipped, see https://github.com/flutter/flutter/issues/88479
   });

--- a/dev/integration_tests/external_textures/test_driver/frame_rate_main_test.dart
+++ b/dev/integration_tests/external_textures/test_driver/frame_rate_main_test.dart
@@ -12,14 +12,14 @@ final RegExp _statsRegExp = RegExp('Produced: (.*)fps\nConsumed: (.*)fps\nWidget
 const Duration _samplingTime = Duration(seconds: 8);
 
 Future<void> main() async {
-  late final FlutterDriver driver;
+  FlutterDriver? driver;
 
   setUpAll(() async {
     driver = await FlutterDriver.connect();
   });
 
   tearDownAll(() async {
-    await driver.close();
+    await driver?.close();
   });
 
   // Verifies we consume texture frames at a rate close to the minimum of the
@@ -31,19 +31,19 @@ Future<void> main() async {
     final SerializableFinder summary = find.byValueKey('summary');
 
     // Wait for calibration to complete and fab to appear.
-    await driver.waitFor(fab);
+    await driver?.waitFor(fab);
 
-    final String calibrationResult = await driver.getText(summary);
+    final String calibrationResult = (await driver?.getText(summary))!;
     final Match? matchCalibration = _calibrationRegExp.matchAsPrefix(calibrationResult);
     expect(matchCalibration, isNotNull);
     final double flutterFrameRate = double.parse(matchCalibration?.group(1) ?? '0');
 
     // Texture frame stats at 0.5x Flutter frame rate
-    await driver.tap(fab);
+    await driver?.tap(fab);
     await Future<void>.delayed(_samplingTime);
-    await driver.tap(fab);
+    await driver?.tap(fab);
 
-    final String statsSlow = await driver.getText(summary);
+    final String statsSlow = (await driver?.getText(summary))!;
     final Match matchSlow = _statsRegExp.matchAsPrefix(statsSlow)!;
     expect(matchSlow, isNotNull);
 
@@ -55,11 +55,11 @@ Future<void> main() async {
     expect(widgetBuilds, 1);
 
     // Texture frame stats at 2.0x Flutter frame rate
-    await driver.tap(fab);
+    await driver?.tap(fab);
     await Future<void>.delayed(_samplingTime);
-    await driver.tap(fab);
+    await driver?.tap(fab);
 
-    final String statsFast = await driver.getText(summary);
+    final String statsFast = (await driver?.getText(summary))!;
     final Match matchFast = _statsRegExp.matchAsPrefix(statsFast)!;
     expect(matchFast, isNotNull);
 

--- a/dev/integration_tests/ui/test_driver/defines_test.dart
+++ b/dev/integration_tests/ui/test_driver/defines_test.dart
@@ -6,17 +6,17 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
-  late FlutterDriver driver;
+  FlutterDriver? driver;
 
   setUpAll(() async {
     driver = await FlutterDriver.connect();
   });
 
   tearDownAll(() async {
-    await driver.close();
+    await driver?.close();
   });
 
   test('Can run with --dart-define', () async {
-    await driver.waitFor(find.text('Example,AValue'));
+    await driver?.waitFor(find.text('Example,AValue'));
   }, timeout: Timeout.none);
 }

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -109,8 +109,10 @@ class VMServiceFlutterDriver extends FlutterDriver {
       while (true) {
         final vms.Isolate isolate = await client.getIsolate(ref.id!);
         if (isolate.pauseEvent!.kind == vms.EventKind.kNone) {
+          _log('Waiting for isolate ${ref.number} to be runnable.');
           await Future<void>.delayed(_kPauseBetweenIsolateRefresh);
         } else {
+          _log('Isolate ${ref.number} is runnable.');
           return isolate;
         }
       }


### PR DESCRIPTION
This does not fix the issue underlying https://github.com/flutter/flutter/issues/152684, but may prevent `adb logcat` from ending before we've captured the logs that explain why the app or emulator are potentially crashing.

Fixes Fixes https://github.com/flutter/flutter/issues/152899