### PR TITLE
if `onTap` is not null, then only it should override children's `onTap`

### DIFF
--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -401,6 +401,21 @@ class _CarouselViewState extends State<CarouselView> {
         return null;
       });
 
+      Widget child = widget.children.elementAt(index);
+
+      if (widget.onTap != null) {
+        child = Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: () {
+              widget.onTap!(index);
+            },
+            overlayColor: effectiveOverlayColor,
+            child: widget.children.elementAt(index),
+          ),
+        );
+      }
+
     return Padding(
       padding: effectivePadding,
       child: Material(
@@ -412,15 +427,7 @@ class _CarouselViewState extends State<CarouselView> {
           fit: StackFit.expand,
           children: <Widget>[
             widget.children[index],
-            Material(
-              color: Colors.transparent,
-              child: InkWell(
-                onTap: () {
-                  widget.onTap?.call(index);
-                },
-                overlayColor: effectiveOverlayColor,
-              ),
-            ),
+            child,
           ],
         ),
       ),


### PR DESCRIPTION
if the `onTap` value is not provided in the `CarouselView` it was overriding the children's `onTap` if any e.g. any button or gesture dectector.

It should only effect if the value is given. Hence, the updated effect is as per below:

https://github.com/user-attachments/assets/2c8fddb2-c344-438e-8e30-3cfda87eb7d4



