### PR TITLE
Remove non-functional, deprecated `package_api_docs` lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -145,7 +145,7 @@ linter:
     # - one_member_abstracts # too many false positives
     - only_throw_errors # this does get disabled in a few places where we have legacy code that uses strings et al
     - overridden_fields
-    - package_api_docs
+    # - package_api_docs # Deprecated (https://github.com/dart-lang/linter/issues/5107)
     - package_names
     - package_prefixed_library_names
     # - parameter_assignments # we do this commonly


### PR DESCRIPTION
Reference: https://github.com/dart-lang/sdk/issues/59554