### PR TITLE
Fix `GlowingOverscrollIndicator` examples

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -321,6 +321,4 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/interactive_viewer/interactive_viewer.constrained.0_test.dart',
   'examples/api/test/widgets/interactive_viewer/interactive_viewer.transformation_controller.0_test.dart',
   'examples/api/test/widgets/notification_listener/notification.0_test.dart',
-  'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart',
-  'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart',
 };

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 /// Flutter code sample for [GlowingOverscrollIndicator].
@@ -14,10 +15,34 @@ class GlowingOverscrollIndicatorExampleApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      scrollBehavior: const AlwaysGlow(),
+      theme: ThemeData(colorSchemeSeed: Colors.amber),
       home: Scaffold(
         appBar: AppBar(title: const Text('GlowingOverscrollIndicator Sample')),
         body: const GlowingOverscrollIndicatorExample(),
       ),
+    );
+  }
+}
+
+const Set<PointerDeviceKind> allPointers = <PointerDeviceKind>{...PointerDeviceKind.values};
+
+class AlwaysGlow extends MaterialScrollBehavior {
+  const AlwaysGlow();
+
+  @override
+  Set<PointerDeviceKind> get dragDevices => allPointers;
+
+  @override
+  Widget buildOverscrollIndicator(
+    BuildContext context,
+    Widget child,
+    ScrollableDetails details,
+  ) {
+    return GlowingOverscrollIndicator(
+      axisDirection: details.direction,
+      color: Colors.amberAccent,
+      child: child,
     );
   }
 }
@@ -27,7 +52,35 @@ class GlowingOverscrollIndicatorExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double leadingPaintOffset = MediaQuery.of(context).padding.top + AppBar().preferredSize.height;
+    const ScrollView scrollView = CustomScrollView(slivers: <Widget>[
+      SliverAppBar(title: Text('Custom PaintOffset')),
+      SliverToBoxAdapter(
+        child: DefaultTextStyle(
+          style: TextStyle(
+            color: Colors.amberAccent,
+            fontSize: 24,
+            fontWeight: FontWeight.w600,
+          ),
+          child: ColoredBox(
+            color: Colors.grey,
+            child: SizedBox(
+              width: double.infinity,
+              height: 80,
+              child: Center(child: Text('Glow all day!')),
+            ),
+          ),
+        ),
+      ),
+      SliverFillRemaining(
+        child: Icon(
+          Icons.sunny,
+          color: Colors.amberAccent,
+          size: 128,
+        ),
+      ),
+    ]);
+
+    final double leadingPaintOffset = MediaQuery.paddingOf(context).top + kToolbarHeight;
     return NotificationListener<OverscrollIndicatorNotification>(
       onNotification: (OverscrollIndicatorNotification notification) {
         if (notification.leading) {
@@ -35,19 +88,7 @@ class GlowingOverscrollIndicatorExample extends StatelessWidget {
         }
         return false;
       },
-      child: CustomScrollView(
-        slivers: <Widget>[
-          const SliverAppBar(title: Text('Custom PaintOffset')),
-          SliverToBoxAdapter(
-            child: Container(
-              color: Colors.amberAccent,
-              height: 100,
-              child: const Center(child: Text('Glow all day!')),
-            ),
-          ),
-          const SliverFillRemaining(child: FlutterLogo()),
-        ],
-      ),
+      child: scrollView,
     );
   }
 }

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
@@ -52,35 +52,8 @@ class GlowingOverscrollIndicatorExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const ScrollView scrollView = CustomScrollView(slivers: <Widget>[
-      SliverAppBar(title: Text('Custom PaintOffset')),
-      SliverToBoxAdapter(
-        child: DefaultTextStyle(
-          style: TextStyle(
-            color: Colors.amberAccent,
-            fontSize: 24,
-            fontWeight: FontWeight.w600,
-          ),
-          child: ColoredBox(
-            color: Colors.grey,
-            child: SizedBox(
-              width: double.infinity,
-              height: 80,
-              child: Center(child: Text('Glow all day!')),
-            ),
-          ),
-        ),
-      ),
-      SliverFillRemaining(
-        child: Icon(
-          Icons.sunny,
-          color: Colors.amberAccent,
-          size: 128,
-        ),
-      ),
-    ]);
-
     final double leadingPaintOffset = MediaQuery.paddingOf(context).top + kToolbarHeight;
