### PR TITLE
Make `TextField` read only when the text input is disabled by setting  `DropdownMenu.requestFocusOnTap` to `false`

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -825,6 +825,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           focusNode: widget.focusNode,
           canRequestFocus: canRequestFocus(),
           enableInteractiveSelection: canRequestFocus(),
+          readOnly: !canRequestFocus(),
           keyboardType: widget.keyboardType,
           textAlign: widget.textAlign,
           textAlignVertical: TextAlignVertical.center,

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2334,6 +2334,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: DropdownMenu<String>(
+            requestFocusOnTap: true,
             controller: controller,
             dropdownMenuEntries: const <DropdownMenuEntry<String>>[
               DropdownMenuEntry<String>(
@@ -2566,6 +2567,53 @@ void main() {
     for (final TestMenu menu in TestMenu.values) {
       expect(find.widgetWithText(MenuItemButton, menu.label), findsNWidgets(2));
     }
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/151686.
+  testWidgets('Setting DropdownMenu.requestFocusOnTap to false makes TextField read only', (WidgetTester tester) async {
+    const String label = 'Test';
+    Widget buildDropdownMenu({ bool? requestFocusOnTap }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: DropdownMenu<TestMenu>(
+              requestFocusOnTap: requestFocusOnTap,
+              dropdownMenuEntries: menuChildren,
+              hintText: label,
+            ),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildDropdownMenu(requestFocusOnTap: true));
+
+    expect(
+      tester.getSemantics(find.byType(TextField)),
+      matchesSemantics(
+        hasFocusAction: true,
+        hasTapAction: true,
+        isTextField: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        label: 'Test',
+        textDirection: TextDirection.ltr,
+      ),
+    );
+
+    await tester.pumpWidget(buildDropdownMenu(requestFocusOnTap: false));
+
+    expect(
+      tester.getSemantics(find.byType(TextField)),
+      matchesSemantics(
+        hasFocusAction: true,
+        isTextField: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        label: 'Test',
+        isReadOnly: true,
+        textDirection: TextDirection.ltr,
+      ),
+    );
   });
 }
 


### PR DESCRIPTION
Fixes [[DropdownMenu] Semantics still reads out "EditBox" when text editing is disabled](https://github.com/flutter/flutter/issues/151686)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const DropdownMenuExample());
}

enum ColorLabel {
  blue('Blue', Colors.blue),
  pink('Pink', Colors.pink),
  green('Green', Colors.green),
  yellow('Orange', Colors.orange),
  grey('Grey', Colors.grey);

  const ColorLabel(this.label, this.color);
  final String label;
  final Color color;
}

class DropdownMenuExample extends StatefulWidget {
  const DropdownMenuExample({super.key});

  @override
  State<DropdownMenuExample> createState() => _DropdownMenuExampleState();
}

class _DropdownMenuExampleState extends State<DropdownMenuExample> {
  ColorLabel? selectedColor;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: SafeArea(
          child: Padding(
            padding: const EdgeInsets.all(16.0),
            child: Column(
              mainAxisAlignment: MainAxisAlignment.center,
              spacing: 16.0,
              children: <Widget>[
                const ExcludeSemantics(child: Text('TexField')),
                const TextField(
                  readOnly: true,
                  decoration: InputDecoration(
                    labelText: 'Color',
                    border: OutlineInputBorder(),
                  ),
                ),
                const ExcludeSemantics(child: Text('DropdownMenu')),
                DropdownMenu<ColorLabel>(
                  requestFocusOnTap: false,
                  label: const Text('Color'),
                  dropdownMenuEntries: ColorLabel.values
                      .map<DropdownMenuEntry<ColorLabel>>((ColorLabel color) {
                    return DropdownMenuEntry<ColorLabel>(
                      value: color,
                      label: color.label,
                      style: MenuItemButton.styleFrom(
                        foregroundColor: color.color,
                      ),
                    );
                  }).toList(),
                ),
              ],
            ),
          ),
        ),
      ),
    );
  }
}

```

</details>

### Preview (with Talkback captions)
|Before | After |
| --------------- | --------------- |
| <img src="https://github.com/user-attachments/assets/0d9f79f3-de5d-4c42-adea-3d700464d001" /> | <img src="https://github.com/user-attachments/assets/cf38508e-61f7-43ff-b420-ffe24cc8e28f" /> |

### Before demo
DropdownMenu announces "EditBox" and "double tap to activate" when setting `DropdownMenu.requestFocusOnTap` to `false` shouldn't allow that

https://github.com/user-attachments/assets/f692a4f6-9d6a-4834-8df0-baf6c65fae29

### After demo
When setting `DropdownMenu.requestFocusOnTap` to `false`, the underlying `TextField` gets read only state which changes the semantics to be not editable or focusable  and remove"EditBox" and "double tap to activate" announcments

https://github.com/user-attachments/assets/0e14a636-6b81-4535-a5d1-c8f301c4f89e


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
