### PR TITLE
Fix `Drawer` prematurely snapping

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -243,6 +243,10 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   bool get isCompleted => status.isCompleted;
 
   /// Whether this animation is running in either direction.
+  ///
+  /// By default, this value is equal to `status.isAnimating`, but
+  /// [AnimationController] overrides this method so that its output
+  /// depends on whether the controller is actively ticking.
   bool get isAnimating => status.isAnimating;
 
   /// {@macro flutter.animation.AnimationStatus.isForwardOrCompleted}

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -448,6 +448,10 @@ class AnimationController extends Animation<double>
   /// controller's ticker might get muted, in which case the animation
   /// controller's callbacks will no longer fire even though time is continuing
   /// to pass. See [Ticker.muted] and [TickerMode].
+  ///
+  /// If the animation was stopped (e.g. with [stop] or by setting a new [value]),
+  /// [isAnimating] will return `false` but the [status] will not change,
+  /// so the value of [AnimationStatus.isAnimating] might still be `true`.
   @override
   bool get isAnimating => _ticker != null && _ticker!.isActive;
 

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -501,8 +501,9 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     if (widget.scrimColor != oldWidget.scrimColor) {
       _scrimColorTween = _buildScrimColorTween();
     }
-    if (widget.isDrawerOpen != oldWidget.isDrawerOpen && !_controller.isAnimating) {
-      _controller.value = widget.isDrawerOpen ? 1.0 : 0.0;
+    final bool drawerOpen = widget.isDrawerOpen;
+    if (drawerOpen != oldWidget.isDrawerOpen && !_controller.status.isAnimating) {
+      _controller.value = drawerOpen ? 1.0 : 0.0;
     }
   }
 

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -501,9 +501,12 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     if (widget.scrimColor != oldWidget.scrimColor) {
       _scrimColorTween = _buildScrimColorTween();
     }
-    final bool drawerOpen = widget.isDrawerOpen;
-    if (drawerOpen != oldWidget.isDrawerOpen && !_controller.status.isAnimating) {
-      _controller.value = drawerOpen ? 1.0 : 0.0;
+
+    if (_controller.status.isAnimating) {
+      return; // Don't snap the drawer open or shut while the user is dragging.
+    }
+    if (widget.isDrawerOpen != oldWidget.isDrawerOpen) {
+      _controller.value = widget.isDrawerOpen ? 1.0 : 0.0;
     }
   }
 

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -259,6 +259,60 @@ void main() {
     expect(state.isEndDrawerOpen, equals(false));
   });
 
+  testWidgets('Open/close drawer by dragging', (WidgetTester tester) async {
+    final ThemeData draggable = ThemeData(platform: TargetPlatform.android);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: draggable,
+        home: const Scaffold(drawer: Drawer()),
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture();
+    final Finder finder = find.byType(Drawer);
+
+    double drawerPosition() {
+      expect(finder, findsOneWidget);
+      final RenderBox renderBox = tester.renderObject(finder);
+      return renderBox.localToGlobal(Offset.zero).dx;
+    }
+
+    // pointer down (drawer is closed)
+    await gesture.addPointer();
+    await gesture.down(const Offset(2,2));
+    expect(finder, findsNothing);
+
+    // open drawer slightly
+    await gesture.moveBy(const Offset(20, 0));
+    await tester.pump();
+    expect(drawerPosition(), isNegative);
+
+    // open drawer more than halfway
+    await gesture.moveBy(const Offset(200, 0));
+    await tester.pump();
+    expect(drawerPosition(), isNegative);
+
+    // drawer fully open
+    await gesture.moveBy(const Offset(200, 0));
+    await tester.pump();
+    expect(drawerPosition(), 0.0);
+
+    // drawer less than halfway closed
+    await gesture.moveBy(const Offset(-100.0, 0));
+    await tester.pump();
+    expect(drawerPosition(), moreOrLessEquals(-100.0));
+
+    // drawer more than halfway closed
+    await gesture.moveBy(const Offset(-100.0, 0));
+    await tester.pump();
+    expect(drawerPosition(), moreOrLessEquals(-200.0));
+
+    // drawer completely closed
+    await gesture.moveTo(const Offset(2, 0));
+    await tester.pump();
+    expect(finder, findsNothing);
+  });
+
   testWidgets('Scaffold.drawer - null restorationId ', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -277,38 +277,39 @@ void main() {
       return renderBox.localToGlobal(Offset.zero).dx;
     }
 
-    // pointer down (drawer is closed)
+    // Pointer down (drawer is closed).
     await gesture.addPointer();
     await gesture.down(const Offset(2,2));
+    await tester.pump();
     expect(finder, findsNothing);
 
-    // open drawer slightly
+    // Open drawer slightly.
     await gesture.moveBy(const Offset(20, 0));
     await tester.pump();
     expect(drawerPosition(), isNegative);
 
-    // open drawer more than halfway
+    // Open drawer more than halfway.
     await gesture.moveBy(const Offset(200, 0));
     await tester.pump();
     expect(drawerPosition(), isNegative);
 
-    // drawer fully open
+    // Drawer is fully open.
     await gesture.moveBy(const Offset(200, 0));
     await tester.pump();
     expect(drawerPosition(), 0.0);
 
-    // drawer less than halfway closed
+    // Drawer is less than halfway closed.
     await gesture.moveBy(const Offset(-100.0, 0));
     await tester.pump();
     expect(drawerPosition(), moreOrLessEquals(-100.0));
 
-    // drawer more than halfway closed
+    // Drawer is more than halfway closed.
     await gesture.moveBy(const Offset(-100.0, 0));
     await tester.pump();
     expect(drawerPosition(), moreOrLessEquals(-200.0));
 
-    // drawer completely closed
-    await gesture.moveTo(const Offset(2, 0));
+    // Drawer is completely closed.
+    await gesture.moveTo(Offset.zero);
     await tester.pump();
     expect(finder, findsNothing);
   });


### PR DESCRIPTION
This regression is due to the fact that `animationController.isAnimating` and `animationController.status.isAnimating` sometimes return opposite values.

This PR implements & tests the bugfix, and also adds documentation to explain this behavior.

<br>

fixes https://github.com/flutter/flutter/issues/153851

cc @azeunkn0wn @huycozy