### PR TITLE
Roll Dartdoc to 8.2.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -121,7 +121,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 8.0.13
+    "$DART" pub global activate dartdoc 8.2.0
 
     # Build and install the snippets tool, which resides in
     # the dev/docs/snippets directory.


### PR DESCRIPTION
This is needed for compatibility with recent versions of the analyzer package that have removed some APIs. (see https://github.com/dart-lang/dartdoc/commit/8100ccf1c1b8a462fd08adcc0cfd8db0f941f44a)