### PR TITLE
remove fujino from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,6 @@
 #
 # Use git ls-files '<pattern>' without a / prefix to see the list of matching files.
 
-/packages/flutter_tools/pubspec.yaml @christopherfujino
 /packages/flutter_tools/templates/module/ios/ @jmagman
 /packages/flutter_tools/templates/**/Podfile* @jmagman
 


### PR DESCRIPTION
Every time someone tries to merge stable into master, I get pinged. It's not worth the distraction. I initially added myself as CODEOWNER because I wanted to make sure people weren't adding unneccessary dependencies to the tool, but I give up.