### PR TITLE
add -v to `flutter install` invocation when setting up android run tests

### DIFF
--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -83,7 +83,9 @@ class AndroidRunOutputTest extends RunOutputTask {
     print('uninstalling...');
     final Process uninstall = await startFlutter(
       'install',
-      options:  <String>['--suppress-analytics', '--uninstall-only', '-d', deviceId],
+      // TODO(andrewkolos): consider removing -v after
+      //  https://github.com/flutter/flutter/issues/153367 is troubleshot.
+      options:  <String>['--suppress-analytics', '--uninstall-only', '-d', deviceId, '-v'],
       isBot: false,
     );
     uninstall.stdout


### PR DESCRIPTION
Experiment to help troubleshoot https://github.com/flutter/flutter/issues/153367

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
