### PR TITLE
Fix DropdownMenu does not rematch initialSelection when entries have changed

### DIFF
--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 // Flutter code sample for [DropdownMenu]s. The first dropdown menu
@@ -14,6 +15,8 @@ void main() {
   runApp(const DropdownMenuExample());
 }
 
+typedef ColorEntry = DropdownMenuEntry<ColorLabel>;
+
 // DropdownMenuEntry labels and values for the first dropdown menu.
 enum ColorLabel {
   blue('Blue', Colors.blue),
@@ -25,21 +28,43 @@ enum ColorLabel {
   const ColorLabel(this.label, this.color);
   final String label;
   final Color color;
+
+  static final List<ColorEntry> entries = UnmodifiableListView<ColorEntry>(
+    values.map<ColorEntry>(
+      (ColorLabel color) => ColorEntry(
+        value: color,
+        label: color.label,
+        enabled: color.label != 'Grey',
+        style: MenuItemButton.styleFrom(
+          foregroundColor: color.color,
+        ),
+      ),
+    ),
+  );
 }
+
+typedef IconEntry  = DropdownMenuEntry<IconLabel>;
 
 // DropdownMenuEntry labels and values for the second dropdown menu.
 enum IconLabel {
   smile('Smile', Icons.sentiment_satisfied_outlined),
-  cloud(
-    'Cloud',
-    Icons.cloud_outlined,
-  ),
+  cloud('Cloud', Icons.cloud_outlined),
   brush('Brush', Icons.brush_outlined),
   heart('Heart', Icons.favorite);
 
   const IconLabel(this.label, this.icon);
   final String label;
   final IconData icon;
+
+  static final List<IconEntry> entries = UnmodifiableListView<IconEntry>(
+    values.map<IconEntry>(
+      (IconLabel icon) => IconEntry(
+        value: icon,
+        label: icon.label,
+        leadingIcon: Icon(icon.icon),
+      ),
+    ),
+  );
 }
 
 class DropdownMenuExample extends StatefulWidget {
@@ -54,29 +79,6 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
   final TextEditingController iconController = TextEditingController();
   ColorLabel? selectedColor;
   IconLabel? selectedIcon;
-
-  final List<DropdownMenuEntry<ColorLabel>> colorEntries = ColorLabel.values.map<DropdownMenuEntry<ColorLabel>>(
-    (ColorLabel color) {
-      return DropdownMenuEntry<ColorLabel>(
-        value: color,
-        label: color.label,
-        enabled: color.label != 'Grey',
-        style: MenuItemButton.styleFrom(
-          foregroundColor: color.color,
-        ),
-      );
-    }
-  ).toList();
-
-  final List<DropdownMenuEntry<IconLabel>> iconEntries = IconLabel.values.map<DropdownMenuEntry<IconLabel>>(
-    (IconLabel icon) {
-      return DropdownMenuEntry<IconLabel>(
-        value: icon,
-        label: icon.label,
-        leadingIcon: Icon(icon.icon),
-      );
-    },
-  ).toList();
 
   @override
   Widget build(BuildContext context) {
@@ -108,7 +110,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                           selectedColor = color;
                         });
                       },
-                      dropdownMenuEntries: colorEntries,
+                      dropdownMenuEntries: ColorLabel.entries,
                     ),
                     const SizedBox(width: 24),
                     DropdownMenu<IconLabel>(
@@ -126,7 +128,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                           selectedIcon = icon;
                         });
                       },
-                      dropdownMenuEntries: iconEntries,
+                      dropdownMenuEntries: IconLabel.entries,
                     ),
                   ],
                 ),

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
@@ -55,6 +55,29 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
   ColorLabel? selectedColor;
   IconLabel? selectedIcon;
 
+  final List<DropdownMenuEntry<ColorLabel>> colorEntries = ColorLabel.values.map<DropdownMenuEntry<ColorLabel>>(
+    (ColorLabel color) {
+      return DropdownMenuEntry<ColorLabel>(
+        value: color,
+        label: color.label,
+        enabled: color.label != 'Grey',
+        style: MenuItemButton.styleFrom(
+          foregroundColor: color.color,
+        ),
+      );
+    }
+  ).toList();
+
+  final List<DropdownMenuEntry<IconLabel>> iconEntries = IconLabel.values.map<DropdownMenuEntry<IconLabel>>(
+    (IconLabel icon) {
+      return DropdownMenuEntry<IconLabel>(
+        value: icon,
+        label: icon.label,
+        leadingIcon: Icon(icon.icon),
+      );
+    },
+  ).toList();
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -85,18 +108,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                           selectedColor = color;
                         });
                       },
