### PR TITLE
Refactor: Deprecate inactiveColor from cupertino checkbox

### DIFF
--- a/packages/flutter/lib/fix_data/fix_cupertino.yaml
+++ b/packages/flutter/lib/fix_data/fix_cupertino.yaml
@@ -341,4 +341,67 @@ transforms:
         oldName: 'trackColor'
         newName: 'inactiveTrackColor'
 
+  # Changes made in https://github.com/flutter/flutter/pull/152981
+  - title: "Replace with 'fillColor'"
+    date: 2024-08-08
+    element:
+      uris: [ 'cupertino.dart' ]
+      constructor: ''
+      inClass: 'CupertinoCheckbox'
+    oneOf:
+      - if: "fillColor == '' && activeColor != ''"
+        changes:
+          - kind: 'addParameter'
+            index: 5
+            name: 'fillColor'
+            style: optional_named
+            argumentValue:
+              expression: "WidgetStateProperty.resolveWith<Color>((Set<WidgetState> states) {\n
+                        if (states.contains(WidgetState.disabled)) {\n
+                          return CupertinoColors.white.withOpacity(0.5);\n
+                        }\n
+                        if (states.contains(WidgetState.selected)) {\n
+                          return {% activeColor %};\n
+                        }\n
+                        return {% inactiveColor %};\n
+                  })"
+              requiredIf: "inactiveColor != ''"
+          - kind: 'removeParameter'
+            name: inactiveColor
+      - if: "fillColor == '' && activeColor == ''"
+        changes:
+          - kind: 'addParameter'
+            index: 5
+            name: 'fillColor'
+            style: optional_named
+            argumentValue:
+              expression: "WidgetStateProperty.resolveWith<Color>((Set<WidgetState> states) {\n
+                        if (states.contains(WidgetState.disabled)) {\n
+                          return CupertinoColors.white.withOpacity(0.5);\n
+                        }\n
+                        if (states.contains(WidgetState.selected)) {\n
+                          return CupertinoDynamicColor.resolve(CupertinoDynamicColor.withBrightness(\n
+                            color: CupertinoColors.activeBlue,\n
+                            darkColor: Color.fromARGB(255, 50, 100, 215),\n
+                          ), context);\n
+                        }\n
+                        return {% inactiveColor %};\n
+                  })"
+              requiredIf: "inactiveColor != ''"
+          - kind: 'removeParameter'
+            name: inactiveColor
+      - if: "fillColor != ''"
+        changes:
+          - kind: 'removeParameter'
+            name: inactiveColor
+    variables:
+      inactiveColor:
+        kind: fragment
+        value: 'arguments[inactiveColor]'
+      activeColor:
+        kind: fragment
+        value: 'arguments[activeColor]'
+      fillColor:
+        kind: fragment
+        value: 'arguments[fillColor]'
 # Before adding a new fix: read instructions at the top of this file.

--- a/packages/flutter/lib/src/cupertino/checkbox.dart
+++ b/packages/flutter/lib/src/cupertino/checkbox.dart
@@ -97,6 +97,11 @@ class CupertinoCheckbox extends StatefulWidget {
     this.tristate = false,
     required this.onChanged,
     this.activeColor,
+    @Deprecated(
+      'Use fillColor instead. '
+      'fillColor now manages the background color in all states. '
+      'This feature was deprecated after v3.24.0-0.2.pre.'
+    )
     this.inactiveColor,
     this.fillColor,
     this.checkColor,
@@ -184,15 +189,19 @@ class CupertinoCheckbox extends StatefulWidget {
   ///
   /// If [fillColor] resolves to null for the requested state, then the fill color
   /// falls back to [activeColor] if the state includes [WidgetState.selected],
-  /// or [inactiveColor] otherwise.
+  /// [CupertinoColors.white] at 50% opacity if checkbox is disabled,
+  /// and [CupertinoColors.white] otherwise.
   final WidgetStateProperty<Color?>? fillColor;
 
   /// The color used if the checkbox is inactive.
   ///
-  /// If [fillColor] returns a non-null color in the unselected
-  /// state, [fillColor] will be used instead of [inactiveColor].
-  ///
-  /// By default, [CupertinoColors.inactiveGray] is used.
+  /// Currently [inactiveColor] is not used. Instead, [fillColor] controls the
+  /// color of the background in all states, including when unselected.
+  @Deprecated(
+    'Use fillColor instead. '
+    'fillColor now manages the background color in all states. '
+    'This feature was deprecated after v3.24.0-0.2.pre.'
+  )
   final Color? inactiveColor;
 
   /// The color to use for the check icon when this checkbox is checked.

--- a/packages/flutter/test_fixes/cupertino/cupertino.dart
+++ b/packages/flutter/test_fixes/cupertino/cupertino.dart
@@ -264,4 +264,9 @@ void main() {
     trackColor: Colors.red,
   );
   Color? inactiveTrackColor =  cupertinoSwitch.trackColor;
+
+  // https://github.com/flutter/flutter/pull/152981
+  CupertinoCheckbox(inactiveColor: Colors.red);
+  CupertinoCheckbox(inactiveColor: Colors.red, activeColor: Colors.white);
+  CupertinoCheckbox(inactiveColor: Colors.red, fillColor: WidgetStatePropertyAll(CupertinoColors.white));
 }

--- a/packages/flutter/test_fixes/cupertino/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino/cupertino.dart.expect
@@ -264,4 +264,28 @@ void main() {
     inactiveTrackColor: Colors.red,
   );
   Color? inactiveTrackColor =  cupertinoSwitch.inactiveTrackColor;
+
+  // https://github.com/flutter/flutter/pull/152981
+  CupertinoCheckbox(fillColor: WidgetStateProperty.resolveWith<Color>((Set<WidgetState> states) {
+    if (states.contains(WidgetState.disabled)) {
+      return CupertinoColors.white.withOpacity(0.5);
+    }
+    if (states.contains(WidgetState.selected)) {
+      return CupertinoDynamicColor.resolve(CupertinoDynamicColor.withBrightness(
+        color: CupertinoColors.activeBlue,
+        darkColor: Color.fromARGB(255, 50, 100, 215),
+      ), context);
+    }
+    return Colors.red;
+  }));
+  CupertinoCheckbox(activeColor: Colors.white, fillColor: WidgetStateProperty.resolveWith<Color>((Set<WidgetState> states) {
+    if (states.contains(WidgetState.disabled)) {
+      return CupertinoColors.white.withOpacity(0.5);
+    }
+    if (states.contains(WidgetState.selected)) {
+      return Colors.white;
+    }
+    return Colors.red;
+  }));
+  CupertinoCheckbox(fillColor: WidgetStatePropertyAll(CupertinoColors.white));
 }


### PR DESCRIPTION
Refactor: Deprecate `inactiveColor` from cupertino checkbox
Fixes #151252 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.