### PR TITLE
Fix typing error in AutofillGroup docs

### DIFF
--- a/packages/flutter/lib/src/widgets/autofill.dart
+++ b/packages/flutter/lib/src/widgets/autofill.dart
@@ -31,7 +31,7 @@ enum AutofillContextAction {
 /// An [AutofillScope] widget that groups [AutofillClient]s together.
 ///
 /// [AutofillClient]s that share the same closest [AutofillGroup] ancestor must
-/// be built together, and they be will be autofilled together.
+/// be built together, and they will be autofilled together.
 ///
 /// {@macro flutter.services.AutofillScope}
 ///


### PR DESCRIPTION
Fixes a small typing error in the AutofillGroup docs

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
