### PR TITLE
Fix and remove a few `no-shuffle` tags in `flutter_tools`.

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -38,7 +38,7 @@ void main() {
 
   setUpAll(() {
     Cache.disableLocking();
-  });  
+  });
 
   group('packages get/upgrade', () {
     late Directory tempDir;

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -28,7 +28,7 @@ import '../../src/test_flutter_command_runner.dart';
 
 void main() {
   late FakeStdio mockStdio;
-  
+
   setUp(() {
     mockStdio = FakeStdio()..stdout.terminalColumns = 80;
 

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=1000"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -35,12 +28,18 @@ import '../../src/test_flutter_command_runner.dart';
 
 void main() {
   late FakeStdio mockStdio;
-
+  
   setUp(() {
     mockStdio = FakeStdio()..stdout.terminalColumns = 80;
+
+    // Some tests below override this with a blank root, always reset it.
+    Cache.flutterRoot = null;
   });
 
-  Cache.disableLocking();
+  setUpAll(() {
+    Cache.disableLocking();
+  });  
+
   group('packages get/upgrade', () {
     late Directory tempDir;
     late FakeAnalytics fakeAnalytics;

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=1000"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/packages/flutter_tools/test/integration.shard/test_test.dart
+++ b/packages/flutter_tools/test/integration.shard/test_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=1000"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'dart:async';
 import 'dart:convert';
 


### PR DESCRIPTION
Two of the tests, `test_test` and `break_on_framework_exceptions`, no longer appear to leak (without changes). Perhaps underlying infrastructure has changed, or some other bug in the tool itself was fixed in meantime.

`packages_test` required resetting `Cache.flutterRoot`.

Work towards https://github.com/flutter/flutter/issues/85160.