### PR TITLE
Migrate `apple-mobile-web-*` to `mobile-web-*`.

### DIFF
--- a/dev/a11y_assessments/web/index.html
+++ b/dev/a11y_assessments/web/index.html
@@ -25,7 +25,7 @@ found in the LICENSE file. -->
   <meta name="description" content=""A new Flutter project."">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="a11y_assessments">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/dev/integration_tests/flutter_gallery/web/index.html
+++ b/dev/integration_tests/flutter_gallery/web/index.html
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
   <meta name="description" content="A demo app for Flutter's material and cupertino widgets, as well as many other features of the Flutter SDK.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Flutter Gallery">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/dev/integration_tests/non_nullable/web/index.html
+++ b/dev/integration_tests/non_nullable/web/index.html
@@ -10,7 +10,7 @@ found in the LICENSE file. -->
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="non_nullable">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/dev/integration_tests/web/web/index.html
+++ b/dev/integration_tests/web/web/index.html
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
 
   <title>Web Test</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/integration_tests/web/web/index_with_blocked_service_workers.html
+++ b/dev/integration_tests/web/web/index_with_blocked_service_workers.html
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
 
   <title>Web Test</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/integration_tests/web/web/index_with_flutterjs.html
+++ b/dev/integration_tests/web/web/index_with_flutterjs.html
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
 
   <title>Web Test</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/integration_tests/web/web/index_with_flutterjs_custom_sw_version.html
+++ b/dev/integration_tests/web/web/index_with_flutterjs_custom_sw_version.html
@@ -10,7 +10,7 @@ found in the LICENSE file. -->
   <title>Integration test. App load with flutter.js. Custom serviceWorkerVersion provided.</title>
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/integration_tests/web/web/index_with_flutterjs_el_nonce.html
+++ b/dev/integration_tests/web/web/index_with_flutterjs_el_nonce.html
@@ -13,7 +13,7 @@ found in the LICENSE file. -->
   <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-SOME_NONCE' 'wasm-unsafe-eval'; font-src https://fonts.gstatic.com; style-src 'nonce-SOME_NONCE'; worker-src 'self';">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/integration_tests/web/web/index_with_flutterjs_el_tt_on.html
+++ b/dev/integration_tests/web/web/index_with_flutterjs_el_tt_on.html
@@ -13,7 +13,7 @@ found in the LICENSE file. -->
   <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/integration_tests/web/web/index_with_flutterjs_entrypoint_loaded.html
+++ b/dev/integration_tests/web/web/index_with_flutterjs_entrypoint_loaded.html
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
 
   <title>Integration test. App load with flutter.js and onEntrypointLoaded API</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/integration_tests/web/web/index_with_flutterjs_short.html
+++ b/dev/integration_tests/web/web/index_with_flutterjs_short.html
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
 
   <title>Web Test</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/integration_tests/web/web/index_without_flutterjs.html
+++ b/dev/integration_tests/web/web/index_without_flutterjs.html
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
 
   <title>Web Test</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
 

--- a/dev/manual_tests/web/index.html
+++ b/dev/manual_tests/web/index.html
@@ -25,7 +25,7 @@ found in the LICENSE file. -->
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="manual_tests">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/examples/api/web/index.html
+++ b/examples/api/web/index.html
@@ -24,7 +24,7 @@ found in the LICENSE file. -->
   <meta name="description" content="A temporary code sample for Curve2D">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="flutter_api_samples">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/packages/flutter_tools/templates/app_shared/web/index.html.tmpl
+++ b/packages/flutter_tools/templates/app_shared/web/index.html.tmpl
@@ -21,7 +21,7 @@
   <meta name="description" content="{{description}}">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="{{projectName}}">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/packages/flutter_tools/test/web.shard/test_data/hot_reload_index_html_samples.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/hot_reload_index_html_samples.dart
@@ -90,7 +90,7 @@ found in the LICENSE file. -->
 
   <title>Web Test</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
   <link rel="manifest" href="manifest.json">
@@ -180,7 +180,7 @@ found in the LICENSE file. -->
 
   <title>Integration test. App load with flutter.js and onEntrypointLoaded API</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
   <link rel="manifest" href="manifest.json">
@@ -212,7 +212,7 @@ found in the LICENSE file. -->
 
   <title>Web Test</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
   <link rel="manifest" href="manifest.json">
@@ -236,7 +236,7 @@ found in the LICENSE file. -->
 
   <title>Web Test</title>
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Web Test">
   <link rel="manifest" href="manifest.json">

--- a/packages/integration_test/example/web/index.html
+++ b/packages/integration_test/example/web/index.html
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="example">
   <link rel="apple-touch-icon" href="/icons/Icon-192.png">


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/154596.

It's less clear to me if your goal was to migrate _all_ of these btw:
https://github.com/search?q=org%3Aflutter+%22mobile-web-app-capable%22&type=code