### PR TITLE
handle `HttpException`s coming from `ChromeTab.connect`

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -610,9 +610,13 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
       ChromeTab? chromeTab;
       try {
-        chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
-          return !chromeTab.url.startsWith('chrome-extension');
-        }, retryFor: const Duration(seconds: 5));
+        chromeTab = await getChromeTabGuarded(
+          chrome.chromeConnection,
+          (ChromeTab chromeTab) {
+            return !chromeTab.url.startsWith('chrome-extension');
+          },
+          retryFor: const Duration(seconds: 5),
+        );
       } on HttpException catch (error, stackTrace) {
         // We were unable to unable to communicate with Chrome.
         _logger.printError(error.toString(), stackTrace: stackTrace);

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -608,16 +608,18 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   }) async {
     if (_chromiumLauncher != null) {
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
-      late final ChromeTab? chromeTab;
+      ChromeTab? chromeTab;
       try {
         chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
           return !chromeTab.url.startsWith('chrome-extension');
         }, retryFor: const Duration(seconds: 5));
-      } on IOException {
+      } on HttpException catch (error, stackTrace) {
         // We were unable to unable to communicate with Chrome.
+        _logger.printError(error.toString(), stackTrace: stackTrace);
         chromeTab = null;
       }
       if (chromeTab == null) {
+        appFailedToStart();
         throwToolExit('Failed to connect to Chrome instance.');
       }
       _wipConnection = await chromeTab.connect();

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -608,9 +608,15 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   }) async {
     if (_chromiumLauncher != null) {
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
-      final ChromeTab? chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
-        return !chromeTab.url.startsWith('chrome-extension');
-      }, retryFor: const Duration(seconds: 5));
+      late final ChromeTab? chromeTab;
+      try {
+        chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
+          return !chromeTab.url.startsWith('chrome-extension');
+        }, retryFor: const Duration(seconds: 5));
+      } on IOException {
+        // We were unable to unable to communicate with Chrome.
+        chromeTab = null;
+      }
       if (chromeTab == null) {
         throwToolExit('Failed to connect to Chrome instance.');
       }

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -610,13 +610,9 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
       ChromeTab? chromeTab;
       try {
-        chromeTab = await getChromeTabGuarded(
-          chrome.chromeConnection,
-          (ChromeTab chromeTab) {
-            return !chromeTab.url.startsWith('chrome-extension');
-          },
-          retryFor: const Duration(seconds: 5),
-        );
+        chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
+          return !chromeTab.url.startsWith('chrome-extension');
+        }, retryFor: const Duration(seconds: 5));
       } on HttpException catch (error, stackTrace) {
         // We were unable to unable to communicate with Chrome.
         _logger.printError(error.toString(), stackTrace: stackTrace);

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -608,18 +608,16 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   }) async {
     if (_chromiumLauncher != null) {
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
-      ChromeTab? chromeTab;
+      late final ChromeTab? chromeTab;
       try {
         chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
           return !chromeTab.url.startsWith('chrome-extension');
         }, retryFor: const Duration(seconds: 5));
-      } on HttpException catch (error, stackTrace) {
+      } on IOException {
         // We were unable to unable to communicate with Chrome.
-        _logger.printError(error.toString(), stackTrace: stackTrace);
         chromeTab = null;
       }
       if (chromeTab == null) {
-        appFailedToStart();
         throwToolExit('Failed to connect to Chrome instance.');
       }
       _wipConnection = await chromeTab.connect();

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -426,9 +426,12 @@ class FlutterWebPlatform extends PlatformPlugin {
         // web once we transition off the HTML renderer. See:
         // https://github.com/flutter/flutter/issues/135700
         try {
-          final ChromeTab chromeTab = (await _browserManager!._browser.chromeConnection.getTab((ChromeTab tab) {
-            return tab.url.contains(_browserManager!._browser.url!);
-          }))!;
+          final ChromeTab chromeTab = (await getChromeTabGuarded(
+            _browserManager!._browser.chromeConnection,
+            (ChromeTab tab) {
+              return tab.url.contains(_browserManager!._browser.url!);
+            },
+          ))!;
           final WipConnection connection = await chromeTab.connect();
           final WipResponse response = await connection.sendCommand('Page.captureScreenshot', <String, Object>{
             // Clip the screenshot to include only the element.

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -451,6 +451,9 @@ class FlutterWebPlatform extends PlatformPlugin {
         } on FormatException catch (ex) {
           _logger.printError('Caught FormatException: $ex');
           return shelf.Response.ok('Caught exception: $ex');
+        } on IOException catch (ex) {
+          _logger.printError('Caught IOException: $ex');
+          return shelf.Response.ok('Caught exception: $ex');
         }
       }
       final String? errorMessage = await _testGoldenComparator.compareGoldens(testUri, bytes, goldenKey, updateGoldens);

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -426,12 +426,9 @@ class FlutterWebPlatform extends PlatformPlugin {
         // web once we transition off the HTML renderer. See:
         // https://github.com/flutter/flutter/issues/135700
         try {
-          final ChromeTab chromeTab = (await getChromeTabGuarded(
-            _browserManager!._browser.chromeConnection,
-            (ChromeTab tab) {
-              return tab.url.contains(_browserManager!._browser.url!);
-            },
-          ))!;
+          final ChromeTab chromeTab = (await _browserManager!._browser.chromeConnection.getTab((ChromeTab tab) {
+            return tab.url.contains(_browserManager!._browser.url!);
+          }))!;
           final WipConnection connection = await chromeTab.connect();
           final WipResponse response = await connection.sendCommand('Page.captureScreenshot', <String, Object>{
             // Clip the screenshot to include only the element.

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -490,7 +490,7 @@ class Chromium {
         if (i == attempts) {
           rethrow;
         }
-      } on IOException catch (_) {
+      } on IOException {
         if (i == attempts) {
           rethrow;
         }

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -490,6 +490,10 @@ class Chromium {
         if (i == attempts) {
           rethrow;
         }
+      } on IOException catch (_) {
+        if (i == attempts) {
+          rethrow;
+        }
       }
       await Future<void>.delayed(const Duration(milliseconds: 25));
     }

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../base/async_guard.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
@@ -512,7 +513,7 @@ class Chromium {
     Duration sigtermDelay = Duration.zero;
     if (_hasValidChromeConnection) {
       try {
-        final ChromeTab? tab = await chromeConnection.getTab(
+        final ChromeTab? tab = await getChromeTabGuarded(chromeConnection,
             (_) => true, retryFor: const Duration(seconds: 1));
         if (tab != null) {
           final WipConnection wipConnection = await tab.connect();
@@ -554,4 +555,14 @@ class Chromium {
       });
     });
   }
+}
+
+// TODO(andrewkolos): Remove when https://github.com/dart-lang/sdk/issues/56566
+//  is fixed.
+Future<ChromeTab?> getChromeTabGuarded(
+  ChromeConnection chromeConnection,
+  bool Function(ChromeTab tab) accept, {
+  Duration? retryFor,
+}) {
+  return asyncGuard(() => chromeConnection.getTab(accept, retryFor: retryFor));
 }

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -8,7 +8,6 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import '../base/async_guard.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
@@ -513,7 +512,7 @@ class Chromium {
     Duration sigtermDelay = Duration.zero;
     if (_hasValidChromeConnection) {
       try {
-        final ChromeTab? tab = await getChromeTabGuarded(chromeConnection,
+        final ChromeTab? tab = await chromeConnection.getTab(
             (_) => true, retryFor: const Duration(seconds: 1));
         if (tab != null) {
           final WipConnection wipConnection = await tab.connect();
@@ -555,14 +554,4 @@ class Chromium {
       });
     });
   }
-}
-
-// TODO(andrewkolos): Remove when https://github.com/dart-lang/sdk/issues/56566
-//  is fixed.
-Future<ChromeTab?> getChromeTabGuarded(
-  ChromeConnection chromeConnection,
-  bool Function(ChromeTab tab) accept, {
-  Duration? retryFor,
-}) {
-  return asyncGuard(() => chromeConnection.getTab(accept, retryFor: retryFor));
 }

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -797,7 +797,6 @@ void main() {
     expect(logger.errorText, isEmpty);
   });
 
-
   test('exits if getTabs throws a connection exception consistently', () async {
     final BufferLogger logger = BufferLogger.test();
     final FakeChromeConnection chromeConnection = FakeChromeConnection();

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -774,6 +774,30 @@ void main() {
     expect(logger.errorText, isEmpty);
   });
 
+  test('can recover if getTabs throws an HttpException', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final FakeChromeConnection chromeConnection = FakeChromeConnection(
+      maxRetries: 4,
+      exception: io.HttpException(
+        'Connection closed before full header was received',
+        uri: Uri.parse('http://localhost:52097/json'),
+      ),
+    );
+    final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
+      fileSystem: fileSystem,
+      platform: platform,
+      processManager: processManager,
+      operatingSystemUtils: operatingSystemUtils,
+      browserFinder: findChromeExecutable,
+      logger: logger,
+    );
+    final FakeProcess process = FakeProcess();
+    final Chromium chrome = Chromium(0, chromeConnection, chromiumLauncher: chromiumLauncher, process: process, logger: logger);
+    expect(await chromiumLauncher.connect(chrome, false), equals(chrome));
+    expect(logger.errorText, isEmpty);
+  });
+
+
   test('exits if getTabs throws a connection exception consistently', () async {
     final BufferLogger logger = BufferLogger.test();
     final FakeChromeConnection chromeConnection = FakeChromeConnection();
@@ -863,11 +887,19 @@ class FakeChromeConnection extends Fake implements ChromeConnection {
   /// Create a connection that throws a connection exception on first
   /// [maxRetries] calls to [getTabs].
   /// If [maxRetries] is `null`, [getTabs] calls never succeed.
-  FakeChromeConnection({this.maxRetries}): _retries = 0;
+  FakeChromeConnection({this.maxRetries, Exception? exception}) : _retries = 0 {
+    this.exception = exception ??
+        ConnectionException(
+          formatException: const FormatException('incorrect format'),
+          responseStatus: 'OK,',
+          responseBody: '<html> ...',
+        );
+  }
 
   final List<ChromeTab> tabs = <ChromeTab>[];
   final int? maxRetries;
   int _retries;
+  late final Exception exception;
 
   @override
   Future<ChromeTab?> getTab(bool Function(ChromeTab tab) accept, {Duration? retryFor}) async {
@@ -878,10 +910,7 @@ class FakeChromeConnection extends Fake implements ChromeConnection {
   Future<List<ChromeTab>> getTabs({Duration? retryFor}) async {
     _retries ++;
     if (maxRetries == null || _retries < maxRetries!) {
-      throw ConnectionException(
-        formatException: const FormatException('incorrect format'),
-        responseStatus: 'OK,',
-        responseBody: '<html> ...');
+      throw exception;
     }
     return tabs;
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/153972  (unless the cause of https://github.com/flutter/flutter/issues/153064#issuecomment-2305662791 happens to also prevent this fix from working).

In this PR, I've looked for all non-test call sites of `ChromeConnection.getTabs` and made sure are all wrapped in `try` blocks that handle `IOException` (`HttpException` is what we see in crash reporting, but I figure any `IOException` might as well be the same for all intents and purposes).

I plan on cherry-picking this the stable branch.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
