### PR TITLE
[ Cocoon ] Wait for task results to be received by the task runner before shutting down the task process

### DIFF
--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -82,11 +82,25 @@ class _TaskRunner {
         localEngine: localEngine,
         localEngineHost: localEngineHost,
       );
+      const Duration taskResultReceivedTimeout = Duration(seconds: 30);
+      _taskResultReceivedTimeout = Timer(
+        taskResultReceivedTimeout,
+        () {
+          logger.severe('Task runner did not acknowledge task results in $taskResultReceivedTimeout.');
+          _closeKeepAlivePort();
+          exitCode = 1;
+        }
+      );
       return ServiceExtensionResponse.result(json.encode(result.toJson()));
     });
     registerExtension('ext.cocoonRunnerReady',
         (String method, Map<String, String> parameters) async {
-      return ServiceExtensionResponse.result('"ready"');
+      return ServiceExtensionResponse.result(json.encode('ready'));
+    });
+    registerExtension('ext.cocoonTaskResultReceived',
+        (String method, Map<String, String> parameters) async {
+      _closeKeepAlivePort();
+      return ServiceExtensionResponse.result(json.encode('acknowledged'));
     });
   }
 
@@ -104,6 +118,7 @@ class _TaskRunner {
   // TODO(ianh): workaround for https://github.com/dart-lang/sdk/issues/23797
   RawReceivePort? _keepAlivePort;
   Timer? _startTaskTimeout;
+  Timer? _taskResultReceivedTimeout;
   bool _taskStarted = false;
 
   final Completer<TaskResult> _completer = Completer<TaskResult>();
@@ -210,7 +225,6 @@ class _TaskRunner {
     } finally {
       await checkForRebootRequired();
       await forceQuitRunningProcesses();
-      _closeKeepAlivePort();
     }
   }
 
@@ -269,6 +283,7 @@ class _TaskRunner {
   /// Disables the keepalive port, allowing the VM to exit.
   void _closeKeepAlivePort() {
     _startTaskTimeout?.cancel();
+    _taskResultReceivedTimeout?.cancel();
     _keepAlivePort?.close();
   }
 

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -66,6 +66,12 @@ Future<TaskResult> task(TaskFunction task, { ProcessManager? processManager }) a
 
 class _TaskRunner {
   _TaskRunner(this.task, this.processManager) {
+    final String successResponse = json.encode(
+      const <String, String>{
+        'result': 'success',
+      },
+    );
+
     registerExtension('ext.cocoonRunTask',
         (String method, Map<String, String> parameters) async {
       final Duration? taskTimeout = parameters.containsKey('timeoutInMinutes')
@@ -95,12 +101,12 @@ class _TaskRunner {
     });
     registerExtension('ext.cocoonRunnerReady',
         (String method, Map<String, String> parameters) async {
-      return ServiceExtensionResponse.result(json.encode('ready'));
+      return ServiceExtensionResponse.result(successResponse);
     });
     registerExtension('ext.cocoonTaskResultReceived',
         (String method, Map<String, String> parameters) async {
       _closeKeepAlivePort();
-      return ServiceExtensionResponse.result(json.encode('acknowledged'));
+      return ServiceExtensionResponse.result(successResponse);
     });
   }
 

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -279,9 +279,6 @@ Future<ConnectionResult> _connectToRunnerIsolate(Uri vmServiceUri) async {
 
   while (true) {
     try {
-      // Make sure VM server is up by successfully opening and closing a socket.
-      await (await WebSocket.connect(url)).close();
-
       // Look up the isolate.
       final VmService client = await vmServiceConnectUri(url);
       VM vm = await client.getVM();

--- a/dev/devicelab/test/runner_test.dart
+++ b/dev/devicelab/test/runner_test.dart
@@ -63,7 +63,7 @@ void main() {
           ],
           eagerError: true,
         );
-      } on RPCError catch(e) {
+      } on RPCError catch (e) {
         fail('Unexpected RPCError: $e');
       }
     });

--- a/dev/devicelab/test/runner_test.dart
+++ b/dev/devicelab/test/runner_test.dart
@@ -42,7 +42,9 @@ void main() {
       expect(printLog[1], 'flaky: false');
     });
 
-    test('Regression test for https://github.com/flutter/flutter/issues/155475.', () async {
+    test('Ensures task results are received before task process shuts down.', () async {
+      // Regression test for https://github.com/flutter/flutter/issues/155475
+      //
       // Runs multiple concurrent instances of a short-lived task in an effort to
       // trigger the race between the VM service processing the response from
       // ext.cocoonRunTask and the VM shutting down, which will throw a RPCError
@@ -51,7 +53,7 @@ void main() {
       // Obviously this isn't foolproof, but this test becoming flaky or failing
       // consistently should signal that we're encountering a shutdown race
       // somewhere.
-      const int runs = 75;
+      const int runs = 30;
       try {
         await Future.wait(
           <Future<void>>[
@@ -66,6 +68,6 @@ void main() {
       } on RPCError catch (e) {
         fail('Unexpected RPCError: $e');
       }
-    });
+    }, timeout: const Timeout.factor(2));
   });
 }


### PR DESCRIPTION
Prior to this fix, `_TaskRunner.run` would immediately cleanup the keep-alive port once the task completed, which would result in the isolate shutting down as soon as the task result was returned from `ext.cocoonRunTask` callback in the form of a
`ServiceExtensionResponse`. Since the service extension response is processed by the service isolate, it was possible for the VM to start shutting down before the service isolate could send the task result data back to the task runner.

This change introduces a new service extension,
`ext.cocoonTaskResultReceived`, that the task runner invokes after it receives the task result from `ext.cocoonRunTask`, notifying the task process that it can close the keep-alive port and shutdown.

Fixes https://github.com/flutter/flutter/issues/155475