### PR TITLE
Expose long press in ```CupertinoButton```

### DIFF
--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -167,12 +167,10 @@ class CupertinoButton extends StatefulWidget {
 
   /// The callback that is called when the button is tapped or otherwise activated.
   ///
-  /// If [onPressed] and [onLongPress] is null, the button will be disabled.
+  /// If [onPressed] and [onLongPress] callbacks are null, then the button will be disabled.
   final VoidCallback? onPressed;
 
-  /// The callback that is called when the button is long pressed.
-  ///
-  /// If [onPressed] and [onLongPress] is null, the button will be disabled.
+  /// If [onPressed] and [onLongPress] callbacks are null, then the button will be disabled.
   final VoidCallback? onLongPress;
 
   /// Minimum size of the button.
@@ -231,7 +229,7 @@ class CupertinoButton extends StatefulWidget {
   final _CupertinoButtonStyle _style;
 
   /// Whether the button is enabled or disabled. Buttons are disabled by default. To
-  /// enable a button, set [onPressed] or [onLongPress] property to a non-null value.
+  /// enable a button, set [onPressed] or [onLongPress] to a non-null value.
   bool get enabled => onPressed != null || onLongPress != null;
 
   @override

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -80,6 +80,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
+    this.onLongPressed,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
        _style = _CupertinoButtonStyle.plain;
@@ -108,6 +109,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
+    this.onLongPressed,
     required this.onPressed,
   }) : _style = _CupertinoButtonStyle.tinted;
 
@@ -131,6 +133,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
+    this.onLongPressed,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
        color = null,
@@ -164,8 +167,13 @@ class CupertinoButton extends StatefulWidget {
 
   /// The callback that is called when the button is tapped or otherwise activated.
   ///
-  /// If this is set to null, the button will be disabled.
+  /// If [onPressed] and [onLongPressed] is null, the button will be disabled.
   final VoidCallback? onPressed;
+
+  /// The callback that is called when the button is long pressed.
+  ///
+  /// If [onPressed] and [onLongPressed] is null, the button will be disabled.
+  final VoidCallback? onLongPressed;
 
   /// Minimum size of the button.
   ///
@@ -223,8 +231,8 @@ class CupertinoButton extends StatefulWidget {
   final _CupertinoButtonStyle _style;
 
   /// Whether the button is enabled or disabled. Buttons are disabled by default. To
-  /// enable a button, set its [onPressed] property to a non-null value.
-  bool get enabled => onPressed != null;
+  /// enable a button, set [onPressed] or [onLongPressed] property to a non-null value.
+  bool get enabled => onPressed != null || onLongPressed != null;
 
   @override
   State<CupertinoButton> createState() => _CupertinoButtonState();
@@ -392,6 +400,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
           onTapUp: enabled ? _handleTapUp : null,
           onTapCancel: enabled ? _handleTapCancel : null,
           onTap: widget.onPressed,
+          onLongPress: widget.onLongPressed,
           child: Semantics(
             button: true,
             child: ConstrainedBox(

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -80,7 +80,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
-    this.onLongPressed,
+    this.onLongPress,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
        _style = _CupertinoButtonStyle.plain;
@@ -109,7 +109,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
-    this.onLongPressed,
+    this.onLongPress,
     required this.onPressed,
   }) : _style = _CupertinoButtonStyle.tinted;
 
@@ -133,7 +133,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
-    this.onLongPressed,
+    this.onLongPress,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
        color = null,
@@ -167,13 +167,13 @@ class CupertinoButton extends StatefulWidget {
 
   /// The callback that is called when the button is tapped or otherwise activated.
   ///
-  /// If [onPressed] and [onLongPressed] is null, the button will be disabled.
+  /// If [onPressed] and [onLongPress] is null, the button will be disabled.
   final VoidCallback? onPressed;
 
   /// The callback that is called when the button is long pressed.
   ///
-  /// If [onPressed] and [onLongPressed] is null, the button will be disabled.
-  final VoidCallback? onLongPressed;
+  /// If [onPressed] and [onLongPress] is null, the button will be disabled.
+  final VoidCallback? onLongPress;
 
   /// Minimum size of the button.
   ///
@@ -231,8 +231,8 @@ class CupertinoButton extends StatefulWidget {
   final _CupertinoButtonStyle _style;
 
   /// Whether the button is enabled or disabled. Buttons are disabled by default. To
-  /// enable a button, set [onPressed] or [onLongPressed] property to a non-null value.
-  bool get enabled => onPressed != null || onLongPressed != null;
+  /// enable a button, set [onPressed] or [onLongPress] property to a non-null value.
+  bool get enabled => onPressed != null || onLongPress != null;
 
   @override
   State<CupertinoButton> createState() => _CupertinoButtonState();
@@ -400,7 +400,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
           onTapUp: enabled ? _handleTapUp : null,
           onTapCancel: enabled ? _handleTapCancel : null,
           onTap: widget.onPressed,
-          onLongPress: widget.onLongPressed,
+          onLongPress: widget.onLongPress,
           child: Semantics(
             button: true,
             child: ConstrainedBox(

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -65,7 +65,7 @@ void main() {
     );
   });
 
-    testWidgets('OnLongPress works!', (WidgetTester tester) async {
+  testWidgets('OnLongPress works!', (WidgetTester tester) async {
     bool value = false;
     await tester.pumpWidget(
       boilerplate(child: CupertinoButton(
@@ -80,6 +80,19 @@ void main() {
     final Finder cupertinoBtn = find.byType(CupertinoButton);
     await tester.longPress(cupertinoBtn);
     expect(value, isTrue);
+  });
+
+  testWidgets('button is disabled if onLongPress and onPressed are both null', (WidgetTester tester) async {
+   await tester.pumpWidget(
+      boilerplate(child: const CupertinoButton(
+        onPressed: null,
+        child: Text('XXXX', style: testStyle),
+      )),
+    );
+
+    expect(find.byType(CupertinoButton), findsOneWidget);
+    final CupertinoButton button = tester.widget(find.byType(CupertinoButton));
+    expect(button.enabled, isFalse);
   });
 
   // TODO(LongCatIsLoong): Uncomment once https://github.com/flutter/flutter/issues/44115

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -65,6 +65,23 @@ void main() {
     );
   });
 
+    testWidgets('OnLongPress works!', (WidgetTester tester) async {
+    bool value = false;
+    await tester.pumpWidget(
+      boilerplate(child: CupertinoButton(
+        onPressed: null,
+        onLongPressed: () {
+          value = !value;
+        },
+        child: const Text('XXXX', style: testStyle),
+      )),
+    );
+    await tester.pump();
+    final Finder cupertinoBtn = find.byType(CupertinoButton);
+    await tester.longPress(cupertinoBtn);
+    expect(value, isTrue);
+  });
+
   // TODO(LongCatIsLoong): Uncomment once https://github.com/flutter/flutter/issues/44115
   // is fixed.
   /*

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -70,7 +70,7 @@ void main() {
     await tester.pumpWidget(
       boilerplate(child: CupertinoButton(
         onPressed: null,
-        onLongPressed: () {
+        onLongPress: () {
           value = !value;
         },
         child: const Text('XXXX', style: testStyle),


### PR DESCRIPTION
Adds long press as per https://github.com/flutter/flutter/issues/153956 request

Fixes #153956

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
