### PR TITLE
[tool] fix android studio preview's version parsing

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -589,13 +589,8 @@ the configured path by running this command: flutter config --android-studio-dir
     final int? patch = int.tryParse(matched[3]);
     if (major == null || minor == null || patch == null) {
       return null;
-if (major == null || minor == null || patch == null) {
-  return null;
-}
-
-return Version(major, minor, patch);
-      return Version(major, minor, patch);
     }
+    return Version(major, minor, patch);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -566,8 +566,10 @@ the configured path by running this command: flutter config --android-studio-dir
   }
 
   static Version? _parseVersion(String text) {
-    // Example string fort EAP: EAP AI-242.21829.142.2422.12358220
-    // We try to capture 2422 here.
+    // Matches the version string for Preview builds on macOS.
+    // Example match: EAP AI-242.21829.142.2422.12358220
+    // We try to capture "2422" here, which can be translated to a
+    // more human-friendly "24.2.2".
     final RegExp eapVersionPattern = RegExp(r'EAP\s+[A-Z]{2}-\d+\.\d+\.\d+\.(\d+)\.\d+');
     final Match? eapVersionMatch = eapVersionPattern.firstMatch(text);
 

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -566,27 +566,26 @@ the configured path by running this command: flutter config --android-studio-dir
   }
 
   static Version? _parseVersion(String text) {
-    Match? match;
     // Example string fort EAP: EAP AI-242.21829.142.2422.12358220
     // We try to capture 2422 here.
-    final RegExp intellijPattern = RegExp(r'EAP\s+[A-Z]{2}-\d+\.\d+\.\d+\.(\d+)\.\d+');
-    match = intellijPattern.firstMatch(text ?? '');
+    final RegExp eapVersionPattern = RegExp(r'EAP\s+[A-Z]{2}-\d+\.\d+\.\d+\.(\d+)\.\d+');
+    final Match? eapVersionMatch = eapVersionPattern.firstMatch(text);
 
-    if (match == null) {
+    if (eapVersionMatch == null) {
       return Version.parse(text);
     }
 
-    final String? matched = match.group(1);
+    final String? rawVersionMatch = eapVersionMatch.group(1);
 
     // length of 4 is because that how version is encrypted: first two digits
     // for year (part of major version), third for minor version, fourth for patch.
-    if (matched == null || matched.length != 4) {
+    if (rawVersionMatch == null || rawVersionMatch.length != 4) {
       return null;
     }
 
-    final int? major = int.tryParse('20${matched[0]}${matched[1]}');
-    final int? minor = int.tryParse(matched[2]);
-    final int? patch = int.tryParse(matched[3]);
+    final int? major = int.tryParse('20${rawVersionMatch[0]}${rawVersionMatch[1]}');
+    final int? minor = int.tryParse(rawVersionMatch[2]);
+    final int? patch = int.tryParse(rawVersionMatch[3]);
     if (major == null || minor == null || patch == null) {
       return null;
     }

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -589,7 +589,11 @@ the configured path by running this command: flutter config --android-studio-dir
     final int? patch = int.tryParse(matched[3]);
     if (major == null || minor == null || patch == null) {
       return null;
-    } else {
+if (major == null || minor == null || patch == null) {
+  return null;
+}
+
+return Version(major, minor, patch);
       return Version(major, minor, patch);
     }
   }

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -56,7 +56,7 @@ class AndroidStudio {
 
     Version? version;
     if (versionString != null) {
-      version = Version.parse(versionString);
+      version = _parseVersion(versionString);
     }
 
     String? pathsSelectorValue;
@@ -563,6 +563,38 @@ the configured path by running this command: flutter config --android-studio-dir
         _validationMessages.add('Unable to determine bundled Java version.');
       }
     }
+  }
+
+  static Version? _parseVersion(String? text) {
+    Match? match;
+    // Example string fort EAP: EAP AI-242.21829.142.2422.12358220
+    // We try to capture 2422 here.
+    final RegExp intellijPattern = RegExp(r'EAP\s+[A-Z]{2}-\d+\.\d+\.\d+\.(\d+)\.\d+');
+    match = intellijPattern.firstMatch(text ?? '');
+
+    if (match == null) {
+      return Version.parse(text);
+    }
+
+    final String? matched = match.group(1);
+
+    // length of 4 is because that how version is encrypted: first two digits
+    // for year (part of major version), third for minor version, fourth for patch.
+    if (matched == null || matched.length != 4) {
+      return null;
+    }
+
+    Version? result;
+    try {
+      final int major = int.parse('20${matched[0]}${matched[1]}');
+      final int minor = int.parse(matched[2]);
+      final int patch = int.parse(matched[3]);
+      result = Version(major, minor, patch);
+    } on FormatException {
+      return null;
+    }
+
+    return result;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -565,7 +565,7 @@ the configured path by running this command: flutter config --android-studio-dir
     }
   }
 
