### PR TITLE
SelectionArea support for triple click/tap to select line on Linux

### DIFF
--- a/examples/api/lib/material/selectable_region/selectable_region.0.dart
+++ b/examples/api/lib/material/selectable_region/selectable_region.0.dart
@@ -186,6 +186,7 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
       case SelectionEventType.selectParagraph:
+      case SelectionEventType.selectLine:
         _start = Offset.zero;
         _end = Offset.infinite;
       case SelectionEventType.granularlyExtendSelection:

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1415,76 +1415,69 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
     late final SelectionResult result;
     final TextPosition? existingSelectionStart = _textSelectionStart;
     final TextPosition? existingSelectionEnd = _textSelectionEnd;
-    switch (event.type) {
-      case SelectionEventType.startEdgeUpdate:
-      case SelectionEventType.endEdgeUpdate:
-        final SelectionEdgeUpdateEvent edgeUpdate = event as SelectionEdgeUpdateEvent;
+    switch (event) {
+      case SelectionEdgeUpdateEvent():
         final TextGranularity granularity = event.granularity;
 
         switch (granularity) {
           case TextGranularity.character:
-            result = _updateSelectionEdge(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
+            result = _updateSelectionEdge(event.globalPosition, isEnd: event.type == SelectionEventType.endEdgeUpdate);
           case TextGranularity.word:
             result = _updateSelectionEdgeByTextBoundary(
-              edgeUpdate.globalPosition,
-              isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate,
+              event.globalPosition,
+              isEnd: event.type == SelectionEventType.endEdgeUpdate,
               getTextBoundary: _getWordBoundaryAtPosition,
             );
           case TextGranularity.paragraph:
             result = _updateSelectionEdgeByMultiSelectableTextBoundary(
-              edgeUpdate.globalPosition,
-              isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate,
+              event.globalPosition,
+              isEnd: event.type == SelectionEventType.endEdgeUpdate,
               getTextBoundary: _getParagraphBoundaryAtPosition,
               getClampedTextBoundary: _getClampedParagraphBoundaryAtPosition,
             );
           case TextGranularity.line:
             result = _updateSelectionEdgeByMultiSelectableTextBoundary(
-              edgeUpdate.globalPosition,
-              isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate,
+              event.globalPosition,
+              isEnd: event.type == SelectionEventType.endEdgeUpdate,
               getTextBoundary: _getLineBoundaryAtPosition,
               getClampedTextBoundary: _getClampedLineBoundaryAtPosition,
             );
           case TextGranularity.document:
             assert(false, 'Moving the selection edge by document is not supported.');
         }
-      case SelectionEventType.clear:
+      case ClearSelectionEvent():
         result = _handleClearSelection();
-      case SelectionEventType.selectAll:
+      case SelectAllSelectionEvent():
         result = _handleSelectAll();
-      case SelectionEventType.selectWord:
-        final SelectWordSelectionEvent selectWord = event as SelectWordSelectionEvent;
-        result = _handleSelectWord(selectWord.globalPosition);
-      case SelectionEventType.selectParagraph:
-        final SelectParagraphSelectionEvent selectParagraph = event as SelectParagraphSelectionEvent;
-        if (selectParagraph.absorb) {
+      case SelectWordSelectionEvent():
+        result = _handleSelectWord(event.globalPosition);
+      case SelectParagraphSelectionEvent():
+        if (event.absorb) {
           _handleSelectAll();
           result = SelectionResult.next;
           _selectableContainsOriginTextBoundary = true;
         } else {
-          result = _handleSelectParagraph(selectParagraph.globalPosition);
+          result = _handleSelectParagraph(event.globalPosition);
         }
-      case SelectionEventType.selectLine:
-        final SelectLineSelectionEvent selectLine = event as SelectLineSelectionEvent;
-        if (selectLine.absorb) {
+      case SelectLineSelectionEvent():
+        if (event.absorb) {
           _handleSelectAll();
           result = SelectionResult.next;
           _selectableContainsOriginTextBoundary = true;
         } else {
-          result = _handleSelectLine(selectLine.globalPosition);
+          result = _handleSelectLine(event.globalPosition);
         }
-      case SelectionEventType.granularlyExtendSelection:
-        final GranularlyExtendSelectionEvent granularlyExtendSelection = event as GranularlyExtendSelectionEvent;
+      case GranularlyExtendSelectionEvent():
         result = _handleGranularlyExtendSelection(
-          granularlyExtendSelection.forward,
-          granularlyExtendSelection.isEnd,
-          granularlyExtendSelection.granularity,
+          event.forward,
+          event.isEnd,
+          event.granularity,
         );
-      case SelectionEventType.directionallyExtendSelection:
-        final DirectionallyExtendSelectionEvent directionallyExtendSelection = event as DirectionallyExtendSelectionEvent;
+      case DirectionallyExtendSelectionEvent():
         result = _handleDirectionallyExtendSelection(
-          directionallyExtendSelection.dx,
-          directionallyExtendSelection.isEnd,
-          directionallyExtendSelection.direction,
+          event.dx,
+          event.isEnd,
+          event.direction,
         );
     }
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1425,11 +1425,25 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
           case TextGranularity.character:
             result = _updateSelectionEdge(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
           case TextGranularity.word:
-            result = _updateSelectionEdgeByTextBoundary(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate, getTextBoundary: _getWordBoundaryAtPosition);
+            result = _updateSelectionEdgeByTextBoundary(
+              edgeUpdate.globalPosition,
+              isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate,
+              getTextBoundary: _getWordBoundaryAtPosition,
+            );
           case TextGranularity.paragraph:
-            result = _updateSelectionEdgeByMultiSelectableTextBoundary(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate, getTextBoundary: _getParagraphBoundaryAtPosition, getClampedTextBoundary: _getClampedParagraphBoundaryAtPosition);
+            result = _updateSelectionEdgeByMultiSelectableTextBoundary(
+              edgeUpdate.globalPosition,
+              isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate,
+              getTextBoundary: _getParagraphBoundaryAtPosition,
+              getClampedTextBoundary: _getClampedParagraphBoundaryAtPosition,
+            );
           case TextGranularity.line:
-            result = _updateSelectionEdgeByMultiSelectableTextBoundary(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate, getTextBoundary: _getLineBoundaryAtPosition, getClampedTextBoundary: _getClampedLineBoundaryAtPosition);
+            result = _updateSelectionEdgeByMultiSelectableTextBoundary(
+              edgeUpdate.globalPosition,
+              isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate,
+              getTextBoundary: _getLineBoundaryAtPosition,
+              getClampedTextBoundary: _getClampedLineBoundaryAtPosition,
+            );
           case TextGranularity.document:
             assert(false, 'Moving the selection edge by document is not supported.');
         }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -2761,50 +2761,44 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
 
   _TextBoundaryRecord _getParagraphBoundaryAtPosition(TextPosition position, String text) {
     final ParagraphBoundary paragraphBoundary = ParagraphBoundary(text);
-    // Use position.offset - 1 when `position` is at the end of the selectable to retrieve
-    // the previous text boundary's location.
-    final int paragraphStart = paragraphBoundary.getLeadingTextBoundaryAt(position.offset == text.length || position.affinity == TextAffinity.upstream ? position.offset - 1 : position.offset) ?? 0;
-    final int paragraphEnd = paragraphBoundary.getTrailingTextBoundaryAt(position.offset) ?? text.length;
-    final TextRange paragraphRange = TextRange(start: paragraphStart, end: paragraphEnd);
-    assert(paragraphRange.isNormalized);
-    return _adjustTextBoundaryAtPosition(paragraphRange, position);
+    return _getTextBoundaryAtPosition(paragraphBoundary, position, text);
   }
 
   _TextBoundaryRecord _getClampedParagraphBoundaryAtPosition(TextPosition position) {
     final ParagraphBoundary paragraphBoundary = ParagraphBoundary(fullText);
-    // Use position.offset - 1 when `position` is at the end of the selectable to retrieve
-    // the previous text boundary's location.
-    int paragraphStart = paragraphBoundary.getLeadingTextBoundaryAt(position.offset == fullText.length || position.affinity == TextAffinity.upstream ? position.offset - 1 : position.offset) ?? 0;
-    int paragraphEnd = paragraphBoundary.getTrailingTextBoundaryAt(position.offset) ?? fullText.length;
-    paragraphStart = paragraphStart < range.start ? range.start : paragraphStart > range.end ? range.end : paragraphStart;
-    paragraphEnd = paragraphEnd > range.end ? range.end : paragraphEnd < range.start ? range.start : paragraphEnd;
-    final TextRange paragraphRange = TextRange(start: paragraphStart, end: paragraphEnd);
-    assert(paragraphRange.isNormalized);
-    return _adjustTextBoundaryAtPosition(paragraphRange, position);
+    return _clampTextBoundaryAtPosition(paragraphBoundary, position);
   }
 
   _TextBoundaryRecord _getLineBoundaryAtPosition(TextPosition position, String text) {
     final LineBoundary lineBoundary = LineBoundary(this);
-    // Use position.offset - 1 when `position` is at the end of the selectable to retrieve
-    // the previous text boundary's location.
-    final int lineStart = lineBoundary.getLeadingTextBoundaryAt(position.offset == text.length || position.affinity == TextAffinity.upstream ? position.offset - 1 : position.offset) ?? 0;
-    final int lineEnd = lineBoundary.getTrailingTextBoundaryAt(position.offset) ?? text.length;
-    final TextRange lineRange = TextRange(start: lineStart, end: lineEnd);
-    assert(lineRange.isNormalized);
-    return _adjustTextBoundaryAtPosition(lineRange, position);
+    return _getTextBoundaryAtPosition(lineBoundary, position, text);
   }
 
   _TextBoundaryRecord _getClampedLineBoundaryAtPosition(TextPosition position) {
     final LineBoundary lineBoundary = LineBoundary(this);
+    return _clampTextBoundaryAtPosition(lineBoundary, position);
+  }
+
+  _TextBoundaryRecord _getTextBoundaryAtPosition(TextBoundary textBoundary, TextPosition position, String text) {
     // Use position.offset - 1 when `position` is at the end of the selectable to retrieve
     // the previous text boundary's location.
-    int lineStart = lineBoundary.getLeadingTextBoundaryAt(position.offset == fullText.length || position.affinity == TextAffinity.upstream ? position.offset - 1 : position.offset) ?? 0;
-    int lineEnd = lineBoundary.getTrailingTextBoundaryAt(position.offset) ?? fullText.length;
-    lineStart = lineStart < range.start ? range.start : lineStart > range.end ? range.end : lineStart;
-    lineEnd = lineEnd > range.end ? range.end : lineEnd < range.start ? range.start : lineEnd;
-    final TextRange lineRange = TextRange(start: lineStart, end: lineEnd);
-    assert(lineRange.isNormalized);
-    return _adjustTextBoundaryAtPosition(lineRange, position);
+    final int boundaryStart = textBoundary.getLeadingTextBoundaryAt(position.offset == text.length || position.affinity == TextAffinity.upstream ? position.offset - 1 : position.offset) ?? 0;
+    final int boundaryEnd = textBoundary.getTrailingTextBoundaryAt(position.offset) ?? text.length;
+    final TextRange boundaryRange = TextRange(start: boundaryStart, end: boundaryEnd);
+    assert(boundaryRange.isNormalized);
+    return _adjustTextBoundaryAtPosition(boundaryRange, position);
+  }
+
+  _TextBoundaryRecord _clampTextBoundaryAtPosition(TextBoundary textBoundary, TextPosition position) {
+    // Use position.offset - 1 when `position` is at the end of the selectable to retrieve
+    // the previous text boundary's location.
+    int boundaryStart = textBoundary.getLeadingTextBoundaryAt(position.offset == fullText.length || position.affinity == TextAffinity.upstream ? position.offset - 1 : position.offset) ?? 0;
+    int boundaryEnd = textBoundary.getTrailingTextBoundaryAt(position.offset) ?? fullText.length;
+    boundaryStart = boundaryStart < range.start ? range.start : boundaryStart > range.end ? range.end : boundaryStart;
+    boundaryEnd = boundaryEnd > range.end ? range.end : boundaryEnd < range.start ? range.start : boundaryEnd;
+    final TextRange boundaryRange = TextRange(start: boundaryStart, end: boundaryEnd);
+    assert(boundaryRange.isNormalized);
+    return _adjustTextBoundaryAtPosition(boundaryRange, position);
   }
 
   SelectionResult _handleDirectionallyExtendSelection(double horizontalBaseline, bool isExtent, SelectionExtendDirection movement) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -2941,8 +2941,8 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
         caretOffset = end.offset;
     }
     final int offset = forward
-      ? textBoundary.getTrailingTextBoundaryAt(caretOffset) ?? range.end
-      : textBoundary.getLeadingTextBoundaryAt(caretOffset) ?? range.start;
+      ? textBoundary.getTrailingTextBoundaryAt(caretOffset)?.clamp(range.start, range.end) ?? range.end
+      : textBoundary.getLeadingTextBoundaryAt(caretOffset)?.clamp(range.start, range.end) ?? range.start;
     return TextPosition(offset: offset);
   }
 
@@ -3132,9 +3132,7 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
   @override
   TextSelection getLineAtOffset(TextPosition position) {
     final TextRange line = paragraph._getLineAtOffset(position);
-    final int start = line.start.clamp(range.start, range.end);
-    final int end = line.end.clamp(range.start, range.end);
-    return TextSelection(baseOffset: start, extentOffset: end);
+    return TextSelection(baseOffset: line.start, extentOffset: line.end);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -309,7 +309,7 @@ enum SelectionEventType {
   /// Used by [SelectParagraphSelectionEvent].
   selectParagraph,
 
-  /// An event to select a paragraph at the location
+  /// An event to select a line at the location
   /// [SelectLineSelectionEvent.globalPosition].
   ///
   /// Used by [SelectLineSelectionEvent].
@@ -411,7 +411,7 @@ class SelectLineSelectionEvent extends SelectionEvent {
   /// Creates a select line event at the [globalPosition].
   const SelectLineSelectionEvent({required this.globalPosition, this.absorb = false}): super._(SelectionEventType.selectLine);
 
-  /// The position in global coordinates to select paragraph at.
+  /// The position in global coordinates to select line at.
   final Offset globalPosition;
 
   /// Whether the selectable receiving the event should be absorbed into

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -309,6 +309,12 @@ enum SelectionEventType {
   /// Used by [SelectParagraphSelectionEvent].
   selectParagraph,
 
+  /// An event to select a paragraph at the location
+  /// [SelectLineSelectionEvent.globalPosition].
+  ///
+  /// Used by [SelectLineSelectionEvent].
+  selectLine,
+
   /// An event that extends the selection by a specific [TextGranularity].
   granularlyExtendSelection,
 
@@ -395,6 +401,21 @@ class SelectParagraphSelectionEvent extends SelectionEvent {
 
   /// Whether the selectable receiving the event should be absorbed into
   /// an encompassing paragraph.
+  final bool absorb;
+}
+
+/// Selects the entire line at the location.
+///
+/// This event can be sent as the result of a triple click to select on Linux.
+class SelectLineSelectionEvent extends SelectionEvent {
+  /// Creates a select line event at the [globalPosition].
+  const SelectLineSelectionEvent({required this.globalPosition, this.absorb = false}): super._(SelectionEventType.selectLine);
+
+  /// The position in global coordinates to select paragraph at.
+  final Offset globalPosition;
+
+  /// Whether the selectable receiving the event should be absorbed into
+  /// an encompassing line.
   final bool absorb;
 }
 

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -404,8 +404,16 @@ abstract class SelectBoundarySelectionEvent extends SelectionEvent {
 abstract class SelectMultiSelectableBoundarySelectionEvent extends SelectBoundarySelectionEvent {
   const SelectMultiSelectableBoundarySelectionEvent._(this.absorb, Offset globalPosition, SelectionEventType type) : super._(globalPosition, type);
 
-  /// Whether the selectable receiving the event should be absorbed into
-  /// an encompassing boundary.
+  /// Whether the [Selectable] receiving the event should be completely
+  /// absorbed into a boundary.
+  ///
+  /// For example, when [absorb] is set to true, and a [Selectable] that is inline
+  /// within a boundary receives this event, it should select all of its content,
+  /// and continue searching for the end of the boundary.
+  ///
+  /// When [absorb] is set to false, and a [Selectable] that is inline with a boundary
+  /// receives this event, it should find the end of the boundary relative to itself
+  /// and stop searching.
   final bool absorb;
 }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1474,6 +1474,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
       case SelectionEventType.selectParagraph:
+      case SelectionEventType.selectLine:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
     }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1889,7 +1889,7 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
   @override
   SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
     final SelectionResult result = super.handleSelectAll(event);
-    _updateInternalSelectionStateForBoundaryEvents();
+    _didReceiveSelectionBoundaryEvents();
     return result;
   }
 
@@ -1898,7 +1898,7 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
   @override
   SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
     final SelectionResult result = super.handleSelectWord(event);
-    _updateInternalSelectionStateForBoundaryEvents();
+    _didReceiveSelectionBoundaryEvents();
     return result;
   }
 
@@ -1907,7 +1907,7 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
   @override
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = super.handleSelectParagraph(event);
-    _updateInternalSelectionStateForBoundaryEvents();
+    _didReceiveSelectionBoundaryEvents();
     return result;
   }
 
@@ -1916,11 +1916,11 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
   @override
   SelectionResult handleSelectLine(SelectLineSelectionEvent event) {
     final SelectionResult result = super.handleSelectLine(event);
-    _updateInternalSelectionStateForBoundaryEvents();
+    _didReceiveSelectionBoundaryEvents();
     return result;
   }
 
-  void _updateInternalSelectionStateForBoundaryEvents() {
+  void _didReceiveSelectionBoundaryEvents() {
     if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
       return;
     }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2536,28 +2536,14 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     return SelectionResult.none;
   }
 
-  SelectionResult _handleSelectBoundary(SelectionEvent event) {
-    assert(
-      event is SelectWordSelectionEvent
-      || event is SelectParagraphSelectionEvent
-      || event is SelectLineSelectionEvent,
-      'This method should only be given selection events that select text boundaries.',
-    );
-    late final Offset effectiveGlobalPosition;
-    if (event.type == SelectionEventType.selectWord) {
-      effectiveGlobalPosition = (event as SelectWordSelectionEvent).globalPosition;
-    } else if (event.type == SelectionEventType.selectParagraph) {
-      effectiveGlobalPosition = (event as SelectParagraphSelectionEvent).globalPosition;
-    } else if (event.type == SelectionEventType.selectLine) {
-      effectiveGlobalPosition = (event as SelectLineSelectionEvent).globalPosition;
-    }
+  SelectionResult _handleSelectBoundary(SelectBoundarySelectionEvent event) {
     SelectionResult? lastSelectionResult;
     for (int index = 0; index < selectables.length; index += 1) {
       bool globalRectsContainPosition = false;
       if (selectables[index].boundingBoxes.isNotEmpty) {
         for (final Rect rect in selectables[index].boundingBoxes) {
           final Rect globalRect = MatrixUtils.transformRect(selectables[index].getTransformTo(null), rect);
-          if (globalRect.contains(effectiveGlobalPosition)) {
+          if (globalRect.contains(event.globalPosition)) {
             globalRectsContainPosition = true;
             break;
           }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1367,7 +1367,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///
   /// If the line is already in the current selection, selection won't
   /// change. One call [clearSelection] first if the selection needs to be
-  /// updated even if the paragraph is already covered by the current selection.
+  /// updated even if the line is already covered by the current selection.
   ///
   /// One can also use [_selectEndTo] or [_selectStartTo] to adjust the selection
   /// edges after calling this method.

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -932,11 +932,16 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
     SelectionResult? lastSelectionResult;
     bool foundStart = false;
     int? lastNextIndex;
+    late final SelectionEvent? maybeSynthesizedEvent;
+    if (event.type == SelectionEventType.selectParagraph) {
+      maybeSynthesizedEvent = SelectParagraphSelectionEvent(globalPosition: event.globalPosition, absorb: true);
+    } else if (event.type == SelectionEventType.selectLine) {
+      maybeSynthesizedEvent = SelectLineSelectionEvent(globalPosition: event.globalPosition, absorb: true);
+    }
     for (int index = 0; index < selectables.length; index += 1) {
       if (!paragraph.selectableBelongsToParagraph(selectables[index])) {
         if (foundStart) {
-          final SelectionEvent synthesizedEvent = SelectParagraphSelectionEvent(globalPosition: event.globalPosition, absorb: true);
-          final SelectionResult result = dispatchSelectionEventToChild(selectables[index], synthesizedEvent);
+          final SelectionResult result = dispatchSelectionEventToChild(selectables[index], maybeSynthesizedEvent!);
           if (selectables.length - 1 == index) {
             currentSelectionEndIndex = index;
             _flushInactiveSelections();
@@ -970,8 +975,7 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
             startIndex = lastNextIndex == null && selectionAtStartOfSelectable ? 0 : index;
           }
           for (int i = startIndex; i < index; i += 1) {
-            final SelectionEvent synthesizedEvent = SelectParagraphSelectionEvent(globalPosition: event.globalPosition, absorb: true);
-            dispatchSelectionEventToChild(selectables[i], synthesizedEvent);
+            dispatchSelectionEventToChild(selectables[i], maybeSynthesizedEvent!);
           }
           currentSelectionStartIndex = startIndex;
           foundStart = true;
@@ -985,12 +989,11 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
         if (!foundStart && lastNextIndex == null) {
           currentSelectionStartIndex = 0;
           for (int i = 0; i < index; i += 1) {
-            final SelectionEvent synthesizedEvent = SelectParagraphSelectionEvent(globalPosition: event.globalPosition, absorb: true);
-            dispatchSelectionEventToChild(selectables[i], synthesizedEvent);
+            dispatchSelectionEventToChild(selectables[i], maybeSynthesizedEvent!);
           }
         }
         currentSelectionEndIndex = index;
-        // Geometry has changed as a result of select paragraph, need to clear the
+        // Geometry has changed as a result of select boundary, need to clear the
         // selection of other selectables to keep selection in sync.
         _flushInactiveSelections();
       }
@@ -1334,7 +1337,7 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
       _lastStartEdgeUpdateGlobalPosition = event.globalPosition;
     }
 
-    if (event.granularity == TextGranularity.paragraph) {
+    if (event.granularity == TextGranularity.paragraph || event.granularity == TextGranularity.line) {
       if (event.type == SelectionEventType.endEdgeUpdate) {
         return currentSelectionEndIndex == -1 ? _initSelection(event, isEnd: true) : _adjustSelection(event, isEnd: true);
       }

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -893,14 +893,14 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
   @override
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectMultiSelectableBoundary(event);
-    _updateInternalSelectionStateForBoundaryEvents();
+    _didReceiveSelectionBoundaryEvents();
     return result;
   }
 
   @override
   SelectionResult handleSelectLine(SelectLineSelectionEvent event) {
     final SelectionResult result = _handleSelectMultiSelectableBoundary(event);
-    _updateInternalSelectionStateForBoundaryEvents();
+    _didReceiveSelectionBoundaryEvents();
     return result;
   }
 
@@ -1293,7 +1293,7 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
   @override
   SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
     final SelectionResult result = super.handleSelectAll(event);
-    _updateInternalSelectionStateForBoundaryEvents();
+    _didReceiveSelectionBoundaryEvents();
     return result;
   }
 
@@ -1302,11 +1302,11 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
   @override
   SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
     final SelectionResult result = super.handleSelectWord(event);
-    _updateInternalSelectionStateForBoundaryEvents();
+    _didReceiveSelectionBoundaryEvents();
     return result;
   }
 
-  void _updateInternalSelectionStateForBoundaryEvents() {
+  void _didReceiveSelectionBoundaryEvents() {
     if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
       return;
     }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2067,6 +2067,7 @@ void main() {
         ),
       );
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text(longText), matching: find.byType(RichText)));
+      // Triple-click.
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
       await tester.pump();
@@ -2082,6 +2083,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 17));
 
+      // Drag.
       await gesture.moveTo(textOffsetToPosition(paragraph, 155));
       await tester.pumpAndSettle();
       expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 167));
@@ -2154,6 +2156,7 @@ void main() {
         ),
       );
       final RenderParagraph paragraphC = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('Text widget C.'), matching: find.byType(RichText)));
