### PR TITLE
Use "run --resident" for flutter-dev.

### DIFF
--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -257,7 +257,7 @@ function shared::execute() {
     flutter-dev)
       # FLUTTER_TOOL_ARGS aren't quoted below, because it is meant to be
       # considered as separate space-separated args.
-      exec "$DART" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" $FLUTTER_TOOL_ARGS "$SCRIPT_PATH" "$@"
+      exec "$DART" run --resident --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" $FLUTTER_TOOL_ARGS "$SCRIPT_PATH" "$@"
       ;;
     flutter*)
       # FLUTTER_TOOL_ARGS aren't quoted below, because it is meant to be


### PR DESCRIPTION
This makes subsequent runs much faster by allowing to skip compilation to Kernel at the cost of introducing a bit of spam into the output when it starts resident compiler for the first time. Seems like a fine trade-off for dev-mode command.

```console
$ time flutter-dev -h
...
________________________________________________________
Executed in    5.32 secs      fish           external
   usr time  438.69 millis    0.09 millis  438.60 millis
   sys time  111.91 millis    2.42 millis  109.48 millis

$ time flutter-dev -h
...
________________________________________________________
Executed in  579.14 millis    fish           external
   usr time  433.87 millis    0.08 millis  433.79 millis
   sys time  109.27 millis    2.57 millis  106.70 millis

```