### PR TITLE
Add test for `navigator.restorable_push_replacement.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -310,7 +310,6 @@ class SampleChecker {
 // See https://github.com/flutter/flutter/issues/130459
 final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/color_scheme/dynamic_content_color.0_test.dart',
-  'examples/api/test/widgets/navigator/navigator.restorable_push_replacement.0_test.dart',
   'examples/api/test/widgets/navigator/restorable_route_future.0_test.dart',
   'examples/api/test/widgets/focus_manager/focus_node.unfocus.0_test.dart',
   'examples/api/test/widgets/nested_scroll_view/nested_scroll_view_state.0_test.dart',

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for [Navigator.restorablePushReplacement].
+/// Flutter code sample for [NavigatorState.restorablePushReplacement].
 
 void main() => runApp(const RestorablePushReplacementExampleApp());
 
@@ -13,14 +13,23 @@ class RestorablePushReplacementExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: RestorablePushReplacementExample(),
+    return const RootRestorationScope(
+      restorationId: 'app',
+      child: MaterialApp(
+        restorationScopeId: 'app',
+        home: RestorablePushReplacementExample(),
+      ),
     );
   }
 }
 
 class RestorablePushReplacementExample extends StatefulWidget {
-  const RestorablePushReplacementExample({super.key});
+  const RestorablePushReplacementExample({
+    this.wasPushed = false,
+    super.key,
+  });
+
+  final bool wasPushed;
 
   @override
   State<RestorablePushReplacementExample> createState() => _RestorablePushReplacementExampleState();
@@ -30,7 +39,9 @@ class _RestorablePushReplacementExampleState extends State<RestorablePushReplace
   @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
     return MaterialPageRoute<void>(
-      builder: (BuildContext context) => const RestorablePushReplacementExample(),
+      builder: (BuildContext context) => const RestorablePushReplacementExample(
+        wasPushed: true,
+      ),
     );
   }
 
@@ -39,6 +50,11 @@ class _RestorablePushReplacementExampleState extends State<RestorablePushReplace
     return Scaffold(
       appBar: AppBar(
         title: const Text('Sample Code'),
+      ),
+      body: Center(
+        child: widget.wasPushed
+            ? const Text('This is a new route.')
+            : const Text('This is the initial route.'),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => Navigator.restorablePushReplacement(context, _myRouteBuilder),

--- a/examples/api/test/widgets/navigator/navigator.restorable_push_replacement.0_test.dart
+++ b/examples/api/test/widgets/navigator/navigator.restorable_push_replacement.0_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/navigator/navigator.restorable_push_replacement.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('It pushes a restorable route and restores it', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.RestorablePushReplacementExampleApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'Sample Code'), findsOne);
+    expect(find.text('This is the initial route.'), findsOne);
+
+    final TestRestorationData initialData = await tester.getRestorationData();
+
+    await tester.tap(find.widgetWithIcon(FloatingActionButton, Icons.add));
+    await tester.pumpAndSettle();
+
+    expect(find.text('This is a new route.'), findsOne);
+
+    await tester.restartAndRestore();
+
+    expect(find.text('This is a new route.'), findsOne);
+
+    final TestRestorationData pushedData = await tester.getRestorationData();
+
+    await tester.restoreFrom(initialData);
+
+    await tester.pumpAndSettle();
+    expect(find.text('This is the initial route.'), findsOne);
+
+    await tester.restoreFrom(pushedData);
+    expect(find.text('This is a new route.'), findsOne);
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
