### PR TITLE
Add background color animation to MaterialInteriorState

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -881,6 +881,7 @@ class _MaterialInteriorState extends AnimatedWidgetBaseState<_MaterialInterior> 
   Tween<double>? _elevation;
   ColorTween? _surfaceTintColor;
   ColorTween? _shadowColor;
+  ColorTween? _backgroundColor;
   ShapeBorderTween? _border;
 
   @override
@@ -893,6 +894,11 @@ class _MaterialInteriorState extends AnimatedWidgetBaseState<_MaterialInterior> 
     _shadowColor = visitor(
       _shadowColor,
       widget.shadowColor,
+      (dynamic value) => ColorTween(begin: value as Color),
+    ) as ColorTween?;
+    _backgroundColor = visitor(
+      _backgroundColor,
+      widget.color,
       (dynamic value) => ColorTween(begin: value as Color),
     ) as ColorTween?;
     _surfaceTintColor = widget.surfaceTintColor != null
@@ -913,9 +919,11 @@ class _MaterialInteriorState extends AnimatedWidgetBaseState<_MaterialInterior> 
   Widget build(BuildContext context) {
     final ShapeBorder shape = _border!.evaluate(animation)!;
     final double elevation = _elevation!.evaluate(animation);
+    final Color backgroundColor = _backgroundColor!.evaluate(animation)!;
+    final Color tintColor = _surfaceTintColor?.evaluate(animation) ?? backgroundColor;
     final Color color = Theme.of(context).useMaterial3
-      ? ElevationOverlay.applySurfaceTint(widget.color, _surfaceTintColor?.evaluate(animation), elevation)
-      : ElevationOverlay.applyOverlay(context, widget.color, elevation);
+      ? ElevationOverlay.applySurfaceTint(backgroundColor, tintColor, elevation)
+      : ElevationOverlay.applyOverlay(context, backgroundColor, elevation);
     final Color shadowColor = _shadowColor!.evaluate(animation)!;
 
     return PhysicalShape(


### PR DESCRIPTION
This PR adds an animation for the background of the ElevatedButton by adding a ColorTween for the backgroundColor to _MaterialInteriorState class and evaluating it against the animation as well as assigning the result to the PhysicalShape constructor.

Fixes #154255 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
(there was no docs on this code beforehand)
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
(not sure which tests I should add here)
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
(42 existing tests weren't passing)

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
