### PR TITLE
Added a warning if `flutter.groovy` uses a `.flutter-plugins` file.

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -688,6 +688,10 @@ class FlutterPlugin implements Plugin<Project> {
         } catch (FileNotFoundException ignored) {
             throw new GradleException("settings.gradle/settings.gradle.kts does not exist: ${settingsGradleFile(project).absolutePath}")
         }
+        // TODO(matanlurey): https://github.com/flutter/flutter/issues/48918.
+        project.logger.quiet("Warning: This project is still reading the deprecated '.flutter-plugins. file.")
+        project.logger.quiet("In an upcoming stable release support for this file will be completely removed and your build will fail.")
+        project.logger.quiet("For an example of updating Android build scripts, see https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply.")
         List<Map<String, Object>> deps = getPluginDependencies(project)
         List<String> plugins = getPluginList(project).collect { it.name as String }
         deps.removeIf { plugins.contains(it.name) }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -691,7 +691,7 @@ class FlutterPlugin implements Plugin<Project> {
         // TODO(matanlurey): https://github.com/flutter/flutter/issues/48918.
         project.logger.quiet("Warning: This project is still reading the deprecated '.flutter-plugins. file.")
         project.logger.quiet("In an upcoming stable release support for this file will be completely removed and your build will fail.")
-        project.logger.quiet("For an example of updating Android build scripts, see https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply.")
+        project.logger.quiet("See https:/flutter.dev/to/flutter-plugins-configuration.")
         List<Map<String, Object>> deps = getPluginDependencies(project)
         List<String> plugins = getPluginList(project).collect { it.name as String }
         deps.removeIf { plugins.contains(it.name) }


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/48918.

This file was soft deprecated in _2020_, but the code was never removed. This warning message will serve as a warning and we'll rip out support for `flutter-plugins` after the _next_ stable release (i.e. after the mid-November branch cut).