### PR TITLE
Temporarily skip CustomPainter SemanticsFlag test to allow new flag to roll in

### DIFF
--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -524,7 +524,11 @@ void _defineTests() {
     );
     expect(semantics, hasSemantics(expectedSemantics, ignoreRect: true, ignoreTransform: true));
     semantics.dispose();
-  });
+  }, skip: true); // TODO(yjbanov): https://github.com/flutter/flutter/issues/66673
+                  // Skipped temporarily to allow https://github.com/flutter/engine/pull/55780
+                  // to roll into the framework, which introduces a new flag. Because this
+                  // test enumerates all flags, the new flag breaks it. This test will need
+                  // to be updated after the roll.
 
   group('diffing', () {
     testWidgets('complains about duplicate keys', (WidgetTester tester) async {


### PR DESCRIPTION
Same as https://github.com/flutter/flutter/pull/157017, but for `CustomPainter`.