### PR TITLE
Handle "Service connection disposed" error from VmService disconnecting while requests are outstanding

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -414,7 +414,8 @@ known, it can be explicitly provided to attach via the command-line, e.g.
         _logger.printStatus('Waiting for a new connection from Flutter on ${device.name}...');
       }
     } on RPCError catch (err) {
-      if (err.code == RPCErrorCodes.kServiceDisappeared) {
+      if (err.code == RPCErrorCodes.kServiceDisappeared ||
+          err.message.contains('Service connection disposed')) {
         throwToolExit('Lost connection to device.');
       }
       rethrow;

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -516,7 +516,8 @@ class DevFS {
       final vm_service.Response response = await _vmService.createDevFS(fsName);
       _baseUri = Uri.parse(response.json!['uri'] as String);
     } on vm_service.RPCError catch (rpcException) {
-      if (rpcException.code == RPCErrorCodes.kServiceDisappeared) {
+      if (rpcException.code == RPCErrorCodes.kServiceDisappeared ||
+          rpcException.message.contains('Service connection disposed')) {
         // This can happen if the device has been disconnected, so translate to
         // a DevFSException, which the caller will handle.
         throw DevFSException('Service disconnected', rpcException);

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -503,11 +503,8 @@ class FlutterVmService {
       // and should begin to shutdown due to the service connection closing.
       // Swallow the exception here and let the shutdown logic elsewhere deal
       // with cleaning up.
-      if (e.code == RPCErrorCodes.kServiceDisappeared) {
-        return null;
-      }
-      if (e.code == RPCErrorCodes.kServerError &&
-          e.message == 'Service connection disposed') {
+      if (e.code == RPCErrorCodes.kServiceDisappeared ||
+          e.message.contains('Service connection disposed')) {
         return null;
       }
       rethrow;
@@ -877,8 +874,9 @@ class FlutterVmService {
     } on vm_service.RPCError catch (err) {
       // If an application is not using the framework or the VM service
       // disappears while handling a request, return null.
-      if ((err.code == RPCErrorCodes.kMethodNotFound)
-          || (err.code == RPCErrorCodes.kServiceDisappeared)) {
+      if ((err.code == RPCErrorCodes.kMethodNotFound) ||
+          (err.code == RPCErrorCodes.kServiceDisappeared) ||
+          (err.message.contains('Service connection disposed'))) {
         return null;
       }
       rethrow;

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -506,6 +506,10 @@ class FlutterVmService {
       if (e.code == RPCErrorCodes.kServiceDisappeared) {
         return null;
       }
+      if (e.code == RPCErrorCodes.kServerError &&
+          e.message == 'Service connection disposed') {
+        return null;
+      }
       rethrow;
     }
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -1125,6 +1125,45 @@ void main() {
       DeviceManager: () => testDeviceManager,
     });
 
+    testUsingContext('Catches "Service connection disposed" error', () async {
+      final FakeAndroidDevice device = FakeAndroidDevice(id: '1')
+        ..portForwarder = const NoOpDevicePortForwarder()
+        ..onGetLogReader = () => NoOpDeviceLogReader('test');
+      final FakeHotRunner hotRunner = FakeHotRunner();
+      final FakeHotRunnerFactory hotRunnerFactory = FakeHotRunnerFactory()
+        ..hotRunner = hotRunner;
+      hotRunner.onAttach = (
+        Completer<DebugConnectionInfo>? connectionInfoCompleter,
+        Completer<void>? appStartedCompleter,
+        bool allowExistingDdsInstance,
+        bool enableDevTools,
+      ) async {
+        await null;
+        throw vm_service.RPCError('flutter._listViews', RPCErrorCodes.kServerError, 'Service connection disposed');
+      };
+
+      testDeviceManager.devices = <Device>[device];
+      testFileSystem.file('lib/main.dart').createSync();
+
+      final AttachCommand command = AttachCommand(
+        hotRunnerFactory: hotRunnerFactory,
+        stdio: stdio,
+        logger: logger,
+        terminal: terminal,
+        signals: signals,
+        platform: platform,
+        processInfo: processInfo,
+        fileSystem: testFileSystem,
+      );
+      await expectLater(createTestCommandRunner(command).run(<String>[
+        'attach',
+      ]), throwsToolExit(message: 'Lost connection to device.'));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      DeviceManager: () => testDeviceManager,
+    });
+
     testUsingContext('Does not catch generic RPC error', () async {
       final FakeAndroidDevice device = FakeAndroidDevice(id: '1')
         ..portForwarder = const NoOpDevicePortForwarder()


### PR DESCRIPTION
Fixes umbrella issue https://github.com/flutter/flutter/issues/153471, including its children: https://github.com/flutter/flutter/issues/153472, https://github.com/flutter/flutter/issues/153473, and https://github.com/flutter/flutter/issues/153474.

The VM service can be disposed at any time during requests (e.g. the user closes the app or stops debugging in VSCode)[^1]. https://github.com/dart-lang/sdk/commit/a479f91e80875dd6661b12108c9b81bdaeb2af65 and https://github.com/dart-lang/sdk/commit/a7d8707a5964e174f2ce321d075e96e37a9a16ad updated package:vm_service to throw new `RPCError`s when the service disconnects while requests are inflight. Therefore, we need to handle these exceptions in the tool. See umbrella issue for more details.

I plan on cherry-picking this change to the stable channel.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

[^1]: https://github.com/flutter/flutter/issues/153471#issuecomment-2296294221