### PR TITLE
[tool] Add `dartFileName` setting for platform plugins 

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -624,19 +624,19 @@ const String _dartPluginRegistryForNonWebTemplate = '''
 
 import 'dart:io'; // flutter_ignore: dart_io_import.
 {{#android}}
-import 'package:{{pluginName}}/{{pluginName}}.dart';
+import 'package:{{pluginName}}/{{dartFileName}}';
 {{/android}}
 {{#ios}}
-import 'package:{{pluginName}}/{{pluginName}}.dart';
+import 'package:{{pluginName}}/{{dartFileName}}';
 {{/ios}}
 {{#linux}}
-import 'package:{{pluginName}}/{{pluginName}}.dart';
+import 'package:{{pluginName}}/{{dartFileName}}';
 {{/linux}}
 {{#macos}}
-import 'package:{{pluginName}}/{{pluginName}}.dart';
+import 'package:{{pluginName}}/{{dartFileName}}';
 {{/macos}}
 {{#windows}}
-import 'package:{{pluginName}}/{{pluginName}}.dart';
+import 'package:{{pluginName}}/{{dartFileName}}';
 {{/windows}}
 
 @pragma('vm:entry-point')
@@ -1433,7 +1433,7 @@ bool _hasPluginInlineImpl(
 /// Determine if the plugin provides an inline Dart implementation.
 bool _hasPluginInlineDartImpl(Plugin plugin, String platformKey) {
   return plugin.pluginDartClassPlatforms[platformKey] != null &&
-      plugin.pluginDartClassPlatforms[platformKey] != 'none';
+      plugin.pluginDartClassPlatforms[platformKey]!.dartClass != 'none';
 }
 
 /// Get the resolved plugin [resolution] from the [candidates] serving as implementation for

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1432,8 +1432,8 @@ bool _hasPluginInlineImpl(
 
 /// Determine if the plugin provides an inline Dart implementation.
 bool _hasPluginInlineDartImpl(Plugin plugin, String platformKey) {
-  return plugin.pluginDartClassPlatforms[platformKey] != null &&
-      plugin.pluginDartClassPlatforms[platformKey]!.dartClass != 'none';
+  final DartPluginClassAndFilePair? platformInfo = plugin.pluginDartClassPlatforms[platformKey];
+  return platformInfo != null && platformInfo.dartClass != 'none';
 }
 
 /// Get the resolved plugin [resolution] from the [candidates] serving as implementation for

--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -13,6 +13,9 @@ const String kPluginClass = 'pluginClass';
 /// Constant for 'dartPluginClass' key in plugin maps.
 const String kDartPluginClass = 'dartPluginClass';
 
+/// Constant for 'dartPluginFile' key in plugin maps.
+const String kDartFileName = 'dartFileName';
+
 /// Constant for 'ffiPlugin' key in plugin maps.
 const String kFfiPlugin = 'ffiPlugin';
 
@@ -68,8 +71,8 @@ abstract class DarwinPlugin {
 /// - an implementation consisting of:
 ///   - the [package] and [pluginClass] that will be the entry point to the
 ///     plugin's native code, and/or
-///   - the [dartPluginClass] that will be the entry point for the plugin's
-///     Dart code
+///   - the [dartPluginClass] with optional [dartFileName] that will be
+///     the entry point for the plugin's Dart code
 /// is required.
 class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
   AndroidPlugin({
@@ -78,6 +81,7 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
     this.package,
     this.pluginClass,
     this.dartPluginClass,
+    this.dartFileName,
     bool? ffiPlugin,
     this.defaultPackage,
     required FileSystem fileSystem,
@@ -89,6 +93,7 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
         package = yaml['package'] as String?,
         pluginClass = yaml[kPluginClass] as String?,
         dartPluginClass = yaml[kDartPluginClass] as String?,
+        dartFileName = yaml[kDartFileName] as String?,
         ffiPlugin = yaml[kFfiPlugin] as bool? ?? false,
         defaultPackage = yaml[kDefaultPackage] as String?,
         _fileSystem = fileSystem;
@@ -125,6 +130,9 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
   /// The Dart plugin main class defined in pubspec.yaml, if any.
   final String? dartPluginClass;
 
+  /// Path to file in which dartPluginClass defined, if any.
+  final String? dartFileName;
+
   /// Is FFI plugin defined in pubspec.yaml.
   final bool ffiPlugin;
 
@@ -141,6 +149,7 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
       if (package != null) 'package': package,
       if (pluginClass != null) 'class': pluginClass,
       if (dartPluginClass != null) kDartPluginClass : dartPluginClass,
+      if (dartFileName != null) kDartFileName: dartFileName,
       if (ffiPlugin) kFfiPlugin: true,
       if (defaultPackage != null) kDefaultPackage : defaultPackage,
       // Mustache doesn't support complex types.
@@ -224,8 +233,8 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
 /// - an implementation consisting of:
 ///   - the [pluginClass] (with optional [classPrefix]) that will be the entry
 ///     point to the plugin's native code, and/or
-///   - the [dartPluginClass] that will be the entry point for the plugin's
-///     Dart code
+///   - the [dartPluginClass] with optional [dartFileName] that will be
+///     the entry point for the plugin's Dart code
 /// is required.
 class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlugin {
   const IOSPlugin({
@@ -233,6 +242,7 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
     required this.classPrefix,
     this.pluginClass,
     this.dartPluginClass,
+    this.dartFileName,
     bool? ffiPlugin,
     this.defaultPackage,
     bool? sharedDarwinSource,
@@ -244,6 +254,7 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
         classPrefix = '',
         pluginClass = yaml[kPluginClass] as String?,
         dartPluginClass = yaml[kDartPluginClass] as String?,
+        dartFileName = yaml[kDartFileName] as String?,
         ffiPlugin = yaml[kFfiPlugin] as bool? ?? false,
         defaultPackage = yaml[kDefaultPackage] as String?,
         sharedDarwinSource = yaml[kSharedDarwinSource] as bool? ?? false;
@@ -265,6 +276,7 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
   final String classPrefix;
   final String? pluginClass;
   final String? dartPluginClass;
+  final String? dartFileName;
   final bool ffiPlugin;
   final String? defaultPackage;
 
@@ -289,6 +301,7 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
       'prefix': classPrefix,
       if (pluginClass != null) 'class': pluginClass,
       if (dartPluginClass != null) kDartPluginClass : dartPluginClass,
+      if (dartFileName != null) kDartFileName : dartFileName,
       if (ffiPlugin) kFfiPlugin: true,
       if (sharedDarwinSource) kSharedDarwinSource: true,
       if (defaultPackage != null) kDefaultPackage : defaultPackage,
@@ -301,11 +314,14 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
 /// The [name] of the plugin is required. Either [dartPluginClass] or
 /// [pluginClass] or [ffiPlugin] are required.
 /// [pluginClass] will be the entry point to the plugin's native code.
+/// [dartFileName] is not required and will be used only if [dartPluginClass]
+/// provided.
 class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlugin {
   const MacOSPlugin({
     required this.name,
     this.pluginClass,
     this.dartPluginClass,
+    this.dartFileName,
     bool? ffiPlugin,
     this.defaultPackage,
     bool? sharedDarwinSource,
@@ -317,6 +333,7 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
         // Treat 'none' as not present. See https://github.com/flutter/flutter/issues/57497.
         pluginClass = yaml[kPluginClass] == 'none' ? null : yaml[kPluginClass] as String?,
         dartPluginClass = yaml[kDartPluginClass] as String?,
+        dartFileName = yaml[kDartFileName] as String?,
         ffiPlugin = yaml[kFfiPlugin] as bool? ?? false,
         defaultPackage = yaml[kDefaultPackage] as String?,
         sharedDarwinSource = yaml[kSharedDarwinSource] as bool? ?? false;
@@ -334,6 +351,7 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
   final String name;
   final String? pluginClass;
   final String? dartPluginClass;
+  final String? dartFileName;
   final bool ffiPlugin;
   final String? defaultPackage;
 
@@ -357,6 +375,7 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
       'name': name,
       if (pluginClass != null) 'class': pluginClass,
       if (dartPluginClass != null) kDartPluginClass: dartPluginClass,
+      if (dartFileName != null) kDartFileName: dartFileName,
       if (ffiPlugin) kFfiPlugin: true,
       if (sharedDarwinSource) kSharedDarwinSource: true,
       if (defaultPackage != null) kDefaultPackage: defaultPackage,
@@ -368,12 +387,15 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
 ///
 /// The [name] of the plugin is required. Either [dartPluginClass] or [pluginClass] are required.
 /// [pluginClass] will be the entry point to the plugin's native code.
+/// [dartFileName] is not required and will be used only if [dartPluginClass]
+/// provided.
 class WindowsPlugin extends PluginPlatform
     implements NativeOrDartPlugin, VariantPlatformPlugin {
   const WindowsPlugin({
     required this.name,
     this.pluginClass,
     this.dartPluginClass,
+    this.dartFileName,
     bool? ffiPlugin,
     this.defaultPackage,
     this.variants = const <PluginPlatformVariant>{},
@@ -409,6 +431,7 @@ class WindowsPlugin extends PluginPlatform
       name: name,
       pluginClass: pluginClass,
       dartPluginClass: yaml[kDartPluginClass] as String?,
+      dartFileName: yaml[kDartFileName] as String?,
       ffiPlugin: yaml[kFfiPlugin] as bool?,
       defaultPackage: yaml[kDefaultPackage] as String?,
       variants: variants,
@@ -427,6 +450,7 @@ class WindowsPlugin extends PluginPlatform
   final String name;
   final String? pluginClass;
   final String? dartPluginClass;
+  final String? dartFileName;
   final bool ffiPlugin;
   final String? defaultPackage;
   final Set<PluginPlatformVariant> variants;
@@ -450,6 +474,7 @@ class WindowsPlugin extends PluginPlatform
       if (pluginClass != null) 'class': pluginClass,
       if (pluginClass != null) 'filename': _filenameForCppClass(pluginClass!),
       if (dartPluginClass != null) kDartPluginClass: dartPluginClass,
+      if (dartFileName != null) kDartFileName: dartFileName,
       if (ffiPlugin) kFfiPlugin: true,
       if (defaultPackage != null) kDefaultPackage: defaultPackage,
     };
@@ -460,11 +485,14 @@ class WindowsPlugin extends PluginPlatform
 ///
 /// The [name] of the plugin is required. Either [dartPluginClass] or [pluginClass] are required.
 /// [pluginClass] will be the entry point to the plugin's native code.
+/// [dartFileName] is not required and will be used only if [dartPluginClass]
+/// provided.
 class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
   const LinuxPlugin({
     required this.name,
     this.pluginClass,
     this.dartPluginClass,
+    this.dartFileName,
     bool? ffiPlugin,
     this.defaultPackage,
   })  : ffiPlugin = ffiPlugin ?? false,
@@ -475,6 +503,7 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
         // Treat 'none' as not present. See https://github.com/flutter/flutter/issues/57497.
         pluginClass = yaml[kPluginClass] == 'none' ? null : yaml[kPluginClass] as String?,
         dartPluginClass = yaml[kDartPluginClass] as String?,
+        dartFileName = yaml[kDartFileName] as String?,
         ffiPlugin = yaml[kFfiPlugin] as bool? ?? false,
         defaultPackage = yaml[kDefaultPackage] as String?;
 
@@ -490,6 +519,7 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
   final String name;
   final String? pluginClass;
   final String? dartPluginClass;
+  final String? dartFileName;
   final bool ffiPlugin;
   final String? defaultPackage;
 
@@ -509,6 +539,7 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
       if (pluginClass != null) 'class': pluginClass,
       if (pluginClass != null) 'filename': _filenameForCppClass(pluginClass!),
       if (dartPluginClass != null) kDartPluginClass: dartPluginClass,
+      if (dartFileName != null) kDartFileName: dartFileName,
       if (ffiPlugin) kFfiPlugin: true,
       if (defaultPackage != null) kDefaultPackage: defaultPackage,
     };

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
@@ -167,8 +166,8 @@ class Plugin {
         }
         final DartPluginClassAndFilePair? dartPair = _getPluginDartClassForPlatform(
           platformsYaml,
-          platform,
-          name,
+          platformKey: platform,
+          pluginName: name,
         );
         if (dartPair != null) {
           dartPluginClasses[platform] = dartPair;
@@ -355,10 +354,10 @@ class Plugin {
   }
 
   static DartPluginClassAndFilePair? _getPluginDartClassForPlatform(
-    YamlMap platformsYaml,
-    String platformKey,
-    String name,
-  ) {
+    YamlMap platformsYaml,{
+    required String platformKey,
+    required String pluginName,
+  }) {
     if (!_supportsPlatform(platformsYaml, platformKey)) {
       return null;
     }
@@ -366,8 +365,8 @@ class Plugin {
       final String dartClass = (platformsYaml[platformKey] as YamlMap)[kDartPluginClass] as String;
       final String dartFileName = (platformsYaml[platformKey] as YamlMap)[kDartFileName]
         as String?
-        ?? '$name.dart';
-      return DartPluginClassAndFilePair(dartClass, dartFileName);
+        ?? '$pluginName.dart';
+      return (dartClass: dartClass, dartFileName: dartFileName);
     }
     return null;
   }
@@ -481,35 +480,13 @@ class PluginInterfaceResolution {
   }
 }
 
-/// A class representing pair of dartPluginClass and dartFileName used as metadata
+/// A record representing pair of dartPluginClass and dartFileName used as metadata
 /// in [PluginInterfaceResolution].
 ///
 /// The [dartClass] and [dartFileName] fields are guaranteed to be non-null:
-/// - instance of this class should be created only if dartClassName
-/// exists in plugin configuration.
+/// - record should be created only if dartClassName exists in plugin configuration.
 /// - dartFileName either taken from configuration, or, if absent, should be
 /// constructed from plugin name.
 /// See also:
-/// - [PluginInterfaceResolution], which uses this class to create Map with metadata.
-@immutable
-class DartPluginClassAndFilePair {
-  const DartPluginClassAndFilePair(this.dartClass, this.dartFileName);
-
-  final String dartClass;
-  final String dartFileName;
-
-  @override
-  bool operator ==(Object other) {
-    if (runtimeType != other.runtimeType) {
-      return false;
-    }
-    return other is DartPluginClassAndFilePair
-        && dartClass == other.dartClass
-        && dartFileName == other.dartFileName;
-  }
-  @override
-  int get hashCode => Object.hash(dartClass, dartFileName);
-
-  @override
-  String toString() => 'DartPluginClassAndFilePair(dartClass: $dartClass, dartFileName: $dartFileName)';
-}
+/// - [PluginInterfaceResolution], which uses this record to create Map with metadata.
+typedef DartPluginClassAndFilePair = ({String dartClass, String dartFileName});

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -494,6 +494,7 @@ class PluginInterfaceResolution {
 @immutable
 class DartPluginClassAndFilePair {
   const DartPluginClassAndFilePair(this.dartClass, this.dartFileName);
+
   final String dartClass;
   final String dartFileName;
 

--- a/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
@@ -92,6 +92,7 @@ void main() {
             'pluginName': 'url_launcher_linux',
             'dartClass': 'UrlLauncherPluginLinux',
             'platform': 'linux',
+            'dartFileName': 'url_launcher_linux.dart'
           })
         );
         expect(resolutions[1].toMap(), equals(
@@ -99,6 +100,7 @@ void main() {
             'pluginName': 'url_launcher_macos',
             'dartClass': 'UrlLauncherPluginMacOS',
             'platform': 'macos',
+            'dartFileName': 'url_launcher_macos.dart',
           })
         );
       });
@@ -157,6 +159,7 @@ void main() {
               'pluginName': 'url_launcher_macos',
               'dartClass': 'UrlLauncherPluginMacOS',
               'platform': 'macos',
+              'dartFileName': 'url_launcher_macos.dart',
             }));
       });
 
@@ -208,6 +211,7 @@ void main() {
             'pluginName': 'url_launcher_macos',
             'dartClass': 'UrlLauncherPluginMacOS',
             'platform': 'macos',
+            'dartFileName': 'url_launcher_macos.dart',
           })
         );
         expect(resolutions[1].toMap(), equals(
@@ -215,6 +219,7 @@ void main() {
             'pluginName': 'transitive_dependency_plugin',
             'dartClass': 'UrlLauncherPluginWindows',
             'platform': 'windows',
+            'dartFileName': 'transitive_dependency_plugin.dart'
           })
         );
       });
@@ -251,6 +256,7 @@ void main() {
             'pluginName': 'url_launcher',
             'dartClass': 'UrlLauncherAndroid',
             'platform': 'android',
+            'dartFileName': 'url_launcher.dart',
           })
         );
         expect(resolutions[1].toMap(), equals(
@@ -258,6 +264,7 @@ void main() {
             'pluginName': 'url_launcher',
             'dartClass': 'UrlLauncherIos',
             'platform': 'ios',
+            'dartFileName': 'url_launcher.dart',
           })
         );
       });
@@ -368,16 +375,19 @@ void main() {
               'pluginName': 'url_launcher',
               'dartClass': 'UrlLauncherLinux',
               'platform': 'linux',
+              'dartFileName': 'url_launcher.dart',
             },
             <String, String>{
               'pluginName': 'url_launcher',
               'dartClass': 'UrlLauncherMacOS',
               'platform': 'macos',
+              'dartFileName': 'url_launcher.dart',
             },
             <String, String>{
               'pluginName': 'url_launcher',
               'dartClass': 'UrlLauncherWindows',
               'platform': 'windows',
+              'dartFileName': 'url_launcher.dart',
             },
           ])
         );
@@ -463,6 +473,7 @@ void main() {
             'pluginName': 'url_launcher_linux',
             'dartClass': 'UrlLauncherPluginLinux',
             'platform': 'linux',
+            'dartFileName': 'url_launcher_linux.dart',
           })
         );
       });
@@ -512,6 +523,7 @@ void main() {
             'pluginName': 'url_launcher_linux',
             'dartClass': 'UrlLauncherPluginLinux',
             'platform': 'linux',
+            'dartFileName': 'url_launcher_linux.dart'
           })
         );
       });
@@ -580,6 +592,7 @@ void main() {
             'pluginName': 'user_selected_url_launcher_implementation',
             'dartClass': 'UrlLauncherPluginLinux',
             'platform': 'linux',
+            'dartFileName': 'user_selected_url_launcher_implementation.dart',
           })
         );
       });
@@ -635,6 +648,7 @@ void main() {
               'pluginName': 'user_selected_url_launcher_implementation',
               'dartClass': 'UrlLauncherAndroid',
               'platform': 'android',
+              'dartFileName': 'user_selected_url_launcher_implementation.dart',
             })
         );
         expect(resolutions[1].toMap(), equals(
@@ -642,6 +656,7 @@ void main() {
               'pluginName': 'url_launcher',
               'dartClass': 'UrlLauncherIos',
               'platform': 'ios',
+              'dartFileName': 'url_launcher.dart'
             })
         );
       });
@@ -914,6 +929,7 @@ void main() {
               'pluginName': 'url_launcher_linux',
               'dartClass': 'UrlLauncherLinux',
               'platform': 'linux',
+              'dartFileName': 'url_launcher_linux.dart'
             })
         );
       });

--- a/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
@@ -92,7 +92,7 @@ void main() {
             'pluginName': 'url_launcher_linux',
             'dartClass': 'UrlLauncherPluginLinux',
             'platform': 'linux',
-            'dartFileName': 'url_launcher_linux.dart'
+            'dartFileName': 'url_launcher_linux.dart',
           })
         );
         expect(resolutions[1].toMap(), equals(
@@ -219,7 +219,7 @@ void main() {
             'pluginName': 'transitive_dependency_plugin',
             'dartClass': 'UrlLauncherPluginWindows',
             'platform': 'windows',
-            'dartFileName': 'transitive_dependency_plugin.dart'
+            'dartFileName': 'transitive_dependency_plugin.dart',
           })
         );
       });
@@ -523,7 +523,7 @@ void main() {
             'pluginName': 'url_launcher_linux',
             'dartClass': 'UrlLauncherPluginLinux',
             'platform': 'linux',
-            'dartFileName': 'url_launcher_linux.dart'
+            'dartFileName': 'url_launcher_linux.dart',
           })
         );
       });
@@ -656,7 +656,7 @@ void main() {
               'pluginName': 'url_launcher',
               'dartClass': 'UrlLauncherIos',
               'platform': 'ios',
-              'dartFileName': 'url_launcher.dart'
+              'dartFileName': 'url_launcher.dart',
             })
         );
       });
@@ -929,7 +929,7 @@ void main() {
               'pluginName': 'url_launcher_linux',
               'dartClass': 'UrlLauncherLinux',
               'platform': 'linux',
-              'dartFileName': 'url_launcher_linux.dart'
+              'dartFileName': 'url_launcher_linux.dart',
             })
         );
       });

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -214,46 +214,134 @@ void main() {
     );
 
     expect(plugin.pluginDartClassPlatforms, <String, DartPluginClassAndFilePair>{
-      'android': const DartPluginClassAndFilePair('AndroidClass', 'src/android_class.dart'),
-      'ios': const DartPluginClassAndFilePair('IosClass', 'src/ios_class.dart'),
-      'linux':  const DartPluginClassAndFilePair('LinuxClass', 'src/linux_class.dart'),
-      'macos':  const DartPluginClassAndFilePair('MacOSClass', 'src/macos_class.dart'),
-      'windows':  const DartPluginClassAndFilePair('WindowsClass', 'src/windows_class.dart'),
+      'android': const (dartClass: 'AndroidClass', dartFileName: 'src/android_class.dart'),
+      'ios': const (dartClass: 'IosClass', dartFileName: 'src/ios_class.dart'),
+      'linux':  const (dartClass: 'LinuxClass', dartFileName: 'src/linux_class.dart'),
+      'macos':  const (dartClass: 'MacOSClass', dartFileName: 'src/macos_class.dart'),
+      'windows':  const (dartClass: 'WindowsClass', dartFileName: 'src/windows_class.dart'),
     });
   });
 
-  testWithoutContext('dartFileName without dartPluginClass has no effect', () {
+  testWithoutContext('dartFileName without dartPluginClass throws (Android)', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
     const String pluginYamlRaw =
       'platforms:\n'
       ' android:\n'
       '  package: com.example\n'
       '  pluginClass: AndroidClass\n'
-      '  dartFileName: src/android_class.dart\n'
+      '  dartFileName: src/android_class.dart\n';
+
+    final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+    expect(
+     () => Plugin.fromYaml(
+        _kTestPluginName,
+        _kTestPluginPath,
+        pluginYaml,
+        null,
+        const <String>[],
+        fileSystem: fileSystem,
+      ),
+      throwsToolExit(
+        message: '"dartFileName" cannot be specified without "dartPluginClass" in Android platform of plugin "$_kTestPluginName"',
+      ),
+    );
+  });
+
+  testWithoutContext('dartFileName without dartPluginClass throws (iOS)', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    const String pluginYamlRaw =
+      'platforms:\n'
       ' ios:\n'
       '  pluginClass: IosClass\n'
-      '  dartFileName: src/ios_class.dart\n'
+      '  dartFileName: src/ios_class.dart\n';
+
+    final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+    expect(
+     () => Plugin.fromYaml(
+        _kTestPluginName,
+        _kTestPluginPath,
+        pluginYaml,
+        null,
+        const <String>[],
+        fileSystem: fileSystem,
+      ),
+      throwsToolExit(
+        message: '"dartFileName" cannot be specified without "dartPluginClass" in iOS platform of plugin "$_kTestPluginName"',
+      ),
+    );
+  });
+
+  testWithoutContext('dartFileName without dartPluginClass throws (Linux)', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    const String pluginYamlRaw =
+      'platforms:\n'
       ' linux:\n'
       '  pluginClass: LinuxClass\n'
-      '  dartFileName: src/linux_class.dart\n'
+      '  dartFileName: src/linux_class.dart\n';
+
+    final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+    expect(
+     () => Plugin.fromYaml(
+        _kTestPluginName,
+        _kTestPluginPath,
+        pluginYaml,
+        null,
+        const <String>[],
+        fileSystem: fileSystem,
+      ),
+      throwsToolExit(
+        message: '"dartFileName" cannot be specified without "dartPluginClass" in Linux platform of plugin "$_kTestPluginName"',
+      ),
+    );
+  });
+
+  testWithoutContext('dartFileName without dartPluginClass throws (MacOS)', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    const String pluginYamlRaw =
+      'platforms:\n'
       ' macos:\n'
       '  pluginClass: MacOSClass\n'
-      '  dartFileName: src/macos_class.dart\n'
+      '  dartFileName: src/macos_class.dart\n';
+
+    final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+    expect(
+     () => Plugin.fromYaml(
+        _kTestPluginName,
+        _kTestPluginPath,
+        pluginYaml,
+        null,
+        const <String>[],
+        fileSystem: fileSystem,
+      ),
+      throwsToolExit(
+        message: '"dartFileName" cannot be specified without "dartPluginClass" in macOS platform of plugin "$_kTestPluginName"',
+      ),
+    );
+  });
+
+
+  testWithoutContext('dartFileName without dartPluginClass throws (Windows)', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    const String pluginYamlRaw =
+      'platforms:\n'
       ' windows:\n'
       '  pluginClass: WindowsClass\n'
       '  dartFileName: src/windows_class.dart\n';
 
     final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
-    final Plugin plugin = Plugin.fromYaml(
-      _kTestPluginName,
-      _kTestPluginPath,
-      pluginYaml,
-      null,
-      const <String>[],
-      fileSystem: fileSystem,
+    expect(
+     () => Plugin.fromYaml(
+        _kTestPluginName,
+        _kTestPluginPath,
+        pluginYaml,
+        null,
+        const <String>[],
+        fileSystem: fileSystem,
+      ),
+      throwsToolExit(
+        message: '"dartFileName" cannot be specified without "dartPluginClass" in Windows platform of plugin "$_kTestPluginName"',
+      ),
     );
-
-    expect(plugin.pluginDartClassPlatforms, <String, DartPluginClassAndFilePair>{});
   });
 
   testWithoutContext('Plugin parsing of legacy format and multi-platform format together is not allowed '
@@ -339,9 +427,9 @@ void main() {
     );
 
     expect(plugin.pluginDartClassPlatforms, <String, DartPluginClassAndFilePair>{
-      'linux':  const DartPluginClassAndFilePair('LinuxClass', 'test_plugin_name.dart'),
-      'macos':  const DartPluginClassAndFilePair('MacOSClass', 'test_plugin_name.dart'),
-      'windows':  const DartPluginClassAndFilePair('WindowsClass', 'test_plugin_name.dart'),
+      'linux':  const (dartClass: 'LinuxClass', dartFileName: 'test_plugin_name.dart'),
+      'macos':  const (dartClass: 'MacOSClass', dartFileName: 'test_plugin_name.dart'),
+      'windows':  const (dartClass: 'WindowsClass', dartFileName: 'test_plugin_name.dart'),
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -183,6 +183,79 @@ void main() {
     expect(windowsPlugin.dartPluginClass, 'WinSamplePlugin');
   });
 
+  testWithoutContext('Plugin parsing allows a dartFileName field with dartPluginClass', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    const String pluginYamlRaw =
+      'platforms:\n'
+      ' android:\n'
+      '  dartPluginClass: AndroidClass\n'
+      '  dartFileName: src/android_class.dart\n'
+      ' ios:\n'
+      '  dartPluginClass: IosClass\n'
+      '  dartFileName: src/ios_class.dart\n'
+      ' linux:\n'
+      '  dartPluginClass: LinuxClass\n'
+      '  dartFileName: src/linux_class.dart\n'
+      ' macos:\n'
+      '  dartPluginClass: MacOSClass\n'
+      '  dartFileName: src/macos_class.dart\n'
+      ' windows:\n'
+      '  dartPluginClass: WindowsClass\n'
+      '  dartFileName: src/windows_class.dart\n';
+
+    final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+    final Plugin plugin = Plugin.fromYaml(
+      _kTestPluginName,
+      _kTestPluginPath,
+      pluginYaml,
+      null,
+      const <String>[],
+      fileSystem: fileSystem,
+    );
+
+    expect(plugin.pluginDartClassPlatforms, <String, DartPluginClassAndFilePair>{
+      'android': const DartPluginClassAndFilePair('AndroidClass', 'src/android_class.dart'),
+      'ios': const DartPluginClassAndFilePair('IosClass', 'src/ios_class.dart'),
+      'linux':  const DartPluginClassAndFilePair('LinuxClass', 'src/linux_class.dart'),
+      'macos':  const DartPluginClassAndFilePair('MacOSClass', 'src/macos_class.dart'),
+      'windows':  const DartPluginClassAndFilePair('WindowsClass', 'src/windows_class.dart'),
+    });
+  });
+
+  testWithoutContext('dartFileName without dartPluginClass has no effect', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    const String pluginYamlRaw =
+      'platforms:\n'
+      ' android:\n'
+      '  package: com.example\n'
+      '  pluginClass: AndroidClass\n'
+      '  dartFileName: src/android_class.dart\n'
+      ' ios:\n'
+      '  pluginClass: IosClass\n'
+      '  dartFileName: src/ios_class.dart\n'
+      ' linux:\n'
+      '  pluginClass: LinuxClass\n'
+      '  dartFileName: src/linux_class.dart\n'
+      ' macos:\n'
+      '  pluginClass: MacOSClass\n'
+      '  dartFileName: src/macos_class.dart\n'
+      ' windows:\n'
+      '  pluginClass: WindowsClass\n'
+      '  dartFileName: src/windows_class.dart\n';
+
+    final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+    final Plugin plugin = Plugin.fromYaml(
+      _kTestPluginName,
+      _kTestPluginPath,
+      pluginYaml,
+      null,
+      const <String>[],
+      fileSystem: fileSystem,
+    );
+
+    expect(plugin.pluginDartClassPlatforms, <String, DartPluginClassAndFilePair>{});
+  });
+
   testWithoutContext('Plugin parsing of legacy format and multi-platform format together is not allowed '
     'and fatal error message contains plugin name', () {
     final FileSystem fileSystem = MemoryFileSystem.test();

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -265,10 +265,10 @@ void main() {
       fileSystem: fileSystem,
     );
 
-    expect(plugin.pluginDartClassPlatforms, <String, String>{
-      'linux': 'LinuxClass',
-      'macos': 'MacOSClass',
-      'windows': 'WindowsClass',
+    expect(plugin.pluginDartClassPlatforms, <String, DartPluginClassAndFilePair>{
+      'linux':  const DartPluginClassAndFilePair('LinuxClass', 'test_plugin_name.dart'),
+      'macos':  const DartPluginClassAndFilePair('MacOSClass', 'test_plugin_name.dart'),
+      'windows':  const DartPluginClassAndFilePair('WindowsClass', 'test_plugin_name.dart'),
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -1684,7 +1684,7 @@ The Flutter Preview device does not support the following plugins from your pubs
           name: 'test',
           path: '/path/to/test/',
           defaultPackagePlatforms: const <String, String>{},
-          pluginDartClassPlatforms: const <String, String>{},
+          pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
           platforms: const <String, PluginPlatform>{
             IOSPlugin.kConfigKey: IOSPlugin(name: 'test', classPrefix: ''),
             MacOSPlugin.kConfigKey: MacOSPlugin(name: 'test'),
@@ -1709,7 +1709,7 @@ The Flutter Preview device does not support the following plugins from your pubs
           name: 'test',
           path: '/path/to/test/',
           defaultPackagePlatforms: const <String, String>{},
-          pluginDartClassPlatforms: const <String, String>{},
+          pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
           platforms: const <String, PluginPlatform>{
             IOSPlugin.kConfigKey: IOSPlugin(name: 'test', classPrefix: '', sharedDarwinSource: true),
             MacOSPlugin.kConfigKey: MacOSPlugin(name: 'test', sharedDarwinSource: true),
@@ -1734,7 +1734,7 @@ The Flutter Preview device does not support the following plugins from your pubs
           name: 'test',
           path: '/path/to/test/',
           defaultPackagePlatforms: const <String, String>{},
-          pluginDartClassPlatforms: const <String, String>{},
+          pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
           platforms: const <String, PluginPlatform>{
             WindowsPlugin.kConfigKey: WindowsPlugin(name: 'test', pluginClass: ''),
           },
@@ -1762,7 +1762,7 @@ The Flutter Preview device does not support the following plugins from your pubs
           name: 'test',
           path: '/path/to/test/',
           defaultPackagePlatforms: const <String, String>{},
-          pluginDartClassPlatforms: const <String, String>{},
+          pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
           platforms: const <String, PluginPlatform>{
             IOSPlugin.kConfigKey: IOSPlugin(name: 'test', classPrefix: ''),
             MacOSPlugin.kConfigKey: MacOSPlugin(name: 'test'),
@@ -1787,7 +1787,7 @@ The Flutter Preview device does not support the following plugins from your pubs
           name: 'test',
           path: '/path/to/test/',
           defaultPackagePlatforms: const <String, String>{},
-          pluginDartClassPlatforms: const <String, String>{},
+          pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
           platforms: const <String, PluginPlatform>{
             IOSPlugin.kConfigKey: IOSPlugin(name: 'test', classPrefix: '', sharedDarwinSource: true),
             MacOSPlugin.kConfigKey: MacOSPlugin(name: 'test', sharedDarwinSource: true),
@@ -1812,7 +1812,7 @@ The Flutter Preview device does not support the following plugins from your pubs
           name: 'test',
           path: '/path/to/test/',
           defaultPackagePlatforms: const <String, String>{},
-          pluginDartClassPlatforms: const <String, String>{},
+          pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
           platforms: const <String, PluginPlatform>{
             WindowsPlugin.kConfigKey: WindowsPlugin(name: 'test', pluginClass: ''),
           },

--- a/packages/flutter_tools/test/general.shard/windows/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/plugins_test.dart
@@ -28,7 +28,7 @@ void main() {
         name: 'test',
         path: 'foo',
         defaultPackagePlatforms: const <String, String>{},
-        pluginDartClassPlatforms: const <String, String>{},
+        pluginDartClassPlatforms: const <String, DartPluginClassAndFilePair>{},
         platforms: const <String, PluginPlatform>{
           WindowsPlugin.kConfigKey: WindowsPlugin(
             name: 'test',


### PR DESCRIPTION
This PR introduces the `dartFileName` parameter for platform plugin configurations with Dart platform implementations. This new parameter allows plugin developers to specify a custom path to the file where the `dartPluginClass` is defined.

**Implementation is opt-in**. `dartFileName` is completely optional and is taken in account only with `dartClassName`. Possibility to set `dartClassName` without `dartFileName` remains. 

**Implementation is backward compatible** – existing configurations using only `dartClassName` remain fully supported. If `dartFileName` is omitted, the system falls back to the previous behavior of deriving the file name from the plugin name.

## Example

```yaml
flutter:
  plugin:
    platforms:
      some_platform:
        dartPluginClass: MyPlugin
        dartFileName: 'src/my_plugin_implementation.dart'
```

fixes #152833 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
