### PR TITLE
text button case rework

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -56,7 +56,7 @@ class MainWidgetState extends State<MainWidget> {
                   // Validate returns true if the form is valid, or false otherwise.
                   if (_formKey.currentState!.validate()) {
                     // If the form is valid, display a snackbar. In the real world,
-                    // you'd often call a server or save the information in a database.
+                    // this might also send a request to a server.
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('Form submitted')),
                     );

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -40,7 +40,7 @@ class MainWidgetState extends State<MainWidget> {
         key: _formKey,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
+          children: <Widget>[
             TextFormField(
             // The validator receives the text that the user has entered.
               validator: (String? value) {

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -42,7 +42,7 @@ class MainWidgetState extends State<MainWidget> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             TextFormField(
-            // The validator receives the text that the user has entered.
+              // The validator receives the text that the user has entered.
               validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return 'Please enter some text';

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -25,9 +25,9 @@ class MainWidget extends StatefulWidget {
 }
 
 class MainWidgetState extends State<MainWidget> {
-  int _count = 0;
 
   String pageTitle = getUseCaseName(TextButtonUseCase());
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context) {
@@ -36,40 +36,39 @@ class MainWidgetState extends State<MainWidget> {
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
       ),
-      body: Center(
+      body: Form(
+        key: _formKey,
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            MergeSemantics(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  const Text('This is a TextButton:'),
-                  TextButton(
-                    onPressed: () {
-                      setState(() { _count++; });
-                    },
-                    child: const Text('Action'),
-                  ),
-                  Text('Clicked $_count time(s).'),
-                ],
-              ),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextFormField(
+            // The validator receives the text that the user has entered.
+              validator: (String? value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter some text';
+                }
+                return null;
+              },
             ),
-            const MergeSemantics(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Text('This is a disabled TextButton:'),
-                  TextButton(
-                    onPressed: null,
-                    child: Text('Action Disabled'),
-                  ),
-                ],
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              child: ElevatedButton(
+                onPressed: () {
+                  // Validate returns true if the form is valid, or false otherwise.
+                  if (_formKey.currentState!.validate()) {
+                    // If the form is valid, display a snackbar. In the real world,
+                    // you'd often call a server or save the information in a database.
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Form submitted')),
+                    );
+                  }
+                },
+              child: const Text('Submit'),
               ),
             ),
           ],
         ),
-      ),
+      )
     );
   }
 }

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -25,7 +25,6 @@ class MainWidget extends StatefulWidget {
 }
 
 class MainWidgetState extends State<MainWidget> {
-
   String pageTitle = getUseCaseName(TextButtonUseCase());
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -67,7 +67,7 @@ class MainWidgetState extends State<MainWidget> {
             ),
           ],
         ),
-      )
+      ),
     );
   }
 }

--- a/dev/a11y_assessments/test/text_button_test.dart
+++ b/dev/a11y_assessments/test/text_button_test.dart
@@ -10,22 +10,7 @@ import 'test_utils.dart';
 void main() {
   testWidgets('text button can run', (WidgetTester tester) async {
     await pumpsUseCase(tester, TextButtonUseCase());
-    expect(find.text('Action'), findsOneWidget);
-    expect(find.text('Action Disabled'), findsOneWidget);
-  });
-
-  testWidgets('text button increments correctly when clicked',
-      (WidgetTester tester) async {
-    await pumpsUseCase(tester, TextButtonUseCase());
-
-    expect(find.text('Action'), findsOneWidget);
-    await tester.tap(find.text('Action'));
-    await tester.pumpAndSettle();
-    expect(find.text('Clicked 1 time(s).'), findsOneWidget);
-
-    await tester.tap(find.text('Action'));
-    await tester.pumpAndSettle();
-    expect(find.text('Clicked 2 time(s).'), findsOneWidget);
+    expect(find.text('Submit'), findsOneWidget);
   });
 
   testWidgets('text button demo page has one h1 tag', (WidgetTester tester) async {

--- a/dev/a11y_assessments/test/text_button_test.dart
+++ b/dev/a11y_assessments/test/text_button_test.dart
@@ -19,7 +19,7 @@ void main() {
     final Finder textFormField = find.byType(TextFormField);
     final Finder submitButton = find.text('Submit');
 
-    // Enter text in field and submit
+    // Enter text in field and submit.
     await tester.enterText(textFormField, 'test text');
     await tester.tap(submitButton);
     await tester.pump();

--- a/dev/a11y_assessments/test/text_button_test.dart
+++ b/dev/a11y_assessments/test/text_button_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:a11y_assessments/use_cases/text_button.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_utils.dart';
@@ -11,6 +12,20 @@ void main() {
   testWidgets('text button can run', (WidgetTester tester) async {
     await pumpsUseCase(tester, TextButtonUseCase());
     expect(find.text('Submit'), findsOneWidget);
+  });
+
+  testWidgets('submit causes snackbar to show', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextButtonUseCase());
+    final Finder textFormField = find.byType(TextFormField);
+    final Finder submitButton = find.text('Submit');
+
+    // Enter text in field and submit
+    await tester.enterText(textFormField, 'test text');
+    await tester.tap(submitButton);
+    await tester.pump();
+
+    // Verify that the snackbar is visible
+    expect(find.text('Form submitted'), findsOneWidget);
   });
 
   testWidgets('text button demo page has one h1 tag', (WidgetTester tester) async {

--- a/dev/a11y_assessments/test/text_button_test.dart
+++ b/dev/a11y_assessments/test/text_button_test.dart
@@ -24,7 +24,7 @@ void main() {
     await tester.tap(submitButton);
     await tester.pump();
 
-    // Verify that the snackbar is visible
+    // Verify that the snackbar is visible.
     expect(find.text('Form submitted'), findsOneWidget);
   });
 


### PR DESCRIPTION
Rework on the text button use case to pass [b/347102786](https://b.corp.google.com/347102786), 

After talking with the tester, it seems like there isn't an issue with the A11y of the text button, rather just how the test case is set up. In order for the text case to pass, there needs to be real time feedback of an action that is done by pressing the text button (think of a dialog popup, or form submission notification). 

So I rewrote the test case to mimic a simple form with a submit button that once submitted, will let the user know it is submitted with a snack bar notification. https://screencast.googleplex.com/cast/NTM0ODc1NDIxMDE2MDY0MHwzYWI4MTZhMS1hMA

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
