### PR TITLE
iOS,macOS: Add list of expected-unsigned binaries

### DIFF
--- a/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
+++ b/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
@@ -87,7 +87,6 @@ List<String> binariesWithoutEntitlements(String flutterRoot) {
   return <String>[
     'artifacts/engine/darwin-x64-profile/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
     'artifacts/engine/darwin-x64-release/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
-    'artifacts/engine/darwin-x64-release/FlutterMacOS.xcframework/macos-arm64_x86_64/dSYMs/FlutterMacOS.framework.dSYM/Contents/Resources/DWARF/FlutterMacOS',
     'artifacts/engine/darwin-x64/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
     'artifacts/engine/darwin-x64/font-subset',
     'artifacts/engine/darwin-x64/impellerc',
@@ -98,10 +97,8 @@ List<String> binariesWithoutEntitlements(String flutterRoot) {
     'artifacts/engine/ios-profile/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
     'artifacts/engine/ios-profile/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
     'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-    'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
     'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
     'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-    'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
     'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
     'artifacts/engine/ios/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
     'artifacts/engine/ios/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
@@ -111,6 +108,21 @@ List<String> binariesWithoutEntitlements(String flutterRoot) {
   ]
   .map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
 }
+
+/// Binaries that are not expected to be codesigned.
+///
+/// This list should be kept in sync with the actual contents of Flutter's cache.
+List<String> unsignedBinaries(String flutterRoot) {
+  return <String>[
+    'artifacts/engine/darwin-x64-release/FlutterMacOS.xcframework/macos-arm64_x86_64/dSYMs/FlutterMacOS.framework.dSYM/Contents/Resources/DWARF/FlutterMacOS',
+    'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+    'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+    'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+    'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+  ]
+  .map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
+}
+
 
 /// xcframeworks that are expected to be codesigned.
 ///
@@ -136,8 +148,8 @@ List<String> signedXcframeworks(String flutterRoot) {
 /// This function ignores code signatures and entitlements, and is intended to
 /// be run on every commit. It should throw if either new binaries are added
 /// to the cache or expected binaries removed. In either case, this class'
-/// [binariesWithEntitlements] or [binariesWithoutEntitlements] lists should
-/// be updated accordingly.
+/// [binariesWithEntitlements], [binariesWithoutEntitlements], and
+/// [unsignedBinaries] lists should be updated accordingly.
 Future<void> verifyExist(
   String flutterRoot,
   {@visibleForTesting ProcessManager processManager = const LocalProcessManager()
@@ -146,16 +158,18 @@ Future<void> verifyExist(
     path.join(flutterRoot, 'bin', 'cache'),
     processManager: processManager,
   );
-  final List<String> allExpectedFiles = binariesWithEntitlements(flutterRoot) + binariesWithoutEntitlements(flutterRoot);
+  final List<String> expectedSigned = binariesWithEntitlements(flutterRoot) + binariesWithoutEntitlements(flutterRoot);
+  final List<String> expectedUnsigned = unsignedBinaries(flutterRoot);
   final Set<String> foundFiles = <String>{
     for (final String binaryPath in binaryPaths)
-      if (allExpectedFiles.contains(binaryPath)) binaryPath
+      if (expectedSigned.contains(binaryPath)) binaryPath
+      else if (expectedUnsigned.contains(binaryPath)) binaryPath
       else throw Exception('Found unexpected binary in cache: $binaryPath'),
   };
 
-  if (foundFiles.length < allExpectedFiles.length) {
+  if (foundFiles.length < expectedSigned.length) {
     final List<String> unfoundFiles = <String>[
-      for (final String file in allExpectedFiles) if (!foundFiles.contains(file)) file,
+      for (final String file in expectedSigned) if (!foundFiles.contains(file)) file,
     ];
     print(
       'Expected binaries not found in cache:\n\n${unfoundFiles.join('\n')}\n\n'
@@ -195,6 +209,11 @@ Future<void> verifySignatures(
     if (signedXcframeworks(flutterRoot).contains(pathToCheck)) {
       verifySignature = true;
     }
+    if (unsignedBinaries(flutterRoot).contains(pathToCheck)) {
+      // Binary is expected to be unsigned. No need to check signature, entitlements.
+      continue;
+    }
+
     if (!verifySignature && !verifyEntitlements) {
       unexpectedFiles.add(pathToCheck);
       print('Unexpected binary or xcframework $pathToCheck found in cache!');


### PR DESCRIPTION
This updates the codesigning test to account for iOS and macOS binaries in the artifact cache that are _expected_ to not be codesigned.

In https://github.com/flutter/engine/pull/54414 we started bundling dSYM (debugging symbols) within Flutter.xcframework, a requirement for App Store verification using Xcode 16.

We did the same for macOS in https://github.com/flutter/engine/pull/54696.

Unlike the framework dylib, dSYM contents are not directly codesigned (though the xcframework containing them is).

Issue: https://github.com/flutter/flutter/issues/154571

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
