### PR TITLE
Fix double tap in a11y mode moves thumb to the center of the `Slider`

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -33,6 +33,8 @@ import 'theme.dart';
 // int _duelCommandment = 1;
 // void setState(VoidCallback fn) { }
 
+const Duration _minimumInteractionTime = Duration(milliseconds: 500);
+
 /// [Slider] uses this callback to paint the value indicator on the overlay.
 ///
 /// Since the value indicator is painted on the Overlay; this method paints the
@@ -943,6 +945,23 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     return Semantics(
       container: true,
       slider: true,
+      onTap: _enabled
+        ? () {
+            setState(() {
+              _focused = true;
+            });
+            overlayController.forward();
+            interactionTimer?.cancel();
+            interactionTimer = Timer(_minimumInteractionTime * timeDilation, () {
+              interactionTimer = null;
+              overlayController.reverse();
+              // Reset the focused state after the overlay has fully disappeared.
+              setState(() {
+                _focused = false;
+              });
+            });
+          }
+        : null,
       onDidGainAccessibilityFocus: handleDidGainAccessibilityFocus,
       child: FocusableActionDetector(
         actions: _actionMap,
@@ -1156,7 +1175,6 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
   static const Duration _positionAnimationDuration = Duration(milliseconds: 75);
-  static const Duration _minimumInteractionTime = Duration(milliseconds: 500);
 
   // This value is the touch target, 48, multiplied by 3.
   static const double _minPreferredTrackWidth = 144.0;


### PR DESCRIPTION
Fixes [[A11y] Double Tap brings the `Slider` thumb to the center of the widget. ](https://github.com/flutter/flutter/issues/156427)

### Description

When double tapping in talkback or voice over mode on mobile platform, the `Slider` thumb moves to the center of the widget and changes the Slider value unexpectedly. When the user expects to swipe or down to adjust the `Slider` thumb. When tapping the `Slider` should show overlay for 500 milliseconds to bring attention instead of the moving the thumb to the center of the widget. 

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatefulWidget {
  const MyApp({super.key});

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  double _sliderValue = 0.2;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(brightness: Brightness.dark),
      home: Scaffold(
        body: Center(
          child: Padding(
            padding: const EdgeInsets.symmetric(horizontal: 16),
            child: IntrinsicHeight(
              child: Slider(
                value: _sliderValue,
                onChanged: (double value) {
                  setState(() {
                    _sliderValue = value;
                  });
                },
              ),
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>

> Note: Semantic node size is known issue aka green box in the demos.

### Before
The demo uses swipe up and down gesture to adjust the `Slider`. However, when double tapped the thumb unexpectedly moves to the center of the widget.


https://github.com/user-attachments/assets/f2764712-dbec-46cd-9087-00985534ad3f



### After
The demo uses swipe up and down gesture to adjust the `Slider`. When double tapped the overlay is shown briefly.


https://github.com/user-attachments/assets/27235a76-edf4-4a6f-ba9d-6d283986c556

### Android Components



https://github.com/user-attachments/assets/e6e0f312-98a2-4748-8127-eac1d899f82c




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
