### PR TITLE
[web:tools] disable search engine choice screen in flutter run

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -214,6 +214,12 @@ class ChromiumLauncher {
       '--no-default-browser-check',
       '--disable-default-apps',
       '--disable-translate',
+
+      // Remove the search engine choice screen. It's irrelevant for app
+      // debugging purposes.
+      // See: https://github.com/flutter/flutter/issues/153928
+      '--disable-search-engine-choice-screen',
+
       if (headless)
         ...<String>[
           '--headless',

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -29,6 +29,7 @@ const List<String> kChromeArgs = <String>[
   '--no-default-browser-check',
   '--disable-default-apps',
   '--disable-translate',
+  '--disable-search-engine-choice-screen',
 ];
 
 const List<String> kCodeCache = <String>[


### PR DESCRIPTION
The choice screen is irrelevant when debugging apps locally. `flutter run` creates a separate user profile for testing only. It doesn't touch users' browser settings.

Fixes https://github.com/flutter/flutter/issues/153928