### PR TITLE
builder gets executed with AnimationStyle.noAnimation

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -968,7 +968,6 @@ class _MaterialAppState extends State<MaterialApp> {
 
     Widget childWidget = child ?? const SizedBox.shrink();
 
-    if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
       if (widget.builder != null) {
         childWidget = Builder(
           builder: (BuildContext context) {
@@ -987,12 +986,13 @@ class _MaterialAppState extends State<MaterialApp> {
           },
         );
       }
-      childWidget = AnimatedTheme(
-        data: theme,
-        duration: widget.themeAnimationStyle?.duration ?? widget.themeAnimationDuration,
-        curve: widget.themeAnimationStyle?.curve ?? widget.themeAnimationCurve,
-        child: childWidget,
-      );
+      if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
+        childWidget = AnimatedTheme(
+          data: theme,
+          duration: widget.themeAnimationStyle?.duration ?? widget.themeAnimationDuration,
+          curve: widget.themeAnimationStyle?.curve ?? widget.themeAnimationCurve,
+          child: childWidget,
+        );
     } else {
       childWidget = Theme(
         data: theme,


### PR DESCRIPTION
Changed the if-statement nesting, so builder gets executed with AnimationStyle.noAnimation.

This is a new pr, because I couldnt figure out, how to update the email of an existing pr. If the cla test passes this time [the other pr](https://github.com/flutter/flutter/pull/156966)  can be closed

https://github.com/flutter/flutter/issues/156959
Pre-launch Checklist

    [✅ ] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) and followed the process outlined there for submitting PRs.
    [ ✅] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page, which explains my responsibilities.
    [ ✅] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md), including [Features we expect every widget to implement](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement).
    [ ✅] I signed the [CLA](https://cla.developers.google.com/).
    [ ✅] I listed at least one issue that this PR fixes in the description above.

I updated/added relevant documentation (doc comments with ///).
I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests).
I followed the [breaking change policy](https://github.com/flutter/flutter/blob/main/docs/contributing/Treehygiene.md#handling-breaking-changes) and added [Data Driven Fixes](https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md) where supported.
    [✅ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord](https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md).