### PR TITLE
Add test for `interactive_viewer.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -322,7 +322,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/scrollbar/raw_scrollbar.0_test.dart',
   'examples/api/test/widgets/interactive_viewer/interactive_viewer.constrained.0_test.dart',
   'examples/api/test/widgets/interactive_viewer/interactive_viewer.transformation_controller.0_test.dart',
-  'examples/api/test/widgets/interactive_viewer/interactive_viewer.0_test.dart',
   'examples/api/test/widgets/notification_listener/notification.0_test.dart',
   'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart',
   'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart',

--- a/examples/api/test/widgets/interactive_viewer/interactive_viewer.0_test.dart
+++ b/examples/api/test/widgets/interactive_viewer/interactive_viewer.0_test.dart
@@ -1,0 +1,63 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/interactive_viewer/interactive_viewer.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Has correct items on screen', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.InteractiveViewerExampleApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'InteractiveViewer Sample'), findsOne);
+    expect(find.byType(InteractiveViewer), findsOne);
+
+    expect(
+      tester.getRect(find.byType(Container)),
+      rectMoreOrLessEquals(const Rect.fromLTRB(0.0, 56.0, 800.0, 600.0)),
+    );
+
+    await tester.drag(find.byType(Container), const Offset(20, 20));
+
+    // Pans.
+    const Offset panStart = Offset(400.0, 300.0);
+    final Offset panEnd = panStart + const Offset(20.0, 20.0);
+    final TestGesture gesture = await tester.startGesture(panStart);
+    await tester.pump();
+    await gesture.moveTo(panEnd);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getRect(find.byType(Container)),
+      rectMoreOrLessEquals(const Rect.fromLTRB(20.0, 76.0, 820.0, 620.0)),
+    );
+
+    // Zooms.
+    const Offset scaleStart1 = Offset(400.0, 300.0);
+    final Offset scaleStart2 = scaleStart1 + const Offset(10.0, 0.0);
+    final Offset scaleEnd1 = scaleStart1 - const Offset(10.0, 0.0);
+    final Offset scaleEnd2 = scaleStart2 + const Offset(10.0, 0.0);
+    final TestGesture gesture1 = await tester.createGesture();
+    final TestGesture gesture2 = await tester.createGesture();
+    await gesture1.down(scaleStart1);
+    await gesture2.down(scaleStart2);
+    await tester.pump();
+    await gesture1.moveTo(scaleEnd1);
+    await gesture2.moveTo(scaleEnd2);
+    await tester.pump();
+    await gesture1.up();
+    await gesture2.up();
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getRect(find.byType(Container)),
+      rectMoreOrLessEquals(const Rect.fromLTRB(-203.0, -58.4, 1077.0, 812.0)),
+    );
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/interactive_viewer/interactive_viewer.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
