### PR TITLE
`SelectionArea`\`SelectableRegion` should collapse selection with `CollapseSelectionEvent`

### DIFF
--- a/examples/api/lib/material/selectable_region/selectable_region.0.dart
+++ b/examples/api/lib/material/selectable_region/selectable_region.0.dart
@@ -171,11 +171,15 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
     switch (event.type) {
       case SelectionEventType.startEdgeUpdate:
       case SelectionEventType.endEdgeUpdate:
+      case SelectionEventType.collapseSelection:
+
         final Rect renderObjectRect = Rect.fromLTWH(0, 0, size.width, size.height);
         // Normalize offset in case it is out side of the rect.
         final Offset point = globalToLocal((event as SelectionEdgeUpdateEvent).globalPosition);
         final Offset adjustedPoint = SelectionUtils.adjustDragOffset(renderObjectRect, point);
-        if (event.type == SelectionEventType.startEdgeUpdate) {
+        if (event.type == SelectionEventType.collapseSelection) {
+          _start = _end = adjustedPoint;
+        } else if (event.type == SelectionEventType.startEdgeUpdate) {
           _start = adjustedPoint;
         } else {
           _end = adjustedPoint;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1438,7 +1438,7 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
         result = _handleSelectAll();
       case SelectionEventType.collapseSelection:
         final CollapseSelectionEvent collapseSelection = event as CollapseSelectionEvent;
-        result = _handleCollapseSelection(event.globalPosition);
+        result = _handleCollapseSelection(collapseSelection.globalPosition);
       case SelectionEventType.selectWord:
         final SelectWordSelectionEvent selectWord = event as SelectWordSelectionEvent;
         result = _handleSelectWord(selectWord.globalPosition);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1436,6 +1436,9 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
         result = _handleClearSelection();
       case SelectionEventType.selectAll:
         result = _handleSelectAll();
+      case SelectionEventType.collapseSelection:
+        final CollapseSelectionEvent collapseSelection = event as CollapseSelectionEvent;
+        result = _handleCollapseSelection(event.globalPosition);
       case SelectionEventType.selectWord:
         final SelectWordSelectionEvent selectWord = event as SelectWordSelectionEvent;
         result = _handleSelectWord(selectWord.globalPosition);
@@ -2645,7 +2648,7 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
     return SelectionResult.none;
   }
 
-  SelectionResult _handleSelectTextBoundary(_TextBoundaryRecord textBoundary) {
+  SelectionResult _handleSelectTextBoundary(_TextBoundaryRecord textBoundary, { bool markOrigin = true }) {
     // This fragment may not contain the boundary, decide what direction the target
     // fragment is located in. Because fragments are separated by placeholder
     // spans, we also check if the beginning or end of the boundary is touching
@@ -2660,7 +2663,9 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
     assert(textBoundary.boundaryStart.offset >= range.start && textBoundary.boundaryEnd.offset <= range.end);
     _textSelectionStart = textBoundary.boundaryStart;
     _textSelectionEnd = textBoundary.boundaryEnd;
-    _selectableContainsOriginTextBoundary = true;
+    if (markOrigin) {
+      _selectableContainsOriginTextBoundary = true;
+    }
     return SelectionResult.end;
   }
 
@@ -2710,6 +2715,12 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
       end = TextPosition(offset: textBoundary.end, affinity: TextAffinity.upstream);
     }
     return (boundaryStart: start, boundaryEnd: end);
+  }
+
+  SelectionResult _handleCollapseSelection(Offset globalPosition) {
+    final TextPosition position = paragraph.getPositionForOffset(paragraph.globalToLocal(globalPosition));
+    final _TextBoundaryRecord collapsedBoundary = (boundaryStart: position, boundaryEnd: position);
+    return _handleSelectTextBoundary(collapsedBoundary, markOrigin: false);
   }
 
   SelectionResult _handleSelectWord(Offset globalPosition) {

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -297,6 +297,12 @@ enum SelectionEventType {
   /// Used by [SelectAllSelectionEvent].
   selectAll,
 
+  /// An event to select collapse the selection at the location
+  /// [CollapseSelectionEvent.globalPosition].
+  ///
+  /// Used by [CollapseSelectionEvent].
+  collapseSelection,
+
   /// An event to select a word at the location
   /// [SelectWordSelectionEvent.globalPosition].
   ///
@@ -370,6 +376,17 @@ class SelectAllSelectionEvent extends SelectionEvent {
 class ClearSelectionEvent extends SelectionEvent {
   /// Create a clear selection event.
   const ClearSelectionEvent(): super._(SelectionEventType.clear);
+}
+
+/// Collapses the selection at the location.
+///
+/// This event can be sent as the result of a single tap or click.
+class CollapseSelectionEvent extends SelectionEvent {
+  /// Creates a collapse selection event at the [globalPosition].
+  const CollapseSelectionEvent({required this.globalPosition}): super._(SelectionEventType.collapseSelection);
+
+  /// The position in global coordinates to collapse the selection at.
+  final Offset globalPosition;
 }
 
 /// Selects the whole word at the location.

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1472,6 +1472,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
         _selectableEndEdgeUpdateRecords.remove(selectable);
         _selectableStartEdgeUpdateRecords.remove(selectable);
       case SelectionEventType.selectAll:
+      case SelectionEventType.collapseSelection:
       case SelectionEventType.selectWord:
       case SelectionEventType.selectParagraph:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1299,8 +1299,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_selectParagraphAt], which selects an entire paragraph at the location.
   ///  * [selectAll], which selects the entire content.
   void _collapseSelectionAt({required Offset offset}) {
-    _selectStartTo(offset: offset);
-    _selectEndTo(offset: offset);
+    // There may be other selection ongoing.
+    _finalizeSelection();
+    _selectable?.dispatchSelectionEvent(CollapseSelectionEvent(globalPosition: offset));
   }
 
   /// Selects a whole word at the `offset` location.
@@ -1864,6 +1865,21 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
     return result;
   }
 
+  /// Collapse the selection in a [Selectable] at the location
+  /// [CollapseSelectionEvent.globalPosition].
+  @override
+  SelectionResult handleCollapseSelection(CollapseSelectionEvent event) {
+    final SelectionResult result = super.handleCollapseSelection(event);
+    if (currentSelectionStartIndex != -1) {
+      _hasReceivedStartEvent.add(selectables[currentSelectionStartIndex]);
+    }
+    if (currentSelectionEndIndex != -1) {
+      _hasReceivedEndEvent.add(selectables[currentSelectionEndIndex]);
+    }
+    _updateLastEdgeEventsFromGeometries();
+    return result;
+  }
+
   /// Selects a word in a [Selectable] at the location
   /// [SelectWordSelectionEvent.globalPosition].
   @override
@@ -1934,6 +1950,7 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
         _hasReceivedStartEvent.remove(selectable);
         _hasReceivedEndEvent.remove(selectable);
       case SelectionEventType.selectAll:
+      case SelectionEventType.collapseSelection:
       case SelectionEventType.selectWord:
       case SelectionEventType.selectParagraph:
         break;
@@ -2497,9 +2514,14 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   }
 
   SelectionResult _handleSelectBoundary(SelectionEvent event) {
-    assert(event is SelectWordSelectionEvent || event is SelectParagraphSelectionEvent, 'This method should only be given selection events that select text boundaries.');
+    assert(event is SelectWordSelectionEvent
+           || event is SelectParagraphSelectionEvent
+           || event is CollapseSelectionEvent,
+           'This method should only be given selection events that select boundaries.');
     late final Offset effectiveGlobalPosition;
-    if (event.type == SelectionEventType.selectWord) {
+    if (event.type == SelectionEventType.collapseSelection) {
+      effectiveGlobalPosition = (event as CollapseSelectionEvent).globalPosition;
+    } else if (event.type == SelectionEventType.selectWord) {
       effectiveGlobalPosition = (event as SelectWordSelectionEvent).globalPosition;
     } else if (event.type == SelectionEventType.selectParagraph) {
       effectiveGlobalPosition = (event as SelectParagraphSelectionEvent).globalPosition;
@@ -2546,6 +2568,13 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     }
     assert(lastSelectionResult == null);
     return SelectionResult.end;
+  }
+
+  /// Collapses the selection in a [Selectable] at the location
+  /// [CollapseSelectionEvent.globalPosition].
+  @protected
+  SelectionResult handleCollapseSelection(CollapseSelectionEvent event) {
+    return _handleSelectBoundary(event);
   }
 
   /// Selects a word in a [Selectable] at the location
@@ -2688,6 +2717,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       case SelectionEventType.selectAll:
         _extendSelectionInProgress = false;
         result = handleSelectAll(event as SelectAllSelectionEvent);
+      case SelectionEventType.collapseSelection:
+        _extendSelectionInProgress = false;
+        result = handleCollapseSelection(event as CollapseSelectionEvent);
       case SelectionEventType.selectWord:
         _extendSelectionInProgress = false;
         result = handleSelectWord(event as SelectWordSelectionEvent);

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -1298,6 +1298,21 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
     return result;
   }
 
+  /// Collapses a selection in a selectable at the location
+  /// [CollapseSelectionEvent.globalPosition].
+  @override
+  SelectionResult handleCollapseSelection(CollapseSelectionEvent event) {
+    final SelectionResult result = super.handleCollapseSelection(event);
+    if (currentSelectionStartIndex != -1) {
+      _hasReceivedStartEvent.add(selectables[currentSelectionStartIndex]);
+    }
+    if (currentSelectionEndIndex != -1) {
+      _hasReceivedEndEvent.add(selectables[currentSelectionEndIndex]);
+    }
+    _updateLastEdgeEventsFromGeometries();
+    return result;
+  }
+
   /// Selects a word in a selectable at the location
   /// [SelectWordSelectionEvent.globalPosition].
   @override
@@ -1361,6 +1376,7 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
         _hasReceivedStartEvent.remove(selectable);
         _hasReceivedEndEvent.remove(selectable);
       case SelectionEventType.selectAll:
+      case SelectionEventType.collapseSelection:
       case SelectionEventType.selectWord:
       case SelectionEventType.selectParagraph:
         break;

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -472,11 +472,9 @@ void main() {
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle();
-      expect(renderSelectionSpy.events.length, 2);
-      expect(renderSelectionSpy.events[0], isA<SelectionEdgeUpdateEvent>());
-      expect((renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent).type, SelectionEventType.startEdgeUpdate);
-      expect(renderSelectionSpy.events[1], isA<SelectionEdgeUpdateEvent>());
-      expect((renderSelectionSpy.events[1] as SelectionEdgeUpdateEvent).type, SelectionEventType.endEdgeUpdate);
+      expect(renderSelectionSpy.events.length, 1);
+      expect(renderSelectionSpy.events[0], isA<CollapseSelectionEvent>());
+      expect((renderSelectionSpy.events[0] as CollapseSelectionEvent).type, SelectionEventType.collapseSelection);
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/102410.
 
     testWidgets('touch long press sends select-word event', (WidgetTester tester) async {
@@ -647,10 +645,8 @@ void main() {
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();
-      expect(
-        renderSelectionSpy.events.every((SelectionEvent element) => element is SelectionEdgeUpdateEvent),
-        isTrue,
-      );
+      expect(renderSelectionSpy.events.length, 1);
+      expect(renderSelectionSpy.events[0], isA<CollapseSelectionEvent>());
     });
   });
 


### PR DESCRIPTION
`SelectableRegion` and `SelectionArea` should use a single `CollapseSelectionEvent` to collapse the selection at a position in a `Selectable` instead of sending two `SelectionEdgeUpdateEvent`s, one for each edge. This prevents the selection from falling into a strange state where it is discontinuous in between both edge update events.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.