### PR TITLE
Add test for `pointer_signal_resolver.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -341,5 +341,4 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/restoration/restoration_mixin.0_test.dart',
   'examples/api/test/widgets/actions/focusable_action_detector.0_test.dart',
   'examples/api/test/widgets/focus_scope/focus_scope.0_test.dart',
-  'examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart',
 };

--- a/examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart
+++ b/examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/gestures/pointer_signal_resolver/pointer_signal_resolver.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ({Color outer, Color inner}) getColors(WidgetTester tester) {
+    final DecoratedBox outerBox = tester.widget(find.byType(DecoratedBox).first);
+    final DecoratedBox innerBox = tester.widget(find.byType(DecoratedBox).last);
+    return (
+      outer: (outerBox.decoration as BoxDecoration).color!,
+      inner: (innerBox.decoration as BoxDecoration).color!,
+    );
+  }
+
+  testWidgets('Scrolling on the boxes changes their color', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.PointerSignalResolverExampleApp(),
+    );
+
+    expect(
+      getColors(tester),
+      (outer: const Color(0x3300ff00), inner: const Color(0xffffff00)),
+    );
+
+    // Scroll on the outer box.
+    final TestPointer pointer = TestPointer(1, PointerDeviceKind.mouse);
+    pointer.hover(const Offset(100, 300));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0.0, 100.0)));
+    await tester.pump();
+
+    // The outer box changes color.
+    ({Color inner, Color outer}) colors = getColors(tester);
+    expect(colors.outer, const Color(0x3300ff0d));
+    expect(colors.inner, const Color(0xffffff00));
+
+    // Scroll on the inner box.
+    pointer.hover(const Offset(400, 300));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0.0, 100.0)));
+    await tester.pump();
+
+    // Both boxes change color.
+    colors = getColors(tester);
+    expect(colors.outer, const Color(0x3300ff1a));
+    expect(colors.inner, const Color(0xfff2ff00));
+
+    // Use PointerSignalResolver.
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+
+    pointer.hover(const Offset(100, 300));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0.0, 100.0)));
+    await tester.pump();
+
+    // The outer box changes color.
+    colors = getColors(tester);
+    expect(colors.outer, const Color(0x3300ff26));
+    expect(colors.inner, const Color(0xfff2ff00));
+
+    // Scroll on the inner box.
+    pointer.hover(const Offset(400, 300));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0.0, 100.0)));
+    await tester.pump();
+
+    // The inner box changes color.
+    colors = getColors(tester);
+    expect(
+      colors.outer,
+      const Color(0x3300ff26),
+    );
+    expect(colors.inner, const Color(0xffe5ff00));
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/test/gestures/pointer_signal_resolver/pointer_signal_resolver.0_test.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
