### PR TITLE
BottomNavigationBar background color

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -845,7 +845,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
       );
     });
     _controllers[widget.currentIndex].value = 1.0;
-    _backgroundColor = widget.items[widget.currentIndex].backgroundColor;
+    _backgroundColor = widget.backgroundColor;
   }
 
   // Computes the default value for the [type] parameter.


### PR DESCRIPTION
The background parameter in BottomNavigationBar widget don't work. But if we pass backgroundColor to BottomNavigationBarItem widget it start working. This is because the BottomNavigationBar is internally taking the background color of a selected BottomNavigationBarItem.