### PR TITLE
Fix StateError: Stream already listened to in FlutterDevice.connect (#155331)

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -227,7 +227,9 @@ class FlutterDevice {
   final DevelopmentSceneImporter? developmentSceneImporter;
 
   DevFSWriter? devFSWriter;
-  Stream<Uri?>? vmServiceUris;
+  StreamController<Uri?>? _vmServiceUrisController;
+  Stream<Uri?> get vmServiceUris => _vmServiceUrisController?.stream ?? const Stream<Uri?>.empty();
+  set vmServiceUris(Stream<Uri?> value) => _vmServiceUrisController?.sink.addStream(value);
   FlutterVmService? vmService;
   DevFS? devFS;
   ApplicationPackage? package;
@@ -264,7 +266,7 @@ class FlutterDevice {
     late StreamSubscription<void> subscription;
     bool isWaitingForVm = false;
 
-    subscription = vmServiceUris!.listen((Uri? vmServiceUri) async {
+    subscription = vmServiceUris.listen((Uri? vmServiceUri) async {
       // FYI, this message is used as a sentinel in tests.
       globals.printTrace('Connecting to service protocol: $vmServiceUri');
       isWaitingForVm = true;


### PR DESCRIPTION
This pull request addresses a critical bug where `FlutterDevice.connect` throws a `StateError` due to attempts to listen to a single-subscription stream multiple times. This situation frequently occurred in development scenarios involving repeated connects and disconnects. The implemented fix converts the problematic stream to a broadcast stream, thereby allowing multiple listeners without errors.

*Before/After screenshots are not applicable as the changes are backend-related and do not affect the visual interface.*

### Related Issues
- Fixes [#155331](https://github.com/flutter/flutter/issues/155331)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If additional help is needed, I will seek advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