+
     return NotificationListener<OverscrollIndicatorNotification>(
       onNotification: (OverscrollIndicatorNotification notification) {
         if (notification.leading) {
@@ -88,7 +61,35 @@ class GlowingOverscrollIndicatorExample extends StatelessWidget {
         }
         return false;
       },
-      child: scrollView,
+      child: const CustomScrollView(
+        slivers: <Widget>[
+          SliverAppBar(title: Text('Custom PaintOffset')),
+          SliverToBoxAdapter(
+            child: DefaultTextStyle(
+              style: TextStyle(
+                color: Colors.amberAccent,
+                fontSize: 24,
+                fontWeight: FontWeight.w600,
+              ),
+              child: ColoredBox(
+                color: Colors.grey,
+                child: SizedBox(
+                  width: double.infinity,
+                  height: 80,
+                  child: Center(child: Text('Glow all day!')),
+                ),
+              ),
+            ),
+          ),
+          SliverFillRemaining(
+            child: Icon(
+              Icons.sunny,
+              color: Colors.amberAccent,
+              size: 128,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
@@ -27,6 +27,8 @@ class GlowingOverscrollIndicatorExampleApp extends StatelessWidget {
 
 const Set<PointerDeviceKind> allPointers = <PointerDeviceKind>{...PointerDeviceKind.values};
 
+/// Passing this class into [MaterialApp.scrollBehavior] ensures that a
+/// [GlowingOverscrollIndicator] is created, regardless of the target platform.
 class AlwaysGlow extends MaterialScrollBehavior {
   const AlwaysGlow();
 

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
@@ -27,8 +27,8 @@ class GlowingOverscrollIndicatorExampleApp extends StatelessWidget {
 
 const Set<PointerDeviceKind> allPointers = <PointerDeviceKind>{...PointerDeviceKind.values};
 
-/// Passing this class into [MaterialApp.scrollBehavior] ensures that a
-/// [GlowingOverscrollIndicator] is created, regardless of the target platform.
+// Passing this class into the MaterialApp constructor ensures that a
+// GlowingOverscrollIndicator is created, regardless of the target platform.
 class AlwaysGlow extends MaterialScrollBehavior {
   const AlwaysGlow();
 

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 /// Flutter code sample for [GlowingOverscrollIndicator].
@@ -14,6 +15,8 @@ class GlowingOverscrollIndicatorExampleApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      scrollBehavior: const AlwaysGlow(),
+      theme: ThemeData(colorSchemeSeed: Colors.amber),
       home: Scaffold(
         appBar: AppBar(title: const Text('GlowingOverscrollIndicator Sample')),
         body: const GlowingOverscrollIndicatorExample(),
@@ -22,29 +25,69 @@ class GlowingOverscrollIndicatorExampleApp extends StatelessWidget {
   }
 }
 
+const Set<PointerDeviceKind> allPointers = <PointerDeviceKind>{...PointerDeviceKind.values};
+
+class AlwaysGlow extends MaterialScrollBehavior {
+  const AlwaysGlow();
+
+  @override
+  Set<PointerDeviceKind> get dragDevices => allPointers;
+
+  @override
+  Widget buildOverscrollIndicator(
+    BuildContext context,
+    Widget child,
+    ScrollableDetails details,
+  ) {
+    return GlowingOverscrollIndicator(
+      axisDirection: details.direction,
+      color: Colors.amberAccent,
+      child: child,
+    );
+  }
+}
+
+
 class GlowingOverscrollIndicatorExample extends StatelessWidget {
   const GlowingOverscrollIndicatorExample({super.key});
 
   @override
   Widget build(BuildContext context) {
+    const ScrollView scrollView = CustomScrollView(slivers: <Widget>[
+      SliverAppBar(title: Text('Custom PaintOffset')),
+      SliverToBoxAdapter(
+        child: DefaultTextStyle(
+          style: TextStyle(
+            color: Colors.amberAccent,
+            fontSize: 24,
+            fontWeight: FontWeight.w600,
+          ),
+          child: ColoredBox(
+            color: Colors.grey,
+            child: SizedBox(
+              width: double.infinity,
+              height: 80,
+              child: Center(child: Text('Glow all day!')),
+            ),
+          ),
+        ),
+      ),
+      SliverFillRemaining(
+        child: Icon(
+          Icons.sunny,
+          color: Colors.amberAccent,
+          size: 128,
+        ),
+      ),
+    ]);
+
     return NestedScrollView(
       headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
         return const <Widget>[
           SliverAppBar(title: Text('Custom NestedScrollViews')),
         ];
       },
-      body: CustomScrollView(
-        slivers: <Widget>[
-          SliverToBoxAdapter(
-            child: Container(
-              color: Colors.amberAccent,
-              height: 100,
-              child: const Center(child: Text('Glow all day!')),
-            ),
-          ),
-          const SliverFillRemaining(child: FlutterLogo()),
-        ],
-      ),
+      body: scrollView,
     );
   }
 }

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
@@ -53,40 +53,40 @@ class GlowingOverscrollIndicatorExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const ScrollView scrollView = CustomScrollView(slivers: <Widget>[
-      SliverToBoxAdapter(
-        child: DefaultTextStyle(
-          style: TextStyle(
-            color: Colors.amberAccent,
-            fontSize: 24,
-            fontWeight: FontWeight.w600,
-          ),
-          child: ColoredBox(
-            color: Colors.grey,
-            child: SizedBox(
-              width: double.infinity,
-              height: 80,
-              child: Center(child: Text('Glow all day!')),
-            ),
-          ),
-        ),
-      ),
-      SliverFillRemaining(
-        child: Icon(
-          Icons.sunny,
-          color: Colors.amberAccent,
-          size: 128,
-        ),
-      ),
-    ]);
-
     return NestedScrollView(
       headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
         return const <Widget>[
           SliverAppBar(title: Text('Custom NestedScrollViews')),
         ];
       },
-      body: scrollView,
+      body: const CustomScrollView(
+        slivers: <Widget>[
+          SliverToBoxAdapter(
+            child: DefaultTextStyle(
+              style: TextStyle(
+                color: Colors.amberAccent,
+                fontSize: 24,
+                fontWeight: FontWeight.w600,
+              ),
+              child: ColoredBox(
+                color: Colors.grey,
+                child: SizedBox(
+                  width: double.infinity,
+                  height: 80,
+                  child: Center(child: Text('Glow all day!')),
+                ),
+              ),
+            ),
+          ),
+          SliverFillRemaining(
+            child: Icon(
+              Icons.sunny,
+              color: Colors.amberAccent,
+              size: 128,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
@@ -27,6 +27,8 @@ class GlowingOverscrollIndicatorExampleApp extends StatelessWidget {
 
 const Set<PointerDeviceKind> allPointers = <PointerDeviceKind>{...PointerDeviceKind.values};
 
+/// Passing this class into [MaterialApp.scrollBehavior] ensures that a
+/// [GlowingOverscrollIndicator] is created, regardless of the target platform.
 class AlwaysGlow extends MaterialScrollBehavior {
   const AlwaysGlow();
 

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
@@ -54,7 +54,6 @@ class GlowingOverscrollIndicatorExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const ScrollView scrollView = CustomScrollView(slivers: <Widget>[
-      SliverAppBar(title: Text('Custom PaintOffset')),
       SliverToBoxAdapter(
         child: DefaultTextStyle(
           style: TextStyle(

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
@@ -27,8 +27,8 @@ class GlowingOverscrollIndicatorExampleApp extends StatelessWidget {
 
 const Set<PointerDeviceKind> allPointers = <PointerDeviceKind>{...PointerDeviceKind.values};
 
-/// Passing this class into [MaterialApp.scrollBehavior] ensures that a
-/// [GlowingOverscrollIndicator] is created, regardless of the target platform.
+// Passing this class into the MaterialApp constructor ensures that a
+// GlowingOverscrollIndicator is created, regardless of the target platform.
 class AlwaysGlow extends MaterialScrollBehavior {
   const AlwaysGlow();
 

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
@@ -40,4 +40,32 @@ void main() {
       matching: find.byType(GlowingOverscrollIndicator),
     ), findsOne);
   });
+
+  testWidgets('Test behavior', (WidgetTester tester) async {
+    bool overscrollNotified = false;
+    double leadingPaintOffset = 0.0;
+
+    await tester.pumpWidget(
+      NotificationListener<OverscrollIndicatorNotification>(
+        onNotification: (OverscrollIndicatorNotification notification) {
+          overscrollNotified = true;
+          leadingPaintOffset = notification.paintOffset;
+          return false;
+        },
+        child: const example.GlowingOverscrollIndicatorExampleApp(),
+      ),
+    );
+
+    expect(leadingPaintOffset, 0);
+    expect(overscrollNotified, isFalse);
+    final BuildContext context = tester.element(find.byType(MaterialApp));
+    final double headerHeight = MediaQuery.paddingOf(context).top + kToolbarHeight;
+
+    final Finder customScrollViewFinder = find.byType(CustomScrollView);
+    await tester.drag(customScrollViewFinder, const Offset(0, 500));
+    await tester.pump();
+
+    expect(leadingPaintOffset, headerHeight);
+    expect(overscrollNotified, isTrue);
+  });
 }

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_api_samples/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Test visibility', (WidgetTester tester) async {
+  testWidgets('Displays widget tree when the example app is run', (WidgetTester tester) async {
     await tester.pumpWidget(const example.GlowingOverscrollIndicatorExampleApp());
 
     expect(find.descendant(
@@ -15,33 +16,48 @@ void main() {
       matching: find.widgetWithText(AppBar, 'GlowingOverscrollIndicator Sample'),
     ), findsOne);
 
-    expect(find.descendant(
-      of: find.byType(CustomScrollView),
+    final Finder customScrollViewFinder = find.byType(CustomScrollView);
+    final Finder sliverAppBarFinder = find.descendant(
+      of: customScrollViewFinder,
       matching: find.widgetWithText(SliverAppBar, 'Custom PaintOffset'),
-    ), findsOne);
+    );
+
+    expect(sliverAppBarFinder, findsOne);
 
     expect(find.descendant(
-      of: find.byType(CustomScrollView),
+      of: customScrollViewFinder,
       matching: find.widgetWithText(Center, 'Glow all day!'),
     ), findsOne);
 
     expect(find.descendant(
-      of: find.byType(CustomScrollView),
+      of: customScrollViewFinder,
       matching: find.byType(SliverToBoxAdapter),
     ), findsOne);
 
     expect(find.descendant(
-      of: find.byType(CustomScrollView),
+      of: customScrollViewFinder,
       matching: find.widgetWithIcon(SliverFillRemaining, Icons.sunny),
     ), findsOne);
 
     expect(find.descendant(
-      of: find.byType(CustomScrollView),
+      of: customScrollViewFinder,
       matching: find.byType(GlowingOverscrollIndicator),
     ), findsOne);
+
+    // Check if GlowingOverscrollIndicator overlays the SliverAppBar
+    final RenderBox overscrollIndicator = tester.renderObject<RenderBox>(
+      find.descendant(
+        of: customScrollViewFinder,
+        matching: find.byType(GlowingOverscrollIndicator),
+      ),
+    );
+    final RenderSliver sliverAppBar = tester.renderObject<RenderSliver>(sliverAppBarFinder);
+    final Matrix4 transform = overscrollIndicator.getTransformTo(sliverAppBar);
+    final Offset? offset = MatrixUtils.getAsTranslation(transform);
+    expect(offset?.dy, 0);
   });
 
-  testWidgets('Test behavior', (WidgetTester tester) async {
+  testWidgets('Triggers a notification listener when the screen is dragged', (WidgetTester tester) async {
     bool overscrollNotified = false;
     double leadingPaintOffset = 0.0;
 
@@ -59,13 +75,11 @@ void main() {
     expect(leadingPaintOffset, 0);
     expect(overscrollNotified, isFalse);
     final BuildContext context = tester.element(find.byType(MaterialApp));
-    final double headerHeight = MediaQuery.paddingOf(context).top + kToolbarHeight;
 
-    final Finder customScrollViewFinder = find.byType(CustomScrollView);
-    await tester.drag(customScrollViewFinder, const Offset(0, 500));
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, 500));
     await tester.pump();
 
-    expect(leadingPaintOffset, headerHeight);
+    expect(leadingPaintOffset, MediaQuery.paddingOf(context).top + kToolbarHeight);
     expect(overscrollNotified, isTrue);
   });
 }

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
@@ -44,7 +44,7 @@ void main() {
       matching: find.byType(GlowingOverscrollIndicator),
     ), findsOne);
 
-    // Check if GlowingOverscrollIndicator overlays the SliverAppBar
+    // Check if GlowingOverscrollIndicator overlays the SliverAppBar.
     final RenderBox overscrollIndicator = tester.renderObject<RenderBox>(
       find.descendant(
         of: customScrollViewFinder,

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
@@ -1,0 +1,72 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Test visibility', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.GlowingOverscrollIndicatorExampleApp());
+
+    expect(find.descendant(
+      of: find.byType(Scaffold),
+      matching: find.widgetWithText(AppBar, 'GlowingOverscrollIndicator Sample'),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(CustomScrollView),
+      matching: find.widgetWithText(SliverAppBar, 'Custom PaintOffset'),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(CustomScrollView),
+      matching: find.widgetWithText(Center, 'Glow all day!'),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(CustomScrollView),
+      matching: find.byType(SliverToBoxAdapter),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(CustomScrollView),
+      matching: find.byType(SliverFillRemaining),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(SliverFillRemaining),
+      matching: find.byType(FlutterLogo),
+    ), findsOne);
+
+  });
+  testWidgets('Test behaviour', (WidgetTester tester) async {
+    bool overscrollNotified = false;
+    double leadingPaintOffset = 0.0;
+
+    // custom listener
+    await tester.pumpWidget(
+      NotificationListener<OverscrollIndicatorNotification>(
+        onNotification: (OverscrollIndicatorNotification notification) {
+          overscrollNotified = true;
+          leadingPaintOffset = notification.paintOffset;
+          return false;
+        },
+        child: const example.GlowingOverscrollIndicatorExampleApp(),
+      ),
+    );
+
+    expect(leadingPaintOffset==0, isTrue);
+    expect(overscrollNotified, isFalse);
+    final BuildContext context = tester.element(find.byType(MaterialApp));
+    final double headerHeight = MediaQuery.of(context).padding.top + AppBar().preferredSize.height;
+
+    final Finder customScrollViewFinder = find.byType(CustomScrollView);
+    await tester.drag(customScrollViewFinder, const Offset(0.0, 500));
+    await tester.pump();
+
+    expect(leadingPaintOffset==headerHeight, isTrue);
+    expect(overscrollNotified, isTrue);
+  });
+}

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart
@@ -32,41 +32,12 @@ void main() {
 
     expect(find.descendant(
       of: find.byType(CustomScrollView),
-      matching: find.byType(SliverFillRemaining),
+      matching: find.widgetWithIcon(SliverFillRemaining, Icons.sunny),
     ), findsOne);
 
     expect(find.descendant(
-      of: find.byType(SliverFillRemaining),
-      matching: find.byType(FlutterLogo),
+      of: find.byType(CustomScrollView),
+      matching: find.byType(GlowingOverscrollIndicator),
     ), findsOne);
-
-  });
-  testWidgets('Test behaviour', (WidgetTester tester) async {
-    bool overscrollNotified = false;
-    double leadingPaintOffset = 0.0;
-
-    // custom listener
-    await tester.pumpWidget(
-      NotificationListener<OverscrollIndicatorNotification>(
-        onNotification: (OverscrollIndicatorNotification notification) {
-          overscrollNotified = true;
-          leadingPaintOffset = notification.paintOffset;
-          return false;
-        },
-        child: const example.GlowingOverscrollIndicatorExampleApp(),
-      ),
-    );
-
-    expect(leadingPaintOffset==0, isTrue);
-    expect(overscrollNotified, isFalse);
-    final BuildContext context = tester.element(find.byType(MaterialApp));
-    final double headerHeight = MediaQuery.of(context).padding.top + AppBar().preferredSize.height;
-
-    final Finder customScrollViewFinder = find.byType(CustomScrollView);
-    await tester.drag(customScrollViewFinder, const Offset(0.0, 500));
-    await tester.pump();
-
-    expect(leadingPaintOffset==headerHeight, isTrue);
-    expect(overscrollNotified, isTrue);
   });
 }

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_api_samples/widgets/overscroll_indicator/glowing_overscr
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Test visibility', (WidgetTester tester) async {
+  testWidgets('Displays widget tree when the example app is run', (WidgetTester tester) async {
     await tester.pumpWidget(const example.GlowingOverscrollIndicatorExampleApp());
 
     expect(find.descendant(
@@ -26,31 +26,24 @@ void main() {
       matching: find.widgetWithText(Center, 'Glow all day!'),
     ), findsOne);
 
+    final Finder customScrollViewFinder = find.byType(CustomScrollView);
+
     expect(find.descendant(
-      of: find.byType(CustomScrollView),
+      of: customScrollViewFinder,
       matching: find.byType(SliverToBoxAdapter),
     ), findsOne);
 
     expect(find.descendant(
-      of: find.byType(CustomScrollView),
+      of: customScrollViewFinder,
       matching: find.widgetWithIcon(SliverFillRemaining, Icons.sunny),
     ), findsOne);
 
     expect(find.descendant(
-      of: find.byType(CustomScrollView),
+      of: customScrollViewFinder,
       matching: find.byType(GlowingOverscrollIndicator),
     ), findsOne);
-  });
 
-  testWidgets('Test behavior', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const example.GlowingOverscrollIndicatorExampleApp(),
-    );
-
-    final Finder customScrollViewFinder = find.byType(CustomScrollView);
-    await tester.drag(customScrollViewFinder, const Offset(0, 500));
-    await tester.pump();
-
+    // Check if GlowingOverscrollIndicator starts just after the SliverAppBar
     final RenderBox overscrollIndicator = tester.renderObject<RenderBox>(
       find.descendant(
         of: customScrollViewFinder,
@@ -62,6 +55,6 @@ void main() {
     );
     final Matrix4 transform = overscrollIndicator.getTransformTo(sliverAppBar);
     final Offset? offset = MatrixUtils.getAsTranslation(transform);
-    expect(offset?.dy, kToolbarHeight);
+    expect(offset?.dy, sliverAppBar.geometry?.paintExtent);
   });
 }

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
@@ -43,7 +43,7 @@ void main() {
       matching: find.byType(GlowingOverscrollIndicator),
     ), findsOne);
 
-    // Check if GlowingOverscrollIndicator starts just after the SliverAppBar
+    // Check if GlowingOverscrollIndicator starts just after the SliverAppBar.
     final RenderBox overscrollIndicator = tester.renderObject<RenderBox>(
       find.descendant(
         of: customScrollViewFinder,

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_api_samples/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
@@ -39,5 +40,28 @@ void main() {
       of: find.byType(CustomScrollView),
       matching: find.byType(GlowingOverscrollIndicator),
     ), findsOne);
+  });
+
+  testWidgets('Test behavior', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.GlowingOverscrollIndicatorExampleApp(),
+    );
+
+    final Finder customScrollViewFinder = find.byType(CustomScrollView);
+    await tester.drag(customScrollViewFinder, const Offset(0, 500));
+    await tester.pump();
+
+    final RenderBox overscrollIndicator = tester.renderObject<RenderBox>(
+      find.descendant(
+        of: customScrollViewFinder,
+        matching: find.byType(GlowingOverscrollIndicator),
+      ),
+    );
+    final RenderSliver sliverAppBar = tester.renderObject<RenderSliver>(
+      find.widgetWithText(SliverAppBar, 'Custom NestedScrollViews'),
+    );
+    final Matrix4 transform = overscrollIndicator.getTransformTo(sliverAppBar);
+    final Offset? offset = MatrixUtils.getAsTranslation(transform);
+    expect(offset?.dy, kToolbarHeight);
   });
 }

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
@@ -25,42 +25,19 @@ void main() {
       matching: find.widgetWithText(Center, 'Glow all day!'),
     ), findsOne);
 
-   expect(find.descendant(
+    expect(find.descendant(
       of: find.byType(CustomScrollView),
       matching: find.byType(SliverToBoxAdapter),
     ), findsOne);
 
     expect(find.descendant(
       of: find.byType(CustomScrollView),
-      matching: find.byType(SliverFillRemaining),
+      matching: find.widgetWithIcon(SliverFillRemaining, Icons.sunny),
     ), findsOne);
 
     expect(find.descendant(
-      of: find.byType(SliverFillRemaining),
-      matching: find.byType(FlutterLogo),
+      of: find.byType(CustomScrollView),
+      matching: find.byType(GlowingOverscrollIndicator),
     ), findsOne);
-
-  });
-  testWidgets('Test behaviour', (WidgetTester tester) async {
-    bool overscrollNotified = false;
-
-    // custom listener
-    await tester.pumpWidget(
-      NotificationListener<OverscrollIndicatorNotification>(
-        onNotification: (OverscrollIndicatorNotification notification) {
-          overscrollNotified = true;
-          return false;
-        },
-        child: const example.GlowingOverscrollIndicatorExampleApp(),
-      ),
-    );
-
-    expect(overscrollNotified, isFalse);
-
-    final Finder customScrollViewFinder = find.byType(CustomScrollView);
-    await tester.drag(customScrollViewFinder, const Offset(0.0, 500));
-    await tester.pump();
-
-    expect(overscrollNotified, isTrue);
   });
 }

--- a/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
+++ b/examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Test visibility', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.GlowingOverscrollIndicatorExampleApp());
+
+    expect(find.descendant(
+      of: find.byType(Scaffold),
+      matching: find.widgetWithText(AppBar, 'GlowingOverscrollIndicator Sample'),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(NestedScrollView),
+      matching: find.widgetWithText(SliverAppBar, 'Custom NestedScrollViews'),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(NestedScrollView),
+      matching: find.widgetWithText(Center, 'Glow all day!'),
+    ), findsOne);
+
+   expect(find.descendant(
+      of: find.byType(CustomScrollView),
+      matching: find.byType(SliverToBoxAdapter),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(CustomScrollView),
+      matching: find.byType(SliverFillRemaining),
+    ), findsOne);
+
+    expect(find.descendant(
+      of: find.byType(SliverFillRemaining),
+      matching: find.byType(FlutterLogo),
+    ), findsOne);
+
+  });
+  testWidgets('Test behaviour', (WidgetTester tester) async {
+    bool overscrollNotified = false;
+
+    // custom listener
+    await tester.pumpWidget(
+      NotificationListener<OverscrollIndicatorNotification>(
+        onNotification: (OverscrollIndicatorNotification notification) {
+          overscrollNotified = true;
+          return false;
+        },
+        child: const example.GlowingOverscrollIndicatorExampleApp(),
+      ),
+    );
+
+    expect(overscrollNotified, isFalse);
+
+    final Finder customScrollViewFinder = find.byType(CustomScrollView);
+    await tester.drag(customScrollViewFinder, const Offset(0.0, 500));
+    await tester.pump();
+
+    expect(overscrollNotified, isTrue);
+  });
+}


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/130459

This pull request adds tests for the example files shown in the [GlowingOverscrollIndicator](https://api.flutter.dev/flutter/widgets/GlowingOverscrollIndicator-class.html) Flutter API reference documentation.