### PR TITLE
fix: cleanup xcode_backend.sh to fix iOS build w/ `NixOS/nixpkgs` flutter

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -6,24 +6,7 @@
 # exit on error, or usage of unset var
 set -euo pipefail
 
-# Needed because if it is set, cd may print the path it changed to.
-unset CDPATH
-
-function follow_links() (
-  cd -P "$(dirname -- "$1")"
-  file="$PWD/$(basename -- "$1")"
-  while [[ -h "$file" ]]; do
-    cd -P "$(dirname -- "$file")"
-    file="$(readlink -- "$file")"
-    cd -P "$(dirname -- "$file")"
-    file="$PWD/$(basename -- "$file")"
-  done
-  echo "$file"
-)
-
-PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
-BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
-FLUTTER_ROOT="$BIN_DIR/../../.."
-DART="$FLUTTER_ROOT/bin/dart"
-
-"$DART" "$BIN_DIR/xcode_backend.dart" "$@"
+# Run `dart ./xcode_backend.dart` with the dart from $FLUTTER_ROOT.
+dart="${FLUTTER_ROOT}/bin/dart"
+xcode_backend_dart="${BASH_SOURCE[0]%.sh}.dart"
+exec "${dart}" "${xcode_backend_dart}" "$@"


### PR DESCRIPTION
### Overview

This patch cleans up the `packages/flutter_tools/bin/xcode_backend.sh` wrapper. All it does now is (morally):

```bash
exec $FLUTTER_ROOT/bin/dart ./xcode_backend.dart
```

Xcode calls this wrapper during an iOS build. The previous `xcode_backend.sh` tries to discover `$FLUTTER_ROOT` from argv[0], even though its presence is already guaranteed (the wrapped `xcode_backend.dart` in fact relies on this env existing).

This `$FLUTTER_ROOT` logic then breaks when run using flutter packaged by `nixpkgs`.

### Extra context

See also: https://github.com/NixOS/nixpkgs/pull/341470

When using nixpkgs flutter, the flutter SDK directory is composed of several immutable layers, joined together using symlinks (called a `symlinkJoin`). Without this patch, the auto-discover traverses the symlinks into the wrong layer, and so it uses an "unwrapped" `dart` command instead of a "wrapped" dart that sets some important envs/flags (like `$FLUTTER_ROOT`).

See: <https://github.com/NixOS/nixpkgs/blob/6ec57b76a9a280f4f99bd0dca1e4ab4880fc02c4/pkgs/development/compilers/flutter/flutter.nix#L126-L134>

Using the "unwrapped" dart then manifests in this error when compiling, since it doesn't see the ios build-support artifacts:

```
$ flutter run -d iphone
Running Xcode build...
Xcode build done.                                            6.4s
Failed to build iOS app
Error (Xcode): Target debug_unpack_ios failed: Error: Flutter failed to create a directory at "/nix/store/xhcdmzj0m8x64fky1mdsyv5311f2sxs9-flutter-3.24.1-unwrapped/bin/cache/artifacts".
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.