### PR TITLE
`Material.of(context)` in the test framework

### DIFF
--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1365,31 +1365,26 @@ void main() {
         ),
       );
 
-      RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+      final Finder findDatePicker = find.byType(CalendarDatePicker);
+      SplashController controller = Material.of(tester.element(findDatePicker));
       expect(
-        inkFeatures,
+        controller,
         isNot(
           paints..circle(radius: 35.0, color: theme.colorScheme.onSurfaceVariant.withOpacity(0.08)),
         ),
       );
-      expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 0));
+      expect(controller, paintsExactlyCountTimes(#clipPath, 0));
 
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer();
       await gesture.moveTo(tester.getCenter(find.text('25')));
       await tester.pumpAndSettle();
-      inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+      controller = Material.of(tester.element(findDatePicker));
       expect(
-        inkFeatures,
-        paints
-          ..circle()
-          ..circle(radius: 35.0, color: theme.colorScheme.onSurfaceVariant.withOpacity(0.08)),
+        controller,
+        paints..circle(radius: 35.0, color: theme.colorScheme.onSurfaceVariant.withOpacity(0.08)),
       );
-      expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 1));
+      expect(controller, paintsExactlyCountTimes(#clipPath, 1));
 
       final Rect expectedClipRect = Rect.fromCircle(
         center: const Offset(400.0, 241.0),
@@ -1397,7 +1392,7 @@ void main() {
       );
       final Path expectedClipPath = Path()..addRect(expectedClipRect);
       expect(
-        inkFeatures,
+        controller,
         paints..clipPath(
           pathMatcher: coversSameAreaAs(
             expectedClipPath,

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -88,24 +88,24 @@ void main() {
     expect(material.elevation, 10.0);
     expect(material.shape, const StadiumBorder());
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    SplashController splashController() {
+      final BuildContext context = tester.element(
+        find.descendant(of: carouselViewMaterial, matching: find.byType(InkWell)),
+      );
+      return Material.of(context);
+    }
 
     // On hovered.
     final TestGesture gesture = await hoverPointerOverCarouselItem(tester, key);
     await tester.pumpAndSettle();
-    expect(inkFeatures, paints..rect(color: Colors.red.withOpacity(1.0)));
+    expect(splashController(), paints..rect(color: Colors.red.withOpacity(1.0)));
 
     // On pressed.
     await tester.pumpAndSettle();
     await gesture.down(tester.getCenter(find.byKey(key)));
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(
-      inkFeatures,
+      splashController(),
       paints
         ..rect()
         ..rect(color: Colors.yellow.withOpacity(1.0)),

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -5373,11 +5373,9 @@ void main() {
       ),
     );
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, isNot(paints..rect(color: theme.hoverColor)));
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 0));
+    SplashController controller = Material.of(tester.element(find.byType(Ink)));
+    expect(controller, isNot(paints..rect(color: theme.hoverColor)));
+    expect(controller, paintsExactlyCountTimes(#clipPath, 0));
 
     // Hover over the delete icon.
     final Offset centerOfDeleteButton = tester.getCenter(find.byType(Icon));
@@ -5386,16 +5384,14 @@ void main() {
     addTearDown(hoverGesture.removePointer);
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: theme.hoverColor));
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 1));
+    controller = Material.of(tester.element(find.byType(Ink)));
+    expect(controller, paints..rect(color: theme.hoverColor));
+    expect(controller, paintsExactlyCountTimes(#clipPath, 1));
 
     const Rect expectedClipRect = Rect.fromLTRB(124.7, 10.0, 142.7, 28.0);
     final Path expectedClipPath = Path()..addRect(expectedClipRect);
     expect(
-      inkFeatures,
+      controller,
       paints..clipPath(
         pathMatcher: coversSameAreaAs(
           expectedClipPath,

--- a/packages/flutter/test/material/date_picker_theme_test.dart
+++ b/packages/flutter/test/material/date_picker_theme_test.dart
@@ -590,15 +590,14 @@ void main() {
     expect(day24Shape.side.width, datePickerTheme.todayBorder?.width);
 
     // Test the day overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DatePickerDialog));
+    final SplashController controller = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('25')));
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints..circle(color: datePickerTheme.dayOverlayColor?.resolve(<MaterialState>{})),
     );
 
@@ -639,7 +638,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.text('2024')));
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints..rect(color: datePickerTheme.yearOverlayColor?.resolve(<MaterialState>{})),
     );
 
@@ -755,15 +754,14 @@ void main() {
     expect(selectedDate.style?.fontSize, datePickerTheme.rangePickerHeaderHeadlineStyle?.fontSize);
 
     // Test the day overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DateRangePickerDialog));
+    final SplashController controller = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('16')));
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints..circle(color: datePickerTheme.dayOverlayColor?.resolve(<MaterialState>{})),
     );
 
@@ -771,7 +769,7 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.text('18')));
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints..circle(color: datePickerTheme.rangeSelectionOverlayColor?.resolve(<MaterialState>{})),
     );
   });
@@ -1088,15 +1086,14 @@ void main() {
     );
 
     // Test the hover overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DatePickerDialog));
+    final SplashController controller = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('2022')));
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints..rect(color: yearOverlayColor.resolve(<MaterialState>{MaterialState.hovered})),
     );
 
@@ -1104,7 +1101,7 @@ void main() {
     await gesture.down(tester.getCenter(find.text('2022')));
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints
         ..rect(color: yearOverlayColor.resolve(<MaterialState>{MaterialState.hovered}))
         ..rect(color: yearOverlayColor.resolve(<MaterialState>{MaterialState.pressed})),
@@ -1121,7 +1118,7 @@ void main() {
 
     // Test the focused overlay color.
     expect(
-      inkFeatures,
+      controller,
       paints..rect(color: yearOverlayColor.resolve(<MaterialState>{MaterialState.focused})),
     );
   });
@@ -1168,15 +1165,14 @@ void main() {
     );
 
     // Test the hover overlay color.
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.byType(DateRangePickerDialog));
+    final SplashController controller = Material.of(context);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text('18')));
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints
         ..circle(color: rangeSelectionOverlayColor.resolve(<MaterialState>{MaterialState.hovered})),
     );
@@ -1187,7 +1183,7 @@ void main() {
     if (kIsWeb) {
       // An extra circle is painted on the web for the hovered state.
       expect(
-        inkFeatures,
+        controller,
         paints
           ..circle(
             color: rangeSelectionOverlayColor.resolve(<MaterialState>{MaterialState.hovered}),
@@ -1201,7 +1197,7 @@ void main() {
       );
     } else {
       expect(
-        inkFeatures,
+        controller,
         paints
           ..circle(
             color: rangeSelectionOverlayColor.resolve(<MaterialState>{MaterialState.hovered}),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -187,18 +187,11 @@ void main() {
       return iconRichText.text.style;
     }
 
-    RenderObject overlayPainter(WidgetTester tester, TestMenu menuItem) {
-      return tester.renderObject(
-        find
-            .descendant(
-              of: findMenuItemButton(menuItem.label),
-              matching: find.byElementPredicate(
-                (Element element) =>
-                    element.renderObject.runtimeType.toString() == '_RenderInkFeatures',
-              ),
-            )
-            .last,
+    SplashController splashController(WidgetTester tester, TestMenu menuItem) {
+      final BuildContext context = tester.element(
+        find.descendant(of: findMenuItemButton(menuItem.label), matching: find.byType(InkWell)),
       );
+      return Material.of(context);
     }
 
     testWidgets('defaults are correct', (WidgetTester tester) async {
@@ -248,7 +241,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, selectedItem),
+        splashController(tester, selectedItem),
         paints..rect(color: themeData.colorScheme.onSurface.withOpacity(0.1).withAlpha(0)),
       );
 
@@ -257,7 +250,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, nonSelectedItem),
+        splashController(tester, nonSelectedItem),
         paints..rect(color: themeData.colorScheme.onSurface.withOpacity(0.08).withAlpha(0)),
       );
     });
@@ -302,7 +295,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, selectedItem),
+        splashController(tester, selectedItem),
         paints..rect(color: focusedOverlayColor.withAlpha(0)),
       );
 
@@ -311,7 +304,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, nonSelectedItem),
+        splashController(tester, nonSelectedItem),
         paints..rect(color: defaultOverlayColor.withAlpha(0)),
       );
     });
