### PR TITLE
fix(Linux): specify application id

### DIFF
--- a/packages/flutter_tools/templates/app_shared/linux.tmpl/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app_shared/linux.tmpl/my_application.cc.tmpl
@@ -117,6 +117,12 @@ static void my_application_class_init(MyApplicationClass* klass) {
 static void my_application_init(MyApplication* self) {}
 
 MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
                                      "flags", G_APPLICATION_NON_UNIQUE,


### PR DESCRIPTION
This change sets the program name to the application ID, which helps various
systems like GTK and desktop environments map this running application to its
corresponding .desktop file. This ensures better integration by allowing the
application to be recognized beyond its binary name.

Notably, this is necessary on Wayland to map the running application window to
the desktop file, and therefore apply the correct icon.

I've tested that this works in both GNOME & KDE Wayland sessions.

Partially addresses https://github.com/flutter/flutter/issues/53229

Resolves https://github.com/flutter/flutter/issues/154521

## Icon Association

### Task switcher

The task switcher shows the application's icon in the bottom-middle. Before it only showed a generic Wayland icon.

| Before 	| After 	|
|--------	|-------	|
| ![before1](https://github.com/user-attachments/assets/6f9392f3-c6ff-4ea4-b71b-7186949e2afd) |![after1](https://github.com/user-attachments/assets/e70d394a-a880-42c9-8409-6b975fb59ce1) |

### Window Decorations

KDE shows the application's icon on the window decorations, at the top-left.  Before it only showed a generic Wayland icon.

| Before 	| After 	|
|--------	|-------	|
| ![before2](https://github.com/user-attachments/assets/8076ccf8-79c7-4a60-b12b-2fe1ccf9c393) | ![after2](https://github.com/user-attachments/assets/7a96def2-030c-45c4-9c3f-403256b5da07) |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
