### PR TITLE
Switch benchmarks to tap at found locations

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/gestures/gesture_detector_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/gesture_detector_bench.dart
@@ -20,9 +20,11 @@ Future<void> execute() async {
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 
+    final addPosition = tester.getCenter(find.text('Add 1'));
+
     Future<void> iter() async {
       // Press a button to update the screen
-      await tester.tapAt(const Offset(760.0, 30.0));
+      await tester.tapAt(addPosition);
       await tester.pump();
     }
 

--- a/dev/benchmarks/microbenchmarks/lib/gestures/gesture_detector_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/gesture_detector_bench.dart
@@ -20,7 +20,7 @@ Future<void> execute() async {
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 
-    final addPosition = tester.getCenter(find.text('Add 1'));
+    final Offset addPosition = tester.getCenter(find.text('Add 1'));
 
     Future<void> iter() async {
       // Press a button to update the screen

--- a/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
@@ -32,15 +32,17 @@ Future<void> execute(BenchmarkingBinding binding) async {
 
     bool drawerIsOpen = false;
     wallClockWatch.start();
+    final drawerController = tester.getCenter(find.byType(DrawerController));
+    final navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
     while (wallClockWatch.elapsed < kBenchmarkTime) {
       binding.drawFrameWatch.reset();
       if (drawerIsOpen) {
-        await tester.tapAt(const Offset(780.0, 250.0)); // Close drawer
+        await tester.tapAt(drawerController); // Close drawer
         await tester.pump();
         totalCloseIterationCount += 1;
         totalCloseFrameElapsedMicroseconds += binding.drawFrameWatch.elapsedMicroseconds;
       } else {
-        await tester.tapAt(const Offset(20.0, 50.0)); // Open drawer
+        await tester.tapAt(navigationMenu); // Open drawer
         await tester.pump();
         totalOpenIterationCount += 1;
         totalOpenFrameElapsedMicroseconds += binding.drawFrameWatch.elapsedMicroseconds;

--- a/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart' show DrawerController;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stocks/main.dart' as stocks;
@@ -32,8 +33,8 @@ Future<void> execute(BenchmarkingBinding binding) async {
 
     bool drawerIsOpen = false;
     wallClockWatch.start();
-    final drawerController = tester.getCenter(find.byType(DrawerController));
-    final navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
+    final Offset drawerController = tester.getCenter(find.byType(DrawerController));
+    final Offset navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
     while (wallClockWatch.elapsed < kBenchmarkTime) {
       binding.drawFrameWatch.reset();
       if (drawerIsOpen) {

--- a/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
@@ -28,7 +28,9 @@ Future<List<double>> runBuildBenchmark() async {
     stocks.main();
     await tester.pump(); // Start startup animation
     await tester.pump(const Duration(seconds: 1)); // Complete startup animation
-    await tester.tapAt(const Offset(20.0, 40.0)); // Open drawer
+
+    final navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
+    await tester.tapAt(navigationMenu); // Open drawer
     await tester.pump(); // Start drawer animation
     await tester.pumpAndSettle(const Duration(seconds: 1)); // Complete drawer animation
 

--- a/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
@@ -29,7 +29,7 @@ Future<List<double>> runBuildBenchmark() async {
     await tester.pump(); // Start startup animation
     await tester.pump(const Duration(seconds: 1)); // Complete startup animation
 
-    final navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
+    final Offset navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
     await tester.tapAt(navigationMenu); // Open drawer
     await tester.pump(); // Start drawer animation
     await tester.pumpAndSettle(const Duration(seconds: 1)); // Complete drawer animation

--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -28,7 +28,8 @@ Future<void> execute() async {
     stocks.main();
     await tester.pump(); // Start startup animation
     await tester.pump(const Duration(seconds: 1)); // Complete startup animation
-    await tester.tapAt(const Offset(20.0, 40.0)); // Open drawer
+    final navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
+    await tester.tapAt(navigationMenu); // Open drawer
     await tester.pump(); // Start drawer animation
     await tester.pump(const Duration(seconds: 1)); // Complete drawer animation
 

--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -28,7 +28,7 @@ Future<void> execute() async {
     stocks.main();
     await tester.pump(); // Start startup animation
     await tester.pump(const Duration(seconds: 1)); // Complete startup animation
-    final navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
+    final Offset navigationMenu = tester.getCenter(find.byTooltip('Open navigation menu'));
     await tester.tapAt(navigationMenu); // Open drawer
     await tester.pump(); // Start drawer animation
     await tester.pump(const Duration(seconds: 1)); // Complete drawer animation


### PR DESCRIPTION
Hard coded locations lead to lying benchmarks

While working on something else, I noticed microbenchmarks weren't animating on Android.