### PR TITLE
iOS: update provisioning profile for 2024-2025 cert

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -268,8 +268,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "version:to_2025"}
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
         ]
       os: Mac-13|Mac-14
       cpu: x86
@@ -286,8 +285,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "version:to_2025"}
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
         ]
       os: Mac-13|Mac-14
       cpu: x86
@@ -304,8 +302,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "none"}
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
         ]
       os: Mac-13|Mac-14
       cpu: arm64

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -127,7 +127,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       device_type: none
@@ -143,7 +143,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       device_type: none
@@ -160,7 +160,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       device_type: none
       mac_model: "Macmini8,1"
@@ -179,7 +179,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       device_type: none
@@ -197,7 +197,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       device_type: none
@@ -269,7 +269,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       cpu: x86
@@ -287,7 +287,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       cpu: x86


### PR DESCRIPTION
Tells our iOS bots to use the provisioning profile stored in the flutter_internal/mac/mobileprovision CIPD packages tagged `version:to_2025`.

This CIPD package contains an updated provisioning profile which supports both the current development signing certificate expiring in October 2024, and the updated signing cert expiring in August 2025.

Also removes the CIPD dependency for devicelab tasks. On devicelab bots, the cert and provisioning profile are deployed via Salt, not via CIPD. We only need this dependency on the Chromium bots.

CIPD packages can be seen at:
https://chrome-infra-packages.appspot.com/p/flutter_internal/mac/mobileprovision

Required for: https://g-issues.chromium.org/issues/366034566

Issue: https://github.com/flutter/flutter/issues/152888

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
