### PR TITLE
fix `Consider using 'named' to avoid unnecessary configuration` inside flutter.groovy

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1359,29 +1359,17 @@ class FlutterPlugin implements Plugin<Project> {
             // The following tasks use the output of copyFlutterAssetsTask,
             // so it's necessary to declare it as an dependency since Gradle 8.
             // See https://docs.gradle.org/8.1/userguide/validation_problems.html#implicit_dependency.
-           def compressAssetsTaskName = "compress${variant.name.capitalize()}Assets"
-project.tasks.whenTaskAdded { task ->
-    if (task.name == compressAssetsTaskName) {
-        task.dependsOn(copyFlutterAssetsTask)
-    }
-}
-
-def bundleAarTaskName = "bundle${variant.name.capitalize()}Aar"
-project.tasks.whenTaskAdded { task ->
-    if (task.name == bundleAarTaskName) {
-        task.dependsOn(copyFlutterAssetsTask)
-    }
-}
-
-def bundleAarTaskWithLintName = "bundle${variant.name.capitalize()}LocalLintAar"
-project.tasks.whenTaskAdded { task ->
-    if (task.name == bundleAarTaskWithLintName) {
-        task.dependsOn(copyFlutterAssetsTask)
-    }
-}
-
-
-
+  def assetTaskNames = [
+                    "compress${variant.name.capitalize()}Assets",
+                    "bundle${variant.name.capitalize()}Aar",
+                    "bundle${variant.name.capitalize()}LocalLintAar"
+            ]
+            def tasks = project.tasks.findAll { task ->
+                assetTaskNames.contains(task.name)
+            }
+            tasks.each { task ->
+                task.dependsOn(copyFlutterAssetsTask)
+            }
             return copyFlutterAssetsTask
         } // end def addFlutterDeps
 

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1359,20 +1359,21 @@ class FlutterPlugin implements Plugin<Project> {
             // The following tasks use the output of copyFlutterAssetsTask,
             // so it's necessary to declare it as an dependency since Gradle 8.
             // See https://docs.gradle.org/8.1/userguide/validation_problems.html#implicit_dependency.
-            def compressAssetsTask = project.tasks.named("compress${variant.name.capitalize()}Assets")
-            if (compressAssetsTask) {
-                compressAssetsTask.dependsOn(copyFlutterAssetsTask)
-            }
+            def compressAssetsTaskName = "compress${variant.name.capitalize()}Assets"
+project.tasks.named(compressAssetsTaskName).configure { task ->
+    task.dependsOn(copyFlutterAssetsTask)
+}
 
-            def bundleAarTask = project.tasks.named("bundle${variant.name.capitalize()}Aar")
-            if (bundleAarTask) {
-                bundleAarTask.dependsOn(copyFlutterAssetsTask)
-            }
+def bundleAarTaskName = "bundle${variant.name.capitalize()}Aar"
+project.tasks.named(bundleAarTaskName).configure { task ->
+    task.dependsOn(copyFlutterAssetsTask)
+}
 
-            def bundleAarTaskWithLint = project.tasks.findByName("bundle${variant.name.capitalize()}LocalLintAar")
-            if (bundleAarTaskWithLint) {
-                bundleAarTaskWithLint.dependsOn(copyFlutterAssetsTask)
-            }
+def bundleAarTaskWithLintName = "bundle${variant.name.capitalize()}LocalLintAar"
+project.tasks.named(bundleAarTaskWithLintName).configure { task ->
+    task.dependsOn(copyFlutterAssetsTask)
+}
+
 
             return copyFlutterAssetsTask
         } // end def addFlutterDeps

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1359,12 +1359,12 @@ class FlutterPlugin implements Plugin<Project> {
             // The following tasks use the output of copyFlutterAssetsTask,
             // so it's necessary to declare it as an dependency since Gradle 8.
             // See https://docs.gradle.org/8.1/userguide/validation_problems.html#implicit_dependency.
-            def compressAssetsTask = project.tasks.findByName("compress${variant.name.capitalize()}Assets")
+            def compressAssetsTask = project.tasks.named("compress${variant.name.capitalize()}Assets")
             if (compressAssetsTask) {
                 compressAssetsTask.dependsOn(copyFlutterAssetsTask)
             }
 
-            def bundleAarTask = project.tasks.findByName("bundle${variant.name.capitalize()}Aar")
+            def bundleAarTask = project.tasks.named("bundle${variant.name.capitalize()}Aar")
             if (bundleAarTask) {
                 bundleAarTask.dependsOn(copyFlutterAssetsTask)
             }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1364,9 +1364,9 @@ class FlutterPlugin implements Plugin<Project> {
                     "bundle${variant.name.capitalize()}Aar",
                     "bundle${variant.name.capitalize()}LocalLintAar"
             ]
-            tasksToCheck.each { Taskname ->
+            tasksToCheck.each { taskTocheck ->
                 try {
-                    project.tasks.named(Taskname).configure { task ->
+                    project.tasks.named(taskTocheck).configure { task ->
                         task.dependsOn(copyFlutterAssetsTask)
                     }
                 } catch (Exception ignored) {

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -14,6 +14,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.Plugin
 import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1359,16 +1359,19 @@ class FlutterPlugin implements Plugin<Project> {
             // The following tasks use the output of copyFlutterAssetsTask,
             // so it's necessary to declare it as an dependency since Gradle 8.
             // See https://docs.gradle.org/8.1/userguide/validation_problems.html#implicit_dependency.
-  def assetTaskNames = [
+               def tasksToCheck = [
                     "compress${variant.name.capitalize()}Assets",
                     "bundle${variant.name.capitalize()}Aar",
                     "bundle${variant.name.capitalize()}LocalLintAar"
             ]
-            def tasks = project.tasks.findAll { task ->
-                assetTaskNames.contains(task.name)
-            }
-            tasks.each { task ->
-                task.dependsOn(copyFlutterAssetsTask)
+
+            tasksToCheck.each { Taskname ->
+                try {
+                    project.tasks.named(Taskname).configure { task ->
+                        task.dependsOn(copyFlutterAssetsTask)
+                    }
+                } catch (Exception ignored) {
+                }
             }
             return copyFlutterAssetsTask
         } // end def addFlutterDeps

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1359,20 +1359,27 @@ class FlutterPlugin implements Plugin<Project> {
             // The following tasks use the output of copyFlutterAssetsTask,
             // so it's necessary to declare it as an dependency since Gradle 8.
             // See https://docs.gradle.org/8.1/userguide/validation_problems.html#implicit_dependency.
-            def compressAssetsTaskName = "compress${variant.name.capitalize()}Assets"
-project.tasks.named(compressAssetsTaskName).configure { task ->
-    task.dependsOn(copyFlutterAssetsTask)
+           def compressAssetsTaskName = "compress${variant.name.capitalize()}Assets"
+project.tasks.whenTaskAdded { task ->
+    if (task.name == compressAssetsTaskName) {
+        task.dependsOn(copyFlutterAssetsTask)
+    }
 }
 
 def bundleAarTaskName = "bundle${variant.name.capitalize()}Aar"
-project.tasks.named(bundleAarTaskName).configure { task ->
-    task.dependsOn(copyFlutterAssetsTask)
+project.tasks.whenTaskAdded { task ->
+    if (task.name == bundleAarTaskName) {
+        task.dependsOn(copyFlutterAssetsTask)
+    }
 }
 
 def bundleAarTaskWithLintName = "bundle${variant.name.capitalize()}LocalLintAar"
-project.tasks.named(bundleAarTaskWithLintName).configure { task ->
-    task.dependsOn(copyFlutterAssetsTask)
+project.tasks.whenTaskAdded { task ->
+    if (task.name == bundleAarTaskWithLintName) {
+        task.dependsOn(copyFlutterAssetsTask)
+    }
 }
+
 
 
             return copyFlutterAssetsTask

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1369,12 +1369,11 @@ class FlutterPlugin implements Plugin<Project> {
                     project.tasks.named(taskTocheck).configure { task ->
                         task.dependsOn(copyFlutterAssetsTask)
                     }
-                } catch (Exception ignored) {
+                } catch (UnknownTaskException ignored) {
                 }
             }
             return copyFlutterAssetsTask
         } // end def addFlutterDeps
-        
         if (isFlutterAppProject()) {
             project.android.applicationVariants.all { variant ->
                 Task assembleTask = getAssembleTask(variant)

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1359,12 +1359,11 @@ class FlutterPlugin implements Plugin<Project> {
             // The following tasks use the output of copyFlutterAssetsTask,
             // so it's necessary to declare it as an dependency since Gradle 8.
             // See https://docs.gradle.org/8.1/userguide/validation_problems.html#implicit_dependency.
-               def tasksToCheck = [
+            def tasksToCheck = [
                     "compress${variant.name.capitalize()}Assets",
                     "bundle${variant.name.capitalize()}Aar",
                     "bundle${variant.name.capitalize()}LocalLintAar"
             ]
-
             tasksToCheck.each { Taskname ->
                 try {
                     project.tasks.named(Taskname).configure { task ->
@@ -1375,7 +1374,7 @@ class FlutterPlugin implements Plugin<Project> {
             }
             return copyFlutterAssetsTask
         } // end def addFlutterDeps
-
+        
         if (isFlutterAppProject()) {
             project.android.applicationVariants.all { variant ->
                 Task assembleTask = getAssembleTask(variant)


### PR DESCRIPTION
see #147122 for context
[gradle docs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) for reference(scroll until [this)](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#eager_apis_to_avoid)

also this the lint : 
![Capture d’écran 2024-10-19 094417](https://github.com/user-attachments/assets/8278c72e-068e-4596-b1ce-7888161bfcc8)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
