### PR TITLE
Add test for `material_state_property.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -312,7 +312,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/bottom_app_bar/bottom_app_bar.2_test.dart',
   'examples/api/test/material/bottom_app_bar/bottom_app_bar.1_test.dart',
   'examples/api/test/material/material_state/material_state_outlined_border.0_test.dart',
-  'examples/api/test/material/material_state/material_state_property.0_test.dart',
   'examples/api/test/material/selectable_region/selectable_region.0_test.dart',
   'examples/api/test/material/selection_container/selection_container_disabled.0_test.dart',
   'examples/api/test/material/selection_container/selection_container.0_test.dart',

--- a/examples/api/test/material/material_state/material_state_property.0_test.dart
+++ b/examples/api/test/material/material_state/material_state_property.0_test.dart
@@ -9,14 +9,14 @@ import 'package:flutter_api_samples/material/material_state/material_state_prope
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Finder findForegroundColor(Color color) {
-    return find.byWidgetPredicate((Widget widget) {
-      if (widget is! Material) {
-        return false;
-      }
-      final TextStyle? textStyle = widget.textStyle;
-      return textStyle?.color == color;
-    });
+  Color getButtonForegroundColor(WidgetTester tester) {
+    final Material widget = tester.widget(
+      find.descendant(
+        of: find.byType(example.MaterialStatePropertyExample),
+        matching:find.widgetWithText(Material, 'TextButton'),
+      ),
+    );
+    return widget.textStyle!.color!;
   }
 
   testWidgets(
@@ -26,12 +26,12 @@ void main() {
         const example.MaterialStatePropertyExampleApp(),
       );
 
-      expect(findForegroundColor(Colors.red), findsOne);
+      expect(getButtonForegroundColor(tester), Colors.red);
     },
   );
 
   testWidgets(
-    'The foreground color of the TextButton should blue when hovered',
+    'The foreground color of the TextButton should be blue when hovered',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         const example.MaterialStatePropertyExampleApp(),
@@ -41,7 +41,7 @@ void main() {
       await gesture.addPointer(location: tester.getCenter(find.byType(TextButton)));
       await tester.pump();
 
-      expect(findForegroundColor(Colors.blue), findsOne);
+      expect(getButtonForegroundColor(tester), Colors.blue);
     },
   );
 }

--- a/examples/api/test/material/material_state/material_state_property.0_test.dart
+++ b/examples/api/test/material/material_state/material_state_property.0_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/material_state/material_state_property.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Finder findForegroundColor(Color color) {
+    return find.byWidgetPredicate((Widget widget) {
+      if (widget is! Material) {
+        return false;
+      }
+      final TextStyle? textStyle = widget.textStyle;
+      return textStyle?.color == color;
+    });
+  }
+
+  testWidgets(
+    'The foreground color of the TextButton should be red by default',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.MaterialStatePropertyExampleApp(),
+      );
+
+      expect(findForegroundColor(Colors.red), findsOne);
+    },
+  );
+
+  testWidgets(
+    'The foreground color of the TextButton should blue when hovered',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.MaterialStatePropertyExampleApp(),
+      );
+
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: tester.getCenter(find.byType(TextButton)));
+      await tester.pump();
+
+      expect(findForegroundColor(Colors.blue), findsOne);
+    },
+  );
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/test/material/material_state/material_state_property.0_test.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
