### PR TITLE
`RenderParagraph`s `_SelectableFragment.boundingBoxes` should consider max line height

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -701,6 +701,10 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
       .maxIntrinsicWidth;
   }
 
+  /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
+  /// This does not require the layout to be updated.
+  double get preferredLineHeight => _textPainter.preferredLineHeight;
+
   double _computeIntrinsicHeight(double width) {
     return (_textIntrinsics
       ..setPlaceholderDimensions(layoutInlineChildren(width, ChildLayoutHelper.dryLayoutChild, ChildLayoutHelper.getDryBaseline))
@@ -903,8 +907,10 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
     }
 
     if (_lastSelectableFragments != null) {
+      int count = 0;
       for (final _SelectableFragment fragment in _lastSelectableFragments!) {
-        fragment.paint(context, offset);
+        fragment.paint(context, offset, count == 0? Color.fromRGBO(255, 0, 0, 100) : Color.fromRGBO(0, 0, 255, 100));
+        count++;
       }
     }
 
@@ -3043,7 +3049,18 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
     return _rect.size;
   }
 
-  void paint(PaintingContext context, Offset offset) {
+  void paint(PaintingContext context, Offset offset, Color color) {
+    final Paint selectionPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..color = color
+      ..strokeWidth = 1.0;
+    for (final TextBox textBox in paragraph.getBoxesForSelection(TextSelection(baseOffset: range.start, extentOffset: range.end), boxHeightStyle: ui.BoxHeightStyle.max)) {
+      context.canvas.drawRect(
+          textBox.toRect().shift(offset), selectionPaint);
+    }
+    //Offset(219.6, 311.5)diff
+    //Offset(199.6, 310.0) original
+    context.canvas.drawCircle(Offset(199.6, 310.0), 2.0, Paint()..color = Color.fromRGBO(255, 0, 0, 100) ..style = PaintingStyle.fill);
     if (_textSelectionStart == null || _textSelectionEnd == null) {
       return;
     }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -704,6 +704,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
   /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
   ///
   /// This does not require the layout to be updated.
+  @visibleForTesting
   double get preferredLineHeight => _textPainter.preferredLineHeight;
 
   double _computeIntrinsicHeight(double width) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -2997,6 +2997,7 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
     if (_cachedBoundingBoxes == null) {
       final List<TextBox> boxes = paragraph.getBoxesForSelection(
         TextSelection(baseOffset: range.start, extentOffset: range.end),
+        boxHeightStyle: ui.BoxHeightStyle.includeLineSpacingMiddle,
       );
       if (boxes.isNotEmpty) {
         _cachedBoundingBoxes = <Rect>[];
@@ -3034,6 +3035,7 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
 
   void didChangeParagraphLayout() {
     _cachedRect = null;
+    _cachedBoundingBoxes = null;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -701,6 +701,10 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
       .maxIntrinsicWidth;
   }
 
+  /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
+  /// This does not require the layout to be updated.
+  double get preferredLineHeight => _textPainter.preferredLineHeight;
+
   double _computeIntrinsicHeight(double width) {
     return (_textIntrinsics
       ..setPlaceholderDimensions(layoutInlineChildren(width, ChildLayoutHelper.dryLayoutChild, ChildLayoutHelper.getDryBaseline))

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -3001,7 +3001,7 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
     if (_cachedBoundingBoxes == null) {
       final List<TextBox> boxes = paragraph.getBoxesForSelection(
         TextSelection(baseOffset: range.start, extentOffset: range.end),
-        boxHeightStyle: ui.BoxHeightStyle.includeLineSpacingMiddle,
+        boxHeightStyle: ui.BoxHeightStyle.max,
       );
       if (boxes.isNotEmpty) {
         _cachedBoundingBoxes = <Rect>[];

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -702,6 +702,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
   }
 
   /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
+  ///
   /// This does not require the layout to be updated.
   double get preferredLineHeight => _textPainter.preferredLineHeight;
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -701,10 +701,6 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
       .maxIntrinsicWidth;
   }
 
-  /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
-  /// This does not require the layout to be updated.
-  double get preferredLineHeight => _textPainter.preferredLineHeight;
-
   double _computeIntrinsicHeight(double width) {
     return (_textIntrinsics
       ..setPlaceholderDimensions(layoutInlineChildren(width, ChildLayoutHelper.dryLayoutChild, ChildLayoutHelper.getDryBaseline))
@@ -907,10 +903,8 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
     }
 
     if (_lastSelectableFragments != null) {
-      int count = 0;
       for (final _SelectableFragment fragment in _lastSelectableFragments!) {
-        fragment.paint(context, offset, count == 0? Color.fromRGBO(255, 0, 0, 100) : Color.fromRGBO(0, 0, 255, 100));
-        count++;
+        fragment.paint(context, offset);
       }
     }
 
@@ -3049,18 +3043,7 @@ class _SelectableFragment with Selectable, Diagnosticable, ChangeNotifier implem
     return _rect.size;
   }
 
-  void paint(PaintingContext context, Offset offset, Color color) {
-    final Paint selectionPaint = Paint()
-      ..style = PaintingStyle.stroke
-      ..color = color
-      ..strokeWidth = 1.0;
-    for (final TextBox textBox in paragraph.getBoxesForSelection(TextSelection(baseOffset: range.start, extentOffset: range.end), boxHeightStyle: ui.BoxHeightStyle.max)) {
-      context.canvas.drawRect(
-          textBox.toRect().shift(offset), selectionPaint);
-    }
-    //Offset(219.6, 311.5)diff
-    //Offset(199.6, 310.0) original
-    context.canvas.drawCircle(Offset(199.6, 310.0), 2.0, Paint()..color = Color.fromRGBO(255, 0, 0, 100) ..style = PaintingStyle.fill);
+  void paint(PaintingContext context, Offset offset) {
     if (_textSelectionStart == null || _textSelectionEnd == null) {
       return;
     }

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -1302,8 +1302,7 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
   /// [SelectWordSelectionEvent.globalPosition].
   @override
   SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
-    debugPrint('$selectables');
-    final SelectionResult result = _handleSelectBoundary(event);
+    final SelectionResult result = super.handleSelectWord(event);
     if (currentSelectionStartIndex != -1) {
       _hasReceivedStartEvent.add(selectables[currentSelectionStartIndex]);
     }
@@ -1312,61 +1311,6 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
     }
     _updateLastEdgeEventsFromGeometries();
     return result;
-  }
-
-  SelectionResult _handleSelectBoundary(SelectionEvent event) {
-    assert(event is SelectWordSelectionEvent || event is SelectParagraphSelectionEvent, 'This method should only be given selection events that select text boundaries.');
-    late final Offset effectiveGlobalPosition;
-    if (event.type == SelectionEventType.selectWord) {
-      effectiveGlobalPosition = (event as SelectWordSelectionEvent).globalPosition;
-    } else if (event.type == SelectionEventType.selectParagraph) {
-      effectiveGlobalPosition = (event as SelectParagraphSelectionEvent).globalPosition;
-    }
-    SelectionResult? lastSelectionResult;
-    for (int index = 0; index < selectables.length; index += 1) {
-      debugPrint('at index $index');
-      bool globalRectsContainPosition = false;
-      if (selectables[index].boundingBoxes.isNotEmpty) {
-        for (final Rect rect in selectables[index].boundingBoxes) {
-          final Rect globalRect = MatrixUtils.transformRect(selectables[index].getTransformTo(null), rect);
-          debugPrint('rect being checked: $globalRect, position: $effectiveGlobalPosition');
-          if (globalRect.contains(effectiveGlobalPosition)) {
-            globalRectsContainPosition = true;
-            break;
-          }
-        }
-      }
-      if (globalRectsContainPosition) {
-        debugPrint('containsss $index ${selectables[index]}');
-        final SelectionGeometry existingGeometry = selectables[index].value;
-        lastSelectionResult = dispatchSelectionEventToChild(selectables[index], event);
-        if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
-          return SelectionResult.next;
-        }
-        if (lastSelectionResult == SelectionResult.next) {
-          continue;
-        }
-        if (index == 0 && lastSelectionResult == SelectionResult.previous) {
-          return SelectionResult.previous;
-        }
-        if (selectables[index].value != existingGeometry) {
-          // Geometry has changed as a result of select word, need to clear the
-          // selection of other selectables to keep selection in sync.
-          selectables
-            .where((Selectable target) => target != selectables[index])
-            .forEach((Selectable target) => dispatchSelectionEventToChild(target, const ClearSelectionEvent()));
-          currentSelectionStartIndex = currentSelectionEndIndex = index;
-        }
-        return SelectionResult.end;
-      } else {
-        if (lastSelectionResult == SelectionResult.next) {
-          currentSelectionStartIndex = currentSelectionEndIndex = index - 1;
-          return SelectionResult.end;
-        }
-      }
-    }
-    assert(lastSelectionResult == null);
-    return SelectionResult.end;
   }
 
   @override

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -16,8 +16,8 @@ import 'semantics_tester.dart';
 
 Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
   const Rect caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);
-  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret) + Offset(0.0, paragraph.preferredLineHeight) + const Offset(kIsWeb ? 1.0 : 0.0, -2.0);
-  return paragraph.localToGlobal(localOffset);
+  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret) + Offset(0.0, paragraph.preferredLineHeight);
+  return paragraph.localToGlobal(localOffset) + const Offset(kIsWeb ? 1.0 : 0.0, -2.0);
 }
 
 Offset globalize(Offset point, RenderBox box) {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -16,8 +16,8 @@ import 'semantics_tester.dart';
 
 Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
   const Rect caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);
-  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret) + Offset(0.0, paragraph.preferredLineHeight);
-  return paragraph.localToGlobal(localOffset) + const Offset(kIsWeb? 1.0 : 0.0, -2.0);
+  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret);
+  return paragraph.localToGlobal(localOffset);
 }
 
 Offset globalize(Offset point, RenderBox box) {
@@ -3431,7 +3431,6 @@ void main() {
                         text:
                             'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
                       ),
-                      // WidgetSpan(child: SizedBox(height: 20,width: 20,)),
                       WidgetSpan(child: SizedBox.shrink()),
                       TextSpan(text: 'Hello, world.'),
                     ],
