### PR TITLE
[devicelab] try waiting for first frame.

### DIFF
--- a/dev/integration_tests/native_driver_test/test_driver/platform_view_blue_orange_gradient_main_test.dart
+++ b/dev/integration_tests/native_driver_test/test_driver/platform_view_blue_orange_gradient_main_test.dart
@@ -23,6 +23,7 @@ void main() async {
     flutterDriver = await FlutterDriver.connect();
     nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
     await nativeDriver.configureForScreenshotTesting();
+    await flutterDriver.waitUntilFirstFrameRasterized();
   });
 
   tearDownAll(() async {


### PR DESCRIPTION
From testing locally, sometimes the first frame rasterization takes longer. Could be related to https://github.com/flutter/flutter/issues/156903
