### PR TITLE
Add back main() methods to benchmark benches.

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_bench.dart
@@ -136,3 +136,7 @@ Future<void> execute()  async {
   );
   printer.printToStdout();
 }
+
+Future<void> main() async {
+  return execute();
+}

--- a/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_bench.dart
@@ -137,6 +137,9 @@ Future<void> execute()  async {
   printer.printToStdout();
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute();
 }

--- a/dev/benchmarks/microbenchmarks/lib/geometry/rrect_contains_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/rrect_contains_bench.dart
@@ -29,6 +29,9 @@ Future<void> execute() async {
   printer.printToStdout();
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute();
 }

--- a/dev/benchmarks/microbenchmarks/lib/geometry/rrect_contains_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/rrect_contains_bench.dart
@@ -28,3 +28,7 @@ Future<void> execute() async {
   );
   printer.printToStdout();
 }
+
+Future<void> main() async {
+  return execute();
+}

--- a/dev/benchmarks/microbenchmarks/lib/gestures/gesture_detector_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/gesture_detector_bench.dart
@@ -49,3 +49,7 @@ Future<void> execute() async {
   );
   printer.printToStdout();
 }
+
+Future<void> main() async {
+  return execute();
+}

--- a/dev/benchmarks/microbenchmarks/lib/gestures/gesture_detector_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/gesture_detector_bench.dart
@@ -50,6 +50,9 @@ Future<void> execute() async {
   printer.printToStdout();
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute();
 }

--- a/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
@@ -58,6 +58,9 @@ Future<void> execute() async {
   printer.printToStdout();
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute();
 }

--- a/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
@@ -57,3 +57,7 @@ Future<void> execute() async {
 
   printer.printToStdout();
 }
+
+Future<void> main() async {
+  return execute();
+}

--- a/dev/benchmarks/microbenchmarks/lib/language/sync_star_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/language/sync_star_bench.dart
@@ -89,3 +89,7 @@ int sumIterable(Iterable<int> values) {
   }
   return result;
 }
+
+Future<void> main() async {
+  return execute();
+}

--- a/dev/benchmarks/microbenchmarks/lib/language/sync_star_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/language/sync_star_bench.dart
@@ -90,6 +90,9 @@ int sumIterable(Iterable<int> values) {
   return result;
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute();
 }

--- a/dev/benchmarks/microbenchmarks/lib/language/sync_star_semantics_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/language/sync_star_semantics_bench.dart
@@ -118,6 +118,9 @@ Iterable<InlineSpanSemanticsInformation> combineSemanticsInfoList(List<InlineSpa
   return result;
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute();
 }

--- a/dev/benchmarks/microbenchmarks/lib/language/sync_star_semantics_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/language/sync_star_semantics_bench.dart
@@ -117,3 +117,7 @@ Iterable<InlineSpanSemanticsInformation> combineSemanticsInfoList(List<InlineSpa
   assert(workingLabel != null);
   return result;
 }
+
+Future<void> main() async {
+  return execute();
+}

--- a/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
@@ -91,6 +91,9 @@ Future<void> execute(BenchmarkingBinding binding) async {
   printer.printToStdout();
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute(BenchmarkingBinding());
 }

--- a/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
@@ -90,3 +90,7 @@ Future<void> execute(BenchmarkingBinding binding) async {
   }
   printer.printToStdout();
 }
+
+Future<void> main() async {
+  return execute(BenchmarkingBinding());
+}

--- a/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
@@ -66,6 +66,9 @@ Future<void> execute() async {
   printer.printToStdout();
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute();
 }

--- a/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
@@ -65,3 +65,7 @@ Future<void> execute() async {
   );
   printer.printToStdout();
 }
+
+Future<void> main() async {
+  return execute();
+}

--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -61,6 +61,9 @@ Future<void> execute() async {
   printer.printToStdout();
 }
 
+//
+//  Note that the benchmark is normally run by benchmark_collection.dart.
+//
 Future<void> main() async {
   return execute();
 }

--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -60,3 +60,7 @@ Future<void> execute() async {
   );
   printer.printToStdout();
 }
+
+Future<void> main() async {
+  return execute();
+}


### PR DESCRIPTION
Dart performance suite builds and launches those several flutter benchmarks independently.

Cf. https://github.com/flutter/flutter/pull/154446
