### PR TITLE
Add test for `build_owner.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -318,7 +318,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/navigator/restorable_route_future.0_test.dart',
   'examples/api/test/widgets/navigator/navigator_state.restorable_push.0_test.dart',
   'examples/api/test/widgets/focus_manager/focus_node.unfocus.0_test.dart',
-  'examples/api/test/widgets/framework/build_owner.0_test.dart',
   'examples/api/test/widgets/nested_scroll_view/nested_scroll_view_state.0_test.dart',
   'examples/api/test/widgets/scroll_position/scroll_metrics_notification.0_test.dart',
   'examples/api/test/widgets/media_query/media_query_data.system_gesture_insets.0_test.dart',

--- a/examples/api/lib/widgets/framework/build_owner.0.dart
+++ b/examples/api/lib/widgets/framework/build_owner.0.dart
@@ -8,12 +8,33 @@ import 'package:flutter/rendering.dart';
 /// Flutter code sample for [BuildOwner].
 
 void main() {
-  WidgetsFlutterBinding.ensureInitialized();
-  final Size size = measureWidget(const SizedBox(width: 640, height: 480));
-
-  // Just displays the size calculated above.
   runApp(
-    WidgetsApp(
+    const BuildOwnerExample(),
+  );
+}
+
+class BuildOwnerExample extends StatefulWidget {
+  const BuildOwnerExample({
+    super.key,
+  });
+
+  @override
+  State<BuildOwnerExample> createState() => _BuildOwnerExampleState();
+}
+
+class _BuildOwnerExampleState extends State<BuildOwnerExample> {
+  late final Size size;
+
+  @override
+  void initState() {
+    super.initState();
+    size = measureWidget(const SizedBox(width: 640, height: 480));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Just displays the size calculated above.
+    return WidgetsApp(
       title: 'BuildOwner Sample',
       color: const Color(0xff000000),
       builder: (BuildContext context, Widget? child) {
@@ -23,8 +44,8 @@ void main() {
           ),
         );
       },
-    ),
-  );
+    );
+  }
 }
 
 Size measureWidget(Widget widget) {

--- a/examples/api/test/widgets/framework/build_owner.0_test.dart
+++ b/examples/api/test/widgets/framework/build_owner.0_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/framework/build_owner.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('BuildOwnerExample displays the measured size', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.BuildOwnerExample());
+
+    expect(find.text('Size(640.0, 480.0)'), findsOne);
+  });
+
+  test('The size of the widget is measured', () {
+    expect(
+      example.measureWidget(const SizedBox(width: 234, height: 567)),
+      const Size(234, 567),
+    );
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/framework/build_owner.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
