### PR TITLE
debug leaks

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -417,6 +417,8 @@ class ImageCache {
         sizeBytes = info.sizeBytes;
         info.dispose();
       }
+
+      ////
       final _CachedImage image = _CachedImage(
         result!,
         sizeBytes: sizeBytes,

--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -647,7 +647,10 @@ abstract class _CachedImageBase {
 }
 
 class _CachedImage extends _CachedImageBase {
-  _CachedImage(super.completer, {super.sizeBytes});
+  _CachedImage(super.completer, {super.sizeBytes}) {
+    print('created _CachedImage ${identityHashCode(this)}, with handle ${identityHashCode(this.handle)}');
+    print(StackTrace.current);
+  }
 }
 
 class _LiveImage extends _CachedImageBase {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -849,7 +849,7 @@ void main() {
     listeners[1].onImage(imageInfo.clone(), false);
 
     // Make sure the second listener can be called re-entrantly.
-    final image1 = imageInfo.clone();
+    final ImageInfo image1 = imageInfo.clone();
     listeners[0].onImage(image1, false);
     listeners[0].onImage(imageInfo.clone(), false);
 

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -825,7 +825,7 @@ void main() {
 
   testWidgets('Precache removes original listener immediately after future completes, does not crash on successive calls #25143',
   // TODO(polina-c): dispose ImageStreamCompleterHandle, https://github.com/flutter/flutter/issues/145599 [leaks-to-clean]
-  // experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
+  experimentalLeakTesting: LeakTesting.settings.withCreationStackTrace(),
   (WidgetTester tester) async {
     final _TestImageStreamCompleter imageStreamCompleter = _TestImageStreamCompleter();
     final _TestImageProvider provider = _TestImageProvider(streamCompleter: imageStreamCompleter);
@@ -851,6 +851,10 @@ void main() {
     // Make sure the second listener can be called re-entrantly.
     listeners[0].onImage(imageInfo.clone(), false);
     listeners[0].onImage(imageInfo.clone(), false);
+
+    imageInfo.dispose();
+    imageStreamCompleter.dispose();
+    imageCache.clear();
   });
 
   testWidgets('Precache completes with onError on error', (WidgetTester tester) async {
@@ -2242,6 +2246,11 @@ class _TestImageStreamCompleter extends ImageStreamCompleter {
     for (final ImageStreamListener listener in localListeners) {
       listener.onError?.call(exception, stackTrace);
     }
+  }
+
+  void dispose() {
+    final List<ImageStreamListener> listenersCopy = listeners.toList();
+    listenersCopy.forEach(removeListener);
   }
 }
 

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -825,7 +825,7 @@ void main() {
 
   testWidgets('Precache removes original listener immediately after future completes, does not crash on successive calls #25143',
   // TODO(polina-c): dispose ImageStreamCompleterHandle, https://github.com/flutter/flutter/issues/145599 [leaks-to-clean]
-  experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
+  // experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
   (WidgetTester tester) async {
     final _TestImageStreamCompleter imageStreamCompleter = _TestImageStreamCompleter();
     final _TestImageProvider provider = _TestImageProvider(streamCompleter: imageStreamCompleter);

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -859,10 +859,6 @@ void main() {
 
     imageInfo.dispose();
     imageStreamCompleter.dispose();
-    // clone1.dispose();
-    // clone2.dispose();
-    // clone3.dispose();
-    // clone4.dispose();
     imageCache.clear();
   });
 

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -864,8 +864,6 @@ void main() {
     // clone3.dispose();
     // clone4.dispose();
     imageCache.clear();
-    await tester.pumpWidget(Placeholder());
-    imageCache.clear();
   });
 
   testWidgets('Precache completes with onError on error', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -845,17 +845,26 @@ void main() {
 
     // Make sure the first listener can be called re-entrantly
     final ImageInfo imageInfo = ImageInfo(image: image10x10);
-    listeners[1].onImage(imageInfo.clone(), false);
-    listeners[1].onImage(imageInfo.clone(), false);
+    final ImageInfo clone1 = imageInfo.clone();
+    final ImageInfo clone2 = imageInfo.clone();
+    final ImageInfo clone3 = imageInfo.clone();
+    final ImageInfo clone4 = imageInfo.clone();
+
+    listeners[1].onImage(clone1, false);
+    listeners[1].onImage(clone2, false);
 
     // Make sure the second listener can be called re-entrantly.
-    final ImageInfo image1 = imageInfo.clone();
-    listeners[0].onImage(image1, false);
-    listeners[0].onImage(imageInfo.clone(), false);
+    listeners[0].onImage(clone3, false);
+    listeners[0].onImage(clone4, false);
 
     imageInfo.dispose();
-    // image1.dispose();
     imageStreamCompleter.dispose();
+    // clone1.dispose();
+    // clone2.dispose();
+    // clone3.dispose();
+    // clone4.dispose();
+    imageCache.clear();
+    await tester.pumpWidget(Placeholder());
     imageCache.clear();
   });
 


### PR DESCRIPTION
command to repro the test:

`flutter test test/widgets/image_test.dart --dart-define LEAK_TRACKING=true --plain-name "Precache removes original listener immediately after future completes, does not crash on successive calls #25143"`