### PR TITLE
Revert: Add wrapWidth parameter of DiagnosticableTree.toStringDeep()

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -3397,9 +3397,6 @@ abstract class DiagnosticableTree with Diagnosticable {
   /// `minLevel` specifies the minimum [DiagnosticLevel] for properties included
   /// in the output.
   ///
-  /// `wrapWidth` specifies the column number where word wrapping will be
-  /// applied.
-  ///
   /// The [toStringDeep] method takes other arguments, but those are intended
   /// for internal use when recursing to the descendants, and so can be ignored.
   ///
@@ -3412,9 +3409,8 @@ abstract class DiagnosticableTree with Diagnosticable {
     String prefixLineOne = '',
     String? prefixOtherLines,
     DiagnosticLevel minLevel = DiagnosticLevel.debug,
-    int wrapWidth = 65,
   }) {
-    return toDiagnosticsNode().toStringDeep(prefixLineOne: prefixLineOne, prefixOtherLines: prefixOtherLines, minLevel: minLevel, wrapWidth: wrapWidth);
+    return toDiagnosticsNode().toStringDeep(prefixLineOne: prefixLineOne, prefixOtherLines: prefixOtherLines, minLevel: minLevel);
   }
 
   @override

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1261,7 +1261,7 @@ void main() {
 
     expect(element, hasAGoodToStringDeep);
     expect(
-      element.toStringDeep(wrapWidth: 200),
+      element.toStringDeep(),
       equalsIgnoringHashCodes(
         'Column-[GlobalKey#00000](direction: vertical, mainAxisAlignment: start, crossAxisAlignment: center, renderObject: RenderFlex#00000)\n'
         '├Container\n'

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1284,6 +1284,16 @@ void main() {
     );
   });
 
+  test('Widget DiagnosticableTree apis do not break', () {
+    // can construct the widget without code changes
+    final _DiagnosticsOverrideWidget widget = _DiagnosticsOverrideWidget();
+    expect(widget.toString(), 'short');
+    expect(widget.toStringShort(), 'short');
+    expect(widget.toStringShallow(), 'shallow');
+    expect(widget.toStringDeep(), 'deep');
+    expect(widget.debugDescribeChildren(), isEmpty);
+  });
+
   testWidgets('scheduleBuild while debugBuildingDirtyElements is true', (WidgetTester tester) async {
     // ignore here is required for testing purpose because changing the flag properly is hard
     // ignore: invalid_use_of_protected_member
@@ -2494,4 +2504,40 @@ class _NullElement extends Element {
 
   @override
   bool get debugDoingBuild => throw UnimplementedError();
+}
+
+class _DiagnosticsOverrideWidget extends LeafRenderObjectWidget {
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    throw UnimplementedError();
+  }
+
+  @override
+  String toStringShort(/*adding any parameter is a breaking change*/) =>
+      'short';
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren(
+      /*adding any parameter is a breaking change*/) {
+    return const <DiagnosticsNode>[];
+  }
+
+  @override
+  String toStringShallow({
+    String joiner = ', ',
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+    // adding any parameter is a breaking change
+  }) {
+    return 'shallow';
+  }
+
+  @override
+  String toStringDeep({
+    String prefixLineOne = '',
+    String? prefixOtherLines,
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+    // adding any parameter is a breaking change
+  }) {
+    return 'deep';
+  }
 }


### PR DESCRIPTION
Reverts `toStringDeep()` change introduced in https://github.com/flutter/flutter/pull/154752

Fixes https://github.com/flutter/flutter/issues/157802

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
