### PR TITLE
Beta test alternate correct macOS framework xcprivacy manifest location

### DIFF
--- a/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
@@ -225,7 +225,19 @@ void main() {
       expect(outputFlutterFramework.childDirectory('Headers'), isNot(exists));
       expect(outputFlutterFramework.childLink('Modules'), isNot(exists));
       expect(outputFlutterFramework.childDirectory('Modules'), isNot(exists));
-      expect(outputFlutterFramework.childFile('PrivacyInfo.xcprivacy'), exists);
+
+      // PrivacyInfo.xcprivacy was first added to the top-level path, but
+      // the correct location is Versions/A/Resources/PrivacyInfo.xcprivacy.
+      // TODO(jmagman): Switch expectation to only check Resources/ once the new path rolls.
+      // https://github.com/flutter/flutter/issues/157016#issuecomment-2420786225
+      final File topLevelPrivacy =  outputFlutterFramework.childFile('PrivacyInfo.xcprivacy');
+      final File resourcesLevelPrivacy = fileSystem.file(fileSystem.path.join(
+        outputFlutterFramework.path,
+        'Resources',
+        'PrivacyInfo.xcprivacy',
+      ));
+
+      expect(topLevelPrivacy.existsSync() || resourcesLevelPrivacy.existsSync(), isTrue);
 
       // Build again without cleaning.
       final ProcessResult secondBuild = processManager.runSync(buildCommand, workingDirectory: workingDirectory);


### PR DESCRIPTION
The PrivacyInfo.xcprivacy file was originally copied to the top-level macOS framework, but instead needs to be in the Resources directory (which is a different path than iOS).  This caused codesigning issues https://github.com/flutter/flutter/issues/157016.

The path is being corrected https://github.com/flutter/engine/pull/55938 so update the framework test to handle either path.  It will be updated to just check the correct path once it rolls into the framework.