@@ -3447,19 +3446,14 @@ void main() {
 
       // Adjust `textOffsetToPosition` result because it returns the wrong vertical position (wrong line).
       // TODO(bleroux): Remove when https://github.com/flutter/flutter/issues/133637 is fixed.
-      final Offset gestureOffset = textOffsetToPosition(paragraph, 125);
+      final Offset gestureOffset = textOffsetToPosition(paragraph, 125).translate(0, 10);
 
       // Right click to select word at position.
       final TestGesture gesture = await tester.startGesture(gestureOffset, kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
       addTearDown(gesture.removePointer);
-      // Hold the press.
       await tester.pump();
       await gesture.up();
       await tester.pump();
-      await expectLater(
-        find.byType(MaterialApp),
-        matchesGoldenFile('selection_area_test_golden.test.1.png'),
-      );
       // Should select "Hello".
       expect(paragraph.selections[0], const TextSelection(baseOffset: 124, extentOffset: 129));
     },

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3398,12 +3398,8 @@ void main() {
       );
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.byKey(outerText), matching: find.byType(RichText)).first);
 
-      // Adjust `textOffsetToPosition` result because it returns the wrong vertical position (wrong line).
-      // TODO(bleroux): Remove when https://github.com/flutter/flutter/issues/133637 is fixed.
-      final Offset gestureOffset = textOffsetToPosition(paragraph, 125).translate(0, 10);
-
       // Right click to select word at position.
