### PR TITLE
Shift Linux_android_emu tests from staging to prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -376,7 +376,6 @@ targets:
 
   - name: Linux_android_emu android views
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/152684
     properties:
       tags: >
         ["framework","hostonly","linux"]
@@ -1296,7 +1295,6 @@ targets:
   - name: Linux_android_emu flutter_driver_android_test
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true # https://github.com/flutter/flutter/issues/152684
     properties:
       shard: flutter_driver_android
       tags: >
@@ -2032,7 +2030,6 @@ targets:
 
   - name: Linux_android_emu android_defines_test
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/152684
     timeout: 60
     properties:
       tags: >
@@ -2457,7 +2454,6 @@ targets:
 
   - name: Linux_android_emu external_textures_integration_test
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/152684
     timeout: 60
     # Functionally the same as "presubmit: false", except that we will run on
     # presubmit during engine rolls. This test is the *only* automated e2e


### PR DESCRIPTION
These tests were moved to staging when they were flaking at a high rate. I landed a couple of changes to fix unrelated issues that were masking the underlying cause. However, these tests are no longer flaking at the same rate in staging as they were in prod. So, I am moving these back to prod and will monitor the flake rate.

Related https://github.com/flutter/flutter/issues/152684