### PR TITLE
Roll `avd_cipd_verison` to latest to use the `crashreport` tool.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -51,7 +51,7 @@ platform_properties:
         [
           {"dependency": "android_sdk", "version": "version:34v3"},
           {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8741513191637853009"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8739520057779466577"},
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       os: Ubuntu
@@ -68,7 +68,7 @@ platform_properties:
         [
           {"dependency": "android_sdk", "version": "version:34v3"},
           {"dependency": "android_virtual_device", "version": "android_34_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8741513191637853009"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8739520057779466577"},
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       os: Ubuntu


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/153445.

I can do a similar set of PRs on flutter/packages and flutter/engine for consistency.

/cc @johnmccutchan @reidbaker @zanderso