### PR TITLE
handle EAGAIN (macOS) in ErrorHandlingProcessManager

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -777,6 +777,7 @@ void _handlePosixException(Exception e, String? message, int errorCode, String? 
 void _handleMacOSException(Exception e, String? message, int errorCode, String? posixPermissionSuggestion) {
   // https://github.com/apple/darwin-xnu/blob/main/bsd/dev/dtrace/scripts/errno.d
   const int ebadarch = 86;
+  const int eagain = 35;
   if (errorCode == ebadarch) {
     final StringBuffer errorBuffer = StringBuffer();
     if (message != null) {
@@ -786,6 +787,17 @@ void _handleMacOSException(Exception e, String? message, int errorCode, String? 
     errorBuffer.writeln('If you are on an ARM Apple Silicon Mac, Flutter requires the Rosetta translation environment. Try running:');
     errorBuffer.writeln('  sudo softwareupdate --install-rosetta --agree-to-license');
     _throwFileSystemException(errorBuffer.toString());
+  }
+  if (errorCode == eagain) {
+    final StringBuffer errorBuffer = StringBuffer();
+    if (message != null) {
+      errorBuffer.writeln('$message.');
+    }
+    errorBuffer.writeln(
+      'Your system may be running into its process limits. '
+      'Consider quitting unused apps and trying again.',
+    );
+    throwToolExit(errorBuffer.toString());
   }
   _handlePosixException(e, message, errorCode, posixPermissionSuggestion);
 }

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -1108,6 +1108,7 @@ Please ensure that the SDK and/or project is installed in a location that has re
     const int enospc = 28;
     const int eacces = 13;
     const int ebadarch = 86;
+    const int eagain = 35;
 
     testWithoutContext('when writing to a full device', () {
       final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
@@ -1188,6 +1189,24 @@ Please ensure that the SDK and/or project is installed in a location that has re
       expect(() async => processManager.run(<String>['foo', '--bar']),
           throwsToolExit(message: expectedMessage));
       expect(() => processManager.runSync(<String>['foo', '--bar']),
+          throwsToolExit(message: expectedMessage));
+    });
+
+    testWithoutContext('when up against resource limits (EAGAIN)', () async {
+      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['foo', '--bar'], exception: ProcessException('', <String>[], '', eagain)),
+      ]);
+
+      final ProcessManager processManager = ErrorHandlingProcessManager(
+        delegate: fakeProcessManager,
+        platform: macOSPlatform,
+      );
+
+      const String expectedMessage = 'Flutter failed to run "foo --bar".\n'
+          'Your system may be running into its process limits. '
+          'Consider quitting unused apps and trying again.';
+
+      expect(() async => processManager.start(<String>['foo', '--bar']),
           throwsToolExit(message: expectedMessage));
     });
   });


### PR DESCRIPTION
~~Fixes~~ Discovered in https://github.com/flutter/flutter/issues/153776.

To my knowledge, `Resource temporarily unavailable` when trying to run a process means that some required resource is at capacity. There may be too many processes active, not enough available ports, or some sort of blocking cache is full, etc. Feel free to independently research and see if you come to the same conclusion.

Then, it seems safe to catch and handle this within the tool's `ErrorHandlingProcessManager` abstraction, as Flutter cannot realistically do anything to prevent this issue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
