### PR TITLE
fix test `chrome.close can recover if getTab throws a StateError`

### DIFF
--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -800,9 +800,10 @@ void main() {
 
   testWithoutContext('chrome.close can recover if getTab throws a StateError', () async {
     final BufferLogger logger = BufferLogger.test();
-    final FakeChromeConnection chromeConnection = FakeChromeConnection(
-      maxRetries: 4,
-      error: StateError('Client is closed.'),
+    final FakeChromeConnectionWithTab chromeConnection = FakeChromeConnectionWithTab(
+      onGetTab: () {
+        throw StateError('Client is closed.');
+      },
     );
     final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
       fileSystem: fileSystem,
@@ -813,7 +814,14 @@ void main() {
       logger: logger,
     );
     final FakeProcess process = FakeProcess();
-    final Chromium chrome = Chromium(0, chromeConnection, chromiumLauncher: chromiumLauncher, process: process, logger: logger,);
+    final Chromium chrome = Chromium(
+      0,
+      chromeConnection,
+      chromiumLauncher: chromiumLauncher,
+      process: process,
+      logger: logger,
+    );
+    await chromiumLauncher.connect(chrome, false);
     await chrome.close();
     expect(logger.errorText, isEmpty);
   });
@@ -944,14 +952,19 @@ typedef OnSendCommand = void Function(String);
 
 /// Fake chrome connection that returns a tab.
 class FakeChromeConnectionWithTab extends Fake implements ChromeConnection {
-  FakeChromeConnectionWithTab({OnSendCommand? onSendCommand, bool throwWebSocketException = false})
-      : _tab = FakeChromeTab(onSendCommand, throwWebSocketException);
+  FakeChromeConnectionWithTab({
+    OnSendCommand? onSendCommand,
+    this.onGetTab,
+    bool throwWebSocketException = false,
+  }) : _tab = FakeChromeTab(onSendCommand, throwWebSocketException);
 
   final FakeChromeTab _tab;
+  void Function()? onGetTab;
   bool throwSocketExceptions = false;
 
   @override
   Future<ChromeTab?> getTab(bool Function(ChromeTab tab) accept, {Duration? retryFor}) async {
+    onGetTab?.call();
     if (throwSocketExceptions) {
       throw const io.SocketException('test');
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/154857.

Does so by:
* adding `await chromiumLauncher.connect(chrome, false);` before the `close` call to make sure we enter[ the block ](https://github.com/flutter/flutter/blob/9cd2fc90af406a5ae798a6e099f3fca3eebd0da0/packages/flutter_tools/lib/src/web/chrome.dart#L521-L535)that actually tries to close chromium
* adding an `onGetTab` callback to `FakeChromeConnectionWithTab`, which the test now uses to throw a StateError upon `getTab` getting called.

## How I verified this change

1. Change `Chromium.close` from using the safer `getChromeTabGuarded` function to using the previous method of calling `ChromeConnection.getTab` directly. Do so by applying this diff:

```diff
diff --git a/packages/flutter_tools/lib/src/web/chrome.dart b/packages/flutter_tools/lib/src/web/chrome.dart
index c9a5fdab81..81bc246ff9 100644
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -520,7 +520,7 @@ class Chromium {
     Duration sigtermDelay = Duration.zero;
     if (_hasValidChromeConnection) {
       try {
-        final ChromeTab? tab = await getChromeTabGuarded(chromeConnection,
+        final ChromeTab? tab = await chromeConnection.getTab(
             (_) => true, retryFor: const Duration(seconds: 1));
         if (tab != null) {
           final WipConnection wipConnection = await tab.connect();
```

2. Then, run the test, which should correctly fail:
```
dart test test/web.shard/chrome_test.dart --name="chrome.close can recover if getTab throws a StateError"`
```
3. Revert the change from step 1 and run again. The test should now pass.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
