### PR TITLE
added ability to disable blur in CupertinoNavigationBar with transparent background color

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -146,6 +146,7 @@ Widget _wrapWithBackground({
   Brightness? brightness,
   required Widget child,
   bool updateSystemUiOverlay = true,
+  bool disableBackgroundFilterBlur = false,
 }) {
   Widget result = child;
   if (updateSystemUiOverlay) {
@@ -182,7 +183,7 @@ Widget _wrapWithBackground({
 
   return ClipRect(
     child: BackdropFilter(
-      enabled: backgroundColor.alpha != 0xFF,
+      enabled: backgroundColor.alpha != 0xFF && !disableBackgroundFilterBlur,
       filter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
       child: childWithBackground,
     ),
@@ -266,6 +267,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
     this.border = _kDefaultNavBarBorder,
     this.backgroundColor,
     this.automaticBackgroundVisibility = true,
+    this.disableBackgroundFilterBlur = false,
     this.brightness,
     this.padding,
     this.transitionBetweenRoutes = true,
@@ -417,6 +419,19 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final bool transitionBetweenRoutes;
 
+  /// {@template flutter.cupertino.CupertinoNavigationBar.disableBackgroundFilterBlur}
+  /// Whether to have blur effect with transparent color.
+  ///
+  /// If the [CupertinoNavigationBar] is not a child of a [CupertinoPageScaffold],
+  /// this has no effect.
+  ///
+  /// When [disableBackgroundFilterBlur] is set to true. The blur effect will be
+  /// disabled.
+  ///
+  /// This value defaults to false.
+  /// {@endtemplate}
+  final bool disableBackgroundFilterBlur;
+
   /// {@template flutter.cupertino.CupertinoNavigationBar.heroTag}
   /// Tag for the navigation bar's Hero widget if [transitionBetweenRoutes] is true.
   ///
@@ -552,6 +567,7 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
       border: effectiveBorder,
       backgroundColor: effectiveBackgroundColor,
       brightness: widget.brightness,
+      disableBackgroundFilterBlur: widget.disableBackgroundFilterBlur,
       child: DefaultTextStyle(
         style: CupertinoTheme.of(context).textTheme.textStyle,
         child: _PersistentNavigationBar(
@@ -676,6 +692,7 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
     this.border = _kDefaultNavBarBorder,
     this.backgroundColor,
     this.automaticBackgroundVisibility = true,
+    this.disableBackgroundFilterBlur = false,
     this.brightness,
     this.padding,
     this.transitionBetweenRoutes = true,
@@ -760,6 +777,9 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// {@macro flutter.cupertino.CupertinoNavigationBar.automaticBackgroundVisibility}
   final bool automaticBackgroundVisibility;
 
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.disableBackgroundFilterBlur}
+  final bool disableBackgroundFilterBlur;
+
   /// {@macro flutter.cupertino.CupertinoNavigationBar.brightness}
   final Brightness? brightness;
 
@@ -840,6 +860,7 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
           persistentHeight: _kNavBarPersistentHeight + MediaQuery.paddingOf(context).top,
           alwaysShowMiddle: widget.alwaysShowMiddle && widget.middle != null,
           stretchConfiguration: widget.stretch ? OverScrollHeaderStretchConfiguration() : null,
+          disableBackgroundFilterBlur: widget.disableBackgroundFilterBlur,
         ),
       ),
     );
@@ -863,6 +884,7 @@ class _LargeTitleNavigationBarSliverDelegate
     required this.persistentHeight,
     required this.alwaysShowMiddle,
     required this.stretchConfiguration,
+    required this.disableBackgroundFilterBlur,
   });
 
   final _NavigationBarStaticComponentsKeys keys;
@@ -878,6 +900,7 @@ class _LargeTitleNavigationBarSliverDelegate
   final Object heroTag;
   final double persistentHeight;
   final bool alwaysShowMiddle;
+  final bool disableBackgroundFilterBlur;
 
   @override
   double get minExtent => persistentHeight;
@@ -922,6 +945,7 @@ class _LargeTitleNavigationBarSliverDelegate
       border: effectiveBorder,
       backgroundColor: effectiveBackgroundColor,
       brightness: brightness,
+      disableBackgroundFilterBlur: disableBackgroundFilterBlur,
       child: DefaultTextStyle(
         style: CupertinoTheme.of(context).textTheme.textStyle,
         child: Stack(
@@ -1014,7 +1038,8 @@ class _LargeTitleNavigationBarSliverDelegate
         || transitionBetweenRoutes != oldDelegate.transitionBetweenRoutes
         || persistentHeight != oldDelegate.persistentHeight
         || alwaysShowMiddle != oldDelegate.alwaysShowMiddle
-        || heroTag != oldDelegate.heroTag;
+        || heroTag != oldDelegate.heroTag
+        || disableBackgroundFilterBlur!=oldDelegate.disableBackgroundFilterBlur;
   }
 }
 

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -157,6 +157,69 @@ void main() {
     );
   });
 
