### PR TITLE
Also run Linux_android_emu tests on API level 34 image

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -58,6 +58,23 @@ platform_properties:
       cores: "8"
       device_type: none
       kvm: "1"
+  linux_android_emu_34:
+    properties:
+      contexts: >-
+        [
+          "android_virtual_device"
+        ]
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:34v3"},
+          {"dependency": "android_virtual_device", "version": "android_34_google_apis_x64.textpb"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8741513191637853009"},
+          {"dependency": "open_jdk", "version": "version:17"}
+        ]
+      os: Ubuntu
+      cores: "8"
+      device_type: none
+      kvm: "1"
   linux_build_test:
     properties:
       dependencies: >-
@@ -376,6 +393,15 @@ targets:
 
   - name: Linux_android_emu android views
     recipe: devicelab/devicelab_drone
+    properties:
+      tags: >
+        ["framework","hostonly","linux"]
+      task_name: android_views
+    timeout: 60
+
+  - name: Linux_android_emu_34 android views
+    recipe: devicelab/devicelab_drone
+    bringup: true
     properties:
       tags: >
         ["framework","hostonly","linux"]
@@ -1304,6 +1330,19 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
         ]
 
+  - name: Linux_android_emu_34 flutter_driver_android_test
+    recipe: flutter/flutter_drone
+    bringup: true
+    timeout: 60
+    properties:
+      shard: flutter_driver_android
+      tags: >
+         ["framework", "hostonly", "shard", "linux"]
+      dependencies: >-
+        [
+          {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
+        ]
+
   - name: Linux realm_checker
     recipe: flutter/flutter_drone
     timeout: 60
@@ -2036,6 +2075,15 @@ targets:
         ["devicelab", "linux"]
       task_name: android_defines_test
 
+  - name: Linux_android_emu_34 android_defines_test
+    recipe: devicelab/devicelab_drone
+    bringup: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "linux"]
+      task_name: android_defines_test
+
   - name: Linux_pixel_7pro android_obfuscate_test
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2454,6 +2502,21 @@ targets:
 
   - name: Linux_android_emu external_textures_integration_test
     recipe: devicelab/devicelab_drone
+    timeout: 60
+    # Functionally the same as "presubmit: false", except that we will run on
+    # presubmit during engine rolls. This test is the *only* automated e2e
+    # test for external textures for the engine, it should never break.
+    runIf:
+      - bin/internal/engine.version
+      - .ci.yaml
+    properties:
+      tags: >
+        ["devicelab", "linux"]
+      task_name: external_textures_integration_test
+
+  - name: Linux_android_emu_34 external_textures_integration_test
+    recipe: devicelab/devicelab_drone
+    bringup: true
     timeout: 60
     # Functionally the same as "presubmit: false", except that we will run on
     # presubmit during engine rolls. This test is the *only* automated e2e


### PR DESCRIPTION
These VMs are relatively inexpensive, so there's no reason not to continue running on the API level 34 image while we work out how to deal with the apparent instability in the 35 images.

Related: https://github.com/flutter/flutter/issues/152684