### PR TITLE
Fix `TimePicker` hour and minute inputs are resized on error

### DIFF
--- a/dev/tools/gen_defaults/lib/time_picker_template.dart
+++ b/dev/tools/gen_defaults/lib/time_picker_template.dart
@@ -331,7 +331,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
       // TODO(rami-a): Remove this workaround once
       // https://github.com/flutter/flutter/issues/54104
       // is fixed.
-      errorStyle: const TextStyle(fontSize: 0, height: 0),
+      errorStyle: const TextStyle(fontSize: 0.0),
     );
   }
 

--- a/dev/tools/gen_defaults/lib/time_picker_template.dart
+++ b/dev/tools/gen_defaults/lib/time_picker_template.dart
@@ -331,7 +331,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
       // TODO(rami-a): Remove this workaround once
       // https://github.com/flutter/flutter/issues/54104
       // is fixed.
-      errorStyle: const TextStyle(fontSize: 0.0),
+      errorStyle: const TextStyle(fontSize: 0),
     );
   }
 

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -2047,7 +2047,14 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
     final bool alwaysUse24HourFormat = MediaQuery.alwaysUse24HourFormatOf(context);
 
     final InputDecorationTheme inputDecorationTheme = timePickerTheme.inputDecorationTheme ?? defaultTheme.inputDecorationTheme;
-    InputDecoration inputDecoration = const InputDecoration().applyDefaults(inputDecorationTheme);
+    InputDecoration inputDecoration = InputDecoration(
+      // Prevent the error text from appearing when
+      // timePickerTheme.inputDecorationTheme is used.
+      // TODO(tahatesser): Remove this workaround once
+      // https://github.com/flutter/flutter/issues/54104
+      // is fixed.
+      errorStyle: defaultTheme.inputDecorationTheme.errorStyle,
+    ).applyDefaults(inputDecorationTheme);
     // Remove the hint text when focused because the centered cursor
     // appears odd above the hint text.
     final String? hintText = focusNode.hasFocus ? null : _formattedValue;
@@ -3341,7 +3348,7 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
       // TODO(rami-a): Remove this workaround once
       // https://github.com/flutter/flutter/issues/54104
       // is fixed.
-      errorStyle: const TextStyle(fontSize: 0, height: 0),
+      errorStyle: const TextStyle(fontSize: 0.0, height: 1.0),
     );
   }
 
@@ -3676,7 +3683,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
       // TODO(rami-a): Remove this workaround once
       // https://github.com/flutter/flutter/issues/54104
       // is fixed.
-      errorStyle: const TextStyle(fontSize: 0, height: 0),
+      errorStyle: const TextStyle(fontSize: 0.0),
     );
   }
 

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -3348,7 +3348,7 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
       // TODO(rami-a): Remove this workaround once
       // https://github.com/flutter/flutter/issues/54104
       // is fixed.
-      errorStyle: const TextStyle(fontSize: 0.0, height: 1.0),
+      errorStyle: const TextStyle(fontSize: 0, height: 1),
     );
   }
 
@@ -3683,7 +3683,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
       // TODO(rami-a): Remove this workaround once
       // https://github.com/flutter/flutter/issues/54104
       // is fixed.
