### PR TITLE
[web] fix --ab option for web benchmarks

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -99,8 +99,8 @@ Future<void> main(List<String> rawArgs) async {
       stderr.writeln(argParser.usage);
       exit(1);
     }
-    if (localEngineHost == null) {
-      stderr.writeln('When running in A/B test mode --local-engine-host is required.\n');
+    if (localWebSdk == null && localEngineHost == null) {
+      stderr.writeln('When running in A/B test mode for mobile --local-engine-host is required.\n');
       stderr.writeln(argParser.usage);
       exit(1);
     }
@@ -137,7 +137,7 @@ Future<void> _runABTest({
   required int runsPerTest,
   required bool silent,
   required String? localEngine,
-  required String localEngineHost,
+  required String? localEngineHost,
   required String? localWebSdk,
   required String? localEngineSrcPath,
   required String? deviceId,

--- a/dev/devicelab/lib/framework/ab.dart
+++ b/dev/devicelab/lib/framework/ab.dart
@@ -32,7 +32,7 @@ class ABTest {
 
   ABTest.fromJsonMap(Map<String, dynamic> jsonResults)
       : localEngine = jsonResults[kLocalEngineKeyName] as String,
-        localEngineHost = jsonResults[kLocalEngineHostKeyName] as String,
+        localEngineHost = jsonResults[kLocalEngineHostKeyName] as String?,
         taskName = jsonResults[kTaskNameKeyName] as String,
         runStart = DateTime.parse(jsonResults[kRunStartKeyName] as String),
         _runEnd = DateTime.parse(jsonResults[kRunEndKeyName] as String),
@@ -40,7 +40,7 @@ class ABTest {
         _bResults = _convertFrom(jsonResults[kBResultsKeyName] as Map<String, dynamic>);
 
   final String localEngine;
-  final String localEngineHost;
+  final String? localEngineHost;
   final String taskName;
   final DateTime runStart;
   DateTime? _runEnd;
@@ -89,7 +89,8 @@ class ABTest {
     kBenchmarkTypeKeyName:     kBenchmarkResultsType,
     kBenchmarkVersionKeyName:  kBenchmarkABVersion,
     kLocalEngineKeyName:       localEngine,
-    kLocalEngineHostKeyName:   localEngineHost,
+    if (localEngineHost != null)
+      kLocalEngineHostKeyName:   localEngineHost,
     kTaskNameKeyName:          taskName,
     kRunStartKeyName:          runStart.toIso8601String(),
     kRunEndKeyName:            runEnd!.toIso8601String(),

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -34,6 +34,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
     await flutter('clean');
     await evalFlutter('build', options: <String>[
       'web',
+      '--no-tree-shake-icons', // local engine builds are frequently out of sync with the Dart Kernel version
       if (benchmarkOptions.useWasm) ...<String>[
         '-O4',
         '--wasm',


### PR DESCRIPTION
Fix the `--ab` option in the benchmark harness:

- Make `--local-engine-host` optional. The web engine doesn't need it, so it doesn't build it. But the tool crashes by failing to find it.
- Disable icon tree shaking because `--ab` runs against local engine build, whose Dart kernel version is out of sync with the framework, which crashes the const finder.