@@ -355,7 +348,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, selectedItem),
+        splashController(tester, selectedItem),
         paints..rect(color: focusedOverlayColor.withAlpha(0)),
       );
 
@@ -364,7 +357,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, nonSelectedItem),
+        splashController(tester, nonSelectedItem),
         paints..rect(color: defaultOverlayColor.withAlpha(0)),
       );
     });
@@ -417,7 +410,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, selectedItem),
+        splashController(tester, selectedItem),
         paints..rect(color: focusedOverlayColor.withAlpha(0)),
       );
 
@@ -426,7 +419,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, nonSelectedItem),
+        splashController(tester, nonSelectedItem),
         paints..rect(color: defaultOverlayColor.withAlpha(0)),
       );
     });
@@ -493,7 +486,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, selectedItem),
+        splashController(tester, selectedItem),
         paints..rect(color: focusedOverlayColor.withAlpha(0)),
       );
 
@@ -502,7 +495,7 @@ void main() {
       await tester.pump();
 
       expect(
-        overlayPainter(tester, nonSelectedItem),
+        splashController(tester, nonSelectedItem),
         paints..rect(color: defaultOverlayColor.withAlpha(0)),
       );
     });

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -68,10 +68,10 @@ void main() {
     // Material 3 uses the InkSparkle which uses a shader, so we can't capture
     // the effect with paint methods.
     if (!material3) {
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
+      expect(
+        Material.of(tester.element(find.text('button'))),
+        paints..circle(color: colorScheme.onPrimary.withOpacity(0.24)),
       );
-      expect(inkFeatures, paints..circle(color: colorScheme.onPrimary.withOpacity(0.24)));
     }
 
     // Only elevation changes when enabled and pressed.
@@ -384,10 +384,8 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+    SplashController splashController() {
+      return Material.of(tester.element(find.text('ElevatedButton')));
     }
 
     double elevation() {
@@ -405,14 +403,14 @@ void main() {
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
     expect(elevation(), 3.0);
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(elevation(), 1.0);
     expect(
-      overlayColor(),
+      splashController(),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.primary.withOpacity(0.1)),
@@ -427,7 +425,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(elevation(), 1.0);
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
 
     focusNode.dispose();
   });
@@ -876,10 +874,8 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(ElevatedButton)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does ElevatedButton work with focus', (WidgetTester tester) async {
@@ -906,10 +902,8 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: focusColor));
 
     focusNode.dispose();
   });
@@ -940,10 +934,8 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: focusColor));
 
     focusNode.dispose();
   });

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -1447,12 +1447,9 @@ void main() {
       await tester.pump(); // Start the splash animation.
       await tester.pump(const Duration(milliseconds: 100)); // Splash is underway.
 
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
       // Check if the ink splash is drawn on top of the background color.
       expect(
-        inkFeatures,
+        Material.of(tester.element(find.byKey(expansionTileKey))),
         paints
           ..path(color: collapsedBackgroundColor)
           ..circle(color: theme.splashColor),

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -492,10 +492,8 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+    SplashController splashController() {
+      return Material.of(tester.element(find.text('FilledButton')));
     }
 
     double elevation() {
@@ -513,14 +511,14 @@ void main() {
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
     expect(elevation(), 1.0);
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.onPrimary.withOpacity(0.08)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.onPrimary.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(elevation(), 0.0);
     expect(
-      overlayColor(),
+      splashController(),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onPrimary.withOpacity(0.1)),
@@ -535,7 +533,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(elevation(), 0.0);
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.onPrimary.withOpacity(0.1)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.onPrimary.withOpacity(0.1)));
     focusNode.dispose();
   });
 
@@ -564,10 +562,9 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+    final Color overlayColor = theme.colorScheme.onSecondaryContainer;
+    SplashController splashController() {
+      return Material.of(tester.element(find.text('FilledButton')));
     }
 
     double elevation() {
@@ -585,20 +582,17 @@ void main() {
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
     expect(elevation(), 1.0);
-    expect(
-      overlayColor(),
-      paints..rect(color: theme.colorScheme.onSecondaryContainer.withOpacity(0.08)),
-    );
+    expect(splashController(), paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(elevation(), 0.0);
     expect(
-      overlayColor(),
+      splashController(),
       paints
         ..rect()
-        ..rect(color: theme.colorScheme.onSecondaryContainer.withOpacity(0.1)),
+        ..rect(color: overlayColor.withOpacity(0.1)),
     );
     // Remove pressed and hovered states
     await gesture.up();
@@ -610,10 +604,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(elevation(), 0.0);
-    expect(
-      overlayColor(),
-      paints..rect(color: theme.colorScheme.onSecondaryContainer.withOpacity(0.1)),
-    );
+    expect(splashController(), paints..rect(color: overlayColor.withOpacity(0.1)));
     focusNode.dispose();
   });
 
@@ -1056,10 +1047,8 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(FilledButton)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does FilledButton work with focus', (WidgetTester tester) async {
@@ -1086,10 +1075,8 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: focusColor));
     focusNode.dispose();
   });
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -28,10 +28,8 @@ void main() {
     mockOnPressedFunction = MockOnPressedFunction();
   });
 
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+  SplashController splashController(WidgetTester tester) {
+    return Material.of(tester.element(find.byType(Icon)));
   }
 
   Finder findTooltipContainer(String tooltipText) {
@@ -1219,7 +1217,7 @@ void main() {
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints..rect(color: theme.colorScheme.onSurfaceVariant.withOpacity(0.08)),
     );
 
@@ -1227,7 +1225,7 @@ void main() {
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSurfaceVariant.withOpacity(0.1)),
@@ -1242,7 +1240,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints..rect(color: theme.colorScheme.onSurfaceVariant.withOpacity(0.1)),
     );
 
@@ -1359,7 +1357,7 @@ void main() {
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints..rect(color: theme.colorScheme.onPrimary.withOpacity(0.08)),
     );
 
@@ -1367,7 +1365,7 @@ void main() {
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onPrimary.withOpacity(0.1)),
@@ -1382,7 +1380,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints..rect(color: theme.colorScheme.onPrimary.withOpacity(0.1)),
     );
 
@@ -1616,7 +1614,7 @@ void main() {
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints..rect(color: theme.colorScheme.onSecondaryContainer.withOpacity(0.08)),
     );
 
@@ -1624,7 +1622,7 @@ void main() {
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSecondaryContainer.withOpacity(0.1)),
@@ -1639,7 +1637,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints..rect(color: theme.colorScheme.onSecondaryContainer.withOpacity(0.1)),
     );
 
@@ -1876,7 +1874,7 @@ void main() {
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints..rect(color: theme.colorScheme.onSurfaceVariant.withOpacity(0.08)),
     );
 
@@ -1884,7 +1882,7 @@ void main() {
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)),
@@ -1899,7 +1897,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints..rect(color: theme.colorScheme.onSurfaceVariant.withOpacity(0.08)),
     );
 
