### PR TITLE
Improve InputDecoration.errorMaxLines documentation

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2876,13 +2876,13 @@ class InputDecoration {
   ///
   /// Defaults to null, which means that soft line breaks in [helperText] are
   /// truncated with an ellipse while hard line breaks are respected.
-  /// For example, an [helperText] that overflows the width of the field will be
-  /// truncated with an ellipse. However, an [helperText] with explicit linebreak
+  /// For example, a [helperText] that overflows the width of the field will be
+  /// truncated with an ellipse. However, a [helperText] with explicit linebreak
   /// characters (\n) will display on multiple lines.
   ///
-  /// To get a long [helperText] wrapping, either set [helperMaxLines] or use
-  /// [helper] which offers more flexibility, for instance it can be set to a
-  /// Text widget with a specific overflow value.
+  /// To cause a long [helperText] to wrap, either set [helperMaxLines] or use
+  /// [helper] which offers more flexibility. For instance, it can be set to a
+  /// [Text] widget with a specific overflow value.
   ///
   /// This value is passed along to the [Text.maxLines] attribute
   /// of the [Text] widget used to display the helper.
@@ -2986,9 +2986,9 @@ class InputDecoration {
   /// truncated with an ellipse. However, an [errorText] with explicit linebreak
   /// characters (\n) will display on multiple lines.
   ///
-  /// To get a long [errorText] wrapping, either set [errorMaxLines] or use
-  /// [error] which offers more flexibility, for instance it can be set to a
-  /// Text widget with a specific overflow value.
+  /// To cause a long [errorText] to wrap, either set [errorMaxLines] or use
+  /// [error] which offers more flexibility. For instance, it can be set to a
+  /// [Text] widget with a specific overflow value.
   ///
   /// This value is passed along to the [Text.maxLines] attribute
   /// of the [Text] widget used to display the error.

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2874,7 +2874,15 @@ class InputDecoration {
 
   /// The maximum number of lines the [helperText] can occupy.
   ///
-  /// Defaults to null, which means that the [helperText] is not limited.
+  /// Defaults to null, which means that soft line breaks in [helperText] are
+  /// truncated with an ellipse while hard line breaks are respected.
+  /// For example, an [helperText] that overflows the width of the field will be
+  /// truncated with an ellipse. However, an [helperText] with explicit linebreak
+  /// characters (\n) will display on multiple lines.
+  ///
+  /// To get a long [helperText] wrapping, either set [helperMaxLines] or use
+  /// [helper] which offers more flexibility, for instance it can be set to a
+  /// Text widget with a specific overflow value.
   ///
   /// This value is passed along to the [Text.maxLines] attribute
   /// of the [Text] widget used to display the helper.
@@ -2972,7 +2980,15 @@ class InputDecoration {
 
   /// The maximum number of lines the [errorText] can occupy.
   ///
-  /// Defaults to null, which means that the [errorText] is not limited.
+  /// Defaults to null, which means that soft line breaks in [errorText] are
+  /// truncated with an ellipse while hard line breaks are respected.
+  /// For example, an [errorText] that overflows the width of the field will be
+  /// truncated with an ellipse. However, an [errorText] with explicit linebreak
+  /// characters (\n) will display on multiple lines.
+  ///
+  /// To get a long [errorText] wrapping, either set [errorMaxLines] or use
+  /// [error] which offers more flexibility, for instance it can be set to a
+  /// Text widget with a specific overflow value.
   ///
   /// This value is passed along to the [Text.maxLines] attribute
   /// of the [Text] widget used to display the error.


### PR DESCRIPTION
## Description

This PR improves the `InputDecoration.errorMaxLines` and `InputDecoration.helperMaxLines` documentations to explain when wrapping and ellipsing are applied.

## Related Issue

Fixes [InputDecoration.errorMaxLines's documentation does not match behavior](https://github.com/flutter/flutter/issues/155626).

