### PR TITLE
Use flutter from in same repo (not path) in `generate_gradle_lockfiles.dart` (again)

### DIFF
--- a/dev/tools/bin/generate_gradle_lockfiles.dart
+++ b/dev/tools/bin/generate_gradle_lockfiles.dart
@@ -190,7 +190,7 @@ void main(List<String> arguments) {
     // Generate Gradle wrapper if it doesn't exist.
     if (!gradleWrapper.existsSync()) {
       exec(
-        'flutter',
+        flutterPath,
         <String>['build', 'apk', '--config-only'],
         workingDirectory: appDirectory,
       );


### PR DESCRIPTION
Fixes another invocation of `flutter`. Follow up to https://github.com/flutter/flutter/pull/155790/.

Checked that this is the only other one (and also the only use of `exec()` left that is relying on the path and shouldn't be (one other use uses git from the path, which is fine, and the other one uses an absolute path).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
