### PR TITLE
Changes the offset computation to first item for RenderSliverMainAxisGroup

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -214,8 +214,6 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childBefore(child as RenderSliver);
         while (current != null) {
-          // If the sliver is not clipped, then we add the scroll extent of the
-          // sliver to the childScrollOffset.
           if (!current.geometry!.hasVisualOverflow || lastChild == child ) {
             childScrollOffset += current.geometry!.scrollExtent;
           }
@@ -226,7 +224,9 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childAfter(child as RenderSliver);
         while (current != null) {
-          childScrollOffset -= current.geometry!.scrollExtent;
+          if (!current.geometry!.hasVisualOverflow || firstChild == child ) {
+            childScrollOffset += current.geometry!.scrollExtent;
+          }
           current = childAfter(current);
         }
         return childScrollOffset;

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -214,16 +214,13 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childBefore(child as RenderSliver);
         while (current != null) {
-          final double scrollExtent = current.geometry!.scrollExtent;
-          childScrollOffset += scrollExtent;
-
           // If the current item is the first visible item, we subtract its scrollExtent
           // to correct the offset, since we accumulated the scrollExtent of this item in the loop.
           // We are not assuming that this is the first item in the list, but rather the first visible one.
-          if (childBefore(current) == null && (childAfter(child) != null) ) {
-            childScrollOffset -= scrollExtent;
+          if (childBefore(current) != null || childAfter(child) == null) {
+          final double scrollExtent = current.geometry!.scrollExtent;
+            childScrollOffset += scrollExtent;
           }
-
           current = childBefore(current);
         }
         return childScrollOffset;

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'dart:math' as math;
+
 import 'package:vector_math/vector_math_64.dart';
 
 import 'object.dart';
@@ -213,7 +214,16 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childBefore(child as RenderSliver);
         while (current != null) {
-          childScrollOffset += current.geometry!.scrollExtent;
+          final double scrollExtent = current.geometry!.scrollExtent;
+          childScrollOffset += scrollExtent;
+
+          // If the current child is the first visible child, subtract its scrollExtent
+          // to correct the offset, since we accumulated its scroll extent in the loop.
+          // Here we are assuming that the child is the first visible child.
+          if (childBefore(current) == null && (childAfter(child) != null) ) {
+            childScrollOffset -= scrollExtent;
+          }
+
           current = childBefore(current);
         }
         return childScrollOffset;

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -218,8 +218,8 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
           // to correct the offset, since we accumulated the scrollExtent of this item in the loop.
           // We are not assuming that this is the first item in the list, but rather the first visible one.
           if (childBefore(current) != null || childAfter(child) == null) {
-          final double scrollExtent = current.geometry!.scrollExtent;
-            childScrollOffset += scrollExtent;
+            final double scrollExtent = current.geometry!.scrollExtent;
+              childScrollOffset += scrollExtent;
           }
           current = childBefore(current);
         }

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -225,7 +225,7 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         RenderSliver? current = childAfter(child as RenderSliver);
         while (current != null) {
           if (!current.geometry!.hasVisualOverflow || firstChild == child ) {
-            childScrollOffset += current.geometry!.scrollExtent;
+            childScrollOffset -= current.geometry!.scrollExtent;
           }
           current = childAfter(current);
         }

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -214,12 +214,10 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childBefore(child as RenderSliver);
         while (current != null) {
-          // If the current item is the first visible item, we subtract its scrollExtent
-          // to correct the offset, since we accumulated the scrollExtent of this item in the loop.
-          // We are not assuming that this is the first item in the list, but rather the first visible one.
-          if (childBefore(current) != null || childAfter(child) == null) {
-            final double scrollExtent = current.geometry!.scrollExtent;
-              childScrollOffset += scrollExtent;
+          // If the sliver is not clipped, then we add the scroll extent of the
+          // sliver to the childScrollOffset.
+          if (current.geometry?.hasVisualOverflow == false) {
+            childScrollOffset += current.geometry!.scrollExtent;
           }
           current = childBefore(current);
         }

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -217,9 +217,9 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
           final double scrollExtent = current.geometry!.scrollExtent;
           childScrollOffset += scrollExtent;
 
-          // If the current child is the first visible child, subtract its scrollExtent
-          // to correct the offset, since we accumulated its scroll extent in the loop.
-          // Here we are assuming that the child is the first visible child.
+          // If the current item is the first visible item, we subtract its scrollExtent
+          // to correct the offset, since we accumulated the scrollExtent of this item in the loop.
+          // We are not assuming that this is the first item in the list, but rather the first visible one.
           if (childBefore(current) == null && (childAfter(child) != null) ) {
             childScrollOffset -= scrollExtent;
           }

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -214,12 +214,11 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childBefore(child as RenderSliver);
         while (current != null) {
-          // If the current sliver is not the first child, add twice the scrollExtent to the scrollOffset
-          // to account for both the current and the previous slivers.
-          // If the current sliver is the first child, add its scrollExtent once to the scrollOffset
-          // to account for only the current sliver.
+          // If the current child is not the first child, then we need to
+          // add the scroll extent of the previous child to the current child's
+          // scroll offset.
           if (childBefore(current) != null) {
-            childScrollOffset += 2 * current.geometry!.scrollExtent;
+            childScrollOffset += childAfter(current)!.geometry!.scrollExtent + child.geometry!.scrollExtent;
           } else if (!(childAfter(child) != null && current.geometry!.hasVisualOverflow)) {
             childScrollOffset += current.geometry!.scrollExtent;
           }

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -216,7 +216,7 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         while (current != null) {
           // If the sliver is not clipped, then we add the scroll extent of the
           // sliver to the childScrollOffset.
-          if (current.geometry?.hasVisualOverflow == false) {
+          if (!current.geometry!.hasVisualOverflow || lastChild == child ) {
             childScrollOffset += current.geometry!.scrollExtent;
           }
           current = childBefore(current);

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -230,14 +230,7 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childAfter(child as RenderSliver);
         while (current != null) {
-          // If the current sliver is not the last child, subtract twice the scrollExtent to the scrollOffset
-          // to account for both the current and the next slivers.
-          // If the current sliver is the last child, subtract its scrollExtent once to the scrollOffset
-          // to account for only the current sliver.
-          if (childAfter(current) != null) {
-            childScrollOffset -= 2 * current.geometry!.scrollExtent;
-          } else if (!(childBefore(child) != null && current.geometry!.hasVisualOverflow)) {
-            childScrollOffset -= current.geometry!.scrollExtent;
+           childScrollOffset -= current.geometry!.scrollExtent;
           }
           current = childAfter(current);
         }

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -230,8 +230,7 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childAfter(child as RenderSliver);
         while (current != null) {
-           childScrollOffset -= current.geometry!.scrollExtent;
-          }
+          childScrollOffset -= current.geometry!.scrollExtent;
           current = childAfter(current);
         }
         return childScrollOffset;

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -214,7 +214,13 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childBefore(child as RenderSliver);
         while (current != null) {
-          if (!current.geometry!.hasVisualOverflow || lastChild == child ) {
+          // If the current sliver is not the first child, add twice the scrollExtent to the scrollOffset
+          // to account for both the current and the previous slivers.
+          // If the current sliver is the first child, add its scrollExtent once to the scrollOffset
+          // to account for only the current sliver.
+          if (childBefore(current) != null) {
+            childScrollOffset += 2 * current.geometry!.scrollExtent;
+          } else if (!(childAfter(child) != null && current.geometry!.hasVisualOverflow)) {
             childScrollOffset += current.geometry!.scrollExtent;
           }
           current = childBefore(current);
@@ -224,7 +230,13 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
         double childScrollOffset = 0.0;
         RenderSliver? current = childAfter(child as RenderSliver);
         while (current != null) {
-          if (!current.geometry!.hasVisualOverflow || firstChild == child ) {
+          // If the current sliver is not the last child, subtract twice the scrollExtent to the scrollOffset
+          // to account for both the current and the next slivers.
+          // If the current sliver is the last child, subtract its scrollExtent once to the scrollOffset
+          // to account for only the current sliver.
+          if (childAfter(current) != null) {
+            childScrollOffset -= 2 * current.geometry!.scrollExtent;
+          } else if (!(childBefore(child) != null && current.geometry!.hasVisualOverflow)) {
             childScrollOffset -= current.geometry!.scrollExtent;
           }
           current = childAfter(current);

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17546,8 +17546,8 @@ void main() {
     await tester.pumpWidget(widget);
     await tester.showKeyboard(find.byType(EditableText));
     await tester.pumpAndSettle();
-    // Regression test for https://github.com/flutter/flutter/issues/154615
-    expect(scrollController.offset, 0.0);
+
+    expect(scrollController.offset, 75.0);
   });
 
   testWidgets('getPositionForPoint is correct when EditableText is scaled', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17546,7 +17546,6 @@ void main() {
     await tester.pumpWidget(widget);
     await tester.showKeyboard(find.byType(EditableText));
     await tester.pumpAndSettle();
-
     expect(scrollController.offset, 75.0);
   });
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17546,7 +17546,8 @@ void main() {
     await tester.pumpWidget(widget);
     await tester.showKeyboard(find.byType(EditableText));
     await tester.pumpAndSettle();
-    expect(scrollController.offset, 75.0);
+    // Regression test for https://github.com/flutter/flutter/issues/154615
+    expect(scrollController.offset, 0.0);
   });
 
   testWidgets('getPositionForPoint is correct when EditableText is scaled', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -804,6 +804,9 @@ void main() {
     addTearDown(controller.dispose);
     final FocusNode textFieldFocus = FocusNode();
     addTearDown(textFieldFocus.dispose);
+    final FocusNode textFieldFocus2 = FocusNode();
+    addTearDown(textFieldFocus2.dispose);
+    const ValueKey<int> firstTextFieldKey = ValueKey<int>(1);
 
     await tester.pumpWidget(
       _buildSliverMainAxisGroup(
@@ -822,6 +825,7 @@ void main() {
           SliverToBoxAdapter(
               child: Material(
             child: TextField(
+              key: firstTextFieldKey,
               focusNode: textFieldFocus,
             ),
           )),
@@ -831,22 +835,26 @@ void main() {
               height: 500,
             ),
           ),
+          SliverToBoxAdapter(
+              child: Material(
+            child: TextField(
+              focusNode: textFieldFocus2,
+            ),
+          )),
         ],
       ),
     );
 
     await tester.pumpAndSettle();
-    await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
-    expect(controller.offset, 0.0);
 
-    controller.jumpTo(100.0);
+    textFieldFocus2.requestFocus();
     await tester.pumpAndSettle();
 
     textFieldFocus.requestFocus();
     await tester.pumpAndSettle();
 
-    expect(controller.offset, 8.0); // 8.0 is contentPadding of TextField; (0.0, 8.0, 0.0, 8.0).
+    expect(tester.getTopLeft(find.byKey(firstTextFieldKey)), const Offset(0, 60));
   });
 }
 

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -795,8 +795,8 @@ void main() {
     );
     Scrollable.ensureVisible(key.currentContext!);
     await tester.pumpAndSettle();
-    // Regression test for https://github.com/flutter/flutter/issues/154615
-    expect(tester.getTopLeft(find.byKey(key)), const Offset(0, 300));
+
+    expect(tester.getTopLeft(find.byKey(key)), Offset.zero);
   });
 
   testWidgets('SliverMainAxisGroup scrolls to the correct position when focusing on a text field within a header', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -799,13 +799,11 @@ void main() {
     expect(tester.getTopLeft(find.byKey(key)), const Offset(0, 300));
   });
 
-  testWidgets('SliverMainAxisGroup scrolls to the correct position', (WidgetTester tester) async {
+  testWidgets('SliverMainAxisGroup scrolls to the correct position when focusing on a text field within a header', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     final FocusNode textFieldFocus = FocusNode();
     addTearDown(textFieldFocus.dispose);
-    final FocusNode textFieldFocus2 = FocusNode();
-    addTearDown(textFieldFocus2.dispose);
 
     await tester.pumpWidget(
       _buildSliverMainAxisGroup(
@@ -833,41 +831,22 @@ void main() {
               height: 500,
             ),
           ),
-          SliverToBoxAdapter(
-            child: Container(
-              color: Colors.black,
-              height: 500,
-            ),
-          ),
-          SliverToBoxAdapter(
-              child: Material(
-            child: TextField(
-              focusNode: textFieldFocus2,
-            ),
-          )),
         ],
       ),
     );
 
     await tester.pumpAndSettle();
-
-    // Scroll a bit to make sure the first text field offset be greater than 0.
-    controller.jumpTo(100);
+    await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
+    expect(controller.offset, 0.0);
 
-    // Ensure the first text field is not visible.
-    expect(controller.offset, 100);
-
-    textFieldFocus2.requestFocus();
+    controller.jumpTo(100.0);
     await tester.pumpAndSettle();
-
-    expect(controller.offset, equals(556));
 
     textFieldFocus.requestFocus();
     await tester.pumpAndSettle();
 
-    // Should be 0 because we scroll to the top.
-    expect(controller.offset, equals(0));
+    expect(controller.offset, 8.0); // 8.0 is contentPadding of TextField; (0.0, 8.0, 0.0, 8.0).
   });
 }
 

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -795,7 +795,8 @@ void main() {
     );
     Scrollable.ensureVisible(key.currentContext!);
     await tester.pumpAndSettle();
-    expect(tester.getTopLeft(find.byKey(key)), Offset.zero);
+    // Regression test for https://github.com/flutter/flutter/issues/154615
+    expect(tester.getTopLeft(find.byKey(key)), const Offset(0, 300));
   });
 
   testWidgets('SliverMainAxisGroup scrolls to the correct position', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -795,7 +795,6 @@ void main() {
     );
     Scrollable.ensureVisible(key.currentContext!);
     await tester.pumpAndSettle();
-
     expect(tester.getTopLeft(find.byKey(key)), Offset.zero);
   });
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/154615
When scrolling back to the top, the position of the first visible item should have its scrollExtent subtracted. Otherwise, the accumulated position may be retained, which may result in the first visible item being hidden in some cases.
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
