### PR TITLE
Fix `IconButton` doesn't show `Tooltip` when hovering within the button area but outside the `Icon`

### DIFF
--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -480,7 +480,14 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
       effectiveChild = resolvedBackgroundBuilder(context, statesController.value, effectiveChild);
     }
 
-    Widget result = ConstrainedBox(
+    if (widget.tooltip != null) {
+      effectiveChild = Tooltip(
+        message: widget.tooltip,
+        child: effectiveChild,
+      );
+    }
+
+    final Widget result = ConstrainedBox(
       constraints: effectiveConstraints,
       child: Material(
         elevation: resolvedElevation!,
@@ -529,13 +536,6 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
         assert(minSize.height >= 0.0);
       case MaterialTapTargetSize.shrinkWrap:
         minSize = Size.zero;
-    }
-
-    if (widget.tooltip != null) {
-      result = Tooltip(
-        message: widget.tooltip,
-        child: result,
-      );
     }
 
     return Semantics(

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -26,6 +26,7 @@ import 'material_state.dart';
 import 'outlined_button.dart';
 import 'text_button.dart';
 import 'theme_data.dart';
+import 'tooltip.dart';
 
 /// {@template flutter.material.ButtonStyleButton.iconAlignment}
 /// Determines the alignment of the icon within the widgets such as:
@@ -85,8 +86,9 @@ abstract class ButtonStyleButton extends StatefulWidget {
     required this.clipBehavior,
     this.statesController,
     this.isSemanticButton = true,
-    required this.child,
     this.iconAlignment = IconAlignment.start,
+    this.tooltip,
+    required this.child,
   });
 
   /// Called when the button is tapped or otherwise activated.
@@ -155,13 +157,19 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// Defaults to true.
   final bool? isSemanticButton;
 
+  /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
+  final IconAlignment iconAlignment;
+
+  /// Text that describes the action that will occur when the button is pressed.
+  ///
+  /// This text is displayed when the user long-presses on the button and is
+  /// used for accessibility.
+  final String? tooltip;
+
   /// Typically the button's label.
   ///
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
-
-  /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
-  final IconAlignment iconAlignment;
 
   /// Returns a [ButtonStyle] that's based primarily on the [Theme]'s
   /// [ThemeData.textTheme] and [ThemeData.colorScheme], but has most values
@@ -469,7 +477,7 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
       effectiveChild = resolvedBackgroundBuilder(context, statesController.value, effectiveChild);
     }
 
-    final Widget result = ConstrainedBox(
+    Widget result = ConstrainedBox(
       constraints: effectiveConstraints,
       child: Material(
         elevation: resolvedElevation!,
@@ -518,6 +526,13 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
         assert(minSize.height >= 0.0);
       case MaterialTapTargetSize.shrinkWrap:
         minSize = Size.zero;
+    }
+
+    if (widget.tooltip != null) {
+      result = Tooltip(
+        message: widget.tooltip,
+        child: result,
+      );
     }
 
     return Semantics(

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -160,10 +160,13 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
   final IconAlignment iconAlignment;
 
-  /// Text that describes the action that will occur when the button is pressed.
+  /// Text that describes the action that will occur when the button is pressed or
+  /// hovered over.
   ///
-  /// This text is displayed when the user long-presses on the button and is
-  /// used for accessibility.
+  /// This text is displayed when the user long-presses or hovers over the button
+  /// in a tooltip. This string is also used for accessibility.
+  ///
+  /// If null, the button will not display a tooltip.
   final String? tooltip;
 
   /// Typically the button's label.

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -719,14 +719,6 @@ class IconButton extends StatelessWidget {
         effectiveIcon = selectedIcon!;
       }
 
-      Widget iconButton = effectiveIcon;
-      if (tooltip != null) {
-        iconButton = Tooltip(
-          message: tooltip,
-          child: effectiveIcon,
-        );
-      }
-
       return _SelectableIconButton(
         style: adjustedStyle,
         onPressed: onPressed,
@@ -734,7 +726,8 @@ class IconButton extends StatelessWidget {
         focusNode: focusNode,
         isSelected: isSelected,
         variant: _variant,
-        child: iconButton,
+        tooltip: tooltip,
+        child: effectiveIcon,
       );
     }
 
@@ -835,6 +828,7 @@ class _SelectableIconButton extends StatefulWidget {
     required this.variant,
     required this.autofocus,
     required this.onPressed,
+    this.tooltip,
     required this.child,
   });
 
@@ -844,6 +838,7 @@ class _SelectableIconButton extends StatefulWidget {
   final _IconButtonVariant variant;
   final bool autofocus;
   final VoidCallback? onPressed;
+  final String? tooltip;
   final Widget child;
 
   @override
@@ -891,6 +886,7 @@ class _SelectableIconButtonState extends State<_SelectableIconButton> {
       onPressed: widget.onPressed,
       variant: widget.variant,
       toggleable: toggleable,
+      tooltip: widget.tooltip,
       child: Semantics(
         selected: widget.isSelected,
         child: widget.child,
@@ -914,6 +910,7 @@ class _IconButtonM3 extends ButtonStyleButton {
     super.statesController,
     required this.variant,
     required this.toggleable,
+    super.tooltip,
     required Widget super.child,
   }) : super(
       onLongPress: null,

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -32,6 +32,13 @@ void main() {
     return tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
   }
 
+  Finder findTooltipContainer(String tooltipText) {
+    return find.ancestor(
+      of: find.text(tooltipText),
+      matching: find.byType(Container),
+    );
+  }
+
   testWidgets('test icon is findable by key', (WidgetTester tester) async {
     const ValueKey<String> key = ValueKey<String>('icon-button');
     await tester.pumpWidget(
@@ -412,45 +419,43 @@ void main() {
   });
 
   testWidgets('test tooltip', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
+    const String tooltipText = 'Test tooltip';
+    Widget buildIconButton({ String? tooltip }) {
+      return MaterialApp(
         theme: theme,
         home: Material(
           child: Center(
             child: IconButton(
               onPressed: mockOnPressedFunction.handler,
               icon: const Icon(Icons.ac_unit),
+              tooltip: tooltip,
             ),
           ),
         ),
-      ),
-    );
+      );
+    }
+
+    await tester.pumpWidget(buildIconButton());
 
     expect(find.byType(Tooltip), findsNothing);
 
     // Clear the widget tree.
     await tester.pumpWidget(Container(key: UniqueKey()));
 
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: theme,
-        home: Material(
-          child: Center(
-            child: IconButton(
-              onPressed: mockOnPressedFunction.handler,
-              icon: const Icon(Icons.ac_unit),
-              tooltip: 'Test tooltip',
-            ),
-          ),
-        ),
-      ),
-    );
+    await tester.pumpWidget(buildIconButton(tooltip: tooltipText));
 
     expect(find.byType(Tooltip), findsOneWidget);
-    expect(find.byTooltip('Test tooltip'), findsOneWidget);
+    expect(find.byTooltip(tooltipText), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Test tooltip'));
+    await tester.tap(find.byTooltip(tooltipText));
     expect(mockOnPressedFunction.called, 1);
+
+    // Hovering over the button should show the tooltip.
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: tester.getCenter(find.byType(IconButton)));
+    await tester.pump();
+
+    expect(findTooltipContainer(tooltipText), findsOneWidget);
   });
 
   testWidgets('IconButton AppBar size', (WidgetTester tester) async {
@@ -2953,6 +2958,39 @@ void main() {
 
       // No exception is thrown.
     });
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/153544.
+  testWidgets('Tooltip is drawn when hovering within IconButton area but outside the Icon tself', (WidgetTester tester) async {
+    const String tooltipText = 'Test tooltip';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.favorite),
+              tooltip: tooltipText,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Verify that the tooltip is not shown initially.
+    expect(findTooltipContainer(tooltipText), findsNothing);
+
+    // Start hovering within IconButton area to show the tooltip.
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+
+    final Offset topLeft = tester.getTopLeft(find.byType(Icon));
+    // Move the cursor just outside the Icon.
+    await gesture.moveTo(Offset(topLeft.dx - 1, topLeft.dy - 1));
+    await tester.pump();
+
+    // Verify that the tooltip is shown.
+    expect(findTooltipContainer(tooltipText), findsOneWidget);
   });
 }
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -2992,6 +2992,45 @@ void main() {
     // Verify that the tooltip is shown.
     expect(findTooltipContainer(tooltipText), findsOneWidget);
   });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/153544.
+  testWidgets('Trigger Ink splash when hovering within layout bounds with tooltip', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: ColoredBox(
+              color: const Color(0xFFFF0000),
+              child: IconButton(
+                onPressed: () {},
+                icon: const Icon(Icons.favorite),
+                tooltip: 'Test tooltip',
+                style: const ButtonStyle(
+                  overlayColor: WidgetStatePropertyAll<Color>(Color(0xFF00FF00)),
+                  padding: WidgetStatePropertyAll<EdgeInsets>(EdgeInsets.all(20)),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Offset topLeft = tester.getTopLeft(find.byType(ColoredBox));
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(topLeft);
+    await gesture.down(topLeft);
+    await tester.pumpAndSettle();
+    expect(
+      getOverlayColor(tester),
+      paints
+        ..rect(color: const Color(0xFFFF0000)) // ColoredBox.
+        ..rect(color: const Color(0xFF00FF00)), // IconButton overlay.
+    );
+  });
 }
 
 Widget wrap({required Widget child, required bool useMaterial3}) {

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -2961,7 +2961,7 @@ void main() {
   });
 
   // This is a regression test for https://github.com/flutter/flutter/issues/153544.
-  testWidgets('Tooltip is drawn when hovering within IconButton area but outside the Icon tself', (WidgetTester tester) async {
+  testWidgets('Tooltip is drawn when hovering within IconButton area but outside the Icon itself', (WidgetTester tester) async {
     const String tooltipText = 'Test tooltip';
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Fixes [Tooltip is not shown consistently on entire IconButton](https://github.com/flutter/flutter/issues/153544)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(
    MaterialApp(
      home: Scaffold(
        body: Center(
          child: Row(
            spacing: 20.0,
            mainAxisAlignment: MainAxisAlignment.center,
            children: <Widget>[
              IconButton(
                padding: const EdgeInsets.all(20.0),
                icon: const ColoredBox(
                  color: Color(0xFFFF0000),
                  child: Icon(Icons.add),
                ),
                onPressed: () {},
                tooltip: 'Tooltip',
              ),
              IconButton.filled(
                padding: const EdgeInsets.all(20.0),
                icon: const ColoredBox(
                  color: Color(0xFFFF0000),
                  child: Icon(Icons.add),
                ),
                onPressed: () {},
                tooltip: 'Tooltip',
              ),
              IconButton.filledTonal(
                padding: const EdgeInsets.all(20.0),
                icon: const ColoredBox(
                  color: Color(0xFFFF0000),
                  child: Icon(Icons.add),
                ),
                onPressed: () {},
                tooltip: 'Tooltip',
              ),
              IconButton.outlined(
                padding: const EdgeInsets.all(20.0),
                icon: const ColoredBox(
                  color: Color(0xFFFF0000),
                  child: Icon(Icons.add),
                ),
                onPressed: () {},
                tooltip: 'Tooltip',
              ),
            ],
          ),
        ),
      ),
    ),
  );
}
```

</details>

### Before (Hover outside the red box but within the `IconButton`)

<img width="579" alt="Screenshot 2024-08-19 at 15 30 35" src="https://github.com/user-attachments/assets/fd2a65f1-f30d-4907-a2d9-c11dc59efb2b">

### Before (Hover outside the red box but within the `IconButton`)

<img width="579" alt="Screenshot 2024-08-19 at 15 30 09" src="https://github.com/user-attachments/assets/b2b4dba7-4d0a-44c9-b1e1-742a900ffd8a">

### Demo


https://github.com/user-attachments/assets/129eb8ee-e132-45c9-80b7-165486c02951




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
