### PR TITLE
[Release] Update bots to expect new entitlements

### DIFF
--- a/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
+++ b/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
@@ -100,6 +100,7 @@ List<String> binariesWithoutEntitlements(String flutterRoot) {
     'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
     'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
     'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+    'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
     'artifacts/engine/ios/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
     'artifacts/engine/ios/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
     'artifacts/engine/ios/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',


### PR DESCRIPTION
When attempting to release the Flutter 3.24.1 hotfix, Flutter framework post submits failed due to the following error:

```
╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════
║ UNEXPECTED ERROR!
║ Exception: Found unexpected binary in cache: /Volumes/Work/s/w/ir/x/w/flutter/bin/cache/artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter
║ #0      verifyExist (file:///Volumes/Work/s/w/ir/x/w/flutter/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart:150:12)
║ <asynchronous suspension>
║ #1      verifyCodesignedTestRunner (file:///Volumes/Work/s/w/ir/x/w/flutter/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart:28:3)
║ <asynchronous suspension>
║ #2      _runFromList (file:///Volumes/Work/s/w/ir/x/w/flutter/dev/bots/utils.dart:601:5)
║ <asynchronous suspension>
║ #3      main (file:///Volumes/Work/s/w/ir/x/w/flutter/dev/bots/test.dart:125:5)
║ <asynchronous suspension>
║ 
║ The test.dart script should be corrected to catch this error and call foundError().
║ Some tests are likely to have been skipped.
╚═══════════════════════════════════════════════════════════════════════════════
```

I've updated the tests to include the listed artifact.  

### Open questions
1. Is it possible that the test failed only on the first binary?
2. Do we expect a need to add the remainder of the [entitlement changes](https://github.com/flutter/engine/commit/c9b9d5780da342eb3f0f5e439a7db06f7d112575)?
3. I am under the assumption that the bots pull from master and are not branch specific, is this a correct assumption?

CC @christopherfujino @cbracken 