### PR TITLE
`CupertinoSlidingSegmentedControl` is able to have proportional layout based on segment content

### DIFF
--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -510,7 +510,6 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
 
   double? _getSegmentWidth(GlobalKey key) {
     final BuildContext? context = key.currentContext;
-    print('context is null? ${context == null}');
     if (context != null) {
       final RenderBox box = context.findRenderObject()! as RenderBox;
       return box.hasSize ? box.size.width : null;
@@ -537,13 +536,13 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
         final GlobalKey key = segmentToKeys[widget.children.keys.elementAt(ltrIndex)]!;
         final double segmentWidth = _getSegmentWidth(key) ?? 0.0;
         subtotalWidth += segmentWidth;
-        print('dx: $dx, subtotal: $subtotalWidth, ltrIndex: $ltrIndex');
+
         if (dx <= subtotalWidth) {
           return widget.children.keys.elementAt(ltrIndex);
         }
       }
     }
-print('ERROR: should not come here');
+
     int index = (dx ~/ (renderBox.size.width / numOfChildren)).clamp(0, numOfChildren - 1);
 
     switch (Directionality.of(context)) {

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -893,7 +893,6 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   double get separatorWidth => _kSeparatorInset.horizontal + _kSeparatorWidth;
   double get totalSeparatorWidth => separatorWidth * (childCount ~/ 2);
 
-  List<double> segmentWidths = <double>[];
   int getClosestSegmentIndex(double dx) {
     int index = 0;
     RenderBox? child = firstChild;
@@ -1068,7 +1067,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   @override
   void performLayout() {
     final BoxConstraints constraints = this.constraints;
-    segmentWidths = _getChildWidths(constraints);
+    final List<double> segmentWidths = _getChildWidths(constraints);
 
     final double childHeight = _getMaxChildHeight(constraints, double.infinity);
     final BoxConstraints separatorConstraints = BoxConstraints(minHeight: childHeight, maxHeight: childHeight);

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -438,7 +438,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
   final TapGestureRecognizer tap = TapGestureRecognizer();
   final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer();
   final LongPressGestureRecognizer longPress = LongPressGestureRecognizer();
-  GlobalKey segmentedControlRenderWidgetKey = GlobalKey();
+  final GlobalKey segmentedControlRenderWidgetKey = GlobalKey();
 
   @override
   void initState() {
@@ -902,17 +902,17 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
   double get totalSeparatorWidth => (_kSeparatorInset.horizontal + _kSeparatorWidth) * (childCount ~/ 2);
 
-  List<double> childWidths = <double>[];
+  List<double> segmentWidths = <double>[];
   int? getSegmentIndex(double dx, TextDirection textDirection) {
     double subtotalWidth = 0;
-    for (int i = 0; i < childWidths.length; i++) {
-      final double segmentWidth = childWidths[i];
+    for (int i = 0; i < segmentWidths.length; i++) {
+      final double segmentWidth = segmentWidths[i];
       subtotalWidth += segmentWidth;
 
       if (dx <= subtotalWidth) {
         return switch (textDirection) {
           TextDirection.ltr => i,
-          TextDirection.rtl => childWidths.length - 1 - i,
+          TextDirection.rtl => segmentWidths.length - 1 - i,
         };
       }
     }
@@ -1018,15 +1018,15 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   }
 
   List<double> _getChildIntrinsicWidths(BoxConstraints constraints) {
-    final List<double> childWidths = <double>[];
+    final List<double> segmentWidths = <double>[];
     RenderBox? child = firstChild;
     while (child != null) {
       final double childWidth = child.getMaxIntrinsicWidth(double.infinity) + 2 * _kSegmentMinPadding;
       child = nonSeparatorChildAfter(child);
-      childWidths.add(childWidth);
+      segmentWidths.add(childWidth);
     }
 
-    final double totalWidth = childWidths.sum;
+    final double totalWidth = segmentWidths.sum;
 
     // If the sum of the children's width is larger than the allowed max width,
     // each segment width should scale down until the overall size can fit in
@@ -1034,8 +1034,8 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     final double allowedMaxWidth = constraints.maxWidth - totalSeparatorWidth;
     if (totalWidth > allowedMaxWidth) {
       final double scale = allowedMaxWidth / totalWidth;
-      for (int i = 0; i < childWidths.length; i++) {
-        childWidths[i] = childWidths[i] * scale;
+      for (int i = 0; i < segmentWidths.length; i++) {
+        segmentWidths[i] = segmentWidths[i] * scale;
       }
     }
 
@@ -1045,11 +1045,11 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     final double allowedMinWidth = constraints.minWidth - totalSeparatorWidth;
     if (totalWidth < allowedMinWidth) {
       final double scale = allowedMinWidth / totalWidth;
-      for (int i = 0; i < childWidths.length; i++) {
-        childWidths[i] = childWidths[i] * scale;
+      for (int i = 0; i < segmentWidths.length; i++) {
+        segmentWidths[i] = segmentWidths[i] * scale;
       }
     }
-    return childWidths;
+    return segmentWidths;
   }
 
   Size _computeOverallSizeFromChildSize(BoxConstraints constraints) {
@@ -1084,10 +1084,10 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     final BoxConstraints constraints = this.constraints;
 
     if (proportionalWidth) {
-      childWidths = _getChildIntrinsicWidths(constraints);
+      segmentWidths = _getChildIntrinsicWidths(constraints);
     } else {
       final Size childSize = _calculateChildSize(constraints);
-      childWidths = List<double>.filled(childCount, childSize.width);
+      segmentWidths = List<double>.filled(childCount, childSize.width);
     }
 
     final double childHeight = _getMaxChildHeight(constraints, double.infinity);
@@ -1096,7 +1096,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     int index = 0;
     double start = 0;
     while (child != null) {
-      final BoxConstraints childConstraints = BoxConstraints.tight(Size(childWidths[index ~/ 2], childHeight));
+      final BoxConstraints childConstraints = BoxConstraints.tight(Size(segmentWidths[index ~/ 2], childHeight));
       child.layout(index.isEven ? childConstraints : separatorConstraints, parentUsesSize: true);
       final _SegmentedControlContainerBoxParentData childParentData = child.parentData! as _SegmentedControlContainerBoxParentData;
       final Offset childOffset = Offset(start, 0);

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -399,6 +399,7 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   final Color backgroundColor;
 
   /// Determine whether segments have proportional widths based on their content.
+  ///
   /// If false, all segments will have the same width, determined by the longest
   /// segment. If true, each segment's width will be determined by its individual
   /// content.

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -397,10 +397,16 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   /// will not be painted if null is specified.
   final Color backgroundColor;
 
-  /// Determine whether each segment has equal width or proportional width based
-  /// on the segment content. If this is false, each segment has equal width
-  /// and the width is determined by the longest segment; If this is true,
-  /// segments have their own width based on the content.
+  /// Determine whether segments have equal widths or proportional widths based
+  /// on their content. If false, all segment will have the same width, determined
+  /// by the longest segment. If true, each segment's width will be determined
+  /// by its individual content.
+  ///
+  /// If the max width of parent constraints is smaller than the width that the
+  /// segmented control needs, The segment widths will scale down proportionally
+  /// to ensure the segment control fits within the boundaries; similarly, if
+  /// the min width of parent constraints is larger, the segment width will scales
+  /// up to meet the min width requirement.
   ///
   /// Defaults to false.
   final bool isProportionalSegment;

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1013,7 +1013,13 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     return maxHeight;
   }
 
-  List<double> _getChildIntrinsicWidths(BoxConstraints constraints) {
+  List<double> _getChildWidths(BoxConstraints constraints) {
+    if (!proportionalWidth) {
+      final double maxChildWidth = _getMaxChildWidth(constraints);
+      final int segmentCount = childCount ~/ 2 + 1;
+      return List<double>.filled(segmentCount, maxChildWidth);
+    }
+
     final List<double> segmentWidths = <double>[];
     RenderBox? child = firstChild;
     while (child != null) {
@@ -1043,12 +1049,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
   Size _computeOverallSize(BoxConstraints constraints) {
     final double maxChildHeight = _getMaxChildHeight(constraints, constraints.maxWidth);
-    if (proportionalWidth) {
-      return constraints.constrain(Size(_getChildIntrinsicWidths(constraints).sum + totalSeparatorWidth, maxChildHeight));
-    }
-    final int childCount = this.childCount ~/ 2 + 1;
-    final double maxChildWidth = _getMaxChildWidth(constraints);
-    return constraints.constrain(Size(maxChildWidth * childCount + totalSeparatorWidth, maxChildHeight));
+    return constraints.constrain(Size(_getChildWidths(constraints).sum + totalSeparatorWidth, maxChildHeight));
   }
 
   @override
@@ -1071,13 +1072,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   @override
   void performLayout() {
     final BoxConstraints constraints = this.constraints;
-
-    if (proportionalWidth) {
-      segmentWidths = _getChildIntrinsicWidths(constraints);
-    } else {
-      final Size childSize = _calculateChildSize(constraints);
-      segmentWidths = List<double>.filled(childCount, childSize.width);
-    }
+    segmentWidths = _getChildWidths(constraints);
 
     final double childHeight = _getMaxChildHeight(constraints, double.infinity);
     final BoxConstraints separatorConstraints = BoxConstraints(minHeight: childHeight, maxHeight: childHeight);

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -898,7 +898,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     RenderBox? child = firstChild;
     while (child != null) {
       final _SegmentedControlContainerBoxParentData childParentData = child.parentData! as _SegmentedControlContainerBoxParentData;
-      final double clampX = dx.clamp(childParentData.offset.dx, child.size.width + childParentData.offset.dx);
+      final double clampX = clampDouble(dx, childParentData.offset.dx, child.size.width + childParentData.offset.dx);
       if (clampX == dx) {
         break;
       }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1053,7 +1053,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   }
 
   Size _computeOverallSizeFromChildSize(BoxConstraints constraints) {
-    final double maxChildHeight = _getMaxChildHeight(constraints, double.infinity);
+    final double maxChildHeight = _getMaxChildHeight(constraints, constraints.maxWidth);
     if (isProportionalSegment) {
       return constraints.constrain(Size(_getChildIntrinsicWidths(constraints).sum + totalSeparatorWidth, maxChildHeight));
     }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1025,12 +1025,32 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   }
 
   List<double> _getChildIntrinsicWidths(BoxConstraints constraints) {
-    final List<double> childWidths = <double>[];
+  List<double> childWidths = <double>[];
     RenderBox? child = firstChild;
     while (child != null) {
       final double childWidth = child.getMaxIntrinsicWidth(double.infinity) + 2 * _kSegmentMinPadding;
       child = nonSeparatorChildAfter(child);
       childWidths.add(childWidth);
+    }
+
+    final double totalWidth = childWidths.sum;
+
+    // If the sum of the children's width is larger than the allowed max width,
+    // each segment width should scale down until the overall size can fit in
+    // the parent constraints.
+    final double allowedMaxWidth = constraints.maxWidth - totalSeparatorWidth;
+    if (totalWidth > allowedMaxWidth) {
+      final double scale = allowedMaxWidth / totalWidth;
+      childWidths = childWidths.map<double>((double width) => width * scale).toList();
+    }
+
+    // If the sum of the children's width is smaller than the allowed min width,
+    // each segment width should scale up until the overall size can fit in
+    // the parent constraints.
+    final double allowedMinWidth = constraints.minWidth - totalSeparatorWidth;
+    if (totalWidth < allowedMinWidth) {
+      final double scale = allowedMinWidth / totalWidth;
+      childWidths = childWidths.map<double>((double width) => width * scale).toList();
     }
     return childWidths;
   }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1044,19 +1044,16 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   @override
   double? computeDryBaseline(covariant BoxConstraints constraints, TextBaseline baseline) {
     final List<double> segmentWidths = _getChildWidths(constraints);
-
     final double childHeight = _getMaxChildHeight(constraints, constraints.maxWidth);
-    final BoxConstraints separatorConstraints = BoxConstraints(minHeight: childHeight, maxHeight: childHeight);
 
     int index = 0;
     BaselineOffset baselineOffset = BaselineOffset.noBaseline;
     RenderBox? child = firstChild;
     while (child != null) {
-      final BoxConstraints childConstraints = BoxConstraints.tight(Size(segmentWidths[index ~/ 2], childHeight));
-      final BoxConstraints constraints = index.isEven ? childConstraints : separatorConstraints;
-      baselineOffset = baselineOffset.minOf(BaselineOffset(child.getDryBaseline(constraints, baseline)));
+      final BoxConstraints childConstraints = BoxConstraints.tight(Size(segmentWidths[index], childHeight));
+      baselineOffset = baselineOffset.minOf(BaselineOffset(child.getDryBaseline(childConstraints, baseline)));
 
-      child = childAfter(child);
+      child = nonSeparatorChildAfter(child);
       index++;
     }
 

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -899,7 +899,8 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     while (child != null) {
       final _SegmentedControlContainerBoxParentData childParentData = child.parentData! as _SegmentedControlContainerBoxParentData;
       final double clampX = clampDouble(dx, childParentData.offset.dx, child.size.width + childParentData.offset.dx);
-      if (clampX == dx) {
+
+      if (dx <= clampX) {
         break;
       }
 

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -912,7 +912,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
       return;
     }
     _isProportionalSegment = value;
-    markNeedsPaint();
+    markNeedsLayout();
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1029,7 +1029,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   }
 
   List<double> _getChildIntrinsicWidths(BoxConstraints constraints) {
-  List<double> childWidths = <double>[];
+    List<double> childWidths = <double>[];
     RenderBox? child = firstChild;
     while (child != null) {
       final double childWidth = child.getMaxIntrinsicWidth(double.infinity) + 2 * _kSegmentMinPadding;

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1045,7 +1045,9 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     final double allowedMaxWidth = constraints.maxWidth - totalSeparatorWidth;
     if (totalWidth > allowedMaxWidth) {
       final double scale = allowedMaxWidth / totalWidth;
-      childWidths = childWidths.map<double>((double width) => width * scale).toList();
+      for (int i = 0; i < childWidths.length; i++) {
+        childWidths[i] = childWidths[i] * scale;
+      }
     }
 
     // If the sum of the children's width is smaller than the allowed min width,
@@ -1054,7 +1056,9 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     final double allowedMinWidth = constraints.minWidth - totalSeparatorWidth;
     if (totalWidth < allowedMinWidth) {
       final double scale = allowedMinWidth / totalWidth;
-      childWidths = childWidths.map<double>((double width) => width * scale).toList();
+      for (int i = 0; i < childWidths.length; i++) {
+        childWidths[i] = childWidths[i] * scale;
+      }
     }
     return childWidths;
   }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1029,7 +1029,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   }
 
   List<double> _getChildIntrinsicWidths(BoxConstraints constraints) {
-    List<double> childWidths = <double>[];
+    final List<double> childWidths = <double>[];
     RenderBox? child = firstChild;
     while (child != null) {
       final double childWidth = child.getMaxIntrinsicWidth(double.infinity) + 2 * _kSegmentMinPadding;

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'dart:math' as math;
+import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -908,7 +909,10 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
       child = nonSeparatorChildAfter(child);
     }
 
-    return index;
+    final int segmentCount = childCount ~/ 2 + 1;
+    // When the thumb is dragging out of bounds, the return result must be
+    // smaller than segment count.
+    return min(index, segmentCount - 1);
   }
 
   RenderBox? nonSeparatorChildAfter(RenderBox child) {

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1102,12 +1102,12 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     }
 
     final double childHeight = _getMaxChildHeight(constraints, double.infinity);
+    final BoxConstraints separatorConstraints = BoxConstraints(minHeight: childHeight, maxHeight: childHeight);
     RenderBox? child = firstChild;
     int index = 0;
     double start = 0;
     while (child != null) {
       final BoxConstraints childConstraints = BoxConstraints.tight(Size(childWidths[index ~/ 2], childHeight));
-      final BoxConstraints separatorConstraints = childConstraints.heightConstraints();
       child.layout(index.isEven ? childConstraints : separatorConstraints, parentUsesSize: true);
       final _SegmentedControlContainerBoxParentData childParentData = child.parentData! as _SegmentedControlContainerBoxParentData;
       final Offset childOffset = Offset(start, 0);

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -895,21 +895,17 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
   List<double> segmentWidths = <double>[];
   int getClosestSegmentIndex(double dx) {
-    double subtotalWidth = 0;
     int index = 0;
-    while (index < segmentWidths.length) {
-      final double segmentWidth = segmentWidths[index];
-      if (index == 0 || index == segmentWidths.length - 1) {
-        subtotalWidth += separatorWidth / 2;
-      } else {
-        subtotalWidth += separatorWidth;
-      }
-
-      subtotalWidth += segmentWidth;
-      if (dx <= subtotalWidth) {
+    RenderBox? child = firstChild;
+    while (child != null) {
+      final _SegmentedControlContainerBoxParentData childParentData = child.parentData! as _SegmentedControlContainerBoxParentData;
+      final double clampX = dx.clamp(childParentData.offset.dx, child.size.width + childParentData.offset.dx);
+      if (clampX == dx) {
         break;
       }
+
       index++;
+      child = nonSeparatorChildAfter(child);
     }
 
     return index;

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -177,9 +177,11 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
           // the same and will always be greater than equal to that of the
           // visible child (at index 0), to keep the size of the entire
           // SegmentedControl widget consistent throughout the animation.
-          DefaultTextStyle.merge(
-            style: const TextStyle(fontWeight: FontWeight.w500),
-            child: widget.child,
+          Offstage(
+            child: DefaultTextStyle.merge(
+              style: const TextStyle(fontWeight: FontWeight.w500),
+              child: widget.child,
+            ),
           ),
         ],
       ),
@@ -1094,8 +1096,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
       final _SegmentedControlContainerBoxParentData childParentData = selectedChild.parentData! as _SegmentedControlContainerBoxParentData;
       final Rect newThumbRect = _kThumbInsets.inflateRect(childParentData.offset & selectedChild.size);
-print('selectedChild.size: ${selectedChild.size}');
-print('newThumbRect.width: ${newThumbRect.width}');
+
       // Update thumb animation's tween, in case the end rect changed (e.g., a
       // new segment is added during the animation).
       if (state.thumbController.isAnimating) {

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -85,8 +85,7 @@ const Duration _kHighlightAnimationDuration = Duration(milliseconds: 200);
 
 class _Segment<T> extends StatefulWidget {
   const _Segment({
-    required ValueKey<T> key,
-    required this.globalKey,
+    required GlobalKey key,
     required this.child,
     required this.pressed,
     required this.highlighted,
@@ -94,7 +93,6 @@ class _Segment<T> extends StatefulWidget {
   }) : super(key: key);
 
   final Widget child;
-  final GlobalKey globalKey;
 
   final bool pressed;
   final bool highlighted;
@@ -512,6 +510,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
 
   double? _getSegmentWidth(GlobalKey key) {
     final BuildContext? context = key.currentContext;
+    print('context is null? ${context == null}');
     if (context != null) {
       final RenderBox box = context.findRenderObject()! as RenderBox;
       return box.hasSize ? box.size.width : null;
@@ -538,12 +537,13 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
         final GlobalKey key = segmentToKeys[widget.children.keys.elementAt(ltrIndex)]!;
         final double segmentWidth = _getSegmentWidth(key) ?? 0.0;
         subtotalWidth += segmentWidth;
+        print('dx: $dx, subtotal: $subtotalWidth, ltrIndex: $ltrIndex');
         if (dx <= subtotalWidth) {
           return widget.children.keys.elementAt(ltrIndex);
         }
       }
     }
-
+print('ERROR: should not come here');
     int index = (dx ~/ (renderBox.size.width / numOfChildren)).clamp(0, numOfChildren - 1);
 
     switch (Directionality.of(context)) {
@@ -710,8 +710,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
           child: MouseRegion(
             cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
             child: _Segment<T>(
-              key: ValueKey<T>(entry.key),
-              globalKey: segmentToKeys[entry.key]!,
+              key: segmentToKeys[entry.key]!,
               highlighted: isHighlighted,
               pressed: pressed == entry.key,
               isDragging: isThumbDragging,

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1041,7 +1041,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     return segmentWidths;
   }
 
-  Size _computeOverallSizeFromChildSize(BoxConstraints constraints) {
+  Size _computeOverallSize(BoxConstraints constraints) {
     final double maxChildHeight = _getMaxChildHeight(constraints, constraints.maxWidth);
     if (proportionalWidth) {
       return constraints.constrain(Size(_getChildIntrinsicWidths(constraints).sum + totalSeparatorWidth, maxChildHeight));
@@ -1065,7 +1065,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    return _computeOverallSizeFromChildSize(constraints);
+    return _computeOverallSize(constraints);
   }
 
   @override
@@ -1098,7 +1098,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
       child = childAfter(child);
       index += 1;
     }
-    size = _computeOverallSizeFromChildSize(constraints);
+    size = _computeOverallSize(constraints);
   }
 
   // This method is used to convert the original unscaled thumb rect painted in

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -977,12 +977,6 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     }
   }
 
-  Size _calculateChildSize(BoxConstraints constraints) {
-    final double childWidth = _getMaxChildWidth(constraints);
-    final double maxHeight = _getMaxChildHeight(constraints, childWidth);
-    return Size(childWidth, maxHeight);
-  }
-
   double _getMaxChildWidth(BoxConstraints constraints) {
     final int childCount = this.childCount ~/ 2 + 1;
     double childWidth = (constraints.minWidth - totalSeparatorWidth) / childCount;
@@ -1049,13 +1043,23 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
   @override
   double? computeDryBaseline(covariant BoxConstraints constraints, TextBaseline baseline) {
-    final Size childSize = _calculateChildSize(constraints);
-    final BoxConstraints childConstraints = BoxConstraints.tight(childSize);
+    final List<double> segmentWidths = _getChildWidths(constraints);
 
+    final double childHeight = _getMaxChildHeight(constraints, constraints.maxWidth);
+    final BoxConstraints separatorConstraints = BoxConstraints(minHeight: childHeight, maxHeight: childHeight);
+
+    int index = 0;
     BaselineOffset baselineOffset = BaselineOffset.noBaseline;
-    for (RenderBox? child = firstChild; child != null; child = childAfter(child)) {
-      baselineOffset = baselineOffset.minOf(BaselineOffset(child.getDryBaseline(childConstraints, baseline)));
+    RenderBox? child = firstChild;
+    while (child != null) {
+      final BoxConstraints childConstraints = BoxConstraints.tight(Size(segmentWidths[index ~/ 2], childHeight));
+      final BoxConstraints constraints = index.isEven ? childConstraints : separatorConstraints;
+      baselineOffset = baselineOffset.minOf(BaselineOffset(child.getDryBaseline(constraints, baseline)));
+
+      child = childAfter(child);
+      index++;
     }
+
     return baselineOffset.offset;
   }
 

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -324,7 +324,7 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
     this.thumbColor = _kThumbColor,
     this.padding = _kHorizontalItemPadding,
     this.backgroundColor = CupertinoColors.tertiarySystemFill,
-    this.isProportionalSegment = false,
+    this.proportionalWidth = false,
   }) : assert(children.length >= 2),
        assert(
          groupValue == null || children.keys.contains(groupValue),
@@ -397,10 +397,10 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   /// will not be painted if null is specified.
   final Color backgroundColor;
 
-  /// Determine whether segments have equal widths or proportional widths based
-  /// on their content. If false, all segment will have the same width, determined
-  /// by the longest segment. If true, each segment's width will be determined
-  /// by its individual content.
+  /// Determine whether segments have proportional widths based on their content.
+  /// If false, all segments will have the same width, determined by the longest
+  /// segment. If true, each segment's width will be determined by its individual
+  /// content.
   ///
   /// If the max width of parent constraints is smaller than the width that the
   /// segmented control needs, The segment widths will scale down proportionally
@@ -409,7 +409,7 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   /// up to meet the min width requirement.
   ///
   /// Defaults to false.
-  final bool isProportionalSegment;
+  final bool proportionalWidth;
 
   /// The color used to paint the interior of the thumb that appears behind the
   /// currently selected item.
@@ -503,7 +503,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
   // them from interfering with the active drag gesture.
   bool get isThumbDragging => _startedOnSelectedSegment ?? false;
 
-  // Converts local coordinate to segments. If `widget.isProportionalSegment` is
+  // Converts local coordinate to segments. If `widget.proportionalWidth` is
   // false, this method assumes each segment has the same width; if it is true,
   // this method assumes segments have their own width based on their contents.
   T segmentForXPosition(double dx) {
@@ -511,7 +511,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     final BuildContext currentContext = segmentedControlRenderWidgetKey.currentContext!;
     final _RenderSegmentedControl<T> renderBox = currentContext.findRenderObject()! as _RenderSegmentedControl<T>;
 
-    if (widget.isProportionalSegment) {
+    if (widget.proportionalWidth) {
       final int? segmentIndex = renderBox.getSegmentIndex(dx, textDirection);
       assert(segmentIndex != null);
       return widget.children.keys.elementAt(segmentIndex!);
@@ -728,7 +728,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
               highlightedIndex: highlightedIndex,
               thumbColor: CupertinoDynamicColor.resolve(widget.thumbColor, context),
               thumbScale: thumbScaleAnimation.value,
-              isProportionalSegment: widget.isProportionalSegment,
+              proportionalWidth: widget.proportionalWidth,
               state: this,
               children: children,
             );
@@ -746,14 +746,14 @@ class _SegmentedControlRenderWidget<T extends Object> extends MultiChildRenderOb
     required this.highlightedIndex,
     required this.thumbColor,
     required this.thumbScale,
-    required this.isProportionalSegment,
+    required this.proportionalWidth,
     required this.state,
   });
 
   final int? highlightedIndex;
   final Color thumbColor;
   final double thumbScale;
-  final bool isProportionalSegment;
+  final bool proportionalWidth;
   final _SegmentedControlState<T> state;
 
   @override
@@ -762,7 +762,7 @@ class _SegmentedControlRenderWidget<T extends Object> extends MultiChildRenderOb
       highlightedIndex: highlightedIndex,
       thumbColor: thumbColor,
       thumbScale: thumbScale,
-      isProportionalSegment: isProportionalSegment,
+      proportionalWidth: proportionalWidth,
       state: state,
     );
   }
@@ -774,7 +774,7 @@ class _SegmentedControlRenderWidget<T extends Object> extends MultiChildRenderOb
       ..thumbColor = thumbColor
       ..thumbScale = thumbScale
       ..highlightedIndex = highlightedIndex
-      ..isProportionalSegment = isProportionalSegment;
+      ..proportionalWidth = proportionalWidth;
   }
 }
 
@@ -819,12 +819,12 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     required int? highlightedIndex,
     required Color thumbColor,
     required double thumbScale,
-    required bool isProportionalSegment,
+    required bool proportionalWidth,
     required this.state,
   }) : _highlightedIndex = highlightedIndex,
        _thumbColor = thumbColor,
        _thumbScale = thumbScale,
-       _isProportionalSegment = isProportionalSegment;
+       _proportionalWidth = proportionalWidth;
 
   final _SegmentedControlState<T> state;
 
@@ -877,13 +877,13 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     markNeedsPaint();
   }
 
-  bool get isProportionalSegment => _isProportionalSegment;
-  bool _isProportionalSegment;
-  set isProportionalSegment(bool value) {
-    if (_isProportionalSegment == value) {
+  bool get proportionalWidth => _proportionalWidth;
+  bool _proportionalWidth;
+  set proportionalWidth(bool value) {
+    if (_proportionalWidth == value) {
       return;
     }
-    _isProportionalSegment = value;
+    _proportionalWidth = value;
     markNeedsLayout();
   }
 
@@ -1054,7 +1054,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
   Size _computeOverallSizeFromChildSize(BoxConstraints constraints) {
     final double maxChildHeight = _getMaxChildHeight(constraints, constraints.maxWidth);
-    if (isProportionalSegment) {
+    if (proportionalWidth) {
       return constraints.constrain(Size(_getChildIntrinsicWidths(constraints).sum + totalSeparatorWidth, maxChildHeight));
     }
     final int childCount = this.childCount ~/ 2 + 1;
@@ -1083,7 +1083,7 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
   void performLayout() {
     final BoxConstraints constraints = this.constraints;
 
-    if (isProportionalSegment) {
+    if (proportionalWidth) {
       childWidths = _getChildIntrinsicWidths(constraints);
     } else {
       final Size childSize = _calculateChildSize(constraints);

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -899,13 +899,19 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
     int index = 0;
     while (index < segmentWidths.length) {
       final double segmentWidth = segmentWidths[index];
-      subtotalWidth += segmentWidth + separatorWidth / 2;
+      if (index == 0 || index == segmentWidths.length - 1) {
+        subtotalWidth += separatorWidth / 2;
+      } else {
+        subtotalWidth += separatorWidth;
+      }
 
+      subtotalWidth += segmentWidth;
       if (dx <= subtotalWidth) {
         break;
       }
       index++;
     }
+
     return index;
   }
 

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1026,21 +1026,14 @@ class _RenderSegmentedControl<T extends Object> extends RenderBox
 
     // If the sum of the children's width is larger than the allowed max width,
     // each segment width should scale down until the overall size can fit in
-    // the parent constraints.
+    // the parent constraints; similarly, if the sum of the children's width is
+    // smaller than the allowed min width, each segment width should scale up
+    // until the overall size can fit in the parent constraints.
     final double allowedMaxWidth = constraints.maxWidth - totalSeparatorWidth;
-    if (totalWidth > allowedMaxWidth) {
-      final double scale = allowedMaxWidth / totalWidth;
-      for (int i = 0; i < segmentWidths.length; i++) {
-        segmentWidths[i] = segmentWidths[i] * scale;
-      }
-    }
-
-    // If the sum of the children's width is smaller than the allowed min width,
-    // each segment width should scale up until the overall size can fit in
-    // the parent constraints.
     final double allowedMinWidth = constraints.minWidth - totalSeparatorWidth;
-    if (totalWidth < allowedMinWidth) {
-      final double scale = allowedMinWidth / totalWidth;
+
+    final double scale = clampDouble(totalWidth, allowedMinWidth, allowedMaxWidth) / totalWidth;
+    if (scale != 1) {
       for (int i = 0; i < segmentWidths.length; i++) {
         segmentWidths[i] = segmentWidths[i] * scale;
       }

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -563,28 +563,22 @@ void main() {
       ),
     );
 
-    final Size firstChildSize = tester.getSize(
-      find.ancestor(
-        of: find.byWidget(children[0]!),
-        matching: find.byType(MetaData)
-      )
-    );
+    Size getChildSize(int index) {
+      return tester.getSize(
+        find.ancestor(
+          of: find.byWidget(children[index]!),
+          matching: find.byType(MetaData)
+        )
+      );
+    }
+
+    final Size firstChildSize = getChildSize(0);
     expect(firstChildSize.width, 50 + 9.25 * 2);
 
-    final Size secondChildSize = tester.getSize(
-      find.ancestor(
-        of: find.byWidget(children[1]!),
-        matching: find.byType(MetaData)
-      )
-    );
+    final Size secondChildSize = getChildSize(1);
     expect(secondChildSize.width, 100 + 9.25 * 2);
 
-    final Size thirdChildSize = tester.getSize(
-      find.ancestor(
-        of: find.byWidget(children[2]!),
-        matching: find.byType(MetaData)
-      )
-    );
+    final Size thirdChildSize = getChildSize(2);
     expect(thirdChildSize.width, 70 + 9.25 * 2);
 
     // Overall segment control width is the sum of the segment widths + horizontal paddings + 2 separator width.

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -647,13 +647,6 @@ void main() {
 
     thirdChildSize = getChildSize(2);
     expect(thirdChildSize.width, 170 + 9.25 * 2);
-    // // Overall segment control width is the sum of the segment widths + horizontal paddings + 2 separator width.
-    // final RenderBox segmentedControl = tester.renderObject(
-    //   find.byKey(const ValueKey<String>('Segmented Control')),
-    // );
-
-    // final double childWidthSum = firstChildSize.width + secondChildSize.width + thirdChildSize.width;
-    // expect(segmentedControl.size.width, childWidthSum + 6.0 + 2.0);
   });
 
 

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -973,6 +973,46 @@ void main() {
     expect(groupValue, 1);
   });
 
+  testWidgets('Non-centered taps work on propotional segments', (WidgetTester tester) async {
+    final Map<int, Widget> children = <int, Widget>{};
+    children[0] = const SizedBox(width: 50, height: 30);
+    children[1] = const SizedBox();
+    children[2] = const SizedBox(width: 100, height: 30);
+
+    await tester.pumpWidget(
+      boilerplate(
+        builder: (BuildContext context) {
+          return CupertinoSlidingSegmentedControl<int>(
+            key: const ValueKey<String>('Segmented Control'),
+            isProportionalSegment: true,
+            children: children,
+            groupValue: groupValue,
+            onValueChanged: defaultCallback,
+          );
+        },
+      ),
+    );
+
+    expect(groupValue, 0);
+
+    final Rect firstChild = tester.getRect(find.ancestor(of: find.byWidget(children[0]!), matching: find.byType(MetaData)));
+    expect(firstChild.width, 50.0 + 9.25 * 2);
+
+    final Rect secondChild = tester.getRect(find.ancestor(of: find.byWidget(children[1]!), matching: find.byType(MetaData)));
+    expect(secondChild.width, 0.0 + 9.25 * 2);
+
+    final Rect thirdChild = tester.getRect(find.ancestor(of: find.byWidget(children[2]!), matching: find.byType(MetaData)));
+    expect(thirdChild.width, 100.0  + 9.25 * 2);
+
+    final Finder child0 = find.ancestor(of: find.byWidget(children[0]!), matching: find.byType(MetaData));
+    final Offset centerOfChild0 = tester.getCenter(child0);
+    await tester.tapAt(centerOfChild0 + Offset(firstChild.width / 2 + 1, 0));
+    expect(groupValue, 1);
+
+    await tester.tapAt(centerOfChild0 + Offset(firstChild.width / 2 + 1 + secondChild.width + 1, 0));
+    expect(groupValue, 2);
+  });
+
   testWidgets('Hit-tests report accurate local position in segments', (WidgetTester tester) async {
     final Map<int, Widget> children = <int, Widget>{};
     late TapDownDetails tapDownDetails;
@@ -988,6 +1028,39 @@ void main() {
         builder: (BuildContext context) {
           return CupertinoSlidingSegmentedControl<int>(
             key: const ValueKey<String>('Segmented Control'),
+            children: children,
+            groupValue: groupValue,
+            onValueChanged: defaultCallback,
+          );
+        },
+      ),
+    );
+
+    expect(groupValue, 0);
+
+    final Offset segment0GlobalOffset = tester.getTopLeft(find.byWidget(children[0]!));
+    await tester.tapAt(segment0GlobalOffset + const Offset(7, 11));
+
+    expect(tapDownDetails.localPosition, const Offset(7, 11));
+    expect(tapDownDetails.globalPosition, segment0GlobalOffset + const Offset(7, 11));
+  });
+
+  testWidgets('Hit-tests report accurate local position in proportional segments', (WidgetTester tester) async {
+    final Map<int, Widget> children = <int, Widget>{};
+    late TapDownDetails tapDownDetails;
+    children[0] = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: (TapDownDetails details) { tapDownDetails = details; },
+      child: const SizedBox(width: 200, height: 200),
+    );
+    children[1] = const Text('Child 2');
+
+    await tester.pumpWidget(
+      boilerplate(
+        builder: (BuildContext context) {
+          return CupertinoSlidingSegmentedControl<int>(
+            key: const ValueKey<String>('Segmented Control'),
+            isProportionalSegment: true,
             children: children,
             groupValue: groupValue,
             onValueChanged: defaultCallback,

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -541,7 +541,7 @@ void main() {
     expect(childWidth, 200.0 + 9.25 * 2);
   });
 
-  testWidgets('If isProportionalSegment is true, the width of each segmented '
+  testWidgets('If proportionalWidth is true, the width of each segmented '
   'control segment is determined by its own content', (WidgetTester tester) async {
     final Map<int, Widget> children = <int, Widget>{
       0: const SizedBox(width: 50, child: Text('First')),
@@ -556,7 +556,7 @@ void main() {
             key: const ValueKey<String>('Segmented Control'),
             children: children,
             groupValue: groupValue,
-            isProportionalSegment: true,
+            proportionalWidth: true,
             onValueChanged: defaultCallback,
           );
         },
@@ -590,7 +590,7 @@ void main() {
     expect(segmentedControl.size.width, childWidthSum + 6.0 + 2.0);
   });
 
-  testWidgets('If isProportionalSegment is true, the width of each segmented '
+  testWidgets('If proportionalWidth is true, the width of each segmented '
   'control segment is updated when children change', (WidgetTester tester) async {
     Map<int, Widget> children = <int, Widget>{
       0: const SizedBox(width: 50, child: Text('First')),
@@ -605,7 +605,7 @@ void main() {
             key: const ValueKey<String>('Segmented Control'),
             children: children,
             groupValue: groupValue,
-            isProportionalSegment: true,
+            proportionalWidth: true,
             onValueChanged: defaultCallback,
           );
         },
@@ -650,7 +650,7 @@ void main() {
   });
 
 
-  testWidgets('If isProportionalSegment is true and the overall segment control width '
+  testWidgets('If proportionalWidth is true and the overall segment control width '
   'is larger than the max width of the parent constraints, each segment scales down', (WidgetTester tester) async {
     final Map<int, Widget> children = <int, Widget>{
       0: const SizedBox(width: 50, child: Text('First')),
@@ -667,7 +667,7 @@ void main() {
               key: const ValueKey<String>('Segmented Control'),
               children: children,
               groupValue: groupValue,
-              isProportionalSegment: true,
+              proportionalWidth: true,
               onValueChanged: defaultCallback,
             ),
           );
@@ -699,7 +699,7 @@ void main() {
     expect(thirdChildSize.width, (200 + 9.25 * 2) * maxAllowedTotal / originalTotal);
   });
 
-  testWidgets('If isProportionalSegment is true and the overall segment control width '
+  testWidgets('If proportionalWidth is true and the overall segment control width '
   'is smaller than the min width of the parent constraints, each segment scales up', (WidgetTester tester) async {
     final Map<int, Widget> children = <int, Widget>{
       0: const SizedBox(width: 20, child: Text('First')),
@@ -716,7 +716,7 @@ void main() {
               key: const ValueKey<String>('Segmented Control'),
               children: children,
               groupValue: groupValue,
-              isProportionalSegment: true,
+              proportionalWidth: true,
               onValueChanged: defaultCallback,
             ),
           );
@@ -977,7 +977,7 @@ void main() {
         builder: (BuildContext context) {
           return CupertinoSlidingSegmentedControl<int>(
             key: const ValueKey<String>('Segmented Control'),
-            isProportionalSegment: true,
+            proportionalWidth: true,
             children: children,
             groupValue: groupValue,
             onValueChanged: defaultCallback,
@@ -1053,7 +1053,7 @@ void main() {
         builder: (BuildContext context) {
           return CupertinoSlidingSegmentedControl<int>(
             key: const ValueKey<String>('Segmented Control'),
-            isProportionalSegment: true,
+            proportionalWidth: true,
             children: children,
             groupValue: groupValue,
             onValueChanged: defaultCallback,

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -586,6 +586,14 @@ void main() {
       )
     );
     expect(thirdChildSize.width, 70 + 9.25 * 2);
+
+    // Overall segment control width is the sum of the segment widths + horizontal paddings + 2 separator width.
+    final RenderBox segmentedControl = tester.renderObject(
+      find.byKey(const ValueKey<String>('Segmented Control')),
+    );
+
+    final double childWidthSum = firstChildSize.width + secondChildSize.width + thirdChildSize.width;
+    expect(segmentedControl.size.width, childWidthSum + 6.0 + 2.0);
   });
 
   testWidgets('Width is finite in unbounded space', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -510,7 +510,7 @@ void main() {
     );
   });
 
-  testWidgets('Width of each segmented control segment is determined by widest widget', (WidgetTester tester) async {
+  testWidgets('Width of each segmented control segment is determined by widest widget by default', (WidgetTester tester) async {
     final Map<int, Widget> children = <int, Widget>{
       0: Container(constraints: const BoxConstraints.tightFor(width: 50.0)),
       1: Container(constraints: const BoxConstraints.tightFor(width: 100.0)),
@@ -539,6 +539,53 @@ void main() {
     final double childWidth = (segmentedControl.size.width - 8) / 3;
 
     expect(childWidth, 200.0 + 9.25 * 2);
+  });
+
+  testWidgets('If isProportionalSegment is true, the width of each segmented '
+  'control segment is determined by its own content', (WidgetTester tester) async {
+    final Map<int, Widget> children = <int, Widget>{
+      0: const SizedBox(width: 50, child: Text('First')),
+      1: const SizedBox(width: 100, child: Text('Second')),
+      2: const SizedBox(width: 70, child: Text('Third')),
+    };
+
+    await tester.pumpWidget(
+      boilerplate(
+        builder: (BuildContext context) {
+          return CupertinoSlidingSegmentedControl<int>(
+            key: const ValueKey<String>('Segmented Control'),
+            children: children,
+            groupValue: groupValue,
+            isProportionalSegment: true,
+            onValueChanged: defaultCallback,
+          );
+        },
+      ),
+    );
+
+    final Size firstChildSize = tester.getSize(
+      find.ancestor(
+        of: find.byWidget(children[0]!),
+        matching: find.byType(MetaData)
+      )
+    );
+    expect(firstChildSize.width, 50 + 9.25 * 2);
+
+    final Size secondChildSize = tester.getSize(
+      find.ancestor(
+        of: find.byWidget(children[1]!),
+        matching: find.byType(MetaData)
+      )
+    );
+    expect(secondChildSize.width, 100 + 9.25 * 2);
+
+    final Size thirdChildSize = tester.getSize(
+      find.ancestor(
+        of: find.byWidget(children[2]!),
+        matching: find.byType(MetaData)
+      )
+    );
+    expect(thirdChildSize.width, 70 + 9.25 * 2);
   });
 
   testWidgets('Width is finite in unbounded space', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -590,6 +590,59 @@ void main() {
     expect(segmentedControl.size.width, childWidthSum + 6.0 + 2.0);
   });
 
+  testWidgets('proportionalWidth rebuild', (WidgetTester tester) async {
+    final Map<int, Widget> children = <int, Widget>{
+      0: const SizedBox(width: 50, child: Text('First')),
+      1: const SizedBox(width: 200, child: Text('Second')),
+      2: const SizedBox(width: 70, child: Text('Third')),
+    };
+    bool proportionalWidth = false;
+
+    await tester.pumpWidget(
+      boilerplate(
+        builder: (BuildContext context) {
+          return CupertinoSlidingSegmentedControl<int>(
+            key: const ValueKey<String>('Segmented Control'),
+            children: children,
+            proportionalWidth: proportionalWidth,
+            groupValue: groupValue,
+            onValueChanged: defaultCallback,
+          );
+        },
+      ),
+    );
+
+    Size getChildSize(int index) {
+      return tester.getSize(
+        find.ancestor(
+          of: find.byWidget(children[index]!),
+          matching: find.byType(MetaData)
+        )
+      );
+    }
+
+    Size firstChildSize = getChildSize(0);
+    expect(firstChildSize.width, 200 + 9.25 * 2);
+
+    Size secondChildSize = getChildSize(1);
+    expect(secondChildSize.width, 200 + 9.25 * 2);
+
+    Size thirdChildSize = getChildSize(2);
+    expect(thirdChildSize.width, 200 + 9.25 * 2);
+
+    setState!(() { proportionalWidth = true; });
+    await tester.pump();
+
+    firstChildSize = getChildSize(0);
+    expect(firstChildSize.width, 50 + 9.25 * 2);
+
+    secondChildSize = getChildSize(1);
+    expect(secondChildSize.width, 200 + 9.25 * 2);
+
+    thirdChildSize = getChildSize(2);
+    expect(thirdChildSize.width, 70 + 9.25 * 2);
+  });
+
   testWidgets('If proportionalWidth is true, the width of each segmented '
   'control segment is updated when children change', (WidgetTester tester) async {
     Map<int, Widget> children = <int, Widget>{


### PR DESCRIPTION
This PR is to add `isProportionalSegment` property to `CupertinoSlidingSegmentedControl`. Originally, the width of each segment is determined by the widest segment and they have equal width. With this property setting to true, the width of each segment is determined by their own contents.

If the max width from parent constraints is smaller than the width that the segmented control needed, each of the segment width will be scaled down; if the min width from parent constraints is larger than the width that the segmented control needed, each of the segment width will be scaled up.

![Screenshot 2024-08-15 at 12 10 44 PM](https://github.com/user-attachments/assets/e32284ac-4169-43ce-9181-3f1d112c5702)

related to: https://github.com/flutter/flutter/issues/43826

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
