### PR TITLE
Enable invalid_runtime_check_with_js_interop_types, use_truncating_division

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -208,7 +208,7 @@ linter:
     - type_init_formals
     - type_literal_in_constant_pattern
     # - unawaited_futures # too many false positives, especially with the way AnimationController works
-    - unintended_html_in_doc_comment
+    # - unintended_html_in_doc_comment # not yet tested
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_breaks

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -114,7 +114,7 @@ linter:
     - implicit_call_tearoffs
     - implicit_reopen
     - invalid_case_patterns
-    # - invalid_runtime_check_with_js_interop_types # not yet tested
+    - invalid_runtime_check_with_js_interop_types
     # - join_return_with_assignment # not required by flutter style
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -208,7 +208,7 @@ linter:
     - type_init_formals
     - type_literal_in_constant_pattern
     # - unawaited_futures # too many false positives, especially with the way AnimationController works
-    # - unintended_html_in_doc_comment # not yet tested
+    - unintended_html_in_doc_comment
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_breaks
@@ -256,6 +256,6 @@ linter:
     - use_super_parameters
     - use_test_throws_matchers
     # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
-    # - use_truncating_division # not yet tested
+    - use_truncating_division
     - valid_regexps
     - void_checks


### PR DESCRIPTION
invalid_runtime_check_with_js_interop_types has been added to recommended: https://github.com/dart-lang/lints/commit/894b5006c463d2e1967fba3a8c3540d8ae249061