### PR TITLE
Uninstall microbenchmarks before running them.

### DIFF
--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -30,6 +30,18 @@ TaskFunction createMicrobenchmarkTask({
         final Directory appDir = dir(
             path.join(flutterDirectory.path, 'dev/benchmarks/microbenchmarks'));
         final Process flutterProcess = await inDirectory(appDir, () async {
+          section('Uninstall microbenchmarks app ($benchmarkPath)');
+
+          await flutter(
+            'install',
+            options: <String>[
+              '-v',
+              '--uninstall-only',
+              '-d',
+              device.deviceId,
+            ],
+          );
+
           final List<String> options = <String>[
             '-v',
             // --release doesn't work on iOS due to code signing issues


### PR DESCRIPTION
Flakes in #153828 stem from adb saying the app isn't installed, but then failing to install wtih `-r`. Several other tests uninstall the app before trying to run it.

Potential corrects #153828 