### PR TITLE
Add test that app builds if migrated to SwiftPM but SwiftPM is turned off

### DIFF
--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
@@ -742,9 +742,18 @@ void main() {
         .childDirectory('Packages')
         .childDirectory('FlutterGeneratedPluginSwiftPackage')
         .childFile('Package.swift');
+      final Directory cocoaPodsPluginFramework = fileSystem
+        .directory(appDirectoryPath)
+        .childDirectory('build')
+        .childDirectory('ios')
+        .childDirectory('iphoneos')
+        .childDirectory('Runner.app')
+        .childDirectory('Frameworks')
+        .childDirectory('${integrationTestPlugin.pluginName}.framework');
 
       expect(xcodeProjectFile.existsSync(), isTrue);
       expect(generatedManifestFile.existsSync(), isTrue);
+      expect(cocoaPodsPluginFramework.existsSync(), isFalse);
 
       String xcodeProject = xcodeProjectFile.readAsStringSync();
       String generatedManifest = generatedManifestFile.readAsStringSync();
@@ -757,7 +766,7 @@ void main() {
       expect(xcodeProject.contains('FlutterGeneratedPluginSwiftPackage'), isTrue);
       expect(generatedManifest.contains(generatedSwiftDependency), isTrue);
 
-      // Disable Swift Package Manager and re-build the app.
+      // Disable Swift Package Manager and do a clean re-build of the app.
       // The build should succeed.
       await SwiftPackageManagerUtils.disableSwiftPackageManager(
         flutterBin,
@@ -769,7 +778,7 @@ void main() {
       await SwiftPackageManagerUtils.buildApp(
         flutterBin,
         appDirectoryPath,
-        options: <String>['ios', '--debug', '-v'],
+        options: <String>['ios', '-v'],
       );
 
       // The app should still have SwiftPM integration,
@@ -784,6 +793,7 @@ void main() {
       expect(xcodeProject.contains('FlutterGeneratedPluginSwiftPackage'), isTrue);
       expect(generatedManifest.contains('integration_test'), isFalse);
       expect(generatedManifest.contains(emptyDependencies), isTrue);
+      expect(cocoaPodsPluginFramework.existsSync(), isTrue);
     } finally {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(


### PR DESCRIPTION
When a Flutter app is migrated to add Swift Package Manager integration, the Xcode project is modified to depend on a local Swift package that's generated by the Flutter tool. This generated package is how plugins are added to the Xcode project if the SwiftPM feature is enabled.

If an app has been migrated to SwiftPM but Flutter's SwiftPM feature is disabled, the [tool must continue to generate a Swift package](https://github.com/flutter/flutter/blob/47c1df9640f8812bed40dc1174dc4acd0eb7fd86/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart#L69-L78) to ensure the app continues to build. Otherwise, the Xcode project would depend on a local package that does not exist.

This adds a high-level integration test that ensures this behavior works as expected, which mirrors this finer-grained unit test: https://github.com/flutter/flutter/blob/47c1df9640f8812bed40dc1174dc4acd0eb7fd86/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart#L340-L382

Part of https://github.com/flutter/flutter/issues/153448

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
