### PR TITLE
Fix TextOverflow ellipsis with TextStyle height 1 cut off the letter

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -890,7 +890,8 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
     }());
 
     if (_needsClipping) {
-      final Rect bounds = offset & size;
+      final Rect bounds =
+          offset.translate(0, -1) & Size(size.width, size.height + 2);
       if (_overflowShader != null) {
         // This layer limits what the shader below blends with to be just the
         // text (as opposed to the text and its background).


### PR DESCRIPTION
TextOverflow ellipsis with TextStyle height 1 will cut off the letter of some characters like g, ế,...
We should increment height of clipping area for prevent this problem.

Before
![Screenshot_1724393819](https://github.com/user-attachments/assets/24662ccd-fa42-4b98-beb4-eb49fc8505f1)

After
![Screenshot_1724393841](https://github.com/user-attachments/assets/2efdbb05-7e3e-4430-8b9e-6c8f5c5c1aa5)

Fixes #153988

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
