### PR TITLE
Add test for `focus_node.unfocus.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -312,7 +312,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/color_scheme/dynamic_content_color.0_test.dart',
   'examples/api/test/widgets/navigator/navigator.restorable_push_replacement.0_test.dart',
   'examples/api/test/widgets/navigator/restorable_route_future.0_test.dart',
-  'examples/api/test/widgets/focus_manager/focus_node.unfocus.0_test.dart',
   'examples/api/test/widgets/nested_scroll_view/nested_scroll_view_state.0_test.dart',
   'examples/api/test/widgets/scroll_position/scroll_metrics_notification.0_test.dart',
   'examples/api/test/widgets/media_query/media_query_data.system_gesture_insets.0_test.dart',

--- a/examples/api/test/widgets/focus_manager/focus_node.unfocus.0_test.dart
+++ b/examples/api/test/widgets/focus_manager/focus_node.unfocus.0_test.dart
@@ -1,0 +1,90 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_api_samples/widgets/focus_manager/focus_node.unfocus.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'Unfocusing with UnfocusDisposition.scope gives the focus to the parent scope',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.UnfocusExampleApp(),
+      );
+
+      await tester.tap(find.byType(TextField).first); // Focuses the first text field.
+      await tester.pump();
+
+      // Changes the focus to the unfocus button.
+      for (int i = 0; i < 6; i++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+      }
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      // After pressing tab once, the focus is on the first text field.
+      expect(
+        find.descendant(
+          of: find.byType(TextField).first,
+          matching: find.byWidgetPredicate(
+            (Widget focus) => focus is Focus && (focus.focusNode?.hasFocus ?? false),
+          ),
+        ),
+        findsOne,
+      );
+    },
+  );
+
+  testWidgets(
+    'Unfocusing with UnfocusDisposition.previouslyFocusedChild gives the focus the previously focused child',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.UnfocusExampleApp(),
+      );
+
+      await tester.tap(find.byType(TextField).first); // Focuses the first text field.
+      await tester.pump();
+
+      // Changes the focus to the second radio button.
+      for (int i = 0; i < 5; i++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+      }
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pumpAndSettle();
+
+      // Changes the focus to the unfocus button.
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      // After pressing tab twice, the focus is on the first text field.
+      for (int i = 0; i < 2; i++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+      }
+
+      expect(
+        find.descendant(
+          of: find.byType(TextField).first,
+          matching: find.byWidgetPredicate(
+            (Widget focus) => focus is Focus && (focus.focusNode?.hasFocus ?? false),
+          ),
+        ),
+        findsOne,
+      );
+    },
+  );
+}

--- a/examples/api/test/widgets/focus_manager/focus_node.unfocus.0_test.dart
+++ b/examples/api/test/widgets/focus_manager/focus_node.unfocus.0_test.dart
@@ -16,7 +16,8 @@ void main() {
         const example.UnfocusExampleApp(),
       );
 
-      await tester.tap(find.byType(TextField).first); // Focuses the first text field.
+      // Focuses the first text field.
+      await tester.tap(find.byType(TextField).first);
       await tester.pump();
 
       // Changes the focus to the unfocus button.
@@ -32,15 +33,8 @@ void main() {
       await tester.pump();
 
       // After pressing tab once, the focus is on the first text field.
-      expect(
-        find.descendant(
-          of: find.byType(TextField).first,
-          matching: find.byWidgetPredicate(
-            (Widget focus) => focus is Focus && (focus.focusNode?.hasFocus ?? false),
-          ),
-        ),
-        findsOne,
-      );
+      final EditableText firstEditableText = tester.firstWidget(find.byType(EditableText));
+      expect(firstEditableText.focusNode.hasFocus, true);
     },
   );
 
@@ -51,7 +45,8 @@ void main() {
         const example.UnfocusExampleApp(),
       );
 
-      await tester.tap(find.byType(TextField).first); // Focuses the first text field.
+      // Focuses the first text field.
+      await tester.tap(find.byType(TextField).first);
       await tester.pump();
 
       // Changes the focus to the second radio button.
@@ -76,15 +71,8 @@ void main() {
         await tester.pump();
       }
 
-      expect(
-        find.descendant(
-          of: find.byType(TextField).first,
-          matching: find.byWidgetPredicate(
-            (Widget focus) => focus is Focus && (focus.focusNode?.hasFocus ?? false),
-          ),
-        ),
-        findsOne,
-      );
+      final EditableText firstEditableText = tester.firstWidget(find.byType(EditableText));
+      expect(firstEditableText.focusNode.hasFocus, true);
     },
   );
 }


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
