### PR TITLE
Fix flavor-conditional asset bundling for path dependencies

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -380,6 +380,7 @@ class ManifestAssetBundle implements AssetBundle {
           targetPlatform,
           packageName: package.name,
           attributedPackage: package,
+          flavor: flavor,
         );
 
         if (packageAssets == null) {
@@ -873,7 +874,7 @@ class ManifestAssetBundle implements AssetBundle {
     TargetPlatform? targetPlatform, {
     String? packageName,
     Package? attributedPackage,
-    String? flavor,
+    required String? flavor,
   }) {
     final Map<_Asset, List<_Asset>> result = <_Asset, List<_Asset>>{};
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -27,9 +27,14 @@ void main() {
     return path.replaceAll('/', globals.fs.path.separator);
   }
 
-  void writePubspecFile(String path, String name, { List<String>? assets }) {
+  void writePubspecFile(
+    String path,
+    String name, {
+    List<String>? assets,
+    List<(String path, String flavor)>? flavoredAssets,
+  }) {
     String assetsSection;
-    if (assets == null) {
+    if (assets == null && flavoredAssets == null) {
       assetsSection = '';
     } else {
       final StringBuffer buffer = StringBuffer();
@@ -38,11 +43,20 @@ flutter:
      assets:
 ''');
 
-      for (final String asset in assets) {
+      for (final String asset in (assets ?? <String>[])) {
         buffer.write('''
        - $asset
 ''');
       }
+
+      for (final (String path, String flavor) in flavoredAssets ?? <(String, String)>[]) {
+        buffer.write('''
+       - path: $path
+         flavors:
+           - $flavor
+''');
+      }
+
       assetsSection = buffer.toString();
     }
 
@@ -89,11 +103,15 @@ $assetsSection
   Future<void> buildAndVerifyAssets(
     List<String> assets,
     List<String> packages,
-    Map<Object,Object> expectedAssetManifest
-  ) async {
+    Map<Object, Object> expectedAssetManifest, {
+    String? flavor,
+  }) async {
 
     final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-    await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+    await bundle.build(
+      packageConfigPath: '.dart_tool/package_config.json',
+      flavor: flavor,
+    );
 
     for (final String packageName in packages) {
       for (final String asset in assets) {
@@ -532,6 +550,73 @@ $assetsSection
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     });
+
+    testUsingContext('Flavored assets are bundled when the app depends on a package', () async {
+      writePubspecFile(
+        'pubspec.yaml',
+        'test',
+      );
+      writePackageConfigFile(
+        <String, String>{
+          'test_package': 'p/p/',
+        },
+      );
+      writePubspecFile(
+        'p/p/pubspec.yaml',
+        'test_package',
+        flavoredAssets: <(String, String)>[('assets/vanilla.txt', 'vanilla')],
+      );
+
+      final List<String> assets = <String>['assets/vanilla.txt'];
+      writeAssets('p/p', assets);
+
+      const Map<Object, Object> expectedAssetManifest = <Object, Object>{
+        'packages/test_package/assets/vanilla.txt': <Map<String, Object>>[
+          <String, Object>{'asset': 'packages/test_package/assets/vanilla.txt'},
+        ]
+      };
+
+      await buildAndVerifyAssets(
+        assets,
+        <String>['test_package'],
+        expectedAssetManifest,
+        flavor: 'vanilla',
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+  });
+
+  testUsingContext('Asset paths can contain URL reserved characters', () async {
+    writePubspecFile('pubspec.yaml', 'test');
+    writePackageConfigFile(<String, String>{'test_package': 'p/p/'});
+
+    final List<String> assets = <String>['a/foo', 'a/foo [x]'];
+    writePubspecFile(
+      'p/p/pubspec.yaml',
+      'test_package',
+      assets: assets,
+    );
+
+    writeAssets('p/p/', assets);
+    const Map<Object, Object> expectedAssetManifest = <Object, Object>{
+      'packages/test_package/a/foo': <Map<String, Object>>[
+        <String, Object>{'asset': 'packages/test_package/a/foo'}
+      ],
+      'packages/test_package/a/foo [x]': <Map<String, Object>>[
+        <String, Object>{'asset': 'packages/test_package/a/foo [x]'}
+      ]
+    };
+
+    await buildAndVerifyAssets(
+      assets,
+      <String>['test_package'],
+      expectedAssetManifest,
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
   });
 
   testUsingContext('Asset paths can contain URL reserved characters', () async {

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -57,7 +57,7 @@ $assetsSection
 ''');
   }
 
-void writePackageConfigFile(Map<String, String> packages) {
+  void writePackageConfigFile(Map<String, String> packages) {
     globals.fs.directory('.dart_tool').childFile('package_config.json')
       ..createSync(recursive: true)
       ..writeAsStringSync(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/155755

When building the asset bundle during, the `--flavor` option isn't considered when searching for assets from dependencies. This PR fixes that.

It's possible that when initially implementing this feature, I thought that flavor-conditional assets didn't make sense for packages. While I still think that way regarding pub packages, using this feature makes a lot more sense for monorepo projects.

<details>

<summary> Pre-launch checklist </summary> 


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

</details>

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
