### PR TITLE
Retry Linux_android_emu tests in presubmit like they are in postsubmit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -407,6 +407,7 @@ targets:
       tags: >
         ["framework","hostonly","linux"]
       task_name: android_views
+      presubmit_max_attempts: "2"
     timeout: 60
 
   - name: Linux_android_emu_34 android views
@@ -1339,6 +1340,7 @@ targets:
         [
           {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
         ]
+      presubmit_max_attempts: "2"
 
   - name: Linux_android_emu_34 flutter_driver_android_test
     recipe: flutter/flutter_drone
@@ -2084,6 +2086,7 @@ targets:
       tags: >
         ["devicelab", "linux"]
       task_name: android_defines_test
+      presubmit_max_attempts: "2"
 
   - name: Linux_android_emu_34 android_defines_test
     recipe: devicelab/devicelab_drone
@@ -2523,6 +2526,7 @@ targets:
       tags: >
         ["devicelab", "linux"]
       task_name: external_textures_integration_test
+      presubmit_max_attempts: "2"
 
   - name: Linux_android_emu_34 external_textures_integration_test
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
To help keep rolls unblocked while the flakiness of these tests is investigated.
