### PR TITLE
Add test for `selection_container_disabled.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -312,7 +312,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/bottom_app_bar/bottom_app_bar.2_test.dart',
   'examples/api/test/material/bottom_app_bar/bottom_app_bar.1_test.dart',
   'examples/api/test/material/selectable_region/selectable_region.0_test.dart',
-  'examples/api/test/material/selection_container/selection_container_disabled.0_test.dart',
   'examples/api/test/material/selection_container/selection_container.0_test.dart',
   'examples/api/test/material/color_scheme/dynamic_content_color.0_test.dart',
   'examples/api/test/material/platform_menu_bar/platform_menu_bar.0_test.dart',

--- a/examples/api/test/material/selection_container/selection_container_disabled.0_test.dart
+++ b/examples/api/test/material/selection_container/selection_container_disabled.0_test.dart
@@ -16,30 +16,60 @@ void main() {
 
     expect(find.widgetWithText(AppBar, 'SelectionContainer.disabled Sample'), findsOne);
 
-    final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Selectable text').first, matching: find.byType(RichText)));
+    final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(
+      find.descendant(
+        of: find.text('Selectable text').first,
+        matching: find.byType(RichText),
+      ),
+    );
     final Rect paragraph1Rect = tester.getRect(find.text('Selectable text').first);
-    final TestGesture gesture = await tester.startGesture(paragraph1Rect.centerLeft, kind: PointerDeviceKind.mouse);
+    final TestGesture gesture = await tester.startGesture(
+      paragraph1Rect.centerLeft,
+      kind: PointerDeviceKind.mouse,
+    );
     addTearDown(gesture.removePointer);
     await tester.pump();
 
     await gesture.moveTo(paragraph1Rect.center);
     await tester.pump();
-    expect(paragraph1.selections.first, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expect(
+      paragraph1.selections.first,
+      const TextSelection(baseOffset: 0, extentOffset: 7),
+    );
 
-    final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Non-selectable text'), matching: find.byType(RichText)));
+    final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(
+      find.descendant(
+        of: find.text('Non-selectable text'),
+        matching: find.byType(RichText),
+      ),
+    );
     final Rect paragraph2Rect = tester.getRect(find.text('Non-selectable text'));
     await gesture.moveTo(paragraph2Rect.center);
     // Should select the rest of paragraph 1.
-    expect(paragraph1.selections.first, const TextSelection(baseOffset: 0, extentOffset: 15));
+    expect(
+      paragraph1.selections.first,
+      const TextSelection(baseOffset: 0, extentOffset: 15),
+    );
     // paragraph2 is in a disabled container.
     expect(paragraph2.selections, isEmpty);
 
-    final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Selectable text').last, matching: find.byType(RichText)));
+    final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(
+      find.descendant(
+        of: find.text('Selectable text').last,
+        matching: find.byType(RichText),
+      ),
+    );
     final Rect paragraph3Rect = tester.getRect(find.text('Selectable text').last);
     await gesture.moveTo(paragraph3Rect.center);
-    expect(paragraph1.selections.first, const TextSelection(baseOffset: 0, extentOffset: 15));
+    expect(
+      paragraph1.selections.first,
+      const TextSelection(baseOffset: 0, extentOffset: 15),
+    );
     expect(paragraph2.selections, isEmpty);
-    expect(paragraph3.selections.first, const TextSelection(baseOffset: 0, extentOffset: 7));
+    expect(
+      paragraph3.selections.first,
+      const TextSelection(baseOffset: 0, extentOffset: 7),
+    );
 
     await gesture.up();
   });

--- a/examples/api/test/material/selection_container/selection_container_disabled.0_test.dart
+++ b/examples/api/test/material/selection_container/selection_container_disabled.0_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_api_samples/material/selection_container/selection_container_disabled.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('A SelectionContainer.disabled should disable selections', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SelectionContainerDisabledExampleApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'SelectionContainer.disabled Sample'), findsOne);
+
+    final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Selectable text').first, matching: find.byType(RichText)));
+    final Rect paragraph1Rect = tester.getRect(find.text('Selectable text').first);
+    final TestGesture gesture = await tester.startGesture(paragraph1Rect.centerLeft, kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    await gesture.moveTo(paragraph1Rect.center);
+    await tester.pump();
+    expect(paragraph1.selections.first, const TextSelection(baseOffset: 0, extentOffset: 7));
+
+    final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Non-selectable text'), matching: find.byType(RichText)));
+    final Rect paragraph2Rect = tester.getRect(find.text('Non-selectable text'));
+    await gesture.moveTo(paragraph2Rect.center);
+    // Should select the rest of paragraph 1.
+    expect(paragraph1.selections.first, const TextSelection(baseOffset: 0, extentOffset: 15));
+    // paragraph2 is in a disabled container.
+    expect(paragraph2.selections, isEmpty);
+
+    final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Selectable text').last, matching: find.byType(RichText)));
+    final Rect paragraph3Rect = tester.getRect(find.text('Selectable text').last);
+    await gesture.moveTo(paragraph3Rect.center);
+    expect(paragraph1.selections.first, const TextSelection(baseOffset: 0, extentOffset: 15));
+    expect(paragraph2.selections, isEmpty);
+    expect(paragraph3.selections.first, const TextSelection(baseOffset: 0, extentOffset: 7));
+
+    await gesture.up();
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/test/material/selection_container/selection_container_disabled.0_test.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