-                      dropdownMenuEntries: ColorLabel.values.map<DropdownMenuEntry<ColorLabel>>(
-                        (ColorLabel color) {
-                          return DropdownMenuEntry<ColorLabel>(
-                            value: color,
-                            label: color.label,
-                            enabled: color.label != 'Grey',
-                            style: MenuItemButton.styleFrom(
-                              foregroundColor: color.color,
-                            ),
-                          );
-                        }
-                      ).toList(),
+                      dropdownMenuEntries: colorEntries,
                     ),
                     const SizedBox(width: 24),
                     DropdownMenu<IconLabel>(
@@ -114,15 +126,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                           selectedIcon = icon;
                         });
                       },
-                      dropdownMenuEntries: IconLabel.values.map<DropdownMenuEntry<IconLabel>>(
-                        (IconLabel icon) {
-                          return DropdownMenuEntry<IconLabel>(
-                            value: icon,
-                            label: icon.label,
-                            leadingIcon: Icon(icon.icon),
-                          );
-                        },
-                      ).toList(),
+                      dropdownMenuEntries: iconEntries,
                     ),
                   ],
                 ),

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.1.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.1.dart
@@ -36,6 +36,12 @@ class DropdownMenuExample extends StatefulWidget {
 
 class _DropdownMenuExampleState extends State<DropdownMenuExample> {
   String dropdownValue = list.first;
+  final List<DropdownMenuEntry<String>> menuEntries = list.map<DropdownMenuEntry<String>>((String value) {
+    return DropdownMenuEntry<String>(
+      value: value,
+      label: value
+    );
+  }).toList();
 
   @override
   Widget build(BuildContext context) {
@@ -47,12 +53,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
           dropdownValue = value!;
         });
       },
-      dropdownMenuEntries: list.map<DropdownMenuEntry<String>>((String value) {
-        return DropdownMenuEntry<String>(
-          value: value,
-          label: value
-        );
-      }).toList(),
+      dropdownMenuEntries: menuEntries,
     );
   }
 }

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.1.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.1.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 /// Flutter code sample for [DropdownMenu].
@@ -34,14 +35,13 @@ class DropdownMenuExample extends StatefulWidget {
   State<DropdownMenuExample> createState() => _DropdownMenuExampleState();
 }
 
+typedef MenuEntry  = DropdownMenuEntry<String>;
+
 class _DropdownMenuExampleState extends State<DropdownMenuExample> {
+  static final List<MenuEntry> menuEntries = UnmodifiableListView<MenuEntry>(
+    list.map<MenuEntry>((String name) => MenuEntry(value: name, label: name)),
+  );
   String dropdownValue = list.first;
-  final List<DropdownMenuEntry<String>> menuEntries = list.map<DropdownMenuEntry<String>>((String value) {
-    return DropdownMenuEntry<String>(
-      value: value,
-      label: value
-    );
-  }).toList();
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart
@@ -39,6 +39,9 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final List<DropdownMenuEntry<String>> menuEntries = list.map<DropdownMenuEntry<String>>((String value) {
+      return DropdownMenuEntry<String>(value: value, label: value);
+    }).toList();
 
     return ListView(
       children: <Widget>[
@@ -62,10 +65,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                     dropdownValue = value!;
                   });
                 },
-                dropdownMenuEntries:
-                    list.map<DropdownMenuEntry<String>>((String value) {
-                  return DropdownMenuEntry<String>(value: value, label: value);
-                }).toList(),
+                dropdownMenuEntries: menuEntries,
               ),
               const Text('Text cursor is shown when hovering over the DropdownMenu.'),
             ],
@@ -92,10 +92,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                     dropdownValue = value!;
                   });
                 },
-                dropdownMenuEntries:
-                    list.map<DropdownMenuEntry<String>>((String value) {
-                  return DropdownMenuEntry<String>(value: value, label: value);
-                }).toList(),
+                dropdownMenuEntries: menuEntries,
               ),
               const Text('Clickable cursor is shown when hovering over the DropdownMenu.'),
             ],
@@ -123,10 +120,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                     dropdownValue = value!;
                   });
                 },
-                dropdownMenuEntries:
-                    list.map<DropdownMenuEntry<String>>((String value) {
-                  return DropdownMenuEntry<String>(value: value, label: value);
-                }).toList(),
+                dropdownMenuEntries: menuEntries,
               ),
               const Text('Default cursor is shown when hovering over the DropdownMenu.'),
             ],
@@ -154,10 +148,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                     dropdownValue = value!;
                   });
                 },
