### PR TITLE
Add `enableSplash` parameter to `CarouselView`

### DIFF
--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -390,28 +390,26 @@ class _CarouselViewState extends State<CarouselView> {
   }
 
   Widget _buildCarouselItem(ThemeData theme, int index) {
-    final EdgeInsets effectivePadding =
-        widget.padding ?? const EdgeInsets.all(4.0);
-    final Color effectiveBackgroundColor =
-        widget.backgroundColor ?? Theme.of(context).colorScheme.surface;
+    final EdgeInsets effectivePadding = widget.padding ?? const EdgeInsets.all(4.0);
+    final Color effectiveBackgroundColor = widget.backgroundColor ?? Theme.of(context).colorScheme.surface;
     final double effectiveElevation = widget.elevation ?? 0.0;
-    final ShapeBorder effectiveShape = widget.shape ??
-        const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(28.0)));
-    final WidgetStateProperty<Color?> effectiveOverlayColor =
-        widget.overlayColor ??
-            WidgetStateProperty.resolveWith((Set<WidgetState> states) {
-              if (states.contains(WidgetState.pressed)) {
-                return theme.colorScheme.onSurface.withOpacity(0.1);
-              }
-              if (states.contains(WidgetState.hovered)) {
-                return theme.colorScheme.onSurface.withOpacity(0.08);
-              }
-              if (states.contains(WidgetState.focused)) {
-                return theme.colorScheme.onSurface.withOpacity(0.1);
-              }
-              return null;
-            });
+    final ShapeBorder effectiveShape = widget.shape
+      ?? const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(28.0))
+      );
+    final WidgetStateProperty<Color?> effectiveOverlayColor = widget.overlayColor
+      ?? WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.pressed)) {
+          return theme.colorScheme.onSurface.withOpacity(0.1);
+        }
+        if (states.contains(WidgetState.hovered)) {
+          return theme.colorScheme.onSurface.withOpacity(0.08);
+        }
+        if (states.contains(WidgetState.focused)) {
+          return theme.colorScheme.onSurface.withOpacity(0.1);
+        }
+        return null;
+      });
     Widget contents = widget.children[index];
 
     if (widget.enableSplash) {

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -197,8 +197,7 @@ class CarouselView extends StatefulWidget {
     required List<int> this.flexWeights,
     required this.children,
   })  : itemExtent = null,
-        assert(disabledChildrenInteraction == true ||
-            (disabledChildrenInteraction == false && onTap == null));
+        assert(disabledChildrenInteraction || onTap == null));
 
   /// The amount of space to surround each carousel item with.
   ///

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -410,8 +410,8 @@ class _CarouselViewState extends State<CarouselView> {
         }
         return null;
       });
-    Widget contents = widget.children[index];
 
+    Widget contents = widget.children[index];
     if (widget.enableSplash) {
       contents = Stack(
         fit: StackFit.expand,

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -389,27 +389,55 @@ class _CarouselViewState extends State<CarouselView> {
     }
   }
 
-  Widget _buildCarouselItem(ThemeData theme, int index) {
-    final EdgeInsets effectivePadding = widget.padding ?? const EdgeInsets.all(4.0);
-    final Color effectiveBackgroundColor = widget.backgroundColor ?? Theme.of(context).colorScheme.surface;
-    final double effectiveElevation = widget.elevation ?? 0.0;
-    final ShapeBorder effectiveShape = widget.shape
-      ?? const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(28.0))
+  Widget _buildCarouselContent(
+      int index, WidgetStateProperty<Color?>? overlayColor) {
+    if (widget.enableSplash) {
+      return Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          widget.children[index],
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () => widget.onTap?.call(index),
+              overlayColor: overlayColor,
+            ),
+          ),
+        ],
       );
