### PR TITLE
Mention partial PRs in the contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ guide to get started.
 ### Helping with existing PRs
 
 Once you've learned the process of contributing, if you aren't sure what to work on next you
-might be interested in helping other developers complete their patches, by picking up an
+might be interested in helping other developers complete their contributions by picking up an
 incomplete patch from the list of [issues with partial patches][has-partial-patch].
 
 [has-partial-patch]: https://github.com/flutter/flutter/labels/has%20partial%20patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,14 @@ are generally excited about improving the Dart & Flutter developer experience.
 Please see the DevTools [CONTRIBUTING.md](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md)
 guide to get started.
 
+### Helping with existing PRs
+
+Once you've learned the process of contributing, if you aren't sure what to work on next you
+might be interested in helping other developers complete their patches, by picking up an
+incomplete patch from the list of [issues with partial patches][has-partial-patch].
+
+[has-partial-patch]: https://github.com/flutter/flutter/labels/has%20partial%20patch
+
 Outreach
 --------
 


### PR DESCRIPTION
Adds a small new subsection to the section on contributing via coding that highlights the list of issues with partial patches that could be picked up by another contributor.