### PR TITLE
Fix MenuController.isOpen throws when unattached

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -650,8 +650,7 @@ class MenuController {
 
   /// Whether or not the associated menu is currently open.
   bool get isOpen {
-    assert(_anchor != null);
-    return _anchor!._isOpen;
+    return _anchor?._isOpen ?? false;
   }
 
   /// Close the menu that this menu controller is associated with.

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -4732,6 +4732,11 @@ void main() {
     await tester.pump();
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('Unattached MenuController returns false when calling isOpen', (WidgetTester tester) async {
+    final MenuController controller = MenuController();
+    expect(controller.isOpen, false);
+  });
 }
 
 List<Widget> createTestMenus({


### PR DESCRIPTION
## Description

This PR change `MenuController.isOpen` to return false when the `MenuController` is not attached.
Previously `MenuController.isOpen` thrown an assert error when the menu controller was unattached.
With this PR, it is now possible to have some widgets outside the `MenuAnchor` body depending on the menu controller state.

## Related Issue

Fixes [Querying isOpen state for a menu controller that was never attached throws an assertion error](https://github.com/flutter/flutter/issues/157329).

## Tests

Adds 1 test.