### PR TITLE
Remove LogicalKeySet usage in one Shortcuts example

### DIFF
--- a/examples/api/lib/widgets/shortcuts/shortcuts.1.dart
+++ b/examples/api/lib/widgets/shortcuts/shortcuts.1.dart
@@ -85,9 +85,9 @@ class _ShortcutsExampleState extends State<ShortcutsExample> {
   @override
   Widget build(BuildContext context) {
     return Shortcuts(
-      shortcuts: <ShortcutActivator, Intent>{
-        LogicalKeySet(LogicalKeyboardKey.arrowUp): const IncrementIntent(2),
-        LogicalKeySet(LogicalKeyboardKey.arrowDown): const DecrementIntent(2),
+      shortcuts: const <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.arrowUp): IncrementIntent(2),
+        SingleActivator(LogicalKeyboardKey.arrowDown): DecrementIntent(2),
       },
       child: Actions(
         actions: <Type, Action<Intent>>{

--- a/examples/api/test/widgets/shortcuts/shortcuts.1_test.dart
+++ b/examples/api/test/widgets/shortcuts/shortcuts.1_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_api_samples/widgets/shortcuts/shortcuts.1.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';
@@ -50,6 +51,26 @@ void main() {
       await tester.pump();
 
       counter -= 2;
+    }
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/156806.
+  testWidgets('SingleActivator is used instead of LogiccalKeySet', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ShortcutsExampleApp(),
+    );
+
+    final Shortcuts shortcuts = tester.firstWidget(
+      find.descendant(
+        of: find.byType(example.ShortcutsExample),
+        matching: find.byType(Shortcuts),
+      )
+    );
+
+    expect(shortcuts.shortcuts.length, 2);
+    for (final ShortcutActivator activator in shortcuts.shortcuts.keys) {
+      expect(activator is LogicalKeySet, false);
+      expect(activator is SingleActivator, true);
     }
   });
 }


### PR DESCRIPTION
## Description

This PR replaces `LogicalKeySet` by `SingleActivator` in one of the Shortcuts example.
According to [LogicalKeySet documentation](https://api.flutter.dev/flutter/widgets/LogicalKeySet-class.html) :
"prefer [SingleActivator](https://api.flutter.dev/flutter/widgets/SingleActivator-class.html) when possible, whose behavior more closely resembles that of typical platforms".

## Related Issue

Related to [LogicalKeySet Not Working on Linux Environment](https://github.com/flutter/flutter/issues/156806).

## Tests

Adds 1 test.