### PR TITLE
Refactor `CircularNotchedRectangle.getOuterPath()`

### DIFF
--- a/packages/flutter/lib/src/painting/notched_shapes.dart
+++ b/packages/flutter/lib/src/painting/notched_shapes.dart
@@ -69,7 +69,8 @@ class CircularNotchedRectangle extends NotchedShape {
 
     // The guest's shape is a circle bounded by the guest rectangle.
     // So the guest's radius is half the guest width.
-    final double notchRadius = guest.width / 2.0;
+    final double r = guest.width / 2.0;
+    final Radius notchRadius = Radius.circular(r);
 
     // The variables [p2yA] and [p2yB] need to be inverted
     // when the notch is drawn on the bottom of a path.
@@ -86,8 +87,7 @@ class CircularNotchedRectangle extends NotchedShape {
     const double s1 = 15.0;
     const double s2 = 1.0;
 
-    final double r = notchRadius;
-    final double a = -1.0 * r - s2;
+    final double a = -r - s2;
     final double b = (inverted ? host.bottom : host.top) - guest.center.dy;
 
     final double n2 = math.sqrt(b * b * r * r * (a * a + b * b - r * r));
@@ -96,7 +96,7 @@ class CircularNotchedRectangle extends NotchedShape {
     final double p2yA = math.sqrt(r * r - p2xA * p2xA) * invertMultiplier;
     final double p2yB = math.sqrt(r * r - p2xB * p2xB) * invertMultiplier;
 
-    final List<Offset?> p = List<Offset?>.filled(6, null);
+    final List<Offset> p = List<Offset>.filled(6, Offset.zero);
 
     // p0, p1, and p2 are the control points for segment A.
     p[0] = Offset(a - s1, b);
@@ -106,47 +106,38 @@ class CircularNotchedRectangle extends NotchedShape {
 
     // p3, p4, and p5 are the control points for segment B, which is a mirror
     // of segment A around the y axis.
-    p[3] = Offset(-1.0 * p[2]!.dx, p[2]!.dy);
-    p[4] = Offset(-1.0 * p[1]!.dx, p[1]!.dy);
-    p[5] = Offset(-1.0 * p[0]!.dx, p[0]!.dy);
+    p[3] = Offset(-1.0 * p[2].dx, p[2].dy);
+    p[4] = Offset(-1.0 * p[1].dx, p[1].dy);
+    p[5] = Offset(-1.0 * p[0].dx, p[0].dy);
 
     // translate all points back to the absolute coordinate system.
     for (int i = 0; i < p.length; i += 1) {
-      p[i] = p[i]! + guest.center;
+      p[i] += guest.center;
     }
 
     // Use the calculated points to draw out a path object.
-    final Path path = Path();
-    path.moveTo(host.left, host.top);
+    final Path path = Path()..moveTo(host.left, host.top);
     if (!inverted) {
       path
-        ..lineTo(p[0]!.dx, p[0]!.dy)
-        ..quadraticBezierTo(p[1]!.dx, p[1]!.dy, p[2]!.dx, p[2]!.dy)
-        ..arcToPoint(
-          p[3]!,
-          radius: Radius.circular(notchRadius),
-          clockwise: false,
-        )
-        ..quadraticBezierTo(p[4]!.dx, p[4]!.dy, p[5]!.dx, p[5]!.dy)
+        ..lineTo(p[0].dx, p[0].dy)
+        ..quadraticBezierTo(p[1].dx, p[1].dy, p[2].dx, p[2].dy)
+        ..arcToPoint(p[3], radius: notchRadius, clockwise: false)
+        ..quadraticBezierTo(p[4].dx, p[4].dy, p[5].dx, p[5].dy)
         ..lineTo(host.right, host.top)
-        ..lineTo(host.right, host.bottom);
+        ..lineTo(host.right, host.bottom)
+        ..lineTo(host.left, host.bottom);
     } else {
       path
         ..lineTo(host.right, host.top)
         ..lineTo(host.right, host.bottom)
-        ..lineTo(p[5]!.dx, p[5]!.dy)
-        ..quadraticBezierTo(p[4]!.dx, p[4]!.dy, p[3]!.dx, p[3]!.dy)
-        ..arcToPoint(
-          p[2]!,
-          radius: Radius.circular(notchRadius),
-          clockwise: false,
-        )
-        ..quadraticBezierTo(p[1]!.dx, p[1]!.dy, p[0]!.dx, p[0]!.dy);
+        ..lineTo(p[5].dx, p[5].dy)
+        ..quadraticBezierTo(p[4].dx, p[4].dy, p[3].dx, p[3].dy)
+        ..arcToPoint(p[2], radius: notchRadius, clockwise: false)
+        ..quadraticBezierTo(p[1].dx, p[1].dy, p[0].dx, p[0].dy)
+        ..lineTo(host.left, host.bottom);
     }
-    path
-      ..lineTo(host.left, host.bottom)
-      ..close();
-    return path;
+
+    return path..close();
   }
 }
 


### PR DESCRIPTION
This pull request is a follow-up on https://github.com/flutter/flutter/pull/151386#pullrequestreview-2170626471.

- The circular notched rectangle's `getOuterPath()` method no longer uses any null-asserts.
- It also used to have 2 variables (`r` and `notchRadius`) that held the same value, but that's no longer the case.