### PR TITLE
Spell check range error

### DIFF
--- a/packages/flutter/lib/src/services/spell_check.dart
+++ b/packages/flutter/lib/src/services/spell_check.dart
@@ -52,6 +52,11 @@ class SuggestionSpan {
 
   @override
   int get hashCode => Object.hash(range.start, range.end, Object.hashAll(suggestions));
+
+  @override
+  String toString() {
+    return 'SuggestionSpan(range: $range, suggestions: $suggestions)';
+  }
 }
 
 /// A data structure grouping together the [SuggestionSpan]s and related text of

--- a/packages/flutter/lib/src/services/spell_check.dart
+++ b/packages/flutter/lib/src/services/spell_check.dart
@@ -103,6 +103,10 @@ abstract class SpellCheckService {
   ///
   /// Returns a [Future] that resolves with a [List] of [SuggestionSpan]s for
   /// all misspelled words in the given [String] for the given [Locale].
+  ///
+  /// A return value that resolves to null indicates that fetching the spell
+  /// check suggestions was unsuccessful. If fetching the suggestions succeeded
+  /// but none were found, the [Future] should resolve to an empty list.
   Future<List<SuggestionSpan>?> fetchSpellCheckSuggestions(
     Locale locale, String text
   );

--- a/packages/flutter/lib/src/services/spell_check.dart
+++ b/packages/flutter/lib/src/services/spell_check.dart
@@ -90,6 +90,11 @@ class SpellCheckResults {
 
   @override
   int get hashCode => Object.hash(spellCheckedText, Object.hashAll(suggestionSpans));
+
+  @override
+  String toString() {
+    return 'SpellCheckResults(spellCheckText: $spellCheckedText, suggestionSpans: $suggestionSpans)';
+  }
 }
 
 /// Determines how spell check results are received for text input.

--- a/packages/flutter/lib/src/widgets/spell_check.dart
+++ b/packages/flutter/lib/src/widgets/spell_check.dart
@@ -5,6 +5,8 @@
 /// @docImport 'editable_text.dart';
 library;
 
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart'
@@ -157,7 +159,7 @@ List<SuggestionSpan> _correctSpellCheckResults(
       );
 
       // Start search for the next misspelled word at the end of currentSpan.
-      searchStart = currentSpan.range.end + 1 + offset;
+      searchStart = math.min(currentSpan.range.end + 1 + offset, newText.length);
       correctedSpellCheckResults.add(adjustedSpan);
     } else if (currentSpanFoundElsewhere) {
       // Word was pushed forward but not modified.
@@ -170,7 +172,7 @@ List<SuggestionSpan> _correctSpellCheckResults(
 
       // Start search for the next misspelled word at the end of the
       // adjusted currentSpan.
-      searchStart = adjustedSpanEnd + 1;
+      searchStart = math.min(adjustedSpanEnd + 1, newText.length);
       // Adjust offset to reflect the difference between where currentSpan
       // was positioned in resultsText versus in newText.
       offset = adjustedSpanStart - currentSpan.range.start;

--- a/packages/flutter/test/services/spell_check_test.dart
+++ b/packages/flutter/test/services/spell_check_test.dart
@@ -8,13 +8,27 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   test('SuggestionSpan.toString', () {
     const SuggestionSpan suggestionSpan = SuggestionSpan(
-      TextRange(start: 0, end: 1),
+      TextRange(start: 12, end: 17),
       <String>[
-        'receive',
         'weird',
       ],
     );
 
-    expect(suggestionSpan.toString(), 'SuggestionSpan(range: TextRange(start: 0, end: 1), suggestions: [receive, weird])');
+    expect(suggestionSpan.toString(), 'SuggestionSpan(range: TextRange(start: 12, end: 17), suggestions: [weird])');
+  });
+
+  test('SpellCheckResults.toString', () {
+    const SuggestionSpan suggestionSpan = SuggestionSpan(
+      TextRange(start: 12, end: 17),
+      <String>[
+        'weird',
+      ],
+    );
+    const SpellCheckResults spellCheckResults = SpellCheckResults(
+      'i before e except after c is so wierd.',
+      <SuggestionSpan>[suggestionSpan],
+    );
+
+    expect(spellCheckResults.toString(), 'SpellCheckResults(spellCheckText: i before e except after c is so wierd., suggestionSpans: [SuggestionSpan(range: TextRange(start: 12, end: 17), suggestions: [weird])])');
   });
 }

--- a/packages/flutter/test/services/spell_check_test.dart
+++ b/packages/flutter/test/services/spell_check_test.dart
@@ -1,0 +1,20 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('SuggestionSpan.toString', () {
+    const SuggestionSpan suggestionSpan = SuggestionSpan(
+      TextRange(start: 0, end: 1),
+      <String>[
+        'receive',
+        'weird',
+      ],
+    );
+
+    expect(suggestionSpan.toString(), 'SuggestionSpan(range: TextRange(start: 0, end: 1), suggestions: [receive, weird])');
+  });
+}

--- a/packages/flutter/test/widgets/spell_check_test.dart
+++ b/packages/flutter/test/widgets/spell_check_test.dart
@@ -384,4 +384,58 @@ void main() {
       expect(textSpanTree, equals(expectedTextSpanTree));
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
   );
+
+  testWidgets(
+    'buildTextSpanWithSpellCheckSuggestions does not throw when text is being deleted',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/152272.
+      const String text = 'Lorem ipsum dolor ';
+      const String resultsText = 'Lorem ipsum dolor sit ';
+      const TextEditingValue value = TextEditingValue(
+        text: text,
+        selection: TextSelection.collapsed(offset: text.length),
+      );
+      const bool composingRegionOutOfRange = false;
+      const SpellCheckResults spellCheckResults = SpellCheckResults(
+        resultsText,
+        <SuggestionSpan>[
+          SuggestionSpan(
+            TextRange(start: 0, end: 5),
+            <String>['suggestion1', 'suggestion2'],
+          ),
+          SuggestionSpan(
+            TextRange(start: 6, end: 11),
+            <String>['suggestion1', 'suggestion2'],
+          ),
+          SuggestionSpan(
+            TextRange(start: 12, end: 17),
+            <String>['suggestion1', 'suggestion2'],
+          ),
+          SuggestionSpan(
+            TextRange(start: 18, end: 21),
+            <String>['suggestion1', 'suggestion2'],
+          ),
+        ],
+      );
+
+      final TextSpan expectedTextSpanTree = TextSpan(children: <TextSpan>[
+        TextSpan(text: 'Lorem', style: misspelledTextStyle),
+        const TextSpan(text: ' '),
+        TextSpan(text: 'ipsum', style: misspelledTextStyle),
+        const TextSpan(text: ' '),
+        TextSpan(text: 'dolor', style: misspelledTextStyle),
+        const TextSpan(text: ' '),
+      ]);
+      final TextSpan textSpanTree = buildTextSpanWithSpellCheckSuggestions(
+        value,
+        composingRegionOutOfRange,
+        null,
+        misspelledTextStyle,
+        spellCheckResults,
+      );
+
+      expect(tester.takeException(), null);
+      expect(textSpanTree, equals(expectedTextSpanTree));
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
+  );
 }


### PR DESCRIPTION
The [algorithm](https://github.com/flutter/flutter/blob/715e476545e5504a57cd3972a1966e0d1f20623f/packages/flutter/lib/src/widgets/spell_check.dart#L120) that adjusts spell check results for a new string had a bug in it where it would throw an error in certain cases where the new string was shorter than the old string, such as when the user is deleting text.

Fixes https://github.com/flutter/flutter/issues/152272