### PR TITLE
[tool] Enable macOS build for single arch

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -21,11 +21,21 @@ class BuildMacosCommand extends BuildSubCommand {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
     usesFlavorOption();
     argParser
-      .addFlag('config-only',
+      ..addFlag('config-only',
         help: 'Update the project configuration without performing a build. '
           'This can be used in CI/CD process that create an archive to avoid '
           'performing duplicate work.'
-    );
+      )
+      ..addOption('darwin-arch',
+        allowed: <String>['x86_64', 'arm64'],
+        help: 'Specifies the target architecture for macOS builds.\n'
+          'When not specified (default):\n'
+          "Debug builds target the host machine's architecture.\n"
+          'Release and Profile builds create universal binaries (x86_64 and arm64).\n'
+          'When specified:\n'
+          'Builds target only the specified architecture.\n'
+          'ONLY_ACTIVE_ARCH is set to YES in Xcode build settings.\n'
+      );
   }
 
   @override
@@ -46,6 +56,10 @@ class BuildMacosCommand extends BuildSubCommand {
   bool get supported => globals.platform.isMacOS;
 
   bool get configOnly => boolArg('config-only');
+
+  DarwinArch? get darwinArch => stringArg('darwin-arch') != null ? DarwinArch
+    .values
+    .byName(stringArg('darwin-arch')!) : null;
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -70,6 +84,7 @@ class BuildMacosCommand extends BuildSubCommand {
         analytics: analytics,
       ),
       usingCISystem: usingCISystem,
+      darwinArch: darwinArch,
     );
     return FlutterCommandResult.success();
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -866,4 +866,274 @@ STDERR STUFF
     ),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
+
+  testUsingContext('By default, invokes build for both x64_64 and arm64 archs (Release)', () async {
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
+    final Directory flutterBuildDir = fileSystem.directory(getMacOSBuildDirectory());
+    createMinimalMockProjectFiles();
+
+    fakeProcessManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          '/usr/bin/env',
+          'xcrun',
+          'xcodebuild',
+          '-workspace', flutterProject.macos.xcodeWorkspace!.path,
+          '-configuration', 'Release',
+          '-scheme', 'Runner',
+          '-derivedDataPath', flutterBuildDir.absolute.path,
+          '-destination', 'platform=macOS',
+          'OBJROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+          'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+          'ONLY_ACTIVE_ARCH=NO',
+          '-quiet',
+          'COMPILER_INDEX_STORE_ENABLE=NO',
+        ],
+      ),
+    ]);
+
+    final BuildCommand command = BuildCommand(
+      artifacts: artifacts,
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: fileSystem,
+      logger: logger,
+      processUtils: processUtils,
+      osUtils: FakeOperatingSystemUtils(),
+    );
+
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'macos', '--no-pub']
+    );
+
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    OperatingSystemUtils: () => osUtils,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatformCustomEnv,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+  });
+
+  testUsingContext('By default, invokes build for both x64_64 and arm64 archs (Profile)', () async {
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
+    final Directory flutterBuildDir = fileSystem.directory(getMacOSBuildDirectory());
+    createMinimalMockProjectFiles();
+
+    fakeProcessManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          '/usr/bin/env',
+          'xcrun',
+          'xcodebuild',
+          '-workspace', flutterProject.macos.xcodeWorkspace!.path,
+          '-configuration', 'Profile',
+          '-scheme', 'Runner',
+          '-derivedDataPath', flutterBuildDir.absolute.path,
+          '-destination', 'platform=macOS',
+          'OBJROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+          'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+          'ONLY_ACTIVE_ARCH=NO',
+          '-quiet',
+          'COMPILER_INDEX_STORE_ENABLE=NO',
+        ],
+      ),
+    ]);
+
+    final BuildCommand command = BuildCommand(
+      artifacts: artifacts,
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: fileSystem,
+      logger: logger,
+      processUtils: processUtils,
+      osUtils: FakeOperatingSystemUtils(),
+    );
+
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'macos', '--profile', '--no-pub']
+    );
+
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    OperatingSystemUtils: () => osUtils,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatformCustomEnv,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithProfile(),
+  });
+
+  testUsingContext('By default, invokes build for current arch (Debug)', () async {
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
+    final Directory flutterBuildDir = fileSystem.directory(getMacOSBuildDirectory());
+    createMinimalMockProjectFiles();
+
+    fakeProcessManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          '/usr/bin/env',
+          'xcrun',
+          'xcodebuild',
+          '-workspace', flutterProject.macos.xcodeWorkspace!.path,
+          '-configuration', 'Debug',
+          '-scheme', 'Runner',
+          '-derivedDataPath', flutterBuildDir.absolute.path,
+          '-destination', 'platform=macOS,arch=arm64',
+          'OBJROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+          'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+          'ONLY_ACTIVE_ARCH=YES',
+          '-quiet',
+          'COMPILER_INDEX_STORE_ENABLE=NO',
+        ],
+      ),
+    ]);
+
+    final BuildCommand command = BuildCommand(
+      artifacts: artifacts,
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: fileSystem,
+      logger: logger,
+      processUtils: processUtils,
+      osUtils: FakeOperatingSystemUtils(),
+    );
+
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'macos', '--debug', '--no-pub']
+    );
+
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    OperatingSystemUtils: () => osUtils,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatformCustomEnv,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+  });
+
+  testUsingContext('Invokes build for x86_64 when --darwin-arch=x86_64 provided', () async {
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
+    final Directory flutterBuildDir = fileSystem.directory(getMacOSBuildDirectory());
+    createMinimalMockProjectFiles();
+
+    fakeProcessManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          '/usr/bin/env',
+          'xcrun',
+          'xcodebuild',
+          '-workspace', flutterProject.macos.xcodeWorkspace!.path,
+          '-configuration', 'Release',
+          '-scheme', 'Runner',
+          '-derivedDataPath', flutterBuildDir.absolute.path,
+          '-destination', 'platform=macOS,arch=x86_64',
+          'OBJROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+          'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+          'ONLY_ACTIVE_ARCH=YES',
+          '-quiet',
+          'COMPILER_INDEX_STORE_ENABLE=NO',
+        ],
+      ),
+    ]);
+
+    final BuildCommand command = BuildCommand(
+      artifacts: artifacts,
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: fileSystem,
+      logger: logger,
+      processUtils: processUtils,
+      osUtils: FakeOperatingSystemUtils(),
+    );
+
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'macos', '--darwin-arch=x86_64', '--no-pub']
+    );
+
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    OperatingSystemUtils: () => osUtils,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatformCustomEnv,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+  });
+
+  testUsingContext('Invokes build for arm64 when --darwin-arch=arm64 provided', () async {
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
+    final Directory flutterBuildDir = fileSystem.directory(getMacOSBuildDirectory());
+    createMinimalMockProjectFiles();
+
+    fakeProcessManager.addCommands(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          '/usr/bin/env',
+          'xcrun',
+          'xcodebuild',
+          '-workspace', flutterProject.macos.xcodeWorkspace!.path,
+          '-configuration', 'Release',
+          '-scheme', 'Runner',
+          '-derivedDataPath', flutterBuildDir.absolute.path,
+          '-destination', 'platform=macOS,arch=arm64',
+          'OBJROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+          'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+          'ONLY_ACTIVE_ARCH=YES',
+          '-quiet',
+          'COMPILER_INDEX_STORE_ENABLE=NO',
+        ],
+      ),
+    ]);
+
+    final BuildCommand command = BuildCommand(
+      artifacts: artifacts,
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: fileSystem,
+      logger: logger,
+      processUtils: processUtils,
+      osUtils: FakeOperatingSystemUtils(),
+    );
+
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'macos', '--darwin-arch=arm64', '--no-pub']
+    );
+
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    OperatingSystemUtils: () => osUtils,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatformCustomEnv,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+  });
+
+  testUsingContext('Build fails when provided arch is not either x86_64 or arm64', () async {
+    createMinimalMockProjectFiles();
+
+    final BuildCommand command = BuildCommand(
+      artifacts: artifacts,
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: fileSystem,
+      logger: logger,
+      processUtils: processUtils,
+      osUtils: FakeOperatingSystemUtils(),
+    );
+
+    expect(createTestCommandRunner(command).run(
+        const <String>['build', 'macos', '--darwin-arch=x86_65', '--no-pub']
+    ), throwsUsageException(message: '"x86_65" is not an allowed value for option "darwin-arch".'));
+  }, overrides: <Type, Generator>{
+    OperatingSystemUtils: () => osUtils,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatformCustomEnv,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+  });
 }


