### PR TITLE
[CP-stable] Bump package:dds from version 4.2.4+1 to 4.2.4+2

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   archive: 3.6.1
   args: 2.5.0
   browser_launcher: 1.1.1
-  dds: 4.2.4+1
+  dds: 4.2.4+2
   dwds: 24.0.0
   completion: 1.0.1
   coverage: 1.8.0
@@ -120,4 +120,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 72aa
+# PUBSPEC CHECKSUM: e5ab


### PR DESCRIPTION
CP Issue: https://github.com/flutter/flutter/issues/155837

Hopefully resolves the majority of the remaining `RPCError` crashes occurring on stable (context: https://github.com/flutter/flutter/issues/153471).

## Context and what is happening here
1. flutter_tools on the stable channel depends on package:dds@4.2.4+1
2. package:dds has a fix for these type of crashes, but was landed in [package:dds@4.2.6](https://github.com/dart-lang/sdk/commit/212e49fda60487853de0e34cc6a5d8cd9172c640)
3. I've created and published a 4.2.4+2 version of package:dds that patches the 4.2.6 fix into 4.2.4+1.
4. This PR makes flutter_tools depend on this new 4.2.4+2 version.

## Verifying this change

Unfortunately, I have not found a way to reproduce this particular crash (neither organically or inorganically through code modification). I am still decently confident this will fix any of the crashes (from https://github.com/flutter/flutter/issues/153471) that include `_withErrorHandling` in their stack trace.

However, we can at least be confident that this shouldn't _break_ anything new. The code change is very small.

The easiest way to check what code is being changed here is to `git diff` the version of package:dds we are bumping from and the one we are bumping to: `git diff /Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/ /Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2`. While I accidentally chose the incorrect base commit when creating 4.2.4+2, the dart code changes should still be minimal:

<details>

<summary>full diff (your IDE probably has a "diff" language mode to make this human-readable)</summary>

<pre>
diff --git a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/CHANGELOG.md b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/CHANGELOG.md
index a515f931cc..72cd187fbc 100644
--- a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/CHANGELOG.md
+++ b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.4+2
+- [DAP] Fixed an issue where "Service connection disposed" errors may go unhandled during termination/shutdown.Uint8List` from `dart:typed_data`.
+- Added `package:dds/dds_launcher.dart`, a library which can be used to launch DDS instances using `dart development-service`.
+
 # 4.2.4+1
 - Added missing type to `Event` in `postEvent`.
 - [DAP] Instaces with both fields and getters of the same name will no longer show duplicates in `variables` responses.
@@ -310,8 +314,8 @@ Hot-fix release of changes in 3.1.2 without the changes in 3.1.1
 # 1.7.0
 - Added `package:dds/vm_service_extensions.dart`, which adds DDS functionality to
   `package:vm_service` when imported.
-  - Added `onEventWithHistory` method and `onLoggingEventWithHistory`, 
-    `onStdoutEventWithHistory`, `onStderrEventWithHistory`, and 
+  - Added `onEventWithHistory` method and `onLoggingEventWithHistory`,
+    `onStdoutEventWithHistory`, `onStderrEventWithHistory`, and
     `onExtensionEventWithHistory` getters.
 - Added `getStreamHistory` RPC.
 
diff --git a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/CONTRIBUTING.md b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/CONTRIBUTING.md
index ddad214772..de7603b2f2 100644
--- a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/CONTRIBUTING.md
+++ b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/CONTRIBUTING.md
@@ -22,6 +22,14 @@ Then you can call `_fileLog('some print debugging message')`, and the log messag
 
 To get logging output in real time, run `tail -f /tmp/dds.log`.
 
+## Running DDS tests
+
+From the `$DART_SDK_ROOT` directory, run:
+
+```shell
+ dart --packages=.dart_tool/package_config.json pkg/dds/test/path/to/your_test.dart
+```
+
 ## Making changes to `package:dds` and `package:devtools_shared`
 
 **If you do not need to build the Dart SDK** to test your changes, you
@@ -38,7 +46,7 @@ dependency_overrides:
 to adding the dependency override above, you will need to add a symbolic link
 to your local `devtools_shared` directory:
 
-From the `sdk/` directory, run:
+From the `$DART_SDK_ROOT` directory, run:
 ```shell
 rm -rf third_party/devtools/devtools_shared;
 ln -s /absolute_path_to/devtools/packages/devtools_shared third_party/devtools/devtools_shared
@@ -51,3 +59,42 @@ To delete the symbolic link after you are done with development, run:
 ```shell
 rm -rf third_party/devtools/devtools_shared
 ```
+
+## Making changes to `package:dds` and `devtools_app`
+
+To test any changes made in `devtools_app`, you will need to first build DevTools.
+
+- If you have not already, make sure to [set-up your DevTools development environment](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md#set-up-your-devtools-environment) so that you can use the `devtools_tool` command.
+
+- Then build DevTools with `devtools_tool build`.
+
+In the SDK, add a symbolic link to your local `devtools/packages/devtools_app/build/web` directory.
+
+From the `$DART_SDK_ROOT` directory, run:
+
+```shell
+rm -rf third_party/devtools/web;
+ln -s /absolute_path_to/devtools/devtools/packages/devtools_app/build/web third_party/devtools/web
+```
+
+**WARNING**: do not run `gclient sync -D` while the symbolic link is present,
+as this could cause issues with your local `devtools_app` code.
+
+Then, build the Dart SDK.
+
+From the `$DART_SDK_ROOT` directory, run:
+
+```shell
+./tools/build.py -mrelease -ax64 create_sdk
+```
+
+To delete the symbolic link after you are done with development, run:
+
+**WARNING**: do not run `gclient sync -D` while the symbolic link is present,
+as this could cause issues with your local `devtools_app` code.
+
+```shell
+rm -rf third_party/devtools/web
+```
+
+Then, run `gclient sync` to pull down the checked in version of DevTools.
diff --git a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/lib/src/dap/adapters/dart.dart b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/lib/src/dap/adapters/dart.dart
index 51228f24be..1a0a1f6287 100644
--- a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/lib/src/dap/adapters/dart.dart
+++ b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/lib/src/dap/adapters/dart.dart
@@ -2845,7 +2845,8 @@ abstract class DartDebugAdapter<TL extends LaunchRequestArguments,
         // errors because these can always occur during shutdown if we were
         // just starting to send (or had just sent) a request.
         if (e.message.contains("The client is closed") ||
-            e.message.contains("The client closed with pending request")) {
+            e.message.contains("The client closed with pending request") ||
+            e.message.contains("Service connection disposed")) {
           return null;
         }
       }
diff --git a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/lib/src/dds_cli_entrypoint.dart b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/lib/src/dds_cli_entrypoint.dart
index 1680cba55c..8546707a5e 100644
--- a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/lib/src/dds_cli_entrypoint.dart
+++ b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/lib/src/dds_cli_entrypoint.dart
@@ -129,7 +129,6 @@ ${argParser.usage}
           'uri': dtdInfo.uri,
         },
     }));
