### PR TITLE
[devicelan] opt android devices into fixed performance mode.

### DIFF
--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -128,6 +128,9 @@ abstract class Device {
   /// A unique device identifier.
   String get deviceId;
 
+  /// Switch the device into fixed/regular performance mode.
+  Future<void> toggleFixedPerformanceMode(bool enable) async {}
+
   /// Whether the device is awake.
   Future<bool> isAwake();
 
@@ -588,6 +591,11 @@ class AndroidDevice extends Device {
   final String deviceId;
   String deviceInfo = '';
   int apiLevel = 0;
+
+  @override
+  Future<void> toggleFixedPerformanceMode(bool enable) async {
+    await shellExec('cmd', <String>['power', 'set-fixed-performance-mode-enabled', if (enable) 'true' else 'false']);
+  }
 
   /// Whether the device is awake.
   @override

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1311,6 +1311,8 @@ class PerfTest {
       late Device selectedDevice;
       selectedDevice = device ?? await devices.workingDevice;
       await selectedDevice.unlock();
+      await selectedDevice.toggleFixedPerformanceMode(true);
+
       final String deviceId = selectedDevice.deviceId;
       final String? localEngine = localEngineFromEnv;
       final String? localEngineHost = localEngineHostFromEnv;
@@ -1415,6 +1417,7 @@ class PerfTest {
       } finally {
         await resetManifest();
         await resetPlist();
+        await selectedDevice.toggleFixedPerformanceMode(false);
       }
 
       final Map<String, dynamic> data = json.decode(


### PR DESCRIPTION
See also: https://developer.android.com/games/optimize/adpf/fixed-performance-mode

Should keep benchmarks more stable so A/B comparisons are appropriate without accounting for CPU/GPU throttling.