+  testWidgets(
+      'Blur affect is disabled when disableBackgroundFilterBlur is true',
+      (WidgetTester test) async {
+    final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await test.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(brightness: Brightness.light),
+        home: CupertinoPageScaffold(
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Title'),
+            automaticBackgroundVisibility: false,
+            disableBackgroundFilterBlur: true,
+          ),
+          child: ListView(
+            controller: scrollController,
+            children: const <Widget>[
+              Placeholder(),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      test.widget(find.byType(BackdropFilter)),
+      isA<BackdropFilter>().having(
+          (BackdropFilter filter) => filter.enabled, 'filter enabled', false),
+    );
+  });
+
+  testWidgets(
+      'Blur affect is enabled when disableBackgroundFilterBlur is false',
+      (WidgetTester test) async {
+    final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await test.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(brightness: Brightness.light),
+        home: CupertinoPageScaffold(
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Title'),
+            automaticBackgroundVisibility: false,
+          ),
+          child: ListView(
+            controller: scrollController,
+            children: const <Widget>[
+              Placeholder(),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      test.widget(find.byType(BackdropFilter)),
+      isA<BackdropFilter>().having(
+          (BackdropFilter filter) => filter.enabled, 'filter enabled', true),
+    );
+  });
+
   testWidgets('Nav bar displays correctly', (WidgetTester tester) async {
     final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
     await tester.pumpWidget(


### PR DESCRIPTION
This PR is enabling the CupertinoNavigationBar and CupertinoSliverNavigationBar to disable blur effect if background color is transparent.

Issues:
https://github.com/flutter/flutter/issues/151716

Before

![Simulator_Screenshot_-_iPhone_15_Pro_Max_-_2024-08-17_at_18 30 43](https://github.com/user-attachments/assets/9297e176-374c-4a4d-b6df-fa81f1b89ae2)

After

![simulator_screenshot_8587DA9F-E18B-4ED4-AFFB-1DA52FF5C0D2](https://github.com/user-attachments/assets/ac6eadbc-be9a-4c4c-9fb4-06e58055bab7)



<details>
  <summary>Demo App Code</summary>

```dart
import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';

void main() => runApp(const NavBarApp());

class NavBarApp extends StatelessWidget {
  const NavBarApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const CupertinoApp(
      theme: CupertinoThemeData(brightness: Brightness.light),
      home: NavBarExample(),
    );
  }
}

class NavBarExample extends StatefulWidget {
  const NavBarExample({super.key});

  @override
  State<NavBarExample> createState() => _NavBarExampleState();
}

class _NavBarExampleState extends State<NavBarExample> {
  @override
  Widget build(BuildContext context) {
    return const CupertinoPageScaffold(
      navigationBar: CupertinoNavigationBar(
        backgroundColor: Colors.transparent,
        automaticBackgroundVisibility: false,
        disableBackgroundFilterBlur: true,
        middle: Text(
          'CupertinoNavigationBar Sample',
          style: TextStyle(color: CupertinoColors.activeBlue),
        ),
      ),
      child: Column(
        children: [
          Image(
            image: NetworkImage(
                'https://flutter.github.io/assets-for-api-docs/assets/widgets/owl.jpg'),
          ),
        ],
      ),
    );
  }
} 
```


</details>


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