-                dropdownMenuEntries:
-                    list.map<DropdownMenuEntry<String>>((String value) {
-                  return DropdownMenuEntry<String>(value: value, label: value);
-                }).toList(),
+                dropdownMenuEntries: menuEntries,
               ),
               const Text('Default cursor is shown when hovering over the DropdownMenu.'),
             ],

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 /// Flutter code sample for [DropdownMenu].
@@ -33,15 +34,17 @@ class DropdownMenuExample extends StatefulWidget {
   State<DropdownMenuExample> createState() => _DropdownMenuExampleState();
 }
 
+typedef MenuEntry = DropdownMenuEntry<String>;
+
 class _DropdownMenuExampleState extends State<DropdownMenuExample> {
+  static final List<MenuEntry> menuEntries = UnmodifiableListView<MenuEntry>(
+    list.map<MenuEntry>((String name) => MenuEntry(value: name, label: name)),
+  );
   String dropdownValue = list.first;
 
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    final List<DropdownMenuEntry<String>> menuEntries = list.map<DropdownMenuEntry<String>>((String value) {
-      return DropdownMenuEntry<String>(value: value, label: value);
-    }).toList();
 
     return ListView(
       children: <Widget>[

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -497,6 +497,18 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   bool _menuHasEnabledItem = false;
   TextEditingController? _localTextEditingController;
 
+  TextEditingValue get _initialTextEditingValue {
+    for (final DropdownMenuEntry<T> entry in filteredEntries) {
+      if (entry.value == widget.initialSelection) {
+        return TextEditingValue(
+          text: entry.label,
+          selection: TextSelection.collapsed(offset: entry.label.length),
+        );
+      }
+    }
+    return TextEditingValue.empty;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -509,8 +521,8 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     filteredEntries = widget.dropdownMenuEntries;
     buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
     _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
+    _localTextEditingController?.value = _initialTextEditingValue;
 
-    matchInitialSelection();
     refreshLeadingPadding();
   }
 
@@ -553,14 +565,14 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         (DropdownMenuEntry<T> entry) => entry.label == _localTextEditingController?.text
       );
       if (!isCurrentSelectionValid) {
-        matchInitialSelection();
+        _localTextEditingController?.value = _initialTextEditingValue;
       }
     }
     if (oldWidget.leadingIcon != widget.leadingIcon) {
       refreshLeadingPadding();
     }
     if (oldWidget.initialSelection != widget.initialSelection) {
-      matchInitialSelection();
+      _localTextEditingController?.value = _initialTextEditingValue;
     }
   }
 
@@ -570,24 +582,6 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia => false,
         TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows => true,
       };
-  }
-
-  // Initialize the text field with the label associated to the entry
-  // whose value matches the initial selection.
-  // Empty the text field when no entry matches the initial selection.
-  void matchInitialSelection() {
-    final int index = filteredEntries.indexWhere(
-      (DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection
-    );
-    if (index != -1) {
-      final String label = filteredEntries[index].label;
-      _localTextEditingController?.value = TextEditingValue(
-        text: label,
-        selection: TextSelection.collapsed(offset: label.length),
-      );
-    } else {
-      _localTextEditingController?.value = TextEditingValue.empty;
-    }
   }
 
   void refreshLeadingPadding() {

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -576,11 +576,14 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   // whose value matches the initial selection.
   // Empty the text field when no entry matches the initial selection.
   void matchInitialSelection() {
-    final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection);
+    final int index = filteredEntries.indexWhere(
+      (DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection
+    );
     if (index != -1) {
+      final String label = filteredEntries[index].label;
       _localTextEditingController?.value = TextEditingValue(
-        text: filteredEntries[index].label,
-        selection: TextSelection.collapsed(offset: filteredEntries[index].label.length),
+        text: label,
+        selection: TextSelection.collapsed(offset: label.length),
       );
     } else {
       _localTextEditingController?.value = TextEditingValue.empty;

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -548,7 +548,13 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       filteredEntries = widget.dropdownMenuEntries;
       buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
       _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
-      matchInitialSelection();
+      // If the text field content matches one of the new entries do not rematch the initialSelection.
+      final bool isCurrentSelectionValid = filteredEntries.any(
+        (DropdownMenuEntry<T> entry) => entry.label == _localTextEditingController?.text
+      );
+      if (!isCurrentSelectionValid) {
+        matchInitialSelection();
+      }
     }
     if (oldWidget.leadingIcon != widget.leadingIcon) {
       refreshLeadingPadding();

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -510,13 +510,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
     _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
 
-    final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection);
-    if (index != -1) {
-      _localTextEditingController?.value = TextEditingValue(
-        text: filteredEntries[index].label,
-        selection: TextSelection.collapsed(offset: filteredEntries[index].label.length),
-      );
-    }
+    matchInitialSelection();
     refreshLeadingPadding();
   }
 
@@ -554,18 +548,13 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       filteredEntries = widget.dropdownMenuEntries;
       buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
       _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
+      matchInitialSelection();
     }
     if (oldWidget.leadingIcon != widget.leadingIcon) {
       refreshLeadingPadding();
     }
     if (oldWidget.initialSelection != widget.initialSelection) {
-      final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection);
-      if (index != -1) {
-        _localTextEditingController?.value = TextEditingValue(
-          text: filteredEntries[index].label,
-          selection: TextSelection.collapsed(offset: filteredEntries[index].label.length),
-        );
-      }
+      matchInitialSelection();
     }
   }
 
