### PR TITLE
Optimize out LayoutBuilder from ReorderableList children

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -14,7 +14,6 @@ import 'basic.dart';
 import 'debug.dart';
 import 'framework.dart';
 import 'inherited_theme.dart';
-import 'layout_builder.dart';
 import 'localizations.dart';
 import 'media_query.dart';
 import 'overlay.dart';
@@ -1087,8 +1086,6 @@ class _ReorderableItemState extends State<_ReorderableItem> {
     }
   }
   bool _dragging = false;
-  BoxConstraints? get childLayoutConstraints => _childLayoutConstraints;
-  BoxConstraints? _childLayoutConstraints;
 
   @override
   void initState() {
@@ -1120,13 +1117,10 @@ class _ReorderableItemState extends State<_ReorderableItem> {
       return SizedBox.fromSize(size: size);
     }
     _listState._registerItem(this);
-    return LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
-      _childLayoutConstraints = constraints;
-      return Transform(
-        transform: Matrix4.translationValues(offset.dx, offset.dy, 0.0),
-        child: widget.child,
-      );
-    });
+    return Transform(
+      transform: Matrix4.translationValues(offset.dx, offset.dy, 0.0),
+      child: widget.child,
+    );
   }
 
   @override
@@ -1346,7 +1340,7 @@ class _DragInfo extends Drag {
     dragOffset = itemRenderBox.globalToLocal(initialPosition);
     itemSize = item.context.size!;
     itemExtent = _sizeExtent(itemSize, scrollDirection);
-    itemLayoutConstraints = item.childLayoutConstraints!;
+    itemLayoutConstraints = itemRenderBox.constraints;
     scrollable = Scrollable.of(item.context);
   }
 

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1117,8 +1117,8 @@ class _ReorderableItemState extends State<_ReorderableItem> {
       return SizedBox.fromSize(size: size);
     }
     _listState._registerItem(this);
-    return Transform(
-      transform: Matrix4.translationValues(offset.dx, offset.dy, 0.0),
+    return Transform.translate(
+      offset: offset,
       child: widget.child,
     );
   }


### PR DESCRIPTION
PR #147863 used a `LayoutBuilder` to ensure `ReorderableList` proxy items are built with the same constraints as their normal counterparts. However we don't actually need the `LayoutBuilder`, we can just grab the constraints from the `RenderBox` at proxy-creation-time.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
