### PR TITLE
Tests of the app_bar.3.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -321,7 +321,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/flexible_space_bar/flexible_space_bar.0_test.dart',
   'examples/api/test/material/selection_area/selection_area.0_test.dart',
   'examples/api/test/material/app_bar/sliver_app_bar.2_test.dart',
-  'examples/api/test/material/app_bar/sliver_app_bar.3_test.dart',
   'examples/api/test/material/navigation_rail/navigation_rail.extended_animation.0_test.dart',
   'examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart',
   'examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1_test.dart',

--- a/examples/api/test/material/app_bar/app_bar.3_test.dart
+++ b/examples/api/test/material/app_bar/app_bar.3_test.dart
@@ -7,9 +7,90 @@ import 'package:flutter_api_samples/material/app_bar/app_bar.3.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  const int listLengthToTest = 3;
+  testWidgets('Check initial visibility of the crucial widgets', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.AppBarApp());
+
+    expect(find.descendant(
+          of: find.byType(DefaultTabController),
+          matching: find.widgetWithText(AppBar, 'AppBar Sample'),
+        ), findsOne);
+
+    expect(find.descendant(
+          of: find.byType(DefaultTabController),
+          matching: find.widgetWithText(TabBar, 'Cloud'),
+        ), findsOne);
+
+    expect(find.descendant(
+          of: find.byType(DefaultTabController),
+          matching: find.widgetWithText(TabBar, 'Beach'),
+        ), findsOne);
+
+    expect(find.descendant(
+          of: find.byType(DefaultTabController),
+          matching: find.widgetWithText(TabBar, 'Sunny'),
+        ), findsOne);
+
+    // Only items with text "Beach $index" should be visible in the initial state.
+    // Checking the visibility of several items on the list.
+    for (int index = 0; index < listLengthToTest; index++){
+      expect(
+        find.descendant(
+          of: find.byType(TabBarView),
+          matching: find.widgetWithText(ListTile, 'Beach $index'),
+        ), findsOne);
+    }
+    expect(find.widgetWithText(ListTile, 'Cloud 0'), findsNothing);
+    expect(find.widgetWithText(ListTile, 'Sunny 0'), findsNothing);
+  });
+
+  testWidgets('Click the Cloud and Sunny tabs', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.AppBarApp());
+
+    // Only items with text "Beach $index" should be visible in the initial state.
+    expect(find.widgetWithText(ListTile, 'Beach 0'), findsOne);
+    expect(find.widgetWithText(ListTile, 'Cloud 0'), findsNothing);
+    expect(find.widgetWithText(ListTile, 'Sunny 0'), findsNothing);
+
+    // Click the "Cloud" tab.
+    final Finder cloudTabFinder = find.descendant(
+      of: find.byType(DefaultTabController),
+      matching: find.widgetWithText(Tab, 'Cloud'));
+
+    await tester.tap(cloudTabFinder);
+    await tester.pumpAndSettle();
+
+    for (int index = 0; index < listLengthToTest; index++){
+      expect(
+        find.descendant(
+          of: find.byType(TabBarView),
+          matching: find.widgetWithText(ListTile, 'Cloud $index'),
+        ), findsOne);
+    }
+    expect(find.widgetWithText(ListTile, 'Beach 0'), findsNothing);
+    expect(find.widgetWithText(ListTile, 'Sunny 0'), findsNothing);
+
+    // Click the "Sunny" tab.
+    final Finder sunnyTabFinder = find.descendant(
+      of: find.byType(DefaultTabController),
+      matching: find.widgetWithText(Tab, 'Sunny'));
+
+    await tester.tap(sunnyTabFinder);
+    await tester.pumpAndSettle();
+
+    for (int index = 0; index < listLengthToTest; index++){
+      expect(
+        find.descendant(
+          of: find.byType(TabBarView),
+          matching: find.widgetWithText(ListTile, 'Sunny $index'),
+        ), findsOne);
+    }
+    expect(find.widgetWithText(ListTile, 'Beach 0'), findsNothing);
+    expect(find.widgetWithText(ListTile, 'Cloud 0'), findsNothing);
+  });
+
   testWidgets(
-    'AppBar elevates when nested scroll view is scrolled underneath the AppBar',
-    (WidgetTester tester) async {
+    'AppBar elevates when nested scroll view is scrolled underneath the AppBar', (WidgetTester tester) async {
       Material getMaterial() => tester.widget<Material>(find.descendant(
         of: find.byType(AppBar),
         matching: find.byType(Material),


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/130459

Created two tests of AppBar.3 example.

1. Checking the initial visibility of widgets
2. Checking the behavior of clicks in Cloud and Sunny tabs

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
