### PR TITLE
Add `WidgetStateProperty` example and tests for it.

### DIFF
--- a/examples/api/lib/widgets/widget_state/widget_state_property.0.dart
+++ b/examples/api/lib/widgets/widget_state/widget_state_property.0.dart
@@ -35,8 +35,8 @@ class WidgetStatePropertyExample extends StatelessWidget {
       style: ButtonStyle(
         foregroundColor: WidgetStateProperty<Color>.fromMap(
           <WidgetStatesConstraint, Color>{
-            WidgetState.pressed | WidgetState.hovered | WidgetState.focused:
-                Colors.blue,
+            WidgetState.focused: Colors.blueAccent,
+            WidgetState.pressed | WidgetState.hovered: Colors.blue,
             WidgetState.any: Colors.red,
           },
         ),

--- a/examples/api/lib/widgets/widget_state/widget_state_property.0.dart
+++ b/examples/api/lib/widgets/widget_state/widget_state_property.0.dart
@@ -29,25 +29,17 @@ class WidgetStatePropertyExampleApp extends StatelessWidget {
 class WidgetStatePropertyExample extends StatelessWidget {
   const WidgetStatePropertyExample({super.key});
 
-  Color _getButtonColor(Set<WidgetState> states) {
-    const Set<WidgetState> interactiveStates = <WidgetState>{
-      WidgetState.pressed,
-      WidgetState.hovered,
-      WidgetState.focused,
-    };
-
-    if (states.any(interactiveStates.contains)) {
-      return Colors.blue;
-    }
-
-    return Colors.red;
-  }
-
   @override
   Widget build(BuildContext context) {
     return TextButton(
       style: ButtonStyle(
-        foregroundColor: WidgetStateProperty.resolveWith(_getButtonColor),
+        foregroundColor: WidgetStateProperty<Color>.fromMap(
+          <WidgetStatesConstraint, Color>{
+            WidgetState.pressed | WidgetState.hovered | WidgetState.focused:
+                Colors.blue,
+            WidgetState.any: Colors.red,
+          },
+        ),
       ),
       onPressed: () {},
       child: const Text('TextButton'),

--- a/examples/api/lib/widgets/widget_state/widget_state_property.0.dart
+++ b/examples/api/lib/widgets/widget_state/widget_state_property.0.dart
@@ -1,0 +1,56 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [WidgetStateProperty].
+
+void main() {
+  runApp(const WidgetStatePropertyExampleApp());
+}
+
+class WidgetStatePropertyExampleApp extends StatelessWidget {
+  const WidgetStatePropertyExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('WidgetStateProperty Sample')),
+        body: const Center(
+          child: WidgetStatePropertyExample(),
+        ),
+      ),
+    );
+  }
+}
+
+class WidgetStatePropertyExample extends StatelessWidget {
+  const WidgetStatePropertyExample({super.key});
+
+  Color _getButtonColor(Set<WidgetState> states) {
+    const Set<WidgetState> interactiveStates = <WidgetState>{
+      WidgetState.pressed,
+      WidgetState.hovered,
+      WidgetState.focused,
+    };
+
+    if (states.any(interactiveStates.contains)) {
+      return Colors.blue;
+    }
+
+    return Colors.red;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      style: ButtonStyle(
+        foregroundColor: WidgetStateProperty.resolveWith(_getButtonColor),
+      ),
+      onPressed: () {},
+      child: const Text('TextButton'),
+    );
+  }
+}

--- a/examples/api/test/widgets/widget_state/widget_state_property.0_test.dart
+++ b/examples/api/test/widgets/widget_state/widget_state_property.0_test.dart
@@ -10,55 +10,44 @@ import 'package:flutter_api_samples/widgets/widget_state/widget_state_property.0
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Future<Color?> getTextColor(WidgetTester tester) async {
+  Color? getTextColor(WidgetTester tester) {
     final BuildContext context = tester.element(find.text('TextButton'));
     final TextStyle textStyle = DefaultTextStyle.of(context).style;
 
     return textStyle.color;
   }
 
-  testWidgets('displays red colored text by default', (WidgetTester tester) async {
+  testWidgets('Displays red colored text by default', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.WidgetStatePropertyExampleApp(),
     );
 
-    expect(
-      await getTextColor(tester),
-      equals(Colors.red),
-    );
+    expect(getTextColor(tester), Colors.red);
   });
 
-  testWidgets('displays blue colored text when button is hovered', (WidgetTester tester) async {
+  testWidgets('Displays blue colored text when button is hovered', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.WidgetStatePropertyExampleApp(),
     );
 
-    expect(
-      await getTextColor(tester),
-      equals(Colors.red),
-    );
+    expect(getTextColor(tester), Colors.red);
 
     // Hover over the TextButton.
-    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    final TestGesture gesture =
+        await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.moveTo(tester.getCenter(find.byType(TextButton)));
 
     await tester.pumpAndSettle();
 
-    expect(
-      await getTextColor(tester),
-      equals(Colors.blue),
-    );
+    expect(getTextColor(tester), Colors.blue);
   });
 
-  testWidgets('displays blue colored text when button is pressed', (WidgetTester tester) async {
+  testWidgets('Displays blue colored text when button is pressed', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.WidgetStatePropertyExampleApp(),
     );
 
-    expect(
-      await getTextColor(tester),
-      equals(Colors.red),
-    );
+    expect(getTextColor(tester), Colors.red);
 
     // Press on the TextButton.
     final TestGesture gesture = await tester.createGesture();
@@ -66,30 +55,21 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    expect(
-      await getTextColor(tester),
-      equals(Colors.blue),
-    );
+    expect(getTextColor(tester), Colors.blue);
   });
 
-  testWidgets('displays blue colored text when button is focused', (WidgetTester tester) async {
+  testWidgets('Displays blue colored text when button is focused', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.WidgetStatePropertyExampleApp(),
     );
 
-    expect(
-      await getTextColor(tester),
-      equals(Colors.red),
-    );
+    expect(getTextColor(tester), Colors.red);
 
     // Focus on the TextButton.
     FocusScope.of(tester.element(find.byType(TextButton))).nextFocus();
 
     await tester.pumpAndSettle();
 
-    expect(
-      await getTextColor(tester),
-      equals(Colors.blueAccent),
-    );
+    expect(getTextColor(tester), Colors.blueAccent);
   });
 }

--- a/examples/api/test/widgets/widget_state/widget_state_property.0_test.dart
+++ b/examples/api/test/widgets/widget_state/widget_state_property.0_test.dart
@@ -1,0 +1,95 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/widget_state/widget_state_property.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<Color?> getTextColor(WidgetTester tester) async {
+    final BuildContext context = tester.element(find.text('TextButton'));
+    final TextStyle textStyle = DefaultTextStyle.of(context).style;
+
+    return textStyle.color;
+  }
+
+  testWidgets('displays red colored text by default', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.WidgetStatePropertyExampleApp(),
+    );
+
+    expect(
+      await getTextColor(tester),
+      equals(Colors.red),
+    );
+  });
+
+  testWidgets('displays blue colored text when button is hovered', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.WidgetStatePropertyExampleApp(),
+    );
+
+    expect(
+      await getTextColor(tester),
+      equals(Colors.red),
+    );
+
+    // Hover over the TextButton.
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(tester.getCenter(find.byType(TextButton)));
+
+    await tester.pumpAndSettle();
+
+    expect(
+      await getTextColor(tester),
+      equals(Colors.blue),
+    );
+  });
+
+  testWidgets('displays blue colored text when button is pressed', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.WidgetStatePropertyExampleApp(),
+    );
+
+    expect(
+      await getTextColor(tester),
+      equals(Colors.red),
+    );
+
+    // Press on the TextButton.
+    final TestGesture gesture = await tester.createGesture();
+    await gesture.down(tester.getCenter(find.byType(TextButton)));
+
+    await tester.pumpAndSettle();
+
+    expect(
+      await getTextColor(tester),
+      equals(Colors.blue),
+    );
+  });
+
+  testWidgets('displays blue colored text when button is focused', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.WidgetStatePropertyExampleApp(),
+    );
+
+    expect(
+      await getTextColor(tester),
+      equals(Colors.red),
+    );
+
+    // Focus on the TextButton.
+    FocusScope.of(tester.element(find.byType(TextButton))).nextFocus();
+
+    await tester.pumpAndSettle();
+
+    expect(
+      await getTextColor(tester),
+      equals(Colors.blue),
+    );
+  });
+}