-      errorStyle: const TextStyle(fontSize: 0.0),
+      errorStyle: const TextStyle(fontSize: 0),
     );
   }
 

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -19,8 +19,16 @@ void main() {
   const String okString = 'OK';
   const String amString = 'AM';
   const String pmString = 'PM';
+
   Material getMaterialFromDialog(WidgetTester tester) {
     return tester.widget<Material>(find.descendant(of: find.byType(Dialog), matching: find.byType(Material)).first);
+  }
+
+  Finder findBorderPainter() {
+    return find.descendant(
+      of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_BorderContainer'),
+      matching: find.byWidgetPredicate((Widget w) => w is CustomPaint),
+    );
   }
 
   testWidgets('Material2 - Dialog size - dial mode', (WidgetTester tester) async {
@@ -2012,6 +2020,43 @@ void main() {
     final RenderParagraph paragraph = tester.renderObject(find.text(':'));
     expect(paragraph.text.style!.color, theme.colorScheme.onSurface);
     expect(paragraph.text.style!.fontSize, 56.0);
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/153549.
+  testWidgets('Time picker hour minute does not resize on error', (WidgetTester tester) async {
+    await startPicker(
+      entryMode: TimePickerEntryMode.input,
+      tester,
+      (TimeOfDay? value) { },
+    );
+
+    expect(tester.getSize(findBorderPainter().first), const Size(96.0, 70.0));
+
+    // Enter invalid hour.
+    await tester.enterText(find.byType(TextField).first, 'AB');
+    await tester.tap(find.text(okString));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(findBorderPainter().first), const Size(96.0, 70.0));
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/153549.
+  testWidgets('Material2 - Time picker hour minute does not resize on error', (WidgetTester tester) async {
+    await startPicker(
+      entryMode: TimePickerEntryMode.input,
+      tester,
+      (TimeOfDay? value) { },
+      materialType: MaterialType.material2,
+    );
+
+    expect(tester.getSize(findBorderPainter().first), const Size(96.0, 70.0));
+
+    // Enter invalid hour.
+    await tester.enterText(find.byType(TextField).first, 'AB');
+    await tester.tap(find.text(okString));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(findBorderPainter().first), const Size(96.0, 70.0));
   });
 }
 

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -858,6 +858,42 @@ void main() {
     expect(paragraph.text.style!.fontSize, 35.0);
     expect(paragraph.text.style!.fontStyle, FontStyle.italic);
   });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/153549.
+  testWidgets('Time picker hour minute does not resize on error', (WidgetTester tester) async {
+    final TimePickerThemeData timePickerTheme = _timePickerTheme(includeInputDecoration: true);
+    final ThemeData theme = ThemeData(timePickerTheme: timePickerTheme);
+    await tester.pumpWidget(_TimePickerLauncher(themeData: theme, entryMode: TimePickerEntryMode.input));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    expect(tester.getSize(findBorderPainter().first), const Size(96.0, 72.0));
+
+    // Enter invalid hour.
+    await tester.enterText(find.byType(TextField).first, 'AB');
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(findBorderPainter().first), const Size(96.0, 72.0));
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/153549.
+  testWidgets('Material2 - Time picker hour minute does not resize on error', (WidgetTester tester) async {
+    final TimePickerThemeData timePickerTheme = _timePickerTheme(includeInputDecoration: true);
+    final ThemeData theme = ThemeData(timePickerTheme: timePickerTheme, useMaterial3: false);
+    await tester.pumpWidget(_TimePickerLauncher(themeData: theme, entryMode: TimePickerEntryMode.input));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    expect(tester.getSize(findBorderPainter().first), const Size(96.0, 70.0));
+
+    // Enter invalid hour.
+    await tester.enterText(find.byType(TextField).first, 'AB');
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(findBorderPainter().first), const Size(96.0, 70.0));
+  });
 }
 
 final Color _selectedColor = Colors.green[100]!;
@@ -969,4 +1005,11 @@ final Finder findDialPaint = find.descendant(
 
 ButtonStyle _actionButtonStyle(WidgetTester tester, String text) {
   return tester.widget<TextButton>(find.widgetWithText(TextButton, text)).style!;
+}
+
+Finder findBorderPainter() {
+  return find.descendant(
+    of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_BorderContainer'),
+    matching: find.byWidgetPredicate((Widget w) => w is CustomPaint),
+  );
 }


### PR DESCRIPTION
Fixes [Defining inputDecorationTheme in TimePickerThemeData Causes Misalignment of Hour and Minute Input Boxes](https://github.com/flutter/flutter/issues/153549)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(
        timePickerTheme: const TimePickerThemeData(
          inputDecorationTheme: InputDecorationTheme(),
        ),
      ),
      home: Scaffold(
        body: Center(
          child: Builder(builder: (BuildContext context) {
            return ElevatedButton(
              onPressed: () async {
                await showTimePicker(
                  context: context,
                  initialEntryMode: TimePickerEntryMode.input,
                  initialTime: TimeOfDay.now(),
                );
              },
              child: const Text('Show Time Picker'),
            );
          }),
        ),
      ),
    );
  }
}

```

</details>

### Before

<img width="578" alt="Screenshot 2024-08-23 at 16 49 25" src="https://github.com/user-attachments/assets/f5da2495-551e-4110-85ea-120323cd38d2">

### After

<img width="578" alt="Screenshot 2024-08-23 at 16 51 03" src="https://github.com/user-attachments/assets/80224a10-e9d2-46d1-b2eb-f16358699744">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
