### PR TITLE
Temporarily skip SemanticsFlag test to allow new flag to roll in

### DIFF
--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -710,7 +710,11 @@ void main() {
       ],
     );
     expect(semantics, hasSemantics(expectedSemantics, ignoreId: true));
-  });
+  }, skip: true); // TODO(yjbanov): https://github.com/flutter/flutter/issues/66673
+                  // Skipped temporarily to allow https://github.com/flutter/engine/pull/55780
+                  // to roll into the framework, which introduces a new flag. Because this
+                  // test enumerates all flags, the new flag breaks it. This test will need
+                  // to be updated after the roll.
 
   testWidgets('Actions can be replaced without triggering semantics update', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);


### PR DESCRIPTION
This test relies on the enumeration of all engine flags, and it will fail when https://github.com/flutter/engine/pull/55780 adds `SemanticsFlag.hasSelectedState`. So temporarily skip the test to allow the new flag to be added. I will later unskip the test and change it to check for the new flag as well.

A step towards https://github.com/flutter/flutter/issues/66673