### PR TITLE
Add tests for `SingleChildScrollView` examples

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -355,8 +355,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/notification_listener/notification.0_test.dart',
   'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart',
   'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart',
-  'examples/api/test/widgets/single_child_scroll_view/single_child_scroll_view.1_test.dart',
-  'examples/api/test/widgets/single_child_scroll_view/single_child_scroll_view.0_test.dart',
   'examples/api/test/widgets/restoration/restoration_mixin.0_test.dart',
   'examples/api/test/widgets/actions/focusable_action_detector.0_test.dart',
   'examples/api/test/widgets/focus_scope/focus_scope.0_test.dart',

--- a/examples/api/test/widgets/single_child_scroll_view/single_child_scroll_view.0_test.dart
+++ b/examples/api/test/widgets/single_child_scroll_view/single_child_scroll_view.0_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_api_samples/widgets/single_child_scroll_view/single_child_scroll_view.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The children should be spaced out equally when the screen is big enough', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SingleChildScrollViewExampleApp(),
+    );
+
+    expect(find.text('Fixed Height Content'), findsExactly(2));
+    expect(tester.getTopLeft(find.byType(Container).first), const Offset(0, 90));
+    expect(tester.getTopLeft(find.byType(Container).last), const Offset(0, 390));
+
+    await tester.fling(find.byType(SingleChildScrollView).last, const Offset(0, -100), 10.0);
+
+    // The view should not scroll when the screen is big enough.
+    expect(tester.getTopLeft(find.byType(Container).first), const Offset(0, 90));
+    expect(tester.getTopLeft(find.byType(Container).last), const Offset(0, 390));
+  });
+
+  testWidgets('The view should be scrollable when the screen is not big enough', (WidgetTester tester) async {
+    tester.view
+      ..physicalSize = const Size(400, 200)
+      ..devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const example.SingleChildScrollViewExampleApp(),
+    );
+
+    expect(find.text('Fixed Height Content'), findsExactly(2));
+    expect(tester.getTopLeft(find.byType(Container).first), Offset.zero);
+    expect(tester.getTopLeft(find.byType(Container).last), const Offset(0, 120));
+
+    await tester.fling(find.byType(SingleChildScrollView).last, const Offset(0, -40), 10.0);
+
+    // The view should scroll when the screen is not big enough.
+    expect(tester.getTopLeft(find.byType(Container).first), const Offset(0, -40));
+    expect(tester.getTopLeft(find.byType(Container).last), const Offset(0, 80));
+  });
+}

--- a/examples/api/test/widgets/single_child_scroll_view/single_child_scroll_view.1_test.dart
+++ b/examples/api/test/widgets/single_child_scroll_view/single_child_scroll_view.1_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_api_samples/widgets/single_child_scroll_view/single_child_scroll_view.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The flexible child should fill the space if the screen is big enough', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SingleChildScrollViewExampleApp(),
+    );
+
+    final Finder fixedHeightFinder = find.widgetWithText(Container, 'Fixed Height Content');
+    final Finder flexibleHeightFinder = find.widgetWithText(Container, 'Flexible Content');
+    expect(tester.getTopLeft(fixedHeightFinder), Offset.zero);
+    expect(tester.getSize(fixedHeightFinder), const Size(800, 120));
+    expect(tester.getTopLeft(flexibleHeightFinder), const Offset(0, 120));
+    expect(tester.getSize(flexibleHeightFinder), const Size(800, 480));
+
+    await tester.fling(find.byType(SingleChildScrollView).last, const Offset(0, -100), 10.0);
+
+    // The view should not scroll when the screen is big enough.
+    expect(tester.getTopLeft(fixedHeightFinder), Offset.zero);
+    expect(tester.getSize(fixedHeightFinder), const Size(800, 120));
+    expect(tester.getTopLeft(flexibleHeightFinder), const Offset(0, 120));
+    expect(tester.getSize(flexibleHeightFinder), const Size(800, 480));
+  });
+
+  testWidgets('The view should be scrollable when the screen is not big enough', (WidgetTester tester) async {
+    tester.view
+      ..physicalSize = const Size(400, 200)
+      ..devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      const example.SingleChildScrollViewExampleApp(),
+    );
+
+    final Finder fixedHeightFinder = find.widgetWithText(Container, 'Fixed Height Content');
+    final Finder flexibleHeightFinder = find.widgetWithText(Container, 'Flexible Content');
+    expect(tester.getTopLeft(fixedHeightFinder), Offset.zero);
+    expect(tester.getSize(fixedHeightFinder), const Size(400, 120));
+    expect(tester.getTopLeft(flexibleHeightFinder), const Offset(0, 120));
+    expect(tester.getSize(flexibleHeightFinder), const Size(400, 120));
+
+    await tester.fling(find.byType(SingleChildScrollView).last, const Offset(0, -40), 10.0);
+
+    // The view should scroll when the screen is not big enough.
+    expect(tester.getTopLeft(fixedHeightFinder), const Offset(0, -40));
+    expect(tester.getSize(fixedHeightFinder), const Size(400, 120));
+    expect(tester.getTopLeft(flexibleHeightFinder), const Offset(0, 80));
+    expect(tester.getSize(flexibleHeightFinder), const Size(400, 120));
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/single_child_scroll_view/single_child_scroll_view.0.dart`
- `examples/api/lib/widgets/single_child_scroll_view/single_child_scroll_view.1.dart`

I also fixed a mistake in the documentation



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