### PR DESCRIPTION
## Issue and Solution

This PR addresses the issue where developers need to build Flutter macOS apps for a specific architecture. Currently, Flutter builds universal binaries for macOS in release mode, which can cause issues when linking to architecture-specific libraries.

The solution introduces a new `--darwin-arch` option to the `flutter build macos` command, allowing developers to specify a single target architecture for the build.

## Usage and Outputs

The `--darwin-arch` option can be used as follows:

`flutter build macos --darwin-arch=<arch>`

Where `<arch>` can be either `x86_64` or `arm64`.

Possible combinations and outputs:

| Option | Debug | Release/Profile |
|---------|-------|-----------------|
| Not specified| Host architecture only | Universal binary (x86_64 and arm64) |
| `--darwin-arch=x86_64` | x86_64 only | x86_64 only |
| `--darwin-arch=arm64` | arm64 only | arm64 only |

Note: The `--darwin-arch` option can be combined with `--debug`, `--profile`, or `--release` flags to specify both architecture and build mode.

## Why not [TargetPlatorm](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/build_info.dart#L554)

I feel like I should address it upfront :) I considered use it as option name, but in my opinion, this would require usage of `TargetPlatform` in implementation to be aligned with other platforms (linux, windows). Problem is `TargetPlatform` now has single `darwin` options. So, using `TargetPlatorm` would cause huge diff (since we should rename `darwin` to `darwin_universal` or something) and I decided to not implement it in first iteration at least. If reviewers decide that `--target-platform` is preferred here, I will implement it: modify `TargetPlatform` to add 2 options for distinct macOS arches and 1 universal option + maybe add some conversion macOS specific methods.

fixes #152221 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
