### PR TITLE
[Swift Package Manager] Test removing the last Flutter plugin

### DIFF
--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
@@ -607,4 +607,87 @@ void main() {
       );
     }
   }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
+
+  test('Removing the last plugin updates the generated Swift package', () async {
+    final Directory workingDirectory = fileSystem.systemTempDirectory
+      .createTempSync('swift_package_manager_remove_last_plugin.');
+    final String workingDirectoryPath = workingDirectory.path;
+    try {
+      await SwiftPackageManagerUtils.enableSwiftPackageManager(
+        flutterBin,
+        workingDirectoryPath,
+      );
+
+      // Create an app with a plugin.
+      final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+        flutterBin,
+        workingDirectoryPath,
+        iosLanguage: 'swift',
+        platform: 'ios',
+        usesSwiftPackageManager: true,
+        options: <String>['--platforms=ios'],
+      );
+
+      final SwiftPackageManagerPlugin integrationTestPlugin =
+        SwiftPackageManagerUtils.integrationTestPlugin('ios');
+
+      SwiftPackageManagerUtils.addDependency(
+        appDirectoryPath: appDirectoryPath,
+        plugin: integrationTestPlugin,
+      );
+
+      // Build the app to generate the Swift package.
+      await SwiftPackageManagerUtils.buildApp(
+        flutterBin,
+        appDirectoryPath,
+        options: <String>['ios', '--config-only', '-v'],
+      );
+
+      // Verify the generated Swift package depends on the plugin.
+      final File generatedManifestFile = fileSystem
+        .directory(appDirectoryPath)
+        .childDirectory('ios')
+        .childDirectory('Flutter')
+        .childDirectory('ephemeral')
+        .childDirectory('Packages')
+        .childDirectory('FlutterGeneratedPluginSwiftPackage')
+        .childFile('Package.swift');
+
+      expect(generatedManifestFile.existsSync(), isTrue);
+
+      String generatedManifest = generatedManifestFile.readAsStringSync();
+      final String generatedSwiftDependency = '''
+    dependencies: [
+        .package(name: "integration_test", path: "${integrationTestPlugin.swiftPackagePlatformPath}")
+    ],
+''';
+
+      expect(generatedManifest.contains(generatedSwiftDependency), isTrue);
+
+      // Remove the plugin and rebuild the app to re-generate the Swift package.
+      SwiftPackageManagerUtils.removeDependency(
+        appDirectoryPath: appDirectoryPath,
+        plugin: integrationTestPlugin,
+      );
+
+      await SwiftPackageManagerUtils.buildApp(
+        flutterBin,
+        appDirectoryPath,
+        options: <String>['ios', '--config-only', '-v'],
+      );
+
+      // Verify the generated Swift package does not depend on the plugin.
+      expect(generatedManifestFile.existsSync(), isTrue);
+
+      generatedManifest = generatedManifestFile.readAsStringSync();
+
+      expect(generatedManifest.contains(generatedSwiftDependency), isFalse);
+    } finally {
+      await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
+      ErrorHandlingFileSystem.deleteIfExists(
+        workingDirectory,
+        recursive: true,
+      );
+    }
+  }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 }

--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
@@ -680,8 +680,10 @@ void main() {
       expect(generatedManifestFile.existsSync(), isTrue);
 
       generatedManifest = generatedManifestFile.readAsStringSync();
+      const String emptyDependencies = 'dependencies: [\n        \n    ],\n';
 
       expect(generatedManifest.contains(generatedSwiftDependency), isFalse);
+      expect(generatedManifest.contains(emptyDependencies), isTrue);
     } finally {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(

--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_utils.dart
@@ -245,6 +245,24 @@ class SwiftPackageManagerUtils {
     );
   }
 
+  static void removeDependency({
+    required SwiftPackageManagerPlugin plugin,
+    required String appDirectoryPath,
+  }) {
+    final File pubspec = fileSystem.file(
+      fileSystem.path.join(appDirectoryPath, 'pubspec.yaml'),
+    );
+    final String pubspecContent = pubspec.readAsStringSync();
+    final String updatedPubspecContent = pubspecContent.replaceFirst(
+      '\n  ${plugin.pluginName}:\n    path: ${plugin.pluginPath}\n',
+      '\n',
+    );
+
+    expect(updatedPubspecContent, isNot(pubspecContent));
+
+    pubspec.writeAsStringSync(updatedPubspecContent);
+  }
+
   static void disableSwiftPackageManagerByPubspec({
     required String appDirectoryPath,
   }) {
@@ -378,4 +396,5 @@ class SwiftPackageManagerPlugin {
   final String platform;
   String get exampleAppPath => fileSystem.path.join(pluginPath, 'example');
   String get exampleAppPlatformPath => fileSystem.path.join(exampleAppPath, platform);
+  String get swiftPackagePlatformPath => fileSystem.path.join(pluginPath, platform, pluginName);
 }


### PR DESCRIPTION
The Flutter tool has a bug where removing the last Flutter plugin does not correctly update the CocoaPods integration.

This adds a test to ensure  that the generated Swift package is properly updated when the last Flutter plugin is removed.

See: https://github.com/flutter/flutter/issues/11819#issuecomment-2289782626

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
