### PR TITLE
[web] Allow control of hitTestBehavior of Platform Views

### DIFF
--- a/packages/flutter/lib/src/widgets/_html_element_view_io.dart
+++ b/packages/flutter/lib/src/widgets/_html_element_view_io.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/rendering.dart';
+
 import 'framework.dart';
 import 'platform_view.dart';
 
@@ -14,6 +16,7 @@ extension HtmlElementViewImpl on HtmlElementView {
     required String tagName,
     bool isVisible = true,
     ElementCreatedCallback? onElementCreated,
+    required PlatformViewHitTestBehavior hitTestBehavior,
   }) {
     throw UnimplementedError('HtmlElementView is only available on Flutter Web');
   }

--- a/packages/flutter/lib/src/widgets/_html_element_view_web.dart
+++ b/packages/flutter/lib/src/widgets/_html_element_view_web.dart
@@ -21,12 +21,16 @@ extension HtmlElementViewImpl on HtmlElementView {
     required String tagName,
     bool isVisible = true,
     ElementCreatedCallback? onElementCreated,
+    required PlatformViewHitTestBehavior hitTestBehavior,
   }) {
     return HtmlElementView(
       key: key,
-      viewType: isVisible ? ui_web.PlatformViewRegistry.defaultVisibleViewType : ui_web.PlatformViewRegistry.defaultInvisibleViewType,
+      viewType: isVisible
+          ? ui_web.PlatformViewRegistry.defaultVisibleViewType
+          : ui_web.PlatformViewRegistry.defaultInvisibleViewType,
       onPlatformViewCreated: _createPlatformViewCallbackForElementCallback(onElementCreated),
       creationParams: <dynamic, dynamic>{'tagName': tagName},
+      hitTestBehavior: hitTestBehavior,
     );
   }
 
@@ -45,7 +49,7 @@ extension HtmlElementViewImpl on HtmlElementView {
         return PlatformViewSurface(
           controller: controller,
           gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
-          hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+          hitTestBehavior: hitTestBehavior,
         );
       },
     );

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -655,6 +655,7 @@ class HtmlElementView extends StatelessWidget {
     required this.viewType,
     this.onPlatformViewCreated,
     this.creationParams,
+    this.hitTestBehavior = PlatformViewHitTestBehavior.opaque,
   });
 
   /// Creates a platform view that creates a DOM element specified by [tagName].
@@ -672,12 +673,14 @@ class HtmlElementView extends StatelessWidget {
     required String tagName,
     bool isVisible = true,
     ElementCreatedCallback? onElementCreated,
+    PlatformViewHitTestBehavior hitTestBehavior = PlatformViewHitTestBehavior.opaque,
   }) =>
       HtmlElementViewImpl.createFromTagName(
         key: key,
         tagName: tagName,
         isVisible: isVisible,
         onElementCreated: onElementCreated,
+        hitTestBehavior: hitTestBehavior,
       );
 
   /// The unique identifier for the HTML view type to be embedded by this widget.
@@ -694,6 +697,9 @@ class HtmlElementView extends StatelessWidget {
 
   /// Passed as the 2nd argument (i.e. `params`) of the registered view factory.
   final Object? creationParams;
+
+  /// {@macro flutter.widgets.AndroidView.hitTestBehavior}
+  final PlatformViewHitTestBehavior hitTestBehavior;
 
   @override
   Widget build(BuildContext context) => buildImpl(context);

--- a/packages/flutter/test/widgets/html_element_view_test.dart
+++ b/packages/flutter/test/widgets/html_element_view_test.dart
@@ -385,6 +385,75 @@ void main() {
 
       expect(createdElement, fakePlatformView.htmlElement);
     });
+
+    group('hitTestBehavior', () {
+      testWidgets('opaque by default', (WidgetTester tester) async {
+        final Key containerKey = UniqueKey();
+        int taps = 0;
+
+        await tester.pumpWidget(
+          GestureDetector(
+            onTap: () => taps++,
+            child: Container(
+              key: containerKey,
+              width: 200,
+              height: 200,
+              // Add a color to make it a visible container. This ensures that
+              // GestureDetector's default hit test behavior works.
+              color: const Color(0xFF00FF00),
+              child: HtmlElementView.fromTagName(tagName: 'div'),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(taps, isZero);
+
+        await tester.tap(
+          find.byKey(containerKey),
+          warnIfMissed: false,
+        );
+
+        // Taps are still zero on the container because the HtmlElementView is
+        // opaque and prevents widgets behind it from receiving pointer events.
+        expect(taps, isZero);
+      });
+
+      testWidgets('can be set to transparent', (WidgetTester tester) async {
+        final Key containerKey = UniqueKey();
+        int taps = 0;
+
+        await tester.pumpWidget(
+          GestureDetector(
+            onTap: () => taps++,
+            child: Container(
+              key: containerKey,
+              width: 200,
+              height: 200,
+              // Add a color to make it a visible container. This ensures that
+              // GestureDetector's default hit test behavior works.
+              color: const Color(0xFF00FF00),
+              child: HtmlElementView.fromTagName(
+                tagName: 'div',
+                hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(taps, isZero);
+
+        await tester.tap(
+          find.byKey(containerKey),
+          warnIfMissed: false,
+        );
+
+        // The container can receive taps because the HtmlElementView is
+        // transparent from a hit testing perspective.
+        expect(taps, 1);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Hit testing behavior is currently hardcoded to `opaque`  in `HtmlElementView` which causes the platform view to swallow pointer events when it's a descendant of a `GestureDetector` (see this [example](https://dartpad.dev/?id=5348fbf82be5eeb7d995f953437f0ce6)).

In order to fix this, we need to make `hitTestBehavior` configurable in `HtmlElementView`. This way users can decide to make their platform views `transparent` for hit testing purposes.

**_Note_**: this specific case isn't fixable by `PointerInterceptor` because the framework is already receiving the pointer events, so there's nothing that `PointerInterceptor` can do. This issue is all happening on the framework side since it treats the rectangle occupied by the platform view as an opaque rectangle for hit testing.

**_Workaround_**: in the meantime, users can work around this limitation by surrounding the `HtmlElementView` with an `IgnorePointer` widget.