### PR TITLE
Added .keys to ColorSwatch

### DIFF
--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -413,7 +413,7 @@ class ColorSwatch<T> extends Color {
   /// The `primary` argument should be the 32 bit ARGB value of one of the
   /// values in the swatch, as would be passed to the [Color.new] constructor
   /// for that same color, and as is exposed by [value]. (This is distinct from
-  /// the specific index of the color in the swatch.)
+  /// the key of any color in the swatch.)
   const ColorSwatch(super.primary, this._swatch);
 
   @protected

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -422,6 +422,9 @@ class ColorSwatch<T> extends Color {
   /// Returns an element of the swatch table.
   Color? operator [](T index) => _swatch[index];
 
+  /// Returns the valid keys for accessing operator[].
+  Iterable<T> get keys => _swatch.keys;
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) {

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -398,7 +398,7 @@ class HSLColor {
 
 /// A color that has a small table of related colors called a "swatch".
 ///
-/// The table is indexed by values of type `T`.
+/// The table is accessed by key values of type `T`.
 ///
 /// See also:
 ///
@@ -420,7 +420,7 @@ class ColorSwatch<T> extends Color {
   final Map<T, Color> _swatch;
 
   /// Returns an element of the swatch table.
-  Color? operator [](T index) => _swatch[index];
+  Color? operator [](T key) => _swatch[key];
 
   /// Returns the valid keys for accessing operator[].
   Iterable<T> get keys => _swatch.keys;

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -436,6 +436,7 @@ void main() {
     expect(greens1.hashCode, greens2.hashCode);
     expect(greens1['2259 C'], const Color(0xFF027223));
     expect(greens1.value, 0xFF027223);
+    expect(listEquals(greens1.keys.toList(), greens2.keys.toList()), isTrue);
   });
 
   test('ColorSwatch.lerp', () {


### PR DESCRIPTION
This addresses the issue that ColorSwatch has operator[], but no way to know what are valid inputs.

issue: https://github.com/flutter/flutter/issues/155113

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
