### PR TITLE
Add test for animated list example

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -334,7 +334,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/nested_scroll_view/nested_scroll_view_state.0_test.dart',
   'examples/api/test/widgets/scroll_position/scroll_metrics_notification.0_test.dart',
   'examples/api/test/widgets/media_query/media_query_data.system_gesture_insets.0_test.dart',
-  'examples/api/test/widgets/animated_list/animated_list.0_test.dart',
   'examples/api/test/widgets/image/image.frame_builder.0_test.dart',
   'examples/api/test/widgets/image/image.loading_builder.0_test.dart',
   'examples/api/test/widgets/page_storage/page_storage.0_test.dart',

--- a/examples/api/test/widgets/animated_list/animated_list.0_test.dart
+++ b/examples/api/test/widgets/animated_list/animated_list.0_test.dart
@@ -1,0 +1,45 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/animated_list/animated_list.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'Items can be selected, added, and removed from AnimatedList',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.AnimatedListSample());
+
+      expect(find.text('Item 0'), findsOne);
+      expect(find.text('Item 1'), findsOne);
+      expect(find.text('Item 2'), findsOne);
+
+      // Add an item at the end of the list
+      await tester.tap(find.byIcon(Icons.add_circle));
+      await tester.pumpAndSettle();
+      expect(find.text('Item 3'), findsOne);
+
+      // Select Item 1.
+      await tester.tap(find.text('Item 1'));
+      await tester.pumpAndSettle();
+
+      // Add item at the top of the list
+      await tester.tap(find.byIcon(Icons.add_circle));
+      await tester.pumpAndSettle();
+      expect(find.text('Item 4'), findsOne);
+
+      // Remove selected item.
+      await tester.tap(find.byIcon(Icons.remove_circle));
+
+      // Item animation is not completed.
+      await tester.pump();
+      expect(find.text('Item 1'), findsOne);
+
+      // When the animation completes, Item 1 disappears.
+      await tester.pumpAndSettle();
+      expect(find.text('Item 1'), findsNothing);
+    },
+  );
+}

--- a/examples/api/test/widgets/animated_list/animated_list.0_test.dart
+++ b/examples/api/test/widgets/animated_list/animated_list.0_test.dart
@@ -16,7 +16,7 @@ void main() {
       expect(find.text('Item 1'), findsOne);
       expect(find.text('Item 2'), findsOne);
 
-      // Add an item at the end of the list
+      // Add an item at the end of the list.
       await tester.tap(find.byIcon(Icons.add_circle));
       await tester.pumpAndSettle();
       expect(find.text('Item 3'), findsOne);
@@ -25,7 +25,7 @@ void main() {
       await tester.tap(find.text('Item 1'));
       await tester.pumpAndSettle();
 
-      // Add item at the top of the list
+      // Add item at the top of the list.
       await tester.tap(find.byIcon(Icons.add_circle));
       await tester.pumpAndSettle();
       expect(find.text('Item 4'), findsOne);


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/animated_list/animated_list.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
