### PR TITLE
[devicelab] remove flaky designation from flutter_driver_android_test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1460,7 +1460,6 @@ targets:
 
   - name: Linux_android_emu_34 flutter_driver_android_test
     recipe: flutter/flutter_drone
-    bringup: true # https://github.com/flutter/flutter/issues/156903
     timeout: 60
     properties:
       shard: flutter_driver_android


### PR DESCRIPTION
https://github.com/flutter/engine/pull/55944 should have fixed all flakes and rolled into framework.