### PR TITLE
fix DropdownMenu menu vertical position

### DIFF
--- a/examples/api/test/material/dropdown_menu/dropdown_menu.0_test.dart
+++ b/examples/api/test/material/dropdown_menu/dropdown_menu.0_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(iconMenu, findsOneWidget);
 
     Finder findMenuItem(String label) {
-      return find.widgetWithText(MenuItemButton, label).last;
+      return find.widgetWithText(MenuItemButton, label).first;
     }
 
     await tester.tap(colorMenu);

--- a/examples/api/test/material/dropdown_menu/dropdown_menu.1_test.dart
+++ b/examples/api/test/material/dropdown_menu/dropdown_menu.1_test.dart
@@ -17,7 +17,7 @@ void main() {
     expect(menu, findsOne);
 
     Finder findMenuItem(String label) {
-      return find.widgetWithText(MenuItemButton, label).last;
+      return find.widgetWithText(MenuItemButton, label).first;
     }
 
     await tester.tap(menu);

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -835,7 +835,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         return;
       }
       setState(() {});
-    }, debugLabel: 'DropdownMenu._onMenuChanged');
+    }, debugLabel: 'DropdownMenu._onMenuClose');
   }
 
   @override

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1022,8 +1022,8 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         child: menuAnchor,
       );
       // Put the menu anchor into a Column with CrossAxisAlignment.stretch
-      // to loose just the height constraints. Doing so, the menu anchor
-      // adjusts to the inner text field intrinsic heigth even if it received
+      // to loosen just the height constraints. Doing so, the menu anchor
+      // adjusts to the inner text field intrinsic height even if it received
       // tight constraints from its parent.
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -49,20 +49,31 @@ void main() {
     );
   }
 
+  Finder findMenuItemButton(String label) {
+    // For each menu items there are two MenuItemButton widgets.
+    // The first one is the real button item in the menu.
+    // The second one is not visible, it is part of _DropdownMenuBody
+    // which is used to compute the dropdown width.
+    return find.widgetWithText(MenuItemButton, label).first;
+  }
+
   Material getButtonMaterial(WidgetTester tester, String itemLabel) {
     return tester.widget<Material>(find.descendant(
-      of: find.widgetWithText(MenuItemButton, itemLabel).last,
+      of: findMenuItemButton(itemLabel),
       matching: find.byType(Material),
     ));
   }
 
   bool isItemHighlighted(WidgetTester tester, ThemeData themeData, String itemLabel) {
-    final Finder buttonMaterial = find.descendant(
-      of: find.widgetWithText(MenuItemButton, itemLabel).last,
-      matching: find.byType(Material),
-    );
-    final Color? color = tester.widget<Material>(buttonMaterial).color;
+    final Color? color = getButtonMaterial(tester, itemLabel).color;
     return color == themeData.colorScheme.onSurface.withOpacity(0.12);
+  }
+
+  Finder findMenuMaterial() {
+    return find.ancestor(
+      of: find.byType(TextButton).first,
+      matching: find.byType(Material),
+    ).first;
   }
 
   testWidgets('DropdownMenu defaults', (WidgetTester tester) async {
@@ -88,23 +99,14 @@ void main() {
     await tester.pump();
     expect(find.byType(MenuAnchor), findsOneWidget);
 
-    final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(TextButton, TestMenu.mainMenu0.label),
-      matching: find.byType(Material),
-    ).at(1);
-    Material material = tester.widget<Material>(menuMaterial);
+    Material material = tester.widget<Material>(findMenuMaterial());
     expect(material.color, themeData.colorScheme.surfaceContainer);
     expect(material.shadowColor, themeData.colorScheme.shadow);
     expect(material.surfaceTintColor, Colors.transparent);
     expect(material.elevation, 3.0);
     expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))));
 
-    final Finder buttonMaterial = find.descendant(
-      of: find.byType(TextButton),
-      matching: find.byType(Material),
-    ).last;
-
-    material = tester.widget<Material>(buttonMaterial);
+    material = getButtonMaterial(tester, TestMenu.mainMenu0.label);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
     expect(material.shape, const RoundedRectangleBorder());
