### PR TITLE
Mark `_LayoutBuilderElement` as always clean

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2911,6 +2911,16 @@ class BuildOwner {
                   'The dirty list for the current build scope is: ${buildScope._dirtyElements}',
         );
       }
+      if (!_debugBuilding && element._inDirtyList) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('BuildOwner.scheduleBuildFor() called inappropriately.'),
+          ErrorHint(
+            'The BuildOwner.scheduleBuildFor() method called on an Element '
+            'that is already in the dirty list.',
+          ),
+          element.describeElement('the dirty Element was'),
+        ]);
+      }
       return true;
     }());
     if (!_scheduledFlushDirtyElements && onBuildScheduled != null) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5147,7 +5147,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// [markNeedsBuild] has been called. The flag is typically reset to false in
   /// the [performRebuild] implementation, but certain elements (that of the
   /// [LayoutBuilder] widget, for example) may choose to override [markNeedsBuild]
-  /// such that it does not set the [dirty] flag to `true` at all.
+  /// such that it does not set the [dirty] flag to `true` when called.
   bool get dirty => _dirty;
   bool _dirty = true;
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2911,17 +2911,6 @@ class BuildOwner {
                   'The dirty list for the current build scope is: ${buildScope._dirtyElements}',
         );
       }
-      // When reactivating an inactivate Element, _scheduleBuildFor should only be
-      // called within _flushDirtyElements.
-      if (!_debugBuilding && element._inDirtyList) {
-        throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('BuildOwner.scheduleBuildFor() called inappropriately.'),
-          ErrorHint(
-            'The BuildOwner.scheduleBuildFor() method should only be called while the '
-            'buildScope() method is actively rebuilding the widget tree.',
-          ),
-        ]);
-      }
       return true;
     }());
     if (!_scheduledFlushDirtyElements && onBuildScheduled != null) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5134,8 +5134,10 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// Returns true if the element has been marked as needing rebuilding.
   ///
   /// The flag is true when the element is first created and after
-  /// [markNeedsBuild] has been called. The flag is reset to false in the
-  /// [performRebuild] implementation.
+  /// [markNeedsBuild] has been called. The flag is typically reset to false in
+  /// the [performRebuild] implementation, but certain elements (that of the
+  /// [LayoutBuilder] widget, for example) may choose to override [markNeedsBuild]
+  /// such that it does not set the [dirty] flag to `true` at all.
   bool get dirty => _dirty;
   bool _dirty = true;
 

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -158,7 +158,10 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
 
   @override
   void markNeedsBuild() {
-    super.markNeedsBuild();
+    // Calling super.markNeedsBuild is not needed. This Element does not need
+    // to performRebuild since this call already does what performRebuild does,
+    // So the element is clean as soon as this method returns and does not have
+    // to be added to the dirty list or marked as dirty.
     renderObject.markNeedsLayout();
     _needsBuild = true;
   }

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1941,6 +1941,18 @@ The findRenderObject() method was called for the following element:
     expect(scopeElement.dirty, isFalse);
     expect(keyedWidget.dirty, isTrue);
   });
+
+  testWidgets('Calling scheduleBuildFor on an Element already in dirty list throws', (WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox());
+    final Element element = tester.element(find.byType(SizedBox));
+    element.markNeedsBuild();
+    expect(
+      () => element.owner!.scheduleBuildFor(element),
+      throwsA(isFlutterError.having(
+        (FlutterError e) => e.message, 'message', contains('The BuildOwner.scheduleBuildFor() method called on an Element that is already in the dirty list.'),
+      )),
+    );
+  });
 }
 
 class _TestInheritedElement extends InheritedElement {

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -850,6 +850,27 @@ void main() {
     expect(paintCount, 3);
     expect(mostRecentOffset, const Offset(60, 60));
   });
+
+  testWidgets('LayoutBuilder in a subtree that skips layout does not throw during the initial treewalk', (WidgetTester tester) async {
+    final OverlayEntry overlayEntry1 = OverlayEntry(maintainState: true, builder: (BuildContext context) => LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) => const Placeholder()));
+    // OverlayEntry2 obstructs OverlayEntry1 and forces it to skip layout.
+    final OverlayEntry overlayEntry2 = OverlayEntry(opaque: true, canSizeOverlay: true, builder: (BuildContext context) => Container());
+    addTearDown(() => overlayEntry1..remove()..dispose());
+    addTearDown(() => overlayEntry2..remove()..dispose());
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        // The UnconstrainedBox makes sure the OverlayEntries are not relayout boundaries.
+        child: UnconstrainedBox(child: Overlay(initialEntries: <OverlayEntry>[overlayEntry1, overlayEntry2])),
+      ),
+    );
+
+    WidgetsBinding.instance.buildOwner!.reassemble(WidgetsBinding.instance.rootElement!);
+    await tester.pump();
+    WidgetsBinding.instance.buildOwner!.reassemble(WidgetsBinding.instance.rootElement!);
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _SmartLayoutBuilder extends ConstrainedLayoutBuilder<BoxConstraints> {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/154060

The error message doesn't make sense to me since one can call `setState` during the idle phase, and I'm not sure what this is guarding against without the right error message.

In the case of #154060 the layout builder was never laid out:
```
├─child 1: _RenderLayoutBuilder#7c319 NEEDS-LAYOUT NEEDS-PAINT
│   creator: LayoutBuilder ← _BodyBuilder ← MediaQuery ←
│     LayoutId-[<_ScaffoldSlot.body>] ← CustomMultiChildLayout ←
│     _ActionsScope ← Actions ← AnimatedBuilder ← DefaultTextStyle ←
│     AnimatedDefaultTextStyle ← _InkFeatures-[GlobalKey#1f6eb ink
│     renderer] ← NotificationListener<LayoutChangedNotification> ← ⋯
│   parentData: offset=Offset(0.0, 0.0); id=_ScaffoldSlot.body
│   constraints: MISSING
│   size: MISSING
```
So https://github.com/flutter/flutter/pull/154681 doesn't really fix #154060 since the layout callback cannot be run without a set of valid constraints. 

Before the `BuildScope` change all `_inDirtyList` flags were unset after the `BuildOwner` finishes rebuilding the widget tree, so `LayoutBuilder._inDirtyLst` is always set to false after a frame even for layout builders that were never laid out.
With the `BuildScope` change, `LayoutBuilder` has its own `BuildScope` which is only flushed after LayoutBuilder gets its constraints. 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
