### PR TITLE
mark build_tests shard as non-flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -420,7 +420,6 @@ targets:
     timeout: 60
 
   - name: Linux build_tests_1_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -440,7 +439,6 @@ targets:
         ["framework", "hostonly", "shard", "linux"]
 
   - name: Linux build_tests_2_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -460,7 +458,6 @@ targets:
         ["framework", "hostonly", "shard", "linux"]
 
   - name: Linux build_tests_3_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -480,7 +477,6 @@ targets:
         ["framework", "hostonly", "shard", "linux"]
 
   - name: Linux build_tests_4_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -500,7 +496,6 @@ targets:
         ["framework", "hostonly", "shard", "linux"]
 
   - name: Linux build_tests_5_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Following up on https://github.com/flutter/flutter/pull/154444. The resharding is done, and the new shards seem to be running fine. I don't think we need `bringup` anymore.
