### PR TITLE
Use discenrable characters (replace `' 🙙 🙛 '` in error logs)

### DIFF
--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -177,16 +177,16 @@ Never reportErrorsAndExit(String message) {
   _hideTimer = null;
   print('$clock $message$reset');
   print(redLine);
-  print('${red}For your convenience, the error messages reported above are repeated here:$reset');
+  print('${red}The error messages reported above are repeated here:$reset');
   final bool printSeparators = _errorMessages.any((List<String> messages) => messages.length > 1);
   if (printSeparators) {
-    print('  🙙  🙛  ');
+    print('  -- This line intentionally left blank --  ');
   }
   for (int index = 0; index < _errorMessages.length * 2 - 1; index += 1) {
     if (index.isEven) {
       _errorMessages[index ~/ 2].forEach(print);
     } else if (printSeparators) {
-      print('  🙙  🙛  ');
+      print('  -- This line intentionally left blank --  ');
     }
   }
   print(redLine);


### PR DESCRIPTION
Fixes an annoyance of mine where I stare at two boxes in the logs and have to guess if they are part of the real output:

<img width="795" alt="Screenshot 2024-10-24 at 12 47 58 PM" src="https://github.com/user-attachments/assets/a986f71c-5533-4899-aeb8-126dc82794fb">

Related to https://github.com/flutter/flutter/issues/157542#issuecomment-2436083676.