### PR TITLE
Implement listenable menu controller

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -696,6 +696,73 @@ class MenuController {
   }
 }
 
+/// A [MenuController] that allows listening to its [isOpen] state.
+class ListenableMenuController extends MenuController implements ValueListenable<bool> {
+  /// Construct a new [ListenableMenuController].
+  ListenableMenuController() {
+    // TODO(polina-c): stop duplicating code across disposables
+    // https://github.com/flutter/flutter/issues/137435
+    if (kFlutterMemoryAllocationsEnabled) {
+      FlutterMemoryAllocations.instance.dispatchObjectCreated(
+        library: 'package:flutter/material.dart',
+        className: '$ListenableMenuController',
+        object: this,
+      );
+    }
+  }
+
+  bool _isDisposed = false;
+  final Set<VoidCallback> _listeners = <VoidCallback>{};
+
+  @override
+  bool get value => isOpen;
+
+  @override
+  void addListener(VoidCallback listener) {
+    _listeners.add(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    _listeners.remove(listener);
+  }
+
+  @override
+  void open({Offset? position}) {
+    super.open(position: position);
+
+    for (final VoidCallback listener in _listeners) {
+      listener();
+    }
+  }
+
+  @override
+  void close() {
+    super.close();
+
+    for (final VoidCallback listener in _listeners) {
+      listener();
+    }
+  }
+
+  /// Dispose of this controller.
+  void dispose() {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    _listeners.clear();
+
+    // TODO(polina-c): stop duplicating code across disposables
+    // https://github.com/flutter/flutter/issues/137435
+    if (kFlutterMemoryAllocationsEnabled) {
+      FlutterMemoryAllocations.instance.dispatchObjectDisposed(
+        object: this,
+      );
+    }
+  }
+}
+
 /// A menu bar that manages cascading child menus.
 ///
 /// This is a Material Design menu bar that typically resides above the main

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2672,6 +2672,72 @@ void main() {
       expect(closed, unorderedEquals(<TestMenu>[TestMenu.mainMenu1, TestMenu.subMenu11]));
       expect(opened, isEmpty);
     });
+
+    testWidgets('Using a ListenableMenuController works', (WidgetTester tester) async {
+      final ListenableMenuController listenableController = ListenableMenuController();
+      addTearDown(listenableController.dispose);
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: true),
+          home: Material(
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: MenuAnchor(
+                childFocusNode: focusNode,
+                controller: listenableController,
+                menuChildren: <Widget>[
+                  MenuItemButton(
+                    child: Text(TestMenu.mainMenu0.label),
+                  ),
+                  MenuItemButton(
+                    child: Text(TestMenu.mainMenu1.label),
+                  ),
+                  MenuItemButton(
+                    child: Text(TestMenu.mainMenu2.label),
+                  ),
+                ],
+                builder: (BuildContext context, MenuController controller, Widget? child) {
+                  return ValueListenableBuilder<bool>(
+                    valueListenable: listenableController,
+                    builder: (BuildContext innerContext, bool isOpen, _) {
+                      return ElevatedButton(
+                        focusNode: focusNode,
+                        onPressed: () {
+                          if (isOpen) {
+                            controller.close();
+                          } else {
+                            controller.open();
+                          }
+                        },
+                        child: Text(isOpen ? 'Close Menu' : 'Open Menu'),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Open Menu'), findsOneWidget);
+      expect(find.text('Close Menu'), findsNothing);
+
+      listenableController.open();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open Menu'), findsNothing);
+      expect(find.text('Close Menu'), findsOneWidget);
+
+      listenableController.close();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open Menu'), findsOneWidget);
+      expect(find.text('Close Menu'), findsNothing);
+    });
   }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/145527
 
   group('MenuItemButton', () {


### PR DESCRIPTION
This PR adds a new subclass of `MenuController`, that allows for listening to the menu state.
I went with a subclass to not break the existing API, as it introduces a `dispose()` method.

Fixes https://github.com/flutter/flutter/issues/156570

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
