### PR TITLE
Fix Menu buttons `MouseRegion` callbacks misfired on Android

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -13,6 +13,7 @@ library;
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -1159,8 +1160,30 @@ class _MenuItemButtonState extends State<MenuItemButton> {
 
     if (widget.onHover != null || widget.requestFocusOnHover) {
       child = MouseRegion(
-        onHover: _handlePointerHover,
-        onExit: _handlePointerExit,
+        onHover: (PointerHoverEvent event) {
+          switch (event.kind) {
+            case PointerDeviceKind.mouse:
+            case PointerDeviceKind.trackpad:
+              _handlePointerHover(event);
+            case PointerDeviceKind.stylus:
+            case PointerDeviceKind.invertedStylus:
+            case PointerDeviceKind.unknown:
+            case PointerDeviceKind.touch:
+              break;
+            }
+        },
+        onExit: (PointerExitEvent event) {
+          switch (event.kind) {
+            case PointerDeviceKind.mouse:
+            case PointerDeviceKind.trackpad:
+              _handlePointerExit(event);
+            case PointerDeviceKind.stylus:
+            case PointerDeviceKind.invertedStylus:
+            case PointerDeviceKind.unknown:
+            case PointerDeviceKind.touch:
+              break;
+          }
+        },
         child: child,
       );
     }
@@ -2029,8 +2052,30 @@ class _SubmenuButtonState extends State<SubmenuButton> {
           }
 
           child = MouseRegion(
-            onHover: handlePointerHover,
-            onExit: handlePointerExit,
+            onHover: (PointerHoverEvent event) {
+              switch (event.kind) {
+                case PointerDeviceKind.mouse:
+                case PointerDeviceKind.trackpad:
+                  handlePointerHover(event);
+                case PointerDeviceKind.stylus:
+                case PointerDeviceKind.invertedStylus:
+                case PointerDeviceKind.unknown:
+                case PointerDeviceKind.touch:
+                  break;
+              }
+            },
+            onExit: (PointerExitEvent event) {
+              switch (event.kind) {
+                case PointerDeviceKind.mouse:
+                case PointerDeviceKind.trackpad:
+                  handlePointerExit(event);
+                case PointerDeviceKind.stylus:
+                case PointerDeviceKind.invertedStylus:
+                case PointerDeviceKind.unknown:
+                case PointerDeviceKind.touch:
+                  break;
+              }
+            },
             child: child,
           );
 


### PR DESCRIPTION
Fixes [SubmenuButton submenus close automatically only on first activation [Android]](https://github.com/flutter/flutter/issues/154842)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Scaffold(
        body: Center(
          child: MenuAnchor(
            builder: (BuildContext context, MenuController controller, Widget? child) => TextButton(
              onPressed: () {
                controller.isOpen ? controller.close() : controller.open();
              },
              child: const Text('Press here'),
            ),
            menuChildren: <Widget>[
              SubmenuButton(

                menuChildren: <Widget>[
                  MenuItemButton(
                    onPressed: () {},
                    child: const Text('Menu item'),
                  ),
                ],
                child: const Text('Submenu'),
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```

</details>

### Before



https://github.com/user-attachments/assets/f0eaca73-dac7-4431-b4b8-228ee3c9a226



### After


https://github.com/user-attachments/assets/6800dca2-9e9e-4aa7-934d-46f1e08fb0dc



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
