### PR TITLE
Missing benchmarks for `foundation/all_elements_bench.dart`

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/benchmark_collection.dart
+++ b/dev/benchmarks/microbenchmarks/lib/benchmark_collection.dart
@@ -87,10 +87,10 @@ Future<void> main() async {
       'foundation/all_elements_bench.dart',
       () async {
         binding.framePolicy =
-            LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+            LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive;
         runApp(const SizedBox.shrink()); // ensure dispose
         await SchedulerBinding.instance.endOfFrame;
-        all_elements_bench.execute();
+        await all_elements_bench.execute();
       }
     ),
   ];


### PR DESCRIPTION
I missed awaiting a future. Probably should have a lint for unawaited futures...