### PR TITLE
when setting up the log reader for a device during `flutter run`, discard any `RPCError` thrown due to the device being disconnected

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -416,7 +416,10 @@ class FlutterDevice {
     _loggingSubscription = null;
   }
 
-  Future<void> initLogReader() async {
+  /// Attempts to set up reading logs from the Flutter app on the device.
+  ///
+  /// This can fail if the device if no longer connected.
+  Future<void> tryInitLogReader() async {
     final vm_service.VM? vm = await vmService!.getVmGuarded();
     if (vm == null) {
       globals.printError(

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -417,7 +417,15 @@ class FlutterDevice {
   }
 
   Future<void> initLogReader() async {
-    final vm_service.VM vm = await vmService!.service.getVM();
+    final vm_service.VM? vm = await vmService!.getVmGuarded();
+    if (vm == null) {
+      globals.printError(
+        'Unable to initiate log reader for device'
+        '${device?.name}, because the Flutter VM service connection '
+        'is closed.',
+      );
+      return;
+    }
     final DeviceLogReader logReader = await device!.getLogReader(app: package);
     logReader.appPid = vm.pid;
   }

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -104,7 +104,7 @@ class ColdRunner extends ResidentRunner {
       if (device!.vmService == null) {
         continue;
       }
-      await device.initLogReader();
+      await device.tryInitLogReader();
       globals.printTrace('Connected to ${device.device!.name}');
     }
 
@@ -154,7 +154,7 @@ class ColdRunner extends ResidentRunner {
     }
 
     for (final FlutterDevice? device in flutterDevices) {
-      await device!.initLogReader();
+      await device!.tryInitLogReader();
     }
     for (final FlutterDevice? device in flutterDevices) {
       final List<FlutterView> views = await device!.vmService!.getFlutterViews();

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -261,7 +261,7 @@ class HotRunner extends ResidentRunner {
     }
 
     for (final FlutterDevice? device in flutterDevices) {
-      await device!.initLogReader();
+      await device!.tryInitLogReader();
       device
         .developmentShaderCompiler
         .configureCompiler(device.targetPlatform);

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -491,6 +491,22 @@ class FlutterVmService {
   final Uri? wsAddress;
   final Uri? httpAddress;
 
+  /// Calls [service.getVM]. However, in the case that an [vm_service.RPCError]
+  /// is thrown due to the service being disconnected, the error is discarded
+  /// and null is returned.
+  Future<vm_service.VM?> getVmGuarded() async {
+    try {
+      return await service.getVM();
+    } on vm_service.RPCError catch (err) {
+      if (err.code == RPCErrorCodes.kServiceDisappeared ||
+          err.message.contains('Service connection disposed')) {
+        globals.printTrace('VmService.getVm call failed: $err');
+        return null;
+      }
+      rethrow;
+    }
+  }
+
   Future<vm_service.Response?> callMethodWrapper(
     String method, {
     String? isolateId,

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -165,7 +165,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   }
 
   @override
-  Future<void> initLogReader() async { }
+  Future<void> tryInitLogReader() async { }
 }
 
 class FakeDevice extends Fake implements Device {

--- a/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
@@ -228,7 +228,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   Future<void> stopEchoingDeviceLog() async { }
 
   @override
-  Future<void> initLogReader() async { }
+  Future<void> tryInitLogReader() async { }
 
   @override
   Future<Uri> setupDevFS(String fsName, Directory rootDirectory) async {

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1948,7 +1948,7 @@ flutter:
     );
     final TestFlutterDevice flutterDevice = TestFlutterDevice(device);
     flutterDevice.vmService = fakeVmServiceHost!.vmService;
-    await flutterDevice.initLogReader();
+    await flutterDevice.tryInitLogReader();
     final BufferLogger logger = globals.logger as BufferLogger;
     expect(
       logger.traceText,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1755,7 +1755,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   Future<void> stopEchoingDeviceLog() async {}
 
   @override
-  Future<void> initLogReader() async {}
+  Future<void> tryInitLogReader() async {}
 
   @override
   Future<Uri?> setupDevFS(String fsName, Directory rootDirectory) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/154903

This PR contains some refactoring. To make the actual change easier to figure out, I've tried to separate parts of the change into multiple commits for easier reviewing 🙂.

**I plan on cherry-picking this change to stable.**

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
