### PR TITLE
Revert "Add verbose logging for customer testing shard"

### DIFF
--- a/dev/customer_testing/run_tests.dart
+++ b/dev/customer_testing/run_tests.dart
@@ -129,9 +129,7 @@ Future<bool> run(List<String> arguments) async {
   return runTests(
     repeat: repeat,
     skipOnFetchFailure: skipOnFetchFailure,
-    // TODO(Piinks): Restore after resolving https://github.com/flutter/flutter/issues/154251
-    // Needed to see time stamps of individual test runs and identify long running test.
-    verbose: true,
+    verbose: verbose,
     numberShards: numberShards,
     shardIndex: shardIndex,
     files: files,


### PR DESCRIPTION
Reverts flutter/flutter#154356

The issue is resolved in https://github.com/flutter/tests/pull/406 so we can remove this verbose logging.
Related to https://github.com/flutter/flutter/issues/154251