### PR TITLE
builder gets executed with AnimationStyle.noAnimation

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -968,31 +968,31 @@ class _MaterialAppState extends State<MaterialApp> {
 
     Widget childWidget = child ?? const SizedBox.shrink();
 
-      if (widget.builder != null) {
-        childWidget = Builder(
-          builder: (BuildContext context) {
-            // Why are we surrounding a builder with a builder?
-            //
-            // The widget.builder may contain code that invokes
-            // Theme.of(), which should return the theme we selected
-            // above in AnimatedTheme. However, if we invoke
-            // widget.builder() directly as the child of AnimatedTheme
-            // then there is no Context separating them, and the
-            // widget.builder() will not find the theme. Therefore, we
-            // surround widget.builder with yet another builder so that
-            // a context separates them and Theme.of() correctly
-            // resolves to the theme we passed to AnimatedTheme.
-            return widget.builder!(context, child);
-          },
-        );
-      }
-      if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
-        childWidget = AnimatedTheme(
-          data: theme,
-          duration: widget.themeAnimationStyle?.duration ?? widget.themeAnimationDuration,
-          curve: widget.themeAnimationStyle?.curve ?? widget.themeAnimationCurve,
-          child: childWidget,
-        );
+    if (widget.builder != null) {
+      childWidget = Builder(
+        builder: (BuildContext context) {
+          // Why are we surrounding a builder with a builder?
+          //
+          // The widget.builder may contain code that invokes
+          // Theme.of(), which should return the theme we selected
+          // above in AnimatedTheme. However, if we invoke
+          // widget.builder() directly as the child of AnimatedTheme
+          // then there is no Context separating them, and the
+          // widget.builder() will not find the theme. Therefore, we
+          // surround widget.builder with yet another builder so that
+          // a context separates them and Theme.of() correctly
+          // resolves to the theme we passed to AnimatedTheme.
+          return widget.builder!(context, child);
+        },
+      );
+    }
+    if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
+      childWidget = AnimatedTheme(
+        data: theme,
+        duration: widget.themeAnimationStyle?.duration ?? widget.themeAnimationDuration,
+        curve: widget.themeAnimationStyle?.curve ?? widget.themeAnimationCurve,
+        child: childWidget,
+      );
     } else {
       childWidget = Theme(
         data: theme,

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -977,7 +977,7 @@ class _MaterialAppState extends State<MaterialApp> {
           // Theme.of(), which should return the theme we selected
           // above in AnimatedTheme. However, if we invoke
           // widget.builder() directly as the child of AnimatedTheme
-          // then there is no Context separating them, and the
+          // then there is no BuildContext separating them, the
           // widget.builder() will not find the theme. Therefore, we
           // surround widget.builder with yet another builder so that
           // a context separates them and Theme.of() correctly

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -968,7 +968,6 @@ class _MaterialAppState extends State<MaterialApp> {
 
     Widget childWidget = child ?? const SizedBox.shrink();
 
-    if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
       if (widget.builder != null) {
         childWidget = Builder(
           builder: (BuildContext context) {
@@ -987,12 +986,13 @@ class _MaterialAppState extends State<MaterialApp> {
           },
         );
       }
-      childWidget = AnimatedTheme(
-        data: theme,
-        duration: widget.themeAnimationStyle?.duration ?? widget.themeAnimationDuration,
-        curve: widget.themeAnimationStyle?.curve ?? widget.themeAnimationCurve,
-        child: childWidget,
-      );
+      if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
+        childWidget = AnimatedTheme(
+          data: theme,
+          duration: widget.themeAnimationStyle?.duration ?? widget.themeAnimationDuration,
+          curve: widget.themeAnimationStyle?.curve ?? widget.themeAnimationCurve,
+          child: childWidget,
+        );
     } else {
       childWidget = Theme(
         data: theme,

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1662,6 +1662,22 @@ void main() {
 
     expect(tester.getSize(find.byType(MaterialApp)), const Size(123, 456));
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/156959.
+  testWidgets(
+    'MaterialApp with builder works when themeAnimationStyle is AnimationStyle.noAnimation',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          themeAnimationStyle: AnimationStyle.noAnimation,
+          builder: (BuildContext context, Widget? child) {
+            return const Text('Works');
+          },
+        ),
+      );
+      expect(find.text('Works'), findsOne);
+    },
+  );
 }
 
 class MockScrollBehavior extends ScrollBehavior {


### PR DESCRIPTION
Changed the if-statement nesting, so builder gets executed with AnimationStyle.noAnimation.

Pre-launch Checklist

Issue: https://github.com/flutter/flutter/issues/156959

[✅ ] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) and followed the process outlined there for submitting PRs.
[ ✅] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page, which explains my responsibilities.
[ ✅] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md), including [Features we expect every widget to implement](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement).
[ ✅] I signed the [CLA](https://cla.developers.google.com/).
[ ✅] I listed at least one issue that this PR fixes in the description above.
I updated/added relevant documentation (doc comments with ///).
I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests).
I followed the [breaking change policy](https://github.com/flutter/flutter/blob/main/docs/contributing/Treehygiene.md#handling-breaking-changes) and added [Data Driven Fixes](https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md) where supported.
[✅ ] All existing and new tests are passing.