### PR TITLE
Fix DropdownMenu focus traversal

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -890,7 +890,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           width: widget.width,
           children: <Widget>[
             textField,
-            ..._initialMenu!.map((Widget item) => controller.isOpen ? item : ExcludeFocus(child: item)),
+            ..._initialMenu!.map((Widget item) => ExcludeFocus(excluding: !controller.isOpen, child: item)),
             trailingButton,
             leadingButton,
           ],

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -670,7 +670,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           )
         : effectiveStyle;
 
-      final Widget  menuItemButton = MenuItemButton(
+      final Widget menuItemButton = MenuItemButton(
         key: enableScrollToHighlight ? buttonItemKeys[i] : null,
         style: effectiveStyle,
         leadingIcon: entry.leadingIcon,
@@ -890,7 +890,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           width: widget.width,
           children: <Widget>[
             textField,
-            ..._initialMenu!,
+            ..._initialMenu!.map((Widget item) => controller.isOpen ? item : ExcludeFocus(child: item)),
             trailingButton,
             leadingButton,
           ],

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2427,6 +2427,44 @@ void main() {
     expect(box, paints..rrect(color: theme.colorScheme.primary));
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/131120.
+  testWidgets('Focus traversal ignores non visible entries', (WidgetTester tester) async {
+    final FocusNode buttonFocusNode = FocusNode();
+    addTearDown(buttonFocusNode.dispose);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: <Widget>[
+            DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren),
+            ElevatedButton(
+              focusNode: buttonFocusNode,
+              onPressed: () {},
+              child: const Text('Button'),
+            )
+          ],
+        ),
+      ),
+    ));
+
+    // Move the focus to the text field.
+    primaryFocus!.nextFocus();
+    await tester.pump();
+    final Element textField = tester.element(find.byType(TextField));
+    expect(Focus.of(textField).hasFocus, isTrue);
+
+    // Move the focus to the dropdown trailing icon.
+    primaryFocus!.nextFocus();
+    await tester.pump();
+    final Element iconButton = tester.firstElement(find.byIcon(Icons.arrow_drop_down));
+    expect(Focus.of(iconButton).hasFocus, isTrue);
+
+    // Move the focus to the elevated button.
+    primaryFocus!.nextFocus();
+    await tester.pump();
+    expect(buttonFocusNode.hasFocus, isTrue);
+  });
+
   testWidgets('DropdownMenu honors inputFormatters', (WidgetTester tester) async {
     int called = 0;
     final TextInputFormatter formatter = TextInputFormatter.withFunction(
@@ -2562,7 +2600,7 @@ void main() {
             DropdownMenu<int>(
               dropdownMenuEntries: <DropdownMenuEntry<int>>[],
             ),
-             DropdownMenu<int>(
+            DropdownMenu<int>(
               textAlign: TextAlign.center,
               dropdownMenuEntries: <DropdownMenuEntry<int>>[],
             ),


### PR DESCRIPTION
## Description

This PR fixes `DropdownMenu` focus traversal.

Before this PR, if a `DropdownMenu` contains several items, the 'tab' key had to be pressed many times before the focus move to the inner text field.

This fix is based on https://github.com/flutter/flutter/issues/131120#issuecomment-1654233358.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/131120.

## Tests

Adds 1 test.