### PR TITLE
fixed where CircularProgressIndicator looses its shape when in tight constraints

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -462,9 +462,13 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
     // as users are already familiar with.
     final double strokeOffset = strokeWidth / 2 * -strokeAlign;
     final Offset arcBaseOffset = Offset(strokeOffset, strokeOffset);
+
+    // Calculating the minumum side for circlular shape when parent have
+    // tight constraints like 'Expanded' widget.
+    final double side = math.min(size.width, size.height);
     final Size arcActualSize = Size(
-      size.width - strokeOffset * 2,
-      size.height - strokeOffset * 2,
+      side - strokeOffset * 2,
+      side - strokeOffset * 2,
     );
 
     if (backgroundColor != null) {


### PR DESCRIPTION
This PR is fixing the issue where CircularProgressIndicator would loose its circular shape when tight constraints are given like in Expanded

Issue: https://github.com/flutter/flutter/issues/157160

Before:

https://github.com/user-attachments/assets/a09cb17f-f1d6-4282-8cf2-b8f65dea6c22

After:

https://github.com/user-attachments/assets/a5c2cc53-97c8-4474-975c-8fa7e84752d5



- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.