### PR TITLE
Add a RegExp for iOS domain when reading domains from xcodeProject 

### DIFF
--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -263,6 +263,7 @@ class IosProject extends XcodeBasedProject {
   static const String _kProductBundleIdVariable = '\$($kProductBundleIdKey)';
 
   static final RegExp _associatedDomainPattern = RegExp(r'^applinks:(.*)');
+  static final RegExp _associatedDomainPatternWithParam = RegExp(r'^applinks:(.*)\?(.*)');
 
   Directory get ephemeralModuleDirectory => parent.directory.childDirectory('.ios');
   Directory get _editableDirectory => parent.directory.childDirectory('ios');
@@ -470,8 +471,10 @@ class IosProject extends XcodeBasedProject {
           if (domains != null) {
             return <String>[
               for (final String domain in domains)
-                if (_associatedDomainPattern.firstMatch(domain) case final RegExpMatch match)
-                  match.group(1)!,
+                 if (_associatedDomainPatternWithParam.firstMatch(domain) case final RegExpMatch match)
+                   match.group(1)!
+                 else if (_associatedDomainPattern.firstMatch(domain) case final RegExpMatch match)
+                 match.group(1)!,
             ];
           }
         }

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -262,7 +262,7 @@ class IosProject extends XcodeBasedProject {
   static final RegExp _productBundleIdPattern = RegExp('^\\s*$kProductBundleIdKey\\s*=\\s*(["\']?)(.*?)\\1;\\s*\$');
   static const String _kProductBundleIdVariable = '\$($kProductBundleIdKey)';
 
-  // The string starts with `applinks:` and ignores the query string which starts with `?`.
+  // The string starts with `applinks:` and ignores the query param which starts with `?`.
   static final RegExp _associatedDomainPattern = RegExp(r'^applinks:([^?]+)');
 
   Directory get ephemeralModuleDirectory => parent.directory.childDirectory('.ios');

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -472,7 +472,7 @@ class IosProject extends XcodeBasedProject {
             return <String>[
               for (final String domain in domains)
                 if (_associatedDomainPattern.firstMatch(domain) case final RegExpMatch match)
-                  match.group(1)!
+                  match.group(1)!,
             ];
           }
         }

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -262,8 +262,8 @@ class IosProject extends XcodeBasedProject {
   static final RegExp _productBundleIdPattern = RegExp('^\\s*$kProductBundleIdKey\\s*=\\s*(["\']?)(.*?)\\1;\\s*\$');
   static const String _kProductBundleIdVariable = '\$($kProductBundleIdKey)';
 
-  static final RegExp _associatedDomainPattern = RegExp(r'^applinks:(.*)');
-  static final RegExp _associatedDomainPatternWithParam = RegExp(r'^applinks:(.*)\?(.*)');
+  // The string starts with `applinks:` and ignores the query string which starts with `?`.
+  static final RegExp _associatedDomainPattern = RegExp(r'^applinks:([^?]+)');
 
   Directory get ephemeralModuleDirectory => parent.directory.childDirectory('.ios');
   Directory get _editableDirectory => parent.directory.childDirectory('ios');
@@ -471,10 +471,8 @@ class IosProject extends XcodeBasedProject {
           if (domains != null) {
             return <String>[
               for (final String domain in domains)
-                 if (_associatedDomainPatternWithParam.firstMatch(domain) case final RegExpMatch match)
+                 if (_associatedDomainPattern.firstMatch(domain) case final RegExpMatch match)
                    match.group(1)!
-                 else if (_associatedDomainPattern.firstMatch(domain) case final RegExpMatch match)
-                 match.group(1)!,
             ];
           }
         }

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -471,8 +471,8 @@ class IosProject extends XcodeBasedProject {
           if (domains != null) {
             return <String>[
               for (final String domain in domains)
-                 if (_associatedDomainPattern.firstMatch(domain) case final RegExpMatch match)
-                   match.group(1)!
+                if (_associatedDomainPattern.firstMatch(domain) case final RegExpMatch match)
+                  match.group(1)!
             ];
           }
         }

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -920,6 +920,7 @@ plugins {
             <String>[
               'applinks:example.com',
               'applinks:example2.com',
+              'applinks:example3.com?mode=developer',
             ],
           );
           final String outputFilePath = await project.ios.outputsUniversalLinkSettings(
@@ -935,6 +936,7 @@ plugins {
               <String>[
                 'example.com',
                 'example2.com',
+                'example3.com',
               ],
             ),
           );


### PR DESCRIPTION
Append the string `?mode=<alternate mode>` to the associated domain to enable alternate mode in some use cases is recommended in apple developer guide (https://developer.apple.com/documentation/xcode/configuring-an-associated-domain#Enable-alternate-mode-for-unreachable-servers)

So when reading these domains from xcode settings, we should consider this case and trim it.













## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
