### PR TITLE
Remove use_modular_headers! from Swift Podfiles

### DIFF
--- a/dev/benchmarks/complex_layout/ios/Podfile
+++ b/dev/benchmarks/complex_layout/ios/Podfile
@@ -29,7 +29,6 @@ flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end

--- a/dev/benchmarks/complex_layout/macos/Podfile
+++ b/dev/benchmarks/complex_layout/macos/Podfile
@@ -28,7 +28,6 @@ flutter_macos_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
 end

--- a/dev/benchmarks/macrobenchmarks/macos/Podfile
+++ b/dev/benchmarks/macrobenchmarks/macos/Podfile
@@ -28,7 +28,6 @@ flutter_macos_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
 end

--- a/dev/integration_tests/channels/macos/Podfile
+++ b/dev/integration_tests/channels/macos/Podfile
@@ -28,7 +28,6 @@ flutter_macos_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/dev/integration_tests/flavors/macos/Podfile
+++ b/dev/integration_tests/flavors/macos/Podfile
@@ -28,7 +28,6 @@ flutter_macos_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/dev/integration_tests/flutter_gallery/macos/Podfile
+++ b/dev/integration_tests/flutter_gallery/macos/Podfile
@@ -28,7 +28,6 @@ flutter_macos_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
 

--- a/dev/integration_tests/ios_app_with_extensions/ios/Podfile
+++ b/dev/integration_tests/ios_app_with_extensions/ios/Podfile
@@ -29,7 +29,6 @@ flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
@@ -37,7 +36,6 @@ end
 target 'watch Extension' do
   platform :watchos
   use_frameworks!
-  use_modular_headers!
 
   pod 'EFQRCode', '6.0'
 end

--- a/dev/integration_tests/ui/macos/Podfile
+++ b/dev/integration_tests/ui/macos/Podfile
@@ -28,7 +28,6 @@ flutter_macos_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
 end

--- a/examples/api/macos/Podfile
+++ b/examples/api/macos/Podfile
@@ -28,7 +28,6 @@ flutter_macos_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
 end

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -29,7 +29,6 @@ flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/packages/flutter_tools/templates/cocoapods/Podfile-macos
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-macos
@@ -28,7 +28,6 @@ flutter_macos_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do


### PR DESCRIPTION
We added `use_modular_headers!` to our `Podfile`s as we originally planned to phase out `use_frameworks!` (see https://github.com/flutter/flutter/pull/42204). However, our plans have now changed and we are instead phasing out CocoaPods entirely in favor of Swift Package Manager.

CocoaPods's `use_frameworks!` and `use_modular_headers!` are two different overlapping options that should not be used together. This change removes the `use_modular_headers!` from the macOS `Podfile` and the iOS Swift `Podfile` (the iOS Objective-C template was recently deprecated https://github.com/flutter/flutter/pull/155867).

This change only affects _new_ Flutter apps. This change does not include an automatic migration as that could break existing apps. Instead, users are encouraged to migrate from CocoaPods to Swift Package Manager.

https://github.com/flutter/flutter/issues/156259

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
