### PR TITLE
Pin Mac tool_integration_test shards to arm64

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4317,9 +4317,8 @@ targets:
   - name: Mac tool_integration_tests_1_5
     recipe: flutter/flutter_drone
     timeout: 60
-    # Flake rate of >2.5% in presubmit
-    presubmit: false # https://github.com/flutter/flutter/issues/150642
     properties:
+      cpu: arm64
       add_recipes_cq: "true"
       dependencies: >-
         [
@@ -4344,6 +4343,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: arm64
       add_recipes_cq: "true"
       dependencies: >-
         [
@@ -4368,6 +4368,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: arm64
       add_recipes_cq: "true"
       dependencies: >-
         [
@@ -4392,6 +4393,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: arm64
       add_recipes_cq: "true"
       dependencies: >-
         [
@@ -4416,6 +4418,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: arm64
       add_recipes_cq: "true"
       dependencies: >-
         [


### PR DESCRIPTION
Using `Mac_arm64` would require these to go through a `bringup: true` dance, which would require not running in presubmit. Instead, this PR just adds the `cpu` property to pin to `arm64` without changing the task name.

Towards https://github.com/flutter/flutter/issues/157758