### PR TITLE
Update the web test suite runner to use the correct flutter_driver output path if FLUTTER_TEST_OUTPUTS_DIR is set

### DIFF
--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -301,7 +301,7 @@ class WebTestsSuite {
       workingDirectory: testAppDirectory,
     );
     // This must match the testOutputsDirectory defined in flutter_driver's driver/common.dart.
-    String driverOutputPath = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? path.join(testAppDirectory, 'build');
+    final String driverOutputPath = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? path.join(testAppDirectory, 'build');
     final String responseFile =
         path.join(driverOutputPath, 'integration_response_data.json');
     if (File(responseFile).existsSync()) {

--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -300,8 +300,10 @@ class WebTestsSuite {
       <String>[ 'clean' ],
       workingDirectory: testAppDirectory,
     );
+    // This must match the testOutputsDirectory defined in flutter_driver's driver/common.dart.
+    String driverOutputPath = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? path.join(testAppDirectory, 'build');
     final String responseFile =
-        path.join(testAppDirectory, 'build', 'integration_response_data.json');
+        path.join(driverOutputPath, 'integration_response_data.json');
     if (File(responseFile).existsSync()) {
       File(responseFile).deleteSync();
     }


### PR DESCRIPTION
A pending change to the flutter_drone LUCI recipe is using a logging library that sets the FLUTTER_TEST_OUTPUTS_DIR environment variable (see https://flutter.googlesource.com/recipes/+/b111cd3ef2297e66905cc48c2cfedce0cf1ba46f)

flutter_driver uses FLUTTER_TEST_OUTPUTS_DIR as its output directory if it is set.  run_web_tests invokes flutter_driver and needs to look for outputs in that directory.