### PR TITLE
Increase timeout for customer_testing test step

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -497,12 +497,12 @@ targets:
     recipe: flutter/flutter_drone
     # Timeout in minutes for the whole task.
     timeout: 60
-    # Timeout in seconds for each individual step.
-    test_timeout_secs: "2700" # 45 minutes * 60
     properties:
       shard: customer_testing
       tags: >
         ["framework", "hostonly", "shard", "linux"]
+      # Timeout in seconds for each individual step.
+      test_timeout_secs: "2700" # 45 minutes * 60
 
   - name: Linux docs_publish
     recipe: flutter/docs
@@ -3701,12 +3701,12 @@ targets:
     recipe: flutter/flutter_drone
     # Timeout in minutes for the whole task.
     timeout: 60
-    # Timeout in seconds for each individual step.
-    test_timeout_secs: "2700" # 45 minutes * 60
     properties:
       shard: customer_testing
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      # Timeout in seconds for each individual step.
+      test_timeout_secs: "2700" # 45 minutes * 60
 
   - name: Mac dart_plugin_registry_test
     recipe: devicelab/devicelab_drone
@@ -5371,12 +5371,12 @@ targets:
     recipe: flutter/flutter_drone
     # Timeout in minutes for the whole task.
     timeout: 60
-    # Timeout in seconds for each individual step.
-    test_timeout_secs: "2700" # 45 minutes * 60
     properties:
       shard: customer_testing
       tags: >
         ["framework", "hostonly", "shard", "windows"]
+      # Timeout in seconds for each individual step.
+      test_timeout_secs: "2700" # 45 minutes * 60
 
   - name: Windows framework_tests_libraries
     recipe: flutter/flutter_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -487,7 +487,7 @@ targets:
       - .ci.yaml
 
   - name: Linux customer_testing
-    # TODO(matanlurey): https://github.com/flutter/flutter/issues/154293
+    # TODO(Piinks): https://github.com/flutter/flutter/issues/154251
     bringup: true
     # This really just runs dev/bots/customer_testing/ci.sh,
     # but it does so indirectly via the flutter_drone recipe
@@ -495,7 +495,10 @@ targets:
     enabled_branches:
       - master
     recipe: flutter/flutter_drone
+    # Timeout in minutes for the whole task.
     timeout: 60
+    # Timeout in seconds for each individual step.
+    test_timeout_secs: "2700" # 45 minutes * 60
     properties:
       shard: customer_testing
       tags: >
@@ -3696,7 +3699,10 @@ targets:
     enabled_branches:
       - master
     recipe: flutter/flutter_drone
+    # Timeout in minutes for the whole task.
     timeout: 60
+    # Timeout in seconds for each individual step.
+    test_timeout_secs: "2700" # 45 minutes * 60
     properties:
       shard: customer_testing
       tags: >
@@ -5363,7 +5369,10 @@ targets:
     enabled_branches:
       - master
     recipe: flutter/flutter_drone
+    # Timeout in minutes for the whole task.
     timeout: 60
+    # Timeout in seconds for each individual step.
+    test_timeout_secs: "2700" # 45 minutes * 60
     properties:
       shard: customer_testing
       tags: >


### PR DESCRIPTION
Related: https://github.com/flutter/flutter/issues/154251

Successful runs are bumping right up against the timeout

See https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20customer_testing/84496/overview which succeeded in 29 minutes vs. https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20customer_testing/84497/overview which failed with a timeout at 30 minutes.

