### PR TITLE
when `ResidentRunner.tryInitLogReader` fails, only log warning on Android

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
+import 'android/android_device.dart';
 import 'application_package.dart';
 import 'artifacts.dart';
 import 'asset.dart';
@@ -421,16 +422,17 @@ class FlutterDevice {
   /// This can fail if the device if no longer connected.
   Future<void> tryInitLogReader() async {
     final vm_service.VM? vm = await vmService!.getVmGuarded();
-    if (vm == null) {
-      globals.printError(
-        'Unable to initiate log reader for device'
-        '${device?.name}, because the Flutter VM service connection '
-        'is closed.',
-      );
-      return;
-    }
     final DeviceLogReader logReader = await device!.getLogReader(app: package);
-    logReader.appPid = vm.pid;
+    if (vm == null && logReader is AdbLogReader) {
+      // TODO(andrewkolos): This is a temporary, hacky fix for
+      //  https://github.com/flutter/flutter/issues/155795 that emphasizes
+      //  simplicity for the sake of being suitable for cherry-picking.
+      globals.printError(
+        'Unable to initiate adb log filtering for device'
+        '${device?.name}. Logs from the device may be more verbose than usual.',
+      );
+    }
+    logReader.appPid = vm?.pid;
   }
 
   Future<int> runHot({

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1944,6 +1944,7 @@ flutter:
     final TestFlutterDevice flutterDevice = TestFlutterDevice(device);
     flutterDevice.vmService = fakeVmServiceHost!.vmService;
     await flutterDevice.tryInitLogReader();
+
     final BufferLogger logger = globals.logger as BufferLogger;
     expect(
       logger.traceText,
@@ -1952,13 +1953,12 @@ flutter:
         'Service connection disposed\n',
       ),
     );
-    expect(
-      logger.errorText,
-      contains(
-        'Unable to initiate log reader for deviceFakeDevice, because '
-        'the Flutter VM service connection is closed.\n',
-      ),
-    );
+    // We should not print a warning since the device does not have a connected
+    // adb log reader.
+    // TODO(andrewkolos): This test is a bit fragile, and is something that
+    //  should be corrected in a follow-up PR (see
+    //  https://github.com/flutter/flutter/issues/155795).
+    expect(logger.errorText, isEmpty);
   }, overrides: <Type, Generator>{
     Logger: () => BufferLogger.test(),
     Artifacts: () => Artifacts.test(),


### PR DESCRIPTION
This is a follow-up to the PR https://github.com/flutter/flutter/pull/155049 (which fixed https://github.com/flutter/flutter/issues/154903). This PR addresses the resulting issue, https://github.com/flutter/flutter/issues/155795. It does so in a hacky way for the sake of simplicity (and thus suitability for cherry-picking). I intend to clean this up on the master channel with yet another follow-up PR, https://github.com/flutter/flutter/pull/155796, which currently exists as a proof-of-concept to make sure I actually have the ability to clean this after myself here.

**I intend to submit a stable hotfix patch with the changes from the original fix (https://github.com/flutter/flutter/pull/155049) and the follow-up changes from this PR.**

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
