### PR TITLE
CheckboxListTile: use Transform.scale only when required

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -499,57 +499,57 @@ class CheckboxListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Widget control;
+    Widget control;
 
     switch (_checkboxType) {
       case _CheckboxType.material:
         control = ExcludeFocus(
-          child: Transform.scale(
-            scale: checkboxScaleFactor,
-            child: Checkbox(
-              value: value,
-              onChanged: enabled ?? true ? onChanged : null,
-              mouseCursor: mouseCursor,
-              activeColor: activeColor,
-              fillColor: fillColor,
-              checkColor: checkColor,
-              hoverColor: hoverColor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-              materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
-              autofocus: autofocus,
-              tristate: tristate,
-              shape: checkboxShape,
-              side: side,
-              isError: isError,
-              semanticLabel: checkboxSemanticLabel,
-            ),
+          child: Checkbox(
+            value: value,
+            onChanged: enabled ?? true ? onChanged : null,
+            mouseCursor: mouseCursor,
+            activeColor: activeColor,
+            fillColor: fillColor,
+            checkColor: checkColor,
+            hoverColor: hoverColor,
+            overlayColor: overlayColor,
+            splashRadius: splashRadius,
+            materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
+            autofocus: autofocus,
+            tristate: tristate,
+            shape: checkboxShape,
+            side: side,
+            isError: isError,
+            semanticLabel: checkboxSemanticLabel,
           ),
         );
       case _CheckboxType.adaptive:
         control = ExcludeFocus(
-          child: Transform.scale(
-            scale: checkboxScaleFactor,
-            child: Checkbox.adaptive(
-              value: value,
-              onChanged: enabled ?? true ? onChanged : null,
-              mouseCursor: mouseCursor,
-              activeColor: activeColor,
-              fillColor: fillColor,
-              checkColor: checkColor,
-              hoverColor: hoverColor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-              materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
-              autofocus: autofocus,
-              tristate: tristate,
-              shape: checkboxShape,
-              side: side,
-              isError: isError,
-              semanticLabel: checkboxSemanticLabel,
-            ),
+          child: Checkbox.adaptive(
+            value: value,
+            onChanged: enabled ?? true ? onChanged : null,
+            mouseCursor: mouseCursor,
+            activeColor: activeColor,
+            fillColor: fillColor,
+            checkColor: checkColor,
+            hoverColor: hoverColor,
+            overlayColor: overlayColor,
+            splashRadius: splashRadius,
+            materialTapTargetSize: materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
+            autofocus: autofocus,
+            tristate: tristate,
+            shape: checkboxShape,
+            side: side,
+            isError: isError,
+            semanticLabel: checkboxSemanticLabel,
           ),
         );
+    }
+    if (checkboxScaleFactor != 1.0) {
+      control = Transform.scale(
+        scale: checkboxScaleFactor,
+        child: control,
+      );
     }
 
     final ListTileThemeData listTileTheme = ListTileTheme.of(context);

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -1277,12 +1277,12 @@ void main() {
       ),
     ));
 
-    final Finder widget = find.ancestor(
+    final Finder transformFinder = find.ancestor(
         of: find.byType(Checkbox),
         matching: find.byType(Transform),
     );
 
-    expect(widget, findsNothing);
+    expect(transformFinder, findsNothing);
   });
 
   testWidgets('CheckboxListTile respects checkboxScaleFactor', (WidgetTester tester) async {

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -1277,14 +1277,12 @@ void main() {
       ),
     ));
 
-    final Transform widget = tester.widget(
-      find.ancestor(
+    final Finder widget = find.ancestor(
         of: find.byType(Checkbox),
         matching: find.byType(Transform),
-      ),
     );
 
-    expect(widget.transform.getMaxScaleOnAxis(), 1.0);
+    expect(widget, findsNothing);
   });
 
   testWidgets('CheckboxListTile respects checkboxScaleFactor', (WidgetTester tester) async {


### PR DESCRIPTION
Make CheckboxListTile use `Transform.scale` only when required.

Fixes: #81334 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
