### PR TITLE
Remove unnecessary breaks in default clauses of switch statements

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -565,7 +565,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         }
       default:
         errors.add('Unexpected child "$yamlKey" found under "flutter".');
-        break;
     }
   }
 }
@@ -704,7 +703,6 @@ void _validateFonts(YamlList fonts, List<String> errors) {
             }
           default:
             errors.add('Unexpected key $fontKey ((${kvp.value.runtimeType})) under font.');
-            break;
         }
       }
     }

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -932,7 +932,6 @@ class BrowserManager {
         default:
         // Unreachable.
           assert(false);
-          break;
       }
     }
   }


### PR DESCRIPTION
See https://dart.googlesource.com/sdk.git/+/045d26bc74209f5acc6466669f89686344e83de2