### PR TITLE
Fix duplicate MaterialApp in api example test

### DIFF
--- a/examples/api/test/material/material_state/material_state_border_side.0_test.dart
+++ b/examples/api/test/material/material_state/material_state_border_side.0_test.dart
@@ -25,11 +25,7 @@ void main() {
     'FilterChip displays the correct border when selected',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: example.MaterialStateBorderSideExampleApp(),
-          ),
-        ),
+        const example.MaterialStateBorderSideExampleApp(),
       );
 
       expect(findBorderColor(Colors.red), findsOne);
@@ -40,11 +36,7 @@ void main() {
     'FilterChip displays the correct border when not selected',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: example.MaterialStateBorderSideExampleApp(),
-          ),
-        ),
+        const example.MaterialStateBorderSideExampleApp(),
       );
 
       await tester.tap(find.byType(FilterChip));

--- a/examples/api/test/widgets/value_listenable_builder/value_listenable_builder.0_test.dart
+++ b/examples/api/test/widgets/value_listenable_builder/value_listenable_builder.0_test.dart
@@ -9,9 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Tapping FAB increments counter', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: example.ValueListenableBuilderExample(),
-      ),
+      const example.ValueListenableBuilderExampleApp(),
     );
 
     String getCount() {


### PR DESCRIPTION
This PR fixes two tests that created a nested `MaterialApp` (and it simplifies another test).