### PR TITLE
Update ios provisioning profiles on 3.24 branch

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -107,7 +107,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       device_type: none
@@ -123,7 +123,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       device_type: none
@@ -140,7 +140,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       device_type: none
       mac_model: "Macmini8,1"
@@ -159,7 +159,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       device_type: none
@@ -177,7 +177,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       device_type: none
@@ -226,7 +226,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       cpu: x86
@@ -244,7 +244,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
-          {"dependency": "apple_signing", "version": "version:to_2024"}
+          {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
       os: Mac-13|Mac-14
       cpu: x86


### PR DESCRIPTION
A cherrypick of https://github.com/flutter/flutter/pull/155101 to the 3.24 RC branch.

Part of https://github.com/flutter/flutter/issues/152888.