### PR TITLE
Detect plugins based on `.flutter-plugins-dependencies`; avoid refreshing twice in iOS/MacOS

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1131,7 +1131,7 @@ Future<void> injectPlugins(
 ///
 /// Assumes [refreshPluginsList] has been called since last change to `pubspec.yaml`.
 bool hasPlugins(FlutterProject project) {
-  return _readFileContent(project.flutterPluginsFile) != null;
+  return _readFileContent(project.flutterPluginsDependenciesFile) != null;
 }
 
 /// Resolves the plugin implementations for all platforms.

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -25,13 +25,6 @@ Future<void> processPodsIfNeeded(
   if (project.usesSwiftPackageManager && !xcodeProject.podfile.existsSync() && !forceCocoaPodsOnly) {
     return;
   }
-  // Ensure that the plugin list is up to date, since hasPlugins relies on it.
-  await refreshPluginsList(
-    project,
-    iosPlatform: project.ios.existsSync(),
-    macOSPlatform: project.macos.existsSync(),
-    forceCocoaPodsOnly: forceCocoaPodsOnly,
-  );
 
   // If there are no plugins and if the project is a not module with an existing
   // podfile, skip processing pods

--- a/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
@@ -9,6 +9,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_plugins.dart';
 import 'package:flutter_tools/src/macos/cocoapod_utils.dart';
 import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -86,6 +87,7 @@ void main() {
             ..writeAsStringSync(pluginYamlTemplate.replaceAll('PLUGIN_CLASS', name));
       }
 
+      flutterProject.flutterPluginsDependenciesFile..createSync()..writeAsStringSync('');
       packageConfigFile.writeAsStringSync(jsonEncode(packageConfig));
     }
 

--- a/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
@@ -9,7 +9,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
-import 'package:flutter_tools/src/flutter_plugins.dart';
 import 'package:flutter_tools/src/macos/cocoapod_utils.dart';
 import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/project.dart';


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/157391.

Two small but interconnected changes here:

1. Update `hasPlugins` to use the presence of `.flutter-plugins-dependencies`, not `.flutter-plugins`
2. Update `processPodsIfNeeded` to rely on the implicit `refreshPluginsList` provided by `FlutterCommand`.
