### PR TITLE
Add minimum height for MaterialBanner

### DIFF
--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -120,6 +120,7 @@ class MaterialBanner extends StatefulWidget {
     this.overflowAlignment = OverflowBarAlignment.end,
     this.animation,
     this.onVisible,
+    this.minActionBarHeight = 52.0
   }) : assert(elevation == null || elevation >= 0.0);
 
   /// The content of the [MaterialBanner].
@@ -155,6 +156,11 @@ class MaterialBanner extends StatefulWidget {
   ///
   /// Typically an [Icon] widget.
   final Widget? leading;
+
+  /// The (optional) minActionBarHeight allows users to set minimum action bar height.
+  ///
+  /// Default is 52.0.
+  final double minActionBarHeight;
 
   /// The color of the surface of this [MaterialBanner].
   ///
@@ -252,6 +258,7 @@ class MaterialBanner extends StatefulWidget {
       actions: actions,
       elevation: elevation,
       leading: leading,
+      minActionBarHeight: minActionBarHeight,
       backgroundColor: backgroundColor,
       surfaceTintColor: surfaceTintColor,
       shadowColor: shadowColor,
@@ -346,7 +353,7 @@ class _MaterialBannerState extends State<MaterialBanner> {
         ?? const EdgeInsetsDirectional.only(end: 16.0);
 
     final Widget actionsBar = ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: 52.0),
+      constraints: BoxConstraints(minHeight: widget.minActionBarHeight),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Align(

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -120,7 +120,7 @@ class MaterialBanner extends StatefulWidget {
     this.overflowAlignment = OverflowBarAlignment.end,
     this.animation,
     this.onVisible,
-    this.minActionBarHeight = 52.0
+    this.minActionBarHeight = 52.0,
   }) : assert(elevation == null || elevation >= 0.0);
 
   /// The content of the [MaterialBanner].

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -157,7 +157,7 @@ class MaterialBanner extends StatefulWidget {
   /// Typically an [Icon] widget.
   final Widget? leading;
 
-  /// The (optional) minActionBarHeight allows users to set minimum action bar height.
+  /// The optional minimum action bar height.
   ///
   /// Default is 52.0.
   final double minActionBarHeight;

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -159,7 +159,7 @@ class MaterialBanner extends StatefulWidget {
 
   /// The optional minimum action bar height.
   ///
-  /// Default is 52.0.
+  /// Default to 52.0.
   final double minActionBarHeight;
 
   /// The color of the surface of this [MaterialBanner].

--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -1175,7 +1175,7 @@ void main() {
     expect(size.height, equals(minActionBarHeight));
   });
 
-   testWidgets('MinimumActionBarHeight respected with ScaffolMessenger', (WidgetTester tester) async {
+   testWidgets('MinimumActionBarHeight respects with ScaffoldMessenger', (WidgetTester tester) async {
     const Key tapTarget = Key('tap-target');
     const double minActionBarHeight = 20;
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -1151,7 +1151,7 @@ void main() {
     expect(topLeft.dx, margin.left);
   });
 
-  testWidgets('MinimumActionBarHeight respected', (WidgetTester tester) async {
+  testWidgets('minActionBarHeight is respected', (WidgetTester tester) async {
     const double minActionBarHeight = 20.0;
     await tester.pumpWidget(
       MaterialApp(
@@ -1174,7 +1174,7 @@ void main() {
     expect(size.height, equals(minActionBarHeight));
   });
 
-   testWidgets('MinimumActionBarHeight respects with ScaffoldMessenger', (WidgetTester tester) async {
+   testWidgets('minimumActionBarHeight is respected when presented by ScaffoldMessenger', (WidgetTester tester) async {
     const Key tapTarget = Key('tap-target');
     const double minActionBarHeight = 20.0;
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -1152,7 +1152,7 @@ void main() {
   });
 
   testWidgets('MinimumActionBarHeight respected', (WidgetTester tester) async {
-    const double minActionBarHeight = 20;
+    const double minActionBarHeight = 20.0;
     await tester.pumpWidget(
       MaterialApp(
         home:Scaffold(
@@ -1165,7 +1165,6 @@ void main() {
             actions: <Widget>[
               SizedBox.shrink(),
             ],
-
           ),
         )
       ),
@@ -1177,7 +1176,7 @@ void main() {
 
    testWidgets('MinimumActionBarHeight respects with ScaffoldMessenger', (WidgetTester tester) async {
     const Key tapTarget = Key('tap-target');
-    const double minActionBarHeight = 20;
+    const double minActionBarHeight = 20.0;
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: Builder(
@@ -1208,12 +1207,9 @@ void main() {
     await tester.tap(find.byKey(tapTarget));
     await tester.pumpAndSettle();
 
-
     final Size materialBarSize = tester.getSize(find.byType(MaterialBanner));
     expect(materialBarSize.height, equals(minActionBarHeight));
-
   });
-
 }
 
 Material _getMaterialFromBanner(WidgetTester tester) {

--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -1150,6 +1150,70 @@ void main() {
     /// Compare the offset of banner from top left
     expect(topLeft.dx, margin.left);
   });
+
+  testWidgets('MinimumActionBarHeight respected', (WidgetTester tester) async {
+    const double minActionBarHeight = 20;
+    await tester.pumpWidget(
+      MaterialApp(
+        home:Scaffold(
+          appBar: AppBar(),
+          body: const MaterialBanner(
+            minActionBarHeight: minActionBarHeight,
+            padding: EdgeInsets.zero,
+            margin: EdgeInsets.zero,
+            content: SizedBox.shrink(),
+            actions: <Widget>[
+              SizedBox.shrink(),
+            ],
+
+          ),
+        )
+      ),
+    );
+
+    final Size size = tester.getSize(find.byType(MaterialBanner));
+    expect(size.height, equals(minActionBarHeight));
+  });
+
+   testWidgets('MinimumActionBarHeight respected with ScaffolMessenger', (WidgetTester tester) async {
+    const Key tapTarget = Key('tap-target');
+    const double minActionBarHeight = 20;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            return GestureDetector(
+              key: tapTarget,
+              onTap: () {
+                ScaffoldMessenger.of(context).showMaterialBanner(const MaterialBanner(
+                  content: SizedBox.shrink(),
+                  padding: EdgeInsets.zero,
+                  margin:  EdgeInsets.zero,
+                  minActionBarHeight: minActionBarHeight,
+                  actions: <Widget>[
+                     SizedBox.shrink()
+                  ],
+                ));
+              },
+              behavior: HitTestBehavior.opaque,
+              child: const SizedBox(
+                height: 100.0,
+                width: 100.0,
+              ),
+            );
+          },
+        ),
+      ),
+    ));
+    await tester.tap(find.byKey(tapTarget));
+    await tester.pumpAndSettle();
+
+
+    final Size materialBarSize = tester.getSize(find.byType(MaterialBanner));
+    expect(materialBarSize.height, equals(minActionBarHeight));
+
+  });
+
 }
 
 Material _getMaterialFromBanner(WidgetTester tester) {


### PR DESCRIPTION
This pr allows defining custom minimum height for material banner

fixes this https://github.com/flutter/flutter/issues/153666


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

