### PR TITLE
Fix `TabBar` tab icons not respecting custom `IconTheme`

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -269,8 +269,8 @@ class _TabStyle extends AnimatedWidget {
   final TabBarThemeData defaults;
   final Widget child;
 
-  MaterialStateColor _resolveWithLabelColor({
-    required BuildContext context,
+  MaterialStateColor _resolveWithLabelColor(
+    BuildContext context, {
     IconThemeData? iconTheme,
   }) {
     final ThemeData themeData = Theme.of(context);
@@ -344,8 +344,8 @@ class _TabStyle extends AnimatedWidget {
       final IconThemeData iconTheme when iconTheme.color != defaultIconColor => iconTheme,
       _ => null,
     };
-    final Color iconColor = _resolveWithLabelColor(context: context, iconTheme: customIconTheme).resolve(states);
-    final Color labelColor = _resolveWithLabelColor(context: context).resolve(states);
+    final Color iconColor = _resolveWithLabelColor(context, iconTheme: customIconTheme).resolve(states);
+    final Color labelColor = _resolveWithLabelColor(context).resolve(states);
 
     return DefaultTextStyle(
       style: textStyle.copyWith(color: labelColor),

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -269,7 +269,10 @@ class _TabStyle extends AnimatedWidget {
   final TabBarThemeData defaults;
   final Widget child;
 
-  MaterialStateColor _resolveWithLabelColor(BuildContext context) {
+  MaterialStateColor _resolveWithLabelColor({
+    required BuildContext context,
+    IconThemeData? iconTheme,
+  }) {
     final ThemeData themeData = Theme.of(context);
     final TabBarThemeData tabBarTheme = TabBarTheme.of(context);
     final Animation<double> animation = listenable as Animation<double>;
@@ -295,6 +298,7 @@ class _TabStyle extends AnimatedWidget {
           ?? tabBarTheme.unselectedLabelColor
           ?? unselectedLabelStyle?.color
           ?? tabBarTheme.unselectedLabelStyle?.color
+          ?? iconTheme?.color
           ?? (themeData.useMaterial3
                ? defaults.unselectedLabelColor!
                : selectedColor.withAlpha(0xB2)); // 70% alpha
@@ -310,6 +314,7 @@ class _TabStyle extends AnimatedWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     final TabBarThemeData tabBarTheme = TabBarTheme.of(context);
     final Animation<double> animation = listenable as Animation<double>;
 
@@ -331,14 +336,23 @@ class _TabStyle extends AnimatedWidget {
     final TextStyle textStyle = isSelected
       ? TextStyle.lerp(selectedStyle, unselectedStyle, animation.value)!
       : TextStyle.lerp(unselectedStyle, selectedStyle, animation.value)!;
-    final Color color = _resolveWithLabelColor(context).resolve(states);
+    final Color defaultIconColor = switch (theme.colorScheme.brightness) {
+      Brightness.light => kDefaultIconDarkColor,
+      Brightness.dark  => kDefaultIconLightColor,
+    };
+    final IconThemeData? customIconTheme = switch (IconTheme.of(context)) {
+      final IconThemeData iconTheme when iconTheme.color != defaultIconColor => iconTheme,
+      _ => null,
+    };
+    final Color iconColor = _resolveWithLabelColor(context: context, iconTheme: customIconTheme).resolve(states);
+    final Color labelColor = _resolveWithLabelColor(context: context).resolve(states);
 
     return DefaultTextStyle(
-      style: textStyle.copyWith(color: color),
+      style: textStyle.copyWith(color: labelColor),
       child: IconTheme.merge(
         data: IconThemeData(
-          size: 24.0,
-          color: color,
+          size: customIconTheme?.size ?? 24.0,
+          color: iconColor,
         ),
         child: child,
       ),


### PR DESCRIPTION
Fixes [TabBar ignores Theme's iconTheme.size](https://github.com/flutter/flutter/issues/155518)

### Description

When `ThemeData.IconTheme`  with color and size, is provided, it can override the default `Tab` icon color and size. 

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(
        iconTheme: const IconThemeData(color: Colors.amber, size: 40),
      ),
      home: const Scaffold(
        body: SafeArea(
          child: DefaultTabController(
            length: 2,
            child: Column(
              children: [
                TabBar(
                  tabs: [
                    Tab(icon: Icon(Icons.backpack_outlined), text: 'Backpack'),
                    Tab(icon: Icon(Icons.map_outlined), text: 'Map'),
                  ],
                  overlayColor: WidgetStatePropertyAll(Colors.transparent),
                ),
                Expanded(
                  child: TabBarView(
                    children: [
                      Icon(Icons.backpack_outlined),
                      Icon(Icons.map_outlined),
                    ],
                  ),
                ),
              ],
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>

---

<img width="666" alt="Screenshot 2024-10-28 at 16 25 06" src="https://github.com/user-attachments/assets/56d31115-7ee9-4378-9811-75a3a2a4ce0f">


<img width="666" alt="Screenshot 2024-10-28 at 16 24 52" src="https://github.com/user-attachments/assets/ab8a3e4b-e912-40ac-b249-6358492581e0">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