@@ -163,18 +165,18 @@ void main() {
 
     TextStyle? iconStyle(WidgetTester tester, Key key) {
       final RichText iconRichText = tester.widget<RichText>(
-        find.descendant(of: find.byKey(key), matching: find.byType(RichText)).last,
+        find.descendant(of: find.byKey(key), matching: find.byType(RichText)).first,
       );
       return iconRichText.text.style;
     }
 
     RenderObject overlayPainter(WidgetTester tester, TestMenu menuItem) {
       return tester.renderObject(find.descendant(
-        of: find.widgetWithText(MenuItemButton, menuItem.label).last,
+        of: findMenuItemButton(menuItem.label),
         matching: find.byElementPredicate(
           (Element element) => element.renderObject.runtimeType.toString() == '_RenderInkFeatures',
         ),
-      ).last);
+      ).first);
     }
 
     testWidgets('defaults are correct', (WidgetTester tester) async {
@@ -212,7 +214,7 @@ void main() {
         return gesture.removePointer();
       });
       await gesture.addPointer();
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, selectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(selectedItem.label)));
       await tester.pump();
 
       expect(
@@ -221,7 +223,7 @@ void main() {
       );
 
       // Hover a non-selected item.
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, nonSelectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(nonSelectedItem.label)));
       await tester.pump();
 
       expect(
@@ -264,7 +266,7 @@ void main() {
         return gesture.removePointer();
       });
       await gesture.addPointer();
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, selectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(selectedItem.label)));
       await tester.pump();
 
       expect(
@@ -273,7 +275,7 @@ void main() {
       );
 
       // Hover a non-selected item.
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, nonSelectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(nonSelectedItem.label)));
       await tester.pump();
 
       expect(
@@ -315,7 +317,7 @@ void main() {
         return gesture.removePointer();
       });
       await gesture.addPointer();
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, selectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(selectedItem.label)));
       await tester.pump();
 
       expect(
@@ -324,7 +326,7 @@ void main() {
       );
 
       // Hover a non-selected item.
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, nonSelectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(nonSelectedItem.label)));
       await tester.pump();
 
       expect(
@@ -375,7 +377,7 @@ void main() {
         return gesture.removePointer();
       });
       await gesture.addPointer();
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, selectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(selectedItem.label)));
       await tester.pump();
 
       expect(
@@ -384,7 +386,7 @@ void main() {
       );
 
       // Hover a non-selected item.
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, nonSelectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(nonSelectedItem.label)));
       await tester.pump();
 
       expect(
@@ -444,7 +446,7 @@ void main() {
         return gesture.removePointer();
       });
       await gesture.addPointer();
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, selectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(selectedItem.label)));
       await tester.pump();
 
       expect(
@@ -453,7 +455,7 @@ void main() {
       );
 
       // Hover a non-selected item.
-      await gesture.moveTo(tester.getCenter(find.widgetWithText(MenuItemButton, nonSelectedItem.label).last));
+      await gesture.moveTo(tester.getCenter(findMenuItemButton(nonSelectedItem.label)));
       await tester.pump();
 
       expect(
@@ -565,7 +567,7 @@ void main() {
 
   testWidgets('Material3 - The width of the text field should always be the same as the menu view',
     (WidgetTester tester) async {
-    final ThemeData themeData = ThemeData(useMaterial3: true);
+    final ThemeData themeData = ThemeData();
     await tester.pumpWidget(
         MaterialApp(
           theme: themeData,
@@ -629,7 +631,7 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<ShortMenu>));
     await tester.pump();
     expect(find.byType(MenuItemButton), findsNWidgets(6));
-    Size buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0').last);
+    Size buttonSize = tester.getSize(findMenuItemButton('I0'));
     expect(buttonSize.width, customBigWidth);
 
     // reset test
@@ -642,7 +644,7 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<ShortMenu>));
     await tester.pump();
     expect(find.byType(MenuItemButton), findsNWidgets(6));
-    buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0').last);
+    buttonSize = tester.getSize(findMenuItemButton('I0'));
     expect(buttonSize.width, customSmallWidth);
   });
 
@@ -698,7 +700,7 @@ void main() {
     await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
 
-    Size buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0').hitTestable());
+    Size buttonSize = tester.getSize(findMenuItemButton('I0'));
     expect(buttonSize.width, 136.0);
 
     // If expandedInsets is EdgeInsets.zero, the width should be the same as its parent.
@@ -710,7 +712,7 @@ void main() {
     await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
 
-    buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0'));
+    buttonSize = tester.getSize(findMenuItemButton('I0'));
     expect(buttonSize.width, parentWidth);
 
     // If expandedInsets is not zero, the width of the text field should be adjusted
@@ -727,7 +729,7 @@ void main() {
     await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
 
-    buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0'));
+    buttonSize = tester.getSize(findMenuItemButton('I0'));
     expect(buttonSize.width, parentWidth - 35.0 - 20.0);
   });
 
@@ -762,7 +764,7 @@ void main() {
     await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
 
-    Size buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0').hitTestable());
+    Size buttonSize = tester.getSize(findMenuItemButton('I0'));
     expect(buttonSize.width, 136.0);
 
     // If expandedInsets is not zero, the width of the text field should be adjusted
@@ -779,7 +781,7 @@ void main() {
     await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
 
-    buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0'));
+    buttonSize = tester.getSize(findMenuItemButton('I0'));
     expect(buttonSize.width, parentWidth - 35.0 - 20.0);
 
     // Regression test for https://github.com/flutter/flutter/issues/151769.
@@ -797,7 +799,7 @@ void main() {
 
     await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
-    buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0'));
+    buttonSize = tester.getSize(findMenuItemButton('I0'));
     expect(buttonSize.width, parentWidth - 35.0 - 20.0);
   });
 
@@ -809,10 +811,10 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
 
-    final Element firstItem = tester.element(find.widgetWithText(MenuItemButton, 'Item 0').last);
+    final Element firstItem = tester.element(findMenuItemButton('Item 0'));
     final RenderBox firstBox = firstItem.renderObject! as RenderBox;
     final Offset topLeft = firstBox.localToGlobal(firstBox.size.topLeft(Offset.zero));
-    final Element lastItem = tester.element(find.widgetWithText(MenuItemButton, 'Item 5').last);
+    final Element lastItem = tester.element(findMenuItemButton('Item 5'));
     final RenderBox lastBox = lastItem.renderObject! as RenderBox;
     final Offset bottomRight = lastBox.localToGlobal(lastBox.size.bottomRight(Offset.zero));
     // height = height of MenuItemButton * 6 = 48 * 6
@@ -844,16 +846,16 @@ void main() {
 
   testWidgets('Material3 - The menuHeight property can be used to show a shorter scrollable menu list instead of the complete list',
     (WidgetTester tester) async {
-  final ThemeData themeData = ThemeData(useMaterial3: true);
+  final ThemeData themeData = ThemeData();
   await tester.pumpWidget(buildTest(themeData, menuChildren));
 
   await tester.tap(find.byType(DropdownMenu<TestMenu>));
   await tester.pumpAndSettle();
 
-  final Element firstItem = tester.element(find.widgetWithText(MenuItemButton, 'Item 0').last);
+  final Element firstItem = tester.element(findMenuItemButton('Item 0'));
   final RenderBox firstBox = firstItem.renderObject! as RenderBox;
   final Offset topLeft = firstBox.localToGlobal(firstBox.size.topLeft(Offset.zero));
-  final Element lastItem = tester.element(find.widgetWithText(MenuItemButton, 'Item 5').last);
+  final Element lastItem = tester.element(findMenuItemButton('Item 5'));
   final RenderBox lastBox = lastItem.renderObject! as RenderBox;
   final Offset bottomRight = lastBox.localToGlobal(lastBox.size.bottomRight(Offset.zero));
   // height = height of MenuItemButton * 6 = 48 * 6
@@ -915,7 +917,7 @@ void main() {
 
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
-    final Finder updatedItemText = find.text('Item 0').last;
+    final Finder updatedItemText = find.text('Item 0').first;
     final Offset updatedItemTextTopLeft = tester.getTopLeft(updatedItemText);
 
     expect(updatedLabelTopLeft.dx, equals(updatedItemTextTopLeft.dx));
@@ -937,7 +939,7 @@ void main() {
 
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
-    final Finder updatedItemText1 = find.text('Item 0').last;
+    final Finder updatedItemText1 = find.text('Item 0').first;
     final Offset updatedItemTextTopLeft1 = tester.getTopLeft(updatedItemText1);
 
     expect(updatedLabelTopLeft1.dx, equals(updatedItemTextTopLeft1.dx));
@@ -996,7 +998,7 @@ void main() {
 
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
-    final Finder updatedItemText = find.text('Item 0').last;
+    final Finder updatedItemText = find.text('Item 0').first;
     final Offset updatedItemTextTopRight = tester.getTopRight(updatedItemText);
 
     expect(updatedLabelTopRight.dx, equals(updatedItemTextTopRight.dx));
@@ -1027,7 +1029,7 @@ void main() {
 
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
-    final Finder updatedItemText1 = find.text('Item 0').last;
+    final Finder updatedItemText1 = find.text('Item 0').first;
     final Offset updatedItemTextTopRight1 = tester.getTopRight(updatedItemText1);
 
     expect(updatedLabelTopRight1.dx, equals(updatedItemTextTopRight1.dx));
@@ -1046,14 +1048,14 @@ void main() {
     await tester.pump();
 
     final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(MenuItemButton, TestMenu.mainMenu0.label),
+      of: findMenuItemButton(TestMenu.mainMenu0.label),
       matching: find.byType(Material),
     ).last;
     expect(menuMaterial, findsOneWidget);
   });
 
-  testWidgets('Leading IconButton status test', (WidgetTester tester) async {
-    final ThemeData themeData = ThemeData(useMaterial3: true);
+  testWidgets('Trailing IconButton status test', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData();
     await tester.pumpWidget(buildTest(themeData, menuChildren, width: 100.0, menuHeight: 100.0));
     await tester.pump();
 
@@ -1072,6 +1074,7 @@ void main() {
 
     // Tap outside
     await tester.tapAt(const Offset(500.0, 500.0));
+    await tester.pump();
     await tester.pump();
 
     iconButton = find.widgetWithIcon(IconButton, Icons.arrow_drop_up);
@@ -1103,11 +1106,7 @@ void main() {
     await tester.tap(iconButton);
     await tester.pump();
 
-    final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(MenuItemButton, TestMenu.mainMenu0.label),
-      matching: find.byType(Material),
-    );
-    expect(menuMaterial, findsNWidgets(3));
+    expect(findMenuItemButton(TestMenu.mainMenu0.label), findsOne);
 
     // didChangeMetrics
     tester.view.physicalSize = const Size(700.0, 700.0);
@@ -1136,7 +1135,7 @@ void main() {
     await tester.pump();
 
     final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(MenuItemButton, TestMenu.mainMenu0.label),
+      of: findMenuItemButton(TestMenu.mainMenu0.label),
       matching: find.byType(Material),
     ).last;
     expect(menuMaterial, findsOneWidget);
@@ -1777,18 +1776,18 @@ void main() {
     expect(controller.text, 'item');
     await tester.pumpAndSettle();
     for (final TestMenu menu in TestMenu.values) {
-      expect(find.widgetWithText(MenuItemButton, menu.label).hitTestable(), findsNothing);
+      expect(findMenuItemButton(menu.label).hitTestable(), findsNothing);
     }
 
     await tester.enterText(find.byType(TextField).first, 'Item');
     expect(controller.text, 'Item');
     await tester.pumpAndSettle();
-    expect(find.widgetWithText(MenuItemButton, 'Item 0').hitTestable(), findsOneWidget);
-    expect(find.widgetWithText(MenuItemButton, 'Menu 1').hitTestable(), findsNothing);
-    expect(find.widgetWithText(MenuItemButton, 'Item 2').hitTestable(), findsOneWidget);
-    expect(find.widgetWithText(MenuItemButton, 'Item 3').hitTestable(), findsOneWidget);
-    expect(find.widgetWithText(MenuItemButton, 'Item 4').hitTestable(), findsOneWidget);
-    expect(find.widgetWithText(MenuItemButton, 'Item 5').hitTestable(), findsOneWidget);
+    expect(findMenuItemButton('Item 0').hitTestable(), findsOneWidget);
+    expect(findMenuItemButton('Menu 1').hitTestable(), findsNothing);
+    expect(findMenuItemButton('Item 2').hitTestable(), findsOneWidget);
+    expect(findMenuItemButton('Item 3').hitTestable(), findsOneWidget);
+    expect(findMenuItemButton('Item 4').hitTestable(), findsOneWidget);
+    expect(findMenuItemButton('Item 5').hitTestable(), findsOneWidget);
   });
 
   testWidgets('Throw assertion error when enable filtering with custom filter callback and enableFilter set on False', (WidgetTester tester) async {
@@ -1837,7 +1836,7 @@ void main() {
     // Open the menu
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
-    final Finder item3 = find.widgetWithText(MenuItemButton, 'Item 3').last;
+    final Finder item3 = findMenuItemButton('Item 3');
     await tester.tap(item3);
     await tester.pumpAndSettle();
 
@@ -1932,14 +1931,14 @@ void main() {
     }
 
     // Disabled item doesn't trigger onSelected callback.
-    final Finder item1 = find.widgetWithText(MenuItemButton, 'Item 1').last;
+    final Finder item1 = findMenuItemButton('Item 1');
     await tester.tap(item1);
     await tester.pumpAndSettle();
 
     expect(controller.text, isMobile ? '' : 'Item 0');
     expect(selectionCount, expectedCount);
 
-    final Finder item2 = find.widgetWithText(MenuItemButton, 'Item 2').last;
+    final Finder item2 = findMenuItemButton('Item 2');
     await tester.tap(item2);
     await tester.pumpAndSettle();
 
@@ -1948,7 +1947,7 @@ void main() {
 
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
-    final Finder item3 = find.widgetWithText(MenuItemButton, 'Item 3').last;
+    final Finder item3 = findMenuItemButton('Item 3');
     await tester.tap(item3);
     await tester.pumpAndSettle();
 
@@ -2113,7 +2112,7 @@ void main() {
       await tester.pump();
 
       // Select another item.
-      final Finder item2 = find.widgetWithText(MenuItemButton, 'Item 2').last;
+      final Finder item2 = findMenuItemButton('Item 2');
       await tester.tap(item2);
       await tester.pumpAndSettle();
       expect(controller.text, TestMenu.mainMenu2.label);
@@ -2207,9 +2206,9 @@ void main() {
     await tester.tap(textFieldFinder);
     await tester.pump();
     // Make a selection.
-    await tester.tap(find.widgetWithText(MenuItemButton, 'Item 0').last);
+    await tester.tap(findMenuItemButton('Item 0'));
     await tester.pump();
-    expect(find.widgetWithText(TextField, 'Item 0'), findsOneWidget);
+    expect(findMenuItemButton('Item 0'), findsOneWidget);
 
     // Set requestFocusOnTap to false.
     await tester.pumpWidget(Container());
@@ -2223,7 +2222,7 @@ void main() {
     await tester.tap(textFieldFinder1);
     await tester.pump();
     // Make a selection.
-    await tester.tap(find.widgetWithText(MenuItemButton, 'Item 0').last);
+    await tester.tap(findMenuItemButton('Item 0'));
     await tester.pump();
     expect(find.widgetWithText(TextField, 'Item 0'), findsOneWidget);
   }, variant: TargetPlatformVariant.all());
@@ -2403,7 +2402,7 @@ void main() {
 
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(MenuItemButton, 'Item 3').last);
+    await tester.tap(findMenuItemButton('Item 3'));
     await tester.pumpAndSettle();
     expect(selectedValue?.label, 'Item 3');
     expect(node.label, '');
@@ -2554,7 +2553,6 @@ void main() {
       decoration: TextDecoration.underline,
     );
     final ThemeData themeData = ThemeData(
-      useMaterial3: true,
       textTheme: const TextTheme(
         bodyLarge: inputTextThemeStyle,
         labelLarge: menuItemTextThemeStyle,
@@ -2573,13 +2571,8 @@ void main() {
     await tester.tap(find.widgetWithIcon(IconButton, Icons.arrow_drop_down).first);
     await tester.pump();
 
-    final Finder buttonMaterial = find.descendant(
-      of: find.byType(TextButton),
-      matching: find.byType(Material),
-    ).last;
-
     // Test menu item text style uses the TextTheme.labelLarge.
-    final Material material = tester.widget<Material>(buttonMaterial);
+    final Material material = getButtonMaterial(tester, TestMenu.mainMenu0.label);
     expect(material.textStyle?.fontSize, menuItemTextThemeStyle.fontSize);
     expect(material.textStyle?.fontStyle, menuItemTextThemeStyle.fontStyle);
     expect(material.textStyle?.wordSpacing, menuItemTextThemeStyle.wordSpacing);
@@ -2616,7 +2609,7 @@ void main() {
     Finder findMenuItemText(String label) {
       final String labelText = '$label $longText';
       return find.descendant(
-        of: find.widgetWithText(MenuItemButton, labelText),
+        of: findMenuItemButton(labelText),
         matching: find.byType(Text),
       ).last;
     }
@@ -2660,7 +2653,7 @@ void main() {
     Finder findMenuItemText(String label) {
       final String labelText = '$label $longText';
       return find.descendant(
-        of: find.widgetWithText(MenuItemButton, labelText),
+        of: findMenuItemButton(labelText),
         matching: find.byType(Text),
       ).last;
     }
@@ -2723,11 +2716,11 @@ void main() {
     expect(tester.getTopLeft(find.text('Hint')).dx, 48.0);
 
     // By default, the text of item 0 should be aligned with the text of the text field.
-    expect(tester.getTopLeft(find.text('Item 0').last).dx, 48.0);
+    expect(tester.getTopLeft(find.text('Item 0').first).dx, 48.0);
 
     // By default, the text of item 1 should be aligned with the text of the text field,
     // so there are some extra padding before "Item 1".
-    expect(tester.getTopLeft(find.text('Item 1').last).dx, 48.0);
+    expect(tester.getTopLeft(find.text('Item 1').first).dx, 48.0);
   });
 
   testWidgets('DropdownMenu can have customized search algorithm', (WidgetTester tester) async {
@@ -2752,7 +2745,7 @@ void main() {
     void checkExpectedHighlight({String? searchResult, required List<String> otherItems}) {
       if (searchResult != null) {
         final Finder material = find.descendant(
-          of: find.widgetWithText(MenuItemButton, searchResult).last,
+          of: findMenuItemButton(searchResult),
           matching: find.byType(Material),
         );
         final Material itemMaterial = tester.widget<Material>(material);
@@ -2761,7 +2754,7 @@ void main() {
 
       for (final String nonHighlight in otherItems) {
         final Finder material = find.descendant(
-          of: find.widgetWithText(MenuItemButton, nonHighlight).last,
+          of: findMenuItemButton(nonHighlight),
           matching: find.byType(Material),
         );
         final Material itemMaterial = tester.widget<Material>(material);
@@ -2852,7 +2845,7 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
-    final Finder item1 = find.widgetWithText(MenuItemButton, 'Item 0').last;
+    final Finder item1 = findMenuItemButton('Item 0');
     await tester.tap(item1);
     await tester.pumpAndSettle();
 
@@ -2903,7 +2896,7 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
-    final Finder item1 = find.widgetWithText(MenuItemButton, 'Item 0').last;
+    final Finder item1 = findMenuItemButton('Item 0');
     await tester.tap(item1);
     await tester.pumpAndSettle();
 
@@ -3006,14 +2999,19 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/131120.
   testWidgets('Focus traversal ignores non visible entries', (WidgetTester tester) async {
-    final FocusNode buttonFocusNode = FocusNode();
+    final FocusNode buttonFocusNode = FocusNode(debugLabel: 'buttonFocusNode');
+    final FocusNode dropdownFocusNode = FocusNode(debugLabel: 'dropdownFocusNode');
     addTearDown(buttonFocusNode.dispose);
+    addTearDown(dropdownFocusNode.dispose);
 
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: Column(
           children: <Widget>[
-            DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren),
+            DropdownMenu<TestMenu>(
+              focusNode: dropdownFocusNode,
+              dropdownMenuEntries: menuChildren,
+            ),
             ElevatedButton(
               focusNode: buttonFocusNode,
               onPressed: () {},
@@ -3026,9 +3024,9 @@ void main() {
 
     // Move the focus to the text field.
     primaryFocus!.nextFocus();
+
     await tester.pump();
-    final Element textField = tester.element(find.byType(TextField));
-    expect(Focus.of(textField).hasFocus, isTrue);
+    expect(dropdownFocusNode.hasFocus, isTrue);
 
     // Move the focus to the dropdown trailing icon.
     primaryFocus!.nextFocus();
@@ -3283,7 +3281,7 @@ void main() {
     }
 
     // Selecting an item would disable filter again.
-    await tester.tap(find.widgetWithText(MenuItemButton, 'Menu 1').last);
+    await tester.tap(findMenuItemButton('Menu 1'));
     await tester.pumpAndSettle();
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
@@ -3486,7 +3484,7 @@ void main() {
     expect(dropdownMenuAnchor.controller!.isOpen, true);
 
     // Tap the dropdown menu item.
-    await tester.tap(find.widgetWithText(MenuItemButton, TestMenu.mainMenu0.label).last);
+    await tester.tap(findMenuItemButton(TestMenu.mainMenu0.label));
     await tester.pumpAndSettle();
     // All menus should be closed.
     expect(find.byType(DropdownMenu<TestMenu>), findsNothing);
@@ -3507,7 +3505,7 @@ void main() {
     expect(dropdownMenuAnchor.controller!.isOpen, true);
 
     // Tap the menu item to open the dropdown menu.
-    await tester.tap(find.widgetWithText(MenuItemButton, TestMenu.mainMenu0.label).last);
+    await tester.tap(findMenuItemButton(TestMenu.mainMenu0.label));
     await tester.pumpAndSettle();
     // Only the dropdown menu should be closed.
     expect(dropdownMenuAnchor.controller!.isOpen, false);
@@ -3527,10 +3525,100 @@ void main() {
     expect(dropdownMenuAnchor.controller!.isOpen, true);
 
     // Tap the dropdown menu item.
-    await tester.tap(find.widgetWithText(MenuItemButton, TestMenu.mainMenu0.label).last);
+    await tester.tap(findMenuItemButton(TestMenu.mainMenu0.label));
     await tester.pumpAndSettle();
     // None of the menus should be closed.
     expect(dropdownMenuAnchor.controller!.isOpen, true);
+  });
+
+  group('The menu is attached at the bottom of the TextField', () {
+    testWidgets('when given loose constraints and expandedInsets is set', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: DropdownMenu<TestMenu>(
+            expandedInsets: EdgeInsets.zero,
+            initialSelection: TestMenu.mainMenu3,
+            dropdownMenuEntries: menuChildrenWithIcons,
+          ),
+        ),
+      ));
+
+      // Open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final double textFieldBottom = tester.getRect(find.byType(TextField)).bottom;
+      final double menuTop = tester.getRect(findMenuMaterial()).top;
+      expect(menuTop, textFieldBottom);
+    });
+
+    testWidgets('when given tight constraints and expandedInsets is set', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 200,
+            height: 300,
+            child: DropdownMenu<TestMenu>(
+              expandedInsets: EdgeInsets.zero,
+              initialSelection: TestMenu.mainMenu3,
+              dropdownMenuEntries: menuChildrenWithIcons,
+            ),
+          ),
+        ),
+      ));
+
+      // Open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final double textFieldBottom = tester.getRect(find.byType(TextField)).bottom;
+      final double menuTop = tester.getRect(findMenuMaterial()).top;
+      expect(menuTop, textFieldBottom);
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/147076.
+    testWidgets('when given loose constraints and expandedInsets is not set', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: DropdownMenu<TestMenu>(
+            initialSelection: TestMenu.mainMenu3,
+            dropdownMenuEntries: menuChildrenWithIcons,
+          ),
+        ),
+      ));
+
+      // Open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final double textFieldBottom = tester.getRect(find.byType(TextField)).bottom;
+      final double menuTop = tester.getRect(findMenuMaterial()).top;
+      expect(menuTop, textFieldBottom);
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/147076.
+    testWidgets('when given tight constraints and expandedInsets is not set', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 300,
+            child: DropdownMenu<TestMenu>(
+              initialSelection: TestMenu.mainMenu3,
+              dropdownMenuEntries: menuChildrenWithIcons,
+            ),
+          ),
+        ),
+      ));
+
+      // Open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final double textFieldBottom = tester.getRect(find.byType(TextField)).bottom;
+      final double menuTop = tester.getRect(findMenuMaterial()).top;
+      expect(menuTop, textFieldBottom);
+    });
   });
 }
 

--- a/packages/flutter/test/material/dropdown_menu_theme_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_theme_test.dart
@@ -7,6 +7,28 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  Finder findMenuItemButton(String label) {
+    // For each menu items there are two MenuItemButton widgets.
+    // The first one is the real button item in the menu.
+    // The second one is not visible, it is part of _DropdownMenuBody
+    // which is used to compute the dropdown width.
+    return find.widgetWithText(MenuItemButton, label).first;
+  }
+
+  Material getButtonMaterial(WidgetTester tester, String itemLabel) {
+    return tester.widget<Material>(find.descendant(
+      of: findMenuItemButton(itemLabel),
+      matching: find.byType(Material),
+    ));
+  }
+
+  Material getMenuMaterial(WidgetTester tester) {
+    return tester.widget<Material>(find.ancestor(
+      of: find.byType(TextButton).first,
+      matching: find.byType(Material),
+    ).first);
+  }
+
   test('DropdownMenuThemeData copyWith, ==, hashCode basics', () {
     expect(const DropdownMenuThemeData(), const DropdownMenuThemeData().copyWith());
     expect(const DropdownMenuThemeData().hashCode, const DropdownMenuThemeData().copyWith().hashCode);
@@ -76,23 +98,14 @@ void main() {
     await tester.pump();
     expect(find.byType(MenuAnchor), findsOneWidget);
 
-    final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(TextButton, 'Item 0'),
-      matching: find.byType(Material),
-    ).at(1);
-    Material material = tester.widget<Material>(menuMaterial);
+    Material material = getMenuMaterial(tester);
     expect(material.color, themeData.colorScheme.surfaceContainer);
     expect(material.shadowColor, themeData.colorScheme.shadow);
     expect(material.surfaceTintColor, Colors.transparent);
     expect(material.elevation, 3.0);
     expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))));
 
-    final Finder buttonMaterial = find.descendant(
-      of: find.widgetWithText(TextButton, 'Item 0'),
-      matching: find.byType(Material),
-    ).last;
-
-    material = tester.widget<Material>(buttonMaterial);
+    material = getButtonMaterial(tester, 'Item 0');
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
     expect(material.shape, const RoundedRectangleBorder());
@@ -155,23 +168,14 @@ void main() {
     await tester.pump();
     expect(find.byType(MenuAnchor), findsOneWidget);
 
-    final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(TextButton, 'Item 0'),
-      matching: find.byType(Material),
-    ).at(1);
-    Material material = tester.widget<Material>(menuMaterial);
+    Material material = getMenuMaterial(tester);
     expect(material.color, Colors.grey);
     expect(material.shadowColor, Colors.brown);
     expect(material.surfaceTintColor, Colors.amberAccent);
     expect(material.elevation, 10.0);
     expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))));
 
-    final Finder buttonMaterial = find.descendant(
-      of: find.widgetWithText(TextButton, 'Item 0'),
-      matching: find.byType(Material),
-    ).last;
-
-    material = tester.widget<Material>(buttonMaterial);
+    material = getButtonMaterial(tester, 'Item 0');
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
     expect(material.shape, const RoundedRectangleBorder());
@@ -258,23 +262,14 @@ void main() {
     await tester.pump();
     expect(find.byType(MenuAnchor), findsOneWidget);
 
-    final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(TextButton, 'Item 0'),
-      matching: find.byType(Material),
-    ).at(1);
-    Material material = tester.widget<Material>(menuMaterial);
+    Material material = getMenuMaterial(tester);
     expect(material.color, Colors.yellow);
     expect(material.shadowColor, Colors.green);
     expect(material.surfaceTintColor, Colors.teal);
     expect(material.elevation, 15.0);
     expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0))));
 
-    final Finder buttonMaterial = find.descendant(
-      of: find.widgetWithText(TextButton, 'Item 0'),
-      matching: find.byType(Material),
-    ).last;
-
-    material = tester.widget<Material>(buttonMaterial);
+    material = getButtonMaterial(tester, 'Item 0');
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
     expect(material.shape, const RoundedRectangleBorder());
@@ -379,23 +374,14 @@ void main() {
     await tester.pump();
     expect(find.byType(MenuAnchor), findsOneWidget);
 
-    final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(TextButton, 'Item 0'),
-      matching: find.byType(Material),
-    ).at(1);
-    Material material = tester.widget<Material>(menuMaterial);
+    Material material = getMenuMaterial(tester);
     expect(material.color, Colors.limeAccent);
     expect(material.shadowColor, Colors.deepOrangeAccent);
     expect(material.surfaceTintColor, Colors.lightBlue);
     expect(material.elevation, 21.0);
     expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(15.0))));
 
-    final Finder buttonMaterial = find.descendant(
-      of: find.widgetWithText(TextButton, 'Item 0'),
-      matching: find.byType(Material),
-    ).last;
-
-    material = tester.widget<Material>(buttonMaterial);
+    material = getButtonMaterial(tester, 'Item 0');
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
     expect(material.shape, const RoundedRectangleBorder());


### PR DESCRIPTION
## Description

This PR fixes `DropdownMenu`  menu vertical position when tight constraints are given to the `DropdownMenu`.

Before:

![image](https://github.com/user-attachments/assets/d8d9b857-07ed-4d3c-afe2-44518d979e66)

After:

![image](https://github.com/user-attachments/assets/a71ea3c8-a408-43a1-8c99-c2612ad4b24b)



## Related Issue

Fixes the minHeight part of [DropdownMenu does not correctly handle incoming maxWidth and minHeight constraints](https://github.com/flutter/flutter/issues/147076).
(The maxWidth part was already fixed in https://github.com/flutter/flutter/pull/147233).

## Tests

Adds 4 tests.
Refactors many existing tests.