-    final WidgetStateProperty<Color?> effectiveOverlayColor = widget.overlayColor
-      ?? WidgetStateProperty.resolveWith((Set<WidgetState> states) {
-        if (states.contains(WidgetState.pressed)) {
-          return theme.colorScheme.onSurface.withOpacity(0.1);
-        }
-        if (states.contains(WidgetState.hovered)) {
-          return theme.colorScheme.onSurface.withOpacity(0.08);
-        }
-        if (states.contains(WidgetState.focused)) {
-          return theme.colorScheme.onSurface.withOpacity(0.1);
-        }
-        return null;
-      });
+    }
+    if (widget.onTap != null) {
+      return GestureDetector(
+        onTap: () => widget.onTap!(index),
+        child: widget.children[index],
+      );
+    }
+    return widget.children[index];
+  }
+
+  Widget _buildCarouselItem(ThemeData theme, int index) {
+    final EdgeInsets effectivePadding =
+        widget.padding ?? const EdgeInsets.all(4.0);
+    final Color effectiveBackgroundColor =
+        widget.backgroundColor ?? Theme.of(context).colorScheme.surface;
+    final double effectiveElevation = widget.elevation ?? 0.0;
+    final ShapeBorder effectiveShape = widget.shape ??
+        const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(28.0)));
+    final WidgetStateProperty<Color?> effectiveOverlayColor =
+        widget.overlayColor ??
+            WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+              if (states.contains(WidgetState.pressed)) {
+                return theme.colorScheme.onSurface.withOpacity(0.1);
+              }
+              if (states.contains(WidgetState.hovered)) {
+                return theme.colorScheme.onSurface.withOpacity(0.08);
+              }
+              if (states.contains(WidgetState.focused)) {
+                return theme.colorScheme.onSurface.withOpacity(0.1);
+              }
+              return null;
+            });
 
     return Padding(
       padding: effectivePadding,
@@ -418,21 +446,7 @@ class _CarouselViewState extends State<CarouselView> {
         color: effectiveBackgroundColor,
         elevation: effectiveElevation,
         shape: effectiveShape,
-        child: widget.enableSplash
-            ? Stack(fit: StackFit.expand, children: <Widget>[
-                widget.children[index],
-                Material(
-                  color: Colors.transparent,
-                  child: InkWell(
-                    onTap: () => widget.onTap?.call(index),
-                    overlayColor: effectiveOverlayColor,
-                  ),
-                ),
-              ])
-            : GestureDetector(
-                onTap: () => widget.onTap?.call(index),
-                child: widget.children[index],
-              ),
+        child: _buildCarouselContent(index, effectiveOverlayColor),
       ),
     );
   }

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -130,10 +130,13 @@ class CarouselView extends StatefulWidget {
     this.scrollDirection = Axis.horizontal,
     this.reverse = false,
     this.onTap,
+    this.disabledChildrenInteraction = true,
     required double this.itemExtent,
     required this.children,
-  }) : consumeMaxWeight = true,
-       flexWeights = null;
+  })  : consumeMaxWeight = true,
+        flexWeights = null,
+        assert(disabledChildrenInteraction == true ||
+            (disabledChildrenInteraction == false && onTap == null));
 
   /// Creates a scrollable list where the size of each child widget is dynamically
   /// determined by the provided [flexWeights].
@@ -190,9 +193,12 @@ class CarouselView extends StatefulWidget {
     this.reverse = false,
     this.consumeMaxWeight = true,
     this.onTap,
+    this.disabledChildrenInteraction = true,
     required List<int> this.flexWeights,
     required this.children,
-  }) : itemExtent = null;
+  })  : itemExtent = null,
+        assert(disabledChildrenInteraction == true ||
+            (disabledChildrenInteraction == false && onTap == null));
 
   /// The amount of space to surround each carousel item with.
   ///
