### PR TITLE
Add SharedXAxisPageTransition

### DIFF
--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -663,9 +663,9 @@ class _SharedXAxisEnterTransition extends StatelessWidget {
           // When the exit transition fades out the new page, the background
           // painted by the transition also fades out, which should reveal the
           // old page below. However, the background painted by the *enter*
-          // transition does not fade out, due to how DualTransitionBuilder
-          // works. When a page is being popped off, this background will
-          // obscure the old page, until the navigator removes the new page
+          // transition does not fade out, as exit transitions are nested in
+          // enter transitions. When a page is being popped off, this background
+          // will obscure the old page, until the navigator removes the new page
           // after the transition ended.
           //
           // Hide the background after the enter transition has completed to

--- a/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
+++ b/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
@@ -30,6 +30,8 @@ import 'page_transitions_theme.dart';
 ///    that's similar to the one provided by Android P.
 ///  * [ZoomPageTransitionsBuilder], which defines the default page transition
 ///    that's similar to the one provided in Android Q.
+///  * [SharedXAxisPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android U.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 class PredictiveBackPageTransitionsBuilder extends PageTransitionsBuilder {


### PR DESCRIPTION
This PR adds a new page transition `SharedXAxisPageTransition` that looks like the default activity transition used in Android 14 (U).

This implementation is modified from https://github.com/flutter/packages/blob/839de2d8fc97505554cefeaf552aaba86a0360e8/packages/animations/lib/src/shared_axis_transition.dart.

DartPad demo: https://dartpad.dev/?id=792fda25e3b5a5e2ee42a9972bfc06da

Resolves #142352 partially because of the following issues.

### Differences from the native implementation
#### Duration
The new transition has a duration of 450ms, which is different from the [current value] of 300ms. There's currently no way for a `PageTransitionsBuilder` to override the page transition duration, so this transition runs a bit too fast. I feel this should be addressed in another PR. (and I'm not sure how should the API be changed. `MaterialPageRouteMixin.transitionDuration` could look up the current builder class to see if it requests a different transition duration, but the predictive back builder has a fallback mechanism?)

The demo above has a duration override available for testing.

#### Edge extension
The native implementation extends the leftmost or rightmost 1 pixel wide edge of activities to 96dp when animating them, which seems to prevent the content below the activity from leaking out. As a side effect, if there are app bars/bottom navbars in a different color from the background that flush with the edge, they will be extended, too. The transition thus feels less distracting (if we ignore the scrollbar :p).

See below for a comparison, where the orange rectangles highlight the difference:

![comparison](https://github.com/user-attachments/assets/ff22a745-7cc1-45b1-9185-b739c19f7362)

---

Animation duration, fade duration, fade start offset, and slide delta X are copied from these files:
- https://android.googlesource.com/platform/frameworks/base/+/aa4b1a18da3e561653d3aed9090deb5d6cbd7c82/core/res/res/anim/activity_open_enter.xml
- https://android.googlesource.com/platform/frameworks/base/+/aa4b1a18da3e561653d3aed9090deb5d6cbd7c82/core/res/res/anim/activity_open_exit.xml
- https://android.googlesource.com/platform/frameworks/base/+/aa4b1a18da3e561653d3aed9090deb5d6cbd7c82/core/res/res/anim/activity_close_enter.xml
- https://android.googlesource.com/platform/frameworks/base/+/aa4b1a18da3e561653d3aed9090deb5d6cbd7c82/core/res/res/anim/activity_close_exit.xml

The `fast_out_extra_slow_in` interpolator:
https://android.googlesource.com/platform/frameworks/base/+/aa4b1a18da3e561653d3aed9090deb5d6cbd7c82/core/res/res/interpolator/fast_out_extra_slow_in.xml

The path looks identical to `Curves.easeInOutCubicEmphasized`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[current value]: https://github.com/flutter/flutter/blob/ece457ba74f47787524bbc6f3e3c3c3ddadae5d3/packages/flutter/lib/src/material/page.dart#L90

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
