### PR TITLE
Fix `NestedScrollView` inner position logic

### DIFF
--- a/examples/api/test/widgets/nested_scroll_view/nested_scroll_view.0_test.dart
+++ b/examples/api/test/widgets/nested_scroll_view/nested_scroll_view.0_test.dart
@@ -41,46 +41,4 @@ void main() {
       lessThan(initialAppBarHeight),
     );
   });
-
-  testWidgets('Maintains scroll position of inactive tab', (WidgetTester tester) async {
-    await tester.pumpWidget(const example.NestedScrollViewExampleApp());
-
-    final Finder finder = find.text('Item 14', skipOffstage: false);
-    Future<void> scroll(VerticalDirection direction) async {
-      switch (direction) {
-        case VerticalDirection.down:
-          await tester.ensureVisible(finder);
-        case VerticalDirection.up:
-          await tester.fling(find.byType(Scaffold), const Offset(0, 20), 20);
-          await tester.pumpAndSettle();
-      }
-    }
-
-    double getScrollPosition() {
-      return Scrollable.of(tester.element(finder)).position.pixels;
-    }
-
-    expect(getScrollPosition(), 0.0);
-
-    // Scroll toward the bottom of Tab 1.
-    await scroll(VerticalDirection.down);
-    final double tab1Position = getScrollPosition();
-
-    // Switch to Tab 2.
-    await tester.tap(find.text('Tab 2'));
-    await tester.pumpAndSettle();
-
-    // Scroll toward the bottom of Tab 2.
-    await scroll(VerticalDirection.down);
-    final double tab2Position = getScrollPosition();
-
-    // Scroll up a bit in Tab 2.
-    await scroll(VerticalDirection.up);
-    expect(getScrollPosition(), lessThan(tab2Position));
-
-    // Switch back to Tab 1.
-    await tester.tap(find.text('Tab 1'));
-    await tester.pumpAndSettle();
-    expect(getScrollPosition(), tab1Position);
-  });
 }

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1322,7 +1322,7 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
     }
 
     final double result = delta + offset;
-    if (result > -0.000001 && result < 0.000001) {
+    if (result.abs() < precisionErrorTolerance) {
       return 0.0;
     }
     return result;

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1320,7 +1320,12 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
       forcePixels(actualNewPixels);
       didUpdateScrollPositionBy(offset);
     }
-    return delta + offset;
+
+    final double result = delta + offset;
+    if (result > -0.000001 && result < 0.000001) {
+      return 0.0;
+    }
+    return result;
   }
 
   // Returns the overscroll.


### PR DESCRIPTION
closes #40740

<p align="center">
  <img 
    src="https://github.com/user-attachments/assets/8a48abd0-466b-4e06-90f3-dd05869bac27"
    alt="NestedScrollController fix"
    height="720px"
  />
</p>

<details> <summary><h4>Demo source code</h4> (click to expand)</summary>

(this is a slightly more concise version of the code sample from #40740)

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(
    const MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Scaffold(body: NewsScreen()),
    ),
  );
}

class NewsScreen extends StatelessWidget {
  const NewsScreen({super.key});

  static const List<String> _tabs = <String>['Featured', 'Popular', 'Latest'];

  static final List<Widget> _tabViews = <Widget>[
    for (final String name in _tabs)
      SafeArea(
        top: false,
        bottom: false,
        child: Builder(builder: (BuildContext context) {
          final handle = NestedScrollView.sliverOverlapAbsorberHandleFor(context);

          return NotificationListener<ScrollNotification>(
            onNotification: (ScrollNotification notification) => true,
            child: CustomScrollView(
              key: PageStorageKey<String>(name),
              slivers: <Widget>[
                SliverOverlapInjector(handle: handle),
                SliverPadding(
                  padding: const EdgeInsets.all(8.0),
                  sliver: SliverList(
                    delegate: SliverChildBuilderDelegate(
                      childCount: 30,
                      (BuildContext context, int index) => Container(
                        margin: const EdgeInsets.only(bottom: 8),
                        width: double.infinity,
                        height: 150,
                        color: const Color(0xFFB0A4C8),
                        alignment: Alignment.center,
                        child: Text(
                          '$name $index',
                          style: const TextStyle(fontWeight: FontWeight.w600),
                        ),
                      ),
                    ),
                  ),
                ),
              ],
            ),
          );
        }),
      ),
  ];

  @override
  Widget build(BuildContext context) {
    return DefaultTabController(
      length: _tabs.length,
      child: NestedScrollView(
        headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) => <Widget>[
          SliverOverlapAbsorber(
            handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
            sliver: SliverSafeArea(
              top: false,
              sliver: SliverAppBar(
                title: const Text('Tab Demo'),
                floating: true,
                pinned: true,
                snap: true,
                forceElevated: innerBoxIsScrolled,
                bottom: TabBar(
                  tabs: _tabs.map((String name) => Tab(text: name)).toList(),
                ),
              ),
            ),
          ),
        ],
        body: TabBarView(children: _tabViews),
      ),
    );
  }
}
```

<br>

</details>

<br>

This bug can be traced to a return statement inside `_NestedScrollPosition`:

```dart
double applyClampedDragUpdate(double delta) {
  // ...
  return delta + offset;
}
```

Thanks to some quirks of floating-point arithmetic, `applyClampedDragUpdate` would sometimes return a tiny non-zero value, which ends up ruining one of the scroll coordinator's equality checks.

https://github.com/flutter/flutter/blob/8990ed6538592fc8aee63b0e137b7b52804a030f/packages/flutter/lib/src/widgets/nested_scroll_view.dart#L658-L664