@@ -289,6 +295,11 @@ class CarouselView extends StatefulWidget {
 
   /// Called when one of the [children] is tapped.
   final ValueChanged<int>? onTap;
+
+  /// Whether the children tap is disabled.
+  /// Noted that this will disable the tap event for all children by covering InkWell.
+  /// Defaults to true.
+  final bool disabledChildrenInteraction;
 
   /// The extent the children are forced to have in the main axis.
   ///
@@ -412,7 +423,7 @@ class _CarouselViewState extends State<CarouselView> {
           fit: StackFit.expand,
           children: <Widget>[
             widget.children[index],
-            if (widget.onTap != null)
+            if (widget.disabledChildrenInteraction)
               Material(
                 color: Colors.transparent,
                 child: InkWell(

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -294,15 +294,12 @@ class CarouselView extends StatefulWidget {
   /// Called when one of the [children] is tapped.
   final ValueChanged<int>? onTap;
 
-  /// Whether the default tap interaction for children is disabled.
+  /// Determines whether an [InkWell] will cover each Carousel item.
   ///
-  /// If true, tap events for all children are disabled by covering them with an [InkWell].
-  /// This prevents direct interaction with child widgets.
+  /// If true (the default), tapping an item will create an ink splash
+  /// as defined by the [ThemeData.splashFactory].
   ///
-  /// If false, tap events are passed through to the child widgets, allowing them
-  /// to handle interactions directly.
-  ///
-  /// Defaults to true.
+  /// Setting this to false allows the [children] to respond to user gestures.
   ///
   /// Note: Setting this to false while also providing an [onTap] callback will
   /// throw an assertion error, as these options are mutually exclusive.

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -389,32 +389,6 @@ class _CarouselViewState extends State<CarouselView> {
     }
   }
 
-  Widget _buildCarouselContent(
-      int index, WidgetStateProperty<Color?>? overlayColor) {
-    if (widget.enableSplash) {
-      return Stack(
-        fit: StackFit.expand,
-        children: <Widget>[
-          widget.children[index],
-          Material(
-            color: Colors.transparent,
-            child: InkWell(
-              onTap: () => widget.onTap?.call(index),
-              overlayColor: overlayColor,
-            ),
-          ),
-        ],
-      );
-    }
-    if (widget.onTap != null) {
-      return GestureDetector(
-        onTap: () => widget.onTap!(index),
-        child: widget.children[index],
-      );
-    }
-    return widget.children[index];
-  }
-
   Widget _buildCarouselItem(ThemeData theme, int index) {
     final EdgeInsets effectivePadding =
         widget.padding ?? const EdgeInsets.all(4.0);
@@ -438,6 +412,28 @@ class _CarouselViewState extends State<CarouselView> {
               }
               return null;
             });
+    Widget contents = widget.children[index];
+
+    if (widget.enableSplash) {
+      contents = Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          contents,
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () => widget.onTap?.call(index),
+              overlayColor: effectiveOverlayColor,
+            ),
+          ),
+        ],
+      );
+    } else if (widget.onTap != null) {
+      contents = GestureDetector(
+        onTap: () => widget.onTap!(index),
+        child: contents,
+      );
+    }
 
     return Padding(
       padding: effectivePadding,
@@ -446,7 +442,7 @@ class _CarouselViewState extends State<CarouselView> {
         color: effectiveBackgroundColor,
         elevation: effectiveElevation,
         shape: effectiveShape,
-        child: _buildCarouselContent(index, effectiveOverlayColor),
+        child: contents,
       ),
     );
   }

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -135,8 +135,7 @@ class CarouselView extends StatefulWidget {
     required this.children,
   })  : consumeMaxWeight = true,
         flexWeights = null,
-        assert(disabledChildrenInteraction == true ||
-            (disabledChildrenInteraction == false && onTap == null));
+        assert(disabledChildrenInteraction || onTap == null);
 
   /// Creates a scrollable list where the size of each child widget is dynamically
   /// determined by the provided [flexWeights].
@@ -197,7 +196,7 @@ class CarouselView extends StatefulWidget {
     required List<int> this.flexWeights,
     required this.children,
   })  : itemExtent = null,
