### PR TITLE
Fix cursor on hover expand/collapse icon (#155207)

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -391,16 +391,19 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
 
       Widget expandIconPadded = Padding(
         padding: const EdgeInsetsDirectional.only(end: 8.0),
-        child: ExpandIcon(
-          color: widget.expandIconColor,
-          disabledColor: child.canTapOnHeader ? widget.expandIconColor : null,
-          isExpanded: _isChildExpanded(index),
-          padding: _kExpandIconPadding,
-          splashColor: child.splashColor,
-          highlightColor: child.highlightColor,
-          onPressed: !child.canTapOnHeader
-              ? (bool isExpanded) => _handlePressed(isExpanded, index)
-              : null,
+        child: IgnorePointer(
+          ignoring: child.canTapOnHeader,
+          child: ExpandIcon(
+            color: widget.expandIconColor,
+            disabledColor: child.canTapOnHeader ? widget.expandIconColor : null,
+            isExpanded: _isChildExpanded(index),
+            padding: _kExpandIconPadding,
+            splashColor: child.splashColor,
+            highlightColor: child.highlightColor,
+            onPressed: !child.canTapOnHeader
+                ? (bool isExpanded) => _handlePressed(isExpanded, index)
+                : null,
+          ),
         ),
       );
 

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -395,14 +395,11 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
           ignoring: child.canTapOnHeader,
           child: ExpandIcon(
             color: widget.expandIconColor,
-            disabledColor: child.canTapOnHeader ? widget.expandIconColor : null,
             isExpanded: _isChildExpanded(index),
             padding: _kExpandIconPadding,
             splashColor: child.splashColor,
             highlightColor: child.highlightColor,
-            onPressed: !child.canTapOnHeader
-                ? (bool isExpanded) => _handlePressed(isExpanded, index)
-                : null,
+            onPressed: (bool isExpanded) => _handlePressed(isExpanded, index)
           ),
         ),
       );

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1271,6 +1271,7 @@ void main() {
     expect(tester.getSemantics(find.byKey(expandedKey)), matchesSemantics(
       label: 'Expanded',
       isButton: true,
+      isEnabled: true,
       isFocusable: true,
       hasEnabledState: true,
       hasTapAction: true,
@@ -1281,6 +1282,7 @@ void main() {
       label: 'Collapsed',
       isButton: true,
       isFocusable: true,
+      isEnabled: true,
       hasEnabledState: true,
       hasTapAction: true,
       hasFocusAction: true,
@@ -2019,19 +2021,17 @@ void main() {
         widget is InkWell && widget.onTap != null)
     );
 
-    final InkWell inkWell = tester.widget<InkWell>(inkWellFinder);
+    final InkWell inkWell = tester.widget<InkWell>(inkWellFinder.first);
     expect(inkWell.splashColor, expectedSplashColor);
     expect(inkWell.highlightColor, expectedHighlightColor);
   });
 
-  testWidgets('ExpandIcon.disabledColor uses expandIconColor color when canTapOnHeader is true', (WidgetTester tester) async {
-    const Color expandIconColor = Color(0xff0000ff);
+  testWidgets('ExpandIcon ignores pointer/tap events when canTapOnHeader is true', (WidgetTester tester) async {
 
     Widget buildWidget({ bool canTapOnHeader = false }) {
       return MaterialApp(
         home: SingleChildScrollView(
           child: ExpansionPanelList(
-            expandIconColor: expandIconColor,
             children: <ExpansionPanel>[
               ExpansionPanel(
                 canTapOnHeader: canTapOnHeader,
@@ -2048,16 +2048,18 @@ void main() {
 
     await tester.pumpWidget(buildWidget());
 
-    await tester.tap(find.text('Panel'));
-    await tester.pumpAndSettle();
+    final Finder ignorePointerFinder = find.descendant(
+      of: find.byType(ExpansionPanelList),
+      matching: find.byType(IgnorePointer),
+    ).first;
 
-    ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
-    expect(expandIcon.disabledColor, isNull);
+    final IgnorePointer ignorePointerFalse = tester.widget(ignorePointerFinder);
+    expect(ignorePointerFalse.ignoring, isFalse);
 
     await tester.pumpWidget(buildWidget(canTapOnHeader: true));
     await tester.pumpAndSettle();
 
-    expandIcon = tester.widget(find.byType(ExpandIcon));
-    expect(expandIcon.disabledColor, expandIconColor);
+    final IgnorePointer ignorePointerTrue = tester.widget(ignorePointerFinder);
+    expect(ignorePointerTrue.ignoring, isTrue);
   });
 }


### PR DESCRIPTION
Fixes [#155207](https://github.com/flutter/flutter/issues/155207).

When ExpansionPanel.canTapOnHeader is true, the cursor doesn't change to a pointer when hovering over the expand/collapse icon, because hover events are blocked.

This PR adds IgnorePointer wrapping to resolve the hover cursor behavior while maintaining the correct tap handling.
