### PR TITLE
Revert #154339, remove bringup on linux customer testing

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -533,8 +533,6 @@ targets:
       - .ci.yaml
 
   - name: Linux customer_testing
-    # TODO(Piinks): https://github.com/flutter/flutter/issues/154251
-    bringup: true
     # This really just runs dev/bots/customer_testing/ci.sh,
     # but it does so indirectly via the flutter_drone recipe
     # calling the dev/bots/test.dart script.
@@ -547,8 +545,6 @@ targets:
       shard: customer_testing
       tags: >
         ["framework", "hostonly", "shard", "linux"]
-      # Timeout in seconds for each individual step.
-      test_timeout_secs: "2700" # 45 minutes * 60
 
   - name: Linux docs_publish
     recipe: flutter/docs
@@ -3751,8 +3747,6 @@ targets:
       shard: customer_testing
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-      # Timeout in seconds for each individual step.
-      test_timeout_secs: "2700" # 45 minutes * 60
 
   - name: Mac dart_plugin_registry_test
     recipe: devicelab/devicelab_drone
@@ -5421,8 +5415,6 @@ targets:
       shard: customer_testing
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      # Timeout in seconds for each individual step.
-      test_timeout_secs: "2700" # 45 minutes * 60
 
   - name: Windows framework_tests_libraries
     recipe: flutter/flutter_drone


### PR DESCRIPTION
Reverts increased timeouts on customer testing from #154339, also removes bringup state from https://github.com/flutter/flutter/issues/154293.
This was related to https://github.com/flutter/flutter/issues/154251, which will be fixed by https://github.com/flutter/tests/pull/406 (so we should land that first).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
