### PR TITLE
mark {Linux,Windows} tool_integration_tests_* non-bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1166,7 +1166,6 @@ targets:
   - name: Linux tool_integration_tests_1_5
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -1193,7 +1192,6 @@ targets:
   - name: Linux tool_integration_tests_2_5
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -1220,7 +1218,6 @@ targets:
   - name: Linux tool_integration_tests_3_5
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -1247,7 +1244,6 @@ targets:
   - name: Linux tool_integration_tests_4_5
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -1274,7 +1270,6 @@ targets:
   - name: Linux tool_integration_tests_5_5
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -5888,7 +5883,6 @@ targets:
   - name: Windows tool_integration_tests_1_8
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -5913,7 +5907,6 @@ targets:
   - name: Windows tool_integration_tests_2_8
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -5938,7 +5931,6 @@ targets:
   - name: Windows tool_integration_tests_3_8
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -5963,7 +5955,6 @@ targets:
   - name: Windows tool_integration_tests_4_8
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -5988,7 +5979,6 @@ targets:
   - name: Windows tool_integration_tests_5_8
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -6013,7 +6003,6 @@ targets:
   - name: Windows tool_integration_tests_6_8
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -6038,7 +6027,6 @@ targets:
   - name: Windows tool_integration_tests_7_8
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -6063,7 +6051,6 @@ targets:
   - name: Windows tool_integration_tests_8_8
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-


### PR DESCRIPTION
Follow-up to https://github.com/flutter/flutter/pull/155631

These have not failed except one flake from gradle exhausting the java heap.