### PR TITLE
[tool][android] Allow --target-platform work properly with --debug mode

### DIFF
--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -228,7 +228,6 @@ Future<void> main() async {
 
       checkFileContains(<String>[
         'flutter_embedding_debug',
-        'x86_debug',
         'x86_64_debug',
         'armeabi_v7a_debug',
         'arm64_v8a_debug',

--- a/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
@@ -34,9 +34,6 @@ Future<void> main() async {
           ...debugAssets,
           ...baseApkFiles,
           'lib/armeabi-v7a/libflutter.so',
-          // Debug mode intentionally includes `x86` and `x86_64`.
-          'lib/x86/libflutter.so',
-          'lib/x86_64/libflutter.so',
         ], apkFiles);
 
         checkCollectionDoesNotContain<String>(<String>[
@@ -65,9 +62,7 @@ Future<void> main() async {
           ...flutterAssets,
           ...debugAssets,
           ...baseApkFiles,
-          // Debug mode intentionally includes `x86` and `x86_64`.
           'lib/x86/libflutter.so',
-          'lib/x86_64/libflutter.so',
         ], apkFiles);
 
         checkCollectionDoesNotContain<String>(<String>[
@@ -96,8 +91,6 @@ Future<void> main() async {
           ...flutterAssets,
           ...debugAssets,
           ...baseApkFiles,
-          // Debug mode intentionally includes `x86` and `x86_64`.
-          'lib/x86/libflutter.so',
           'lib/x86_64/libflutter.so',
         ], apkFiles);
 

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -637,11 +637,6 @@ class FlutterPlugin implements Plugin<Project> {
                     "io.flutter:flutter_embedding_$flutterBuildMode:$engineVersion")
         }
         List<String> platforms = getTargetPlatforms().collect()
-        // Debug mode includes x86 and x64, which are commonly used in emulators.
-        if (flutterBuildMode == "debug" && !useLocalEngine()) {
-            platforms.add("android-x86")
-            platforms.add("android-x64")
-        }
         platforms.each { platform ->
             String arch = PLATFORM_ARCH_MAP[platform].replace("-", "_")
             // Add the `libflutter.so` dependency.

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -48,14 +48,44 @@ class BuildApkCommand extends BuildSubCommand {
           help: 'Generate build files used by flutter but '
                 'do not build any artifacts.')
       ..addMultiOption('target-platform',
-        defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],
         allowed: <String>['android-arm', 'android-arm64', 'android-x86', 'android-x64'],
         // https://github.com/flutter/flutter/issues/153359 tracks debug build type support.
         help:
-            'The target platform for which the app is compiled. Supports release but not debug build types.',
+            'The target platform for which the app is compiled.',
       );
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
   }
+
+  BuildMode get buildMode {
+    if (boolArg('release')) {
+      return BuildMode.release;
+    } else if (boolArg('profile')) {
+      return BuildMode.profile;
+    } else if (boolArg('debug')) {
+      return BuildMode.debug;
+    } else if (boolArg('jit-release')) {
+      return BuildMode.jitRelease;
+    }
+    // The build defaults to release.
+    return BuildMode.release;
+  }
+  static const List<String> _kDefaultJitArchs = <String>[
+    'android-arm',
+    'android-arm64',
+    'android-x86',
+    'android-x64',
+  ];
+  static const List<String> _kDefaultAotArchs = <String>[
+    'android-arm',
+    'android-arm64',
+    'android-x64',
+  ];
+  List<String> get targetArchs => stringsArg('target-platform').isEmpty
+    ? switch (buildMode) {
+      BuildMode.release || BuildMode.profile => _kDefaultAotArchs,
+      BuildMode.debug || BuildMode.jitRelease => _kDefaultJitArchs,
+    }
+    : stringsArg('target-platform');
 
   @override
   final String name = 'apk';
@@ -81,46 +111,20 @@ class BuildApkCommand extends BuildSubCommand {
 
   @override
   Future<CustomDimensions> get usageValues async {
-    String buildMode;
-
-    if (boolArg('release')) {
-      buildMode = 'release';
-    } else if (boolArg('debug')) {
-      buildMode = 'debug';
-    } else if (boolArg('profile')) {
-      buildMode = 'profile';
-    } else {
-      // The build defaults to release.
-      buildMode = 'release';
-    }
-
     return CustomDimensions(
-      commandBuildApkTargetPlatform: stringsArg('target-platform').join(','),
-      commandBuildApkBuildMode: buildMode,
+      commandBuildApkTargetPlatform: targetArchs.join(','),
+      commandBuildApkBuildMode: buildMode.cliName,
       commandBuildApkSplitPerAbi: boolArg('split-per-abi'),
     );
   }
 
   @override
   Future<Event> unifiedAnalyticsUsageValues(String commandPath) async {
-    final String buildMode;
-
-    if (boolArg('release')) {
-      buildMode = 'release';
-    } else if (boolArg('debug')) {
-      buildMode = 'debug';
-    } else if (boolArg('profile')) {
-      buildMode = 'profile';
-    } else {
-      // The build defaults to release.
-      buildMode = 'release';
-    }
-
     return Event.commandUsageValues(
       workflow: commandPath,
       commandHasTerminal: hasTerminal,
-      buildApkTargetPlatform: stringsArg('target-platform').join(','),
-      buildApkBuildMode: buildMode,
+      buildApkTargetPlatform: targetArchs.join(','),
+      buildApkBuildMode: buildMode.cliName,
       buildApkSplitPerAbi: boolArg('split-per-abi'),
     );
   }
@@ -131,10 +135,11 @@ class BuildApkCommand extends BuildSubCommand {
       exitWithNoSdkMessage();
     }
     final BuildInfo buildInfo = await getBuildInfo();
+
     final AndroidBuildInfo androidBuildInfo = AndroidBuildInfo(
       buildInfo,
       splitPerAbi: boolArg('split-per-abi'),
-      targetArchs: stringsArg('target-platform').map<AndroidArch>(getAndroidArchForName),
+      targetArchs: targetArchs.map<AndroidArch>(getAndroidArchForName),
     );
     validateBuild(androidBuildInfo);
     displayNullSafetyMode(androidBuildInfo.buildInfo);

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -49,14 +49,13 @@ class BuildApkCommand extends BuildSubCommand {
                 'do not build any artifacts.')
       ..addMultiOption('target-platform',
         allowed: <String>['android-arm', 'android-arm64', 'android-x86', 'android-x64'],
-        // https://github.com/flutter/flutter/issues/153359 tracks debug build type support.
         help:
             'The target platform for which the app is compiled.',
       );
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
   }
 
-  BuildMode get buildMode {
+  BuildMode get _buildMode {
     if (boolArg('release')) {
       return BuildMode.release;
     } else if (boolArg('profile')) {
@@ -66,7 +65,6 @@ class BuildApkCommand extends BuildSubCommand {
     } else if (boolArg('jit-release')) {
       return BuildMode.jitRelease;
     }
-    // The build defaults to release.
     return BuildMode.release;
   }
   static const List<String> _kDefaultJitArchs = <String>[
@@ -80,8 +78,8 @@ class BuildApkCommand extends BuildSubCommand {
     'android-arm64',
     'android-x64',
   ];
-  List<String> get targetArchs => stringsArg('target-platform').isEmpty
-    ? switch (buildMode) {
+  List<String> get _targetArchs => stringsArg('target-platform').isEmpty
+    ? switch (_buildMode) {
       BuildMode.release || BuildMode.profile => _kDefaultAotArchs,
       BuildMode.debug || BuildMode.jitRelease => _kDefaultJitArchs,
     }
@@ -112,8 +110,8 @@ class BuildApkCommand extends BuildSubCommand {
   @override
   Future<CustomDimensions> get usageValues async {
     return CustomDimensions(
-      commandBuildApkTargetPlatform: targetArchs.join(','),
-      commandBuildApkBuildMode: buildMode.cliName,
+      commandBuildApkTargetPlatform: _targetArchs.join(','),
+      commandBuildApkBuildMode: _buildMode.cliName,
       commandBuildApkSplitPerAbi: boolArg('split-per-abi'),
     );
   }
@@ -123,8 +121,8 @@ class BuildApkCommand extends BuildSubCommand {
     return Event.commandUsageValues(
       workflow: commandPath,
       commandHasTerminal: hasTerminal,
-      buildApkTargetPlatform: targetArchs.join(','),
-      buildApkBuildMode: buildMode.cliName,
+      buildApkTargetPlatform: _targetArchs.join(','),
+      buildApkBuildMode: _buildMode.cliName,
       buildApkSplitPerAbi: boolArg('split-per-abi'),
     );
   }
@@ -139,7 +137,7 @@ class BuildApkCommand extends BuildSubCommand {
     final AndroidBuildInfo androidBuildInfo = AndroidBuildInfo(
       buildInfo,
       splitPerAbi: boolArg('split-per-abi'),
-      targetArchs: targetArchs.map<AndroidArch>(getAndroidArchForName),
+      targetArchs: _targetArchs.map<AndroidArch>(getAndroidArchForName),
     );
     validateBuild(androidBuildInfo);
     displayNullSafetyMode(androidBuildInfo.buildInfo);

--- a/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
@@ -48,8 +48,9 @@ void main() {
     testUsingContext('indicate the default target platforms', () async {
       final String projectPath = await createProject(tempDir,
           arguments: <String>['--no-pub', '--template=app']);
-      await runBuildApkCommand(projectPath);
 
+      // Without buildMode flag.
+      await runBuildApkCommand(projectPath);
       expect(
         fakeAnalytics.sentEvents,
         contains(
@@ -58,6 +59,157 @@ void main() {
             commandHasTerminal: false,
             buildApkTargetPlatform: 'android-arm,android-arm64,android-x64',
             buildApkBuildMode: 'release',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+      await runBuildApkCommand(projectPath, arguments: <String>['--debug']);
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm,android-arm64,android-x86,android-x64',
+            buildApkBuildMode: 'debug',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+      await runBuildApkCommand(projectPath, arguments: <String>['--jit-release']);
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm,android-arm64,android-x86,android-x64',
+            buildApkBuildMode: 'jit_release',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+      await runBuildApkCommand(projectPath, arguments: <String>['--profile']);
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm,android-arm64,android-x64',
+            buildApkBuildMode: 'profile',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+      await runBuildApkCommand(projectPath, arguments: <String>['--release']);
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm,android-arm64,android-x64',
+            buildApkBuildMode: 'release',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+    }, overrides: <Type, Generator>{
+      AndroidBuilder: () => FakeAndroidBuilder(),
+      Analytics: () => fakeAnalytics,
+    });
+
+    testUsingContext('Each build mode respects --target-platform', () async {
+      final String projectPath = await createProject(tempDir,
+          arguments: <String>['--no-pub', '--template=app']);
+
+      // Without buildMode flag.
+      await runBuildApkCommand(
+        projectPath,
+        arguments: <String>['--target-platform=android-arm'],
+      );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm',
+            buildApkBuildMode: 'release',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+      await runBuildApkCommand(
+        projectPath,
+        arguments: <String>['--debug', '--target-platform=android-arm'],
+      );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm',
+            buildApkBuildMode: 'debug',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+      await runBuildApkCommand(
+        projectPath,
+        arguments: <String>['--release', '--target-platform=android-arm'],
+      );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm',
+            buildApkBuildMode: 'release',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+      await runBuildApkCommand(
+        projectPath,
+        arguments: <String>['--profile', '--target-platform=android-arm'],
+      );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm',
+            buildApkBuildMode: 'profile',
+            buildApkSplitPerAbi: false,
+          ),
+        ),
+      );
+
+      await runBuildApkCommand(
+        projectPath,
+        arguments: <String>['--jit-release', '--target-platform=android-arm'],
+      );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.commandUsageValues(
+            workflow: 'apk',
+            commandHasTerminal: false,
+            buildApkTargetPlatform: 'android-arm',
+            buildApkBuildMode: 'jit_release',
             buildApkSplitPerAbi: false,
           ),
         ),


### PR DESCRIPTION

This PR addresses an issue where the `--target-platform` flag was not being respected when building APKs in debug mode. Previously, debug builds would always include `x86` and `x64` architectures, regardless of the specified target platform. This change ensures that the `--target-platform` flag is honored across all build modes, including debug.

To achieve this, `BuildApkCommand` has been slightly changed to become responsible for list of archs that should be built in the current run,rather than just parsing arguments. Previously, this responsibility was distributed to gradle, which could be frustrating (in my opinion)

Fixes #153359 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
