### PR TITLE
Android predictive back should work after returning to the app from a notification

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1368,9 +1368,9 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     switch (_appLifecycleState) {
       case null:
       case AppLifecycleState.detached:
-      case AppLifecycleState.inactive:
         // Avoid updating the engine when the app isn't ready.
         return true;
+      case AppLifecycleState.inactive:
       case AppLifecycleState.resumed:
       case AppLifecycleState.hidden:
       case AppLifecycleState.paused:

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -767,7 +767,9 @@ void main() {
       expect(frameworkHandlesBacks.last, isFalse);
 
       // Set the app state to inactive, where setFrameworkHandlesBack is still
-      // called.
+      // called. This could happen when responding to a tap on a notification
+      // when the app is not active and immediately navigating, for example.
+      // See https://github.com/flutter/flutter/pull/154313.
       await setAppLifeCycleState(AppLifecycleState.inactive);
 
       final int inactiveStartCallsLength = frameworkHandlesBacks.length;
@@ -781,7 +783,6 @@ void main() {
 
       // Set the app state to detached, where setFrameworkHandlesBack shouldn't
       // be called.
-      //await setAppLifeCycleState(AppLifecycleState.paused);
       await setAppLifeCycleState(AppLifecycleState.detached);
 
       final int finalCallsLength = frameworkHandlesBacks.length;

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -766,24 +766,25 @@ void main() {
       await tester.pumpAndSettle();
       expect(frameworkHandlesBacks.last, isFalse);
 
-      // Set the app state to inactive, where setFrameworkHandlesBack shouldn't
-      // be called.
+      // Set the app state to inactive, where setFrameworkHandlesBack is still
+      // called.
       await setAppLifeCycleState(AppLifecycleState.inactive);
 
-      final int finalCallsLength = frameworkHandlesBacks.length;
+      final int inactiveStartCallsLength = frameworkHandlesBacks.length;
       const NavigationNotification(canHandlePop: true).dispatch(currentContext);
       await tester.pumpAndSettle();
-      expect(frameworkHandlesBacks, hasLength(finalCallsLength));
+      expect(frameworkHandlesBacks, hasLength(inactiveStartCallsLength + 1));
 
       const NavigationNotification(canHandlePop: false).dispatch(currentContext);
       await tester.pumpAndSettle();
-      expect(frameworkHandlesBacks, hasLength(finalCallsLength));
+      expect(frameworkHandlesBacks, hasLength(inactiveStartCallsLength + 2));
 
-      // Set the app state to detached, which also shouldn't call
-      // setFrameworkHandlesBack. Must go to paused, then detached.
-      await setAppLifeCycleState(AppLifecycleState.paused);
+      // Set the app state to detached, where setFrameworkHandlesBack shouldn't
+      // be called.
+      //await setAppLifeCycleState(AppLifecycleState.paused);
       await setAppLifeCycleState(AppLifecycleState.detached);
 
+      final int finalCallsLength = frameworkHandlesBacks.length;
       const NavigationNotification(canHandlePop: true).dispatch(currentContext);
       await tester.pumpAndSettle();
       expect(frameworkHandlesBacks, hasLength(finalCallsLength));


### PR DESCRIPTION
When the app is closed, sends a notification, and the user taps on it to return to the app, Flutter needs to update the engine with the navigation state for predictive back. However, at that time the app is in AppLifeCycleState.inactive. I had assumed we wouldn't want to talk to the engine in that state, but I wasn't aware of this notification case.

This PR allows navigation updates to go through in `inactive` state so that predictive back works after returning from a notification.


Google bug b/354579427