### PR TITLE
fix some unintended HTML tags in docs

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -208,7 +208,7 @@ linter:
     - type_init_formals
     - type_literal_in_constant_pattern
     # - unawaited_futures # too many false positives, especially with the way AnimationController works
-    # - unintended_html_in_doc_comment # not yet tested
+    # - unintended_html_in_doc_comment # blocked on https://github.com/dart-lang/linter/issues/5065
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_breaks

--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -252,7 +252,7 @@ class AssetImage extends AssetBundleImageProvider {
 
   /// The name used to generate the key to obtain the asset. For local assets
   /// this is [assetName], and for assets from packages the [assetName] is
-  /// prefixed 'packages/<package_name>/'.
+  /// prefixed `packages/<package_name>/`.
   String get keyName => package == null ? assetName : 'packages/$package/$assetName';
 
   /// The bundle from which the image will be obtained.

--- a/packages/flutter/lib/src/painting/linear_border.dart
+++ b/packages/flutter/lib/src/painting/linear_border.dart
@@ -13,7 +13,7 @@ import 'basic_types.dart';
 import 'borders.dart';
 import 'edge_insets.dart';
 
-/// Defines the relative size and alignment of one <LinearBorder> edge.
+/// Defines the relative size and alignment of one [LinearBorder] edge.
 ///
 /// A [LinearBorder] defines a box outline as zero to four edges, each
 /// of which is rendered as a single line. The width and color of the

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1642,7 +1642,7 @@ class SemanticsProperties extends DiagnosticableTree {
   /// This handler is invoked when the user wants to replace the current text in
   /// the text field with a new text.
   ///
-  /// Voice access users can trigger this handler by speaking "type <text>" to
+  /// Voice access users can trigger this handler by speaking `type <text>` to
   /// their Android devices.
   final SetTextHandler? onSetText;
 
@@ -4111,7 +4111,7 @@ class SemanticsConfiguration {
   /// This handler is invoked when the user wants to replace the current text in
   /// the text field with a new text.
   ///
-  /// Voice access users can trigger this handler by speaking "type <text>" to
+  /// Voice access users can trigger this handler by speaking `type <text>` to
   /// their Android devices.
   SetTextHandler? get onSetText => _onSetText;
   SetTextHandler? _onSetText;

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -136,10 +136,10 @@ class Dismissible extends StatefulWidget {
   ///
   /// The widget cannot be dragged again until the returned future resolves.
   ///
-  /// If the returned Future<bool> completes true, then this widget will be
+  /// If the returned `Future<bool>` completes true, then this widget will be
   /// dismissed, otherwise it will be moved back to its original location.
   ///
-  /// If the returned Future<bool?> completes to false or null the [onResize]
+  /// If the returned `Future<bool?>` completes to false or null the [onResize]
   /// and [onDismissed] callbacks will not run.
   final ConfirmDismissCallback? confirmDismiss;
 

--- a/packages/flutter/lib/src/widgets/scrollable_helpers.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_helpers.dart
@@ -156,7 +156,7 @@ class ScrollableDetails {
 ///
 /// The scroll velocity is controlled by the [velocityScalar]:
 ///
-/// velocity = <distance of overscroll> * [velocityScalar].
+/// velocity = (distance of overscroll) * [velocityScalar].
 class EdgeDraggingAutoScroller {
   /// Creates a auto scroller that scrolls the [scrollable].
   EdgeDraggingAutoScroller(
@@ -179,7 +179,7 @@ class EdgeDraggingAutoScroller {
   /// The velocity scalar per pixel over scroll.
   ///
   /// It represents how the velocity scale with the over scroll distance. The
-  /// auto-scroll velocity = <distance of overscroll> * velocityScalar.
+  /// auto-scroll velocity = (distance of overscroll) * velocityScalar.
   /// {@endtemplate}
   final double velocityScalar;
 


### PR DESCRIPTION
I used the `unintended_html_in_doc_comment` to find these, but sadly the lint is not ready to be enabled yet due to https://github.com/dart-lang/sdk/issues/59516.