### PR TITLE
Revert "Marks Mac channels_integration_test to be flaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5115,7 +5115,6 @@ targets:
       - .ci.yaml
 
   - name: Mac channels_integration_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/151881
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Reverts flutter/flutter#151882

Flake rate is back under the threshold https://github.com/flutter/flutter/issues/151881#issuecomment-2272996113

Closes https://github.com/flutter/flutter/issues/151881