+      // Triple-click.
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraphC, 2), kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
       await tester.pump();
@@ -2169,6 +2172,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(paragraphC.selections[0], const TextSelection(baseOffset: 0, extentOffset: 14));
 
+      // Drag.
       await gesture.moveTo(textOffsetToPosition(paragraphC, 7));
       await tester.pump();
       expect(paragraphC.selections[0], const TextSelection(baseOffset: 0, extentOffset: 14));
@@ -2206,6 +2210,7 @@ void main() {
         ),
       );
       final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('first text widget'), matching: find.byType(RichText)));
+      // Triple-click.
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
       await tester.pump();
@@ -2221,6 +2226,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
 
+      // Drag.
       await gesture.moveTo(textOffsetToPosition(paragraph1, 14));
       await tester.pump();
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 25));
@@ -2274,6 +2280,7 @@ void main() {
         ),
       );
       final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('second text widget'), matching: find.byType(RichText)));
+      // Triple-click.
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph2, 2), kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
       await tester.pump();
@@ -2352,6 +2359,7 @@ void main() {
         ),
       );
       final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('Fine, thank you.'), matching: find.byType(RichText)));
+      // Triple-click.
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 18), kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
       await tester.pump();
@@ -2367,6 +2375,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(paragraph3.selections[0], const TextSelection(baseOffset: 17, extentOffset: 29));
 
