### PR TITLE
Monomorphic Mapper

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -353,23 +353,8 @@ class _WidgetStateColorTransparent extends WidgetStateColor {
 }
 
 @immutable
-class _WidgetStateColorMapper extends _WidgetStateColorTransparent {
-  const _WidgetStateColorMapper(this.map);
-
-  final WidgetStateMap<Color> map;
-
-  _WidgetStateMapper<Color> get _mapper => _WidgetStateMapper<Color>(map);
-
-  @override
-  Color resolve(Set<WidgetState> states) => _mapper.resolve(states);
-
-  @override
-  bool operator ==(Object other) {
-    return other is _WidgetStateColorMapper && other.map == map;
-  }
-
-  @override
-  int get hashCode => map.hashCode;
+class _WidgetStateColorMapper extends WidgetStateMapper<Color> implements WidgetStateColor {
+  const _WidgetStateColorMapper(super.map);
 }
 
 /// Defines a [MouseCursor] whose value depends on a set of [WidgetState]s which
@@ -408,10 +393,31 @@ abstract class WidgetStateMouseCursor extends MouseCursor implements WidgetState
   /// const constructors so that they can be used in const expressions.
   const WidgetStateMouseCursor();
 
+  /// Creates a [WidgetStateMouseCursor] using a [WidgetPropertyResolver]
+  /// callback.
+  ///
+  /// A [debugDescription] may optionally be provided.
+  ///
+  /// If used as a regular [MouseCursor], the cursor resolved
+  /// in the default state (the empty set of states) will be used.
+  const factory WidgetStateMouseCursor.resolveWith(
+    WidgetPropertyResolver<MouseCursor> callback, {
+    String debugDescription,
+  }) = _WidgetStateMouseCursor;
+
+  /// Creates a [WidgetStateMouseCursor] from a [WidgetStateMap].
+  ///
+  /// {@macro flutter.widgets.WidgetStateProperty.fromMap}
+  /// It should only be used with classes that document support for
+  /// [WidgetStateMouseCursor], such as [ButtonStyle.mouseCursor].
+  const factory WidgetStateMouseCursor.fromMap(
+    WidgetStateMap<MouseCursor> map,
+  ) = _WidgetMouseCursorMapper;
+
   @protected
   @override
   MouseCursorSession createSession(int device) {
-    return resolve(<WidgetState>{}).createSession(device);
+    return resolve(const <WidgetState>{}).createSession(device);
   }
 
   /// Returns a [MouseCursor] that's to be used when a component is in the
@@ -426,11 +432,15 @@ abstract class WidgetStateMouseCursor extends MouseCursor implements WidgetState
   /// disabled, the cursor resolves to [SystemMouseCursors.basic].
   ///
   /// This cursor is the default for many widgets.
-  static const WidgetStateMouseCursor clickable = _EnabledAndDisabledMouseCursor(
-    enabledCursor: SystemMouseCursors.click,
-    disabledCursor: SystemMouseCursors.basic,
-    name: 'clickable',
+  static const WidgetStateMouseCursor clickable = WidgetStateMouseCursor.resolveWith(
+    _clickable, debugDescription: 'WidgetStateMouseCursor(clickable)',
   );
+  static MouseCursor _clickable(Set<WidgetState> states) {
+    if (states.contains(WidgetState.disabled)) {
+      return SystemMouseCursors.basic;
+    }
+    return SystemMouseCursors.click;
+  }
 
   /// A mouse cursor for widgets related to text, which resolves differently
   /// when the widget is disabled.
@@ -439,34 +449,34 @@ abstract class WidgetStateMouseCursor extends MouseCursor implements WidgetState
   /// disabled, the cursor resolves to [SystemMouseCursors.basic].
   ///
   /// This cursor is the default for many widgets.
-  static const WidgetStateMouseCursor textable = _EnabledAndDisabledMouseCursor(
-    enabledCursor: SystemMouseCursors.text,
-    disabledCursor: SystemMouseCursors.basic,
-    name: 'textable',
+  static const WidgetStateMouseCursor textable = WidgetStateMouseCursor.resolveWith(
+    _textable, debugDescription: 'WidgetStateMouseCursor(textable)',
   );
+  static MouseCursor _textable(Set<WidgetState> states) {
+    if (states.contains(WidgetState.disabled)) {
+      return SystemMouseCursors.basic;
+    }
+    return SystemMouseCursors.text;
+  }
 }
 
-class _EnabledAndDisabledMouseCursor extends WidgetStateMouseCursor {
-  const _EnabledAndDisabledMouseCursor({
-    required this.enabledCursor,
-    required this.disabledCursor,
-    required this.name,
+class _WidgetStateMouseCursor extends WidgetStateMouseCursor {
+  const _WidgetStateMouseCursor(
+    this._resolve, {
+    this.debugDescription = 'WidgetStateMouseCursor()',
   });
 
-  final MouseCursor enabledCursor;
-  final MouseCursor disabledCursor;
-  final String name;
+  final WidgetPropertyResolver<MouseCursor> _resolve;
 
   @override
-  MouseCursor resolve(Set<WidgetState> states) {
-    if (states.contains(WidgetState.disabled)) {
-      return disabledCursor;
-    }
-    return enabledCursor;
-  }
+  MouseCursor resolve(Set<WidgetState> states) => _resolve(states);
 
   @override
-  String get debugDescription => 'WidgetStateMouseCursor($name)';
+  final String debugDescription;
+}
+
+class _WidgetMouseCursorMapper extends WidgetStateMapper<MouseCursor> implements WidgetStateMouseCursor {
+  const _WidgetMouseCursorMapper(super.map);
 }
 
 /// Defines a [BorderSide] whose value depends on a set of [WidgetState]s
@@ -613,23 +623,8 @@ class _WidgetStateBorderSide extends WidgetStateBorderSide {
   BorderSide? resolve(Set<WidgetState> states) => _resolve(states);
 }
 
-class _WidgetBorderSideMapper extends WidgetStateBorderSide {
-  const _WidgetBorderSideMapper(this.map);
-
-  final WidgetStateMap<BorderSide?> map;
-
-  _WidgetStateMapper<BorderSide?> get _mapper => _WidgetStateMapper<BorderSide?>(map);
-
-  @override
-  BorderSide? resolve(Set<WidgetState> states) => _mapper.resolve(states);
-
-  @override
-  bool operator ==(Object other) {
-    return other is _WidgetBorderSideMapper && other.map == map;
-  }
-
-  @override
-  int get hashCode => map.hashCode;
+class _WidgetBorderSideMapper extends WidgetStateMapper<BorderSide?> implements WidgetStateBorderSide {
+  const _WidgetBorderSideMapper(super.map);
 }
 
 /// Defines an [OutlinedBorder] whose value depends on a set of [WidgetState]s
@@ -660,11 +655,46 @@ abstract class WidgetStateOutlinedBorder extends OutlinedBorder implements Widge
   /// const constructors so that they can be used in const expressions.
   const WidgetStateOutlinedBorder();
 
+  /// Creates a [WidgetStateOutlinedBorder] using a [WidgetPropertyResolver]
+  /// callback.
+  ///
+  /// This constructor should only be used with widgets that support
+  /// [WidgetStateOutlinedBorder], such as [ChipThemeData.shape]
+  /// (if used as a regular [OutlinedBorder], it acts the same as
+  /// an empty `RoundedRectangleBorder()` constructor).
+  const factory WidgetStateOutlinedBorder.resolveWith(
+    WidgetPropertyResolver<OutlinedBorder?> callback,
+  ) = _WidgetStateOutlinedBorder;
+
+  /// Creates a [WidgetStateOutlinedBorder] from a [WidgetStateMap].
+  ///
+  /// {@macro flutter.widgets.WidgetStateProperty.fromMap}
+  /// It should only be used with widgets that support
+  /// [WidgetStateOutlinedBorder], such as [ChipThemeData.shape]
+  /// (throws an error if used as a regular [OutlinedBorder]).
+  /// {@macro flutter.widgets.WidgetState.any}
+  const factory WidgetStateOutlinedBorder.fromMap(
+    WidgetStateMap<OutlinedBorder?> map,
+  ) = _WidgetOutlinedBorderMapper;
+
   /// Returns an [OutlinedBorder] that's to be used when a component is in the
   /// specified state. Return null to defer to the default value of the widget
   /// or theme.
   @override
   OutlinedBorder? resolve(Set<WidgetState> states);
+}
+
+class _WidgetStateOutlinedBorder extends RoundedRectangleBorder implements WidgetStateOutlinedBorder {
+  const _WidgetStateOutlinedBorder(this._resolve);
+
+  final WidgetPropertyResolver<OutlinedBorder?> _resolve;
+
+  @override
+  OutlinedBorder? resolve(Set<WidgetState> states) => _resolve(states);
+}
+
+class _WidgetOutlinedBorderMapper extends WidgetStateMapper<OutlinedBorder?> implements WidgetStateOutlinedBorder {
+  const _WidgetOutlinedBorderMapper(super.map);
 }
 
 /// Defines a [TextStyle] that is also a [WidgetStateProperty].
@@ -735,23 +765,8 @@ class _WidgetStateTextStyle extends WidgetStateTextStyle {
   TextStyle resolve(Set<WidgetState> states) => _resolve(states);
 }
 
-class _WidgetTextStyleMapper extends WidgetStateTextStyle {
-  const _WidgetTextStyleMapper(this.map);
-
-  final WidgetStateMap<TextStyle> map;
-
-  _WidgetStateMapper<TextStyle> get _mapper => _WidgetStateMapper<TextStyle>(map);
-
-  @override
-  TextStyle resolve(Set<WidgetState> states) => _mapper.resolve(states);
-
-  @override
-  bool operator ==(Object other) {
-    return other is _WidgetTextStyleMapper && other.map == map;
-  }
-
-  @override
-  int get hashCode => map.hashCode;
+class _WidgetTextStyleMapper extends WidgetStateMapper<TextStyle> implements WidgetStateTextStyle {
+  const _WidgetTextStyleMapper(super.map);
 }
 
 /// Interface for classes that [resolve] to a value of type `T` based
@@ -807,7 +822,7 @@ abstract class WidgetStateProperty<T> {
   /// {@macro flutter.widgets.WidgetState.any}
   ///
   /// {@macro flutter.widgets.WidgetStateMap}
-  const factory WidgetStateProperty.fromMap(WidgetStateMap<T> map) = _WidgetStateMapper<T>;
+  const factory WidgetStateProperty.fromMap(WidgetStateMap<T> map) = WidgetStateMapper<T>;
 
   /// Resolves the value for the given set of states if `value` is a
   /// [WidgetStateProperty], otherwise returns the value itself.
@@ -946,16 +961,35 @@ class _WidgetStatePropertyWith<T> implements WidgetStateProperty<T> {
 /// {@endtemplate}
 typedef WidgetStateMap<T> = Map<WidgetStatesConstraint, T>;
 
-// A private class, used to create the [WidgetStateProperty.fromMap] constructor.
+/// Uses a [WidgetStateMap] to resolve to a single value of type `T` based on
+/// the current set of Widget states.
+///
+/// {@macro flutter.widgets.WidgetStateMap}
+///
+/// Classes that extend [WidgetStateMapper] can implement any other interface,
+/// but should only be used for fields that document their support for
+/// [WidgetStateProperty] objects.
+///
+/// The only exceptions are classes such as [double] that are marked as
+/// `base` or `final`, since they can't be implemented—a [double] property
+/// can't be set up to also accept [WidgetStateProperty] objects
+/// and would need to pick one or the other.
+///
+/// For example, a [WidgetStateColor.fromMap] object can be passed anywhere that
+/// accepts either a [Color] or a [WidgetStateProperty] object, but attempting
+/// to access a [Color] field (such as [Color.value]) on the mapper object
+/// throws a [FlutterError].
 @immutable
-class _WidgetStateMapper<T> implements WidgetStateProperty<T> {
-  const _WidgetStateMapper(this.map);
+class WidgetStateMapper<T> with Diagnosticable implements WidgetStateProperty<T> {
+  /// Creates a [WidgetStateProperty] object that can resolve
+  /// to a value of type [T] using the provided [map].
+  const WidgetStateMapper(WidgetStateMap<T> map) : _map = map;
 
-  final WidgetStateMap<T> map;
+  final WidgetStateMap<T> _map;
 
   @override
   T resolve(Set<WidgetState> states) {
-    for (final MapEntry<WidgetStatesConstraint, T> entry in map.entries) {
+    for (final MapEntry<WidgetStatesConstraint, T> entry in _map.entries) {
       if (entry.key.isSatisfiedBy(states)) {
         return entry.value;
       }
@@ -976,14 +1010,43 @@ class _WidgetStateMapper<T> implements WidgetStateProperty<T> {
 
   @override
   bool operator ==(Object other) {
-    return other is _WidgetStateMapper && mapEquals(map, other.map);
+    return other is WidgetStateMapper<T> && mapEquals(_map, other._map);
   }
 
   @override
-  int get hashCode => MapEquality<WidgetStatesConstraint, T>().hash(map);
+  int get hashCode => MapEquality<WidgetStatesConstraint, T>().hash(_map);
 
   @override
-  String toString() => '$map';
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'WidgetStateMapper<$T>($_map)';
+  }
+
+  @override
+  Never noSuchMethod(Invocation invocation) {
+    throw FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary(
+        'There was an attempt to access the "${invocation.memberName}" '
+        'field of a WidgetStateMapper<$T> object.',
+      ),
+      ErrorDescription('$this'),
+      ErrorDescription(
+        'WidgetStateProperty objects should only be used '
+        'in places that document their support.',
+      ),
+      ErrorHint(
+        'Double-check whether the map was used in a place that '
+        'documents support for WidgetStateProperty objects. If so, '
+        'please file a bug report. (The https://pub.dev/ page for a package '
+        'contains a link to "View/report issues".)',
+      ),
+    ]);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties, {String prefix = ''}) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<WidgetStateMap<T>>('map', _map));
+  }
 }
 
 /// Convenience class for creating a [WidgetStateProperty] that

--- a/packages/flutter/test/widgets/widget_state_property_test.dart
+++ b/packages/flutter/test/widgets/widget_state_property_test.dart
@@ -145,6 +145,121 @@ void main() {
     expect(borderSide.color, isSameColorAs(const Color(0xff0000ff)));
     expect(borderSide.width, 12.0);
   });
+
+  test('.fromMap() constructors perform accurate equality checks', () {
+    const Color white = Color(0xFFFFFFFF);
+    const Color black = Color(0xFF000000);
+    final WidgetStateColor color1 = WidgetStateColor.fromMap(
+      <WidgetStatesConstraint, Color>{
+        WidgetState.focused | WidgetState.hovered: white,
+        WidgetState.any: black,
+      },
+    );
+    final WidgetStateColor color2 = WidgetStateColor.fromMap(
+      <WidgetStatesConstraint, Color>{
+        WidgetState.focused | WidgetState.hovered: white,
+        WidgetState.any: black,
+      },
+    );
+    final WidgetStateColor color3 = WidgetStateColor.fromMap(
+      <WidgetStatesConstraint, Color>{
+        WidgetState.focused | WidgetState.hovered: black,
+        WidgetState.any: white,
+      },
+    );
+    expect(color1 == color2, isTrue);
+    expect(color1 == color3, isFalse);
+
+    const BorderSide whiteBorder = BorderSide(color: white);
+    const BorderSide blackBorder = BorderSide();
+    final WidgetStateBorderSide side1 = WidgetStateBorderSide.fromMap(
+      <WidgetStatesConstraint, BorderSide>{
+        WidgetState.focused | WidgetState.hovered: whiteBorder,
+        WidgetState.any: blackBorder,
+      },
+    );
+    final WidgetStateBorderSide side2 = WidgetStateBorderSide.fromMap(
+      <WidgetStatesConstraint, BorderSide>{
+        WidgetState.focused | WidgetState.hovered: whiteBorder,
+        WidgetState.any: blackBorder,
+      },
+    );
+    final WidgetStateBorderSide side3 = WidgetStateBorderSide.fromMap(
+      <WidgetStatesConstraint, BorderSide>{
+        WidgetState.focused | WidgetState.hovered: blackBorder,
+        WidgetState.any: whiteBorder,
+      },
+    );
+    expect(side1 == side2, isTrue);
+    expect(side1 == side3, isFalse);
+
+    const OutlinedBorder whiteRRect = RoundedRectangleBorder(side: whiteBorder);
+    const OutlinedBorder blackRRect = RoundedRectangleBorder(side: blackBorder);
+    final WidgetStateOutlinedBorder border1 = WidgetStateOutlinedBorder.fromMap(
+      <WidgetStatesConstraint, OutlinedBorder>{
+        WidgetState.focused | WidgetState.hovered: whiteRRect,
+        WidgetState.any: blackRRect,
+      },
+    );
+    final WidgetStateOutlinedBorder border2 = WidgetStateOutlinedBorder.fromMap(
+      <WidgetStatesConstraint, OutlinedBorder>{
+        WidgetState.focused | WidgetState.hovered: whiteRRect,
+        WidgetState.any: blackRRect,
+      },
+    );
+    final WidgetStateOutlinedBorder border3 = WidgetStateOutlinedBorder.fromMap(
+      <WidgetStatesConstraint, OutlinedBorder>{
+        WidgetState.focused | WidgetState.hovered: blackRRect,
+        WidgetState.any: whiteRRect,
+      },
+    );
+    expect(border1 == border2, isTrue);
+    expect(border1 == border3, isFalse);
+
+    final WidgetStateMouseCursor cursor1 = WidgetStateMouseCursor.fromMap(
+      <WidgetStatesConstraint, MouseCursor>{
+        WidgetState.focused | WidgetState.hovered: MouseCursor.defer,
+        WidgetState.any: MouseCursor.uncontrolled,
+      },
+    );
+    final WidgetStateMouseCursor cursor2 = WidgetStateMouseCursor.fromMap(
+      <WidgetStatesConstraint, MouseCursor>{
+        WidgetState.focused | WidgetState.hovered: MouseCursor.defer,
+        WidgetState.any: MouseCursor.uncontrolled,
+      },
+    );
+    final WidgetStateMouseCursor cursor3 = WidgetStateMouseCursor.fromMap(
+      <WidgetStatesConstraint, MouseCursor>{
+        WidgetState.focused | WidgetState.hovered: MouseCursor.uncontrolled,
+        WidgetState.any: MouseCursor.defer,
+      },
+    );
+    expect(cursor1 == cursor2, isTrue);
+    expect(cursor1 == cursor3, isFalse);
+
+    const TextStyle whiteText = TextStyle(color: white);
+    const TextStyle blackText = TextStyle(color: black);
+    final WidgetStateTextStyle style1 = WidgetStateTextStyle.fromMap(
+      <WidgetStatesConstraint, TextStyle>{
+        WidgetState.focused | WidgetState.hovered: whiteText,
+        WidgetState.any: blackText,
+      },
+    );
+    final WidgetStateTextStyle style2 = WidgetStateTextStyle.fromMap(
+      <WidgetStatesConstraint, TextStyle>{
+        WidgetState.focused | WidgetState.hovered: whiteText,
+        WidgetState.any: blackText,
+      },
+    );
+    final WidgetStateTextStyle style3 = WidgetStateTextStyle.fromMap(
+      <WidgetStatesConstraint, TextStyle>{
+        WidgetState.focused | WidgetState.hovered: blackText,
+        WidgetState.any: whiteText,
+      },
+    );
+    expect(style1 == style2, isTrue);
+    expect(style1 == style3, isFalse);
+  });
 }
 
-Set<WidgetState> enabled = <WidgetState>{};
+const Set<WidgetState> enabled = <WidgetState>{};


### PR DESCRIPTION
This class looks like it _should_ give valid equality checks:

```dart
class _WidgetStateColorMapper extends _WidgetStateColorTransparent {
  const _WidgetStateColorMapper(this.map);

  final WidgetStateMap<Color> map;

  _WidgetStateMapper<Color> get _mapper => _WidgetStateMapper<Color>(map);

  @override
  Color resolve(Set<WidgetState> states) => _mapper.resolve(states);

  @override
  bool operator ==(Object other) {
    return other is _WidgetStateColorMapper && other.map == map;
  }

  @override
  int get hashCode => map.hashCode;
}
```

But I made a mistake: I should have used `other._mapper == _mapper` and `_mapper.hashCode`.

<br>

It'd be pretty nice if no copy-pasting was needed in the first place:

```dart
class _WidgetStateColorMapper extends WidgetStateMapper<Color> implements WidgetStateColor {
  const _WidgetStateColorMapper(super.map);
}
```

<br><br>

This PR makes `WidgetStateMapper` a public class, similar to `WidgetStatePropertyAll`. The new API, when used incorrectly, will `throw` with a detailed error message, rather than silently returning irrelevant values.