### PR TITLE
RadioListTile: add property to scale the radio

### DIFF
--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -477,49 +477,50 @@ class RadioListTile<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Widget control;
+    Widget control;
     switch (_radioType) {
       case _RadioType.material:
         control = ExcludeFocus(
-          child: Transform.scale(
-            scale: radioScaleFactor,
-            child: Radio<T>(
-              value: value,
-              groupValue: groupValue,
-              onChanged: onChanged,
-              toggleable: toggleable,
-              activeColor: activeColor,
-              materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
-              autofocus: autofocus,
-              fillColor: fillColor,
-              mouseCursor: mouseCursor,
-              hoverColor: hoverColor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-            ),
+          child: Radio<T>(
+            value: value,
+            groupValue: groupValue,
+            onChanged: onChanged,
+            toggleable: toggleable,
+            activeColor: activeColor,
+            materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
+            autofocus: autofocus,
+            fillColor: fillColor,
+            mouseCursor: mouseCursor,
+            hoverColor: hoverColor,
+            overlayColor: overlayColor,
+            splashRadius: splashRadius,
           ),
         );
       case _RadioType.adaptive:
         control = ExcludeFocus(
-          child: Transform.scale(
-            scale: radioScaleFactor,
-            child: Radio<T>.adaptive(
-              value: value,
-              groupValue: groupValue,
-              onChanged: onChanged,
-              toggleable: toggleable,
-              activeColor: activeColor,
-              materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
-              autofocus: autofocus,
-              fillColor: fillColor,
-              mouseCursor: mouseCursor,
-              hoverColor: hoverColor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-              useCupertinoCheckmarkStyle: useCupertinoCheckmarkStyle,
-            ),
+          child: Radio<T>.adaptive(
+            value: value,
+            groupValue: groupValue,
+            onChanged: onChanged,
+            toggleable: toggleable,
+            activeColor: activeColor,
+            materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
+            autofocus: autofocus,
+            fillColor: fillColor,
+            mouseCursor: mouseCursor,
+            hoverColor: hoverColor,
+            overlayColor: overlayColor,
+            splashRadius: splashRadius,
+            useCupertinoCheckmarkStyle: useCupertinoCheckmarkStyle,
           ),
         );
+    }
+
+    if (radioScaleFactor != 1.0) {
+      control = Transform.scale(
+        scale: radioScaleFactor,
+        child: control,
+      );
     }
 
     final ListTileThemeData listTileTheme = ListTileTheme.of(context);

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -200,6 +200,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.focusNode,
     this.onFocusChange,
     this.enableFeedback,
+    this.radioScaleFactor = 1.0,
     this.internalAddSemanticForOnTap = false,
   }) : _radioType = _RadioType.material,
        useCupertinoCheckmarkStyle = false,
@@ -240,6 +241,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.focusNode,
     this.onFocusChange,
     this.enableFeedback,
+    this.radioScaleFactor = 1.0,
     this.useCupertinoCheckmarkStyle = false,
     this.internalAddSemanticForOnTap = false,
   }) : _radioType = _RadioType.adaptive,
