### PR TITLE
[WIP DO NOT REVIEW] Add new assert and verbosity to existing assert

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -906,7 +906,10 @@ class AnimationController extends Animation<double>
   void _tick(Duration elapsed) {
     _lastElapsedDuration = elapsed;
     final double elapsedInSeconds = elapsed.inMicroseconds.toDouble() / Duration.microsecondsPerSecond;
-    assert(elapsedInSeconds >= 0.0);
+    assert(
+      elapsedInSeconds >= 0.0,
+      'elapsedInSeconds was expected to be >= 0, but it was $elapsedInSeconds ($elapsed)',
+    );
     _value = clampDouble(_simulation!.x(elapsedInSeconds), lowerBound, upperBound);
     if (_simulation!.isDone(elapsedInSeconds)) {
       _status = (_direction == _AnimationDirection.forward) ?

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -1066,7 +1066,19 @@ mixin SchedulerBinding on BindingBase {
 
   Duration? _firstRawTimeStampInEpoch;
   Duration _epochStart = Duration.zero;
-  Duration _lastRawTimeStamp = Duration.zero;
+
+  // TODO(tvolkert): this indirection was added to aid in tracking down
+  // https://github.com/flutter/flutter/issues/106277; remove the indirection
+  // once the issue has been resolved.
+  Duration __lastRawTimeStamp = Duration.zero;
+  Duration get _lastRawTimeStamp => __lastRawTimeStamp;
+  set _lastRawTimeStamp(Duration value) {
+    assert(
+      value >= __lastRawTimeStamp,
+      'Frame timestamp ($value) is before last known frame timestamp ($__lastRawTimeStamp)',
+    );
+    __lastRawTimeStamp = value;
+  }
 
   /// Prepares the scheduler for a non-monotonic change to how time stamps are
   /// calculated.


### PR DESCRIPTION
This is intended to help track down flutter/flutter#106277. The new assert can be removed once the issue has been resolved.

Relevant issue: flutter/flutter#106277

[test-exempt]: this is intended to catch a case that should never happen in the engine (sending a timestamp older than one it previously sent), so I'm unable to test this case since causing the assert to hit would involve adding code to the engine that we don't want in the engine :-)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