-        assert(disabledChildrenInteraction || onTap == null));
+        assert(disabledChildrenInteraction || onTap == null);
 
   /// The amount of space to surround each carousel item with.
   ///

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -412,15 +412,14 @@ class _CarouselViewState extends State<CarouselView> {
           fit: StackFit.expand,
           children: <Widget>[
             widget.children[index],
-            Material(
-              color: Colors.transparent,
-              child: InkWell(
-                onTap: () {
-                  widget.onTap?.call(index);
-                },
-                overlayColor: effectiveOverlayColor,
+            if (widget.onTap != null)
+              Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  onTap: () => widget.onTap?.call(index),
+                  overlayColor: effectiveOverlayColor,
+                ),
               ),
-            ),
           ],
         ),
       ),

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -296,9 +296,18 @@ class CarouselView extends StatefulWidget {
   /// Called when one of the [children] is tapped.
   final ValueChanged<int>? onTap;
 
-  /// Whether the children tap is disabled.
-  /// Noted that this will disable the tap event for all children by covering InkWell.
+  /// Whether the default tap interaction for children is disabled.
+  ///
+  /// If true, tap events for all children are disabled by covering them with an [InkWell].
+  /// This prevents direct interaction with child widgets.
+  ///
+  /// If false, tap events are passed through to the child widgets, allowing them
+  /// to handle interactions directly.
+  ///
   /// Defaults to true.
+  ///
+  /// Note: Setting this to false while also providing an [onTap] callback will
+  /// throw an assertion error, as these options are mutually exclusive.
   final bool disabledChildrenInteraction;
 
   /// The extent the children are forced to have in the main axis.

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -418,25 +418,21 @@ class _CarouselViewState extends State<CarouselView> {
         color: effectiveBackgroundColor,
         elevation: effectiveElevation,
         shape: effectiveShape,
-        child: Stack(
-          fit: StackFit.expand,
-          children: <Widget>[
-            if (widget.enableSplash) ...<Widget>[
-              widget.children[index],
-              Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  onTap: () => widget.onTap?.call(index),
-                  overlayColor: effectiveOverlayColor,
+        child: widget.enableSplash
+            ? Stack(fit: StackFit.expand, children: <Widget>[
+                widget.children[index],
+                Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    onTap: () => widget.onTap?.call(index),
+                    overlayColor: effectiveOverlayColor,
+                  ),
                 ),
-              ),
-            ] else
-              GestureDetector(
+              ])
+            : GestureDetector(
                 onTap: () => widget.onTap?.call(index),
                 child: widget.children[index],
               ),
-          ],
-        ),
       ),
     );
   }

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -134,8 +134,7 @@ class CarouselView extends StatefulWidget {
     required double this.itemExtent,
     required this.children,
   })  : consumeMaxWeight = true,
-        flexWeights = null,
-        assert(enableSplash || onTap == null);
+        flexWeights = null;
 
   /// Creates a scrollable list where the size of each child widget is dynamically
   /// determined by the provided [flexWeights].
@@ -195,8 +194,7 @@ class CarouselView extends StatefulWidget {
     this.enableSplash = true,
     required List<int> this.flexWeights,
     required this.children,
-  })  : itemExtent = null,
-        assert(enableSplash || onTap == null);
+  })  : itemExtent = null;
 
   /// The amount of space to surround each carousel item with.
   ///
@@ -300,9 +298,6 @@ class CarouselView extends StatefulWidget {
   /// as defined by the [ThemeData.splashFactory].
   ///
   /// Setting this to false allows the [children] to respond to user gestures.
-  ///
-  /// Note: Setting this to false while also providing an [onTap] callback will
-  /// throw an assertion error, as these options are mutually exclusive.
   final bool enableSplash;
 
   /// The extent the children are forced to have in the main axis.
@@ -426,14 +421,19 @@ class _CarouselViewState extends State<CarouselView> {
         child: Stack(
           fit: StackFit.expand,
           children: <Widget>[
-            widget.children[index],
-            if (widget.enableSplash)
+            if (widget.enableSplash) ...<Widget>[
+              widget.children[index],
               Material(
                 color: Colors.transparent,
                 child: InkWell(
                   onTap: () => widget.onTap?.call(index),
                   overlayColor: effectiveOverlayColor,
                 ),
+              ),
+            ] else
+              GestureDetector(
+                onTap: () => widget.onTap?.call(index),
+                child: widget.children[index],
               ),
           ],
         ),

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -133,8 +133,8 @@ class CarouselView extends StatefulWidget {
     this.enableSplash = true,
     required double this.itemExtent,
     required this.children,
-  })  : consumeMaxWeight = true,
-        flexWeights = null;
+  }) : consumeMaxWeight = true,
+       flexWeights = null;
 
   /// Creates a scrollable list where the size of each child widget is dynamically
   /// determined by the provided [flexWeights].
