### PR TITLE
`CupertinoSlidingSegmentedControl` update

### DIFF
--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -645,8 +645,6 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
   }
 
   void onUpdate(DragUpdateDetails details) {
-    final T touchDownSegment = segmentForXPosition(details.localPosition.dx);
-
     // If drag gesture starts on disabled segment, no update needed.
     if (_startedOnDisabledSegment) {
       return;
@@ -654,6 +652,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
 
     // If drag gesture starts on enabled segment and dragging on disabled segment,
     // no update needed.
+    final T touchDownSegment = segmentForXPosition(details.localPosition.dx);
     if (widget.disabledChildren.contains(touchDownSegment)) {
       return;
     }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -385,10 +385,6 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
 
   /// The identifier of the widget that is currently selected.
   ///
-  /// When there is no highlighted segment in the segmented control, but the [groupValue]
-  /// is not null, it means this this segment was highlighted before but it is
-  /// disabled; if [groupValue] is null, it means no segment is highlighted.
-  ///
   /// This must be one of the keys in the [Map] of [children].
   /// If this attribute is null, no widget will be initially selected.
   final T? groupValue;

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -106,8 +106,8 @@ class _Segment<T> extends StatefulWidget {
     required this.highlighted,
     required this.isDragging,
     required this.enabled,
-    required this.isLeftSegment,
-    required this.isRightSegment,
+    required this.isLeftmostSegment,
+    required this.isRightmostSegment,
   }) : super(key: key);
 
   final Widget child;
@@ -115,8 +115,8 @@ class _Segment<T> extends StatefulWidget {
   final bool pressed;
   final bool highlighted;
   final bool enabled;
-  final bool isLeftSegment;
-  final bool isRightSegment;
+  final bool isLeftmostSegment;
+  final bool isRightmostSegment;
 
   // Whether the thumb of the parent widget (CupertinoSlidingSegmentedControl)
   // is currently being dragged.
@@ -172,9 +172,9 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
   @override
   Widget build(BuildContext context) {
     Alignment scaleAlignment;
-    if (widget.isLeftSegment) {
+    if (widget.isLeftmostSegment) {
       scaleAlignment = Alignment.centerLeft;
-    } else if (widget.isRightSegment) {
+    } else if (widget.isRightmostSegment) {
       scaleAlignment = Alignment.centerRight;
     } else {
       scaleAlignment = Alignment.center;
@@ -733,12 +733,12 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
       }
 
       final TextDirection textDirection = Directionality.of(context);
-      final bool isLeftSegment = switch (textDirection) {
+      final bool isLeftmostSegment = switch (textDirection) {
         TextDirection.ltr => highlightedIndex == 0,
         TextDirection.rtl => highlightedIndex == children.length - 1
       };
 
-      final bool isRightSegment = switch (textDirection) {
+      final bool isRightmostSegment = switch (textDirection) {
         TextDirection.ltr => highlightedIndex == children.length - 1,
         TextDirection.rtl => highlightedIndex == 0
       };
@@ -757,8 +757,8 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
               pressed: pressed == entry.key,
               isDragging: isThumbDragging,
               enabled: enabled,
-              isLeftSegment: isLeftSegment,
-              isRightSegment: isRightSegment,
+              isLeftmostSegment: isLeftmostSegment,
+              isRightmostSegment: isRightmostSegment,
               child: entry.value,
             ),
           ),

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -122,8 +122,8 @@ class _Segment<T> extends StatefulWidget {
   // is currently being dragged.
   final bool isDragging;
 
-  bool get shouldFadeoutContent => pressed && !highlighted;
-  bool get shouldScaleContent => pressed && highlighted && isDragging;
+  bool get shouldFadeoutContent => pressed && !highlighted && enabled;
+  bool get shouldScaleContent => pressed && highlighted && isDragging && enabled;
 
   @override
   _SegmentState<T> createState() => _SegmentState<T>();
@@ -350,7 +350,7 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
     super.key,
     required this.children,
     required this.onValueChanged,
-    this.setEnabled,
+    Set<T>? disabledChildren,
     this.groupValue,
     this.thumbColor = _kThumbColor,
     this.padding = _kHorizontalItemPadding,
@@ -360,7 +360,7 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
        assert(
          groupValue == null || children.keys.contains(groupValue),
          'The groupValue must be either null or one of the keys in the children map.',
-       );
+       ), disabledChildren = disabledChildren ?? <T>{};
 
   /// The identifying keys and corresponding widget values in the
   /// segmented control.
@@ -371,11 +371,16 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   /// The map must have more than one entry.
   final Map<T, Widget> children;
 
-  /// The identifying keys and the corresponding widget status whether the
-  /// segment is enabled or not.
+  /// A set to indicate disabled segments.
   ///
-  /// If this is null, all segments are selectable by default.
-  final Map<T, bool>? setEnabled;
+  /// Disabled children cannot be highlighted and don't show any animation
+  /// when they are tapped or long pressed. So if this set contains [groupValue],
+  /// [groupValue] cannot be highlighted until it is switched to an enabled
+  /// segment.
+  ///
+  /// By default, all segments are selectable. The default text color for
+  /// disabled segments is `Color.fromARGB(115, 176, 176, 176)`.
+  final Set<T> disabledChildren;
 
   /// The identifier of the widget that is currently selected.
   ///
@@ -478,6 +483,8 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
   final LongPressGestureRecognizer longPress = LongPressGestureRecognizer();
   final GlobalKey segmentedControlRenderWidgetKey = GlobalKey();
 
+  T? get groupValue => widget.disabledChildren.contains(widget.groupValue) ? null : widget.groupValue;
+
   @override
   void initState() {
     super.initState();
@@ -501,14 +508,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     // Empty callback to enable the long press recognizer.
     longPress.onLongPress = () { };
 
-    highlighted = widget.groupValue;
-    if (widget.setEnabled != null) {
-      // If `setEnabled` map contains the `groupValue` and the status is set to
-      // false, then this segment should not be highlighted.
-      if (widget.setEnabled!.containsKey(widget.groupValue) && !widget.setEnabled![widget.groupValue]!) {
-        highlighted = null;
-      }
-    }
+    highlighted = groupValue;
   }
 
   @override
@@ -518,17 +518,10 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     // Temporarily ignore highlight changes from the widget when the thumb is
     // being dragged. When the drag gesture finishes the widget will be forced
     // to build (see the onEnd method), and didUpdateWidget will be called again.
-    if (!isThumbDragging && highlighted != widget.groupValue) {
+    if (!isThumbDragging && highlighted != groupValue) {
       thumbController.animateWith(_kThumbSpringAnimationSimulation);
       thumbAnimatable = null;
-      if (widget.setEnabled != null) {
-        // If `setEnabled` map contains the `groupValue` and the status is set to
-        // false, then no update needed.
-        if (widget.setEnabled!.containsKey(widget.groupValue) && !widget.setEnabled![widget.groupValue]!) {
-          return;
-        }
-      }
-      highlighted = widget.groupValue;
+      highlighted = groupValue;
     }
   }
 
@@ -604,12 +597,10 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     if (highlighted == newValue) {
       return;
     }
-    if (widget.setEnabled != null) {
-      // If `setEnabled` map contains the `groupValue` and the status is set to
-      // false, then no update needed.
-      if (widget.setEnabled!.containsKey(newValue) && !widget.setEnabled![newValue]!) {
-        return;
-      }
+    // If `disabledChildren` set contains the `groupValue`, then no update
+    // needed.
+    if (widget.disabledChildren.contains(newValue)) {
+      return;
     }
     setState(() { highlighted = newValue; });
     // Additionally, start the thumb animation if the highlighted segment
@@ -623,6 +614,9 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
   }
 
   void onPressedChangedByGesture(T? newValue) {
+    if (widget.disabledChildren.contains(newValue)) {
+      return;
+    }
     if (pressed != newValue) {
       setState(() { pressed = newValue; });
     }
@@ -635,12 +629,10 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     }
     final T segment = segmentForXPosition(details.localPosition.dx);
     onPressedChangedByGesture(null);
-    if (segment != widget.groupValue) {
-      if (widget.setEnabled != null) {
-        // When disabled segment is tapped, `onValueChanged` should not be called.
-        if (widget.setEnabled!.containsKey(segment) && !widget.setEnabled![segment]!) {
-          return;
-        }
+    if (segment != groupValue) {
+      // When disabled segment is tapped, `onValueChanged` should not be called.
+      if (widget.disabledChildren.contains(segment)) {
+        return;
       }
       widget.onValueChanged(segment);
     }
@@ -673,13 +665,13 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     final T? pressed = this.pressed;
     if (isThumbDragging) {
       _playThumbScaleAnimation(isExpanding: true);
-      if (highlighted != widget.groupValue) {
+      if (highlighted != groupValue) {
         widget.onValueChanged(highlighted);
       }
     } else if (pressed != null) {
       onHighlightChangedByGesture(pressed);
       assert(pressed == highlighted);
-      if (highlighted != widget.groupValue) {
+      if (highlighted != groupValue) {
         widget.onValueChanged(highlighted);
       }
     }
@@ -733,11 +725,6 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
         );
       }
 
-      bool enabled = true;
-      if (widget.setEnabled != null && widget.setEnabled!.containsKey(entry.key)) {
-        enabled = widget.setEnabled![entry.key]!;
-      }
-
       final TextDirection textDirection = Directionality.of(context);
       final bool isLeftmostSegment = switch (textDirection) {
         TextDirection.ltr => highlightedIndex == 0,
@@ -752,9 +739,14 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
       children.add(
         Semantics(
           button: true,
-          onTap: () { widget.onValueChanged(entry.key); },
+          onTap: () {
+            if (widget.disabledChildren.contains(entry.key)) {
+              return;
+            }
+            widget.onValueChanged(entry.key);
+           },
           inMutuallyExclusiveGroup: true,
-          selected: widget.groupValue == entry.key,
+          selected: groupValue == entry.key,
           child: MouseRegion(
             cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
             child: _Segment<T>(
@@ -762,7 +754,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
               highlighted: isHighlighted,
               pressed: pressed == entry.key,
               isDragging: isThumbDragging,
-              enabled: enabled,
+              enabled: !widget.disabledChildren.contains(entry.key),
               isLeftmostSegment: isLeftmostSegment,
               isRightmostSegment: isRightmostSegment,
               child: entry.value,

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -171,7 +171,7 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
 
   @override
   Widget build(BuildContext context) {
-    Alignment scaleAlignment;
+    final Alignment scaleAlignment;
     if (widget.isLeftmostSegment) {
       scaleAlignment = Alignment.centerLeft;
     } else if (widget.isRightmostSegment) {
@@ -784,6 +784,8 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     return UnconstrainedBox(
       constrainedAxis: Axis.horizontal,
       child: Container(
+        // Clip the thumb shadow if it is outside of the segmented control. This
+        // behavior is eyeballed by the iOS 17.5 simulator.
         clipBehavior: Clip.antiAlias,
         padding: widget.padding.resolve(Directionality.of(context)),
         decoration: BoxDecoration(

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -93,6 +93,8 @@ class _Segment<T> extends StatefulWidget {
     required this.highlighted,
     required this.isDragging,
     required this.enabled,
+    required this.isLeftSegment,
+    required this.isRightSegment,
   }) : super(key: key);
 
   final Widget child;
@@ -100,6 +102,8 @@ class _Segment<T> extends StatefulWidget {
   final bool pressed;
   final bool highlighted;
   final bool enabled;
+  final bool isLeftSegment;
+  final bool isRightSegment;
 
   // Whether the thumb of the parent widget (CupertinoSlidingSegmentedControl)
   // is currently being dragged.
@@ -154,6 +158,14 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
 
   @override
   Widget build(BuildContext context) {
+    Alignment scaleAlignment;
+    if (widget.isLeftSegment) {
+      scaleAlignment = Alignment.centerLeft;
+    } else if (widget.isRightSegment) {
+      scaleAlignment = Alignment.centerRight;
+    } else {
+      scaleAlignment = Alignment.center;
+    }
     return MetaData(
       // Expand the hitTest area of this widget.
       behavior: HitTestBehavior.opaque,
@@ -175,6 +187,7 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
               duration: _kHighlightAnimationDuration,
               curve: Curves.ease,
               child: ScaleTransition(
+                alignment: scaleAlignment,
                 scale: highlightPressScaleAnimation,
                 child: widget.child,
               ),
@@ -706,6 +719,17 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
         enabled = widget.setEnabled![entry.key]!;
       }
 
+      final TextDirection textDirection = Directionality.of(context);
+      final bool isLeftSegment = switch (textDirection) {
+        TextDirection.ltr => highlightedIndex == 0,
+        TextDirection.rtl => highlightedIndex == children.length - 1
+      };
+
+      final bool isRightSegment = switch (textDirection) {
+        TextDirection.ltr => highlightedIndex == children.length - 1,
+        TextDirection.rtl => highlightedIndex == 0
+      };
+
       children.add(
         Semantics(
           button: true,
@@ -720,6 +744,8 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
               pressed: pressed == entry.key,
               isDragging: isThumbDragging,
               enabled: enabled,
+              isLeftSegment: isLeftSegment,
+              isRightSegment: isRightSegment,
               child: entry.value,
             ),
           ),
@@ -1177,6 +1203,10 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     }
 
     final int? highlightedChildIndex = highlightedIndex;
+    final bool isLeadingChild = highlightedChildIndex != null
+      && highlightedChildIndex == 0;
+    final bool isTrailingChild = highlightedChildIndex != null
+      && highlightedChildIndex == children.length ~/ 2;
     // Paint thumb if there's a highlighted segment.
     if (highlightedChildIndex != null) {
       final RenderBox selectedChild = children[highlightedChildIndex * 2];
@@ -1205,8 +1235,17 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
       final Rect unscaledThumbRect = state.thumbAnimatable?.evaluate(state.thumbController) ?? newThumbRect;
       currentThumbRect = unscaledThumbRect;
+
+      double delta = 0;
+      if (isLeadingChild) {
+        delta = unscaledThumbRect.width - unscaledThumbRect.width * thumbScale;
+      }
+
+      if (isTrailingChild) {
+        delta = unscaledThumbRect.width * thumbScale - unscaledThumbRect.width;
+      }
       final Rect thumbRect = Rect.fromCenter(
-        center: unscaledThumbRect.center,
+        center: unscaledThumbRect.center - Offset(delta / 2, 0),
         width: unscaledThumbRect.width * thumbScale,
         height: unscaledThumbRect.height * thumbScale,
       );

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -43,10 +43,8 @@ const CupertinoDynamicColor _kThumbColor = CupertinoDynamicColor.withBrightness(
   darkColor: Color(0xFF636366),
 );
 
-// The height of the separator.
-const double _kSeparatorHeight = 18.0;
 // The amount of space by which to inset each separator.
-const EdgeInsets _kSeparatorInset = EdgeInsets.symmetric(vertical: (_kMinSegmentedControlHeight - _kSeparatorHeight) / 2);
+const EdgeInsets _kSeparatorInset = EdgeInsets.symmetric(vertical: 5);
 const double _kSeparatorWidth = 1;
 const Radius _kSeparatorRadius = Radius.circular(_kSeparatorWidth / 2);
 

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1216,10 +1216,8 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     }
 
     final int? highlightedChildIndex = highlightedIndex;
-    final bool isLeadingChild = highlightedChildIndex != null
-      && highlightedChildIndex == 0;
-    final bool isTrailingChild = highlightedChildIndex != null
-      && highlightedChildIndex == children.length ~/ 2;
+    final bool isLeadingChild = highlightedChildIndex == 0;
+    final bool isTrailingChild = highlightedChildIndex == children.length ~/ 2;
     // Paint thumb if there's a highlighted segment.
     if (highlightedChildIndex != null) {
       final RenderBox selectedChild = children[highlightedChildIndex * 2];

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -72,14 +72,13 @@ const double _kContentPressedMinOpacity = 0.2;
 // Inspected from iOS 17.5 simulator.
 const double _kFontSize = 13.0;
 
-// The value inspected from iOS 17.5 simulator is RegularG3, so `FontWeight.w500`
-// is eyeballed value which looks the most similar to RegularG3.
+// Inspected from iOS 17.5 simulator.
 const FontWeight _kFontWeight = FontWeight.w500;
 
-// The value inspected from iOS 17.5 simulator is MediumG3, so `FontWeight.w600`
-// is eyeballed value which looks the most similar to MediumG3.
+// Inspected from iOS 17.5 simulator.
 const FontWeight _kHighlightedFontWeight = FontWeight.w600;
 
+// Inspected from iOS 17.5 simulator
 const Color _kDisabledContentColor = Color.fromARGB(115, 176, 176, 176);
 
 // The spring animation used when the thumb changes its rect.

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -375,7 +375,7 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   ///
   /// Disabled children cannot be highlighted and don't show any animation
   /// when they are tapped or long pressed. So if this set contains [groupValue],
-  /// [groupValue] cannot be highlighted until it is switched to an enabled
+  /// there is no segment getting highlighted until it is switched to an enabled
   /// segment.
   ///
   /// By default, all segments are selectable. The default text color for

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -365,7 +365,8 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   /// The map must have more than one entry.
   final Map<T, Widget> children;
 
-  /// A set to indicate disabled segments.
+  /// The set of identifying keys that correspond to the segments that should be
+  /// disabled.
   ///
   /// Disabled children cannot be highlighted and don't show any animation
   /// when they are tapped or long pressed. So if this set contains [groupValue],

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -206,7 +206,13 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
               ),
             ),
           ),
-          widget.child,
+          DefaultTextStyle.merge(
+            style: const TextStyle(
+              fontWeight: _kHighlightedFontWeight,
+              fontSize: _kFontSize,
+            ),
+            child: widget.child
+          ),
         ],
       ),
     );

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -52,7 +52,7 @@ const Radius _kSeparatorRadius = Radius.circular(_kSeparatorWidth / 2);
 
 // The minimum scale factor of the thumb, when being pressed on for a sufficient
 // amount of time.
-const double _kMinThumbScale = 0.95; // quncheng: ???
+const double _kMinThumbScale = 0.95;
 
 // The minimum horizontal distance between the edges of the separator and the
 // closest child.

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -372,10 +372,18 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   /// there is no segment getting highlighted until it is switched to an enabled
   /// segment.
   ///
+  /// [onValueChanged] will not be called if the segment is disabled. However, if
+  /// an enabled segment is "highlighted" by dragging gesture and becomes disabled
+  /// before dragging stops, [onValueChanged] will be triggered when release finger.
+  ///
   /// By default, all segments are selectable.
   final Set<T> disabledChildren;
 
   /// The identifier of the widget that is currently selected.
+  ///
+  /// When there is no highlighted segment in the segmented control, but the [groupValue]
+  /// is not null, it means this this segment was highlighted before but it is
+  /// disabled; if [groupValue] is null, it means no segment is highlighted.
   ///
   /// This must be one of the keys in the [Map] of [children].
   /// If this attribute is null, no widget will be initially selected.

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -600,8 +600,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     if (highlighted == newValue) {
       return;
     }
-    // If `disabledChildren` set contains the `groupValue`, then no update
-    // needed.
+    // If `disabledChildren` set contains the `newValue`, then no update needed.
     if (widget.disabledChildren.contains(newValue)) {
       return;
     }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -79,7 +79,7 @@ const FontWeight _kFontWeight = FontWeight.w500;
 const FontWeight _kHighlightedFontWeight = FontWeight.w600;
 
 // Inspected from iOS 17.5 simulator
-const Color _kDisabledContentColor = Color.fromARGB(115, 176, 176, 176);
+const Color _kDisabledContentColor = Color.fromARGB(115, 122, 122, 122);
 
 // The spring animation used when the thumb changes its rect.
 final SpringSimulation _kThumbSpringAnimationSimulation = SpringSimulation(

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -339,6 +339,10 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   /// The map must have more than one entry.
   final Map<T, Widget> children;
 
+  /// The identifying keys and the corresponding widget status whether the
+  /// segment is enabled or not.
+  ///
+  /// If this is null, all segments are selectable by default.
   final Map<T, bool>? setEnabled;
 
   /// The identifier of the widget that is currently selected.
@@ -466,6 +470,13 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     longPress.onLongPress = () { };
 
     highlighted = widget.groupValue;
+    if (widget.setEnabled != null) {
+      // If `setEnabled` map contains the `groupValue` and the status is set to
+      // false, then this segment should not be highlighted.
+      if (widget.setEnabled!.containsKey(widget.groupValue) && !widget.setEnabled![widget.groupValue]!) {
+        highlighted = null;
+      }
+    }
   }
 
   @override
@@ -478,6 +489,13 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     if (!isThumbDragging && highlighted != widget.groupValue) {
       thumbController.animateWith(_kThumbSpringAnimationSimulation);
       thumbAnimatable = null;
+      if (widget.setEnabled != null) {
+        // If `setEnabled` map contains the `groupValue` and the status is set to
+        // false, then no update needed.
+        if (widget.setEnabled!.containsKey(widget.groupValue) && !widget.setEnabled![widget.groupValue]!) {
+          return;
+        }
+      }
       highlighted = widget.groupValue;
     }
   }
@@ -554,6 +572,13 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     if (highlighted == newValue) {
       return;
     }
+    if (widget.setEnabled != null) {
+      // If `setEnabled` map contains the `groupValue` and the status is set to
+      // false, then no update needed.
+      if (widget.setEnabled!.containsKey(newValue) && !widget.setEnabled![newValue]!) {
+        return;
+      }
+    }
     setState(() { highlighted = newValue; });
     // Additionally, start the thumb animation if the highlighted segment
     // changes. If the thumbController is already running, the render object's
@@ -579,6 +604,12 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     final T segment = segmentForXPosition(details.localPosition.dx);
     onPressedChangedByGesture(null);
     if (segment != widget.groupValue) {
+      if (widget.setEnabled != null) {
+        // When disabled segment is tapped, `onValueChanged` should not be called.
+        if (widget.setEnabled!.containsKey(segment) && !widget.setEnabled![segment]!) {
+          return;
+        }
+      }
       widget.onValueChanged(segment);
     }
   }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -67,6 +67,8 @@ const double _kTouchYDistanceThreshold = 50.0 * 50.0;
 
 // The minimum opacity of an unselected segment, when the user presses on the
 // segment and it starts to fadeout.
+//
+// Inspected from iOS 17.5 simulator.
 const double _kContentPressedMinOpacity = 0.2;
 
 const Color _kDisabledContentColor = Color.fromARGB(115, 176, 176, 176);

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -71,6 +71,17 @@ const double _kTouchYDistanceThreshold = 50.0 * 50.0;
 // Inspected from iOS 17.5 simulator.
 const double _kContentPressedMinOpacity = 0.2;
 
+// Inspected from iOS 17.5 simulator.
+const double _kFontSize = 13.0;
+
+// The value inspected from iOS 17.5 simulator is RegularG3, so `FontWeight.w500`
+// is eyeballed value which looks the most similar to RegularG3.
+const FontWeight _kFontWeight = FontWeight.w500;
+
+// The value inspected from iOS 17.5 simulator is MediumG3, so `FontWeight.w600`
+// is eyeballed value which looks the most similar to MediumG3.
+const FontWeight _kHighlightedFontWeight = FontWeight.w600;
+
 const Color _kDisabledContentColor = Color.fromARGB(115, 176, 176, 176);
 
 // The spring animation used when the thumb changes its rect.
@@ -182,8 +193,8 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
               style: DefaultTextStyle.of(context)
                 .style
                 .merge(TextStyle(
-                  fontWeight: widget.highlighted ? FontWeight.w600 : FontWeight.w500,
-                  fontSize: 13,
+                  fontWeight: widget.highlighted ? _kHighlightedFontWeight : _kFontWeight,
+                  fontSize: _kFontSize,
                   color: widget.enabled ? null : _kDisabledContentColor,
                 )),
               duration: _kHighlightAnimationDuration,

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -22,7 +22,7 @@ import 'colors.dart';
 
 // Minimum padding from edges of the segmented control to edges of
 // encompassing widget.
-const EdgeInsetsGeometry _kHorizontalItemPadding = EdgeInsets.symmetric(vertical: 2, horizontal: 2);
+const EdgeInsetsGeometry _kHorizontalItemPadding = EdgeInsets.symmetric(vertical: 2, horizontal: 3);
 
 // The corner radius of the segmented control.
 const Radius _kCornerRadius = Radius.circular(9);
@@ -44,9 +44,8 @@ const CupertinoDynamicColor _kThumbColor = CupertinoDynamicColor.withBrightness(
 );
 
 // The height of the separator.
-const double _kSeparatorHeight = 12.0;
+const double _kSeparatorHeight = 18.0;
 // The amount of space by which to inset each separator.
-// const EdgeInsets _kSeparatorInset = EdgeInsets.symmetric(vertical: 6);
 const EdgeInsets _kSeparatorInset = EdgeInsets.symmetric(vertical: (_kMinSegmentedControlHeight - _kSeparatorHeight) / 2);
 const double _kSeparatorWidth = 1;
 const Radius _kSeparatorRadius = Radius.circular(_kSeparatorWidth / 2);

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -542,7 +542,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
   bool? _startedOnSelectedSegment;
 
   // Whether the current drag gesture started on a disabled segment. When this
-  // flag is true, the `onDown` and `onUpdate` methods will return directly.
+  // flag is true, drag gestures will be ignored.
   bool _startedOnDisabledSegment = false;
 
   // Whether an ongoing horizontal drag gesture that started on the thumb is

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -850,6 +850,12 @@ class _SegmentedControlRenderWidget<T extends Object> extends MultiChildRenderOb
 
 class _SegmentedControlContainerBoxParentData extends ContainerBoxParentData<RenderBox> { }
 
+enum _Location {
+  leftmost,
+  rightmost,
+  inbetween;
+}
+
 // The behavior of a UISegmentedControl as observed on iOS 13.1:
 //
 // 1. Tap up inside events will set the current selected index to the index of the
@@ -1216,8 +1222,6 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     }
 
     final int? highlightedChildIndex = highlightedIndex;
-    final bool isLeadingChild = highlightedChildIndex == 0;
-    final bool isTrailingChild = highlightedChildIndex == children.length ~/ 2;
     // Paint thumb if there's a highlighted segment.
     if (highlightedChildIndex != null) {
       final RenderBox selectedChild = children[highlightedChildIndex * 2];
@@ -1247,14 +1251,21 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
       final Rect unscaledThumbRect = state.thumbAnimatable?.evaluate(state.thumbController) ?? newThumbRect;
       currentThumbRect = unscaledThumbRect;
 
-      double delta = 0;
-      if (isLeadingChild) {
-        delta = unscaledThumbRect.width - unscaledThumbRect.width * thumbScale;
+      final _Location childLocation;
+      if (highlightedChildIndex == 0) {
+        childLocation = _Location.leftmost;
+      } else if (highlightedChildIndex == children.length ~/ 2) {
+        childLocation = _Location.rightmost;
+      } else {
+        childLocation = _Location.inbetween;
       }
 
-      if (isTrailingChild) {
-        delta = unscaledThumbRect.width * thumbScale - unscaledThumbRect.width;
-      }
+      final double delta = switch (childLocation) {
+        _Location.leftmost => unscaledThumbRect.width - unscaledThumbRect.width * thumbScale,
+        _Location.rightmost => unscaledThumbRect.width * thumbScale - unscaledThumbRect.width,
+        _Location.inbetween => 0,
+      };
+
       final Rect thumbRect = Rect.fromCenter(
         center: unscaledThumbRect.center - Offset(delta / 2, 0),
         width: unscaledThumbRect.width * thumbScale,

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -372,8 +372,7 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   /// there is no segment getting highlighted until it is switched to an enabled
   /// segment.
   ///
-  /// By default, all segments are selectable. The default text color for
-  /// disabled segments is `Color.fromARGB(115, 176, 176, 176)`.
+  /// By default, all segments are selectable.
   final Set<T> disabledChildren;
 
   /// The identifier of the widget that is currently selected.

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1209,7 +1209,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     final List<RenderBox> children = getChildrenAsList();
 
     // Children contains both segment and separator and the order is segment ->
-    // separator -> segment. So to paint separators, indes should start from 1 and
+    // separator -> segment. So to paint separators, index should start from 1 and
     // the step should be 2.
     for (int index = 1; index < childCount; index += 2) {
       _paintSeparator(context, offset, children[index]);

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -400,7 +400,7 @@ void main() {
     expect(getHighlightedIndex(tester), null);
   });
 
-  testWidgets('Non-null but disabled input for value results in no child initially selected', (WidgetTester tester) async {
+  testWidgets('Disabled segment can be selected programmtically', (WidgetTester tester) async {
     const Map<int, Widget> children = <int, Widget>{
       0: Text('Child 1'),
       1: Text('Child 2'),
@@ -425,7 +425,7 @@ void main() {
       ),
     );
 
-    expect(getHighlightedIndex(tester), null);
+    expect(getHighlightedIndex(tester), 0);
   });
 
   testWidgets('Long press not-selected child interactions', (WidgetTester tester) async {
@@ -606,13 +606,13 @@ void main() {
     }
 
     final Size firstChildSize = getChildSize(0);
-    expect(firstChildSize.width, 50 + 9.25 * 2);
+    expect(firstChildSize.width, 50 + 10.0 * 2);
 
     final Size secondChildSize = getChildSize(1);
-    expect(secondChildSize.width, 100 + 9.25 * 2);
+    expect(secondChildSize.width, 100 + 10.0 * 2);
 
     final Size thirdChildSize = getChildSize(2);
-    expect(thirdChildSize.width, 70 + 9.25 * 2);
+    expect(thirdChildSize.width, 70 + 10.0 * 2);
 
     // Overall segment control width is the sum of the segment widths + horizontal paddings + 2 separator width.
     final RenderBox segmentedControl = tester.renderObject(
@@ -655,25 +655,25 @@ void main() {
     }
 
     Size firstChildSize = getChildSize(0);
-    expect(firstChildSize.width, 200 + 9.25 * 2);
+    expect(firstChildSize.width, 200 + 10.0 * 2);
 
     Size secondChildSize = getChildSize(1);
-    expect(secondChildSize.width, 200 + 9.25 * 2);
+    expect(secondChildSize.width, 200 + 10.0 * 2);
 
     Size thirdChildSize = getChildSize(2);
-    expect(thirdChildSize.width, 200 + 9.25 * 2);
+    expect(thirdChildSize.width, 200 + 10.0 * 2);
 
     setState!(() { proportionalWidth = true; });
     await tester.pump();
 
     firstChildSize = getChildSize(0);
-    expect(firstChildSize.width, 50 + 9.25 * 2);
+    expect(firstChildSize.width, 50 + 10.0 * 2);
 
     secondChildSize = getChildSize(1);
-    expect(secondChildSize.width, 200 + 9.25 * 2);
+    expect(secondChildSize.width, 200 + 10.0 * 2);
 
     thirdChildSize = getChildSize(2);
-    expect(thirdChildSize.width, 70 + 9.25 * 2);
+    expect(thirdChildSize.width, 70 + 10.0 * 2);
   });
 
   testWidgets('If proportionalWidth is true, the width of each segmented '
@@ -708,13 +708,13 @@ void main() {
     }
 
     Size firstChildSize = getChildSize(0);
-    expect(firstChildSize.width, 50 + 9.25 * 2);
+    expect(firstChildSize.width, 50 + 10.0 * 2);
 
     Size secondChildSize = getChildSize(1);
-    expect(secondChildSize.width, 100 + 9.25 * 2);
+    expect(secondChildSize.width, 100 + 10.0 * 2);
 
     Size thirdChildSize = getChildSize(2);
-    expect(thirdChildSize.width, 70 + 9.25 * 2);
+    expect(thirdChildSize.width, 70 + 10.0 * 2);
 
     setState!(() {
       children = <int, Widget>{
@@ -726,13 +726,13 @@ void main() {
     await tester.pump();
 
     firstChildSize = getChildSize(0);
-    expect(firstChildSize.width, 0 + 9.25 * 2);
+    expect(firstChildSize.width, 0 + 10.0 * 2);
 
     secondChildSize = getChildSize(1);
-    expect(secondChildSize.width, 220 + 9.25 * 2);
+    expect(secondChildSize.width, 220 + 10.0 * 2);
 
     thirdChildSize = getChildSize(2);
-    expect(thirdChildSize.width, 170 + 9.25 * 2);
+    expect(thirdChildSize.width, 170 + 10.0 * 2);
   });
 
 
@@ -770,19 +770,19 @@ void main() {
       );
     }
 
-    // Without constraints, the overall size should be 405.5:  50 + 100 + 200
-    // + 9.25 * 6(horizontal padding). To fit in 194(allowed max width - padding),
+    // Without constraints, the overall size should be 410:  50 + 100 + 200
+    // + 10.0 * 6(horizontal padding). To fit in 194(allowed max width - padding),
     // each segment width should scale down to original width * (194 - separator) / 413.5.
     final Size firstChildSize = getChildSize(0);
     const double maxAllowedTotal = 200 - 6 - 2;
-    const double originalTotal = 405.5;
-    expect(firstChildSize.width, (50 + 9.25 * 2) * maxAllowedTotal / originalTotal);
+    const double originalTotal = 410;
+    expect(firstChildSize.width, (50 + 10.0 * 2) * maxAllowedTotal / originalTotal);
 
     final Size secondChildSize = getChildSize(1);
-    expect(secondChildSize.width, (100 + 9.25 * 2) * maxAllowedTotal / originalTotal);
+    expect(secondChildSize.width, (100 + 10.0 * 2) * maxAllowedTotal / originalTotal);
 
     final Size thirdChildSize = getChildSize(2);
-    expect(thirdChildSize.width, (200 + 9.25 * 2) * maxAllowedTotal / originalTotal);
+    expect(thirdChildSize.width, (200 + 10.0 * 2) * maxAllowedTotal / originalTotal);
   });
 
   testWidgets('If proportionalWidth is true and the overall segment control width '
@@ -819,19 +819,19 @@ void main() {
       );
     }
 
-    // Without constraints, the overall size should be 155.5:  20 + 30 + 50
-    // + 9.25 * 6(horizontal padding). To fit in 194(allowed max width - padding),
+    // Without constraints, the overall size should be 160.0:  20 + 30 + 50
+    // + 10.0 * 6(horizontal padding). To fit in 194(allowed max width - padding),
     // each segment width should scale up to original width * (194 - separator) / 155.5.
     final Size firstChildSize = getChildSize(0);
     const double constraintsMinWidth = 200 - 6 - 2;
-    const double originalTotal = 155.5;
-    expect(firstChildSize.width, moreOrLessEquals((20 + 9.25 * 2) * constraintsMinWidth / originalTotal));
+    const double originalTotal = 160.0;
+    expect(firstChildSize.width, moreOrLessEquals((20 + 10.0 * 2) * constraintsMinWidth / originalTotal));
 
     final Size secondChildSize = getChildSize(1);
-    expect(secondChildSize.width, moreOrLessEquals((30 + 9.25 * 2) * constraintsMinWidth / originalTotal));
+    expect(secondChildSize.width, moreOrLessEquals((30 + 10.0 * 2) * constraintsMinWidth / originalTotal));
 
     final Size thirdChildSize = getChildSize(2);
-    expect(thirdChildSize.width, moreOrLessEquals((50 + 9.25 * 2) * constraintsMinWidth / originalTotal));
+    expect(thirdChildSize.width, moreOrLessEquals((50 + 10.0 * 2) * constraintsMinWidth / originalTotal));
   });
 
   testWidgets('Width is finite in unbounded space', (WidgetTester tester) async {
@@ -1075,13 +1075,13 @@ void main() {
     expect(groupValue, 0);
 
     final Rect firstChild = tester.getRect(find.ancestor(of: find.byWidget(children[0]!), matching: find.byType(MetaData)));
-    expect(firstChild.width, 50.0 + 9.25 * 2);
+    expect(firstChild.width, 50.0 + 10.0 * 2);
 
     final Rect secondChild = tester.getRect(find.ancestor(of: find.byWidget(children[1]!), matching: find.byType(MetaData)));
-    expect(secondChild.width, 0.0 + 9.25 * 2);
+    expect(secondChild.width, 0.0 + 10.0 * 2);
 
     final Rect thirdChild = tester.getRect(find.ancestor(of: find.byWidget(children[2]!), matching: find.byType(MetaData)));
-    expect(thirdChild.width, 100.0  + 9.25 * 2);
+    expect(thirdChild.width, 100.0  + 10.0 * 2);
 
     final Finder child0 = find.ancestor(of: find.byWidget(children[0]!), matching: find.byType(MetaData));
     final Offset centerOfChild0 = tester.getCenter(child0);
@@ -1472,14 +1472,13 @@ void main() {
     expect(callbackCalled, isFalse);
   });
 
-  testWidgets('Disable "highlighted" segment during drag, highlight disappears', (WidgetTester tester) async {
+  testWidgets('Disable "highlighted" segment during drag, highlight stays', (WidgetTester tester) async {
     const Map<int, Widget> children = <int, Widget>{
       0: Text('A'),
       1: Text('B'),
       2: Text('C'),
     };
     Set<int> disabledChildren = <int>{};
-
     await tester.pumpWidget(
       boilerplate(
         builder: (BuildContext context) {
@@ -1518,8 +1517,8 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    // When dragging stops, highlight disappears.
-    expect(getHighlightedIndex(tester), null);
+    // When dragging stops, highlight stays.
+    expect(getHighlightedIndex(tester), 1);
   });
 
   testWidgets('Disable "highlighted" segment during drag, onValueChanged is still called', (WidgetTester tester) async {
@@ -1571,7 +1570,7 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    expect(getHighlightedIndex(tester), null);
+    expect(getHighlightedIndex(tester), 1);
     expect(callbackCalled, 1);
   });
 
@@ -1604,8 +1603,8 @@ void main() {
       );
     }
 
-    expect(getChildSize(0).width, 32.5);
-    expect(getChildSize(2).width, 60.5);
+    expect(getChildSize(0).width, 33.0);
+    expect(getChildSize(2).width, 59.0);
 
     // Start dragging.
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('A')));

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// reduced-test-set:
+//   This file is run as part of a reduced test set in CI on Mac and Windows
+//   machines.
+@Tags(<String>['reduced-test-set'])
+library;
 import 'dart:collection';
 
 import 'package:flutter/cupertino.dart';

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -1889,9 +1889,7 @@ void main() {
         home: CupertinoPageScaffold(
           child: Center(
             child: CupertinoSlidingSegmentedControl<int>(
-              setEnabled: const <int, bool> {
-                0: false,
-              },
+              disabledChildren: const <int> { 0 },
               children: children,
               onValueChanged: defaultCallback,
             ),
@@ -1929,9 +1927,7 @@ void main() {
       boilerplate(
         builder: (BuildContext context) {
           return CupertinoSlidingSegmentedControl<int>(
-            setEnabled: const <int, bool> {
-              0: false,
-            },
+            disabledChildren: const <int> { 0 },
             children: children,
             groupValue: groupValue,
             onValueChanged: defaultCallback,
@@ -1959,5 +1955,46 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(getHighlightedIndex(tester), 2); // The highlighted index doesn't change
+  });
+
+  testWidgets('Several segments can be disabled', (WidgetTester tester) async {
+    const Map<int, Widget> children = <int, Widget>{
+      0: Text('A'),
+      1: Text('BB'),
+      2: Text('CCCC'),
+    };
+
+    int onValueChangedCalled = 0;
+    await tester.pumpWidget(
+      boilerplate(
+        builder: (BuildContext context) {
+          return CupertinoSlidingSegmentedControl<int>(
+            disabledChildren: const <int> { 0, 1, 2 },
+            children: children,
+            groupValue: groupValue,
+            onValueChanged: (int? value) {
+              onValueChangedCalled += 1;
+              defaultCallback.call(value);
+            },
+          );
+        },
+      )
+    );
+
+    // All segments are disabled, so onValueChangedCalled should always be 0.
+    await tester.tap(find.text('A'));
+    await tester.pumpAndSettle();
+
+    expect(onValueChangedCalled, 0);
+
+    await tester.tap(find.text('CCCC'));
+    await tester.pumpAndSettle();
+
+    expect(onValueChangedCalled, 0);
+
+    await tester.tap(find.text('BB'));
+    await tester.pumpAndSettle();
+
+    expect(onValueChangedCalled, 0);
   });
 }

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -1755,4 +1755,172 @@ void main() {
       kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,
     );
   });
+
+  testWidgets('CupertinoSlidingSegmentedControl defaults - no selection', (WidgetTester tester) async {
+    const Map<int, Widget> children = <int, Widget>{
+      0: Text('A'),
+      1: Text('BB'),
+      2: Text('CCCC'),
+    };
+
+    Widget buildSlidingSegmentedControl({ Brightness? brightness }) {
+      return CupertinoApp(
+        theme: CupertinoThemeData(
+          brightness: brightness ?? Brightness.light,
+        ),
+        home: CupertinoPageScaffold(
+          child: Center(
+            child: CupertinoSlidingSegmentedControl<int>(
+              children: children,
+              onValueChanged: defaultCallback,
+            ),
+          ),
+        )
+      );
+    }
+
+    // Light theme
+    await tester.pumpWidget(buildSlidingSegmentedControl());
+
+    await expectLater(
+      find.byType(CupertinoSlidingSegmentedControl<int>),
+      matchesGoldenFile('cupertino_sliding_segmented_control.light_theme.png'),
+    );
+
+    // Dark theme
+    await tester.pumpWidget(buildSlidingSegmentedControl(brightness: Brightness.dark));
+
+    await expectLater(
+      find.byType(CupertinoSlidingSegmentedControl<int>),
+      matchesGoldenFile('cupertino_sliding_segmented_control.dark_theme.png'),
+    );
+  });
+
+  testWidgets('CupertinoSlidingSegmentedControl defaults - group value is not null', (WidgetTester tester) async {
+    const Map<int, Widget> children = <int, Widget>{
+      0: Text('A'),
+      1: Text('BB'),
+      2: Text('CCCC'),
+    };
+
+    Widget buildSlidingSegmentedControl({ Brightness? brightness }) {
+      return CupertinoApp(
+        theme: CupertinoThemeData(
+          brightness: brightness ?? Brightness.light,
+        ),
+        home: CupertinoPageScaffold(
+          child: Center(
+            child: CupertinoSlidingSegmentedControl<int>(
+              groupValue: 1,
+              children: children,
+              onValueChanged: defaultCallback,
+            ),
+          ),
+        )
+      );
+    }
+
+    // Light theme
+    await tester.pumpWidget(buildSlidingSegmentedControl());
+
+    await expectLater(
+      find.byType(CupertinoSlidingSegmentedControl<int>),
+      matchesGoldenFile('cupertino_sliding_segmented_control.with_selection.light_theme.png'),
+    );
+
+    // Dark theme
+    await tester.pumpWidget(buildSlidingSegmentedControl(brightness: Brightness.dark));
+
+    await expectLater(
+      find.byType(CupertinoSlidingSegmentedControl<int>),
+      matchesGoldenFile('cupertino_sliding_segmented_control.with_selection.dark_theme.png'),
+    );
+  });
+
+  testWidgets('CupertinoSlidingSegmentedControl defaults - disabled', (WidgetTester tester) async {
+    const Map<int, Widget> children = <int, Widget>{
+      0: Text('A'),
+      1: Text('BB'),
+      2: Text('CCCC'),
+    };
+
+    Widget buildSlidingSegmentedControl({ Brightness? brightness }) {
+      return CupertinoApp(
+        theme: CupertinoThemeData(
+          brightness: brightness ?? Brightness.light,
+        ),
+        home: CupertinoPageScaffold(
+          child: Center(
+            child: CupertinoSlidingSegmentedControl<int>(
+              setEnabled: const <int, bool> {
+                0: false,
+              },
+              children: children,
+              onValueChanged: defaultCallback,
+            ),
+          ),
+        )
+      );
+    }
+
+    // Light theme
+    await tester.pumpWidget(buildSlidingSegmentedControl());
+
+    await expectLater(
+      find.byType(CupertinoSlidingSegmentedControl<int>),
+      matchesGoldenFile('cupertino_sliding_segmented_control.disabled.light_theme.png'),
+    );
+
+    // Dark theme
+    await tester.pumpWidget(buildSlidingSegmentedControl(brightness: Brightness.dark));
+
+    await expectLater(
+      find.byType(CupertinoSlidingSegmentedControl<int>),
+      matchesGoldenFile('cupertino_sliding_segmented_control.disabled.dark_theme.png'),
+    );
+  });
+
+  testWidgets('Segment can be disabled', (WidgetTester tester) async {
+    const Map<int, Widget> children = <int, Widget>{
+      0: Text('A'),
+      1: Text('BB'),
+      2: Text('CCCC'),
+    };
+
+    groupValue = 1;
+    await tester.pumpWidget(
+      boilerplate(
+        builder: (BuildContext context) {
+          return CupertinoSlidingSegmentedControl<int>(
+            setEnabled: const <int, bool> {
+              0: false,
+            },
+            children: children,
+            groupValue: groupValue,
+            onValueChanged: defaultCallback,
+          );
+        },
+      )
+    );
+
+    expect(getHighlightedIndex(tester), 1);
+
+    // Tap disabled segment
+    await tester.tap(find.text('A'));
+    await tester.pumpAndSettle();
+
+    expect(getHighlightedIndex(tester), 1); // The highlighted index doesn't change
+
+    // Tap enabled segment
+    await tester.tap(find.text('CCCC'));
+    await tester.pumpAndSettle();
+
+    expect(getHighlightedIndex(tester), 2);
+
+    // Tap disabled segment
+    await tester.tap(find.text('A'));
+    await tester.pumpAndSettle();
+
+    expect(getHighlightedIndex(tester), 2); // The highlighted index doesn't change
+  });
 }

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -279,7 +279,7 @@ void main() {
 
       DefaultTextStyle textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1').first);
 
-      expect(textStyle.style.fontWeight, FontWeight.w500);
+      expect(textStyle.style.fontWeight, FontWeight.w600);
 
       await tester.tap(find.byIcon(const IconData(1)));
       await tester.pump();
@@ -288,7 +288,7 @@ void main() {
       textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1').first);
 
       expect(groupValue, 1);
-      expect(textStyle.style.fontWeight, FontWeight.normal);
+      expect(textStyle.style.fontWeight, FontWeight.w500);
     },
   );
 
@@ -543,7 +543,7 @@ void main() {
     // to each child equally.
     final double childWidth = (segmentedControl.size.width - 8) / 3;
 
-    expect(childWidth, 200.0 + 9.25 * 2);
+    expect(childWidth, 200.0 + 10 * 2);
   });
 
   testWidgets('If proportionalWidth is true, the width of each segmented '
@@ -835,7 +835,7 @@ void main() {
 
     expect(
       segmentedControl.size.width,
-      70 * 2 + 9.25 * 4 + 3 * 2 + 1, // 2 children + 4 child padding + 2 outer padding + 1 separator
+      70 * 2 + 10.0 * 4 + 3 * 2 + 1, // 2 children + 4 child padding + 2 outer padding + 1 separator
     );
   });
 
@@ -1168,18 +1168,30 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
 
-    // The thumb shrinks but does not moves towards left.
+    // The thumb shrinks but does not moves towards left; the shrink alignment
+    // is Alignment.centerRight, with ltr text direction because "Child 2" is
+    // the trailing item.
     expect(currentThumbScale(tester), lessThan(1));
+    double centerDelta = tester.getSize(find.text('Child 2')).width * (1 - currentThumbScale(tester)) / 2;
     expect(
-      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center,
-      offsetMoreOrLessEquals(tester.getCenter(find.text('Child 2')), epsilon: 0.01),
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dy,
+      moreOrLessEquals(tester.getCenter(find.text('Child 2')).dy, epsilon: 0.01),
+    );
+    expect(
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dx,
+      moreOrLessEquals(tester.getCenter(find.text('Child 2')).dx - centerDelta, epsilon: 0.01),
     );
 
     await tester.pumpAndSettle();
     expect(currentThumbScale(tester), moreOrLessEquals(0.95, epsilon: 0.01));
+    centerDelta = tester.getSize(find.text('Child 2')).width * (1 - currentThumbScale(tester));
     expect(
-      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center,
-      offsetMoreOrLessEquals(tester.getCenter(find.text('Child 2')), epsilon: 0.01),
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dy,
+      moreOrLessEquals(tester.getCenter(find.text('Child 2')).dy, epsilon: 0.01),
+    );
+    expect(
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dx,
+      moreOrLessEquals(tester.getCenter(find.text('Child 2')).dx - centerDelta / 2, epsilon: 0.01),
     );
 
     // Drag to Child 1.
@@ -1196,9 +1208,14 @@ void main() {
 
     await tester.pumpAndSettle();
     expect(currentThumbScale(tester), moreOrLessEquals(0.95, epsilon: 0.01));
+    centerDelta = tester.getSize(find.text('Child 1')).width * (1 - currentThumbScale(tester));
     expect(
-      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center,
-      offsetMoreOrLessEquals(tester.getCenter(find.text('Child 1')), epsilon: 0.01),
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dy,
+      moreOrLessEquals(tester.getCenter(find.text('Child 1')).dy, epsilon: 0.01),
+    );
+    expect(
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dx,
+      moreOrLessEquals(tester.getCenter(find.text('Child 1')).dx + centerDelta / 2, epsilon: 0.01),
     );
 
     await gesture.up();
@@ -1401,8 +1418,13 @@ void main() {
 
     // The ongoing drag gesture should veto the programmatic change.
     expect(
-      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center,
-      offsetMoreOrLessEquals(tester.getCenter(find.text('A')), epsilon: 0.01),
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dy,
+      moreOrLessEquals(tester.getCenter(find.text('A')).dy, epsilon: 0.01),
+    );
+    final  double centerDelta = tester.getSize(find.text('A')).width * (1 - currentThumbScale(tester)) / 2;
+    expect(
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dx,
+      moreOrLessEquals(tester.getCenter(find.text('A')).dx + centerDelta, epsilon: 0.01),
     );
 
     // Move the pointer to 'B'. The onValueChanged callback will be called but
@@ -1517,8 +1539,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center,
-      offsetMoreOrLessEquals(tester.getCenter(find.text('A')), epsilon: 0.01),
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dy,
+      moreOrLessEquals(tester.getCenter(find.text('A')).dy, epsilon: 0.01),
+    );
+    double centerDelta = tester.getSize(find.text('A')).width * (1 - currentThumbScale(tester)) / 2;
+    expect(
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dx,
+      moreOrLessEquals(tester.getCenter(find.text('A')).dx + centerDelta, epsilon: 0.01),
     );
 
     // A different drag.
@@ -1527,8 +1554,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center,
-      offsetMoreOrLessEquals(tester.getCenter(find.text('A')), epsilon: 0.01),
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dy,
+      moreOrLessEquals(tester.getCenter(find.text('A')).dy, epsilon: 0.01),
+    );
+    centerDelta = tester.getSize(find.text('A')).width * (1 - currentThumbScale(tester)) / 2;
+    expect(
+      currentUnscaledThumbRect(tester, useGlobalCoordinate: true).center.dx,
+      moreOrLessEquals(tester.getCenter(find.text('A')).dx + centerDelta, epsilon: 0.01),
     );
 
     await gesture.up();


### PR DESCRIPTION
This PR is to improve `CupertinoSlidingSegmentedControl` fidelity and add a new property `setEnabled` so that segments can be disabled now.

Fidelity update includes:
* small change on default thumb radius (Based on iOS 17 Figma file)
* separator height (Based on the comparison with SegmentedControl example in Xcode)
* segment min padding (Based on iOS 17 Figma file)
* thumb scale alignment (Based on the comparison with SegmentedControl example in Xcode). If the thumb is on the first or last position in SegmentedControl, the alignment should be `Alignment.leftCenter` and `Alignment.rightCenter` respectively, assuming the text direction is left to right. For segments in middle, they should have center alignment as previously.
* TextStyle update (Based on both the Figma file and the Xcode example)
* Clipped thumb shadow if the shadow is outside of the segmented control (Based on the Xcode example)
* Fixed the overall size shaking issue during segment switching on macOS and iOS

<details><summary>Alignment update demo</summary>

https://github.com/user-attachments/assets/6de3986f-6810-4dc4-8688-f87120557d89

</details>

<details><summary>Comparison before and after</summary>

Before:
![Screenshot 2024-08-08 at 1 42 57 PM](https://github.com/user-attachments/assets/fe2e49a8-4bbd-4d54-9aba-1f47ab9bd9d9)

After:
![Screenshot 2024-08-08 at 1 43 50 PM](https://github.com/user-attachments/assets/d3292f74-8d04-40ed-ae72-bf2e9b1751a4)


</details>

<details><summary>Shaking issue</summary>

Before:

https://github.com/user-attachments/assets/910d1271-75ea-4cec-8666-24090f9d4fb0


After:

https://github.com/user-attachments/assets/bc5ae3e1-600d-49a6-95d9-b1f5d1bd9f6d



</details>

The `disabledChildren` feature can be used to disable segments. The default disabled color comes from the inspection in the Xcode example.

<details><summary>Disabled feature demos</summary>

Disabled segment cannot be highlighted:

https://github.com/user-attachments/assets/70339364-23d5-41c7-b071-c7abe92abd62

`groupValue` can still be highlighted programmatically if it is disabled.

![Screenshot 2024-09-04 at 5 45 25 PM](https://github.com/user-attachments/assets/99d37903-3605-475f-b87a-ae118a23e94d)




</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.