### PR TITLE
Fix DropdownMenu menu does not follow the text field

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -804,6 +804,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       controller: _controller,
       menuChildren: menu,
       crossAxisUnconstrained: false,
+      layerLink: LayerLink(),
       builder: (BuildContext context, MenuController controller, Widget? child) {
         assert(_initialMenu != null);
         final Widget trailingButton = Padding(

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -395,7 +395,7 @@ class _MenuAnchorState extends State<MenuAnchor> {
 
   @override
   Widget build(BuildContext context) {
-    Widget contents =_buildContents(context);
+    Widget contents = _buildContents(context);
     if (widget.layerLink != null) {
       contents = CompositedTransformTarget(
         link: widget.layerLink!,

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2791,6 +2791,47 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.offset, 0.0);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/149037.
+  testWidgets('Dropdown menu follows the text field when keyboard opens', (WidgetTester tester) async {
+    Widget boilerplate(double bottomInsets) {
+      return MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(viewInsets: EdgeInsets.only(bottom: bottomInsets)),
+          child: Scaffold(
+            body: Center(
+              child: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Build once without bottom insets and open the menu.
+    await tester.pumpWidget(boilerplate(0.0));
+    await tester.tap(find.byType(TextField).first);
+    await tester.pump();
+
+    Finder findMenuPanels() {
+      return find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_MenuPanel');
+    }
+
+    // Menu vertical position is just under the text field.
+    expect(
+      tester.getRect(findMenuPanels()).top,
+      tester.getRect(find.byType(TextField).first).bottom,
+    );
+
+    // Simulate the keyboard opening resizing the view.
+    await tester.pumpWidget(boilerplate(100.0));
+    await tester.pump();
+
+    // Menu vertical position is just under the text field.
+    expect(
+      tester.getRect(findMenuPanels()).top,
+      tester.getRect(find.byType(TextField).first).bottom,
+    );
+  });
 }
 
 enum TestMenu {

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3800,6 +3800,59 @@ void main() {
         ]),
       );
     });
+
+    testWidgets('Menu follows content position when a LayerLink is provided', (WidgetTester tester) async {
+      final MenuController controller = MenuController();
+      final UniqueKey contentKey = UniqueKey();
+
+      Widget boilerplate(double bottomInsets) {
+        return MaterialApp(
+          home: MediaQuery(
+            data: MediaQueryData(
+              viewInsets: EdgeInsets.only(bottom: bottomInsets),
+            ),
+            child: Scaffold(
+              body: Center(
+                child: MenuAnchor(
+                  controller: controller,
+                  layerLink: LayerLink(),
+                  menuChildren: <Widget>[
+                    MenuItemButton(
+                      onPressed: () {},
+                      child: const Text('Button 1'),
+                    ),
+                  ],
+                  builder: (BuildContext context, MenuController controller, Widget? child) {
+                    return SizedBox(key: contentKey, width: 100, height: 100);
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      // Build once without bottom insets and open the menu.
+      await tester.pumpWidget(boilerplate(0.0));
+      controller.open();
+      await tester.pump();
+
+      // Menu vertical position is just under the content.
+      expect(
+        tester.getRect(findMenuPanels()).top,
+        tester.getRect(find.byKey(contentKey)).bottom,
+      );
+
+      // Simulate the keyboard opening resizing the view.
+      await tester.pumpWidget(boilerplate(100.0));
+      await tester.pump();
+
+      // Menu vertical position is just under the content.
+      expect(
+        tester.getRect(findMenuPanels()).top,
+        tester.getRect(find.byKey(contentKey)).bottom,
+      );
+    });
   });
 
   group('LocalizedShortcutLabeler', () {


### PR DESCRIPTION
## Description

This PR fixes the `DropdownMenu` menu position when the keyboard appear on mobile device.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/149037.
Fixes https://github.com/flutter/flutter/issues/123395.
Fixes https://github.com/flutter/flutter/issues/151856.

## Tests

Adds 2 tests.
