### PR TITLE
Mark slow Mac builds as unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3579,8 +3579,6 @@ targets:
   - name: Mac build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
     timeout: 60
-    # Flake rate of >3.5% in presubmit
-    presubmit: false # https://github.com/flutter/flutter/issues/150642
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -3693,8 +3691,6 @@ targets:
   - name: Mac_arm64 build_tests_1_4
     recipe: flutter/flutter_drone
     timeout: 60
-    # Flake rate of >2.5% in presubmit
-    presubmit: false # https://github.com/flutter/flutter/issues/150642
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4103,8 +4099,6 @@ targets:
   - name: Mac_arm64 module_test_ios
     recipe: devicelab/devicelab_drone
     timeout: 60
-    # Flake rate of >10% in presubmit
-    presubmit: false # https://github.com/flutter/flutter/issues/150642
     properties:
       dependencies: >-
         [
@@ -4286,8 +4280,6 @@ targets:
   - name: Mac tool_integration_tests_1_5
     recipe: flutter/flutter_drone
     timeout: 60
-    # Flake rate of >2.5% in presubmit
-    presubmit: false # https://github.com/flutter/flutter/issues/150642
     properties:
       add_recipes_cq: "true"
       dependencies: >-


### PR DESCRIPTION
I don't know how to investigate the slow Mac bots if they are never flaking, because they are off https://github.com/flutter/flutter/pull/151870
