### PR TITLE
Replace `ListTile` usage with `CupertinoListTile`

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -80,13 +80,13 @@ const CupertinoDynamicColor _kOffLabelColor = CupertinoDynamicColor.withBrightne
 ///
 /// {@tool snippet}
 ///
-/// This sample shows how to use a [CupertinoSwitch] in a [ListTile]. The
-/// [MergeSemantics] is used to turn the entire [ListTile] into a single item
+/// This sample shows how to use a [CupertinoSwitch] in a [CupertinoListTile]. The
+/// [MergeSemantics] is used to turn the entire [CupertinoListTile] into a single item
 /// for accessibility tools.
 ///
 /// ```dart
 /// MergeSemantics(
-///   child: ListTile(
+///   child: CupertinoListTile(
 ///     title: const Text('Lights'),
 ///     trailing: CupertinoSwitch(
 ///       value: _lights,

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -1366,7 +1366,7 @@ void main() {
             }
             return Material(
               child: MergeSemantics(
-                child: CupertinoListTile(
+                child: ListTile(
                   title: const Text('test'),
                   onTap: () {
                     onChanged(!value);

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -1366,7 +1366,7 @@ void main() {
             }
             return Material(
               child: MergeSemantics(
-                child: ListTile(
+                child: CupertinoListTile(
                   title: const Text('test'),
                   onTap: () {
                     onChanged(!value);


### PR DESCRIPTION
This PR replaces the `ListTile` usage in the cupertino switch example with `CupertinoListTile`.

Fixes #154450

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
