### PR TITLE
Set default Cupertino `primaryContrastingColor` to white

### DIFF
--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -22,7 +22,7 @@ export 'package:flutter/foundation.dart' show Brightness;
 const _CupertinoThemeDefaults _kDefaultTheme = _CupertinoThemeDefaults(
   null,
   CupertinoColors.systemBlue,
-  CupertinoColors.systemBackground,
+  CupertinoColors.white,
   CupertinoDynamicColor.withBrightness(
     color: Color(0xF0F9F9F9),
     darkColor: Color(0xF01D1D1D),

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -454,7 +454,7 @@ void main() {
         ),
       ),
     );
-    expect(textStyle.color, isSameColorAs(CupertinoColors.black));
+    expect(textStyle.color, isSameColorAs(CupertinoColors.white));
     decoration = tester.widget<DecoratedBox>(
       find.descendant(
         of: find.byType(CupertinoButton),

--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -337,7 +337,7 @@ void main() {
       DefaultTextStyle textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1').first);
       IconThemeData iconTheme = IconTheme.of(tester.element(find.byIcon(const IconData(1))));
 
-      expect(textStyle.style.color, isSameColorAs(CupertinoColors.black));
+      expect(textStyle.style.color, isSameColorAs(CupertinoColors.white));
       expect(iconTheme.color, isSameColorAs(CupertinoColors.systemBlue.darkColor));
 
       await tester.tap(find.byIcon(const IconData(1)));
@@ -348,7 +348,7 @@ void main() {
       iconTheme = IconTheme.of(tester.element(find.byIcon(const IconData(1))));
 
       expect(textStyle.style.color, isSameColorAs(CupertinoColors.systemBlue.darkColor));
-      expect(iconTheme.color, isSameColorAs(CupertinoColors.black));
+      expect(iconTheme.color, isSameColorAs(CupertinoColors.white));
     },
   );
 

--- a/packages/flutter/test/cupertino/theme_test.dart
+++ b/packages/flutter/test/cupertino/theme_test.dart
@@ -225,12 +225,16 @@ void main() {
   });
 
   late Brightness currentBrightness;
-  void colorMatches(Color? componentColor, CupertinoDynamicColor expectedDynamicColor) {
-    switch (currentBrightness) {
-      case Brightness.light:
-        expect(componentColor, isSameColorAs(expectedDynamicColor.color));
-      case Brightness.dark:
-        expect(componentColor, isSameColorAs(expectedDynamicColor.darkColor));
+  void colorMatches(Color? componentColor, Color expectedDynamicColor) {
+    if (expectedDynamicColor is CupertinoDynamicColor) {
+      switch (currentBrightness) {
+        case Brightness.light:
+          expect(componentColor, isSameColorAs(expectedDynamicColor.color));
+        case Brightness.dark:
+          expect(componentColor, isSameColorAs(expectedDynamicColor.darkColor));
+      }
+    } else {
+      expect(componentColor, isSameColorAs(expectedDynamicColor));
     }
   }
 
@@ -254,7 +258,7 @@ void main() {
 
       final CupertinoThemeData theme = await testTheme(tester, data);
 
-      colorMatches(theme.primaryContrastingColor, CupertinoColors.systemBackground);
+      colorMatches(theme.primaryContrastingColor, CupertinoColors.white);
       colorMatches(theme.barBackgroundColor, barBackgroundColor);
       colorMatches(theme.scaffoldBackgroundColor, CupertinoColors.systemBackground);
       colorMatches(theme.textTheme.textStyle.color, CupertinoColors.label);


### PR DESCRIPTION
**Fixes #152846 in accordance with iOS HIG**

Previously the `_CupertinoThemeDefaults _kDefaultTheme` would set the `primaryContrastingColor` to `CupertinoColors.systemBackground`, which was white-ish in light mode, and black-ish in dark mode. That was in accordance with Apple Design Resources from 5 years ago.

> Before:
> <img width="594" alt="image" src="https://github.com/user-attachments/assets/63e88abb-6933-446f-a7ba-55109d0f353c">


As of now, iOS HIG suggests that the `primaryContrastingColor` (in combination with the currently default `primaryColor: CupertinoColors.systemBlue`) be white (regardless of light/dark modes, contrast, elevation, etc.)

> After:
> <img width="594" alt="image" src="https://github.com/user-attachments/assets/2a48f22b-a886-46dd-aada-6d157cb4ac06">

Example code:
```dart
import 'package:flutter/cupertino.dart';
import 'package:flutter/widgets.dart';

void main() =>
  runApp(
    CupertinoApp(
      theme: CupertinoThemeData(
        brightness: Brightness.dark,
      ),
      home: Center(child:
        CupertinoButton.filled(
          onPressed: () {},
          child: Row(
            mainAxisSize: MainAxisSize.min,
            children: <Widget>[
              Icon(CupertinoIcons.add),
              Text('Add'),
            ],
          ),
          )
      )
    )
  );

```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
