### PR TITLE
Add test for `focus_scope.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -326,5 +326,4 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/notification_listener/notification.0_test.dart',
   'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart',
   'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart',
-  'examples/api/test/widgets/focus_scope/focus_scope.0_test.dart',
 };

--- a/examples/api/test/widgets/focus_scope/focus_scope.0_test.dart
+++ b/examples/api/test/widgets/focus_scope/focus_scope.0_test.dart
@@ -1,0 +1,59 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_api_samples/widgets/focus_scope/focus_scope.0.dart'
+  as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  bool hasFocus(WidgetTester tester, IconData icon) =>
+    tester.widget<IconButton>(
+      find.ancestor(
+        of: find.byIcon(icon),
+        matching: find.byType(IconButton),
+      ),
+    ).focusNode!.hasFocus;
+
+  testWidgets('The focus is restricted to the foreground', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.FocusScopeExampleApp(),
+    );
+
+    expect(find.text('FOREGROUND'), findsOne);
+    expect(hasFocus(tester, Icons.menu), true);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(hasFocus(tester, Icons.menu), true);
+  });
+
+  testWidgets('The background can be focused', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.FocusScopeExampleApp(),
+    );
+
+    expect(find.text('FOREGROUND'), findsOne);
+    expect(hasFocus(tester, Icons.menu), true);
+
+    await tester.tap(find.byIcon(Icons.menu));
+    await tester.pumpAndSettle();
+
+
+    expect(hasFocus(tester, Icons.close), true);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(hasFocus(tester, Icons.menu), false);
+    expect(hasFocus(tester, Icons.close), false);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(hasFocus(tester, Icons.close), true);
+  });
+}

--- a/examples/api/test/widgets/focus_scope/focus_scope.0_test.dart
+++ b/examples/api/test/widgets/focus_scope/focus_scope.0_test.dart
@@ -42,7 +42,6 @@ void main() {
     await tester.tap(find.byIcon(Icons.menu));
     await tester.pumpAndSettle();
 
-
     expect(hasFocus(tester, Icons.close), true);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/focus_scope/focus_scope.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