@@ -194,7 +194,7 @@ class CarouselView extends StatefulWidget {
     this.enableSplash = true,
     required List<int> this.flexWeights,
     required this.children,
-  })  : itemExtent = null;
+  }) : itemExtent = null;
 
   /// The amount of space to surround each carousel item with.
   ///

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -130,12 +130,12 @@ class CarouselView extends StatefulWidget {
     this.scrollDirection = Axis.horizontal,
     this.reverse = false,
     this.onTap,
-    this.disabledChildrenInteraction = true,
+    this.enableSplash = true,
     required double this.itemExtent,
     required this.children,
   })  : consumeMaxWeight = true,
         flexWeights = null,
-        assert(disabledChildrenInteraction || onTap == null);
+        assert(enableSplash || onTap == null);
 
   /// Creates a scrollable list where the size of each child widget is dynamically
   /// determined by the provided [flexWeights].
@@ -192,11 +192,11 @@ class CarouselView extends StatefulWidget {
     this.reverse = false,
     this.consumeMaxWeight = true,
     this.onTap,
-    this.disabledChildrenInteraction = true,
+    this.enableSplash = true,
     required List<int> this.flexWeights,
     required this.children,
   })  : itemExtent = null,
-        assert(disabledChildrenInteraction || onTap == null);
+        assert(enableSplash || onTap == null);
 
   /// The amount of space to surround each carousel item with.
   ///