@@ -575,6 +564,21 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia => false,
         TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows => true,
       };
+  }
+
+  // Initialize the text field with the label associated to the entry
+  // whose value matches the initial selection.
+  // Empty the text field when no entry matches the initial selection.
+  void matchInitialSelection() {
+    final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection);
+    if (index != -1) {
+      _localTextEditingController?.value = TextEditingValue(
+        text: filteredEntries[index].label,
+        selection: TextSelection.collapsed(offset: filteredEntries[index].label.length),
+      );
+    } else {
+      _localTextEditingController?.value = TextEditingValue.empty;
+    }
   }
 
   void refreshLeadingPadding() {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1997,7 +1997,7 @@ void main() {
   });
 
   testWidgets(
-    'When the initial selection matches a menu entry the text field should display the corresponding value',
+    'When the initial selection matches a menu entry, the text field displays the corresponding value',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController();
       addTearDown(controller.dispose);
@@ -2021,7 +2021,7 @@ void main() {
   );
 
   testWidgets(
-    'When the initial selection does not match any menu entries the text field should be empty',
+    'Text field is empty when the initial selection does not match any menu entries',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController();
       addTearDown(controller.dispose);

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2106,7 +2106,7 @@ void main() {
       await tester.pumpWidget(boilerplate(menuChildren));
       expect(controller.text, TestMenu.mainMenu3.label);
 
-      // Open the menu
+      // Open the menu.
       await tester.tap(find.byType(DropdownMenu<TestMenu>));
       await tester.pump();
 

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1996,6 +1996,90 @@ void main() {
     expect(itemMaterial.color, themeData.colorScheme.onSurface.withOpacity(0.12));
   });
 
+  testWidgets(
+    'When the initial selection matches a menu entry the text field should display the corresponding value',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: DropdownMenu<TestMenu>(
+                initialSelection: TestMenu.mainMenu3,
+                dropdownMenuEntries: menuChildren,
+                controller: controller,
+              ),
+            );
+          }
+        ),
+      ));
+
+      expect(controller.text, TestMenu.mainMenu3.label);
+    },
+  );
+
+  testWidgets(
+    'When the initial selection does not match any menu entries the text field should be empty',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: DropdownMenu<TestMenu>(
+                initialSelection: TestMenu.mainMenu3,
+                // Use a menu entries which does not contain TestMenu.mainMenu3.
+                dropdownMenuEntries: menuChildren.getRange(0, 1).toList(),
+                controller: controller,
+              ),
+            );
+          }
+        ),
+      ));
+
+      expect(controller.text, isEmpty);
+    },
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/155660.
+  testWidgets('Updating the menu entries refreshes the initial selection', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    Widget boilerplate(List<DropdownMenuEntry<TestMenu>> entries) {
+      return MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: DropdownMenu<TestMenu>(
+                initialSelection: TestMenu.mainMenu3,
+                dropdownMenuEntries: entries,
+                controller: controller,
+              ),
+            );
+          }
+        ),
+      );
+    }
+
+    // The text field should be empty when the initial selection does not match
+    // any menu items.
+    await tester.pumpWidget(boilerplate(menuChildren.getRange(0, 1).toList()));
+    expect(controller.text, '');
+
+    // When the menu entries is updated the initial selection should be rematched.
+    await tester.pumpWidget(boilerplate(menuChildren));
+    expect(controller.text, TestMenu.mainMenu3.label);
+
+    // Update the entries with none matching the initial selection.
+    await tester.pumpWidget(boilerplate(menuChildren.getRange(0, 1).toList()));
+    expect(controller.text, '');
+  });
+
   testWidgets('The default text input field should not be focused on mobile platforms '
       'when it is tapped', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();


### PR DESCRIPTION
## Description

This PR makes DropdownMenu rematching the initialSelection when the entries are updated.
If the new entries contains one entry whose value matches `initialSelection` this entry's label is used to initialize the inner text field, if no entries matches `initialSelection` the text field is emptied.

## Related Issue

Fixes [DropdownMenu.didUpdateWidget should re-match initialSelection when dropdownMenuEntries have changed](https://github.com/flutter/flutter/issues/155660).

## Tests

Adds 3 tests.
