### PR TITLE
Add test `custom_scroll_view.1.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -358,6 +358,5 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/restoration/restoration_mixin.0_test.dart',
   'examples/api/test/widgets/actions/focusable_action_detector.0_test.dart',
   'examples/api/test/widgets/focus_scope/focus_scope.0_test.dart',
-  'examples/api/test/widgets/scroll_view/custom_scroll_view.1_test.dart',
   'examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart',
 };

--- a/examples/api/test/widgets/scroll_view/custom_scroll_view.1_test.dart
+++ b/examples/api/test/widgets/scroll_view/custom_scroll_view.1_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/scroll_view/custom_scroll_view.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'Pressing the add button  should add items above and below and keep the scroll position',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.CustomScrollViewExampleApp());
+
+      expect(find.widgetWithText(AppBar, 'Press on the plus to add items above and below'), findsOne);
+
+      expect(find.text('Item: -2'), findsNothing);
+      expect(find.text('Item: -1'), findsNothing);
+      expect(find.text('Item: 0'), findsOne);
+      expect(find.text('Item: 1'), findsNothing);
+      expect(find.text('Item: 2'), findsNothing);
+
+      expect(tester.getTopLeft(find.widgetWithText(Container, 'Item: 0')), const Offset(0, 56));
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pump();
+
+      expect(find.text('Item: -2'), findsNothing);
+      expect(find.text('Item: -1', skipOffstage: false), findsOne);
+      expect(find.text('Item: 0'), findsOne);
+      expect(find.text('Item: 1'), findsOne);
+      expect(find.text('Item: 2'), findsNothing);
+
+      expect(
+        tester.getTopLeft(find.widgetWithText(Container, 'Item: 0')),
+        const Offset(0, 56),
+        reason: 'The scroll position should not change when adding items above the current position',
+      );
+
+      // Scroll up a bit.
+      await tester.fling(find.byType(CustomScrollView).last, const Offset(0, 50), 10.0);
+
+      expect(
+        tester.getTopLeft(find.widgetWithText(Container, 'Item: 0')),
+        const Offset(0, 106),
+        reason: 'The scroll position should not change when adding items above the current position',
+      );
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pump();
+
+      expect(find.text('Item: -2', skipOffstage: false), findsOne);
+      expect(find.text('Item: -1'), findsOne);
+      expect(find.text('Item: 0'), findsOne);
+      expect(find.text('Item: 1'), findsOne);
+      expect(find.text('Item: 2'), findsOne);
+
+      expect(
+        tester.getTopLeft(find.widgetWithText(Container, 'Item: 0')),
+        const Offset(0, 106),
+        reason: 'The scroll position should not change when adding items above the current position',
+      );
+    },
+  );
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/scroll_view/custom_scroll_view.1.dart`

I also fixed a mistake in the documentation



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