@@ -468,43 +470,54 @@ class RadioListTile<T> extends StatelessWidget {
   /// Defaults to false.
   final bool useCupertinoCheckmarkStyle;
 
+  /// Controls the scaling factor applied to the [Radio] within the [RadioListTile].
+  ///
+  /// Defaults to 1.0.
+  final double radioScaleFactor;
+
   @override
   Widget build(BuildContext context) {
     final Widget control;
     switch (_radioType) {
       case _RadioType.material:
         control = ExcludeFocus(
-          child: Radio<T>(
-            value: value,
-            groupValue: groupValue,
-            onChanged: onChanged,
-            toggleable: toggleable,
-            activeColor: activeColor,
-            materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
-            autofocus: autofocus,
-            fillColor: fillColor,
-            mouseCursor: mouseCursor,
-            hoverColor: hoverColor,
-            overlayColor: overlayColor,
-            splashRadius: splashRadius,
+          child: Transform.scale(
+            scale: radioScaleFactor,
+            child: Radio<T>(
+              value: value,
+              groupValue: groupValue,
+              onChanged: onChanged,
+              toggleable: toggleable,
+              activeColor: activeColor,
+              materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
+              autofocus: autofocus,
+              fillColor: fillColor,
+              mouseCursor: mouseCursor,
+              hoverColor: hoverColor,
+              overlayColor: overlayColor,
+              splashRadius: splashRadius,
+            ),
           ),
         );
       case _RadioType.adaptive:
         control = ExcludeFocus(
-          child: Radio<T>.adaptive(
-            value: value,
-            groupValue: groupValue,
-            onChanged: onChanged,
-            toggleable: toggleable,
-            activeColor: activeColor,
-            materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
-            autofocus: autofocus,
-            fillColor: fillColor,
-            mouseCursor: mouseCursor,
-            hoverColor: hoverColor,
-            overlayColor: overlayColor,
-            splashRadius: splashRadius,
-            useCupertinoCheckmarkStyle: useCupertinoCheckmarkStyle,
+          child: Transform.scale(
+            scale: radioScaleFactor,
+            child: Radio<T>.adaptive(
+              value: value,
+              groupValue: groupValue,
+              onChanged: onChanged,
+              toggleable: toggleable,
+              activeColor: activeColor,
+              materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
+              autofocus: autofocus,
+              fillColor: fillColor,
+              mouseCursor: mouseCursor,
+              hoverColor: hoverColor,
+              overlayColor: overlayColor,
+              splashRadius: splashRadius,
+              useCupertinoCheckmarkStyle: useCupertinoCheckmarkStyle,
+            ),
           ),
         );
     }

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -1589,8 +1589,7 @@ void main() {
     expect(offsetPlatform, const Offset(72.0, 16.0));
   });
 
-  testWidgets('RadioListTile renders with default scale',
-      (WidgetTester tester) async {
+  testWidgets('RadioListTile renders with default scale', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Material(
         child: RadioListTile<bool>(
@@ -1609,9 +1608,8 @@ void main() {
     expect(widget, findsNothing);
   });
 
-  testWidgets('RadioListTile respects radioScaleFactor',
-      (WidgetTester tester) async {
-        const double scale = 1.4;
+  testWidgets('RadioListTile respects radioScaleFactor', (WidgetTester tester) async {
+    const double scale = 1.4;
     await tester.pumpWidget(const MaterialApp(
       home: Material(
         child: RadioListTile<bool>(

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -1588,4 +1588,50 @@ void main() {
     final Offset offsetPlatform = tester.getTopLeft(platform);
     expect(offsetPlatform, const Offset(72.0, 16.0));
   });
+
+  testWidgets('RadioListTile renders with default scale',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Material(
+        child: RadioListTile<bool>(
+          value: false,
+          groupValue: false,
+          onChanged: null,
+        ),
+      ),
+    ));
+
+    final Transform widget = tester.widget(
+      find.ancestor(
+        of: find.byType(Radio<bool>),
+        matching: find.byType(Transform),
+      ),
+    );
+
+    expect(widget.transform.getMaxScaleOnAxis(), 1.0);
+  });
+
+  testWidgets('RadioListTile respects radioScaleFactor',
+      (WidgetTester tester) async {
+        const double scale = 1.4;
+    await tester.pumpWidget(const MaterialApp(
+      home: Material(
+        child: RadioListTile<bool>(
+          value: false,
+          groupValue: false,
+          onChanged: null,
+          radioScaleFactor: scale,
+        ),
+      ),
+    ));
+
+    final Transform widget = tester.widget(
+      find.ancestor(
+        of: find.byType(Radio<bool>),
+        matching: find.byType(Transform),
+      ),
+    );
+
+    expect(widget.transform.getMaxScaleOnAxis(), scale);
+  });
 }

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -1601,14 +1601,12 @@ void main() {
       ),
     ));
 
-    final Transform widget = tester.widget(
-      find.ancestor(
-        of: find.byType(Radio<bool>),
-        matching: find.byType(Transform),
-      ),
+    final Finder widget = find.ancestor(
+      of: find.byType(Radio<bool>),
+      matching: find.byType(Transform),
     );
 
-    expect(widget.transform.getMaxScaleOnAxis(), 1.0);
+    expect(widget, findsNothing);
   });
 
   testWidgets('RadioListTile respects radioScaleFactor',

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -1600,12 +1600,12 @@ void main() {
       ),
     ));
 
-    final Finder widget = find.ancestor(
+    final Finder transformFinder = find.ancestor(
       of: find.byType(Radio<bool>),
       matching: find.byType(Transform),
     );
 
-    expect(widget, findsNothing);
+    expect(transformFinder, findsNothing);
   });
 
   testWidgets('RadioListTile respects radioScaleFactor', (WidgetTester tester) async {


### PR DESCRIPTION
Added a property in the RadioListTile to scale the underlying Radio using `Transform.scale`.

Fixes: #81334 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