-      final TestGesture gesture = await tester.startGesture(gestureOffset, kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 125), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
       addTearDown(gesture.removePointer);
       await tester.pump();
       await gesture.up();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -16,8 +16,8 @@ import 'semantics_tester.dart';
 
 Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
   const Rect caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);
-  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret);
-  return paragraph.localToGlobal(localOffset);
+  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret) + Offset(0.0, paragraph.preferredLineHeight);
+  return paragraph.localToGlobal(localOffset) + const Offset(kIsWeb? 1.0 : 0.0, -2.0);
 }
 
 Offset globalize(Offset point, RenderBox box) {
@@ -3431,6 +3431,7 @@ void main() {
                         text:
                             'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
                       ),
+                      // WidgetSpan(child: SizedBox(height: 20,width: 20,)),
                       WidgetSpan(child: SizedBox.shrink()),
                       TextSpan(text: 'Hello, world.'),
                     ],
@@ -3446,14 +3447,19 @@ void main() {
 
       // Adjust `textOffsetToPosition` result because it returns the wrong vertical position (wrong line).
       // TODO(bleroux): Remove when https://github.com/flutter/flutter/issues/133637 is fixed.
-      final Offset gestureOffset = textOffsetToPosition(paragraph, 125).translate(0, 10);
+      final Offset gestureOffset = textOffsetToPosition(paragraph, 125);
 
       // Right click to select word at position.
       final TestGesture gesture = await tester.startGesture(gestureOffset, kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
       addTearDown(gesture.removePointer);
+      // Hold the press.
       await tester.pump();
       await gesture.up();
       await tester.pump();
+      await expectLater(
+        find.byType(MaterialApp),
+        matchesGoldenFile('selection_area_test_golden.test.1.png'),
+      );
       // Should select "Hello".
       expect(paragraph.selections[0], const TextSelection(baseOffset: 124, extentOffset: 129));
     },

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -16,7 +16,7 @@ import 'semantics_tester.dart';
 
 Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
   const Rect caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);
