### PR TITLE
Do not cancel the VmService's subscription to the isolate event stream in FlutterVmService.findExtensionIsolate

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -986,11 +986,6 @@ class FlutterVmService {
       throw VmServiceDisappearedException();
     } finally {
       await isolateEvents.cancel();
-      try {
-        await service.streamCancel(vm_service.EventStreams.kIsolate);
-      } on vm_service.RPCError {
-        // It's ok for cleanup to fail, such as when the service disappears.
-      }
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/integration_test_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/integration_test_device_test.dart
@@ -97,12 +97,6 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
-        method: 'streamCancel',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      const FakeVmServiceRequest(
         method: 'streamListen',
         args: <String, Object>{
           'streamId': 'Extension',

--- a/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
@@ -153,12 +153,6 @@ void main() {
           'isolateId': '1',
         },
       ),
-      const FakeVmServiceRequest(
-        method: 'streamCancel',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
       listViews,
       listViews,
       const FakeVmServiceRequest(
@@ -225,12 +219,6 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
-        method: 'streamCancel',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      const FakeVmServiceRequest(
         method: 'ext.flutter.activeDevToolsServerAddress',
         args: <String, Object>{
           'value': 'http://localhost:8080',
@@ -270,13 +258,6 @@ void main() {
         method: kListViewsMethod,
         error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
       ),
-      const FakeVmServiceRequest(
-        method: 'streamCancel',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-        error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
-      ),
     ], httpAddress: Uri.parse('http://localhost:1234'));
 
     final FakeFlutterDevice device = FakeFlutterDevice()
@@ -311,12 +292,6 @@ void main() {
           'isolateId': '1',
         },
       ),
-      const FakeVmServiceRequest(
-        method: 'streamCancel',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
       listViews,
       listViews,
       const FakeVmServiceRequest(
@@ -344,13 +319,6 @@ void main() {
       ),
       const FakeVmServiceRequest(
         method: kListViewsMethod,
-        error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
-      ),
-      const FakeVmServiceRequest(
-        method: 'streamCancel',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
         error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
       ),
     ], httpAddress: Uri.parse('http://localhost:5678'));

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -535,12 +535,6 @@ void main() {
             'isolateId': '1',
           },
         ),
-        const FakeVmServiceRequest(
-          method: 'streamCancel',
-          args: <String, Object>{
-            'streamId': 'Isolate',
-          },
-        ),
       ]);
 
       final vm_service.IsolateRef isolateRef = await fakeVmServiceHost.vmService.findExtensionIsolate(kExtensionName);
@@ -592,12 +586,6 @@ void main() {
             'isolateId': '2',
           },
         ),
-        const FakeVmServiceRequest(
-          method: 'streamCancel',
-          args: <String, Object>{
-            'streamId': 'Isolate',
-          },
-        ),
       ]);
 
       final vm_service.IsolateRef isolateRef = await fakeVmServiceHost.vmService.findExtensionIsolate(otherExtensionName);
@@ -644,12 +632,6 @@ void main() {
             isolate: isolate2,
           ),
         ),
-        const FakeVmServiceRequest(
-          method: 'streamCancel',
-          args: <String, Object>{
-            'streamId': 'Isolate',
-          },
-        ),
       ]);
 
       final vm_service.IsolateRef isolateRef = await fakeVmServiceHost.vmService.findExtensionIsolate(otherExtensionName);
@@ -672,12 +654,6 @@ void main() {
           jsonResponse: isolate.toJson()..['extensionRPCs'] = <String>[kExtensionName],
           args: <String, Object>{
             'isolateId': '1',
-          },
-        ),
-        const FakeVmServiceRequest(
-          method: 'streamCancel',
-          args: <String, Object>{
-            'streamId': 'Isolate',
           },
         ),
       ]);
@@ -710,12 +686,6 @@ void main() {
             timestamp: 1,
           ),
         ),
-        const FakeVmServiceRequest(
-          method: 'streamCancel',
-          args: <String, Object>{
-            'streamId': 'Isolate',
-          },
-        ),
       ]);
 
       final vm_service.IsolateRef isolateRef = await fakeVmServiceHost.vmService.findExtensionIsolate(kExtensionName);
@@ -732,13 +702,6 @@ void main() {
         ),
         const FakeVmServiceRequest(
           method: kListViewsMethod,
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
-        ),
-        const FakeVmServiceRequest(
-          method: 'streamCancel',
-          args: <String, Object>{
-            'streamId': 'Isolate',
-          },
           error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
         ),
       ]);

--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -81,7 +81,7 @@ void main() {
   });
 
   testWithoutContext('hot restart works without error', () async {
-    await flutter.run(verbose: true, noDevtools: true);
+    await flutter.run(verbose: true);
     await flutter.hotRestart();
   });
 


### PR DESCRIPTION
The stream subscriptions in the device's VmService are used by other parts of FlutterVmService and other components throughout flutter_tools.  Components that listen to streams should not call VmService.streamCancel because that will interfere with other users who still want the events.

See https://github.com/flutter/flutter/issues/153049
See https://github.com/flutter/flutter/issues/153563