### PR TITLE
[CP-stable] handle `HttpException`s coming from ChromeTab.connect

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -612,10 +612,22 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   }) async {
     if (_chromiumLauncher != null) {
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
-      final ChromeTab? chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
-        return !chromeTab.url.startsWith('chrome-extension');
-      }, retryFor: const Duration(seconds: 5));
+      ChromeTab? chromeTab;
+      try {
+        chromeTab = await getChromeTabGuarded(
+          chrome.chromeConnection,
+          (ChromeTab chromeTab) {
+            return !chromeTab.url.startsWith('chrome-extension');
+          },
+          retryFor: const Duration(seconds: 5),
+        );
+      } on HttpException catch (error, stackTrace) {
+        // We were unable to unable to communicate with Chrome.
+        _logger.printError(error.toString(), stackTrace: stackTrace);
+        chromeTab = null;
+      }
       if (chromeTab == null) {
+        appFailedToStart();
         throwToolExit('Failed to connect to Chrome instance.');
       }
       _wipConnection = await chromeTab.connect();

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -426,9 +426,12 @@ class FlutterWebPlatform extends PlatformPlugin {
         // web once we transition off the HTML renderer. See:
         // https://github.com/flutter/flutter/issues/135700
         try {
-          final ChromeTab chromeTab = (await _browserManager!._browser.chromeConnection.getTab((ChromeTab tab) {
-            return tab.url.contains(_browserManager!._browser.url!);
-          }))!;
+          final ChromeTab chromeTab = (await getChromeTabGuarded(
+            _browserManager!._browser.chromeConnection,
+            (ChromeTab tab) {
+              return tab.url.contains(_browserManager!._browser.url!);
+            },
+          ))!;
           final WipConnection connection = await chromeTab.connect();
           final WipResponse response = await connection.sendCommand('Page.captureScreenshot', <String, Object>{
             // Clip the screenshot to include only the element.
@@ -450,6 +453,9 @@ class FlutterWebPlatform extends PlatformPlugin {
           return shelf.Response.ok('WIP error: $ex');
         } on FormatException catch (ex) {
           _logger.printError('Caught FormatException: $ex');
+          return shelf.Response.ok('Caught exception: $ex');
+        } on IOException catch (ex) {
+          _logger.printError('Caught IOException: $ex');
           return shelf.Response.ok('Caught exception: $ex');
         }
       }


### PR DESCRIPTION
(copied from original PR description)

Fixes [#153972](https://github.com/flutter/flutter/issues/153972) (unless the cause of [#153064](https://github.com/flutter/flutter/issues/153064#issuecomment-2305662791) happens to also prevent this fix from working).

In this PR, I've looked for all non-test call sites of `ChromeConnection.getTabs` and made sure are all wrapped in `try` blocks that handle `IOException` (`HttpException` is what we see in crash reporting, but I figure any `IOException` might as well be the same for all intents and purposes).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
