### PR TITLE
Add xcresulttool --legacy flag for deprecated usage

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcresult.dart
+++ b/packages/flutter_tools/lib/src/ios/xcresult.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import '../../src/base/process.dart';
 import '../../src/convert.dart' show json;
 import '../../src/macos/xcode.dart';
+import '../base/version.dart';
 import '../convert.dart';
 
 /// The generator of xcresults.
@@ -35,18 +36,22 @@ class XCResultGenerator {
 
   /// Generates the XCResult.
   ///
-  /// Calls `xcrun xcresulttool get --path <resultPath> --format json`,
+  /// Calls `xcrun xcresulttool get --legacy --path <resultPath> --format json`,
   /// then stores the useful information the json into an [XCResult] object.
   ///
   /// A`issueDiscarders` can be passed to discard any issues that matches the description of any [XCResultIssueDiscarder] in the list.
   Future<XCResult> generate(
       {List<XCResultIssueDiscarder> issueDiscarders =
           const <XCResultIssueDiscarder>[]}) async {
+    final Version? xcodeVersion = xcode.currentVersion;
     final RunResult result = await processUtils.run(
       <String>[
         ...xcode.xcrunCommand(),
         'xcresulttool',
         'get',
+        // See https://github.com/flutter/flutter/issues/151502
+        if (xcodeVersion != null && xcodeVersion >= Version(16, 0, 0))
+          '--legacy',
         '--path',
         resultPath,
         '--format',
@@ -74,7 +79,7 @@ class XCResultGenerator {
 
 /// The xcresult of an `xcodebuild` command.
 ///
-/// This is the result from an `xcrun xcresulttool get --path <resultPath> --format json` run.
+/// This is the result from an `xcrun xcresulttool get --legacy --path <resultPath> --format json` run.
 /// The result contains useful information such as build errors and warnings.
 class XCResult {
   /// Parse the `resultJson` and stores useful information in the returned `XCResult`.


### PR DESCRIPTION
Workaround to add the `--legacy` flag until https://github.com/flutter/flutter/issues/151502 can adopt the non-deprecated usage.

This will allow Xcode errors to be parseable again.

Fixes https://github.com/flutter/flutter/issues/152989


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
