### PR TITLE
In native_assets_test, ignore a failure to delete a temp directory

### DIFF
--- a/dev/devicelab/lib/tasks/native_assets_test.dart
+++ b/dev/devicelab/lib/tasks/native_assets_test.dart
@@ -216,6 +216,10 @@ Future<T> inTempDir<T>(Future<T> Function(Directory tempDirectory) fun) async {
   try {
     return await fun(tempDirectory);
   } finally {
-    tempDirectory.deleteSync(recursive: true);
+    try {
+      tempDirectory.deleteSync(recursive: true);
+    } catch (_) {
+      // Ignore failures to delete a temporary directory.
+    }
   }
 }


### PR DESCRIPTION
Tree closed on failures like:

https://ci.chromium.org/ui/p/flutter/builders/prod/Windows_mokey%20native_assets_android/6/overview