### PR TITLE
When the app enters the detached state, clear the record of the last SystemChrome style sent to the host

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -27,6 +27,7 @@ import 'raw_keyboard.dart' show RawKeyboard;
 import 'restoration.dart';
 import 'service_extensions.dart';
 import 'system_channels.dart';
+import 'system_chrome.dart';
 import 'text_input.dart';
 
 export 'dart:ui' show ChannelBuffers, RootIsolateToken;
@@ -284,7 +285,10 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
   Future<String?> _handleLifecycleMessage(String? message) async {
     final AppLifecycleState? state = _parseAppLifecycleMessage(message!);
     final List<AppLifecycleState> generated = _generateStateTransitions(lifecycleState, state!);
-    generated.forEach(handleAppLifecycleStateChanged);
+    for (final AppLifecycleState stateChange in generated) {
+      handleAppLifecycleStateChanged(stateChange);
+      SystemChrome.handleAppLifecycleStateChanged(stateChange);
+    }
     return null;
   }
 

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -641,6 +641,17 @@ abstract final class SystemChrome {
     });
   }
 
+  /// Called by the binding during a transition to a new app lifecycle state.
+  static void handleAppLifecycleStateChanged(AppLifecycleState state) {
+    // When the app is detached, clear the record of the style sent to the host
+    // so that it will be sent again when the app is reattached.
+    if (state == AppLifecycleState.detached) {
+      scheduleMicrotask(() {
+        _latestStyle = null;
+      });
+    }
+  }
+
   static SystemUiOverlayStyle? _pendingStyle;
 
   /// The last style that was set using [SystemChrome.setSystemUIOverlayStyle].


### PR DESCRIPTION
This ensures that the style will be sent again after the host is reattached

Fixes https://github.com/flutter/flutter/issues/150418