### PR TITLE
simplify/denoise status logging when downloading artifacts; tell user how far along the process the tool is

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -1334,6 +1334,7 @@ class AnonymousSpinnerStatus extends Status {
   final List<String> _animation;
 
   Timer? timer;
+  @visibleForTesting
   int ticks = 0;
   int _lastAnimationFrameLength = 0;
   bool timedOut = false;

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -717,6 +717,9 @@ class Cache {
 
     final Map<String, List<ArtifactSet>> neededArtifactsByUserFriendlyName = <String, List<ArtifactSet>>{};
     for (final ArtifactSet artifact in neededArtifacts) {
+      if (await artifact.isUpToDate(_fileSystem)) {
+        continue;
+      }
       final String userFriendlyName = artifact.developmentArtifact.feature == null
           ? '${artifact.developmentArtifact.name} tools'
           : '${artifact.developmentArtifact.feature!.name} tools';

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -701,14 +701,13 @@ class Cache {
     if (!_lockEnabled) {
       return;
     }
-    final List<ArtifactSet> neededArtifacts = <ArtifactSet>[];
 
+    final List<ArtifactSet> neededArtifacts = <ArtifactSet>[];
     for (final ArtifactSet artifact in _artifacts) {
       if (!requiredArtifacts.contains(artifact.developmentArtifact)) {
         _logger.printTrace('Artifact $artifact is not required, skipping update.');
         continue;
       }
-
       if (await artifact.isUpToDate(_fileSystem)) {
         continue;
       }
@@ -718,7 +717,7 @@ class Cache {
     for (final (int i, ArtifactSet artifact) in neededArtifacts.indexed) {
       try {
         final List<String> statusMessageParts = <String>[
-          'Downloading ${artifact.stampName}',
+          'Downloading artifacts: ${artifact.stampName}',
           if (neededArtifacts.length > 1)
             ' (${i + 1} of ${neededArtifacts.length})',
           '...',

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -728,11 +728,14 @@ class Cache {
 
     for (final (int i, MapEntry<String, List<ArtifactSet>> artifactGroup) in neededArtifactsByUserFriendlyName.entries.indexed) {
       try {
-        // TODO make this not ugly.
+        final List<String> statusMessageParts = <String>[
+          'Downloading ${artifactGroup.key}',
+          if (neededArtifactsByUserFriendlyName.length > 1)
+            ' (${i + 1} of ${neededArtifactsByUserFriendlyName.length})',
+          '...',
+        ];
         final Status? progress = artifactGroup.value.any((ArtifactSet a) => a.logUpdates)
-            ? _logger.startProgress(
-                'Downloading ${artifactGroup.key} (${i + 1} of ${neededArtifactsByUserFriendlyName.length})...',
-              )
+            ? _logger.startProgress(statusMessageParts.join())
             : null;
         for (final ArtifactSet artifact in artifactGroup.value) {
           await artifact.update(

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -90,21 +90,21 @@ const Feature flutterWebFeature = Feature.fullyEnabled(
 
 /// The [Feature] for macOS desktop.
 const Feature flutterMacOSDesktopFeature = Feature.fullyEnabled(
-  name: 'support for desktop on macOS',
+  name: 'Flutter for macOS',
   configSetting: 'enable-macos-desktop',
   environmentOverride: 'FLUTTER_MACOS',
 );
 
 /// The [Feature] for Linux desktop.
 const Feature flutterLinuxDesktopFeature = Feature.fullyEnabled(
-  name: 'support for desktop on Linux',
+  name: 'Flutter for Linux',
   configSetting: 'enable-linux-desktop',
   environmentOverride: 'FLUTTER_LINUX',
 );
 
 /// The [Feature] for Windows desktop.
 const Feature flutterWindowsDesktopFeature = Feature.fullyEnabled(
-  name: 'support for desktop on Windows',
+  name: 'Flutter for Windows',
   configSetting: 'enable-windows-desktop',
   environmentOverride: 'FLUTTER_WINDOWS',
 );

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -829,6 +829,10 @@ class IosUsbArtifacts extends CachedArtifact {
 
   @override
   bool isUpToDateInner(FileSystem fileSystem) {
+    if (!_platform.isMacOS && !ignorePlatformFiltering) {
+      return true;
+    }
+
     final List<String>? executables =_kExecutables[name];
     if (executables == null) {
       return true;

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -132,6 +132,9 @@ class PubDependencies extends ArtifactSet {
       outputMode: PubOutputMode.failuresOnly,
     );
   }
+
+  @override
+  bool get logUpdates => false;
 }
 
 /// A cached artifact containing fonts used for Material Design.
@@ -149,10 +152,13 @@ class MaterialFonts extends CachedArtifact {
     OperatingSystemUtils operatingSystemUtils,
   ) async {
     final Uri archiveUri = _toStorageUri(version!);
-    return artifactUpdater.downloadZipArchive('Downloading Material fonts...', archiveUri, location);
+    return artifactUpdater.downloadZipArchive(archiveUri, location);
   }
 
   Uri _toStorageUri(String path) => Uri.parse('${cache.storageBaseUrl}/$path');
+
+  @override
+  bool get logUpdates => true;
 }
 
 /// A cached artifact containing the web dart:ui sources, platform dill files,
@@ -181,8 +187,11 @@ class FlutterWebSdk extends CachedArtifact {
   ) async {
     final Uri url = Uri.parse('${cache.storageBaseUrl}/flutter_infra_release/flutter/$version/flutter-web-sdk.zip');
     ErrorHandlingFileSystem.deleteIfExists(location, recursive: true);
-    await artifactUpdater.downloadZipArchive('Downloading Web SDK...', url, location);
+    await artifactUpdater.downloadZipArchive(url, location);
   }
+
+  @override
+  bool get logUpdates => true;
 }
 
 // In previous builds, CanvasKit artifacts were stored in a different location
@@ -215,6 +224,9 @@ class LegacyCanvasKitRemover extends ArtifactSet {
     OperatingSystemUtils operatingSystemUtils,
     {bool offline = false}
   ) => _getLegacyCanvasKitDirectory(fileSystem).delete(recursive: true);
+
+  @override
+  bool get logUpdates => false;
 }
 
 /// A cached artifact containing the dart:ui source code.
@@ -417,7 +429,6 @@ class AndroidMavenArtifacts extends ArtifactSet {
     final Directory tempDir = cache.getRoot().createTempSync('flutter_gradle_wrapper.');
     globals.gradleUtils?.injectGradleWrapperIfNeeded(tempDir);
 
-    final Status status = logger.startProgress('Downloading Android Maven dependencies...');
     final File gradle = tempDir.childFile(
       _platform.isWindows ? 'gradlew.bat' : 'gradlew',
     );
@@ -437,7 +448,6 @@ class AndroidMavenArtifacts extends ArtifactSet {
         logger.printError('Failed to download the Android dependencies');
       }
     } finally {
-      status.stop();
       tempDir.deleteSync(recursive: true);
       globals.androidSdk?.reinitialize();
     }
@@ -453,6 +463,9 @@ class AndroidMavenArtifacts extends ArtifactSet {
 
   @override
   String get name => 'android-maven-artifacts';
+
+  @override
+  bool get logUpdates => true;
 }
 
 /// Artifacts used for internal builds. The flutter tool builds Android projects
@@ -532,7 +545,7 @@ class GradleWrapper extends CachedArtifact {
     OperatingSystemUtils operatingSystemUtils,
   ) async {
     final Uri archiveUri = _toStorageUri(version!);
-    await artifactUpdater.downloadZippedTarball('Downloading Gradle Wrapper...', archiveUri, location);
+    await artifactUpdater.downloadZippedTarball(archiveUri, location);
     // Delete property file, allowing templates to provide it.
     // Remove NOTICE file. Should not be part of the template.
     final File propertiesFile = fileSystem.file(fileSystem.path.join(location.path, 'gradle', 'wrapper', 'gradle-wrapper.properties'));
@@ -562,6 +575,9 @@ class GradleWrapper extends CachedArtifact {
     }
     return true;
   }
+
+  @override
+  bool get logUpdates => true;
 }
 
 /// Common functionality for pulling Fuchsia SDKs.
@@ -581,9 +597,11 @@ abstract class _FuchsiaSDKArtifacts extends CachedArtifact {
 
   Future<void> _doUpdate(ArtifactUpdater artifactUpdater) {
     final String url = '${cache.cipdBaseUrl}/$_path/+/$version';
-    return artifactUpdater.downloadZipArchive('Downloading package fuchsia SDK...',
-                               Uri.parse(url), location);
+    return artifactUpdater.downloadZipArchive(Uri.parse(url), location);
   }
+
+  @override
+  bool get logUpdates => true;
 }
 
 /// The pre-built flutter runner for Fuchsia development.
@@ -615,8 +633,11 @@ class FlutterRunnerSDKArtifacts extends CachedArtifact {
       return;
     }
     final String url = '${cache.cipdBaseUrl}/flutter/fuchsia/+/git_revision:$version';
-    await artifactUpdater.downloadZipArchive('Downloading package flutter runner...', Uri.parse(url), location);
+    await artifactUpdater.downloadZipArchive(Uri.parse(url), location);
   }
+
+  @override
+  bool get logUpdates => true;
 }
 
 /// Implementations of this class can resolve URLs for packages that are versioned.
@@ -662,11 +683,7 @@ class FlutterRunnerDebugSymbols extends CachedArtifact {
   Future<void> _downloadDebugSymbols(String targetArch, ArtifactUpdater artifactUpdater) async {
     final String packageName = 'fuchsia-debug-symbols-$targetArch';
     final String url = packageResolver.resolveUrl(packageName, version!);
-    await artifactUpdater.downloadZipArchive(
-      'Downloading debug symbols for flutter runner - arch:$targetArch...',
-      Uri.parse(url),
-      location,
-    );
+    await artifactUpdater.downloadZipArchive(Uri.parse(url), location);
   }
 
   @override
@@ -681,6 +698,9 @@ class FlutterRunnerDebugSymbols extends CachedArtifact {
     await _downloadDebugSymbols('x64', artifactUpdater);
     await _downloadDebugSymbols('arm64', artifactUpdater);
   }
+
+  @override
+  bool get logUpdates => true;
 }
 
 /// The Fuchsia core SDK for Linux.
@@ -833,8 +853,11 @@ class IosUsbArtifacts extends CachedArtifact {
     if (location.existsSync()) {
       location.deleteSync(recursive: true);
     }
-    await artifactUpdater.downloadZipArchive('Downloading $name...', archiveUri, location);
+    await artifactUpdater.downloadZipArchive(archiveUri, location);
   }
+
+  @override
+  bool get logUpdates => true;
 
   @visibleForTesting
   Uri get archiveUri => Uri.parse(

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1744,8 +1744,13 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
       } else {
         offline = false;
       }
-      await globals.cache.updateAll(<DevelopmentArtifact>{DevelopmentArtifact.universal}, offline: offline);
-      await globals.cache.updateAll(await requiredArtifacts, offline: offline);
+      await globals.cache.updateAll(
+        <DevelopmentArtifact>{
+          ...await requiredArtifacts,
+          DevelopmentArtifact.universal,
+        },
+        offline: offline,
+      );
     }
     globals.cache.releaseLock();
 

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -36,11 +36,9 @@ void main() {
     );
 
     await artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), exists);
   });
 
@@ -64,11 +62,9 @@ void main() {
     fileSystem.file('out/test/foo.txt').createSync(recursive: true);
 
     await artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), exists);
     expect(fileSystem.file('out/bar'), exists);
     expect(fileSystem.file('out/test/foo.txt'), isNot(exists));
@@ -106,11 +102,9 @@ void main() {
 
     expect(staleEntitlementsFile, exists);
     await artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
-    expect(logger.statusText, contains('test message'));
     expect(desiredArtifact, exists);
     expect(entitlementsFile, isNot(exists));
     expect(nestedWithoutEntitlementsFile, isNot(exists));
@@ -141,11 +135,9 @@ void main() {
     );
 
     await artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), exists);
   });
 
@@ -177,11 +169,9 @@ void main() {
     );
 
     await artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), exists);
   });
 