-  static Version? _parseVersion(String? text) {
+  static Version? _parseVersion(String text) {
     Match? match;
     // Example string fort EAP: EAP AI-242.21829.142.2422.12358220
     // We try to capture 2422 here.

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -584,17 +584,14 @@ the configured path by running this command: flutter config --android-studio-dir
       return null;
     }
 
-    Version? result;
-    try {
-      final int major = int.parse('20${matched[0]}${matched[1]}');
-      final int minor = int.parse(matched[2]);
-      final int patch = int.parse(matched[3]);
-      return Version(major, minor, patch);
-    } on FormatException {
+    final int? major = int.tryParse('20${matched[0]}${matched[1]}');
+    final int? minor = int.tryParse(matched[2]);
+    final int? patch = int.tryParse(matched[3]);
+    if (major == null || minor == null || patch == null) {
       return null;
+    } else {
+      return Version(major, minor, patch);
     }
-
-    return result;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -589,7 +589,7 @@ the configured path by running this command: flutter config --android-studio-dir
       final int major = int.parse('20${matched[0]}${matched[1]}');
       final int minor = int.parse(matched[2]);
       final int patch = int.parse(matched[3]);
-      result = Version(major, minor, patch);
+      return Version(major, minor, patch);
     } on FormatException {
       return null;
     }

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -261,6 +261,7 @@ void main() {
         homeMac,
         'Library',
         'Application Support',
+        'Google',
         'AndroidStudioPreview2022.3',
       )));
       expect(studio.validationMessages, <String>['Java version 123']);

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -131,6 +131,7 @@ void main() {
         fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
+      expect(studio.version, equals(Version(4, 1, null)));
       expect(studio, isNotNull);
       expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,
@@ -173,6 +174,7 @@ void main() {
         fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
+      expect(studio.version, equals(Version(2020, 3, null)));
       expect(studio, isNotNull);
       expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,
@@ -215,6 +217,7 @@ void main() {
         fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
+      expect(studio.version, equals(Version(3, 3, null)));
       expect(studio, isNotNull);
       expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,
@@ -256,6 +259,7 @@ void main() {
         fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
+      expect(studio.version, equals(Version(2022, 3, 1)));
       expect(studio, isNotNull);
       expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,


### PR DESCRIPTION
This PR willing to fix issue when `flutter doctor` validator can't determine version of Android Studio EAP.

These are before/after outputs of `flutter doctor -v` showcasing change in behaviour of validator. Each output has 3 `Android Studio` sections, 1 for stable and 2 for different EAP versions. 

<details>
<summary>before, (stable, 3.24.3), 2 issues related to versions of Android Studio</summary>

```console
[✓] Flutter (Channel stable, 3.24.3, on macOS 14.7 23H124 darwin-arm64, locale en-RU)
    • Flutter version 3.24.3 on channel stable at /Users/samer/fvm/versions/stable
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision 2663184aa7 (4 weeks ago), 2024-09-11 16:27:48 -0500
    • Engine revision 36335019a8
    • Dart version 3.5.3
    • DevTools version 2.37.3

[✓] Android toolchain - develop for Android devices (Android SDK version 34.0.0)
    • Android SDK at /Users/samer/Library/Android/sdk
    • Platform android-35, build-tools 34.0.0
    • Java binary at: /Users/samer/Library/Java/JavaVirtualMachines/jbr-17.0.7/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment JBR-17.0.7+7-964.1-nomod (build 17.0.7+7-b964.1)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS (Xcode 16.0)
    • Xcode at /Applications/Xcode-16.0.app/Contents/Developer
    • Build 16A242d
    • CocoaPods version 1.15.2

[✓] Chrome - develop for the web
    • Chrome at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

[✓] Android Studio (version 2024.1)
    • Android Studio at /Users/samer/Applications/Android Studio Koala Feature Drop 2024.1.2.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 17.0.11+0-17.0.11b1207.24-11852314)

[!] Android Studio (version unknown)
    • Android Studio at /Users/samer/Applications/Android Studio Ladybug Feature Drop 2024.2.2 Canary 2.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    ✗ Unable to determine Android Studio version.
    • Java version OpenJDK Runtime Environment (build 21.0.3+-79915917-b509.11)

[!] Android Studio (version unknown)
    • Android Studio at /Users/samer/Applications/Android Studio.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    ✗ Unable to determine Android Studio version.
    • Java version OpenJDK Runtime Environment (build 21.0.3+-79915917-b509.11)

[✓] IntelliJ IDEA Ultimate Edition (version EAP IU-243.12818.47)
    • IntelliJ at /Users/samer/Applications/IntelliJ IDEA Ultimate.app
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart

[✓] VS Code (version 1.94.0)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.98.0

[✓] Connected device (5 available)
    • sdk gphone64 arm64 (mobile)     • emulator-5554             • android-arm64  • Android 15 (API 35) (emulator)
    • iPhone (Михаил) (mobile)        • 00008020-001254DA1E39002E • ios            • iOS 17.6.1 21G93
    • macOS (desktop)                 • macos                     • darwin-arm64   • macOS 14.7 23H124 darwin-arm64
    • Mac Designed for iPad (desktop) • mac-designed-for-ipad     • darwin         • macOS 14.7 23H124 darwin-arm64
    • Chrome (web)                    • chrome                    • web-javascript • Google Chrome 129.0.6668.90
    ! Error: Browsing on the local area network for Михаил Новосельцев’s iPad. Ensure the device is unlocked and attached with a cable or associated with the same local area network as this Mac.
      The device must be opted into Developer Mode to connect wirelessly. (code -27)

[✓] Network resources
    • All expected network resources are available.

! Doctor found issues in 2 categories.
```
</details>

<details>
<summary>after,  no issues regarding Android Studio</summary>

```console
[!] Flutter (Channel [user-branch], 3.26.0-1.0.pre.383, on macOS 14.7 23H124 darwin-arm64, locale en-RU)
    ! Flutter version 3.26.0-1.0.pre.383 on channel [user-branch] at /Users/samer/projects/flutter
      Currently on an unknown channel. Run `flutter channel` to switch to an official channel.
      If that doesn't fix the issue, reinstall Flutter by following instructions at https://flutter.dev/setup.
    • Upstream repository git@github.com:Sameri11/flutter.git
    • FLUTTER_GIT_URL = git@github.com:Sameri11/flutter.git
    • Framework revision 852508425d (20 minutes ago), 2024-10-07 21:22:45 +0500
    • Engine revision 683a14c1f1
    • Dart version 3.6.0 (build 3.6.0-326.0.dev)
    • DevTools version 2.40.0
    • If those were intentional, you can disregard the above warnings; however it is recommended to use "git" directly to perform update
      checks and upgrades.

[✓] Android toolchain - develop for Android devices (Android SDK version 34.0.0)
    • Android SDK at /Users/samer/Library/Android/sdk
    • Platform android-35, build-tools 34.0.0
    • Java binary at: /Users/samer/Library/Java/JavaVirtualMachines/jbr-17.0.7/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment JBR-17.0.7+7-964.1-nomod (build 17.0.7+7-b964.1)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS (Xcode 16.0)
    • Xcode at /Applications/Xcode-16.0.app/Contents/Developer
    • Build 16A242d
    • CocoaPods version 1.15.2

[✓] Chrome - develop for the web
    • Chrome at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

[✓] Android Studio (version 2024.1)
    • Android Studio at /Users/samer/Applications/Android Studio Koala Feature Drop 2024.1.2.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 17.0.11+0-17.0.11b1207.24-11852314)

[✓] Android Studio (version 2024.2.2)
    • Android Studio at /Users/samer/Applications/Android Studio Ladybug Feature Drop 2024.2.2 Canary 2.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 21.0.3+-79915917-b509.11)

[✓] Android Studio (version 2024.2.1)
    • Android Studio at /Users/samer/Applications/Android Studio.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 21.0.3+-79915917-b509.11)

[✓] IntelliJ IDEA Ultimate Edition (version EAP IU-243.12818.47)
    • IntelliJ at /Users/samer/Applications/IntelliJ IDEA Ultimate.app
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart

[✓] VS Code (version 1.94.0)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.98.0

[✓] Connected device (5 available)
    • sdk gphone64 arm64 (mobile)     • emulator-5554             • android-arm64  • Android 15 (API 35) (emulator)
    • iPhone (Михаил) (mobile)        • 00008020-001254DA1E39002E • ios            • iOS 17.6.1 21G93
    • macOS (desktop)                 • macos                     • darwin-arm64   • macOS 14.7 23H124 darwin-arm64
    • Mac Designed for iPad (desktop) • mac-designed-for-ipad     • darwin         • macOS 14.7 23H124 darwin-arm64
    • Chrome (web)                    • chrome                    • web-javascript • Google Chrome 129.0.6668.90
    ! Error: Browsing on the local area network for Михаил Новосельцев’s iPad. Ensure the device is unlocked and attached with a cable or
      associated with the same local area network as this Mac.
      The device must be opted into Developer Mode to connect wirelessly. (code -27)

[✓] Network resources
    • All expected network resources are available.

! Doctor found issues in 1 category.
```
</details>

Logic behind these changes explained in https://github.com/flutter/flutter/issues/121925#issuecomment-2352826925 

fixes #121925

**Tests**: updated existing tests by adding version checking, but I don't mind writing new ones if necessary – please tell me if so.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