@@ -2609,13 +2607,13 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(splashController(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints
         ..rect(color: overlayColor.withOpacity(0.08))
         ..rect(color: overlayColor.withOpacity(0.1)),
@@ -2629,7 +2627,7 @@ void main() {
     // Focused.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(splashController(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
   });
 
   testWidgets('IconButton.styleFrom highlight, hover, focus colors overrides overlayColor', (
@@ -2665,13 +2663,13 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: hoverColor));
+    expect(splashController(tester), paints..rect(color: hoverColor));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints
         ..rect(color: hoverColor)
         ..rect(color: highlightColor),
@@ -2685,7 +2683,7 @@ void main() {
     // Focused.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: focusColor));
+    expect(splashController(tester), paints..rect(color: focusColor));
   });
 
   testWidgets('IconButton.styleFrom with transparent overlayColor', (WidgetTester tester) async {
@@ -2710,13 +2708,13 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    expect(splashController(tester), paints..rect(color: overlayColor));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController(tester),
       paints
         ..rect(color: overlayColor)
         ..rect(color: overlayColor),
@@ -2730,7 +2728,7 @@ void main() {
     // Focused.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    expect(splashController(tester), paints..rect(color: overlayColor));
   });
 
   group('IconTheme tests in Material 3', () {
@@ -3011,7 +3009,7 @@ void main() {
     await gesture.down(topLeft);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      Material.of(tester.element(find.byType(ColoredBox))),
       paints
         ..rect(color: const Color(0xFFFF0000)) // ColoredBox.
         ..rect(color: const Color(0xFF00FF00)), // IconButton overlay.

--- a/packages/flutter/test/material/icon_button_theme_test.dart
+++ b/packages/flutter/test/material/icon_button_theme_test.dart
@@ -8,12 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-  }
-
   test('IconButtonThemeData lerp special cases', () {
     expect(IconButtonThemeData.lerp(null, null, 0), null);
     const IconButtonThemeData data = IconButtonThemeData();
@@ -313,13 +307,14 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    final SplashController controller = Material.of(tester.element(find.byType(Icon)));
+    expect(controller, paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      controller,
       paints
         ..rect(color: overlayColor.withOpacity(0.08))
         ..rect(color: overlayColor.withOpacity(0.1)),
@@ -333,6 +328,6 @@ void main() {
     // Focused.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(controller, paints..rect(color: overlayColor.withOpacity(0.1)));
   });
 }

--- a/packages/flutter/test/material/ink_sparkle_test.dart
+++ b/packages/flutter/test/material/ink_sparkle_test.dart
@@ -57,14 +57,14 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 200));
 
-      final MaterialInkController material = Material.of(tester.element(buttonFinder));
-      expect(material, paintsExactlyCountTimes(#drawRect, 1));
+      final MaterialInkController controller = Material.of(tester.element(buttonFinder));
+      expect(controller, paintsExactlyCountTimes(#drawRect, 1));
 
-      expect((material as dynamic).debugInkFeatures, hasLength(1));
+      expect(controller.splashes, hasLength(1));
 
       await tester.pumpAndSettle();
       // ink feature is disposed.
-      expect((material as dynamic).debugInkFeatures, isEmpty);
+      expect(controller.splashes, isEmpty);
     },
     skip: kIsWeb, // [intended] shaders are not yet supported for web.
   );

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -11,10 +11,9 @@ import '../widgets/feedback_tester.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  RenderObject getInkFeatures(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+  SplashController splashController(WidgetTester tester, {Type type = InkWell}) {
+    final BuildContext context = tester.element(find.byType(type));
+    return Material.of(context);
   }
 
   testWidgets('InkWell gestures control test', (WidgetTester tester) async {
@@ -181,9 +180,8 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.byType(SizedBox)));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
     expect(
-      inkFeatures,
+      splashController(tester),
       paints..rect(
         rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
         color: const Color(0xff00ff00),
@@ -228,9 +226,8 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.byType(SizedBox)));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
     expect(
-      inkFeatures,
+      splashController(tester),
       paints..rect(
         rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
         color: const Color(0xff00ff00),
@@ -265,12 +262,12 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#drawRect, 0));
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints..rect(
         rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
         color: const Color(0xff0000ff),
@@ -317,12 +314,12 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#drawRect, 0));
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(
-      inkFeatures,
+      controller,
       paints..rect(
         rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
         color: const Color(0xff0000ff),
@@ -362,14 +359,14 @@ void main() {
     final TestGesture gesture = await tester.startGesture(
       tester.getRect(find.byType(InkWell)).center,
     );
-    final RenderObject inkFeatures = getInkFeatures(tester);
+    final SplashController controller = splashController(tester);
     expect(
-      inkFeatures,
+      controller,
       paints..rect(rect: const Rect.fromLTRB(0, 0, 100, 100), color: pressedColor.withAlpha(0)),
     );
     await tester.pumpAndSettle(); // Let the press highlight animation finish.
     expect(
-      inkFeatures,
+      controller,
       paints..rect(rect: const Rect.fromLTRB(0, 0, 100, 100), color: pressedColor),
     );
     await gesture.up();
@@ -431,12 +428,12 @@ void main() {
       await tester.pumpWidget(boilerplate(focusNode: focusNode));
       await tester.pumpAndSettle();
 
-      final RenderObject inkFeatures = getInkFeatures(tester);
-      expect(inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+      final SplashController controller = splashController(tester);
+      expect(controller, paintsExactlyCountTimes(#drawRect, 0));
       focusNode.requestFocus();
       await tester.pumpAndSettle();
 
-      expect(inkFeatures, paints..rect(rect: inkRect, color: selectedFocusedColor));
+      expect(controller, paints..rect(rect: inkRect, color: selectedFocusedColor));
     });
 
     testWidgets('when hovered', (WidgetTester tester) async {
@@ -448,8 +445,7 @@ void main() {
       await gesture.moveTo(tester.getCenter(find.byType(SizedBox)));
       await tester.pumpAndSettle();
 
-      final RenderObject inkFeatures = getInkFeatures(tester);
-      expect(inkFeatures, paints..rect(rect: inkRect, color: selectedHoveredColor));
+      expect(splashController(tester), paints..rect(rect: inkRect, color: selectedHoveredColor));
     });
 
     testWidgets('when pressed', (WidgetTester tester) async {
@@ -459,10 +455,10 @@ void main() {
       final TestGesture gesture = await tester.startGesture(
         tester.getRect(find.byType(InkWell)).center,
       );
-      final RenderObject inkFeatures = getInkFeatures(tester);
-      expect(inkFeatures, paints..rect(rect: inkRect, color: selectedPressedColor.withAlpha(0)));
+      final SplashController controller = splashController(tester);
+      expect(controller, paints..rect(rect: inkRect, color: selectedPressedColor.withAlpha(0)));
       await tester.pumpAndSettle(); // Let the press highlight animation finish.
-      expect(inkFeatures, paints..rect(rect: inkRect, color: selectedPressedColor));
+      expect(controller, paints..rect(rect: inkRect, color: selectedPressedColor));
       await gesture.up();
     });
   });
@@ -506,8 +502,7 @@ void main() {
       tester.getRect(find.byType(InkWell)).center,
     );
     await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paints..circle(x: 50, y: 50, color: splashColor));
+    expect(splashController(tester), paints..circle(x: 50, y: 50, color: splashColor));
     await gesture.up();
     focusNode.dispose();
   });
@@ -564,8 +559,7 @@ void main() {
       tester.getRect(find.byType(InkWell)).center,
     );
     await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paints..circle(x: 50, y: 50, color: splashColor));
+    expect(splashController(tester), paints..circle(x: 50, y: 50, color: splashColor));
     await gesture.up();
     focusNode.dispose();
   });
@@ -593,11 +587,11 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
+    final SplashController controller = splashController(tester, type: InkResponse);
+    expect(controller, paintsExactlyCountTimes(#drawCircle, 0));
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paints..circle(radius: 20, color: const Color(0xff0000ff)));
+    expect(controller, paints..circle(radius: 20, color: const Color(0xff0000ff)));
     focusNode.dispose();
   });
 
@@ -624,15 +618,15 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 0));
 
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 1));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 1));
 
     expect(
-      inkFeatures,
+      controller,
       paints..rrect(
         rrect: RRect.fromLTRBR(350.0, 250.0, 450.0, 350.0, const Radius.circular(10)),
         color: const Color(0xff0000ff),
@@ -663,8 +657,8 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 0));
 
     // Hover the ink well.
     final TestGesture gesture = await tester.createGesture(
@@ -673,10 +667,10 @@ void main() {
     );
     await gesture.addPointer(location: tester.getRect(find.byType(InkWell)).center);
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 1));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 1));
 
     expect(
-      inkFeatures,
+      controller,
       paints..rrect(
         rrect: RRect.fromLTRBR(350.0, 250.0, 450.0, 350.0, const Radius.circular(10)),
         color: const Color(0xff00ff00),
@@ -711,14 +705,14 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 0));
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#clipPath, 0));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 0));
 
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 1));
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 1));
+    expect(controller, paintsExactlyCountTimes(#clipPath, 1));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 1));
 
     // Create a rounded rectangle path with a radius that makes it similar to the custom border circle.
     const Rect expectedClipRect = Rect.fromLTRB(0, 0, 100, 100);
@@ -726,7 +720,7 @@ void main() {
         Path()..addRRect(RRect.fromRectAndRadius(expectedClipRect, const Radius.circular(50.0)));
     // The ink well custom border path should match the rounded rectangle path.
     expect(
-      inkFeatures,
+      controller,
       paints..clipPath(
         pathMatcher: coversSameAreaAs(
           expectedClipPath,
@@ -762,9 +756,9 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 0));
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#clipPath, 0));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 0));
 
     // Hover the ink well.
     final TestGesture gesture = await tester.createGesture(
@@ -773,8 +767,8 @@ void main() {
     );
     await gesture.addPointer(location: tester.getRect(find.byType(InkWell)).center);
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 1));
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 1));
+    expect(controller, paintsExactlyCountTimes(#clipPath, 1));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 1));
 
     // Create a rounded rectangle path with a radius that makes it similar to the custom border circle.
     const Rect expectedClipRect = Rect.fromLTRB(0, 0, 100, 100);
@@ -782,7 +776,7 @@ void main() {
         Path()..addRRect(RRect.fromRectAndRadius(expectedClipRect, const Radius.circular(50.0)));
     // The ink well custom border path should match the rounded rectangle path.
     expect(
-      inkFeatures,
+      controller,
       paints..clipPath(
         pathMatcher: coversSameAreaAs(
           expectedClipPath,
@@ -818,18 +812,18 @@ void main() {
 
     await tester.pumpWidget(boilerplate(10));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
+    final SplashController controller = splashController(tester, type: InkResponse);
+    expect(controller, paintsExactlyCountTimes(#drawCircle, 0));
 
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 1));
-    expect(inkFeatures, paints..circle(radius: 10, color: const Color(0xff0000ff)));
+    expect(controller, paintsExactlyCountTimes(#drawCircle, 1));
+    expect(controller, paints..circle(radius: 10, color: const Color(0xff0000ff)));
 
     await tester.pumpWidget(boilerplate(20));
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 1));
-    expect(inkFeatures, paints..circle(radius: 20, color: const Color(0xff0000ff)));
+    expect(controller, paintsExactlyCountTimes(#drawCircle, 1));
+    expect(controller, paints..circle(radius: 20, color: const Color(0xff0000ff)));
     focusNode.dispose();
   });
 
@@ -859,19 +853,19 @@ void main() {
 
     await tester.pumpWidget(boilerplate(BoxShape.circle));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 0));
+    final SplashController controller = splashController(tester, type: InkResponse);
+    expect(controller, paintsExactlyCountTimes(#drawCircle, 0));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 0));
 
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 1));
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 0));
+    expect(controller, paintsExactlyCountTimes(#drawCircle, 1));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 0));
 
     await tester.pumpWidget(boilerplate(BoxShape.rectangle));
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 1));
+    expect(controller, paintsExactlyCountTimes(#drawCircle, 0));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 1));
     focusNode.dispose();
   });
 
@@ -900,14 +894,14 @@ void main() {
 
     await tester.pumpWidget(boilerplate(BorderRadius.circular(10)));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 0));
 
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 1));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 1));
     expect(
-      inkFeatures,
+      controller,
       paints..rrect(
         rrect: RRect.fromLTRBR(350.0, 250.0, 450.0, 350.0, const Radius.circular(10)),
         color: const Color(0xff0000ff),
@@ -916,9 +910,9 @@ void main() {
 
     await tester.pumpWidget(boilerplate(BorderRadius.circular(30)));
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRRect, 1));
+    expect(controller, paintsExactlyCountTimes(#drawRRect, 1));
     expect(
-      inkFeatures,
+      controller,
       paints..rrect(
         rrect: RRect.fromLTRBR(350.0, 250.0, 450.0, 350.0, const Radius.circular(30)),
         color: const Color(0xff0000ff),
@@ -955,18 +949,18 @@ void main() {
 
     await tester.pumpWidget(boilerplate(BorderRadius.circular(20)));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#clipPath, 0));
 
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 1));
+    expect(controller, paintsExactlyCountTimes(#clipPath, 1));
 
     const Rect expectedClipRect = Rect.fromLTRB(0, 0, 100, 100);
     Path expectedClipPath =
         Path()..addRRect(RRect.fromRectAndRadius(expectedClipRect, const Radius.circular(20)));
     expect(
-      inkFeatures,
+      controller,
       paints..clipPath(
         pathMatcher: coversSameAreaAs(
           expectedClipPath,
@@ -981,7 +975,7 @@ void main() {
     expectedClipPath =
         Path()..addRRect(RRect.fromRectAndRadius(expectedClipRect, const Radius.circular(40)));
     expect(
-      inkFeatures,
+      controller,
       paints..clipPath(
         pathMatcher: coversSameAreaAs(
           expectedClipPath,
@@ -1024,14 +1018,14 @@ void main() {
     await tester.pumpWidget(boilerplate(BorderRadius.circular(20)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#clipPath, 0));
 
     final TestGesture gesture = await tester.startGesture(
       tester.getRect(find.byType(InkWell)).center,
     );
     await tester.pump(const Duration(milliseconds: 200)); // Unconfirmed splash is well underway.
-    expect(inkFeatures, paintsExactlyCountTimes(#clipPath, 2)); // Splash and highlight.
+    expect(controller, paintsExactlyCountTimes(#clipPath, 2)); // Splash and highlight.
 
     const Rect expectedClipRect = Rect.fromLTRB(0, 0, 100, 100);
     Path expectedClipPath =
@@ -1039,7 +1033,7 @@ void main() {
 
     // Check that the splash and the highlight are correctly clipped.
     expect(
-      inkFeatures,
+      controller,
       paints
         ..clipPath(
           pathMatcher: coversSameAreaAs(
@@ -1064,7 +1058,7 @@ void main() {
 
     // Check that the splash and the highlight are correctly clipped.
     expect(
-      inkFeatures,
+      controller,
       paints
         ..clipPath(
           pathMatcher: coversSameAreaAs(
@@ -1115,11 +1109,11 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+    final SplashController controller = splashController(tester);
+    expect(controller, paintsExactlyCountTimes(#drawRect, 0));
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+    expect(controller, paintsExactlyCountTimes(#drawRect, 0));
     focusNode.dispose();
   });
 
@@ -2228,8 +2222,7 @@ void main() {
     expect(log, equals(<String>['tap-down', 'double-tap']));
 
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = getInkFeatures(tester);
-    expect(inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+    expect(splashController(tester), paintsExactlyCountTimes(#drawRect, 0));
   });
 
   testWidgets(
@@ -2277,8 +2270,7 @@ void main() {
       expect(log, equals(<String>['tap-down', 'tap-down', 'tap-cancel', 'double-tap']));
 
       await tester.pumpAndSettle();
-      final RenderObject inkFeatures = getInkFeatures(tester);
-      expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
+      expect(splashController(tester), paintsExactlyCountTimes(#drawCircle, 0));
     },
   );
 
@@ -2364,10 +2356,10 @@ void main() {
     await tester.pumpAndSettle();
     await gesture.moveTo(const Offset(10, 10)); // fade out the overlay
     await tester.pump(); // trigger the fade out animation
-    final RenderObject inkFeatures = getInkFeatures(tester);
+    final SplashController controller = splashController(tester);
     // Fadeout begins with the MaterialStates.hovered overlay color
     expect(
-      inkFeatures,
+      controller,
       paints..rect(
         rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
         color: const Color(0xff00ff00),
@@ -2376,7 +2368,7 @@ void main() {
     // 50ms fadeout is 50% complete, overlay color alpha goes from 0xff to 0x80
     await tester.pump(const Duration(milliseconds: 25));
     expect(
-      inkFeatures,
+      controller,
       paints..rect(
         rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
         color: const Color(0x8000ff00),
@@ -2445,8 +2437,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200));
 
       // No splash should be painted.
-      final RenderObject inkFeatures = getInkFeatures(tester);
-      expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
+      expect(splashController(tester), paintsExactlyCountTimes(#drawCircle, 0));
 
       await gesture.up();
     },

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -291,12 +291,6 @@ TextStyle? getIconStyle(WidgetTester tester, IconData icon) {
   return iconRichText.text.style;
 }
 
-RenderObject getOverlayColor(WidgetTester tester) {
-  return tester.allRenderObjects.firstWhere(
-    (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-  );
-}
-
 void main() {
   // TODO(bleroux): migrate all M2 tests to M3.
   // See https://github.com/flutter/flutter/issues/139076
@@ -8512,7 +8506,8 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    final BuildContext context = tester.element(find.byType(InputDecorator));
+    expect(Material.of(context), paints..rect(color: overlayColor));
   });
 
   testWidgets('Suffix IconButton inherits IconButtonTheme', (WidgetTester tester) async {
@@ -8562,7 +8557,8 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    final BuildContext context = tester.element(find.byType(InputDecorator));
+    expect(Material.of(context), paints..rect(color: overlayColor));
   });
 
   testWidgets('Prefix IconButton color respects IconButtonTheme foreground color states', (

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -122,10 +122,8 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(MaterialButton)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does MaterialButton work with focus', (WidgetTester tester) async {
@@ -148,10 +146,8 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: focusColor));
 
     focusNode.dispose();
   });
@@ -192,6 +188,10 @@ void main() {
     );
     await tester.pumpAndSettle();
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    SplashController splashController() {
+      final BuildContext context = tester.element(find.text('button'));
+      return Material.of(context);
+    }
 
     // Base elevation
     Material material = tester.widget<Material>(rawButtonMaterial);
@@ -201,10 +201,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     material = tester.widget<Material>(rawButtonMaterial);
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(splashController(), paints..rect(color: focusColor));
     expect(focusNode.hasPrimaryFocus, isTrue);
     expect(material.elevation, equals(focusElevation));
 
@@ -215,11 +212,8 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(MaterialButton)));
     await tester.pumpAndSettle();
     material = tester.widget<Material>(rawButtonMaterial);
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(
-      inkFeatures,
+      splashController(),
       paints
         ..rect(color: focusColor)
         ..rect(color: hoverColor),
@@ -235,11 +229,8 @@ void main() {
     addTearDown(gesture2.removePointer);
     await tester.pumpAndSettle();
     material = tester.widget<Material>(rawButtonMaterial);
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     expect(
-      inkFeatures,
+      splashController(),
       paints
         ..rect(color: focusColor)
         ..rect(color: highlightColor),

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -167,12 +167,6 @@ void main() {
     );
   }
 
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-  }
-
   TextStyle iconStyle(WidgetTester tester, IconData icon) {
     final RichText iconRichText = tester.widget<RichText>(
       find.descendant(of: find.byIcon(icon), matching: find.byType(RichText)),
@@ -3180,6 +3174,10 @@ void main() {
           ),
         ),
       );
+      SplashController splashController() {
+        final BuildContext context = tester.element(find.text('MenuItem'));
+        return Material.of(context);
+      }
 
       // Hovered.
       final Offset center = tester.getCenter(find.byType(MenuItemButton));
@@ -3187,13 +3185,13 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(center);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+      expect(splashController(), paints..rect(color: overlayColor.withOpacity(0.08)));
 
       // Highlighted (pressed).
       await gesture.down(center);
       await tester.pumpAndSettle();
       expect(
-        getOverlayColor(tester),
+        splashController(),
         paints
           ..rect(color: overlayColor.withOpacity(0.08))
           ..rect(color: overlayColor.withOpacity(0.08))
@@ -4502,6 +4500,8 @@ void main() {
         ),
       ),
     );
+    final BuildContext context = tester.element(find.text('Submenu'));
+    final SplashController controller = Material.of(context);
 
     // Hovered.
     final Offset center = tester.getCenter(find.byType(SubmenuButton));
@@ -4509,13 +4509,13 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(controller, paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      controller,
       paints
         ..rect(color: overlayColor.withOpacity(0.08))
         ..rect(color: overlayColor.withOpacity(0.08))

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -650,16 +650,14 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.access_alarm)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final SplashController controller = Material.of(tester.element(find.text('AC')));
     Offset indicatorCenter = const Offset(600, 30);
     const Size includedIndicatorSize = Size(64, 32);
     const Size excludedIndicatorSize = Size(74, 40);
 
     // Test ripple when NavigationBar is using `NavigationDestinationLabelBehavior.alwaysShow` (default).
     expect(
-      inkFeatures,
+      controller,
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -703,7 +701,7 @@ void main() {
     indicatorCenter = const Offset(600, 40);
 
     expect(
-      inkFeatures,
+      controller,
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -745,7 +743,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      inkFeatures,
+      controller,
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -788,7 +786,7 @@ void main() {
     indicatorCenter = const Offset(600, 30);
 
     expect(
-      inkFeatures,
+      controller,
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -1056,13 +1054,15 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(NavigationIndicator).last));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
+    // This test extracts the controller from the allRenderObjects iterable
+    // in order to prevent some wonkiness when running via skwasm.
+    final RenderObject controller = tester.allRenderObjects.firstWhere(
+      (RenderObject object) => object.runtimeType.toString() == '_RenderSplashes',
     );
 
     // Test hovered state.
     expect(
-      inkFeatures,
+      controller,
       kIsWeb
           ? (paints
             ..rrect()
@@ -1076,7 +1076,7 @@ void main() {
 
     // Test pressed state.
     expect(
-      inkFeatures,
+      controller,
       kIsWeb
           ? (paints
             ..circle()
@@ -1096,7 +1096,7 @@ void main() {
 
     // Test focused state.
     expect(
-      inkFeatures,
+      controller,
       kIsWeb
           ? (paints
             ..circle()
@@ -1210,16 +1210,14 @@ void main() {
       await gesture.moveTo(tester.getCenter(find.byIcon(Icons.access_alarm)));
       await tester.pumpAndSettle();
 
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+      final SplashController controller = Material.of(tester.element(find.text('AC')));
       Offset indicatorCenter = const Offset(600, 33);
       const Size includedIndicatorSize = Size(64, 32);
       const Size excludedIndicatorSize = Size(74, 40);
 
       // Test ripple when NavigationBar is using `NavigationDestinationLabelBehavior.alwaysShow` (default).
       expect(
-        inkFeatures,
+        controller,
         paints
           ..clipPath(
             pathMatcher: isPathThat(
@@ -1263,7 +1261,7 @@ void main() {
       indicatorCenter = const Offset(600, 40);
 
       expect(
-        inkFeatures,
+        controller,
         paints
           ..clipPath(
             pathMatcher: isPathThat(
@@ -1305,7 +1303,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        inkFeatures,
+        controller,
         paints
           ..clipPath(
             pathMatcher: isPathThat(
@@ -1348,7 +1346,7 @@ void main() {
       indicatorCenter = const Offset(600, 33);
 
       expect(
-        inkFeatures,
+        controller,
         paints
           ..clipPath(
             pathMatcher: isPathThat(

--- a/packages/flutter/test/material/navigation_bar_theme_test.dart
+++ b/packages/flutter/test/material/navigation_bar_theme_test.dart
@@ -288,13 +288,15 @@ void main() {
       await gesture.moveTo(tester.getCenter(find.byType(NavigationIndicator).last));
       await tester.pumpAndSettle();
 
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
+      // This test extracts the controller from the allRenderObjects iterable
+      // in order to prevent some wonkiness when running via skwasm.
+      final RenderObject controller = tester.allRenderObjects.firstWhere(
+        (RenderObject object) => object.runtimeType.toString() == '_RenderSplashes',
       );
 
       // Test hovered state.
       expect(
-        inkFeatures,
+        controller,
         kIsWeb
             ? (paints
               ..rrect()
@@ -308,7 +310,7 @@ void main() {
 
       // Test pressed state.
       expect(
-        inkFeatures,
+        controller,
         kIsWeb
             ? (paints
               ..circle()
@@ -328,7 +330,7 @@ void main() {
 
       // Test focused state.
       expect(
-        inkFeatures,
+        controller,
         kIsWeb
             ? (paints
               ..circle()

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -11,6 +11,14 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
+  SplashController splashController(WidgetTester tester) {
+    final BuildContext context = tester.element(
+      find.descendant(of: find.byType(NavigationRail), matching: find.byType(Expanded)),
+    );
+
+    return Material.of(context);
+  }
+
   testWidgets('Custom selected and unselected textStyles are honored', (WidgetTester tester) async {
     const TextStyle selectedTextStyle = TextStyle(fontWeight: FontWeight.w300, fontSize: 17.0);
     const TextStyle unselectedTextStyle = TextStyle(fontWeight: FontWeight.w800, fontSize: 11.0);
@@ -3132,15 +3140,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const Rect indicatorRect = Rect.fromLTRB(12.0, 0.0, 68.0, 32.0);
     const Rect includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      splashController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3194,15 +3199,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const Rect indicatorRect = Rect.fromLTRB(12.0, 6.0, 68.0, 38.0);
     const Rect includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      splashController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3260,15 +3262,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const Rect indicatorRect = Rect.fromLTRB(22.0, 16.0, 78.0, 48.0);
     const Rect includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      splashController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3325,15 +3324,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const Rect indicatorRect = Rect.fromLTRB(-3.0, 6.0, 53.0, 38.0);
     const Rect includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      splashController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3392,15 +3388,12 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
     const Rect indicatorRect = Rect.fromLTRB(132.0, 16.0, 188.0, 48.0);
     const Rect includedRect = indicatorRect;
     final Rect excludedRect = includedRect.inflate(10);
 
     expect(
-      inkFeatures,
+      splashController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3455,10 +3448,6 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-
     // Default values from M3 specification.
     const double indicatorHeight = 32.0;
     const double destinationWidth = 72.0;
@@ -3486,7 +3475,7 @@ void main() {
     const double secondIndicatorVerticalOffset = secondDestinationVerticalOffset;
 
     expect(
-      inkFeatures,
+      splashController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3553,10 +3542,6 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-
     // Default values from M3 specification.
     const double railMinWidth = 80.0;
     const double indicatorHeight = 32.0;
@@ -3594,7 +3579,7 @@ void main() {
     const double secondIndicatorVerticalOffset = secondDestinationVerticalOffset + indicatorOffset;
 
     expect(
-      inkFeatures,
+      splashController(tester),
       paints
         ..clipPath(
           pathMatcher: isPathThat(
@@ -3660,10 +3645,6 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byIcon(Icons.favorite_border)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-
     // Default values from M3 specification.
     const double railMinExtendedWidth = 256.0;
     const double indicatorHeight = 32.0;
@@ -3697,7 +3678,7 @@ void main() {
     const double secondDestinationHorizontalOffset = 800 - railMinExtendedWidth; // RTL.
 
     expect(
-      inkFeatures,
+      Material.of(tester.element(find.byType(NavigationRail))),
       paints
         ..clipPath(
           pathMatcher: isPathThat(

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -73,10 +73,8 @@ void main() {
     // Material 3 uses the InkSparkle which uses a shader, so we can't capture
     // the effect with paint methods.
     if (!material3) {
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-      expect(inkFeatures, paints..circle(color: colorScheme.primary.withOpacity(0.12)));
+      final BuildContext context = tester.element(find.text('button'));
+      expect(Material.of(context), paints..circle(color: colorScheme.primary.withOpacity(0.12)));
     }
 
     await gesture.up();
@@ -364,10 +362,9 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+    SplashController splashController() {
+      final BuildContext context = tester.element(find.text('OutlinedButton'));
+      return Material.of(context);
     }
 
     // Hovered.
@@ -376,13 +373,13 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      splashController(),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.primary.withOpacity(0.1)),
@@ -396,7 +393,7 @@ void main() {
     // Focused.
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
 
     focusNode.dispose();
   });
@@ -425,10 +422,8 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.byType(OutlinedButton)));
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does OutlinedButton work with focus', (WidgetTester tester) async {
@@ -459,10 +454,8 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: focusColor));
 
     final Finder buttonMaterial = find.descendant(
       of: find.byType(OutlinedButton),
@@ -504,10 +497,8 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: focusColor));
 
     final Finder buttonMaterial = find.descendant(
       of: find.byType(OutlinedButton),

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -529,24 +529,19 @@ void main() {
       ),
     );
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
     await tester.pumpAndSettle();
-    expect(inkFeatures, paints..rect(color: hoveredColor.withOpacity(1.0)));
+    BuildContext context = tester.element(find.byType(SearchBar));
+    expect(Material.of(context), paints..rect(color: hoveredColor.withOpacity(1.0)));
 
     // On pressed.
     await tester.pumpAndSettle();
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    context = tester.element(find.byType(SearchBar));
     expect(
-      inkFeatures,
+      Material.of(context),
       paints
         ..rect()
         ..rect(color: pressedColor.withOpacity(1.0)),
@@ -559,11 +554,9 @@ void main() {
     // Remove the pointer so we are no longer hovering.
     await gesture.removePointer();
     await tester.pump();
-    inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    context = tester.element(find.byType(SearchBar));
     expect(
-      inkFeatures,
+      Material.of(context),
       paints
         ..rect()
         ..rect(color: focusedColor.withOpacity(1.0)),

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -18,12 +18,6 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-  }
-
   Widget boilerplate({required Widget child}) {
     return Directionality(textDirection: TextDirection.ltr, child: Center(child: child));
   }
@@ -582,6 +576,8 @@ void main() {
     final Material material = tester.widget<Material>(
       find.descendant(of: find.byType(TextButton), matching: find.byType(Material)),
     );
+    final BuildContext context = tester.element(find.text('2'));
+    final SplashController controller = Material.of(context);
 
     // Hovered.
     final Offset center = tester.getCenter(find.text('2'));
@@ -589,17 +585,14 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(
-      getOverlayColor(tester),
-      paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)),
-    );
+    expect(controller, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
     expect(material.textStyle?.color, theme.colorScheme.onSurface);
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      controller,
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)),
@@ -761,7 +754,8 @@ void main() {
     await gesture.addPointer();
     await gesture.down(tester.getCenter(find.text('1')));
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: foregroundColor.withOpacity(0.08)));
+    final BuildContext context = tester.element(find.text('1'));
+    expect(Material.of(context), paints..rect(color: foregroundColor.withOpacity(0.08)));
   });
 
   testWidgets('Disabled SegmentedButton has correct states when rebuilding', (
@@ -952,6 +946,10 @@ void main() {
         ),
       ),
     );
+    SplashController splashController(String buttonText) {
+      final BuildContext context = tester.element(find.text(buttonText));
+      return Material.of(context);
+    }
 
     // Hovered selected segment,
     Offset center = tester.getCenter(find.text('Option 1'));
@@ -959,20 +957,20 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(splashController('Option 1'), paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Hovered unselected segment,
     center = tester.getCenter(find.text('Option 2'));
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+    expect(splashController('Option 2'), paints..rect(color: overlayColor.withOpacity(0.08)));
 
     // Highlighted unselected segment (pressed).
     center = tester.getCenter(find.text('Option 1'));
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController('Option 1'),
       paints
         ..rect(color: overlayColor.withOpacity(0.08))
         ..rect(color: overlayColor.withOpacity(0.1)),
@@ -988,7 +986,7 @@ void main() {
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      splashController('Option 2'),
       paints
         ..rect(color: overlayColor.withOpacity(0.08))
         ..rect(color: overlayColor.withOpacity(0.1)),
@@ -1002,12 +1000,12 @@ void main() {
     // Focused unselected segment.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(splashController('Option 1'), paints..rect(color: overlayColor.withOpacity(0.1)));
 
     // Focused selected segment.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+    expect(splashController('Option 2'), paints..rect(color: overlayColor.withOpacity(0.1)));
   });
 
   testWidgets('SegmentedButton.styleFrom with transparent overlayColor', (
@@ -1037,13 +1035,15 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    final BuildContext context = tester.element(find.text('Option'));
+    final SplashController controller = Material.of(context);
+    expect(controller, paints..rect(color: overlayColor));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      getOverlayColor(tester),
+      controller,
       paints
         ..rect(color: overlayColor)
         ..rect(color: overlayColor),
@@ -1057,7 +1057,7 @@ void main() {
     // Focused.
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
-    expect(getOverlayColor(tester), paints..rect(color: overlayColor));
+    expect(controller, paints..rect(color: overlayColor));
   });
 
   // This is a regression test for https://github.com/flutter/flutter/issues/144990.

--- a/packages/flutter/test/material/segmented_button_theme_test.dart
+++ b/packages/flutter/test/material/segmented_button_theme_test.dart
@@ -9,12 +9,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  RenderObject getOverlayColor(WidgetTester tester) {
-    return tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-  }
-
   test('SegmentedButtonThemeData copyWith, ==, hashCode basics', () {
     expect(const SegmentedButtonThemeData(), const SegmentedButtonThemeData().copyWith());
     expect(
@@ -518,6 +512,10 @@ void main() {
           ),
         ),
       );
+      SplashController splashController(String buttonText) {
+        final BuildContext context = tester.element(find.text(buttonText));
+        return Material.of(context);
+      }
 
       // Hovered selected segment,
       Offset center = tester.getCenter(find.text('Option 1'));
@@ -525,20 +523,20 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(center);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+      expect(splashController('Option 1'), paints..rect(color: overlayColor.withOpacity(0.08)));
 
       // Hovered unselected segment,
       center = tester.getCenter(find.text('Option 2'));
       await gesture.moveTo(center);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.08)));
+      expect(splashController('Option 2'), paints..rect(color: overlayColor.withOpacity(0.08)));
 
       // Highlighted unselected segment (pressed).
       center = tester.getCenter(find.text('Option 1'));
       await gesture.down(center);
       await tester.pumpAndSettle();
       expect(
-        getOverlayColor(tester),
+        splashController('Option 1'),
         paints
           ..rect(color: overlayColor.withOpacity(0.08))
           ..rect(color: overlayColor.withOpacity(0.1)),
@@ -554,7 +552,7 @@ void main() {
       await gesture.down(center);
       await tester.pumpAndSettle();
       expect(
-        getOverlayColor(tester),
+        splashController('Option 2'),
         paints
           ..rect(color: overlayColor.withOpacity(0.08))
           ..rect(color: overlayColor.withOpacity(0.1)),
@@ -568,12 +566,12 @@ void main() {
       // Focused unselected segment.
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+      expect(splashController('Option 1'), paints..rect(color: overlayColor.withOpacity(0.1)));
 
       // Focused selected segment.
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pumpAndSettle();
-      expect(getOverlayColor(tester), paints..rect(color: overlayColor.withOpacity(0.1)));
+      expect(splashController('Option 2'), paints..rect(color: overlayColor.withOpacity(0.1)));
     },
   );
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -518,22 +518,24 @@ void main() {
       buildFrame(tabs: tabs, value: selectedValue, useMaterial3: theme.useMaterial3),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+    SplashController splashController(String text) {
+      final BuildContext context = tester.element(find.text(text));
+      return Material.of(context);
     }
 
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    expect(
+      splashController(selectedValue),
+      paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)),
+    );
 
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      splashController(selectedValue),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.primary.withOpacity(0.1)),
@@ -543,12 +545,15 @@ void main() {
 
     await gesture.moveTo(tester.getCenter(find.text(unselectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
+    expect(
+      splashController(unselectedValue),
+      paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)),
+    );
 
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      splashController(unselectedValue),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.primary.withOpacity(0.1)),
@@ -572,22 +577,24 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+    SplashController splashController(String text) {
+      final BuildContext context = tester.element(find.text(text));
+      return Material.of(context);
     }
 
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
+    expect(
+      splashController(selectedValue),
+      paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)),
+    );
 
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      splashController(selectedValue),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)),
@@ -597,12 +604,15 @@ void main() {
 
     await gesture.moveTo(tester.getCenter(find.text(unselectedValue)));
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
+    expect(
+      splashController(unselectedValue),
+      paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)),
+    );
 
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      splashController(unselectedValue),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)),
@@ -4669,11 +4679,9 @@ void main() {
       await gesture.addPointer();
       await gesture.moveTo(tester.getCenter(find.byType(Tab)));
       await tester.pumpAndSettle();
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+      final BuildContext context = tester.element(find.text('A'));
       expect(
-        inkFeatures,
+        Material.of(context),
         paints..rect(
           rect: const Rect.fromLTRB(0.0, 276.0, 800.0, 324.0),
           color: const Color(0xff00ff00),
@@ -4710,10 +4718,8 @@ void main() {
           tester.getRect(find.byType(InkWell)).center,
         );
         await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
-        final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-          (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-        );
-        expect(inkFeatures, paints..circle(x: 400, y: 24, color: splashColor));
+        final BuildContext context = tester.element(find.text('A'));
+        expect(Material.of(context), paints..circle(x: 400, y: 24, color: splashColor));
         await gesture.up();
       },
     );
@@ -6217,7 +6223,7 @@ void main() {
               return Colors.black54;
             }),
             splashBorderRadius: BorderRadius.circular(radius),
-            tabs: const <Widget>[Tab(child: Text(''))],
+            tabs: const <Widget>[Tab(child: Text('Tab'))],
           ),
         ),
       ),
@@ -6229,11 +6235,9 @@ void main() {
     );
     await gesture.moveTo(tester.getCenter(find.byType(Tab)));
     await tester.pumpAndSettle();
-    final RenderObject object = tester.allRenderObjects.firstWhere(
-      (RenderObject element) => element.runtimeType.toString() == '_RenderInkFeatures',
-    );
+    final BuildContext context = tester.element(find.text('Tab'));
     expect(
-      object,
+      Material.of(context),
       paints..rrect(
         color: hoverColor,
         rrect: RRect.fromRectAndRadius(
@@ -6436,23 +6440,22 @@ void main() {
     await tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', useMaterial3: theme.useMaterial3));
 
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08))));
-    expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.08))));
+    final BuildContext context = tester.element(find.text('C'));
+    final SplashController controller = Material.of(context);
+    expect(controller, isNot(paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08))));
+    expect(controller, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.08))));
 
     // Start hovering unselected tab.
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.byType(Tab).first));
     await tester.pumpAndSettle();
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
+    expect(controller, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
 
     // Start hovering selected tab.
     await gesture.moveTo(tester.getCenter(find.byType(Tab).last));
     await tester.pumpAndSettle();
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    expect(controller, paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
   });
 
   testWidgets('Tab has correct selected/unselected focus color', (WidgetTester tester) async {
@@ -6465,21 +6468,20 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.1))));
-    expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.1))));
+    final BuildContext context = tester.element(find.text('C'));
+    final SplashController controller = Material.of(context);
+    expect(controller, isNot(paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.1))));
+    expect(controller, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.1))));
 
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
     expect(tester.binding.focusManager.primaryFocus?.hasPrimaryFocus, isTrue);
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)));
+    expect(controller, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.1)));
 
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pumpAndSettle();
     expect(tester.binding.focusManager.primaryFocus?.hasPrimaryFocus, isTrue);
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
+    expect(controller, paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
   });
 
   testWidgets('Tab has correct selected/unselected pressed color', (WidgetTester tester) async {
@@ -6491,15 +6493,14 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.1))));
+    final BuildContext context = tester.element(find.text('B'));
+    final SplashController controller = Material.of(context);
+    expect(controller, isNot(paints..rect(color: theme.colorScheme.primary.withOpacity(0.1))));
 
     // Press unselected tab.
     TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('A')));
     await tester.pumpAndSettle(); // Let the press highlight animation finish.
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
+    expect(controller, paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
 
     // Release pressed gesture.
     await gesture.up();
@@ -6508,7 +6509,7 @@ void main() {
     // Press selected tab.
     gesture = await tester.startGesture(tester.getCenter(find.text('B')));
     await tester.pumpAndSettle(); // Let the press highlight animation finish.
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
+    expect(controller, paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
   });
 
   testWidgets('Material3 - Default TabAlignment', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -68,10 +68,8 @@ void main() {
     // Material 3 uses the InkSparkle which uses a shader, so we can't capture
     // the effect with paint methods.
     if (!material3) {
-      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-      expect(inkFeatures, paints..circle(color: colorScheme.primary.withOpacity(0.12)));
+      final BuildContext context = tester.element(find.text('button'));
+      expect(Material.of(context), paints..circle(color: colorScheme.primary.withOpacity(0.12)));
     }
 
     await gesture.up();
@@ -464,10 +462,9 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
+    SplashController splashController() {
+      final BuildContext context = tester.element(find.text('TextButton'));
+      return Material.of(context);
     }
 
     // Hovered.
@@ -476,13 +473,13 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
     expect(
-      overlayColor(),
+      splashController(),
       paints
         ..rect()
         ..rect(color: theme.colorScheme.primary.withOpacity(0.1)),
@@ -496,7 +493,7 @@ void main() {
     // Focused.
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.1)));
 
     focusNode.dispose();
   });
@@ -686,10 +683,8 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byType(TextButton)));
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    final BuildContext context = tester.element(find.byType(Container));
+    expect(Material.of(context), paints..rect(color: hoverColor));
   });
 
   testWidgets('Does TextButton work with focus', (WidgetTester tester) async {
@@ -719,10 +714,8 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
-      (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-    );
-    expect(inkFeatures, paints..rect(color: focusColor));
+    final BuildContext context = tester.element(find.text('button'));
+    expect(Material.of(context), paints..rect(color: focusColor));
 
     focusNode.dispose();
   });
@@ -2490,12 +2483,6 @@ void main() {
       ),
     );
 
-    RenderObject overlayColor() {
-      return tester.allRenderObjects.firstWhere(
-        (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
-      );
-    }
-
     final Offset center = tester.getCenter(find.byType(TextButton));
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.stylus);
     await gesture.addPointer();
@@ -2505,7 +2492,8 @@ void main() {
 
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+    final BuildContext context = tester.element(find.text('TextButton'));
+    expect(Material.of(context), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
     expect(hasBeenHovered, isTrue);
   });
 

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -671,20 +671,22 @@ void main() {
     await tester.pumpAndSettle();
     await hoverGesture.moveTo(Offset.zero);
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.04)));
+    SplashController splashController() {
+      final BuildContext context = tester.element(find.text('First child'));
+      return Material.of(context);
+    }
+
+    expect(splashController(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.04)));
 
     // splashColor
     final TestGesture touchGesture = await tester.createGesture();
     await touchGesture.down(center); // The button is on hovered and pressed
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..circle(color: theme.colorScheme.onSurface.withOpacity(0.16)));
+    expect(
+      splashController(),
+      paints..circle(color: theme.colorScheme.onSurface.withOpacity(0.16)),
+    );
 
     await touchGesture.up();
     await tester.pumpAndSettle();
@@ -694,10 +696,7 @@ void main() {
     // focusColor
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.12)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.12)));
 
     await hoverGesture.removePointer();
 
@@ -726,10 +725,12 @@ void main() {
     await hoverGesture.moveTo(center);
     await tester.pumpAndSettle();
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.primary.withOpacity(0.04)));
+    SplashController splashController() {
+      final BuildContext context = tester.element(find.text('First child'));
+      return Material.of(context);
+    }
+
+    expect(splashController(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.04)));
     await hoverGesture.moveTo(Offset.zero);
 
     // splashColor
@@ -737,10 +738,7 @@ void main() {
     await touchGesture.down(center); // The button is on hovered and pressed
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..circle(color: theme.colorScheme.primary.withOpacity(0.16)));
+    expect(splashController(), paints..circle(color: theme.colorScheme.primary.withOpacity(0.16)));
 
     await touchGesture.up();
     await tester.pumpAndSettle();
@@ -750,10 +748,7 @@ void main() {
     // focusColor
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..rect(color: theme.colorScheme.primary.withOpacity(0.12)));
+    expect(splashController(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.12)));
 
     await hoverGesture.removePointer();
 
@@ -789,11 +784,12 @@ void main() {
     await touchGesture.down(center);
     await tester.pumpAndSettle();
 
-    RenderObject inkFeatures;
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..circle(color: splashColor));
+    SplashController splashController() {
+      final BuildContext context = tester.element(find.text('First child'));
+      return Material.of(context);
+    }
+
+    expect(splashController(), paints..circle(color: splashColor));
 
     await touchGesture.up();
     await tester.pumpAndSettle();
@@ -804,19 +800,13 @@ void main() {
     await hoverGesture.moveTo(center);
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    expect(splashController(), paints..rect(color: hoverColor));
     await hoverGesture.moveTo(Offset.zero);
 
     // focusColor
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(splashController(), paints..rect(color: focusColor));
 
     await hoverGesture.removePointer();
 

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -460,11 +460,12 @@ void main() {
     await touchGesture.down(center);
     await tester.pumpAndSettle();
 
-    RenderObject inkFeatures;
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..circle(color: splashColor));
+    SplashController splashController() {
+      final BuildContext context = tester.element(find.text('First child'));
+      return Material.of(context);
+    }
+
+    expect(splashController(), paints..circle(color: splashColor));
 
     await touchGesture.up();
     await tester.pumpAndSettle();
@@ -475,19 +476,13 @@ void main() {
     await hoverGesture.moveTo(center);
     await tester.pumpAndSettle();
 
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..rect(color: hoverColor));
+    expect(splashController(), paints..rect(color: hoverColor));
     await hoverGesture.moveTo(Offset.zero);
 
     // focusColor
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
-      return object.runtimeType.toString() == '_RenderInkFeatures';
-    });
-    expect(inkFeatures, paints..rect(color: focusColor));
+    expect(splashController(), paints..rect(color: focusColor));
 
     await hoverGesture.removePointer();
 


### PR DESCRIPTION
This PR renames the private `_RenderInkFeatures` class to `SplashController`, in preparation for an upcoming migration.
- [flutter.dev/go/layered-material-widgets](https://flutter.dev/go/layered-material-widgets)

<br><br>

Since **InkWell** handles ink splashes on its own, there's hardly ever a need for a developer to call `Material.of(context)` directly.

So let's use it to clean up some tests!

```dart
// before
final RenderObject inkFeatures = tester.allRenderObjects.firstWhere(
  (RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures',
);
expect(inkFeatures, paints..rect(color: focusColor));


// after
final BuildContext context = tester.element(find.text('button'));
expect(Material.of(context), paints..rect(color: focusColor));
```

<br>

**Edit:** I tried doing something fancy… **SplashController** is now an `extension type`! It exposes only the methods developers would want to see, and the type interface is "compiled away" completely and won't impact runtime performance :)