### PR TITLE
Improve 'flutter downgrade' error message

### DIFF
--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -110,9 +110,18 @@ class DowngradeCommand extends FlutterCommand {
     final String? lastFlutterVersion = persistentToolState.lastActiveVersion(channel);
     final String? currentFlutterVersion = _flutterVersion?.frameworkRevision;
     if (lastFlutterVersion == null || currentFlutterVersion == lastFlutterVersion) {
-      final String trailing = await _createErrorMessage(workingDirectory, channel);
+      final String trailing = await _createErrorMessage(
+        workingDirectory,
+        channel,
+      );
       throwToolExit(
-        'There is no previously recorded version for channel "$currentChannel".\n'
+        "It looks like you haven't run "
+        '"flutter upgrade" on channel "$currentChannel".\n'
+        '\n'
+        '"flutter downgrade" undoes the last "flutter upgrade".\n'
+        '\n'
+        'To switch to a specific Flutter version, see: '
+        'https://flutter.dev/to/switch-flutter-version'
         '$trailing'
       );
     }
@@ -181,7 +190,10 @@ class DowngradeCommand extends FlutterCommand {
   }
 
   // Formats an error message that lists the currently stored versions.
-  Future<String> _createErrorMessage(String workingDirectory, Channel currentChannel) async {
+  Future<String> _createErrorMessage(
+    String workingDirectory,
+    Channel currentChannel,
+  ) async {
     final StringBuffer buffer = StringBuffer();
     for (final Channel channel in Channel.values) {
       if (channel == currentChannel) {
@@ -191,11 +203,19 @@ class DowngradeCommand extends FlutterCommand {
       if (sha == null) {
         continue;
       }
-      final RunResult parseResult = await _processUtils!.run(<String>[
-        'git', 'describe', '--tags', sha,
-      ], workingDirectory: workingDirectory);
+      final RunResult parseResult = await _processUtils!.run(
+        <String>['git', 'describe', '--tags', sha],
+        workingDirectory: workingDirectory,
+      );
       if (parseResult.exitCode == 0) {
-        buffer.writeln('Channel "${getNameForChannel(channel)}" was previously on: ${parseResult.stdout}.');
+        if (buffer.isEmpty) {
+          buffer.writeln();
+        }
+        buffer.writeln();
+        buffer.writeln(
+          'Channel "${getNameForChannel(channel)}" was previously on: '
+          '${parseResult.stdout}.'
+        );
       }
     }
     return buffer.toString();

--- a/packages/flutter_tools/test/commands.shard/hermetic/downgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/downgrade_test.dart
@@ -77,10 +77,16 @@ void main() {
       logger: bufferLogger,
     );
 
-    expect(createTestCommandRunner(command).run(const <String>['downgrade']),
-      throwsToolExit(message:
-        'There is no previously recorded version for channel "beta".\n'
-        'Channel "master" was previously on: v1.2.3.'
+    expect(
+      createTestCommandRunner(command).run(const <String>['downgrade']),
+      throwsToolExit(message: '''
+It looks like you haven't run "flutter upgrade" on channel "beta".
+
+"flutter downgrade" undoes the last "flutter upgrade".
+
+To switch to a specific Flutter version, see: https://flutter.dev/to/switch-flutter-version
+
+Channel "master" was previously on: v1.2.3.''',
       ),
     );
   });


### PR DESCRIPTION
`flutter downgrade` fails if you haven't used `flutter upgrade`:

```
$ flutter downgrade
There is no previously recorded version for channel "stable".
```

It's not clear what actions a user should take from this error message. Here's the new error message:

```
$ flutter downgrade
It looks like you haven't run "flutter upgrade" on channel "stable".

"flutter downgrade" undoes the last "flutter upgrade".

To switch to a specific Flutter version, see: https://flutter.dev/to/switch-flutter-version
```

Depends on https://github.com/flutter/website/pull/11098

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
