### PR TITLE
fix ReorderableList not passing in item extent builder

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -411,6 +411,7 @@ class ReorderableListState extends State<ReorderableList> {
             itemExtent: widget.itemExtent,
             prototypeItem: widget.prototypeItem,
             itemBuilder: widget.itemBuilder,
+            itemExtentBuilder: widget.itemExtentBuilder,
             itemCount: widget.itemCount,
             onReorder: widget.onReorder,
             onReorderStart: widget.onReorderStart,

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -923,6 +923,52 @@ void main() {
     ), throwsAssertionError);
   });
 
+  testWidgets('ReorderableList passes itemExtentBuilder to SliverReorderableList', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/155936
+    const int itemCount = 5;
+    const List<double> items = <double>[10.0, 20.0, 30.0, 40.0, 50.0];
+    final Map<int, double> itemExtents = <int, double>{};
+
+    void handleReorder(int fromIndex, int toIndex) {
+      if (toIndex > fromIndex) {
+        toIndex -= 1;
+      }
+      items.insert(toIndex, items.removeAt(fromIndex));
+    }
+
+    // The list has five elements, that indicate the extent for the item at the given index.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ReorderableList(
+          itemBuilder: (BuildContext context, int index) => SizedBox(
+            key: ValueKey<double>(items[index]),
+            width: 100,
+            height: items[index],
+          ),
+          itemCount: itemCount,
+          onReorder: handleReorder,
+          itemExtentBuilder: (int index, SliverLayoutDimensions dimensions) {
+            final double extent = items[index];
+
+            itemExtents[index] = extent;
+
+            return extent;
+          },
+        ),
+      ),
+    );
+
+    const Map<int, double> expectedExtents = <int, double>{
+      0: 10.0,
+      1: 20.0,
+      2: 30.0,
+      3: 40.0,
+      4: 50.0,
+    };
+
+    expect(const MapEquality<int, double>().equals(itemExtents, expectedExtents), isTrue);
+  });
+
   testWidgets('SliverReorderableList asserts on both non-null itemExtent and prototypeItem', (WidgetTester tester) async {
     final List<int> numbers = <int>[0,1,2];
     expect(() => SliverReorderableList(

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -927,7 +927,6 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/155936
     const int itemCount = 5;
     const List<double> items = <double>[10.0, 20.0, 30.0, 40.0, 50.0];
-    final Map<int, double> itemExtents = <int, double>{};
 
     void handleReorder(int fromIndex, int toIndex) {
       if (toIndex > fromIndex) {
@@ -942,17 +941,12 @@ void main() {
         home: ReorderableList(
           itemBuilder: (BuildContext context, int index) => SizedBox(
             key: ValueKey<double>(items[index]),
-            width: 100,
-            height: items[index],
+            child: Text('Item $index'),
           ),
           itemCount: itemCount,
           onReorder: handleReorder,
           itemExtentBuilder: (int index, SliverLayoutDimensions dimensions) {
-            final double extent = items[index];
-
-            itemExtents[index] = extent;
-
-            return extent;
+            return items[index];
           },
         ),
       ),
@@ -964,6 +958,11 @@ void main() {
       2: 30.0,
       3: 40.0,
       4: 50.0,
+    };
+
+    final Map<int, double> itemExtents = <int, double>{
+      for (int i = 0; i < itemCount; i++)
+        i: tester.getSize(find.text('Item $i')).height,
     };
 
     expect(const MapEquality<int, double>().equals(itemExtents, expectedExtents), isTrue);


### PR DESCRIPTION
This PR fixes the `ReorderableList` in `flutter/widgets.dart` not passing the item extent builder to the underlying SliverReorderableList. I double checked and the material equivalent is working as intended.

Fixes https://github.com/flutter/flutter/issues/155936

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
