### PR TITLE
Fix showSnackBar can't access useMaterial3 from the theme

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -986,6 +986,16 @@ class _MaterialAppState extends State<MaterialApp> {
         },
       );
     }
+
+    childWidget = ScaffoldMessenger(
+      key: widget.scaffoldMessengerKey,
+      child: DefaultSelectionStyle(
+        selectionColor: effectiveSelectionColor,
+        cursorColor: effectiveCursorColor,
+        child: childWidget,
+      ),
+    );
+
     if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
       childWidget = AnimatedTheme(
         data: theme,
@@ -1000,14 +1010,7 @@ class _MaterialAppState extends State<MaterialApp> {
       );
     }
 
-    return ScaffoldMessenger(
-      key: widget.scaffoldMessengerKey,
-      child: DefaultSelectionStyle(
-        selectionColor: effectiveSelectionColor,
-        cursorColor: effectiveCursorColor,
-        child: childWidget,
-      ),
-    );
+    return childWidget;
   }
 
   Widget _buildWidgetApp(BuildContext context) {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -2869,8 +2869,7 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/115924.
   testWidgets('Default ScaffoldMessenger can access ambient theme', (WidgetTester tester) async {
-    ScaffoldMessengerState? scaffoldMessenger;
-    const Key tapTarget = Key('tap-target');
+    final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 
     final ColorScheme colorScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
     final ThemeData customTheme = ThemeData(
@@ -2878,31 +2877,15 @@ void main() {
       visualDensity: VisualDensity.comfortable,
     );
 
-    await tester.pumpWidget(MaterialApp(
-      theme: customTheme,
-      home: Scaffold(
-        body: Builder(
-          builder: (BuildContext context) {
-            return GestureDetector(
-              key: tapTarget,
-              onTap: () {
-                scaffoldMessenger = ScaffoldMessenger.maybeOf(context);
-              },
-              behavior: HitTestBehavior.opaque,
-              child: const SizedBox(
-                height: 100.0,
-                width: 100.0,
-              ),
-            );
-          },
-        ),
+    await tester.pumpWidget(
+      MaterialApp(
+        scaffoldMessengerKey: scaffoldMessengerKey,
+        theme: customTheme,
+        home: const SizedBox.shrink(),
       ),
-    ));
+    );
 
-    await tester.tap(find.byKey(tapTarget));
-    await tester.pump();
-
-    final ThemeData messengerTheme = Theme.of(scaffoldMessenger!.context);
+    final ThemeData messengerTheme = Theme.of(scaffoldMessengerKey.currentContext!);
     expect(messengerTheme.colorScheme, colorScheme);
     expect(messengerTheme.visualDensity, VisualDensity.comfortable);
   });

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -2867,7 +2867,47 @@ void main() {
       expect(tester.takeException(), isNull);
   });
 
-   testWidgets('ScaffoldMessenger showSnackBar default animation', (WidgetTester tester) async {
+  // Regression test for https://github.com/flutter/flutter/issues/115924.
+  testWidgets('Default ScaffoldMessenger can access ambient theme', (WidgetTester tester) async {
+    ScaffoldMessengerState? scaffoldMessenger;
+    const Key tapTarget = Key('tap-target');
+
+    final ColorScheme colorScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
+    final ThemeData customTheme = ThemeData(
+      colorScheme: colorScheme,
+      visualDensity: VisualDensity.comfortable,
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      theme: customTheme,
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            return GestureDetector(
+              key: tapTarget,
+              onTap: () {
+                scaffoldMessenger = ScaffoldMessenger.maybeOf(context);
+              },
+              behavior: HitTestBehavior.opaque,
+              child: const SizedBox(
+                height: 100.0,
+                width: 100.0,
+              ),
+            );
+          },
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byKey(tapTarget));
+    await tester.pump();
+
+    final ThemeData messengerTheme = Theme.of(scaffoldMessenger!.context);
+    expect(messengerTheme.colorScheme, colorScheme);
+    expect(messengerTheme.visualDensity, VisualDensity.comfortable);
+  });
+
+  testWidgets('ScaffoldMessenger showSnackBar default animation', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: Builder(


### PR DESCRIPTION
## Description

This PR makes it possible for the `MaterialApp` built in `ScaffoldMessenger` state to access the ambient theme.

Before this PR, the built in messenger was above the theme.
After this PR, the build in messenger is below the theme.

## Related Issue

Fixes [Can't access useMaterial3 from the theme in the showSnackBar method](https://github.com/flutter/flutter/issues/115924)

## Tests

Adds 1 test.