### PR TITLE
`SelectionContainer.getSelectionContent()` add newline char iff none exists in `Selectable`'s result.

### DIFF
--- a/packages/flutter/lib/src/widgets/selection_container.dart
+++ b/packages/flutter/lib/src/widgets/selection_container.dart
@@ -196,7 +196,6 @@ class _SelectionContainerState extends State<SelectionContainer> with Selectable
     return SelectedContent(plainText: '$plainText\n');
   }
 
-
   @override
   SelectionResult dispatchSelectionEvent(SelectionEvent event) {
     assert(!widget._disabled);

--- a/packages/flutter/lib/src/widgets/selection_container.dart
+++ b/packages/flutter/lib/src/widgets/selection_container.dart
@@ -179,8 +179,23 @@ class _SelectionContainerState extends State<SelectionContainer> with Selectable
   @override
   SelectedContent? getSelectedContent() {
     assert(!widget._disabled);
-    return widget.delegate!.getSelectedContent();
+    final SelectedContent? content = widget.delegate?.getSelectedContent();
+    if (content == null) {
+      return null;
+    }
+
+    final String plainText = content.plainText;
+
+    // If plainText is empty or already ends with a newline character,
+    // then return the original SelectedContent as-is.
+    if (plainText.endsWith('\n')) {
+      return content;
+    }
+
+    // Else, append the newline character in a new SelectedContent object.
+    return SelectedContent(plainText: '$plainText\n');
   }
+
 
   @override
   SelectionResult dispatchSelectionEvent(SelectionEvent event) {

--- a/packages/flutter/lib/src/widgets/selection_container.dart
+++ b/packages/flutter/lib/src/widgets/selection_container.dart
@@ -196,6 +196,7 @@ class _SelectionContainerState extends State<SelectionContainer> with Selectable
     return SelectedContent(plainText: '$plainText\n');
   }
 
+
   @override
   SelectionResult dispatchSelectionEvent(SelectionEvent event) {
     assert(!widget._disabled);

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -5829,5 +5829,6 @@ resting in the night sky.
     expect(data, isNotNull);
     expect(data!.text, testValue);
 
-  }, variant: TargetPlatformVariant.all());
+  }, variant: KeySimulatorTransitModeVariant.all());
+
 }

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -5828,6 +5828,5 @@ resting in the night sky.
     final ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
     expect(data, isNotNull);
     expect(data!.text, testValue);
-
   }, variant: TargetPlatformVariant.all());
 }

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -5829,6 +5829,5 @@ resting in the night sky.
     expect(data, isNotNull);
     expect(data!.text, testValue);
 
-  }, variant: KeySimulatorTransitModeVariant.all());
-
+  }, variant: TargetPlatformVariant.all());
 }


### PR DESCRIPTION
Fixes:
- Introduce a non-breaking, small, enriching change to SelectionContainer's `getSelectionContent()` method which just appends the new-line token **if and only if** one doesn’t already exist.

According to the selection feature's history, the flutter [style guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#lazy-programming), and other contributor reading materials, the goal of flutter is to bring value to customers followed by value to the programmers serving the customers with [high quality products](https://github.com/flutter/flutter/blob/main/docs/about/Values.md#-maintaining-quality). Flutter does many things well but one known issue has been the content collected from the Selectables.

Related issues:
- https://github.com/flutter/flutter/issues/104548
- https://github.com/flutter/flutter/issues/154253

There has been a year-long effort,  to not only fix this issue but also improve on the API by user Rexios80 but each iteration was contested, which exhibits that an ideal API for this feature is currently unknown among the reviewers:
- https://github.com/flutter/flutter/pull/126835
- https://github.com/flutter/flutter/pull/146625

Without a clear roadmap, drastically changing the API is not on the table. However, we can still improve the **immediate** value for the customers of Flutter. Because **as it currently behaves, the copied content is useless to all**.

In main, the current behavior provides run-on content for common selectable widgets (like Text) such as this:
```
WE START WHERE CARFAX ENDFor a high-value purchase, VIN history just isn’t enough. There are many small problems that owners are not oblicated to report, and many minor issues that an owner might not even know about.Our inspections will find all those details that you will have no other way of finding. Every knick, dent, paint bubble, is something that will show up on our report.
```

After this patch I have this:
```
WE START WHERE CARFAX ENDS
For a high-value purchase, VIN history just isn’t enough. There are many small problems that owners are not oblicated to report, and many minor issues that an owner might not even know about.
Our inspections will find all those details that you will have no other way of finding. Every knick, dent, paint bubble, is something that will show up on our report.
```

Now that every Selectable's content is terminated by a new-line character, pasted content is readable. Before, not even the pasted content was useful. Furthermore, parsing the result for _most_ use-cases can be achieved by splitting on the new-line character. Before, this was also not possible since the content was appended directly to the tail of the last content without terminators. With this minor change, it brings (arguably so) **actual** value to the feature. :^)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
