### PR TITLE
Use `.flutter-plugin-dependencies` to decide if plugins exist in a project.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1010,13 +1010,14 @@ Future<void> refreshPluginsList(
   bool iosPlatform = false,
   bool macOSPlatform = false,
   bool forceCocoaPodsOnly = false,
+  bool writeLegacyPluginsList = true,
 }) async {
   final List<Plugin> plugins = await findPlugins(project);
   // Sort the plugins by name to keep ordering stable in generated files.
   plugins.sort((Plugin left, Plugin right) => left.name.compareTo(right.name));
-  // TODO(franciscojma): Remove once migration is complete.
+  // TODO(matanlurey): Remove once migration is complete.
   // Write the legacy plugin files to avoid breaking existing apps.
-  final bool legacyChanged = _writeFlutterPluginsListLegacy(project, plugins);
+  final bool legacyChanged = writeLegacyPluginsList && _writeFlutterPluginsListLegacy(project, plugins);
 
   final bool changed = _writeFlutterPluginsList(
     project,

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1132,7 +1132,7 @@ Future<void> injectPlugins(
 ///
 /// Assumes [refreshPluginsList] has been called since last change to `pubspec.yaml`.
 bool hasPlugins(FlutterProject project) {
-  return _readFileContent(project.flutterPluginsFile) != null;
+  return _readFileContent(project.flutterPluginsDependenciesFile) != null;
 }
 
 /// Resolves the plugin implementations for all platforms.

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -31,6 +31,12 @@ Future<void> processPodsIfNeeded(
     iosPlatform: project.ios.existsSync(),
     macOSPlatform: project.macos.existsSync(),
     forceCocoaPodsOnly: forceCocoaPodsOnly,
+    // TODO(matanlurey): As-per discussion on https://github.com/flutter/flutter/pull/157393
+    // we'll assume that iOS/MacOS builds do not use or rely on the `.flutter-plugins` legacy
+    // file being generated. A better long-term fix would be not to have a call to refreshPluginsList
+    // at all, and instead have it implicitly run by the FlutterCommand instead. See
+    // https://github.com/flutter/flutter/issues/157391 for details.
+    writeLegacyPluginsList: false,
   );
 
   // If there are no plugins and if the project is a not module with an existing

--- a/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
@@ -86,6 +86,7 @@ void main() {
             ..writeAsStringSync(pluginYamlTemplate.replaceAll('PLUGIN_CLASS', name));
       }
 
+      flutterProject.flutterPluginsDependenciesFile.createSync();
       packageConfigFile.writeAsStringSync(jsonEncode(packageConfig));
     }
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -448,6 +448,20 @@ dependencies:
         ProcessManager: () => FakeProcessManager.any(),
       });
 
+      testUsingContext('Opting out of writeLegacyPluginsList omits .flutter-plugins', () async {
+        createFakePlugins(fs, <String>[
+          'plugin_d',
+          'plugin_a',
+          '/local_plugins/plugin_c',
+          '/local_plugins/plugin_b',
+        ]);
+
+        await refreshPluginsList(flutterProject, writeLegacyPluginsList: false);
+
+        expect(flutterProject.flutterPluginsFile.existsSync(), false);
+        expect(flutterProject.flutterPluginsDependenciesFile.existsSync(), true);
+      });
+
       testUsingContext(
         'Refreshing the plugin list modifies .flutter-plugins '
         'and .flutter-plugins-dependencies when there are plugins', () async {


### PR DESCRIPTION
Unblocks https://github.com/flutter/flutter/pull/157527, work towards https://github.com/flutter/flutter/issues/48918.

`.flutter-plugins-dependencies` has existed since ~2019, and `.flutter-plugins` is deprecated. Right now the tool writes both files, so switching from one (to the other) is a non-breaking change - the only change that was required is a fairly esoteric (custom) test fixture that was trying to mimic the results of the file system as the tool runs that needed to be updated.