### PR TITLE
Adjust timeout for devicelab tests

### DIFF
--- a/dev/bots/suite_runners/run_framework_tests.dart
+++ b/dev/bots/suite_runners/run_framework_tests.dart
@@ -235,7 +235,11 @@ Future<void> frameworkTestsRunner() async {
       tests: <String>[ 'test' ],
     );
     await runDartTest(path.join(flutterRoot, 'dev', 'bots'));
-    await runDartTest(path.join(flutterRoot, 'dev', 'devicelab'), ensurePrecompiledTool: false); // See https://github.com/flutter/flutter/issues/86209
+    await runDartTest(
+      path.join(flutterRoot, 'dev', 'devicelab'),
+      ensurePrecompiledTool: false,  // See https://github.com/flutter/flutter/issues/86209
+      perTestTimeout: Duration(seconds: 45) // Standard 30 is flaky because of a long running test, https://github.com/flutter/flutter/issues/156456
+    );
     await runDartTest(path.join(flutterRoot, 'dev', 'conductor', 'core'), forceSingleCore: true);
     // TODO(gspencergoog): Remove the exception for fatalWarnings once https://github.com/flutter/flutter/issues/113782 has landed.
     await runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'android_semantics_testing'), fatalWarnings: false);

--- a/dev/bots/suite_runners/run_framework_tests.dart
+++ b/dev/bots/suite_runners/run_framework_tests.dart
@@ -238,7 +238,6 @@ Future<void> frameworkTestsRunner() async {
     await runDartTest(
       path.join(flutterRoot, 'dev', 'devicelab'),
       ensurePrecompiledTool: false,  // See https://github.com/flutter/flutter/issues/86209
-      perTestTimeout: Duration(seconds: 45) // Standard 30 is flaky because of a long running test, https://github.com/flutter/flutter/issues/156456
     );
     await runDartTest(path.join(flutterRoot, 'dev', 'conductor', 'core'), forceSingleCore: true);
     // TODO(gspencergoog): Remove the exception for fatalWarnings once https://github.com/flutter/flutter/issues/113782 has landed.

--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -91,7 +91,7 @@ void main() {
         emitsThrough(contains('VM service still not ready. It is possible the target has failed')),
       );
       expect(process.kill(), isTrue);
-    });
+    }, timeout: const Timeout(Duration(seconds: 45))); // Standard 30 is flaky because this is a long running test, https://github.com/flutter/flutter/issues/156456
 
     test('exits with code 1 when results are mixed', () async {
       await expectScriptResult(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156456

There is a known long running test that has been bumping up against the default timeout. This adjusts the perTestTimeout for the devicelab tests to add 15 seconds to stop this from flaking.

The test is question: https://github.com/flutter/flutter/blob/82ebb74c6411afc55a8b0937535d6baeb03ea826/dev/devicelab/test/run_test.dart#L76

`test/run_test.dart: run.dart script prints a message after a few seconds when failing to connect (this test takes >10s)`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
