### PR TITLE
iOS,macOS: Do not copy unsigned_binaries.txt to build outputs

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -87,7 +87,12 @@ abstract class UnpackMacOS extends Target {
     await _thinFramework(environment, frameworkBinaryPath);
   }
 
-  static const List<String> _copyDenylist = <String>['entitlements.txt', 'without_entitlements.txt'];
+  /// Files that should not be copied to build output directory if found during framework copy step.
+  static const List<String> _copyDenylist = <String>[
+    'entitlements.txt',
+    'without_entitlements.txt',
+    'unsigned_binaries.txt',
+  ];
 
   void _removeDenylistedFiles(Directory directory) {
     for (final FileSystemEntity entity in directory.listSync(recursive: true)) {

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1034,7 +1034,11 @@ class ArtifactUpdater {
   final List<File> downloadedFiles = <File>[];
 
   /// These filenames, should they exist after extracting an archive, should be deleted.
-  static const Set<String> _denylistedBasenames = <String>{'entitlements.txt', 'without_entitlements.txt'};
+  static const Set<String> _denylistedBasenames = <String>{
+    'entitlements.txt',
+    'without_entitlements.txt',
+    'unsigned_binaries.txt',
+  };
   void _removeDenylistedFiles(Directory directory) {
     for (final FileSystemEntity entity in directory.listSync(recursive: true)) {
       if (entity is! File) {

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -83,6 +83,7 @@ void main() {
     File? desiredArtifact;
     File? entitlementsFile;
     File? nestedWithoutEntitlementsFile;
+    File? unsignedBinariesFile;
     operatingSystemUtils.unzipCallbacks[localZipPath] = (Directory outputDirectory) {
       desiredArtifact = outputDirectory.childFile('artifact.bin')..createSync();
       entitlementsFile = outputDirectory.childFile('entitlements.txt')..createSync();
@@ -90,6 +91,7 @@ void main() {
           .childDirectory('dir')
           .childFile('without_entitlements.txt')
           ..createSync(recursive: true);
+      unsignedBinariesFile = outputDirectory.childFile('unsigned_binaries.txt')..createSync();
     };
     final ArtifactUpdater artifactUpdater = ArtifactUpdater(
       fileSystem: fileSystem,
@@ -114,6 +116,7 @@ void main() {
     expect(desiredArtifact, exists);
     expect(entitlementsFile, isNot(exists));
     expect(nestedWithoutEntitlementsFile, isNot(exists));
+    expect(unsignedBinariesFile, isNot(exists));
     expect(staleEntitlementsFile, isNot(exists));
   });
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -173,10 +173,11 @@ void main() {
     ProcessManager: () => processManager,
   });
 
-  testUsingContext('deletes entitlements.txt and without_entitlements.txt files after copying', () async {
+  testUsingContext('deletes entitlements.txt, without_entitlements.txt, unsigned_binaries.txt files after copying', () async {
     binary.createSync(recursive: true);
     final File entitlements = environment.outputDir.childFile('entitlements.txt');
     final File withoutEntitlements = environment.outputDir.childFile('without_entitlements.txt');
+    final File unsignedBinaries = environment.outputDir.childFile('unsigned_binaries.txt');
     final File nestedEntitlements = environment
         .outputDir
         .childDirectory('first_level')
@@ -201,6 +202,7 @@ void main() {
         onRun: (_) {
           entitlements.writeAsStringSync('foo');
           withoutEntitlements.writeAsStringSync('bar');
+          unsignedBinaries.writeAsStringSync('baz');
           nestedEntitlements.writeAsStringSync('somefile.bin');
         },
       ),
@@ -211,6 +213,7 @@ void main() {
     await const DebugUnpackMacOS().build(environment);
     expect(entitlements.existsSync(), isFalse);
     expect(withoutEntitlements.existsSync(), isFalse);
+    expect(unsignedBinaries.existsSync(), isFalse);
     expect(nestedEntitlements.existsSync(), isFalse);
 
     expect(processManager, hasNoRemainingExpectations);


### PR DESCRIPTION
There are three categories of binaries produced as part of the framework artifacts:
* Those that use APIs that require entitlements and must be code-signed; e.g. gen_snapshot
* Those that do not use APIs that require entitlements and must be code-signed; e.g. Flutter.framework dylib.
* Those that do not need to be code-signed; e.g. Flutter.dSYM symbols.

We are adding the third category in https://github.com/flutter/engine/pull/54977. The Cocoon code signing aspect of this was handled in https://github.com/flutter/cocoon/pull/3890.

This ensures these files don't get copied into the build output should they appear in the artifact cache.

Issue: https://github.com/flutter/flutter/issues/154571

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
