### PR TITLE
[devicelab] handle missed lifecycle messages.

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
@@ -32,7 +32,10 @@ class BackButtonMemoryTest extends MemoryTest {
       // Push back button, wait for it to be seen by the Flutter app.
       prepareForNextMessage('AppLifecycleState.paused');
       await device!.shellExec('input', <String>['keyevent', 'KEYCODE_BACK']);
-      await receivedNextMessage;
+
+      // Note: post UI/platform merge, we consistently miss this message. From
+      // local logcat it seems to be printed but it does not reach the tool.
+      await receivedNextMessage?.timeout(const Duration(seconds: 4), onTimeout: () {});
 
       // Give Android time to settle (e.g. run GCs) after closing the app.
       await Future<void>.delayed(const Duration(milliseconds: 100));


### PR DESCRIPTION
This test waits on the application to print a message before continuting, but that message does not reach the test post UI/platform thread merge.

The test otherwise seems to function fine, and the app isn't crashing.