### PR TITLE
Add test for `navigator.restorable_push_and_remove_until.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -310,7 +310,6 @@ class SampleChecker {
 // See https://github.com/flutter/flutter/issues/130459
 final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/color_scheme/dynamic_content_color.0_test.dart',
-  'examples/api/test/widgets/navigator/navigator.restorable_push_and_remove_until.0_test.dart',
   'examples/api/test/widgets/navigator/navigator.restorable_push.0_test.dart',
   'examples/api/test/widgets/navigator/navigator_state.restorable_push_replacement.0_test.dart',
   'examples/api/test/widgets/navigator/navigator_state.restorable_push_and_remove_until.0_test.dart',

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart
@@ -13,8 +13,12 @@ class RestorablePushAndRemoveUntilExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: RestorablePushAndRemoveUntilExample(),
+    return const RootRestorationScope(
+      restorationId: 'app',
+      child: MaterialApp(
+        restorationScopeId: 'app',
+        home: RestorablePushAndRemoveUntilExample(),
+      ),
     );
   }
 }

--- a/examples/api/test/widgets/navigator/navigator.restorable_push_and_remove_until.0_test.dart
+++ b/examples/api/test/widgets/navigator/navigator.restorable_push_and_remove_until.0_test.dart
@@ -1,0 +1,52 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('It pushes and restorable route and pops it', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.RestorablePushAndRemoveUntilExampleApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'Sample Code'), findsOne);
+    expect(find.byType(BackButton), findsNothing);
+
+    await tester.tap(find.widgetWithIcon(FloatingActionButton, Icons.add));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BackButton), findsNothing);
+  });
+
+  testWidgets('It pushes and restorable route and restores it', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.RestorablePushAndRemoveUntilExampleApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'Sample Code'), findsOne);
+    expect(find.byType(BackButton), findsNothing);
+
+    await tester.tap(find.widgetWithIcon(FloatingActionButton, Icons.add));
+    await tester.pumpAndSettle();
+
+    await tester.restartAndRestore();
+
+    expect(find.byType(BackButton), findsOne);
+
+    final TestRestorationData data = await tester.getRestorationData();
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BackButton), findsNothing);
+
+    await tester.restoreFrom(data);
+    expect(find.byType(BackButton), findsOne);
+  });
+}

--- a/examples/api/test/widgets/navigator/navigator.restorable_push_and_remove_until.0_test.dart
+++ b/examples/api/test/widgets/navigator/navigator.restorable_push_and_remove_until.0_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_api_samples/widgets/navigator/navigator.restorable_push_
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('It pushes and restorable route and pops it', (WidgetTester tester) async {
+  testWidgets('It pushes a restorable route and pops it', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.RestorablePushAndRemoveUntilExampleApp(),
     );
@@ -24,7 +24,7 @@ void main() {
     expect(find.byType(BackButton), findsNothing);
   });
 
-  testWidgets('It pushes and restorable route and restores it', (WidgetTester tester) async {
+  testWidgets('It pushes a restorable route and restores it', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.RestorablePushAndRemoveUntilExampleApp(),
     );


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
