### PR TITLE
fix(ScrollAction): unsafe non-null assertion

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable_helpers.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_helpers.dart
@@ -460,17 +460,18 @@ class ScrollAction extends ContextAction<ScrollIntent> {
         return true;
       }());
 
-      if (primaryScrollController.position.context.notificationContext == null
-          && Scrollable.maybeOf(primaryScrollController.position.context.notificationContext!) == null) {
+      final BuildContext? notificationContext = primaryScrollController.position.context.notificationContext;
+      if (notificationContext != null) {
+        state = Scrollable.maybeOf(notificationContext);
+      }
+      if (state == null) {
         return;
       }
-      state = Scrollable.maybeOf(primaryScrollController.position.context.notificationContext!);
     }
-    assert(state != null, '$ScrollAction was invoked on a context that has no scrollable parent');
-    assert(state!.position.hasPixels, 'Scrollable must be laid out before it can be scrolled via a ScrollAction');
+    assert(state.position.hasPixels, 'Scrollable must be laid out before it can be scrolled via a ScrollAction');
 
     // Don't do anything if the user isn't allowed to scroll.
-    if (state!.resolvedPhysics != null && !state.resolvedPhysics!.shouldAcceptUserOffset(state.position)) {
+    if (state.resolvedPhysics != null && !state.resolvedPhysics!.shouldAcceptUserOffset(state.position)) {
       return;
     }
     final double increment = getDirectionalIncrement(state, intent);


### PR DESCRIPTION
This conditional most likely was meant to use `||` instead of `&&` operator to check if `notificationContext` is null OR if no Scrollable was found for this `notificationContext`. Using the AND operator instead causes the null assertion to fail when notificationContext is null, while also causing an assertion failure when notificationContext is not null, but no Scrollable is found for it. While at it, let's also deduplicate the Scrollable.maybeOf call.

This fix is purely speculative, I didn't encounter this error, but rather was reading the ScrollAction's source and stumbled upon this. ~~With that said I wasn't actually able to trigger this error condition, thus why there are no tests included with this PR, if anyone has ideas on how this could be triggered, I'll be happy to include such test cases.~~

fixes #158063

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
