### PR TITLE
CarouselView: `onTap != null` checked to avoid override of children's `onTap` (if any)

### DIFF
--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -412,15 +412,16 @@ class _CarouselViewState extends State<CarouselView> {
           fit: StackFit.expand,
           children: <Widget>[
             widget.children[index],
-            Material(
-              color: Colors.transparent,
-              child: InkWell(
-                onTap: () {
-                  widget.onTap?.call(index);
-                },
-                overlayColor: effectiveOverlayColor,
+            if (widget.onTap != null)
+              Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  onTap: () {
+                    widget.onTap!.call(index);
+                  },
+                  overlayColor: effectiveOverlayColor,
+                ),
               ),
-            ),
           ],
         ),
       ),

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -8,6 +8,85 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  testWidgets('Widget renders correctly with onTap', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    int? tappedIndex;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: CarouselView(
+            onTap: (int index) {
+              tappedIndex = index;
+            },
+            itemExtent: 100,
+            children: List<Widget>.generate(1, (int index) {
+              return Center(child: Text('Item $index'));
+            }),
+          ),
+        ),
+      ),
+    );
+
+    final Finder carouselViewMaterial = find.descendant(
+      of: find.byType(CarouselView),
+      matching: find.byType(Material),
+    ).first;
+
+    final Material material = tester.widget<Material>(carouselViewMaterial);
+    expect(material.clipBehavior, Clip.antiAlias);
+    expect(material.color, colorScheme.surface);
+    expect(material.elevation, 0.0);
+    expect(material.shape, const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(28.0))
+    ));
+
+    // Tap on the InkWell
+    await tester.tap(find.byType(InkWell));
+    await tester.pumpAndSettle();
+
+    // Verify that onTap has been called, index value has been updated
+    expect(tappedIndex, isNotNull);
+  });
+
+  testWidgets('Widget renders correctly without onTap', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: CarouselView(
+            itemExtent: 200,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(child: Text('Item $index'));
+            }),
+          ),
+        ),
+      ),
+    );
+
+    final Finder carouselViewMaterial = find.descendant(
+      of: find.byType(CarouselView),
+      matching: find.byType(Material),
+    ).first;
+
+    final Material material = tester.widget<Material>(carouselViewMaterial);
+    expect(material.clipBehavior, Clip.antiAlias);
+    expect(material.color, colorScheme.surface);
+    expect(material.elevation, 0.0);
+    expect(material.shape, const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(28.0))
+    ));
+
+    // Verify that InkWell is not present
+    expect(find.byType(InkWell), findsNothing);
+  });
+
   testWidgets('CarouselView defaults', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     final ColorScheme colorScheme = theme.colorScheme;


### PR DESCRIPTION
## `onTap` in `CarouselView` overrides the children `onTap` even if its value is `null`
The `onTap` method in `CarouselView` overrides the `onTap` of any button widget or `GestureDetector` in the children. Hence, this should only override if the value is `not null`.

### Before
Can't click through any of the tappable in the children although the `onTap` is `null`.
https://github.com/user-attachments/assets/e78eee17-4d19-43bf-8d0f-0904a23be2d1

### After
If the `onTap` is null, it will click through. If its `not null` it will override
https://github.com/user-attachments/assets/2c8fddb2-c344-438e-8e30-3cfda87eb7d4

### Issue Fixed
#155199 Has been fixed in this PR in better way

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
