### PR TITLE
Implement actionsPadding for AppBar

### DIFF
--- a/dev/tools/gen_defaults/lib/app_bar_template.dart
+++ b/dev/tools/gen_defaults/lib/app_bar_template.dart
@@ -56,6 +56,12 @@ class _${blockName}DefaultsM3 extends AppBarTheme {
 
   @override
   TextStyle? get titleTextStyle => ${textStyle('md.comp.top-app-bar.small.headline')};
+  
+  // TODO(Craftplacer): Consider using EdgeInsets.only(right: 8.0) instead of
+  // EdgeInsets.zero for Material 3 in the future,
+  // https://github.com/flutter/flutter/issues/155747
+  @override
+  EdgeInsets? get actionsPadding => EdgeInsets.zero; 
 }
 
 // Variant configuration

--- a/dev/tools/gen_defaults/lib/app_bar_template.dart
+++ b/dev/tools/gen_defaults/lib/app_bar_template.dart
@@ -56,12 +56,12 @@ class _${blockName}DefaultsM3 extends AppBarTheme {
 
   @override
   TextStyle? get titleTextStyle => ${textStyle('md.comp.top-app-bar.small.headline')};
-  
+
   // TODO(Craftplacer): Consider using EdgeInsets.only(right: 8.0) instead of
   // EdgeInsets.zero for Material 3 in the future,
   // https://github.com/flutter/flutter/issues/155747
   @override
-  EdgeInsets? get actionsPadding => EdgeInsets.zero; 
+  EdgeInsets? get actionsPadding => EdgeInsets.zero;
 }
 
 // Variant configuration

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -748,7 +748,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@template flutter.material.appbar.actionsPadding}
   /// The padding between the [actions] and the end of the AppBar.
   ///
-  /// By default, the value of [AppBar.actionsPadding] is [EdgeInsets.zero].
+  /// Defaults to zero.
   /// {@endtemplate}
   final EdgeInsetsGeometry? actionsPadding;
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -746,7 +746,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final Clip? clipBehavior;
 
   /// {@template flutter.material.appbar.marginPadding}
-  /// The padding between the [actions] and the right edge of the AppBar.
+  /// The padding between the [actions] and the end of the AppBar.
   ///
   /// By default, the value of [AppBar.actionsPadding] is 0.0.
   /// {@endtemplate}

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -2449,12 +2449,12 @@ class _AppBarDefaultsM3 extends AppBarTheme {
 
   @override
   TextStyle? get titleTextStyle => _textTheme.titleLarge;
-  
+
   // TODO(Craftplacer): Consider using EdgeInsets.only(right: 8.0) instead of
   // EdgeInsets.zero for Material 3 in the future,
   // https://github.com/flutter/flutter/issues/155747
   @override
-  EdgeInsets? get actionsPadding => EdgeInsets.zero; 
+  EdgeInsets? get actionsPadding => EdgeInsets.zero;
 }
 
 // Variant configuration

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -748,9 +748,9 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@template flutter.material.appbar.actionsPadding}
   /// The padding between the [actions] and the end of the AppBar.
   ///
-  /// By default, the value of [AppBar.actionsPadding] is 0.0.
+  /// By default, the value of [AppBar.actionsPadding] is [EdgeInsets.zero].
   /// {@endtemplate}
