### PR TITLE
Add deprecation warning for "flutter create --ios-language"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -258,6 +258,14 @@ class CreateCommand extends CreateBase {
         'template: the language will always be C or C++.',
         exitCode: 2,
       );
+    } else if (!generateModule && argResults!.wasParsed('ios-language')) {
+      // Swift is not yet supported for add-to-app https://github.com/flutter/flutter/issues/23955.
+      globals.printWarning(
+          'The "ios-language" option is deprecated and will be removed in a future Flutter release.');
+      if (stringArg('ios-language') == 'objc') {
+        globals.printWarning(
+            'Please comment in https://github.com/flutter/flutter/issues/148586 describing your use-case for using Objective-C instead of Swift.');
+      }
     }
 
     final String organization = await getOrganization();

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -258,8 +258,7 @@ class CreateCommand extends CreateBase {
         'template: the language will always be C or C++.',
         exitCode: 2,
       );
-    } else if (!generateModule && argResults!.wasParsed('ios-language')) {
-      // Swift is not yet supported for add-to-app https://github.com/flutter/flutter/issues/23955.
+    } else if (argResults!.wasParsed('ios-language')) {
       globals.printWarning(
           'The "ios-language" option is deprecated and will be removed in a future Flutter release.');
       if (stringArg('ios-language') == 'objc') {

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -96,11 +96,13 @@ abstract class CreateBase extends FlutterCommand {
           'The project name for this new Flutter project. This must be a valid dart package name.',
     );
     argParser.addOption(
+      hide: true,
       'ios-language',
       abbr: 'i',
       defaultsTo: 'swift',
       allowed: <String>['objc', 'swift'],
-      help: 'The language to use for iOS-specific code, either Objective-C (legacy) or Swift (recommended).'
+      help: 'This option is deprecated and will be removed in a future Flutter release.\n'
+          'The language to use for iOS-specific code, either Objective-C (legacy) or Swift (recommended).'
     );
     argParser.addOption(
       'android-language',

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -96,13 +96,12 @@ abstract class CreateBase extends FlutterCommand {
           'The project name for this new Flutter project. This must be a valid dart package name.',
     );
     argParser.addOption(
-      hide: true,
       'ios-language',
       abbr: 'i',
       defaultsTo: 'swift',
       allowed: <String>['objc', 'swift'],
-      help: 'This option is deprecated and will be removed in a future Flutter release.\n'
-          'The language to use for iOS-specific code, either Objective-C (legacy) or Swift (recommended).'
+      help: '(deprecated) The language to use for iOS-specific code, either Objective-C (legacy) or Swift (recommended).',
+      hide: !verboseHelp,
     );
     argParser.addOption(
       'android-language',

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -100,7 +100,7 @@ abstract class CreateBase extends FlutterCommand {
       abbr: 'i',
       defaultsTo: 'swift',
       allowed: <String>['objc', 'swift'],
-      help: '(deprecated) The language to use for iOS-specific code, either Objective-C (legacy) or Swift (recommended).',
+      help: '(deprecated) The language to use for iOS-specific code, either Swift (recommended) or Objective-C (legacy).',
       hide: !verboseHelp,
     );
     argParser.addOption(
@@ -108,7 +108,7 @@ abstract class CreateBase extends FlutterCommand {
       abbr: 'a',
       defaultsTo: 'kotlin',
       allowed: <String>['java', 'kotlin'],
-      help: 'The language to use for Android-specific code, either Java (legacy) or Kotlin (recommended).',
+      help: 'The language to use for Android-specific code, either Kotlin (recommended) or Java (legacy).',
     );
     argParser.addFlag(
       'skip-name-checks',

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1686,6 +1686,36 @@ void main() {
     expect(displayName, 'My Project');
   });
 
+  testUsingContext('should not show --ios-language deprecation warning issue for Swift', () async {
+    Cache.flutterRoot = '../..';
+
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    await runner.run(<String>['create', '--no-pub', '--ios-language=swift', projectDir.path]);
+    expect(logger.warningText, contains('The "ios-language" option is deprecated and will be removed in a future Flutter release.'));
+    expect(logger.warningText, isNot(contains('https://github.com/flutter/flutter/issues/148586')));
+
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(),
+    Logger: () => logger,
+  });
+
+  testUsingContext('should show --ios-language deprecation warning issue for Objective-C', () async {
+    Cache.flutterRoot = '../..';
+
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    await runner.run(<String>['create', '--no-pub', '--ios-language=objc', projectDir.path]);
+    expect(logger.warningText, contains('The "ios-language" option is deprecated and will be removed in a future Flutter release.'));
+    expect(logger.warningText, contains('https://github.com/flutter/flutter/issues/148586'));
+
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(),
+    Logger: () => logger,
+  });
+
   testUsingContext('has correct content and formatting with macOS app template', () async {
     Cache.flutterRoot = '../..';
 


### PR DESCRIPTION
The Objective-C  `flutter create --ios-language objc` template will be removed in https://github.com/flutter/flutter/issues/148586.

Add a deprecation warning when this flag is passed.  Add an additional warning when Objective-C is specified requesting the user's use-case.



Do not show the warning when creating the module, as Swift is not supported for it yet https://github.com/flutter/flutter/issues/23955

![Screenshot 2024-09-27 at 8 54 16 PM](https://github.com/user-attachments/assets/112be47f-a5bd-4f57-9a9d-c96c7bbc8ac3)


Part of https://github.com/flutter/flutter/issues/148586

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
