### PR TITLE
Implicitly `@protected` Navigator

### DIFF
--- a/packages/flutter/lib/src/widgets/restoration.dart
+++ b/packages/flutter/lib/src/widgets/restoration.dart
@@ -661,6 +661,7 @@ mixin RestorationMixin<S extends StatefulWidget> on State<S> {
   /// The restoration ID used for the [RestorationBucket] in which the mixin
   /// will store the restoration data of all registered properties.
   ///
+  /// {@template flutter.widgets.RestorationMixin.restorationId}
   /// The restoration ID is used to claim a child [RestorationScope] from the
   /// surrounding [RestorationScope] (accessed via [RestorationScope.of]) and
   /// the ID must be unique in that scope (otherwise an exception is triggered
@@ -678,6 +679,7 @@ mixin RestorationMixin<S extends StatefulWidget> on State<S> {
   /// The restoration ID returned by this getter is often provided in the
   /// constructor of the [StatefulWidget] that this [State] object is associated
   /// with.
+  /// {@endtemplate}
   @protected
   String? get restorationId;
 

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1966,7 +1966,7 @@ void main() {
           '   The onGenerateRoute callback must never return null, unless an\n'
           '   onUnknownRoute callback is provided as well.\n'
           '   The Navigator was:\n'
-          '     NavigatorState#00000(lifecycle state: initialized)\n',
+          '     _NavigatorState#00000(lifecycle state: initialized)\n',
         ),
       );
     });
@@ -1994,7 +1994,7 @@ void main() {
           '   route "/".\n'
           '   The onUnknownRoute callback must never return null.\n'
           '   The Navigator was:\n'
-          '     NavigatorState#00000(lifecycle state: initialized)\n',
+          '     _NavigatorState#00000(lifecycle state: initialized)\n',
         ),
       );
     });
@@ -2841,8 +2841,8 @@ void main() {
         'FlutterError\n'
         '   A HeroController can not be shared by multiple Navigators. The\n'
         '   Navigators that share the same HeroController are:\n'
-        '   - NavigatorState#00000(tickers: tracking 1 ticker)\n'
-        '   - NavigatorState#00000(tickers: tracking 1 ticker)\n'
+        '   - _NavigatorState#00000(tickers: tracking 1 ticker)\n'
+        '   - _NavigatorState#00000(tickers: tracking 1 ticker)\n'
         '   Please create a HeroControllerScope for each Navigator or use a\n'
         '   HeroControllerScope.none to prevent subtree from receiving a\n'
         '   HeroController.\n',


### PR DESCRIPTION
> ### Avoid exposing API oceans
> A smaller API surface is easier to understand.

<br><br>

This pull request allows `NavigatorState` methods to benefit from [`@protected`](https://main-api.flutter.dev/flutter/meta/protected-constant.html), without needing to add `@protected` anywhere!

mini-design doc: [flutter.dev/go/implicitly-protected](https://docs.google.com/document/d/15Rx894OxW1w2Lcgj-ObDMDyLokDB-zpZluX4yUBqbL8/edit?usp=sharing)

### Before

![navigator before this PR](https://github.com/user-attachments/assets/5d2dc37c-abe9-44f4-ad16-4396a3aeeaf7)

### After

![navigator after this PR](https://github.com/user-attachments/assets/c8f00029-01bf-46a4-b242-3d3c16305edf)
(the result after this PR and #157873 are merged)

<br><br>

This is possible thanks to Dart's [extension types](https://dart.dev/language/extension-types) feature.
`NavigatorState` (originally spanning over 2,000 lines of code) has been split into an "internal" and "external" type.

```dart
extension type NavigatorState._(_NavigatorState _state) implements State<Navigator>, TickerProvider {}

class _NavigatorState extends State<Navigator> with TickerProviderStateMixin, RestorationMixin {}
```

The extension type wrapper exposes `State<Navigator>` instead of the concrete implementation. Static analysis is now performed against the base `State` class, so whether the overridden methods are `@protected` doesn't matter!