### PR TITLE
Fix image: Clearing rendered images at an inappropriate time.

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1087,7 +1087,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
       _imageStream!.removeListener(oldListener);
     }
     if (widget.image != oldWidget.image) {
-      _resolveImage();
+      _resolveImage(updatedImage: true);
     }
   }
 
@@ -1110,7 +1110,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
         ?? SemanticsBinding.instance.accessibilityFeatures.invertColors;
   }
 
-  void _resolveImage() {
+  void _resolveImage({bool updatedImage = false}) {
     final ScrollAwareImageProvider provider = ScrollAwareImageProvider<Object>(
       context: _scrollAwareContext,
       imageProvider: widget.image,
@@ -1120,7 +1120,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
         context,
         size: widget.width != null && widget.height != null ? Size(widget.width!, widget.height!) : null,
       ));
-    _updateSourceStream(newStream);
+    _updateSourceStream(newStream, updatedImage: updatedImage);
   }
 
   ImageStreamListener? _imageStreamListener;
@@ -1183,7 +1183,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   // Updates _imageStream to newStream, and moves the stream listener
   // registration from the old stream to the new stream (if a listener was
   // registered).
-  void _updateSourceStream(ImageStream newStream) {
+  void _updateSourceStream(ImageStream newStream, {bool updatedImage = false}) {
     if (_imageStream?.key == newStream.key) {
       return;
     }
@@ -1192,7 +1192,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
       _imageStream!.removeListener(_getListener());
     }
 
-    if (!widget.gaplessPlayback) {
+    if (updatedImage && !widget.gaplessPlayback) {
       setState(() { _replaceImage(info: null); });
     }
 

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -2123,6 +2123,57 @@ void main() {
 
     codec.dispose();
   });
+
+  testWidgets('Do not clean up rendered images if the Image Provider is not updated', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    final _TestImageProvider imageProvider1 = _TestImageProvider();
+    await tester.pumpWidget(
+      Container(
+        key: key,
+        child: Image(
+          image: imageProvider1,
+          excludeFromSemantics: true,
+        ),
+      ),
+      phase: EnginePhase.layout,
+    );
+
+    imageProvider1.complete(image10x10);
+    await tester.idle();
+    await tester.pump(null, EnginePhase.layout);
+
+    RenderImage renderImage = key.currentContext!.findRenderObject()! as RenderImage;
+    expect(renderImage.image, isNotNull);
+
+    await tester.pumpWidget(
+      Container(
+        key: key,
+        child: Image(
+          image: imageProvider1,
+          excludeFromSemantics: true,
+        ),
+      ),
+      phase: EnginePhase.layout,
+    );
+
+    renderImage = key.currentContext!.findRenderObject()! as RenderImage;
+    expect(renderImage.image, isNotNull);
+    
+    final _TestImageProvider imageProvider2 = _TestImageProvider();
+    await tester.pumpWidget(
+      Container(
+        key: key,
+        child: Image(
+          image: imageProvider2,
+          excludeFromSemantics: true,
+        ),
+      ),
+      phase: EnginePhase.layout,
+    );
+
+    renderImage = key.currentContext!.findRenderObject()! as RenderImage;
+    expect(renderImage.image, isNull);
+  });
 }
 
 @immutable


### PR DESCRIPTION
Fixed: 
https://github.com/flutter/flutter/issues/153265
https://github.com/flutter/flutter/issues/124382#issuecomment-1563726475

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
