### PR TITLE
Remove duplicated widget of the week video embed

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -96,8 +96,6 @@ enum _ScaffoldSlot {
 /// ** See code in examples/api/lib/material/scaffold/scaffold_messenger.0.dart **
 /// {@end-tool}
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=lytQi-slT5Y}
-///
 /// See also:
 ///
 ///  * [SnackBar], which is a temporary notification typically shown near the


### PR DESCRIPTION
The `ScaffoldMessenger` widget embeds its widget of the week video twice: https://main-api.flutter.dev/flutter/material/ScaffoldMessenger-class.html