### PR TITLE
Started waiting for validation layers before starting the countdown for errors.

### DIFF
--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -69,7 +69,7 @@ Future<TaskResult> run() async {
     await adb.cancel();
   });
 
-  if (!isUsingValidationLayers || impellerBackendCount != 1) {
+  if (impellerBackendCount != 1) {
     return TaskResult.failure('Not using Vulkan validation layers.');
   }
   if (hasValidationErrors){

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -20,7 +20,7 @@ Future<TaskResult> run() async {
   final Directory appDir =
       dir(path.join(flutterDirectory.path, 'examples/hello_world'));
 
-  bool isUsingValidationLayers = false;
+  Completer<void> isUsingValidationLayers = Completer<void>();
   bool hasValidationErrors = false;
   int impellerBackendCount = 0;
   final Completer<void> didReceiveBackendMessage = Completer<void>();
@@ -40,7 +40,7 @@ Future<TaskResult> run() async {
         }
         if (data.contains(
             'Using the Impeller rendering backend (Vulkan with Validation Layers)')) {
-          isUsingValidationLayers = true;
+          isUsingValidationLayers.complete();
         }
         // "ImpellerValidationBreak" comes from the engine:
         // https://github.com/flutter/engine/blob/4160ebacdae2081d6f3160432f5f0dd87dbebec1/impeller/base/validation.cc#L40
@@ -61,6 +61,7 @@ Future<TaskResult> run() async {
     );
 
     await didReceiveBackendMessage.future;
+    await isUsingValidationLayers.future;
     // Since we are waiting for the lack of errors, there is no determinate
     // amount of time we can wait.
     await Future<void>.delayed(const Duration(seconds: 30));


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/151528

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