--- a/examples/api/test/widgets/widget_state/widget_state_property.0_test.dart
+++ b/examples/api/test/widgets/widget_state/widget_state_property.0_test.dart
@@ -89,7 +89,7 @@ void main() {
 
     expect(
       await getTextColor(tester),
-      equals(Colors.blue),
+      equals(Colors.blueAccent),
     );
   });
 }

--- a/examples/api/test/widgets/widget_state/widget_state_property.0_test.dart
+++ b/examples/api/test/widgets/widget_state/widget_state_property.0_test.dart
@@ -33,8 +33,7 @@ void main() {
     expect(getTextColor(tester), Colors.red);
 
     // Hover over the TextButton.
-    final TestGesture gesture =
-        await tester.createGesture(kind: PointerDeviceKind.mouse);
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.moveTo(tester.getCenter(find.byType(TextButton)));
 
     await tester.pumpAndSettle();

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -765,6 +765,16 @@ class _WidgetTextStyleMapper extends WidgetStateTextStyle {
 /// of their current material state and [resolve] the button style's
 /// material state properties when their value is needed.
 ///
+/// {@tool dartpad}
+/// This example shows how you can override the default text and icon
+/// color (the "foreground color") of a [TextButton] with a
+/// [WidgetStateProperty]. In this example, the button's text color
+/// will be `Colors.blue` when the button is being pressed, hovered,
+/// or focused. Otherwise, the text color will be `Colors.red`.
+///
+/// ** See code in examples/api/lib/widgets/widget_state/widget_state_property.0.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [MaterialStateProperty], the Material specific version of

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -766,11 +766,11 @@ class _WidgetTextStyleMapper extends WidgetStateTextStyle {
 /// material state properties when their value is needed.
 ///
 /// {@tool dartpad}
-/// This example shows how you can override the default text and icon
-/// color (the "foreground color") of a [TextButton] with a
-/// [WidgetStateProperty]. In this example, the button's text color
-/// will be `Colors.blue` when the button is being pressed, hovered,
-/// or focused. Otherwise, the text color will be `Colors.red`.
+/// This example shows how the default text and icon color
+/// (the "foreground color") of a [TextButton] can be overridden with a
+/// [WidgetStateProperty]. In this example, the button's text color will be
+/// `Colors.blue` when the button is being pressed, hovered, or focused.
+/// Otherwise, the text color will be `Colors.red`.
 ///
 /// ** See code in examples/api/lib/widgets/widget_state/widget_state_property.0.dart **
 /// {@end-tool}


### PR DESCRIPTION
This PR contributes to https://github.com/flutter/flutter/issues/155313

### Description
- Adds example for `WidgetStateProperty`
- Adds tests for `examples/api/lib/widgets/widget_state/widget_state_property.0.dart`

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.