### PR TITLE
fix NestedScrollView crash with multiple ScrollPositions

### DIFF
--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart
@@ -19,178 +19,112 @@ class NestedScrollViewExampleApp extends StatelessWidget {
   }
 }
 
-class NestedScrollViewExample extends StatefulWidget {
+class NestedScrollViewExample extends StatelessWidget {
   const NestedScrollViewExample({super.key});
 
   @override
-  State<NestedScrollViewExample> createState() =>
-      NestedScrollViewExampleState();
-}
-
-class NestedScrollViewExampleState extends State<NestedScrollViewExample>
-    with TickerProviderStateMixin {
-  final List<String> _tabs = <String>['Tab 1', 'Tab 2'];
-
-  late TabController _tabController;
-  int _selectedIndex = 0;
-
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(
-      initialIndex: _selectedIndex,
-      vsync: this,
-      length: _tabs.length,
-    );
-    _tabController.addListener(() {
-      setState(() {
-        _selectedIndex = _tabController.index;
-      });
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: NestedScrollView(
-        headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-          // These are the slivers that show up in the "outer" scroll view.
-          return <Widget>[
-            SliverOverlapAbsorber(
-              // This widget takes the overlapping behavior of the SliverAppBar,
-              // and redirects it to the SliverOverlapInjector below. If it is
-              // missing, then it is possible for the nested "inner" scroll view
-              // below to end up under the SliverAppBar even when the inner
-              // scroll view thinks it has not been scrolled.
-              // This is not necessary if the "headerSliverBuilder" only builds
-              // widgets that do not overlap the next sliver.
-              handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-              sliver: SliverAppBar(
-                title: const Text('Books'), // This is the title in the app bar.
-                pinned: true,
-                expandedHeight: 150.0,
-                // The "forceElevated" property causes the SliverAppBar to show
-                // a shadow. The "innerBoxIsScrolled" parameter is true when the
-                // inner scroll view is scrolled beyond its "zero" point, i.e.
-                // when it appears to be scrolled below the SliverAppBar.
-                // Without this, there are cases where the shadow would appear
-                // or not appear inappropriately, because the SliverAppBar is
-                // not actually aware of the precise position of the inner
-                // scroll views.
-                forceElevated: innerBoxIsScrolled,
-                bottom: TabBar(
-                  controller: _tabController,
-                  // These are the widgets to put in each tab in the tab bar.
-                  tabs: <Widget>[
-                    for (final String name in _tabs) Tab(text: name),
-                  ],
-                ),
-              ),
-            ),
-          ];
-        },
-        body: TabBarView(
-          controller: _tabController,
-          // These are the contents of the tab views, below the tabs.
-          children: <Widget>[
-            for (final (int index, String name) in _tabs.indexed)
-              TabViewContentExample(
-                name: name,
-                isSelected: index == _selectedIndex,
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class TabViewContentExample extends StatefulWidget {
-  const TabViewContentExample({
-    required this.name,
-    required this.isSelected,
-    super.key,
-  });
-
-  final String name;
-  final bool isSelected;
-
-  @override
-  State<TabViewContentExample> createState() => TabViewContentExampleState();
-}
-
-class TabViewContentExampleState extends State<TabViewContentExample>
-    with AutomaticKeepAliveClientMixin {
-  @override
-  bool get wantKeepAlive => true;
-
-  final ScrollController _scrollController = ScrollController();
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    super.build(context);
-
-    return SafeArea(
-      top: false,
-      bottom: false,
-      child: Builder(
-        // This Builder is needed to provide a BuildContext that is "inside"
-        // the NestedScrollView, so that sliverOverlapAbsorberHandleFor() can
-        // find the NestedScrollView.
-        builder: (BuildContext context) {
-          final ScrollController scrollController = PrimaryScrollController.of(context);
-          return CustomScrollView(
-            // When this inner scroll view is associated with the
-            // PrimaryScrollController, the NestedScrollView can control it.
-            // If the "controller" property is set, then this scroll view will
-            // not be associated with the NestedScrollView.
-            // The PageStorageKey should be unique to this ScrollView;
-            // it allows the list to remember its scroll position when
-            // the tab view is not on the screen.
-            controller:
-                widget.isSelected ? scrollController : _scrollController,
-            key: PageStorageKey<String>(widget.name),
-            slivers: <Widget>[
-              SliverOverlapInjector(
-                // This is the flip side of the SliverOverlapAbsorber above.
-                handle:
-                    NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-              ),
-              SliverPadding(
-                padding: const EdgeInsets.all(8.0),
-                // In this example, the inner scroll view has fixed-height list
-                // items, hence the use of SliverFixedExtentList. However, one
-                // could use any sliver widget here, e.g. SliverList or
-                // SliverGrid.
-                sliver: SliverFixedExtentList(
-                  // The items in this example are fixed to 48 pixels high.
-                  // This matches the Material Design spec for ListTile widgets.
-                  itemExtent: 48.0,
-                  delegate: SliverChildBuilderDelegate(
-                    (BuildContext context, int index) {
-                      // This builder is called for each child.
-                      // In this example, we just number each list item.
-                      return ListTile(
-                        title: Text('Item $index'),
-                      );
-                    },
-                    // The childCount of the SliverChildBuilderDelegate
-                    // specifies how many children this inner list has.
-                    // In this example, each tab has a list of exactly 30 items,
-                    // but this is arbitrary.
-                    childCount: 30,
+    final List<String> tabs = <String>['Tab 1', 'Tab 2'];
+    return DefaultTabController(
+      length: tabs.length, // This is the number of tabs.
+      child: Scaffold(
+        body: NestedScrollView(
+          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+            // These are the slivers that show up in the "outer" scroll view.
+            return <Widget>[
+              SliverOverlapAbsorber(
+                // This widget takes the overlapping behavior of the SliverAppBar,
+                // and redirects it to the SliverOverlapInjector below. If it is
+                // missing, then it is possible for the nested "inner" scroll view
+                // below to end up under the SliverAppBar even when the inner
+                // scroll view thinks it has not been scrolled.
+                // This is not necessary if the "headerSliverBuilder" only builds
+                // widgets that do not overlap the next sliver.
+                handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+                sliver: SliverAppBar(
+                  title: const Text('Books'), // This is the title in the app bar.
+                  pinned: true,
+                  expandedHeight: 150.0,
+                  // The "forceElevated" property causes the SliverAppBar to show
+                  // a shadow. The "innerBoxIsScrolled" parameter is true when the
+                  // inner scroll view is scrolled beyond its "zero" point, i.e.
+                  // when it appears to be scrolled below the SliverAppBar.
+                  // Without this, there are cases where the shadow would appear
+                  // or not appear inappropriately, because the SliverAppBar is
+                  // not actually aware of the precise position of the inner
+                  // scroll views.
+                  forceElevated: innerBoxIsScrolled,
+                  bottom: TabBar(
+                    // These are the widgets to put in each tab in the tab bar.
+                    tabs: tabs.map((String name) => Tab(text: name)).toList(),
                   ),
                 ),
               ),
-            ],
-          );
-        },
+            ];
+          },
+          body: TabBarView(
+            // These are the contents of the tab views, below the tabs.
+            children: tabs.map((String name) {
+              return SafeArea(
+                top: false,
+                bottom: false,
+                child: Builder(
+                  // This Builder is needed to provide a BuildContext that is
+                  // "inside" the NestedScrollView, so that
+                  // sliverOverlapAbsorberHandleFor() can find the
+                  // NestedScrollView.
+                  builder: (BuildContext context) {
+                    return CustomScrollView(
+                      // The "controller" and "primary" members should be left
+                      // unset, so that the NestedScrollView can control this
+                      // inner scroll view.
+                      // If the "controller" property is set, then this scroll
+                      // view will not be associated with the NestedScrollView.
+                      // The PageStorageKey should be unique to this ScrollView;
+                      // it allows the list to remember its scroll position when
+                      // the tab view is not on the screen.
+                      key: PageStorageKey<String>(name),
+                      slivers: <Widget>[
+                        SliverOverlapInjector(
+                          // This is the flip side of the SliverOverlapAbsorber
+                          // above.
+                          handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+                        ),
+                        SliverPadding(
+                          padding: const EdgeInsets.all(8.0),
+                          // In this example, the inner scroll view has
+                          // fixed-height list items, hence the use of
+                          // SliverFixedExtentList. However, one could use any
+                          // sliver widget here, e.g. SliverList or SliverGrid.
+                          sliver: SliverFixedExtentList(
+                            // The items in this example are fixed to 48 pixels
+                            // high. This matches the Material Design spec for
+                            // ListTile widgets.
+                            itemExtent: 48.0,
+                            delegate: SliverChildBuilderDelegate(
+                              (BuildContext context, int index) {
+                                // This builder is called for each child.
+                                // In this example, we just number each list item.
+                                return ListTile(
+                                  title: Text('Item $index'),
+                                );
+                              },
+                              // The childCount of the SliverChildBuilderDelegate
+                              // specifies how many children this inner list
+                              // has. In this example, each tab has a list of
+                              // exactly 30 items, but this is arbitrary.
+                              childCount: 30,
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              );
+            }).toList(),
+          ),
+        ),
       ),
     );
   }

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart
@@ -19,112 +19,178 @@ class NestedScrollViewExampleApp extends StatelessWidget {
   }
 }
 
-class NestedScrollViewExample extends StatelessWidget {
+class NestedScrollViewExample extends StatefulWidget {
   const NestedScrollViewExample({super.key});
 
   @override
+  State<NestedScrollViewExample> createState() =>
+      NestedScrollViewExampleState();
+}
+
+class NestedScrollViewExampleState extends State<NestedScrollViewExample>
+    with TickerProviderStateMixin {
+  final List<String> _tabs = <String>['Tab 1', 'Tab 2'];
+
+  late TabController _tabController;
+  int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      initialIndex: _selectedIndex,
+      vsync: this,
+      length: _tabs.length,
+    );
+    _tabController.addListener(() {
+      setState(() {
+        _selectedIndex = _tabController.index;
+      });
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final List<String> tabs = <String>['Tab 1', 'Tab 2'];
-    return DefaultTabController(
-      length: tabs.length, // This is the number of tabs.
-      child: Scaffold(
-        body: NestedScrollView(
-          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-            // These are the slivers that show up in the "outer" scroll view.
-            return <Widget>[
-              SliverOverlapAbsorber(
-                // This widget takes the overlapping behavior of the SliverAppBar,
-                // and redirects it to the SliverOverlapInjector below. If it is
-                // missing, then it is possible for the nested "inner" scroll view
-                // below to end up under the SliverAppBar even when the inner
-                // scroll view thinks it has not been scrolled.
-                // This is not necessary if the "headerSliverBuilder" only builds
-                // widgets that do not overlap the next sliver.
-                handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-                sliver: SliverAppBar(
-                  title: const Text('Books'), // This is the title in the app bar.
-                  pinned: true,
-                  expandedHeight: 150.0,
-                  // The "forceElevated" property causes the SliverAppBar to show
-                  // a shadow. The "innerBoxIsScrolled" parameter is true when the
-                  // inner scroll view is scrolled beyond its "zero" point, i.e.
-                  // when it appears to be scrolled below the SliverAppBar.
-                  // Without this, there are cases where the shadow would appear
-                  // or not appear inappropriately, because the SliverAppBar is
-                  // not actually aware of the precise position of the inner
-                  // scroll views.
-                  forceElevated: innerBoxIsScrolled,
-                  bottom: TabBar(
-                    // These are the widgets to put in each tab in the tab bar.
-                    tabs: tabs.map((String name) => Tab(text: name)).toList(),
+    return Scaffold(
+      body: NestedScrollView(
+        headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+          // These are the slivers that show up in the "outer" scroll view.
+          return <Widget>[
+            SliverOverlapAbsorber(
+              // This widget takes the overlapping behavior of the SliverAppBar,
+              // and redirects it to the SliverOverlapInjector below. If it is
+              // missing, then it is possible for the nested "inner" scroll view
+              // below to end up under the SliverAppBar even when the inner
+              // scroll view thinks it has not been scrolled.
+              // This is not necessary if the "headerSliverBuilder" only builds
+              // widgets that do not overlap the next sliver.
+              handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+              sliver: SliverAppBar(
+                title: const Text('Books'), // This is the title in the app bar.
+                pinned: true,
+                expandedHeight: 150.0,
+                // The "forceElevated" property causes the SliverAppBar to show
+                // a shadow. The "innerBoxIsScrolled" parameter is true when the
+                // inner scroll view is scrolled beyond its "zero" point, i.e.
+                // when it appears to be scrolled below the SliverAppBar.
+                // Without this, there are cases where the shadow would appear
+                // or not appear inappropriately, because the SliverAppBar is
+                // not actually aware of the precise position of the inner
+                // scroll views.
+                forceElevated: innerBoxIsScrolled,
+                bottom: TabBar(
+                  controller: _tabController,
+                  // These are the widgets to put in each tab in the tab bar.
+                  tabs: <Widget>[
+                    for (final String name in _tabs) Tab(text: name),
+                  ],
+                ),
+              ),
+            ),
+          ];
+        },
+        body: TabBarView(
+          controller: _tabController,
+          // These are the contents of the tab views, below the tabs.
+          children: <Widget>[
+            for (final (int index, String name) in _tabs.indexed)
+              TabViewContentExample(
+                name: name,
+                isSelected: index == _selectedIndex,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class TabViewContentExample extends StatefulWidget {
+  const TabViewContentExample({
+    required this.name,
+    required this.isSelected,
+    super.key,
+  });
+
+  final String name;
+  final bool isSelected;
+
+  @override
+  State<TabViewContentExample> createState() => TabViewContentExampleState();
+}
+
+class TabViewContentExampleState extends State<TabViewContentExample>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    return SafeArea(
+      top: false,
+      bottom: false,
+      child: Builder(
+        // This Builder is needed to provide a BuildContext that is "inside"
+        // the NestedScrollView, so that sliverOverlapAbsorberHandleFor() can
+        // find the NestedScrollView.
+        builder: (BuildContext context) {
+          final ScrollController scrollController = PrimaryScrollController.of(context);
+          return CustomScrollView(
+            // When this inner scroll view is associated with the
+            // PrimaryScrollController, the NestedScrollView can control it.
+            // If the "controller" property is set, then this scroll view will
+            // not be associated with the NestedScrollView.
+            // The PageStorageKey should be unique to this ScrollView;
+            // it allows the list to remember its scroll position when
+            // the tab view is not on the screen.
+            controller:
+                widget.isSelected ? scrollController : _scrollController,
+            key: PageStorageKey<String>(widget.name),
+            slivers: <Widget>[
+              SliverOverlapInjector(
+                // This is the flip side of the SliverOverlapAbsorber above.
+                handle:
+                    NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+              ),
+              SliverPadding(
+                padding: const EdgeInsets.all(8.0),
+                // In this example, the inner scroll view has fixed-height list
+                // items, hence the use of SliverFixedExtentList. However, one
+                // could use any sliver widget here, e.g. SliverList or
+                // SliverGrid.
+                sliver: SliverFixedExtentList(
+                  // The items in this example are fixed to 48 pixels high.
+                  // This matches the Material Design spec for ListTile widgets.
+                  itemExtent: 48.0,
+                  delegate: SliverChildBuilderDelegate(
+                    (BuildContext context, int index) {
+                      // This builder is called for each child.
+                      // In this example, we just number each list item.
+                      return ListTile(
+                        title: Text('Item $index'),
+                      );
+                    },
+                    // The childCount of the SliverChildBuilderDelegate
+                    // specifies how many children this inner list has.
+                    // In this example, each tab has a list of exactly 30 items,
+                    // but this is arbitrary.
+                    childCount: 30,
                   ),
                 ),
               ),
-            ];
-          },
-          body: TabBarView(
-            // These are the contents of the tab views, below the tabs.
-            children: tabs.map((String name) {
-              return SafeArea(
-                top: false,
-                bottom: false,
-                child: Builder(
-                  // This Builder is needed to provide a BuildContext that is
-                  // "inside" the NestedScrollView, so that
-                  // sliverOverlapAbsorberHandleFor() can find the
-                  // NestedScrollView.
-                  builder: (BuildContext context) {
-                    return CustomScrollView(
-                      // The "controller" and "primary" members should be left
-                      // unset, so that the NestedScrollView can control this
-                      // inner scroll view.
-                      // If the "controller" property is set, then this scroll
-                      // view will not be associated with the NestedScrollView.
-                      // The PageStorageKey should be unique to this ScrollView;
-                      // it allows the list to remember its scroll position when
-                      // the tab view is not on the screen.
-                      key: PageStorageKey<String>(name),
-                      slivers: <Widget>[
-                        SliverOverlapInjector(
-                          // This is the flip side of the SliverOverlapAbsorber
-                          // above.
-                          handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-                        ),
-                        SliverPadding(
-                          padding: const EdgeInsets.all(8.0),
-                          // In this example, the inner scroll view has
-                          // fixed-height list items, hence the use of
-                          // SliverFixedExtentList. However, one could use any
-                          // sliver widget here, e.g. SliverList or SliverGrid.
-                          sliver: SliverFixedExtentList(
-                            // The items in this example are fixed to 48 pixels
-                            // high. This matches the Material Design spec for
-                            // ListTile widgets.
-                            itemExtent: 48.0,
-                            delegate: SliverChildBuilderDelegate(
-                              (BuildContext context, int index) {
-                                // This builder is called for each child.
-                                // In this example, we just number each list item.
-                                return ListTile(
-                                  title: Text('Item $index'),
-                                );
-                              },
-                              // The childCount of the SliverChildBuilderDelegate
-                              // specifies how many children this inner list
-                              // has. In this example, each tab has a list of
-                              // exactly 30 items, but this is arbitrary.
-                              childCount: 30,
-                            ),
-                          ),
-                        ),
-                      ],
-                    );
-                  },
-                ),
-              );
-            }).toList(),
-          ),
-        ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.3.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.3.dart
@@ -23,25 +23,23 @@ class NestedScrollViewExample extends StatefulWidget {
   const NestedScrollViewExample({super.key});
 
   @override
-  State<NestedScrollViewExample> createState() =>
-      NestedScrollViewExampleState();
+  State<NestedScrollViewExample> createState() => NestedScrollViewExampleState();
 }
 
 class NestedScrollViewExampleState extends State<NestedScrollViewExample>
     with TickerProviderStateMixin {
-  final List<String> _tabs = <String>['Tab 1', 'Tab 2'];
+  static const List<String> _tabs = <String>['Tab 1', 'Tab 2'];
 
-  late TabController _tabController;
+  late final TabController _tabController = TabController(
+    initialIndex: _selectedIndex,
+    vsync: this,
+    length: _tabs.length,
+  );
   int _selectedIndex = 0;
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(
-      initialIndex: _selectedIndex,
-      vsync: this,
-      length: _tabs.length,
-    );
     _tabController.addListener(() {
       setState(() {
         _selectedIndex = _tabController.index;
@@ -116,10 +114,10 @@ class TabViewContentExample extends StatefulWidget {
   final bool isSelected;
 
   @override
-  State<TabViewContentExample> createState() => TabViewContentExampleState();
+  State<TabViewContentExample> createState() => _TabViewContentExampleState();
 }
 
-class TabViewContentExampleState extends State<TabViewContentExample>
+class _TabViewContentExampleState extends State<TabViewContentExample>
     with AutomaticKeepAliveClientMixin {
   @override
   bool get wantKeepAlive => true;
@@ -139,58 +137,49 @@ class TabViewContentExampleState extends State<TabViewContentExample>
     return SafeArea(
       top: false,
       bottom: false,
-      child: Builder(
-        // This Builder is needed to provide a BuildContext that is "inside"
-        // the NestedScrollView, so that sliverOverlapAbsorberHandleFor() can
-        // find the NestedScrollView.
-        builder: (BuildContext context) {
-          final ScrollController scrollController = PrimaryScrollController.of(context);
-          return CustomScrollView(
-            // When this inner scroll view is associated with the
-            // PrimaryScrollController, the NestedScrollView can control it.
-            // If the "controller" property is set, then this scroll view will
-            // not be associated with the NestedScrollView.
-            // The PageStorageKey should be unique to this ScrollView;
-            // it allows the list to remember its scroll position when
-            // the tab view is not on the screen.
-            controller:
-                widget.isSelected ? scrollController : _scrollController,
-            key: PageStorageKey<String>(widget.name),
-            slivers: <Widget>[
-              SliverOverlapInjector(
-                // This is the flip side of the SliverOverlapAbsorber above.
-                handle:
-                    NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-              ),
-              SliverPadding(
-                padding: const EdgeInsets.all(8.0),
-                // In this example, the inner scroll view has fixed-height list
-                // items, hence the use of SliverFixedExtentList. However, one
-                // could use any sliver widget here, e.g. SliverList or
-                // SliverGrid.
-                sliver: SliverFixedExtentList(
-                  // The items in this example are fixed to 48 pixels high.
-                  // This matches the Material Design spec for ListTile widgets.
-                  itemExtent: 48.0,
-                  delegate: SliverChildBuilderDelegate(
+      child: CustomScrollView(
+        // When this inner scroll view is associated with the
+        // PrimaryScrollController, the NestedScrollView can control it.
+        // If the "controller" property is set, then this scroll view will not
+        // be associated with the NestedScrollView.
+        // The PageStorageKey should be unique to this ScrollView;
+        // it allows the list to remember its scroll position when the tab view
+        // is not on the screen.
+        controller: widget.isSelected
+            ? PrimaryScrollController.of(context)
+            : _scrollController,
+        key: PageStorageKey<String>(widget.name),
+        slivers: <Widget>[
+          SliverOverlapInjector(
+            // This is the flip side of the SliverOverlapAbsorber above.
+            handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.all(8.0),
+            // In this example, the inner scroll view has fixed-height list
+            // items, hence the use of SliverFixedExtentList. However, one could
+            // use any sliver widget here, e.g. SliverList or SliverGrid.
+            sliver: SliverFixedExtentList(
+              // The items in this example are fixed to 48 pixels high.
+              // This matches the Material Design spec for ListTile widgets.
+              itemExtent: 48.0,
+              delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) {
-                      // This builder is called for each child.
-                      // In this example, we just number each list item.
-                      return ListTile(
-                        title: Text('Item $index'),
-                      );
-                    },
-                    // The childCount of the SliverChildBuilderDelegate
-                    // specifies how many children this inner list has.
-                    // In this example, each tab has a list of exactly 30 items,
-                    // but this is arbitrary.
-                    childCount: 30,
-                  ),
-                ),
+                  // This builder is called for each child.
+                  // In this example, we just number each list item.
+                  return ListTile(
+                    title: Text('Item $index'),
+                  );
+                },
+                // The childCount of the SliverChildBuilderDelegate
+                // specifies how many children this inner list has.
+                // In this example, each tab has a list of exactly 30 items, but
+                // this is arbitrary.
+                childCount: 30,
               ),
-            ],
-          );
-        },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.3.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.3.dart
@@ -1,0 +1,197 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [NestedScrollView].
+
+void main() => runApp(const NestedScrollViewExampleApp());
+
+class NestedScrollViewExampleApp extends StatelessWidget {
+  const NestedScrollViewExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: NestedScrollViewExample(),
+    );
+  }
+}
+
+class NestedScrollViewExample extends StatefulWidget {
+  const NestedScrollViewExample({super.key});
+
+  @override
+  State<NestedScrollViewExample> createState() =>
+      NestedScrollViewExampleState();
+}
+
+class NestedScrollViewExampleState extends State<NestedScrollViewExample>
+    with TickerProviderStateMixin {
+  final List<String> _tabs = <String>['Tab 1', 'Tab 2'];
+
+  late TabController _tabController;
+  int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      initialIndex: _selectedIndex,
+      vsync: this,
+      length: _tabs.length,
+    );
+    _tabController.addListener(() {
+      setState(() {
+        _selectedIndex = _tabController.index;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: NestedScrollView(
+        headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+          // These are the slivers that show up in the "outer" scroll view.
+          return <Widget>[
+            SliverOverlapAbsorber(
+              // This widget takes the overlapping behavior of the SliverAppBar,
+              // and redirects it to the SliverOverlapInjector below. If it is
+              // missing, then it is possible for the nested "inner" scroll view
+              // below to end up under the SliverAppBar even when the inner
+              // scroll view thinks it has not been scrolled.
+              // This is not necessary if the "headerSliverBuilder" only builds
+              // widgets that do not overlap the next sliver.
+              handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+              sliver: SliverAppBar(
+                title: const Text('Books'), // This is the title in the app bar.
+                pinned: true,
+                expandedHeight: 150.0,
+                // The "forceElevated" property causes the SliverAppBar to show
+                // a shadow. The "innerBoxIsScrolled" parameter is true when the
+                // inner scroll view is scrolled beyond its "zero" point, i.e.
+                // when it appears to be scrolled below the SliverAppBar.
+                // Without this, there are cases where the shadow would appear
+                // or not appear inappropriately, because the SliverAppBar is
+                // not actually aware of the precise position of the inner
+                // scroll views.
+                forceElevated: innerBoxIsScrolled,
+                bottom: TabBar(
+                  controller: _tabController,
+                  // These are the widgets to put in each tab in the tab bar.
+                  tabs: <Widget>[
+                    for (final String name in _tabs) Tab(text: name),
+                  ],
+                ),
+              ),
+            ),
+          ];
+        },
+        body: TabBarView(
+          controller: _tabController,
+          // These are the contents of the tab views, below the tabs.
+          children: <Widget>[
+            for (final (int index, String name) in _tabs.indexed)
+              TabViewContentExample(
+                name: name,
+                isSelected: index == _selectedIndex,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class TabViewContentExample extends StatefulWidget {
+  const TabViewContentExample({
+    required this.name,
+    required this.isSelected,
+    super.key,
+  });
+
+  final String name;
+  final bool isSelected;
+
+  @override
+  State<TabViewContentExample> createState() => TabViewContentExampleState();
+}
+
+class TabViewContentExampleState extends State<TabViewContentExample>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    return SafeArea(
+      top: false,
+      bottom: false,
+      child: Builder(
+        // This Builder is needed to provide a BuildContext that is "inside"
+        // the NestedScrollView, so that sliverOverlapAbsorberHandleFor() can
+        // find the NestedScrollView.
+        builder: (BuildContext context) {
+          final ScrollController scrollController = PrimaryScrollController.of(context);
+          return CustomScrollView(
+            // When this inner scroll view is associated with the
+            // PrimaryScrollController, the NestedScrollView can control it.
+            // If the "controller" property is set, then this scroll view will
+            // not be associated with the NestedScrollView.
+            // The PageStorageKey should be unique to this ScrollView;
+            // it allows the list to remember its scroll position when
+            // the tab view is not on the screen.
+            controller:
+                widget.isSelected ? scrollController : _scrollController,
+            key: PageStorageKey<String>(widget.name),
+            slivers: <Widget>[
+              SliverOverlapInjector(
+                // This is the flip side of the SliverOverlapAbsorber above.
+                handle:
+                    NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+              ),
+              SliverPadding(
+                padding: const EdgeInsets.all(8.0),
+                // In this example, the inner scroll view has fixed-height list
+                // items, hence the use of SliverFixedExtentList. However, one
+                // could use any sliver widget here, e.g. SliverList or
+                // SliverGrid.
+                sliver: SliverFixedExtentList(
+                  // The items in this example are fixed to 48 pixels high.
+                  // This matches the Material Design spec for ListTile widgets.
+                  itemExtent: 48.0,
+                  delegate: SliverChildBuilderDelegate(
+                    (BuildContext context, int index) {
+                      // This builder is called for each child.
+                      // In this example, we just number each list item.
+                      return ListTile(
+                        title: Text('Item $index'),
+                      );
+                    },
+                    // The childCount of the SliverChildBuilderDelegate
+                    // specifies how many children this inner list has.
+                    // In this example, each tab has a list of exactly 30 items,
+                    // but this is arbitrary.
+                    childCount: 30,
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/examples/api/test/widgets/nested_scroll_view/nested_scroll_view.3_test.dart
+++ b/examples/api/test/widgets/nested_scroll_view/nested_scroll_view.3_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/nested_scroll_view/nested_scroll_view.3.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Shows all elements', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.NestedScrollViewExampleApp());
+    expect(find.byType(NestedScrollView), findsOneWidget);
+    expect(find.byType(SliverAppBar), findsOneWidget);
+    expect(find.byType(TabBarView), findsOneWidget);
+    expect(find.byType(Tab), findsNWidgets(2));
+    expect(find.byType(CustomScrollView), findsAtLeast(1));
+    expect(find.text('Books'), findsOneWidget);
+    expect(find.text('Tab 1'), findsOneWidget);
+    expect(find.text('Tab 2'), findsOneWidget);
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 14'), findsNothing);
+    expect(find.text('Item 14', skipOffstage: false), findsOneWidget);
+    expect(find.textContaining(RegExp(r'Item \d\d?'), skipOffstage: false), findsAtLeast(15));
+
+    await tester.tap(find.text('Tab 2'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining(RegExp(r'Item \d\d?'), skipOffstage: false), findsAtLeast(15));
+  });
+
+  testWidgets('Shrinks app bar on scroll', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.NestedScrollViewExampleApp());
+
+    final double initialAppBarHeight = tester.getTopLeft(find.byType(TabBarView)).dy;
+    expect(find.text('Item 1'), findsOneWidget);
+    await tester.ensureVisible(find.text('Item 14', skipOffstage: false));
+    await tester.pump();
+    expect(find.text('Item 1'), findsNothing);
+
+    expect(
+      tester.getTopLeft(find.byType(TabBarView)).dy,
+      lessThan(initialAppBarHeight),
+    );
+  });
+
+  testWidgets('Change tab and scroll test', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.NestedScrollViewExampleApp());
+
+    await tester.tap(find.text('Tab 1'));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -300));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -74,6 +74,15 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// ** See code in examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This example shows how to keep the state of tabs using
+/// [AutomaticKeepAliveClientMixin] in [NestedScrollView]. By switching between
+/// [ScrollController] and [PrimaryScrollController] based on the selected tab,
+/// the scroll positions of the tabs can be made independent.
+///
+/// ** See code in examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.3.dart **
+/// {@end-tool}
+///
 /// ## [SliverAppBar]s with [NestedScrollView]s
 ///
 /// Using a [SliverAppBar] in the outer scroll view, or [headerSliverBuilder],

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1191,7 +1191,9 @@ class _NestedScrollController extends ScrollController {
 
   @override
   void attach(ScrollPosition position) {
-    assert(position is _NestedScrollPosition);
+    if (position is! _NestedScrollPosition) {
+      return;
+    }
     super.attach(position);
     coordinator.updateParent();
     coordinator.updateCanDrag();
@@ -1201,8 +1203,10 @@ class _NestedScrollController extends ScrollController {
 
   @override
   void detach(ScrollPosition position) {
-    assert(position is _NestedScrollPosition);
-    (position as _NestedScrollPosition).setParent(null);
+    if (position is! _NestedScrollPosition) {
+      return;
+    }
+    position.setParent(null);
     position.removeListener(_scheduleUpdateShadow);
     super.detach(position);
     _scheduleUpdateShadow();

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -241,7 +241,7 @@ void main() {
         await tester.pumpAndSettle();
         expect(tester.takeException(), isNull);
       });
-  
+
   testWidgets('ScrollDirection test', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/107101
     final List<ScrollDirection> receivedResult = <ScrollDirection>[];

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -208,8 +208,9 @@ class TabPageState extends State<TabPage> with AutomaticKeepAliveClientMixin {
             slivers: <Widget>[
               SliverList(
                 delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) =>
-                      ListTile(title: Text('Item $index')),
+                  (BuildContext context, int index) {
+                    return ListTile(title: Text('Item $index'));
+                  },
                   childCount: 30,
                 ),
               ),

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -110,16 +110,16 @@ Widget buildTest({
 }
 
 
-class _TabBarViewInNestedScrollView extends StatefulWidget {
-  const _TabBarViewInNestedScrollView();
+class TabBarViewInNestedScrollView extends StatefulWidget {
+  const TabBarViewInNestedScrollView({super.key});
 
   @override
-  State<_TabBarViewInNestedScrollView> createState() =>
-      _TabBarViewInNestedScrollViewState();
+  State<TabBarViewInNestedScrollView> createState() =>
+      TabBarViewInNestedScrollViewState();
 }
 
-class _TabBarViewInNestedScrollViewState
-    extends State<_TabBarViewInNestedScrollView> with TickerProviderStateMixin {
+class TabBarViewInNestedScrollViewState
+    extends State<TabBarViewInNestedScrollView> with TickerProviderStateMixin {
   final List<int> _tabs = <int>[0, 1];
 
   late TabController _tabController;
@@ -154,45 +154,42 @@ class _TabBarViewInNestedScrollViewState
               bottom: TabBar(
                 controller: _tabController,
                 tabs:
-                _tabs.map((int index) => Tab(text: 'tab $index')).toList(),
+                    _tabs.map((int index) => Tab(text: 'tab $index')).toList(),
               ),
             ),
           ];
         },
         body: TabBarView(
           controller: _tabController,
-          children: _tabs
-              .map((int e) => _TabPage(
-            tab: e,
-            isSelected: _selectedIndex == e,
-          ))
-              .toList(),
+          children: <Widget>[
+            for (final int index in _tabs)
+              TabPage(isSelected: _selectedIndex == index),
+          ],
         ),
       ),
     );
   }
 }
 
-class _TabPage extends StatefulWidget {
-  const _TabPage({required this.tab, required this.isSelected});
+class TabPage extends StatefulWidget {
+  const TabPage({super.key, required this.isSelected});
 
-  final int tab;
   final bool isSelected;
 
   @override
-  _TabPageState createState() => _TabPageState();
+  TabPageState createState() => TabPageState();
 }
 
-class _TabPageState extends State<_TabPage> with AutomaticKeepAliveClientMixin {
+class TabPageState extends State<TabPage> with AutomaticKeepAliveClientMixin {
   @override
   bool get wantKeepAlive => true;
 
-  late ScrollController _scrollController;
+  final ScrollController _scrollController = ScrollController();
 
   @override
-  void initState() {
-    super.initState();
-    _scrollController = ScrollController();
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   @override
@@ -204,15 +201,14 @@ class _TabPageState extends State<_TabPage> with AutomaticKeepAliveClientMixin {
       bottom: false,
       child: Builder(
         builder: (BuildContext context) {
-          final ScrollController scrollController =
-            PrimaryScrollController.of(context);
+          final ScrollController scrollController = PrimaryScrollController.of(context);
           return CustomScrollView(
             controller:
-            widget.isSelected ? scrollController : _scrollController,
+                widget.isSelected ? scrollController : _scrollController,
             slivers: <Widget>[
               SliverList(
                 delegate: SliverChildBuilderDelegate(
-                      (BuildContext context, int index) =>
+                  (BuildContext context, int index) =>
                       ListTile(title: Text('Item $index')),
                   childCount: 30,
                 ),
@@ -229,7 +225,7 @@ void main() {
   testWidgets('Change tab and scroll test', (WidgetTester tester) async {
         await tester.pumpWidget(
           const MaterialApp(
-            home: _TabBarViewInNestedScrollView(),
+            home: TabBarViewInNestedScrollView(),
           ),
         );
 


### PR DESCRIPTION
Previously, when receiving a ScrollPosition other than _NestedScrollPosition, an assert check caused unintended behavior. This has been changed to simply return without the check. While the specification of NestedScrollView still only accepts _NestedScrollPosition as its ScrollPosition, this change allows handling multiple ScrollPositions even in Debug builds.
This fix addresses the issue of "NestedScrollView's use of PrimaryScrollController breaks when there are multiple inner ScrollPositions."

Fixes https://github.com/flutter/flutter/issues/40740
Fixes https://github.com/flutter/flutter/issues/159123

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
