### PR TITLE
catch `StateError` thrown from `Chromium.close`

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -608,20 +608,18 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   }) async {
     if (_chromiumLauncher != null) {
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
-      ChromeTab? chromeTab;
-      try {
-        chromeTab = await getChromeTabGuarded(
-          chrome.chromeConnection,
-          (ChromeTab chromeTab) {
-            return !chromeTab.url.startsWith('chrome-extension');
-          },
-          retryFor: const Duration(seconds: 5),
-        );
-      } on HttpException catch (error, stackTrace) {
-        // We were unable to unable to communicate with Chrome.
-        _logger.printError(error.toString(), stackTrace: stackTrace);
-        chromeTab = null;
-      }
+      ChromeTab? chromeTab;      
+      chromeTab = await getChromeTabGuarded(
+        chrome.chromeConnection,
+        (ChromeTab chromeTab) {
+          return !chromeTab.url.startsWith('chrome-extension');
+        },
+        retryFor: const Duration(seconds: 5),
+        onError: (Object error, StackTrace stackTrace) {
+          // We were unable to unable to communicate with Chrome.
+          _logger.printError(error.toString(), stackTrace: stackTrace);
+        }
+      );
       if (chromeTab == null) {
         appFailedToStart();
         throwToolExit('Failed to connect to Chrome instance.');

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -614,7 +614,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           return !chromeTab.url.startsWith('chrome-extension');
         },
         retryFor: const Duration(seconds: 5),
-        onError: (Object error, StackTrace stackTrace) {
+        onIoError: (Object error, StackTrace stackTrace) {
           // We were unable to unable to communicate with Chrome.
           _logger.printError(error.toString(), stackTrace: stackTrace);
         }

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -608,8 +608,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   }) async {
     if (_chromiumLauncher != null) {
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
-      ChromeTab? chromeTab;      
-      chromeTab = await getChromeTabGuarded(
+      final ChromeTab? chromeTab = await getChromeTabGuarded(
         chrome.chromeConnection,
         (ChromeTab chromeTab) {
           return !chromeTab.url.startsWith('chrome-extension');

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -454,9 +454,6 @@ class FlutterWebPlatform extends PlatformPlugin {
         } on FormatException catch (ex) {
           _logger.printError('Caught FormatException: $ex');
           return shelf.Response.ok('Caught exception: $ex');
-        } on IOException catch (ex) {
-          _logger.printError('Caught IOException: $ex');
-          return shelf.Response.ok('Caught exception: $ex');
         }
       }
       final String? errorMessage = await _testGoldenComparator.compareGoldens(testUri, bytes, goldenKey, updateGoldens);

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -845,7 +845,7 @@ void main() {
         ));
   });
 
-  test('Chromium close sends browser close command', () async {
+  testWithoutContext('Chromium close sends browser close command', () async {
     final BufferLogger logger = BufferLogger.test();
     final List<String> commands = <String>[];
     void onSendCommand(String cmd) { commands.add(cmd); }
@@ -865,7 +865,7 @@ void main() {
     expect(commands, contains('Browser.close'));
   });
 
-  test('Chromium close handles a SocketException when connecting to Chrome', () async {
+  testWithoutContext('Chromium close handles a SocketException when connecting to Chrome', () async {
     final BufferLogger logger = BufferLogger.test();
     final FakeChromeConnectionWithTab chromeConnection = FakeChromeConnectionWithTab();
     final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
@@ -883,7 +883,7 @@ void main() {
     await chrome.close();
   });
 
-  test('Chromium close handles a WebSocketException when closing the WipConnection', () async {
+  testWithoutContext('Chromium close handles a WebSocketException when closing the WipConnection', () async {
     final BufferLogger logger = BufferLogger.test();
     final FakeChromeConnectionWithTab chromeConnection = FakeChromeConnectionWithTab(throwWebSocketException: true);
     final ChromiumLauncher chromiumLauncher = ChromiumLauncher(


### PR DESCRIPTION
Fixes crasher https://github.com/flutter/flutter/issues/154203.

Also does a little refactoring to move exception handling into the `getChromeTabGuarded` utility function.

I plan on cherry-picking a subset of this change. This would be included in the custom CP patch for https://github.com/flutter/flutter/issues/153064.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
