### PR TITLE
Test alternate correct macOS framework xcprivacy manifest location

### DIFF
--- a/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
@@ -225,7 +225,19 @@ void main() {
       expect(outputFlutterFramework.childDirectory('Headers'), isNot(exists));
       expect(outputFlutterFramework.childLink('Modules'), isNot(exists));
       expect(outputFlutterFramework.childDirectory('Modules'), isNot(exists));
-      expect(outputFlutterFramework.childFile('PrivacyInfo.xcprivacy'), exists);
+
+      // PrivacyInfo.xcprivacy was first added to the top-level path, but
+      // the correct location is Versions/A/Resources/PrivacyInfo.xcprivacy.
+      // TODO(jmagman): Switch expectation to only check Resources/ once the new path rolls.
+      // https://github.com/flutter/flutter/issues/157016#issuecomment-2420786225
+      final File topLevelPrivacy =  outputFlutterFramework.childFile('PrivacyInfo.xcprivacy');
+      final File resourcesLevelPrivacy = fileSystem.file(fileSystem.path.join(
+        outputFlutterFramework.path,
+        'Resources',
+        'PrivacyInfo.xcprivacy',
+      ));
+
+      expect(topLevelPrivacy.existsSync() || resourcesLevelPrivacy.existsSync(), isTrue);
 
       // Build again without cleaning.
       final ProcessResult secondBuild = processManager.runSync(buildCommand, workingDirectory: workingDirectory);


### PR DESCRIPTION
Cherry-pick the beta branch test https://github.com/flutter/flutter/pull/157136 back to master  so this doesn't regress in the next beta.

This is the framework test for https://github.com/flutter/flutter/issues/157016 on master.  Engine fix can be merged once this merges.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
