### PR TITLE
Add tests for sliver grid delegate with fixed cross axis count examples

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -322,8 +322,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/app_bar/sliver_app_bar.2_test.dart',
   'examples/api/test/material/app_bar/sliver_app_bar.3_test.dart',
   'examples/api/test/material/navigation_rail/navigation_rail.extended_animation.0_test.dart',
-  'examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart',
-  'examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1_test.dart',
   'examples/api/test/painting/star_border/star_border.0_test.dart',
   'examples/api/test/widgets/navigator/navigator.restorable_push_and_remove_until.0_test.dart',
   'examples/api/test/widgets/navigator/navigator.restorable_push.0_test.dart',

--- a/examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0.dart
+++ b/examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0.dart
@@ -30,7 +30,7 @@ class SliverGridDelegateWithFixedCrossAxisCountExample extends StatelessWidget {
     return GridView(
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 4,
-        childAspectRatio: 0.5,
+        childAspectRatio: 2,
       ),
       children: List<Widget>.generate(20, (int i) {
         return Builder(builder: (BuildContext context) {

--- a/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart
+++ b/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_api_samples/rendering/sliver_grid/sliver_grid_delegate_w
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Each tiles should have a width of 200.0 and a height of 400.0', (WidgetTester tester) async {
+  testWidgets('Each tiles should have a width of 200.0 and a height of 100.0', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.SliverGridDelegateWithFixedCrossAxisCountExampleApp(),
     );

--- a/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart
+++ b/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Example app has ScrollDirection represented', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SliverGridDelegateWithFixedCrossAxisCountExampleApp(),
+    );
+
+    for (int i = 0; i < 4; i++) {
+      expect(find.text('$i'), findsOne);
+      final Element element = tester.element(find.text('0'));
+
+      expect(element.size, const Size(200, 400));
+    }
+  });
+}

--- a/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart
+++ b/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart
@@ -12,11 +12,11 @@ void main() {
       const example.SliverGridDelegateWithFixedCrossAxisCountExampleApp(),
     );
 
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 20; i++) {
       expect(find.text('$i'), findsOne);
       final Element element = tester.element(find.text('$i'));
 
-      expect(element.size, const Size(200, 400));
+      expect(element.size, const Size(200, 100));
     }
   });
 }

--- a/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart
+++ b/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart
@@ -7,14 +7,14 @@ import 'package:flutter_api_samples/rendering/sliver_grid/sliver_grid_delegate_w
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Example app has ScrollDirection represented', (WidgetTester tester) async {
+  testWidgets('Each tiles should have a width of 200.0 and a height of 400.0', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.SliverGridDelegateWithFixedCrossAxisCountExampleApp(),
     );
 
     for (int i = 0; i < 4; i++) {
       expect(find.text('$i'), findsOne);
-      final Element element = tester.element(find.text('0'));
+      final Element element = tester.element(find.text('$i'));
 
       expect(element.size, const Size(200, 400));
     }

--- a/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1_test.dart
+++ b/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1_test.dart
@@ -7,14 +7,14 @@ import 'package:flutter_api_samples/rendering/sliver_grid/sliver_grid_delegate_w
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Example app has ScrollDirection represented', (WidgetTester tester) async {
+  testWidgets('Each tiles should have a width of 200.0 and a height of 150.0', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.SliverGridDelegateWithFixedCrossAxisCountExampleApp(),
     );
 
     for (int i = 0; i < 4; i++) {
       expect(find.text('$i'), findsOne);
-      final Element element = tester.element(find.text('0'));
+      final Element element = tester.element(find.text('$i'));
 
       expect(element.size, const Size(200, 150));
     }

--- a/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1_test.dart
+++ b/examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Example app has ScrollDirection represented', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SliverGridDelegateWithFixedCrossAxisCountExampleApp(),
+    );
+
+    for (int i = 0; i < 4; i++) {
+      expect(find.text('$i'), findsOne);
+      final Element element = tester.element(find.text('0'));
+
+      expect(element.size, const Size(200, 150));
+    }
+  });
+}

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -314,7 +314,7 @@ abstract class SliverGridDelegate {
 /// {@tool dartpad}
 /// Here is an example using the [childAspectRatio] property. On a device with a
 /// screen width of 800.0, it creates a GridView with each tile with a width of
-/// 200.0 and a height of 400.0.
+/// 200.0 and a height of 100.0.
 ///
 /// ** See code in examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0.dart **
 /// {@end-tool}

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -314,7 +314,7 @@ abstract class SliverGridDelegate {
 /// {@tool dartpad}
 /// Here is an example using the [childAspectRatio] property. On a device with a
 /// screen width of 800.0, it creates a GridView with each tile with a width of
-/// 200.0 and a height of 100.0.
+/// 200.0 and a height of 400.0.
 ///
 /// ** See code in examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0.dart **
 /// {@end-tool}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0.dart`
- `examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1.dart`

I also fixed a mistake in the documentation



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