+      // Drag.
       await gesture.moveTo(textOffsetToPosition(paragraph3, 4));
       await tester.pump();
       expect(paragraph3.selections[0], const TextSelection(baseOffset: 29, extentOffset: 0));

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2125,7 +2125,8 @@ void main() {
       expect(paragraph.selections[0], const TextSelection(baseOffset: 167, extentOffset: 0));
       await gesture.up();
     }, variant: TargetPlatformVariant.only(TargetPlatform.linux),
-       skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+       skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('mouse can select multiple widgets on triple click drag when selecting inside a WidgetSpan on Linux', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
@@ -2182,7 +2183,8 @@ void main() {
 
       await gesture.up();
     }, variant: TargetPlatformVariant.only(TargetPlatform.linux),
-       skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+       skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('mouse can select multiple widgets line-by-line with a triple click drag on Linux', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
@@ -2249,7 +2251,8 @@ void main() {
 
       await gesture.up();
     }, variant: TargetPlatformVariant.only(TargetPlatform.linux),
-       skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+       skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('mouse can select multiple widgets line-by-line on triple click drag and return to origin paragraph on Linux', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
@@ -2326,7 +2329,8 @@ void main() {
 
       await gesture.up();
     }, variant: TargetPlatformVariant.only(TargetPlatform.linux),
-       skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+       skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('mouse can reverse selection across multiple widgets line-by-line with a triple click drag on Linux', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
@@ -2380,7 +2384,8 @@ void main() {
 
       await gesture.up();
     }, variant: TargetPlatformVariant.only(TargetPlatform.linux),
-       skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+       skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('mouse can select multiple widgets', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();


### PR DESCRIPTION
This change adds support for triple click/tap to select a line at the location on Linux. Also adds support for extending selection by line on triple click followed by a drag.

Fixes: #129583 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.