@@ -306,7 +306,7 @@ class CarouselView extends StatefulWidget {
   ///
   /// Note: Setting this to false while also providing an [onTap] callback will
   /// throw an assertion error, as these options are mutually exclusive.
-  final bool disabledChildrenInteraction;
+  final bool enableSplash;
 
   /// The extent the children are forced to have in the main axis.
   ///
@@ -430,7 +430,7 @@ class _CarouselViewState extends State<CarouselView> {
           fit: StackFit.expand,
           children: <Widget>[
             widget.children[index],
-            if (widget.disabledChildrenInteraction)
+            if (widget.enableSplash)
               Material(
                 color: Colors.transparent,
                 child: InkWell(

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -294,7 +294,7 @@ class CarouselView extends StatefulWidget {
 
   /// Determines whether an [InkWell] will cover each Carousel item.
   ///
-  /// If true (the default), tapping an item will create an ink splash
+  /// If true, tapping an item will create an ink splash
   /// as defined by the [ThemeData.splashFactory].
   ///
   /// Setting this to false allows the [children] to respond to user gestures.

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -298,6 +298,8 @@ class CarouselView extends StatefulWidget {
   /// as defined by the [ThemeData.splashFactory].
   ///
   /// Setting this to false allows the [children] to respond to user gestures.
+  ///
+  /// Defaults to true.
   final bool enableSplash;
 
   /// The extent the children are forced to have in the main axis.

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1244,7 +1244,7 @@ void main() {
         home: Scaffold(
           body: CarouselView(
             itemExtent: 350,
-            onTap: (index) {
+            onTap: (int index) {
               tappedIndex = index;
             },
             children: List<Widget>.generate(3, (int index) {
@@ -1296,7 +1296,6 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Attempt to tap the button (should not work)
     await tester.tap(find.text('Button 1'), warnIfMissed: false);
     expect(buttonPressed, isFalse);
   });
@@ -1323,28 +1322,56 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Verify button can be pressed
     await tester.tap(find.text('Button 1'));
     expect(buttonPressed, isTrue);
   });
 
-  testWidgets('CarouselView throws assertion error when enableSplash is false and onTap is set', (WidgetTester tester) async {
-    expect(() => tester.pumpWidget(
+
+  testWidgets('CarouselView with enableSplash false - container is clickable without triggering children onTap', (WidgetTester tester) async {
+    int tappedIndex = -1;
+    bool buttonPressed = false;
+    await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: CarouselView(
             itemExtent: 350,
             enableSplash: false,
-            onTap: (index) {},
+            onTap: (int index) {
+              tappedIndex = index;
+            },
             children: List<Widget>.generate(3, (int index) {
-              return Center(
-                child: Text('Item $index'),
+              return Column(
+                children: [
+                  Text('Item $index'),
+                  ElevatedButton(
+                    onPressed: () => buttonPressed = true,
+                    child: Text('Button $index'),
+                  ),
+                ],
               );
             }),
           ),
         ),
       )
-    ), throwsAssertionError);
+    );
+    await tester.pumpAndSettle();
+
+    final Finder carouselItem = find.text('Item 1');
+    await tester.tap(carouselItem, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(tappedIndex, 1);
+    expect(buttonPressed,false);
+
+    final Finder anotherCarouselItem = find.text('Item 2');
+    await tester.tap(anotherCarouselItem, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(tappedIndex, 2);
+    expect(buttonPressed,false);
+
+    await tester.tap(find.text('Button 1'), warnIfMissed: false);
+    expect(buttonPressed, isTrue);
   });
 }
 

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1275,7 +1275,7 @@ void main() {
     expect(tappedIndex, 2);
   });
 
-  testWidgets('CarouselView with disabledChildrenInteraction true - children are not directly interactive', (WidgetTester tester) async {
+  testWidgets('CarouselView with enableSplash true - children are not directly interactive', (WidgetTester tester) async {
     bool buttonPressed = false;
     await tester.pumpWidget(
       MaterialApp(
@@ -1301,14 +1301,14 @@ void main() {
     expect(buttonPressed, isFalse);
   });
 
-  testWidgets('CarouselView with disabledChildrenInteraction false - children are directly interactive', (WidgetTester tester) async {
+  testWidgets('CarouselView with enableSplash false - children are directly interactive', (WidgetTester tester) async {
     bool buttonPressed = false;
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: CarouselView(
             itemExtent: 350,
-            disabledChildrenInteraction: false,
+            enableSplash: false,
             children: List<Widget>.generate(3, (int index) {
               return Center(
                 child: ElevatedButton(
@@ -1328,13 +1328,13 @@ void main() {
     expect(buttonPressed, isTrue);
   });
 
-  testWidgets('CarouselView throws assertion error when disabledChildrenInteraction is false and onTap is set', (WidgetTester tester) async {
+  testWidgets('CarouselView throws assertion error when enableSplash is false and onTap is set', (WidgetTester tester) async {
     expect(() => tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: CarouselView(
             itemExtent: 350,
-            disabledChildrenInteraction: false,
+            enableSplash: false,
             onTap: (index) {},
             children: List<Widget>.generate(3, (int index) {
               return Center(

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1341,7 +1341,7 @@ void main() {
             },
             children: List<Widget>.generate(3, (int index) {
               return Column(
-                children: [
+                children: <Widget>[
                   Text('Item $index'),
                   ElevatedButton(
                     onPressed: () => buttonPressed = true,

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1263,7 +1263,7 @@ void main() {
     await tester.tap(carouselItem, warnIfMissed: false);
     await tester.pumpAndSettle();
 
-    // Verify that the onTap callback was called with the correct index
+    // Verify that the onTap callback was called with the correct index.
     expect(tappedIndex, 1);
 
     // Test tapping another item

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1266,7 +1266,7 @@ void main() {
     // Verify that the onTap callback was called with the correct index.
     expect(tappedIndex, 1);
 
-    // Test tapping another item
+    // Tap another item.
     final Finder anotherCarouselItem = find.text('Item 2');
     await tester.tap(anotherCarouselItem, warnIfMissed: false);
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1297,7 +1297,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Attempt to tap the button (should not work)
-    await tester.tap(find.byType(ElevatedButton).at(1), warnIfMissed: false);
+    await tester.tap(find.text('Button 1'), warnIfMissed: false);
     expect(buttonPressed, isFalse);
   });
 

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1271,7 +1271,7 @@ void main() {
     await tester.tap(anotherCarouselItem, warnIfMissed: false);
     await tester.pumpAndSettle();
 
-    // Verify that the onTap callback was called with the new index
+    // Verify that the onTap callback was called with the new index.
     expect(tappedIndex, 2);
   });
 

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1236,6 +1236,116 @@ void main() {
     // This should be less than 330.0 because the item is shrunk; width is 800.0 - 330.0 - 330.0
     expect(tester.getRect(getItem(2)).width, 140.0);
   });
+
+  testWidgets('CarouselView onTap is clickable', (WidgetTester tester) async {
+    int tappedIndex = -1;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CarouselView(
+            itemExtent: 350,
+            onTap: (index) {
+              tappedIndex = index;
+            },
+            children: List<Widget>.generate(3, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final Finder carouselItem = find.text('Item 1');
+    await tester.tap(carouselItem, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    // Verify that the onTap callback was called with the correct index
+    expect(tappedIndex, 1);
+
+    // Test tapping another item
+    final Finder anotherCarouselItem = find.text('Item 2');
+    await tester.tap(anotherCarouselItem, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    // Verify that the onTap callback was called with the new index
+    expect(tappedIndex, 2);
+  });
+
+  testWidgets('CarouselView with disabledChildrenInteraction true - children are not directly interactive', (WidgetTester tester) async {
+    bool buttonPressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CarouselView(
+            itemExtent: 350,
+            children: List<Widget>.generate(3, (int index) {
+              return Center(
+                child: ElevatedButton(
+                  onPressed: () => buttonPressed = true,
+                  child: Text('Button $index'),
+                ),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+    await tester.pumpAndSettle();
+
+    // Attempt to tap the button (should not work)
+    await tester.tap(find.byType(ElevatedButton).at(1), warnIfMissed: false);
+    expect(buttonPressed, isFalse);
+  });
+
+  testWidgets('CarouselView with disabledChildrenInteraction false - children are directly interactive', (WidgetTester tester) async {
+    bool buttonPressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CarouselView(
+            itemExtent: 350,
+            disabledChildrenInteraction: false,
+            children: List<Widget>.generate(3, (int index) {
+              return Center(
+                child: ElevatedButton(
+                  onPressed: () => buttonPressed = true,
+                  child: Text('Button $index'),
+                ),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+    await tester.pumpAndSettle();
+
+    // Verify button can be pressed
+    await tester.tap(find.text('Button 1'));
+    expect(buttonPressed, isTrue);
+  });
+
+  testWidgets('CarouselView throws assertion error when disabledChildrenInteraction is false and onTap is set', (WidgetTester tester) async {
+    expect(() => tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CarouselView(
+            itemExtent: 350,
+            disabledChildrenInteraction: false,
+            onTap: (index) {},
+            children: List<Widget>.generate(3, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    ), throwsAssertionError);
+  });
 }
 
 Finder getItem(int index) {


### PR DESCRIPTION
This PR fixes #154701 by adding a new parameter to the CarouselView widget that allows developers to control which parts of the carousel are clickable. Currently, an InkWell covers the entire carousel, preventing child widgets from being clickable even when children widget have their clickable widgets.

The new `enableSplash` parameter allows developers to disable this default behavior of `InkWell` without breaking any existing code. If `enableSplash` is `false`, the `onTap` of the `CarouselView` will be disabled. And developer can define their own click behavior likes animation, the clickable widget and so on.