### PR TITLE
add `HttpException` to the list of handled exceptions within `ResidentWebRunner::run`

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -383,6 +383,10 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       appFailedToStart();
       _logger.printError('$error', stackTrace: stackTrace);
       throwToolExit(kExitMessage);
+    } on HttpException catch (error, stackTrace) {
+      appFailedToStart();
+      _logger.printError('$error', stackTrace: stackTrace);
+      throwToolExit(kExitMessage);
     } on Exception {
       appFailedToStart();
       rethrow;

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1317,20 +1317,27 @@ flutter:
     ProcessManager: () => processManager,
   });
 
-  testUsingContext('Successfully turns HttpException into ToolExit',
-      () async {
+  testUsingContext('Successfully turns HttpException into ToolExit', () async {
     final BufferLogger logger = BufferLogger.test();
-    final ResidentRunner residentWebRunner =
-        setUpResidentRunner(flutterDevice, logger: logger);
+    final ResidentRunner residentWebRunner = setUpResidentRunner(
+      flutterDevice,
+      logger: logger,
+    );
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     setupMocks();
     webDevFS.exception = const HttpException(
       'Connection closed before full header was received',
     );
 
-    await expectLater(residentWebRunner.run, throwsToolExit());
+    await expectLater(
+      residentWebRunner.run,
+      throwsToolExit(
+        message:
+            'Failed to establish connection with the application instance in Chrome.',
+      ),
+    );
     expect(logger.errorText, contains('HttpException'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost.hasRemainingExpectations, isFalse);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1317,7 +1317,7 @@ flutter:
     ProcessManager: () => processManager,
   });
 
-  testUsingContext('Successfully turns HttpException into ToolExit', () async {
+  testUsingContext('Turns HttpException from ChromeTab::connect into ToolExit', () async {
     final BufferLogger logger = BufferLogger.test();
     final ResidentRunner residentWebRunner = setUpResidentRunner(
       flutterDevice,
@@ -1325,15 +1325,42 @@ flutter:
     );
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     setupMocks();
-    webDevFS.exception = const HttpException(
-      'Connection closed before full header was received',
+    final FakeChromeConnection chromeConnection = FakeChromeConnection();
+    final TestChromiumLauncher chromiumLauncher = TestChromiumLauncher();
+    final FakeProcess process = FakeProcess();
+    final Chromium chrome = Chromium(
+      1,
+      chromeConnection,
+      chromiumLauncher: chromiumLauncher,
+      process: process,
+      logger: logger,
     );
+    chromiumLauncher.setInstance(chrome);
+
+    flutterDevice.device = GoogleChromeDevice(
+      fileSystem: fileSystem,
+      chromiumLauncher: chromiumLauncher,
+      logger: logger,
+      platform: FakePlatform(),
+      processManager: FakeProcessManager.any(),
+    );
+    webDevFS.baseUri = Uri.parse('http://localhost:8765/app/');
+
+    final FakeChromeTab chromeTab = FakeChromeTab(
+      'index.html',
+      connectException: HttpException(
+        'Connection closed before full header was received',
+        uri: Uri(
+          path: 'http://localhost:50094/devtools/page/3036A94908353E86E183B6A40F54104B',
+        ),
+      ),
+    );
+    chromeConnection.tabs.add(chromeTab);
 
     await expectLater(
       residentWebRunner.run,
       throwsToolExit(
-        message:
-            'Failed to establish connection with the application instance in Chrome.',
+        message: 'Failed to establish connection with the application instance in Chrome.',
       ),
     );
     expect(logger.errorText, contains('HttpException'));
@@ -1622,14 +1649,21 @@ class FakeChromeConnection extends Fake implements ChromeConnection {
 }
 
 class FakeChromeTab extends Fake implements ChromeTab {
-  FakeChromeTab(this.url);
+  FakeChromeTab(this.url, {
+    Exception? connectException,
+  }): _connectException = connectException;
 
   @override
   final String url;
+
+  final Exception? _connectException;
   final FakeWipConnection connection = FakeWipConnection();
 
   @override
   Future<WipConnection> connect({Function? onError}) async {
+    if (_connectException != null) {
+      throw _connectException;
+    }
     return connection;
   }
 }

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1317,6 +1317,25 @@ flutter:
     ProcessManager: () => processManager,
   });
 
+  testUsingContext('Successfully turns HttpException into ToolExit',
+      () async {
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner =
+        setUpResidentRunner(flutterDevice, logger: logger);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    setupMocks();
+    webDevFS.exception = const HttpException(
+      'Connection closed before full header was received',
+    );
+
+    await expectLater(residentWebRunner.run, throwsToolExit());
+    expect(logger.errorText, contains('HttpException'));
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
+
   testUsingContext('Successfully turns AppConnectionException into ToolExit',
       () async {
     final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/153298, a major crasher of the flutter tool. I plan on cherry-picking this change.

In `ResidentWebRunner::run`, many connection-related exceptions are caught, logged, and have `ToolExit`s thrown in their place ([code](https://github.com/flutter/flutter/blob/d23be7a07de3bd7f02db367fce52eff79021df24/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart#L370-L385), [PR that introduced this](https://github.com/flutter/flutter/pull/50895)). However, `HttpException` is not included in this list. See https://github.com/flutter/flutter/issues/153298#issuecomment-2290900158 for details if interested.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
