### PR TITLE
Move analyzer_benchmark to the devicelab

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -358,11 +358,15 @@ targets:
       tags: >
         ["framework","hostonly","shard","linux"]
 
+  # This is a benchmark that does not require an attached device. However, we
+  # are intentionally running it in the devicelab to ensure that it does not
+  # run on a VM in order to avoid noisy results from the benchmark.
   - name: Linux analyzer_benchmark
     recipe: devicelab/devicelab_drone
-    presubmit: false
     timeout: 60
     properties:
+      os: Linux
+      device_type: "mokey"
       test_timeout_secs: "3600" # 1 hour
       dependencies: >-
         [
@@ -370,9 +374,8 @@ targets:
           {"dependency": "open_jdk", "version": "version:17"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
-      cores: "32"
       tags: >
-        ["devicelab", "hostonly", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: analyzer_benchmark
 
   - name: Linux coverage


### PR DESCRIPTION
We want this benchmark to run in the devicelab rather than on a VM so that it will give consistent results across runs.

First run (results at the bottom):
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8733793239434768065/+/u/run_analyzer_benchmark/stdout

