### PR TITLE
`const SizedBox.fromSize()`

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2412,9 +2412,7 @@ class SizedBox extends SingleChildRenderObjectWidget {
       height = 0.0;
 
   /// Creates a box with the specified size.
-  SizedBox.fromSize({ super.key, super.child, Size? size })
-    : width = size?.width,
-      height = size?.height;
+  const factory SizedBox.fromSize({Key? key, Size? size, Widget? child}) = _SizedBoxFromSize;
 
   /// Creates a box whose [width] and [height] are equal.
   const SizedBox.square({super.key, super.child, double? dimension})
@@ -2447,8 +2445,8 @@ class SizedBox extends SingleChildRenderObjectWidget {
   String toStringShort() {
     final String type = switch ((width, height)) {
       (double.infinity, double.infinity) => '${objectRuntimeType(this, 'SizedBox')}.expand',
-      (0.0, 0.0) => '${objectRuntimeType(this, 'SizedBox')}.shrink',
-      _ => objectRuntimeType(this, 'SizedBox'),
+      (0.0, 0.0)                         => '${objectRuntimeType(this, 'SizedBox')}.shrink',
+      _                                  => objectRuntimeType(this, 'SizedBox'),
     };
     return key == null ? type : '$type-$key';
   }
@@ -2465,6 +2463,46 @@ class SizedBox extends SingleChildRenderObjectWidget {
     }
     properties.add(DoubleProperty('width', width, defaultValue: null, level: level));
     properties.add(DoubleProperty('height', height, defaultValue: null, level: level));
+  }
+}
+
+class _SizedBoxFromSize extends SingleChildRenderObjectWidget implements SizedBox {
+  const _SizedBoxFromSize({super.key, this.size, super.child});
+
+  final Size? size;
+
+  @override
+  double? get width => size?.width;
+
+  @override
+  double? get height => size?.height;
+
+  @override
+  BoxConstraints get _additionalConstraints => switch (size) {
+    final Size size => BoxConstraints.tight(size),
+    null            => const BoxConstraints(),
+  };
+
+  @override
+  RenderConstrainedBox createRenderObject(BuildContext context) {
+    return RenderConstrainedBox(additionalConstraints: _additionalConstraints);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderConstrainedBox renderObject) {
+    renderObject.additionalConstraints = _additionalConstraints;
+  }
+
+  @override
+  String toStringShort() {
+    final String type = objectRuntimeType(this, 'SizedBox');
+    return key == null ? type : '$type-$key';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Size>('size', size, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/material/card_theme_test.dart
+++ b/packages/flutter/test/material/card_theme_test.dart
@@ -205,9 +205,9 @@ void main() {
       home: Scaffold(
         body: RepaintBoundary(
           key: painterKey,
-          child: Center(
+          child: const Center(
             child: Card(
-              child: SizedBox.fromSize(size: const Size(200, 300)),
+              child: SizedBox.fromSize(size: Size(200, 300)),
             ),
           ),
         ),
@@ -389,9 +389,9 @@ void main() {
         home: Scaffold(
           body: RepaintBoundary(
             key: painterKey,
-            child: Center(
+            child: const Center(
               child: Card(
-                child: SizedBox.fromSize(size: const Size(200, 300)),
+                child: SizedBox.fromSize(size: Size(200, 300)),
               ),
             ),
           ),

--- a/packages/flutter/test/widgets/overlay_portal_test.dart
+++ b/packages/flutter/test/widgets/overlay_portal_test.dart
@@ -423,7 +423,7 @@ void main() {
                 return OverlayPortal(
                   controller: controller1,
                   overlayChildBuilder: (BuildContext context) => const SizedBox(),
-                  child: SizedBox.fromSize(size: size),
+                  child: const SizedBox.fromSize(size: size),
                 );
               },
             ),

--- a/packages/flutter/test/widgets/sized_box_test.dart
+++ b/packages/flutter/test/widgets/sized_box_test.dart
@@ -20,11 +20,11 @@ void main() {
     expect(c.width, 10.0);
     expect(c.height, 20.0);
 
-    final SizedBox d = SizedBox.fromSize();
+    const SizedBox d = SizedBox.fromSize();
     expect(d.width, isNull);
     expect(d.height, isNull);
 
-    final SizedBox e = SizedBox.fromSize(size: const Size(1.0, 2.0));
+    const SizedBox e = SizedBox.fromSize(size: Size(1.0, 2.0));
     expect(e.width, 1.0);
     expect(e.height, 2.0);
 

--- a/packages/flutter/test/widgets/view_test.dart
+++ b/packages/flutter/test/widgets/view_test.dart
@@ -473,7 +473,7 @@ void main() {
   testWidgets('RenderView sizes itself to child if constraints allow it (unconstrained)', (WidgetTester tester) async {
     const Size size = Size(300, 600);
     tester.view.physicalConstraints = const ViewConstraints(); // unconstrained
-    await tester.pumpWidget(SizedBox.fromSize(size: size));
+    await tester.pumpWidget(const SizedBox.fromSize(size: size));
 
     final RenderView renderView = tester.renderObject<RenderView>(find.byType(View));
     expect(renderView.constraints, const BoxConstraints());
@@ -490,7 +490,7 @@ void main() {
     const ViewConstraints viewConstraints = ViewConstraints(maxWidth: 333, maxHeight: 666);
     final BoxConstraints boxConstraints = BoxConstraints.fromViewConstraints(viewConstraints / tester.view.devicePixelRatio);
     tester.view.physicalConstraints = viewConstraints;
-    await tester.pumpWidget(SizedBox.fromSize(size: size));
+    await tester.pumpWidget(const SizedBox.fromSize(size: size));
 
     final RenderView renderView = tester.renderObject<RenderView>(find.byType(View));
     expect(renderView.constraints, boxConstraints);
@@ -506,7 +506,7 @@ void main() {
     const Size size = Size(3000, 6000);
     const ViewConstraints viewConstraints = ViewConstraints(maxWidth: 300, maxHeight: 600);
     tester.view.physicalConstraints = viewConstraints;
-    await tester.pumpWidget(SizedBox.fromSize(size: size));
+    await tester.pumpWidget(const SizedBox.fromSize(size: size));
 
     final RenderView renderView = tester.renderObject<RenderView>(find.byType(View));
     expect(renderView.size, const Size(100, 200)); // viewConstraints.biggest / devicePixelRatio


### PR DESCRIPTION
Recently I learned that instead of

```dart
BoxConstraints.tightFor(size.width, size.height)
```

you can do

```dart
BoxConstraints.tight(size)
```

<br>

Now, every single `SizedBox` constructor can be `const`!