@@ -221,7 +211,6 @@ void main() {
     );
 
     await expectLater(() async => artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsToolExit(message: 'k7iFrf4SQT9WfcQ==')); // validate that the hash mismatch message is included.
@@ -250,7 +239,6 @@ void main() {
     );
 
     await artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
@@ -278,12 +266,10 @@ void main() {
     );
 
     await expectLater(() async => artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsToolExit());
 
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), isNot(exists));
   });
 
@@ -309,12 +295,10 @@ void main() {
     );
 
     await expectLater(() async => artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://foo-bar/test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsToolExit());
 
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), isNot(exists));
   });
 
@@ -336,12 +320,10 @@ void main() {
     );
 
     await expectLater(() async => artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsArgumentError);
 
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), isNot(exists));
   });
 
@@ -362,11 +344,9 @@ void main() {
     operatingSystemUtils.failures = 1;
 
     await artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), exists);
   });
 
@@ -387,11 +367,9 @@ void main() {
     operatingSystemUtils.failures = 1;
 
     await artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
-    expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), exists);
   });
 
@@ -412,7 +390,6 @@ void main() {
     operatingSystemUtils.failures = 2;
 
     expect(artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsToolExit());
@@ -437,7 +414,6 @@ void main() {
     operatingSystemUtils.failures = 2;
 
     expect(artifactUpdater.downloadZipArchive(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsToolExit());
@@ -461,7 +437,6 @@ void main() {
     );
 
     await artifactUpdater.downloadZippedTarball(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
@@ -518,7 +493,6 @@ void main() {
     handler.addError(errorDirectory, FileSystemOp.delete, const FileSystemException('', '', OSError('', kSharingViolation)));
 
     await expectLater(() async => artifactUpdater.downloadZippedTarball(
-      'test message',
       Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsToolExit(

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -278,8 +278,8 @@ void main() {
       });
       expect(
         logger.statusText,
-        'Downloading artifact1 (1 of 2)...\n'
-        'Downloading artifact2 (2 of 2)...\n',
+        'Downloading artifacts: artifact1 (1 of 2)...\n'
+        'Downloading artifacts: artifact2 (2 of 2)...\n',
       );
 
       artifact1.upToDate = false;
@@ -288,7 +288,7 @@ void main() {
         DevelopmentArtifact.androidGenSnapshot,
       });
       // Don't print (1 of 1)
-      expect(logger.statusText, 'Downloading artifact1...\n');
+      expect(logger.statusText, 'Downloading artifacts: artifact1...\n');
     });
 
     testWithoutContext("getter dyLdLibEntry concatenates the output of each artifact's dyLdLibEntry getter", () async {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -414,7 +414,7 @@ void main() {
 
     Uri? packageUrl;
     final ArtifactUpdater artifactUpdater = FakeArtifactUpdater()
-      ..onDownloadZipArchive = (String message, Uri url, Directory location) {
+      ..onDownloadZipArchive = (Uri url, Directory location) {
         location.childDirectory('package_dir').createSync();
         packageUrl = url;
       };
@@ -819,11 +819,9 @@ void main() {
     final FakeArtifactUpdater artifactUpdater = FakeArtifactUpdater();
     final FlutterWebSdk webSdk = FlutterWebSdk(cache);
 
-    final List<String> messages = <String>[];
     final List<String> downloads = <String>[];
     final List<String> locations = <String>[];
-    artifactUpdater.onDownloadZipArchive = (String message, Uri uri, Directory location) {
-      messages.add(message);
+    artifactUpdater.onDownloadZipArchive = (Uri uri, Directory location) {
       downloads.add(uri.toString());
       locations.add(location.path);
       location.createSync(recursive: true);
@@ -832,10 +830,6 @@ void main() {
     webCacheDirectory.childFile('bar').createSync(recursive: true);
 
     await webSdk.updateInner(artifactUpdater, fileSystem, FakeOperatingSystemUtils());
-
-    expect(messages, <String>[
-      'Downloading Web SDK...',
-    ]);
 
     expect(downloads, <String>[
       'https://storage.googleapis.com/flutter_infra_release/flutter/hijklmnop/flutter-web-sdk.zip',
@@ -878,7 +872,7 @@ void main() {
 
     final List<String> downloads = <String>[];
     final List<String> locations = <String>[];
-    artifactUpdater.onDownloadZipArchive = (String message, Uri uri, Directory location) {
+    artifactUpdater.onDownloadZipArchive = (Uri uri, Directory location) {
       downloads.add(uri.toString());
       locations.add(location.path);
       location.createSync(recursive: true);
@@ -901,7 +895,7 @@ void main() {
     final FakeArtifactUpdater artifactUpdater = FakeArtifactUpdater();
     final FlutterWebSdk webSdk = FlutterWebSdk(cache);
 
-    artifactUpdater.onDownloadZipArchive = (String message, Uri uri, Directory location) {
+    artifactUpdater.onDownloadZipArchive = (Uri uri, Directory location) {
       location.createSync(recursive: true);
       location.childFile('foo').createSync();
     };
@@ -1164,6 +1158,9 @@ class FakeCachedArtifact extends EngineCachedArtifact {
 
   @override
   List<String> getPackageDirs() => packageDirs;
+
+  @override
+  bool get logUpdates => true;
 }
 
 class FakeSimpleArtifact extends CachedArtifact {
@@ -1175,6 +1172,9 @@ class FakeSimpleArtifact extends CachedArtifact {
 
   @override
   Future<void> updateInner(ArtifactUpdater artifactUpdater, FileSystem fileSystem, OperatingSystemUtils operatingSystemUtils) async { }
+
+  @override
+  bool get logUpdates => true;
 }
 
 class FakeSecondaryCachedArtifact extends Fake implements CachedArtifact {
@@ -1195,6 +1195,9 @@ class FakeSecondaryCachedArtifact extends Fake implements CachedArtifact {
 
   @override
   DevelopmentArtifact get developmentArtifact => DevelopmentArtifact.universal;
+
+  @override
+  bool get logUpdates => true;
 }
 
 class FakeIosUsbArtifacts extends Fake implements IosUsbArtifacts {
@@ -1203,6 +1206,9 @@ class FakeIosUsbArtifacts extends Fake implements IosUsbArtifacts {
 
   @override
   String stampName = 'ios-usb';
+
+  @override
+  bool get logUpdates => true;
 }
 
 class FakeSecondaryCache extends Fake implements Cache {
@@ -1306,17 +1312,17 @@ class FakeAndroidSdk extends Fake implements AndroidSdk {
 }
 
 class FakeArtifactUpdater extends Fake implements ArtifactUpdater {
-  void Function(String, Uri, Directory)? onDownloadZipArchive;
-  void Function(String, Uri, Directory)? onDownloadZipTarball;
+  void Function(Uri, Directory)? onDownloadZipArchive;
+  void Function(Uri, Directory)? onDownloadZipTarball;
 
   @override
-  Future<void> downloadZippedTarball(String message, Uri url, Directory location) async {
-    onDownloadZipTarball?.call(message, url, location);
+  Future<void> downloadZippedTarball(Uri url, Directory location) async {
+    onDownloadZipTarball?.call(url, location);
   }
 
   @override
-  Future<void> downloadZipArchive(String message, Uri url, Directory location) async {
-    onDownloadZipArchive?.call(message, url, location);
+  Future<void> downloadZipArchive(Uri url, Directory location) async {
+    onDownloadZipArchive?.call(url, location);
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -256,9 +256,11 @@ void main() {
     testWithoutContext('should print status messages about each artifact update (grouped by development artifact)', () async {
       final FakeSecondaryCachedArtifact artifact1 = FakeSecondaryCachedArtifact()
         ..upToDate = false
+        ..name = 'artifact1'
         ..developmentArtifact = DevelopmentArtifact.androidGenSnapshot;
       final FakeSecondaryCachedArtifact artifact2 = FakeSecondaryCachedArtifact()
         ..upToDate = false
+        ..name = 'artifact2'
         ..developmentArtifact = DevelopmentArtifact.universal;
       final FileSystem fileSystem = MemoryFileSystem.test();
 
@@ -276,8 +278,8 @@ void main() {
       });
       expect(
         logger.statusText,
-        'Downloading Flutter for Android tools (1 of 2)...\n'
-        'Downloading universal tools (2 of 2)...\n',
+        'Downloading artifact1 (1 of 2)...\n'
+        'Downloading artifact2 (2 of 2)...\n',
       );
 
       artifact1.upToDate = false;
@@ -285,7 +287,8 @@ void main() {
       await cache.updateAll(<DevelopmentArtifact>{
         DevelopmentArtifact.androidGenSnapshot,
       });
-      expect(logger.statusText, 'Downloading Flutter for Android tools...\n');
+      // Don't print (1 of 1)
+      expect(logger.statusText, 'Downloading artifact1...\n');
     });
 
     testWithoutContext("getter dyLdLibEntry concatenates the output of each artifact's dyLdLibEntry getter", () async {
@@ -1232,7 +1235,10 @@ class FakeSecondaryCachedArtifact extends Fake implements CachedArtifact {
   DevelopmentArtifact developmentArtifact = DevelopmentArtifact.universal;
 
   @override
-  String get name => 'fake_secondary_cached_artifact';
+  String name = 'fake_secondary_cached_artifact';
+
+  @override
+  String get stampName => name;
 
   @override
   bool get logUpdates => true;

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -1197,6 +1197,9 @@ class FakeSecondaryCachedArtifact extends Fake implements CachedArtifact {
   DevelopmentArtifact get developmentArtifact => DevelopmentArtifact.universal;
 
   @override
+  String get name => 'fake_secondary_cached_artifact';
+
+  @override
   bool get logUpdates => true;
 }
 

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -282,7 +282,9 @@ void main() {
 
       artifact1.upToDate = false;
       logger.clear();
-      await cache.updateAll({DevelopmentArtifact.androidGenSnapshot});
+      await cache.updateAll(<DevelopmentArtifact>{
+        DevelopmentArtifact.androidGenSnapshot,
+      });
       expect(logger.statusText, 'Downloading Flutter for Android tools...\n');
     });
 

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -87,18 +87,24 @@ void main() {
     });
 
     testWithoutContext('Flutter macOS desktop help string', () {
-      expect(flutterMacOSDesktopFeature.generateHelpMessage(),
-      'Enable or disable support for desktop on macOS.');
+      expect(
+        flutterMacOSDesktopFeature.generateHelpMessage(),
+        'Enable or disable Flutter for macOS.',
+      );
     });
 
     testWithoutContext('Flutter Linux desktop help string', () {
-      expect(flutterLinuxDesktopFeature.generateHelpMessage(),
-      'Enable or disable support for desktop on Linux.');
+      expect(
+        flutterLinuxDesktopFeature.generateHelpMessage(),
+        'Enable or disable Flutter for Linux.',
+      );
     });
 
     testWithoutContext('Flutter Windows desktop help string', () {
-      expect(flutterWindowsDesktopFeature.generateHelpMessage(),
-      'Enable or disable support for desktop on Windows.');
+      expect(
+        flutterWindowsDesktopFeature.generateHelpMessage(),
+        'Enable or disable Flutter for Windows.',
+      );
     });
 
     testWithoutContext('help string on multiple channels', () {

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -106,7 +106,6 @@ void main() {
         cache.artifacts,
         <Set<DevelopmentArtifact>>[
           <DevelopmentArtifact>{DevelopmentArtifact.universal},
-          <DevelopmentArtifact>{},
         ],
       );
     },

--- a/packages/flutter_tools/test/integration.shard/cache_test.dart
+++ b/packages/flutter_tools/test/integration.shard/cache_test.dart
@@ -162,17 +162,17 @@ Future<void> main(List<String> args) async {
 }
 
 class FakeArtifactUpdater extends Fake implements ArtifactUpdater {
-  void Function(String, Uri, Directory)? onDownloadZipArchive;
-  void Function(String, Uri, Directory)? onDownloadZipTarball;
+  void Function(Uri, Directory)? onDownloadZipArchive;
+  void Function(Uri, Directory)? onDownloadZipTarball;
 
   @override
-  Future<void> downloadZippedTarball(String message, Uri url, Directory location) async {
-    onDownloadZipTarball?.call(message, url, location);
+  Future<void> downloadZippedTarball(Uri url, Directory location) async {
+    onDownloadZipTarball?.call(url, location);
   }
 
   @override
-  Future<void> downloadZipArchive(String message, Uri url, Directory location) async {
-    onDownloadZipArchive?.call(message, url, location);
+  Future<void> downloadZipArchive(Uri url, Directory location) async {
+    onDownloadZipArchive?.call(url, location);
   }
 
   @override
@@ -191,4 +191,7 @@ class FakeVersionlessArtifact extends CachedArtifact {
 
   @override
   Future<void> updateInner(ArtifactUpdater artifactUpdater, FileSystem fileSystem, OperatingSystemUtils operatingSystemUtils) async { }
+
+  @override
+  bool get logUpdates => true;
 }

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -41,6 +41,9 @@ class FakeDyldEnvironmentArtifact extends ArtifactSet {
   @override
   Future<void> update(ArtifactUpdater artifactUpdater, Logger logger, FileSystem fileSystem, OperatingSystemUtils operatingSystemUtils, {bool offline = false}) async {
   }
+
+  @override
+  bool get logUpdates => true;
 }
 
 /// A fake process implementation which can be provided all necessary values.


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/152275 (only via improvement—the _best_ solution would probably be a single status message that is dynamically updated as we make progress, but that would be way more involved).

Before:
```
Downloading android-arm-profile/darwin-x64 tools...                520ms
Downloading android-arm-release/darwin-x64 tools...                322ms
Downloading android-arm64-profile/darwin-x64 tools...              352ms
Downloading android-arm64-release/darwin-x64 tools...              352ms
Downloading android-x64-profile/darwin-x64 tools...                380ms
Downloading android-x64-release/darwin-x64 tools...                344ms
Downloading android-arm-profile/linux-x64 tools...                 356ms
Downloading android-arm-release/linux-x64 tools...                 394ms
Downloading android-arm64-profile/linux-x64 tools...               356ms
Downloading android-arm64-release/linux-x64 tools...               350ms
Downloading android-x64-profile/linux-x64 tools...                 358ms
Downloading android-x64-release/linux-x64 tools...                 310ms
Downloading android-arm-profile/windows-x64 tools...               321ms
Downloading android-arm-release/windows-x64 tools...               303ms
Downloading android-arm64-profile/windows-x64 tools...             320ms
Downloading android-arm64-release/windows-x64 tools...             378ms
Downloading android-x64-profile/windows-x64 tools...               300ms
Downloading android-x64-release/windows-x64 tools...               312ms
Downloading dart-sdk-darwin-x64 tools...                            5.9s
Downloading dart-sdk-linux-x64 tools...                             6.4s
Downloading dart-sdk-windows-x64 tools...                           5.8s
Downloading android-x86 tools...                                   767ms
Downloading android-x64 tools...                                   813ms
Downloading android-arm tools...                                   684ms
Downloading android-arm-profile tools...                           580ms
Downloading android-arm-release tools...                           536ms
Downloading android-arm64 tools...                                 781ms
Downloading android-arm64-profile tools...                         535ms
Downloading android-arm64-release tools...                         453ms
Downloading android-x64-profile tools...                           538ms
Downloading android-x64-release tools...                           560ms
Downloading android-x86-jit-release tools...                       634ms
Downloading ios tools...                                         2,434ms
Downloading ios-profile tools...                                 2,639ms
Downloading ios-release tools...                                 2,002ms
Downloading Web SDK...                                           1,956ms
Downloading package sky_engine...                                  258ms
Downloading package flutter_gpu...                                 174ms
Downloading flutter_patched_sdk tools...                           340ms
Downloading flutter_patched_sdk_product tools...                   444ms
Downloading windows-arm64 tools...                               1,104ms
Downloading linux-arm64 tools...                                 1,123ms
Downloading darwin-arm64 tools...                                1,197ms
Downloading windows-arm64-debug/windows-arm64-flutter tools...      2,359ms
Downloading windows-arm64/flutter-cpp-client-wrapper tools...        135ms
Downloading windows-arm64-profile/windows-arm64-flutter tools...      2,036ms
Downloading windows-arm64-release/windows-arm64-flutter tools...      2,069ms
Downloading darwin-x64/framework tools...                        1,204ms
Downloading darwin-x64/gen_snapshot tools...                       487ms
Downloading darwin-x64-profile/framework tools...                  823ms
Downloading darwin-x64-profile tools...                            366ms
Downloading darwin-x64-profile/gen_snapshot tools...               543ms
Downloading darwin-x64-release/framework tools...                  555ms
Downloading darwin-x64-release tools...                            352ms
Downloading darwin-x64-release/gen_snapshot tools...               391ms
Downloading linux-arm64-debug/linux-arm64-flutter-gtk tools...        938ms
Downloading linux-arm64-profile/linux-arm64-flutter-gtk tools...        550ms
Downloading linux-arm64-release/linux-arm64-flutter-gtk tools...        558ms
Downloading darwin-arm64/font-subset tools...                      312ms
Downloading linux-arm64/font-subset tools...                       286ms
Downloading windows-arm64/font-subset tools...                     162ms
```

After:
```
Downloading artifacts: material_fonts (1 of 16)...                 717ms
Downloading artifacts: gradle_wrapper (2 of 16)...                  33ms
Downloading artifacts: android-sdk (3 of 16)...                    47.2s
Downloading artifacts: android-internal-build-artifacts (4 of 16)...         5.6s
Downloading artifacts: ios-sdk (5 of 16)...                        25.2s
Downloading artifacts: flutter_web_sdk (6 of 16)...                 4.4s
Downloading artifacts: flutter_sdk (7 of 16)...                     8.5s
Downloading artifacts: windows-sdk (8 of 16)...                    14.1s
Downloading artifacts: macos-sdk (9 of 16)...                      19.5s
Downloading artifacts: linux-sdk (10 of 16)...                   2,671ms
Downloading artifacts: libimobiledevice (11 of 16)...              164ms
Downloading artifacts: usbmuxd (12 of 16)...                       141ms
Downloading artifacts: libplist (13 of 16)...                       71ms
Downloading artifacts: openssl (14 of 16)...                       142ms
Downloading artifacts: ios-deploy (15 of 16)...                    113ms
Downloading artifacts: font-subset (16 of 16)...                   784ms
```

Notice we lose some precision here: `android-sdk` takes 68.5s on a good internet connection (granted `precache --all` isn't a good example of a everyday user behavior).

If you want to test behavior locally, simply `rm -rf` the `bin/cache` directory in your flutter installation, and go do some `flutter run`/`flutter upgrade`/`flutter precache` stuff and see what gets printed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
