### PR TITLE
Change flag internalAddSemanticForOnTap default value to true

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -410,7 +410,7 @@ class ListTile extends StatelessWidget {
     this.minLeadingWidth,
     this.minTileHeight,
     this.titleAlignment,
-    this.internalAddSemanticForOnTap = false,
+    this.internalAddSemanticForOnTap = true,
   }) : assert(!isThreeLine || subtitle != null);
 
   /// A widget to display before the title.

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -270,22 +270,18 @@ void main() {
               children: <Widget>[
                 const ListTile(
                   title: Text('one'),
-                  internalAddSemanticForOnTap: true,
                 ),
                 ListTile(
                   title: const Text('two'),
                   onTap: () {},
-                  internalAddSemanticForOnTap: true,
                 ),
                 const ListTile(
                   title: Text('three'),
                   selected: true,
-                  internalAddSemanticForOnTap: true,
                 ),
                 const ListTile(
                   title: Text('four'),
                   enabled: false,
-                  internalAddSemanticForOnTap: true,
                 ),
               ],
             ),


### PR DESCRIPTION
This is a follow up on https://github.com/flutter/flutter/pull/152526 


1. Make changes with an additional parameter ( bool internalAddSemanticForOnTap = false) (https://github.com/flutter/flutter/pull/152526 )
2. Send regular CLs in google3 to pass internalAddSemanticForOnTap: true, and update the tests / text goldens 3. accordingly.  g3 fix sent:  cl/661353802
3. Send a PR to flip the default value to true. (This PR)
4. Send CLs internally to remove internalAddSemanticForOnTap: true.
5. Send another PR to remove the now-redundant internalAddSemanticForOnTap flag.
(<----This PR is step 3)

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
