### PR TITLE
Fix git command in Quality-Assurance.md

### DIFF
--- a/docs/releases/Quality-Assurance.md
+++ b/docs/releases/Quality-Assurance.md
@@ -12,7 +12,7 @@ When a beta build is announced, switch to the beta channel:
 
 If you get a `git` error, then you probably have a contributor checkout of Flutter. Use git instead:
 
-> `git fetch upstream/beta && git checkout beta`
+> `git fetch upstream && git checkout upstream/beta`
 
 Either way, check that everything is as you expect:
 


### PR DESCRIPTION
Correct the Quality-Assurance contributing doc's wrong git command.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.