-  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret);
+  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret) + Offset(0.0, paragraph.preferredLineHeight) + const Offset(kIsWeb ? 1.0 : 0.0, -2.0);
   return paragraph.localToGlobal(localOffset);
 }
 
@@ -3444,12 +3444,8 @@ void main() {
       );
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.byKey(outerText), matching: find.byType(RichText)).first);
 
-      // Adjust `textOffsetToPosition` result because it returns the wrong vertical position (wrong line).
-      // TODO(bleroux): Remove when https://github.com/flutter/flutter/issues/133637 is fixed.
-      final Offset gestureOffset = textOffsetToPosition(paragraph, 125).translate(0, 10);
-
       // Right click to select word at position.
-      final TestGesture gesture = await tester.startGesture(gestureOffset, kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 125), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
       addTearDown(gesture.removePointer);
       await tester.pump();
       await gesture.up();


### PR DESCRIPTION
Fixes #133637

This change updates the `_SelectableFragment.boundingBoxes` logic to consider the max line height. Previously we were using boxes that were tightly bound around each glyph, so you would have to click within the bounds of the glyph for double tap to select word to work. This is different than `SelectableText` which considers the max line height, as well as the native web behavior that also considers the max line height.

## Web
https://github.com/user-attachments/assets/4ce8c0ca-ec6f-4969-88b1-baa356be8278

## Flutter SelectableText
https://github.com/user-attachments/assets/54c22ad3-75d7-475b-856b-e9b2dbe09d54

## Flutter Text widget under SelectionArea
https://github.com/user-attachments/assets/27db0e2b-1d19-43cc-8ab3-16050e3a5bc7

After this change, Flutter's Text widget under a SelectionArea now matches the SelectableText and native web behavior.

This change also:
* Invalidates the cached bounding boxes when the paragraph layout changes.
* Updates `textOffsetToPosition` to consider `preferredLineHeight`. In cases when the text wraps, it was sometimes inaccurate.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.