-    stderr.close();
   } catch (e, st) {
     writeErrorResponse(e, st);
   } finally {
diff --git a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/pubspec.yaml b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/pubspec.yaml
index c159257a1a..e136322d54 100644
--- a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/pubspec.yaml
+++ b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dds
-version: 4.2.4+1
+version: 4.2.4+2
 description: >-
   A library used to spawn the Dart Developer Service, used to communicate with
   a Dart VM Service instance.

</pre>

</details>

You might have notice this extraneous change in particular:

```diff
diff --git a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/lib/src/dds_cli_entrypoint.dart b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/lib/src/dds_cli_entrypoint.dart
index 1680cba55c..8546707a5e 100644
--- a/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+1/lib/src/dds_cli_entrypoint.dart
+++ b/Users/andrewkolos/.pub-cache/hosted/pub.dev/dds-4.2.4+2/lib/src/dds_cli_entrypoint.dart
@@ -129,7 +129,6 @@ ${argParser.usage}
           'uri': dtdInfo.uri,
         },
     }));
-    stderr.close();
   } catch (e, st) {
     writeErrorResponse(e, st);
   } finally {
```

This is is from https://github.com/dart-lang/sdk/commit/56416078a07d191418dafde3bdbeb73053fa9033. As you can see, there is already a `stderr.close` call in the finally block, so this change is just a refactor and safe to be in this cherry-pick.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