-  final double? actionsPadding;
+  final EdgeInsetsGeometry? actionsPadding;
 
   bool _getEffectiveCenterTitle(ThemeData theme) {
     bool platformCenter() {
@@ -914,10 +914,10 @@ class _AppBarState extends State<AppBar> {
       ?? defaults.actionsIconTheme?.copyWith(color: actionForegroundColor)
       ?? overallIconTheme;
 
-    // TODO(Craftplacer): consider using 8.0 instead of 0.0 for Material 3 in the future
-    final double actionsPadding = widget.actionsPadding
+    // TODO(Craftplacer): consider using EdgeInsets.only(right: 8.0) instead of EdgeInsets.zero for Material 3 in the future, https://github.com/flutter/flutter/issues/155747
+    final EdgeInsetsGeometry actionsPadding = widget.actionsPadding
       ?? appBarTheme.actionsPadding
-      ?? 0.0;
+      ?? EdgeInsets.zero;
 
     TextStyle? toolbarTextStyle = widget.toolbarTextStyle
       ?? appBarTheme.toolbarTextStyle
@@ -1033,7 +1033,7 @@ class _AppBarState extends State<AppBar> {
     Widget? actions;
     if (widget.actions != null && widget.actions!.isNotEmpty) {
       actions = Padding(
-        padding: EdgeInsetsDirectional.only(end: actionsPadding),
+        padding: actionsPadding,
         child: Row(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: theme.useMaterial3 ? CrossAxisAlignment.center : CrossAxisAlignment.stretch,
@@ -1274,7 +1274,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final Clip? clipBehavior;
   final _SliverAppVariant variant;
   final bool accessibleNavigation;
-  final double? actionsPadding;
+  final EdgeInsetsGeometry? actionsPadding;
 
   @override
   double get minExtent => collapsedHeight;
@@ -1941,7 +1941,7 @@ class SliverAppBar extends StatefulWidget {
   /// {@macro flutter.material.appbar.actionsPadding}
   ///
   /// This property is used to configure an [AppBar].
-  final double? actionsPadding;
+  final EdgeInsetsGeometry? actionsPadding;
 
   final _SliverAppVariant _variant;
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -745,7 +745,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@macro flutter.material.Material.clipBehavior}
   final Clip? clipBehavior;
 
-  /// {@template flutter.material.appbar.marginPadding}
+  /// {@template flutter.material.appbar.actionsPadding}
   /// The padding between the [actions] and the end of the AppBar.
   ///
   /// By default, the value of [AppBar.actionsPadding] is 0.0.

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -914,10 +914,9 @@ class _AppBarState extends State<AppBar> {
       ?? defaults.actionsIconTheme?.copyWith(color: actionForegroundColor)
       ?? overallIconTheme;
 
-    // TODO(Craftplacer): consider using EdgeInsets.only(right: 8.0) instead of EdgeInsets.zero for Material 3 in the future, https://github.com/flutter/flutter/issues/155747
     final EdgeInsetsGeometry actionsPadding = widget.actionsPadding
       ?? appBarTheme.actionsPadding
-      ?? EdgeInsets.zero;
+      ?? defaults.actionsPadding!;
 
     TextStyle? toolbarTextStyle = widget.toolbarTextStyle
       ?? appBarTheme.toolbarTextStyle
@@ -2395,6 +2394,9 @@ class _AppBarDefaultsM2 extends AppBarTheme {
 
   @override
   TextStyle? get titleTextStyle => _theme.textTheme.titleLarge;
+
+  @override
+  EdgeInsets? get actionsPadding => EdgeInsets.zero;
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES - AppBar
@@ -2447,6 +2449,12 @@ class _AppBarDefaultsM3 extends AppBarTheme {
 
   @override
   TextStyle? get titleTextStyle => _textTheme.titleLarge;
+  
+  // TODO(Craftplacer): Consider using EdgeInsets.only(right: 8.0) instead of
+  // EdgeInsets.zero for Material 3 in the future,
+  // https://github.com/flutter/flutter/issues/155747
+  @override
+  EdgeInsets? get actionsPadding => EdgeInsets.zero; 
 }
 
 // Variant configuration

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -218,6 +218,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.systemOverlayStyle,
     this.forceMaterialTransparency = false,
     this.clipBehavior,
+    this.actionsPadding,
   }) : assert(elevation == null || elevation >= 0.0),
        preferredSize = _PreferredAppBarSize(toolbarHeight, bottom?.preferredSize.height);
 
@@ -744,6 +745,13 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@macro flutter.material.Material.clipBehavior}
   final Clip? clipBehavior;
 
+  /// {@template flutter.material.appbar.marginPadding}
+  /// The padding between the [actions] and the right edge of the AppBar.
+  ///
+  /// By default, the value of [AppBar.actionsPadding] is 0.0.
+  /// {@endtemplate}
+  final double? actionsPadding;
+
   bool _getEffectiveCenterTitle(ThemeData theme) {
     bool platformCenter() {
       switch (theme.platform) {
@@ -906,6 +914,11 @@ class _AppBarState extends State<AppBar> {
       ?? defaults.actionsIconTheme?.copyWith(color: actionForegroundColor)
       ?? overallIconTheme;
 
+    // TODO(Craftplacer): consider using 8.0 instead of 0.0 for Material 3 in the future
+    final double actionsPadding = widget.actionsPadding
+      ?? appBarTheme.actionsPadding
+      ?? 0.0;
+
     TextStyle? toolbarTextStyle = widget.toolbarTextStyle
       ?? appBarTheme.toolbarTextStyle
       ?? defaults.toolbarTextStyle?.copyWith(color: foregroundColor);
@@ -1019,10 +1032,13 @@ class _AppBarState extends State<AppBar> {
 
     Widget? actions;
     if (widget.actions != null && widget.actions!.isNotEmpty) {
-      actions = Row(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: theme.useMaterial3 ? CrossAxisAlignment.center : CrossAxisAlignment.stretch,
-        children: widget.actions!,
+      actions = Padding(
+        padding: EdgeInsetsDirectional.only(end: actionsPadding),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: theme.useMaterial3 ? CrossAxisAlignment.center : CrossAxisAlignment.stretch,
+          children: widget.actions!,
+        ),
       );
     } else if (hasEndDrawer) {
       actions = EndDrawerButton(
@@ -1219,6 +1235,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     required this.clipBehavior,
     required this.variant,
     required this.accessibleNavigation,
+    required this.actionsPadding,
   }) : assert(primary || topPadding == 0.0),
        _bottomHeight = bottom?.preferredSize.height ?? 0.0;
 
@@ -1257,6 +1274,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final Clip? clipBehavior;
   final _SliverAppVariant variant;
   final bool accessibleNavigation;
+  final double? actionsPadding;
 
   @override
   double get minExtent => collapsedHeight;
@@ -1338,6 +1356,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         titleTextStyle: titleTextStyle,
         systemOverlayStyle: systemOverlayStyle,
         forceMaterialTransparency: forceMaterialTransparency,
+        actionsPadding: actionsPadding,
       ),
     );
     return appBar;
@@ -1376,7 +1395,8 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         || titleTextStyle != oldDelegate.titleTextStyle
         || systemOverlayStyle != oldDelegate.systemOverlayStyle
         || forceMaterialTransparency != oldDelegate.forceMaterialTransparency
-        || accessibleNavigation != oldDelegate.accessibleNavigation;
+        || accessibleNavigation != oldDelegate.accessibleNavigation
+        || actionsPadding != oldDelegate.actionsPadding;
   }
 
   @override
@@ -1516,6 +1536,7 @@ class SliverAppBar extends StatefulWidget {
     this.systemOverlayStyle,
     this.forceMaterialTransparency = false,
     this.clipBehavior,
+    this.actionsPadding,
   }) : assert(floating || !snap, 'The "snap" argument only makes sense for floating app bars.'),
        assert(stretchTriggerOffset > 0.0),
        assert(
@@ -1584,6 +1605,7 @@ class SliverAppBar extends StatefulWidget {
     this.systemOverlayStyle,
     this.forceMaterialTransparency = false,
     this.clipBehavior,
+    this.actionsPadding,
  }) : assert(floating || !snap, 'The "snap" argument only makes sense for floating app bars.'),
        assert(stretchTriggerOffset > 0.0),
        assert(
@@ -1652,6 +1674,7 @@ class SliverAppBar extends StatefulWidget {
     this.systemOverlayStyle,
     this.forceMaterialTransparency = false,
     this.clipBehavior,
+    this.actionsPadding,
   }) : assert(floating || !snap, 'The "snap" argument only makes sense for floating app bars.'),
        assert(stretchTriggerOffset > 0.0),
        assert(
@@ -1915,6 +1938,11 @@ class SliverAppBar extends StatefulWidget {
   /// {@macro flutter.material.Material.clipBehavior}
   final Clip? clipBehavior;
 
+  /// {@macro flutter.material.appbar.actionsPadding}
+  ///
+  /// This property is used to configure an [AppBar].
+  final double? actionsPadding;
+
   final _SliverAppVariant _variant;
 
   @override
@@ -2059,6 +2087,7 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
           clipBehavior: widget.clipBehavior,
           variant: widget._variant,
           accessibleNavigation: MediaQuery.of(context).accessibleNavigation,
+          actionsPadding: widget.actionsPadding,
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -156,7 +156,7 @@ class AppBarTheme with Diagnosticable {
 
   /// Overrides the default value of [AppBar.actionsPadding]
   /// property in all descendant [AppBar] widgets.
-  final double? actionsPadding;
+  final EdgeInsetsGeometry? actionsPadding;
 
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
@@ -177,7 +177,7 @@ class AppBarTheme with Diagnosticable {
     TextStyle? toolbarTextStyle,
     TextStyle? titleTextStyle,
     SystemUiOverlayStyle? systemOverlayStyle,
-    double? actionsPadding,
+    EdgeInsetsGeometry? actionsPadding,
   }) {
     assert(
       color == null || backgroundColor == null,
@@ -231,7 +231,7 @@ class AppBarTheme with Diagnosticable {
       toolbarTextStyle: TextStyle.lerp(a?.toolbarTextStyle, b?.toolbarTextStyle, t),
       titleTextStyle: TextStyle.lerp(a?.titleTextStyle, b?.titleTextStyle, t),
       systemOverlayStyle: t < 0.5 ? a?.systemOverlayStyle : b?.systemOverlayStyle,
-      actionsPadding: lerpDouble(a?.actionsPadding, b?.actionsPadding, t),
+      actionsPadding: EdgeInsetsGeometry.lerp(a?.actionsPadding, b?.actionsPadding, t),
     );
   }
 
@@ -299,6 +299,6 @@ class AppBarTheme with Diagnosticable {
     properties.add(DiagnosticsProperty<double>('toolbarHeight', toolbarHeight, defaultValue: null));
     properties.add(DiagnosticsProperty<TextStyle>('toolbarTextStyle', toolbarTextStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<TextStyle>('titleTextStyle', titleTextStyle, defaultValue: null));
-    properties.add(DiagnosticsProperty<double>('actionsPadding', actionsPadding, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('actionsPadding', actionsPadding, defaultValue: null));
   }
 }

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -46,6 +46,7 @@ class AppBarTheme with Diagnosticable {
     this.toolbarTextStyle,
     this.titleTextStyle,
     this.systemOverlayStyle,
+    this.actionsPadding,
   }) : assert(
          color == null || backgroundColor == null,
          'The color and backgroundColor parameters mean the same thing. Only specify one.',
@@ -153,6 +154,10 @@ class AppBarTheme with Diagnosticable {
   /// property in all descendant [AppBar] widgets.
   final SystemUiOverlayStyle? systemOverlayStyle;
 
+  /// Overrides the default value of [AppBar.actionsPadding]
+  /// property in all descendant [AppBar] widgets.
+  final double? actionsPadding;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   AppBarTheme copyWith({
@@ -172,6 +177,7 @@ class AppBarTheme with Diagnosticable {
     TextStyle? toolbarTextStyle,
     TextStyle? titleTextStyle,
     SystemUiOverlayStyle? systemOverlayStyle,
+    double? actionsPadding,
   }) {
     assert(
       color == null || backgroundColor == null,
@@ -193,6 +199,7 @@ class AppBarTheme with Diagnosticable {
       toolbarTextStyle: toolbarTextStyle ?? this.toolbarTextStyle,
       titleTextStyle: titleTextStyle ?? this.titleTextStyle,
       systemOverlayStyle: systemOverlayStyle ?? this.systemOverlayStyle,
+      actionsPadding: actionsPadding ?? this.actionsPadding,
     );
   }
 
@@ -224,6 +231,7 @@ class AppBarTheme with Diagnosticable {
       toolbarTextStyle: TextStyle.lerp(a?.toolbarTextStyle, b?.toolbarTextStyle, t),
       titleTextStyle: TextStyle.lerp(a?.titleTextStyle, b?.titleTextStyle, t),
       systemOverlayStyle: t < 0.5 ? a?.systemOverlayStyle : b?.systemOverlayStyle,
+      actionsPadding: lerpDouble(a?.actionsPadding, b?.actionsPadding, t),
     );
   }
 
@@ -244,6 +252,7 @@ class AppBarTheme with Diagnosticable {
     toolbarTextStyle,
     titleTextStyle,
     systemOverlayStyle,
+    actionsPadding,
   );
 
   @override
@@ -269,7 +278,8 @@ class AppBarTheme with Diagnosticable {
         && other.toolbarHeight == toolbarHeight
         && other.toolbarTextStyle == toolbarTextStyle
         && other.titleTextStyle == titleTextStyle
-        && other.systemOverlayStyle == systemOverlayStyle;
+        && other.systemOverlayStyle == systemOverlayStyle
+        && other.actionsPadding == actionsPadding;
   }
 
   @override
@@ -289,5 +299,6 @@ class AppBarTheme with Diagnosticable {
     properties.add(DiagnosticsProperty<double>('toolbarHeight', toolbarHeight, defaultValue: null));
     properties.add(DiagnosticsProperty<TextStyle>('toolbarTextStyle', toolbarTextStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<TextStyle>('titleTextStyle', titleTextStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<double>('actionsPadding', actionsPadding, defaultValue: null));
   }
 }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3263,7 +3263,7 @@ void main() {
       return MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            actions: [
+            actions: <Widget>[
               SizedBox.square(key: actionKey, dimension: 40.0),
             ],
             actionsPadding: actionsPadding,

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3274,10 +3274,10 @@ void main() {
 
     await tester.pumpWidget(buildAppBar());
 
-    // Test actions position without actions padding.
+    // Actions padding default to zero padding.
     Offset actionsOffset = tester.getTopRight(find.byKey(actionKey));
     final Offset appBarOffset = tester.getTopRight(find.byKey(appBarKey));
-    expect(actionsOffset.dx, appBarOffset.dx);
+    expect(appBarOffset.dx - actionsOffset.dx, 0);
 
     const EdgeInsets actionsPadding = EdgeInsets.only(right: 8.0);
     await tester.pumpWidget(buildAppBar(actionsPadding: actionsPadding));

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3254,6 +3254,36 @@ void main() {
     expect(find.text('Second Screen'), findsNothing);
   });
 
+  testWidgets('AppBar actions padding can be adjusted', (WidgetTester tester) async {
+    const double testActionsPadding = 8.0;
+    final Key actionKey = UniqueKey();
+    final Finder finder = find.byKey(actionKey);
+
+    Widget buildApp([double? actionsPadding]) {
+      return MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            actions: [
+              SizedBox.square(key: actionKey, dimension: 40.0),
+            ],
+            actionsPadding: actionsPadding,
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+
+    final Offset offsetA = tester.getTopRight(finder);
+
+    // use theoretical Material 3 default
+    await tester.pumpWidget(buildApp(testActionsPadding));
+
+    final Offset offsetB = tester.getTopRight(finder);
+
+    expect(offsetB.dx, equals(offsetA.dx - testActionsPadding));
+  });
+
   group('Material 2', () {
     testWidgets('Material2 - AppBar draws a light system bar for a dark background', (WidgetTester tester) async {
       final ThemeData darkTheme = ThemeData.dark(useMaterial3: false);

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3259,7 +3259,7 @@ void main() {
     final Key actionKey = UniqueKey();
     final Finder finder = find.byKey(actionKey);
 
-    Widget buildApp([double? actionsPadding]) {
+    Widget buildApp([EdgeInsetsGeometry? actionsPadding]) {
       return MaterialApp(
         home: Scaffold(
           appBar: AppBar(
@@ -3277,7 +3277,7 @@ void main() {
     final Offset offsetA = tester.getTopRight(finder);
 
     // use theoretical Material 3 default
-    await tester.pumpWidget(buildApp(testActionsPadding));
+    await tester.pumpWidget(buildApp(const EdgeInsets.only(right: testActionsPadding)));
 
     final Offset offsetB = tester.getTopRight(finder);
 

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3255,14 +3255,14 @@ void main() {
   });
 
   testWidgets('AppBar actions padding can be adjusted', (WidgetTester tester) async {
-    const double testActionsPadding = 8.0;
+    final Key appBarKey = UniqueKey();
     final Key actionKey = UniqueKey();
-    final Finder finder = find.byKey(actionKey);
 
-    Widget buildApp([EdgeInsetsGeometry? actionsPadding]) {
+    Widget buildAppBar({ EdgeInsetsGeometry? actionsPadding }) {
       return MaterialApp(
         home: Scaffold(
           appBar: AppBar(
+            key: appBarKey,
             actions: <Widget>[
               SizedBox.square(key: actionKey, dimension: 40.0),
             ],
@@ -3272,15 +3272,17 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(buildApp());
+    await tester.pumpWidget(buildAppBar());
 
-    final Offset offsetA = tester.getTopRight(finder);
+    // Test actions position without actions padding.
+    Offset actionsOffset = tester.getTopRight(find.byKey(actionKey));
+    final Offset appBarOffset = tester.getTopRight(find.byKey(appBarKey));
+    expect(actionsOffset.dx, appBarOffset.dx);
 
-    await tester.pumpWidget(buildApp(const EdgeInsets.only(right: testActionsPadding)));
-
-    final Offset offsetB = tester.getTopRight(finder);
-
-    expect(offsetB.dx, equals(offsetA.dx - testActionsPadding));
+    const EdgeInsets actionsPadding = EdgeInsets.only(right: 8.0);
+    await tester.pumpWidget(buildAppBar(actionsPadding: actionsPadding));
+    actionsOffset = tester.getTopRight(find.byKey(actionKey));
+    expect(actionsOffset.dx, equals(appBarOffset.dx - actionsPadding.right));
   });
 
   group('Material 2', () {

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3276,7 +3276,6 @@ void main() {
 
     final Offset offsetA = tester.getTopRight(finder);
 
-    // use theoretical Material 3 default
     await tester.pumpWidget(buildApp(const EdgeInsets.only(right: testActionsPadding)));
 
     final Offset offsetB = tester.getTopRight(finder);


### PR DESCRIPTION
This pull requests adds a new `actionsPadding` property to AppBar, which controls the padding of the actions row's end. By default, no padding is added.

As it was already discussed in the linked issue below (https://github.com/flutter/flutter/issues/115349#issuecomment-1315582192), it is not feasible to change defaults. This PR is an interim solution to allow developers to change layout across the app, until that change/transition can be made (see: the new TODO line). 

Different to the original code from 2018, this PR only adds padding to the actual actions row, instead of the entire `NavigationToolbar`.

Fixes #155747

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

