### PR TITLE
Allow opting out of `.flutter-plugins`, opt-out in `refreshPluginsList`.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1010,13 +1010,14 @@ Future<void> refreshPluginsList(
   bool iosPlatform = false,
   bool macOSPlatform = false,
   bool forceCocoaPodsOnly = false,
+  bool writeLegacyPluginsList = true,
 }) async {
   final List<Plugin> plugins = await findPlugins(project);
   // Sort the plugins by name to keep ordering stable in generated files.
   plugins.sort((Plugin left, Plugin right) => left.name.compareTo(right.name));
-  // TODO(franciscojma): Remove once migration is complete.
+  // TODO(matanlurey): Remove once migration is complete.
   // Write the legacy plugin files to avoid breaking existing apps.
-  final bool legacyChanged = _writeFlutterPluginsListLegacy(project, plugins);
+  final bool legacyChanged = writeLegacyPluginsList && _writeFlutterPluginsListLegacy(project, plugins);
 
   final bool changed = _writeFlutterPluginsList(
     project,

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1132,7 +1132,7 @@ Future<void> injectPlugins(
 ///
 /// Assumes [refreshPluginsList] has been called since last change to `pubspec.yaml`.
 bool hasPlugins(FlutterProject project) {
-  return _readFileContent(project.flutterPluginsFile) != null;
+  return _readFileContent(project.flutterPluginsDependenciesFile) != null;
 }
 
 /// Resolves the plugin implementations for all platforms.

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -32,10 +32,10 @@ Future<void> processPodsIfNeeded(
     macOSPlatform: project.macos.existsSync(),
     forceCocoaPodsOnly: forceCocoaPodsOnly,
     // TODO(matanlurey): As-per discussion on https://github.com/flutter/flutter/pull/157393
-    // we'll assume that iOS/MacOS builds do not use or rely on the `.flutter-plugins` legacy
-    // file being generated. A better long-term fix would be not to have a call to refreshPluginsList
-    // at all, and instead have it implicitly run by the FlutterCommand instead. See
-    // https://github.com/flutter/flutter/issues/157391 for details.
+    //  we'll assume that iOS/MacOS builds do not use or rely on the `.flutter-plugins` legacy
+    //  file being generated. A better long-term fix would be not to have a call to refreshPluginsList
+    //  at all, and instead have it implicitly run by the FlutterCommand instead. See
+    //  https://github.com/flutter/flutter/issues/157391 for details.
     writeLegacyPluginsList: false,
   );
 

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -31,6 +31,12 @@ Future<void> processPodsIfNeeded(
     iosPlatform: project.ios.existsSync(),
     macOSPlatform: project.macos.existsSync(),
     forceCocoaPodsOnly: forceCocoaPodsOnly,
+    // TODO(matanlurey): As-per discussion on https://github.com/flutter/flutter/pull/157393
+    // we'll assume that iOS/MacOS builds do not use or rely on the `.flutter-plugins` legacy
+    // file being generated. A better long-term fix would be not to have a call to refreshPluginsList
+    // at all, and instead have it implicitly run by the FlutterCommand instead. See
+    // https://github.com/flutter/flutter/issues/157391 for details.
+    writeLegacyPluginsList: false,
   );
 
   // If there are no plugins and if the project is a not module with an existing

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -448,6 +448,20 @@ dependencies:
         ProcessManager: () => FakeProcessManager.any(),
       });
 
+      testUsingContext('Opting out of writeLegacyPluginsList omits .flutter-plugins', () async {
+        createFakePlugins(fs, <String>[
+          'plugin_d',
+          'plugin_a',
+          '/local_plugins/plugin_c',
+          '/local_plugins/plugin_b',
+        ]);
+
+        await refreshPluginsList(flutterProject, writeLegacyPluginsList: false);
+
+        expect(flutterProject.flutterPluginsFile.existsSync(), false);
+        expect(flutterProject.flutterPluginsDependenciesFile.existsSync(), true);
+      });
+
       testUsingContext(
         'Refreshing the plugin list modifies .flutter-plugins '
         'and .flutter-plugins-dependencies when there are plugins', () async {

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -458,8 +458,8 @@ dependencies:
 
         await refreshPluginsList(flutterProject, writeLegacyPluginsList: false);
 
-        expect(flutterProject.flutterPluginsFile.existsSync(), false);
-        expect(flutterProject.flutterPluginsDependenciesFile.existsSync(), true);
+        expect(flutterProject.flutterPluginsFile, isNot(exists));
+        expect(flutterProject.flutterPluginsDependenciesFile, exists);
       });
 
       testUsingContext(


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/48918.

Workaround for https://github.com/flutter/flutter/issues/157391 (see https://github.com/flutter/flutter/pull/157393#issuecomment-2434336047).

I'll run all post-submit tasks as well on this PR using `test: all`.