### PR TITLE
Make ViewAnchor a LookupBoundary

### DIFF
--- a/packages/flutter/lib/src/widgets/lookup_boundary.dart
+++ b/packages/flutter/lib/src/widgets/lookup_boundary.dart
@@ -47,14 +47,15 @@ import 'framework.dart';
 /// tree, which is rather uncommon. Such anomalies are created by
 /// [RenderObjectElement]s that don't attach their [RenderObject] to the closest
 /// ancestor [RenderObjectElement], e.g. because they bootstrap a separate
-/// stand-alone render tree.
-// TODO(goderbauer): Reference the View widget here once available.
-/// This behavior breaks the assumption some widgets have about the structure of
-/// the render tree: These widgets may try to reach out to an ancestor widget,
-/// assuming that their associated [RenderObject]s are also ancestors, which due
-/// to the anomaly may not be the case. At the point where the divergence in the
-/// two trees is introduced, a [LookupBoundary] can be used to hide that ancestor
-/// from the querying widget.
+/// stand-alone render tree. This behavior breaks the assumption some widgets
+/// have about the structure of the render tree: These widgets may try to reach
+/// out to an ancestor widget, assuming that their associated [RenderObject]s
+/// are also ancestors, which due to the anomaly may not be the case. At the
+/// point where the divergence in the two trees is introduced, a
+/// [LookupBoundary] can be used to hide that ancestor from the querying widget.
+/// The [ViewAnchor], for example, wraps its [ViewAnchor.view] child in a
+/// [LookupBoundary] because the [RenderObject] produced by that widget subtree
+/// is not attached to the render tree that the [ViewAnchor] itself belongs to.
 ///
 /// As an example, [Material.of] relies on lookup boundaries to hide the
 /// [Material] widget from certain descendant button widget. Buttons reach out

--- a/packages/flutter/lib/src/widgets/view.dart
+++ b/packages/flutter/lib/src/widgets/view.dart
@@ -597,7 +597,7 @@ class _RawViewElement extends RenderTreeRootElement {
 class _ViewScope extends InheritedWidget {
   const _ViewScope({required this.view, required super.child});
 
-  final FlutterView? view;
+  final FlutterView view;
 
   @override
   bool updateShouldNotify(_ViewScope oldWidget) => view != oldWidget.view;
@@ -713,8 +713,7 @@ class ViewAnchor extends StatelessWidget {
     return _MultiChildComponentWidget(
       views: <Widget>[
         if (view != null)
-          _ViewScope(
-            view: null,
+          LookupBoundary(
             child: view!,
           ),
       ],

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
+import '../widgets/multi_view_testing.dart';
 import '../widgets/test_border.dart' show TestBorder;
 
 class NotifyMaterial extends StatelessWidget {
@@ -1240,6 +1241,43 @@ void main() {
         ),
       );
     });
+  });
+
+  testWidgets('Material is not visible from sub-views', (WidgetTester tester) async {
+    MaterialInkController? outsideView;
+    MaterialInkController? insideView;
+    MaterialInkController? outsideViewAnchor;
+
+    await tester.pumpWidget(
+      Material(
+        child: Builder(
+          builder: (BuildContext context) {
+            outsideViewAnchor = Material.maybeOf(context);
+            return ViewAnchor(
+              view: Builder(
+                builder: (BuildContext context) {
+                  outsideView = Material.maybeOf(context);
+                  return View(
+                    view: FakeView(tester.view),
+                    child: Builder(
+                      builder: (BuildContext context) {
+                        insideView = Material.maybeOf(context);
+                        return const SizedBox();
+                      },
+                    ),
+                  );
+                },
+              ),
+              child: const SizedBox(),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(outsideViewAnchor, isNotNull);
+    expect(outsideView, isNull);
+    expect(insideView, isNull);
   });
 }
 

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
+import 'multi_view_testing.dart';
 import 'semantics_tester.dart';
 
 void main() {
@@ -1757,6 +1759,46 @@ void main() {
       errors.first.toString().replaceAll('\n', ' '),
       contains('Overlay was given infinite constraints and cannot be sized by a suitable child.'),
     );
+  });
+
+  testWidgets('Overlay is not visible from sub-views', (WidgetTester tester) async {
+    OverlayState? outsideView;
+    OverlayState? insideView;
+    OverlayState? outsideViewAnchor;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Overlay.wrap(
+          child: Builder(
+            builder: (BuildContext context) {
+              outsideViewAnchor = Overlay.maybeOf(context);
+              return ViewAnchor(
+                view: Builder(
+                  builder: (BuildContext context) {
+                    outsideView = Overlay.maybeOf(context);
+                    return View(
+                      view: FakeView(tester.view),
+                      child: Builder(
+                        builder: (BuildContext context) {
+                          insideView = Overlay.maybeOf(context);
+                          return const SizedBox();
+                        },
+                      ),
+                    );
+                  },
+                ),
+                child: const SizedBox(),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(outsideViewAnchor, isNotNull);
+    expect(outsideView, isNull);
+    expect(insideView, isNull);
   });
 }
 


### PR DESCRIPTION
So, uhm, 2 years ago in https://github.com/flutter/flutter/pull/116429 we introduced this concept of a lookup boundary to hide certain InheritedWidgets in widget subtrees who belong to a different render tree than the InheritedWidget itself. This is for example needed for the Material widget: Buttons reach out to their Material ancestor to draw ink splashes on its associated render object. This only produces the desired effect if the button render object is a descendant of the Material render object (the two need to be in the same render tree). Overlay widgets have a similar problem. 

Lookup boundaries were specifically designed for multi view support, where a sub view would be powered by a separate and independent render tree. Ergo, widgets in the sub view shouldn't see these InheritedWidgets if they are part of the parent view. After all, it would be strange if clicking on a button in a subview draws the ink splash effect into the parent view. Unfortunately, we (and by that I really mean I) forgot to put a LayoutBoundary into the relevant multi view widgets when those were introduced in https://github.com/flutter/flutter/pull/125003. This PR addresses that by wrapping the `ViewAnchor.view` child in a LookupBoundary so that its subtree (which bootstraps a separate render tree) cannot see these InheritedWidgets in the parent view.