### PR TITLE
[Windows] Improve symlink ERROR_ACCESS_DENIED error message

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -993,8 +993,8 @@ void _createPlatformPluginSymlinks(Directory symlinkDirectory, List<Object?>? pl
         e,
         platform: globals.platform,
         os: globals.os,
-        destination: 'dest',
-        source: 'source',
+        destination: link.path,
+        source: path,
       );
       rethrow;
     }

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -1844,24 +1844,73 @@ The Flutter Preview device does not support the following plugins from your pubs
       );
     });
 
-    testWithoutContext('Symlink ERROR_ACCESS_DENIED failures show developers paths that were used', () async {
-      final Platform platform = FakePlatform(operatingSystem: 'windows');
-      final FakeOperatingSystemUtils os = FakeOperatingSystemUtils('Microsoft Windows [Version 10.0.14972.1]');
+    testUsingContext('Symlink ERROR_ACCESS_DENIED failures show developers paths that were used', () async {
+      final FakeFlutterProject flutterProject = FakeFlutterProject()
+        ..directory = globals.fs.currentDirectory.childDirectory('app');
+      final Directory windowsManagedDirectory = flutterProject.directory
+          .childDirectory('windows')
+          .childDirectory('flutter');
+      final FakeWindowsProject windowsProject = FakeWindowsProject()
+        ..managedDirectory = windowsManagedDirectory
+        ..pluginSymlinkDirectory = windowsManagedDirectory
+            .childDirectory('ephemeral')
+            .childDirectory('.plugin_symlinks')
+        ..exists = true;
 
-      const FileSystemException e = FileSystemException('', '', OSError('', 5));
+      final File dependenciesFile = flutterProject.directory
+        .childFile('.flutter-plugins-dependencies');
+      flutterProject
+        ..flutterPluginsDependenciesFile = dependenciesFile
+        ..windows = windowsProject;
+
+      flutterProject.directory.childFile('.packages').createSync(recursive: true);
+
+      const String dependenciesFileContents = r'''
+{
+  "plugins": {
+    "windows": [
+      {
+        "name": "some_plugin",
+        "path": "C:\\some_plugin"
+      }
+    ]
+  }
+}
+''';
+      dependenciesFile.writeAsStringSync(dependenciesFileContents);
+
+      const String expectedMessage =
+        'ERROR_ACCESS_DENIED file system exception thrown while trying to '
+        r'create a symlink from C:\some_plugin to '
+        r'C:\app\windows\flutter\ephemeral\.plugin_symlinks\some_plugin';
 
       expect(
-        () => handleSymlinkException(
-          e,
-          platform: platform,
-          os: os,
-          source: pubCachePath,
-          destination: ephemeralPackagePath,
+        () => createPluginSymlinks(
+          flutterProject,
+          featureFlagsOverride: TestFeatureFlags(isWindowsEnabled: true),
         ),
-        throwsToolExit(
-          message: 'ERROR_ACCESS_DENIED file system exception thrown while trying to create a symlink from $pubCachePath to $ephemeralPackagePath',
-        ),
+        throwsToolExit(message: expectedMessage),
       );
+    }, overrides: <Type, Generator>{
+      FileSystem: () {
+        final FileExceptionHandler handle = FileExceptionHandler();
+        final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
+          platform: FakePlatform(),
+          delegate: MemoryFileSystem.test(
+            style: FileSystemStyle.windows,
+            opHandle: handle.opHandle,
+          ),
+        );
+        const String pluginSymlinkPath = r'C:\app\windows\flutter\ephemeral\.plugin_symlinks\some_plugin';
+        handle.addError(
+          fileSystem.link(pluginSymlinkPath),
+          FileSystemOp.create,
+          const FileSystemException('', '', OSError('', 5)),
+        );
+        return fileSystem;
+      },
+      Platform: () => FakePlatform(operatingSystem: 'windows'),
+      ProcessManager: () => FakeProcessManager.empty(),
     });
 
     testWithoutContext('Symlink failures instruct developers to run as administrator on older versions of Windows', () async {


### PR DESCRIPTION
Currently, if creating a symlink on Windows fails due to `ERROR_ACCESS_DENIED`, you'll get an error message like:

```
Error: ERROR_ACCESS_DENIED file system exception thrown while trying to create a symlink from source to dest
```

The `source` and `dest` paths are incorrect.

This will help us debug: https://github.com/flutter/flutter/issues/153758

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
