### PR TITLE
Add and plumb `useImplicitPubspecResolution` across `flutter_tools`.

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -34,7 +34,7 @@ const List<String> _kRequiredOptions = <String>[
 Future<void> main(List<String> args) {
   return runInContext<void>(() => run(args), overrides: <Type, Generator>{
     Usage: () => DisabledUsage(),
-  });
+  }, useImplicitPubspecResolution: true);
 }
 
 Future<void> writeAssetFile(libfs.File outputFile, AssetBundleEntry asset) async {

--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -43,7 +43,7 @@ const String _kOptionCoveragePath = 'coverage-path';
 void main(List<String> args) {
   runInContext<void>(() => run(args), overrides: <Type, Generator>{
     Usage: () => DisabledUsage(),
-  });
+  }, useImplicitPubspecResolution: true);
 }
 
 Future<void> run(List<String> args) async {

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -347,6 +347,7 @@ class Environment {
     required Analytics analytics,
     String? engineVersion,
     required bool generateDartPluginRegistry,
+    required bool useImplicitPubspecResolution,
     Directory? buildDir,
     Map<String, String> defines = const <String, String>{},
     Map<String, String> inputs = const <String, String>{},
@@ -391,6 +392,7 @@ class Environment {
       engineVersion: engineVersion,
       inputs: inputs,
       generateDartPluginRegistry: generateDartPluginRegistry,
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     );
   }
 
@@ -412,6 +414,7 @@ class Environment {
     Usage? usage,
     Analytics? analytics,
     bool generateDartPluginRegistry = false,
+    bool useImplicitPubspecResolution = true,
     required FileSystem fileSystem,
     required Logger logger,
     required Artifacts artifacts,
@@ -435,6 +438,7 @@ class Environment {
       analytics: analytics ?? const NoOpAnalytics(),
       engineVersion: engineVersion,
       generateDartPluginRegistry: generateDartPluginRegistry,
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     );
   }
 
@@ -457,6 +461,7 @@ class Environment {
     this.engineVersion,
     required this.inputs,
     required this.generateDartPluginRegistry,
+    required this.useImplicitPubspecResolution,
   });
 
   /// The [Source] value which is substituted with the path to [projectDir].
@@ -556,6 +561,10 @@ class Environment {
   /// When [true], the main entrypoint is wrapped and the wrapper becomes
   /// the new entrypoint.
   final bool generateDartPluginRegistry;
+
+  /// Whether to generate a `.flutter-plugins` file and for Flutter i10n source
+  /// generation to default to `synthetic-package: true`.
+  final bool useImplicitPubspecResolution;
 
   late final DepfileService depFileService = DepfileService(
     logger: logger,

--- a/packages/flutter_tools/lib/src/build_system/targets/localizations.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/localizations.dart
@@ -56,6 +56,7 @@ class GenerateLocalizationsTarget extends Target {
       file: configFile,
       logger: environment.logger,
       defaultArbDir: defaultArbDir,
+      defaultSyntheticPackage: environment.useImplicitPubspecResolution,
     );
     await generateLocalizations(
       logger: environment.logger,

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -37,6 +37,7 @@ class BundleBuilder {
   Future<void> build({
     required TargetPlatform platform,
     required BuildInfo buildInfo,
+    required bool useImplicitPubspecResolution,
     FlutterProject? project,
     String? mainPath,
     String manifestPath = defaultManifestPath,
@@ -79,6 +80,7 @@ class BundleBuilder {
       analytics: globals.analytics,
       platform: globals.platform,
       generateDartPluginRegistry: true,
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     );
     final Target target = buildInfo.mode == BuildMode.debug
         ? globals.buildTargets.copyFlutterBundle

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -26,6 +26,7 @@ import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 
 /// All currently implemented targets.
 List<Target> _kDefaultTargets = <Target>[
@@ -252,6 +253,7 @@ class AssembleCommand extends FlutterCommand {
         ? null
         : globals.flutterVersion.engineRevision,
       generateDartPluginRegistry: true,
+      useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
     );
     return result;
   }

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -280,6 +280,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
             ? _logger
             : NotifyingLogger(verbose: _logger.isVerbose, parent: _logger),
           logToStdout: true,
+          useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
         )
       : null;
 
@@ -466,6 +467,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
       printDtd: boolArg(FlutterGlobalOptions.kPrintDtd, global: true),
     );
 
+    final bool useImplicitPubspecResolution = globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution);
     return buildInfo.isDebug
       ? _hotRunnerFactory.build(
           flutterDevices,
@@ -478,11 +480,13 @@ known, it can be explicitly provided to attach via the command-line, e.g.
           nativeAssetsYamlFile: stringArg(FlutterOptions.kNativeAssetsYamlFile),
           nativeAssetsBuilder: _nativeAssetsBuilder,
           analytics: analytics,
+          useImplicitPubspecResolution: useImplicitPubspecResolution,
         )
       : ColdRunner(
           flutterDevices,
           target: targetFile,
           debuggingOptions: debuggingOptions,
+          useImplicitPubspecResolution: useImplicitPubspecResolution,
         );
   }
 
@@ -509,6 +513,7 @@ class HotRunnerFactory {
     FlutterProject? flutterProject,
     String? nativeAssetsYamlFile,
     required HotRunnerNativeAssetsBuilder? nativeAssetsBuilder,
+    required bool useImplicitPubspecResolution,
     required Analytics analytics,
   }) => HotRunner(
     devices,
@@ -523,5 +528,6 @@ class HotRunnerFactory {
     nativeAssetsYamlFile: nativeAssetsYamlFile,
     nativeAssetsBuilder: nativeAssetsBuilder,
     analytics: analytics,
+    useImplicitPubspecResolution: useImplicitPubspecResolution,
   );
 }

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -13,6 +13,7 @@ import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 import 'build.dart';
 
 class BuildBundleCommand extends BuildSubCommand {
@@ -149,6 +150,7 @@ class BuildBundleCommand extends BuildSubCommand {
       depfilePath: stringArg('depfile'),
       assetDirPath: stringArg('asset-dir'),
       buildNativeAssets: false,
+      useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
     );
     return FlutterCommandResult.success();
   }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -21,6 +21,7 @@ import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';
 import '../runner/flutter_command.dart' show DevelopmentArtifact, FlutterCommandResult;
+import '../runner/flutter_command_runner.dart';
 import '../version.dart';
 import 'build.dart';
 
@@ -460,6 +461,7 @@ end
               ? null
               : globals.flutterVersion.engineRevision,
           generateDartPluginRegistry: true,
+          useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
         );
         Target target;
         // Always build debug for simulator.

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -19,6 +19,7 @@ import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';
 import '../runner/flutter_command.dart' show DevelopmentArtifact, FlutterCommandResult;
+import '../runner/flutter_command_runner.dart';
 import '../version.dart';
 import 'build_ios_framework.dart';
 
@@ -239,6 +240,7 @@ end
         analytics: globals.analytics,
         engineVersion: globals.artifacts!.usesLocalArtifacts ? null : globals.flutterVersion.engineRevision,
         generateDartPluginRegistry: true,
+        useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
       );
       Target target;
       // Always build debug for simulator.

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -10,6 +10,7 @@ import '../features.dart';
 import '../globals.dart' as globals;
 import '../runner/flutter_command.dart'
     show DevelopmentArtifact, FlutterCommandResult, FlutterOptions;
+import '../runner/flutter_command_runner.dart';
 import '../web/compile.dart';
 import '../web/file_generators/flutter_service_worker_js.dart';
 import '../web/web_constants.dart';
@@ -226,6 +227,7 @@ class BuildWebCommand extends BuildSubCommand {
       flutterVersion: globals.flutterVersion,
       usage: globals.flutterUsage,
       analytics: globals.analytics,
+      useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
     );
     await webBuilder.buildWeb(
       project,

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -21,6 +21,7 @@ import '../flutter_project_metadata.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 import '../template.dart';
 
 const List<String> _kAvailablePlatforms = <String>[
@@ -574,6 +575,7 @@ abstract class CreateBase extends FlutterCommand {
         projectDir: project.directory,
         packageConfigPath: packageConfigPath(),
         generateDartPluginRegistry: true,
+        useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
       );
 
       // Generate the l10n synthetic package that will be injected into the

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -377,7 +377,8 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
     final CustomDevice device = CustomDevice(
       config: config,
       logger: logger,
-      processManager: _processManager
+      processManager: _processManager,
+      useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
     );
 
     bool result = true;

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -28,6 +28,7 @@ import '../ios/devices.dart';
 import '../macos/macos_ipad_device.dart';
 import '../resident_runner.dart';
 import '../runner/flutter_command.dart' show FlutterCommandCategory, FlutterCommandResult, FlutterOptions;
+import '../runner/flutter_command_runner.dart';
 import '../web/web_device.dart';
 import 'run.dart';
 
@@ -260,6 +261,7 @@ class DriveCommand extends RunCommandBase {
       processUtils: globals.processUtils,
       dartSdkPath: globals.artifacts!.getArtifactPath(Artifact.engineDartBinary),
       devtoolsLauncher: DevtoolsLauncher.instance!,
+      useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
     );
     final File packageConfigFile = findPackageConfigFileOrDefault(_fileSystem.currentDirectory);
 

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -11,6 +11,7 @@ import '../base/logger.dart';
 import '../localizations/gen_l10n.dart';
 import '../localizations/localizations_utils.dart';
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 
 /// A command to generate localizations source files for a Flutter project.
 ///
@@ -146,10 +147,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
             'generated as a synthetic package or at a specified directory in '
             'the Flutter project.\n'
             '\n'
-            'DEPRECATED: https://flutter.dev/to/flutter-gen-deprecation\n'
-            '\n'
-            'This flag inherits its default from --implicit-pubspec-resolution '
-            'if omitted.\n'
+            'This flag is set to true by default.\n'
             '\n'
             'When synthetic-package is set to false, it will generate the '
             'localizations files in the directory specified by arb-dir by default.\n'
@@ -249,7 +247,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
         file: _fileSystem.file('l10n.yaml'),
         logger: _logger,
         defaultArbDir: defaultArbDir,
-        defaultSyntheticPackage: globalResults!.flag('implicit-pubspec-resolution'),
+        defaultSyntheticPackage: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
       );
       _logger.printStatus(
         'Because l10n.yaml exists, the options defined there will be used '

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -146,7 +146,10 @@ class GenerateLocalizationsCommand extends FlutterCommand {
             'generated as a synthetic package or at a specified directory in '
             'the Flutter project.\n'
             '\n'
-            'This flag is set to true by default.\n'
+            'DEPRECATED: https://flutter.dev/to/flutter-gen-deprecation\n'
+            '\n'
+            'This flag inherits its default from --implicit-pubspec-resolution '
+            'if omitted.\n'
             '\n'
             'When synthetic-package is set to false, it will generate the '
             'localizations files in the directory specified by arb-dir by default.\n'
@@ -246,6 +249,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
         file: _fileSystem.file('l10n.yaml'),
         logger: _logger,
         defaultArbDir: defaultArbDir,
+        defaultSyntheticPackage: globalResults!.flag('implicit-pubspec-resolution'),
       );
       _logger.printStatus(
         'Because l10n.yaml exists, the options defined there will be used '

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -305,6 +305,7 @@ class PackagesGetCommand extends FlutterCommand {
           projectDir: rootProject.directory,
           packageConfigPath: packageConfigPath(),
           generateDartPluginRegistry: true,
+          useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
         );
 
         await generateLocalizationsSyntheticPackage(
@@ -328,6 +329,7 @@ class PackagesGetCommand extends FlutterCommand {
           projectDir: rootProject.directory,
           packageConfigPath: packageConfigPath(),
           generateDartPluginRegistry: true,
+          useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
         );
         final BuildResult result = await globals.buildSystem.build(
           const GenerateLocalizationsTarget(),

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -35,8 +35,9 @@ import '../web/web_runner.dart';
 import 'daemon.dart';
 
 /// Shared logic between `flutter run` and `flutter drive` commands.
-abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
-  RunCommandBase({ required bool verboseHelp }) {
+abstract class RunCommandBase extends FlutterCommand
+    with DeviceBasedDevelopmentArtifacts {
+  RunCommandBase({required bool verboseHelp}) {
     addBuildModeFlags(verboseHelp: verboseHelp, defaultToRelease: false);
     usesDartDefineOption();
     usesFlavorOption();
@@ -46,112 +47,133 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     addBundleSkSLPathOption(hide: !verboseHelp);
     usesApplicationBinaryOption();
     argParser
-      ..addFlag('trace-startup',
+      ..addFlag(
+        'trace-startup',
         negatable: false,
-        help: 'Trace application startup, then exit, saving the trace to a file. '
-              'By default, this will be saved in the "build" directory. If the '
-              'FLUTTER_TEST_OUTPUTS_DIR environment variable is set, the file '
-              'will be written there instead.',
+        help:
+            'Trace application startup, then exit, saving the trace to a file. '
+            'By default, this will be saved in the "build" directory. If the '
+            'FLUTTER_TEST_OUTPUTS_DIR environment variable is set, the file '
+            'will be written there instead.',
       )
-      ..addFlag('cache-startup-profile',
-        help: 'Caches the CPU profile collected before the first frame for startup '
-              'analysis.',
+      ..addFlag(
+        'cache-startup-profile',
+        help:
+            'Caches the CPU profile collected before the first frame for startup '
+            'analysis.',
       )
-      ..addFlag('verbose-system-logs',
+      ..addFlag(
+        'verbose-system-logs',
         negatable: false,
         help: 'Include verbose logging from the Flutter engine.',
       )
-      ..addFlag('cache-sksl',
+      ..addFlag(
+        'cache-sksl',
         negatable: false,
-        help: 'Cache the shader in the SkSL format instead of in binary or GLSL formats.',
+        help:
+            'Cache the shader in the SkSL format instead of in binary or GLSL formats.',
       )
-      ..addFlag('dump-skp-on-shader-compilation',
+      ..addFlag(
+        'dump-skp-on-shader-compilation',
         negatable: false,
-        help: 'Automatically dump the skp that triggers new shader compilations. '
-              'This is useful for writing custom ShaderWarmUp to reduce jank. '
-              'By default, this is not enabled as it introduces significant overhead. '
-              'This is only available in profile or debug builds.',
+        help:
+            'Automatically dump the skp that triggers new shader compilations. '
+            'This is useful for writing custom ShaderWarmUp to reduce jank. '
+            'By default, this is not enabled as it introduces significant overhead. '
+            'This is only available in profile or debug builds.',
       )
-      ..addFlag('purge-persistent-cache',
+      ..addFlag(
+        'purge-persistent-cache',
         negatable: false,
         help: 'Removes all existing persistent caches. This allows reproducing '
-              'shader compilation jank that normally only happens the first time '
-              'an app is run, or for reliable testing of compilation jank fixes '
-              '(e.g. shader warm-up).',
+            'shader compilation jank that normally only happens the first time '
+            'an app is run, or for reliable testing of compilation jank fixes '
+            '(e.g. shader warm-up).',
       )
-      ..addOption('route',
+      ..addOption(
+        'route',
         help: 'Which route to load when running the app.',
       )
-      ..addOption('vmservice-out-file',
+      ..addOption(
+        'vmservice-out-file',
         help: 'A file to write the attached vmservice URL to after an '
-              'application is started.',
+            'application is started.',
         valueHelp: 'project/example/out.txt',
         hide: !verboseHelp,
       )
       ..addFlag('disable-service-auth-codes',
-        negatable: false,
-        hide: !verboseHelp,
-        help: '(deprecated) Allow connections to the VM service without using authentication codes. '
-              '(Not recommended! This can open your device to remote code execution attacks!)'
-      )
-      ..addFlag('start-paused',
+          negatable: false,
+          hide: !verboseHelp,
+          help:
+              '(deprecated) Allow connections to the VM service without using authentication codes. '
+              '(Not recommended! This can open your device to remote code execution attacks!)')
+      ..addFlag(
+        'start-paused',
         defaultsTo: startPausedDefault,
         help: 'Start in a paused mode and wait for a debugger to connect.',
       )
       ..addOption('dart-flags',
-        hide: !verboseHelp,
-        help: 'Pass a list of comma separated flags to the Dart instance at '
+          hide: !verboseHelp,
+          help: 'Pass a list of comma separated flags to the Dart instance at '
               'application startup. Flags passed through this option must be '
               'present on the allowlist defined within the Flutter engine. If '
               'a disallowed flag is encountered, the process will be '
               'terminated immediately.\n\n'
               'This flag is not available on the stable channel and is only '
               'applied in debug and profile modes. This option should only '
-              'be used for experiments and should not be used by typical users.'
-      )
-      ..addFlag('endless-trace-buffer',
+              'be used for experiments and should not be used by typical users.')
+      ..addFlag(
+        'endless-trace-buffer',
         negatable: false,
         help: 'Enable tracing to an infinite buffer, instead of a ring buffer. '
-              'This is useful when recording large traces. To use an endless buffer to '
-              'record startup traces, combine this with "--trace-startup".',
+            'This is useful when recording large traces. To use an endless buffer to '
+            'record startup traces, combine this with "--trace-startup".',
       )
-      ..addFlag('trace-systrace',
+      ..addFlag(
+        'trace-systrace',
         negatable: false,
         help: 'Enable tracing to the system tracer. This is only useful on '
-              'platforms where such a tracer is available (Android, iOS, '
-              'macOS and Fuchsia).',
+            'platforms where such a tracer is available (Android, iOS, '
+            'macOS and Fuchsia).',
       )
-      ..addOption('trace-to-file',
+      ..addOption(
+        'trace-to-file',
         help: 'Write the timeline trace to a file at the specified path. The '
-              "file will be in Perfetto's proto format; it will be possible to "
-              "load the file into Perfetto's trace viewer.",
+            "file will be in Perfetto's proto format; it will be possible to "
+            "load the file into Perfetto's trace viewer.",
         valueHelp: 'path/to/trace.binpb',
       )
-      ..addFlag('trace-skia',
+      ..addFlag(
+        'trace-skia',
         negatable: false,
         help: 'Enable tracing of Skia code. This is useful when debugging '
-              'the raster thread (formerly known as the GPU thread). '
-              'By default, Flutter will not log Skia code, as it introduces significant '
-              'overhead that may affect recorded performance metrics in a misleading way.',
+            'the raster thread (formerly known as the GPU thread). '
+            'By default, Flutter will not log Skia code, as it introduces significant '
+            'overhead that may affect recorded performance metrics in a misleading way.',
       )
-      ..addOption('trace-allowlist',
+      ..addOption(
+        'trace-allowlist',
         hide: !verboseHelp,
         help: 'Filters out all trace events except those that are specified in '
-              'this comma separated list of allowed prefixes.',
+            'this comma separated list of allowed prefixes.',
         valueHelp: 'foo,bar',
       )
-      ..addOption('trace-skia-allowlist',
+      ..addOption(
+        'trace-skia-allowlist',
         hide: !verboseHelp,
-        help: 'Filters out all Skia trace events except those that are specified in '
-              'this comma separated list of allowed prefixes.',
+        help:
+            'Filters out all Skia trace events except those that are specified in '
+            'this comma separated list of allowed prefixes.',
         valueHelp: 'skia.gpu,skia.shaders',
       )
-      ..addFlag('enable-dart-profiling',
+      ..addFlag(
+        'enable-dart-profiling',
         defaultsTo: true,
         help: 'Whether the Dart VM sampling CPU profiler is enabled. This flag '
-              'is only meaningful in debug and profile builds.',
+            'is only meaningful in debug and profile builds.',
       )
-      ..addFlag('enable-software-rendering',
+      ..addFlag(
+        'enable-software-rendering',
         negatable: false,
         help: '(deprecated) Enable rendering using the Skia software backend. '
             'This is useful when testing Flutter on emulators. By default, '
@@ -160,26 +182,30 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
             'when using the Impeller rendering engine.',
         hide: !verboseHelp,
       )
-      ..addFlag('skia-deterministic-rendering',
+      ..addFlag(
+        'skia-deterministic-rendering',
         negatable: false,
-        help: '(deprecated) When combined with "--enable-software-rendering", this should provide completely '
+        help:
+            '(deprecated) When combined with "--enable-software-rendering", this should provide completely '
             'deterministic (i.e. reproducible) Skia rendering. This is useful for testing purposes '
             '(e.g. when comparing screenshots). This option is not supported '
             'when using the Impeller rendering engine.',
         hide: !verboseHelp,
       )
-      ..addMultiOption('dart-entrypoint-args',
+      ..addMultiOption(
+        'dart-entrypoint-args',
         abbr: 'a',
         help: 'Pass a list of arguments to the Dart entrypoint at application '
-              'startup. By default this is main(List<String> args). Specify '
-              'this option multiple times each with one argument to pass '
-              'multiple arguments to the Dart entrypoint. Currently this is '
-              'only supported on desktop platforms.',
+            'startup. By default this is main(List<String> args). Specify '
+            'this option multiple times each with one argument to pass '
+            'multiple arguments to the Dart entrypoint. Currently this is '
+            'only supported on desktop platforms.',
       )
-      ..addFlag('uninstall-first',
+      ..addFlag(
+        'uninstall-first',
         hide: !verboseHelp,
         help: 'Uninstall previous versions of the app on the device '
-              'before reinstalling. Currently only supported on iOS.',
+            'before reinstalling. Currently only supported on iOS.',
       )
       ..addFlag(
         FlutterOptions.kWebWasmFlag,
@@ -209,13 +235,16 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   bool get traceStartup => boolArg('trace-startup');
   bool get enableDartProfiling => boolArg('enable-dart-profiling');
   bool get cacheSkSL => boolArg('cache-sksl');
-  bool get dumpSkpOnShaderCompilation => boolArg('dump-skp-on-shader-compilation');
+  bool get dumpSkpOnShaderCompilation =>
+      boolArg('dump-skp-on-shader-compilation');
   bool get purgePersistentCache => boolArg('purge-persistent-cache');
   bool get disableServiceAuthCodes => boolArg('disable-service-auth-codes');
   bool get cacheStartupProfile => boolArg('cache-startup-profile');
-  bool get runningWithPrebuiltApplication => argResults![FlutterOptions.kUseApplicationBinary] != null;
+  bool get runningWithPrebuiltApplication =>
+      argResults![FlutterOptions.kUseApplicationBinary] != null;
   bool get trackWidgetCreation => boolArg('track-widget-creation');
-  ImpellerStatus get enableImpeller => ImpellerStatus.fromBool(argResults!['enable-impeller'] as bool?);
+  ImpellerStatus get enableImpeller =>
+      ImpellerStatus.fromBool(argResults!['enable-impeller'] as bool?);
   bool get enableVulkanValidation => boolArg('enable-vulkan-validation');
   bool get uninstallFirst => boolArg('uninstall-first');
   bool get enableEmbedderApi => boolArg('enable-embedder-api');
@@ -235,19 +264,19 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
 
   bool get useWasm => boolArg(FlutterOptions.kWebWasmFlag);
 
-  WebRendererMode get webRenderer => WebRendererMode.fromCliOption(
-    stringArg(FlutterOptions.kWebRendererFlag),
-    useWasm: useWasm
-  );
+  WebRendererMode get webRenderer =>
+      WebRendererMode.fromCliOption(stringArg(FlutterOptions.kWebRendererFlag),
+          useWasm: useWasm);
 
   /// Create a debugging options instance for the current `run` or `drive` invocation.
   @visibleForTesting
   @protected
   Future<DebuggingOptions> createDebuggingOptions(bool webMode) async {
     final BuildInfo buildInfo = await getBuildInfo();
-    final int? webBrowserDebugPort = featureFlags.isWebEnabled && argResults!.wasParsed('web-browser-debug-port')
-      ? int.parse(stringArg('web-browser-debug-port')!)
-      : null;
+    final int? webBrowserDebugPort = featureFlags.isWebEnabled &&
+            argResults!.wasParsed('web-browser-debug-port')
+        ? int.parse(stringArg('web-browser-debug-port')!)
+        : null;
     final List<String> webBrowserFlags = featureFlags.isWebEnabled
         ? stringsArg(FlutterOptions.kWebBrowserFlag)
         : const <String>[];
@@ -262,13 +291,21 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         dartEntrypointArgs: stringsArg('dart-entrypoint-args'),
         hostname: featureFlags.isWebEnabled ? stringArg('web-hostname') : '',
         port: featureFlags.isWebEnabled ? stringArg('web-port') : '',
-        tlsCertPath: featureFlags.isWebEnabled ? stringArg('web-tls-cert-path') : null,
-        tlsCertKeyPath: featureFlags.isWebEnabled ? stringArg('web-tls-cert-key-path') : null,
-        webUseSseForDebugProxy: featureFlags.isWebEnabled && stringArg('web-server-debug-protocol') == 'sse',
-        webUseSseForDebugBackend: featureFlags.isWebEnabled && stringArg('web-server-debug-backend-protocol') == 'sse',
-        webUseSseForInjectedClient: featureFlags.isWebEnabled && stringArg('web-server-debug-injected-client-protocol') == 'sse',
-        webEnableExposeUrl: featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
-        webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
+        tlsCertPath:
+            featureFlags.isWebEnabled ? stringArg('web-tls-cert-path') : null,
+        tlsCertKeyPath: featureFlags.isWebEnabled
+            ? stringArg('web-tls-cert-key-path')
+            : null,
+        webUseSseForDebugProxy: featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-protocol') == 'sse',
+        webUseSseForDebugBackend: featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-backend-protocol') == 'sse',
+        webUseSseForInjectedClient: featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-injected-client-protocol') == 'sse',
+        webEnableExposeUrl:
+            featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
+        webRunHeadless:
+            featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
         webHeaders: webHeaders,
@@ -291,9 +328,14 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         enableDds: enableDds,
         dartEntrypointArgs: stringsArg('dart-entrypoint-args'),
         dartFlags: stringArg('dart-flags') ?? '',
-        useTestFonts: argParser.options.containsKey('use-test-fonts') && boolArg('use-test-fonts'),
-        enableSoftwareRendering: argParser.options.containsKey('enable-software-rendering') && boolArg('enable-software-rendering'),
-        skiaDeterministicRendering: argParser.options.containsKey('skia-deterministic-rendering') && boolArg('skia-deterministic-rendering'),
+        useTestFonts: argParser.options.containsKey('use-test-fonts') &&
+            boolArg('use-test-fonts'),
+        enableSoftwareRendering:
+            argParser.options.containsKey('enable-software-rendering') &&
+                boolArg('enable-software-rendering'),
+        skiaDeterministicRendering:
+            argParser.options.containsKey('skia-deterministic-rendering') &&
+                boolArg('skia-deterministic-rendering'),
         traceSkia: boolArg('trace-skia'),
         traceAllowlist: traceAllowlist,
         traceSkiaAllowlist: stringArg('trace-skia-allowlist'),
@@ -311,24 +353,34 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         verboseSystemLogs: boolArg('verbose-system-logs'),
         hostname: featureFlags.isWebEnabled ? stringArg('web-hostname') : '',
         port: featureFlags.isWebEnabled ? stringArg('web-port') : '',
-        tlsCertPath: featureFlags.isWebEnabled ? stringArg('web-tls-cert-path') : null,
-        tlsCertKeyPath: featureFlags.isWebEnabled ? stringArg('web-tls-cert-key-path') : null,
-        webUseSseForDebugProxy: featureFlags.isWebEnabled && stringArg('web-server-debug-protocol') == 'sse',
-        webUseSseForDebugBackend: featureFlags.isWebEnabled && stringArg('web-server-debug-backend-protocol') == 'sse',
-        webUseSseForInjectedClient: featureFlags.isWebEnabled && stringArg('web-server-debug-injected-client-protocol') == 'sse',
-        webEnableExposeUrl: featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
-        webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
+        tlsCertPath:
+            featureFlags.isWebEnabled ? stringArg('web-tls-cert-path') : null,
+        tlsCertKeyPath: featureFlags.isWebEnabled
+            ? stringArg('web-tls-cert-key-path')
+            : null,
+        webUseSseForDebugProxy: featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-protocol') == 'sse',
+        webUseSseForDebugBackend: featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-backend-protocol') == 'sse',
+        webUseSseForInjectedClient: featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-injected-client-protocol') == 'sse',
+        webEnableExposeUrl:
+            featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
+        webRunHeadless:
+            featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
-        webEnableExpressionEvaluation: featureFlags.isWebEnabled && boolArg('web-enable-expression-evaluation'),
-        webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,
+        webEnableExpressionEvaluation: featureFlags.isWebEnabled &&
+            boolArg('web-enable-expression-evaluation'),
+        webLaunchUrl:
+            featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,
         webHeaders: webHeaders,
         webRenderer: webRenderer,
         webUseWasm: useWasm,
         vmserviceOutFile: stringArg('vmservice-out-file'),
-        fastStart: argParser.options.containsKey('fast-start')
-          && boolArg('fast-start')
-          && !runningWithPrebuiltApplication,
+        fastStart: argParser.options.containsKey('fast-start') &&
+            boolArg('fast-start') &&
+            !runningWithPrebuiltApplication,
         nullAssertions: boolArg('null-assertions'),
         nativeNullAssertions: boolArg('native-null-assertions'),
         enableImpeller: enableImpeller,
@@ -351,8 +403,8 @@ class RunCommand extends RunCommandBase {
   RunCommand({
     bool verboseHelp = false,
     HotRunnerNativeAssetsBuilder? nativeAssetsBuilder,
-  }) : _nativeAssetsBuilder = nativeAssetsBuilder,
-       super(verboseHelp: verboseHelp) {
+  })  : _nativeAssetsBuilder = nativeAssetsBuilder,
+        super(verboseHelp: verboseHelp) {
     requiresPubspecYaml();
     usesFilesystemOptions(hide: !verboseHelp);
     usesExtraDartFlagOptions(verboseHelp: verboseHelp);
@@ -367,71 +419,88 @@ class RunCommand extends RunCommandBase {
     addPublishPort(verboseHelp: verboseHelp);
     addIgnoreDeprecationOption();
     argParser
-      ..addFlag('await-first-frame-when-tracing',
+      ..addFlag(
+        'await-first-frame-when-tracing',
         defaultsTo: true,
-        help: 'Whether to wait for the first frame when tracing startup ("--trace-startup"), '
-              'or just dump the trace as soon as the application is running. The first frame '
-              'is detected by looking for a Timeline event with the name '
-              '"${Tracing.firstUsefulFrameEventName}". '
-              "By default, the widgets library's binding takes care of sending this event.",
+        help:
+            'Whether to wait for the first frame when tracing startup ("--trace-startup"), '
+            'or just dump the trace as soon as the application is running. The first frame '
+            'is detected by looking for a Timeline event with the name '
+            '"${Tracing.firstUsefulFrameEventName}". '
+            "By default, the widgets library's binding takes care of sending this event.",
       )
-      ..addFlag('use-test-fonts',
+      ..addFlag(
+        'use-test-fonts',
         help: 'Enable (and default to) the "Ahem" font. This is a special font '
-              'used in tests to remove any dependencies on the font metrics. It '
-              'is enabled when you use "flutter test". Set this flag when running '
-              'a test using "flutter run" for debugging purposes. This flag is '
-              'only available when running in debug mode.',
+            'used in tests to remove any dependencies on the font metrics. It '
+            'is enabled when you use "flutter test". Set this flag when running '
+            'a test using "flutter run" for debugging purposes. This flag is '
+            'only available when running in debug mode.',
       )
-      ..addFlag('build',
+      ..addFlag(
+        'build',
         defaultsTo: true,
         help: 'If necessary, build the app before running.',
       )
-      ..addOption('project-root',
+      ..addOption(
+        'project-root',
         hide: !verboseHelp,
         help: 'Specify the project root directory.',
       )
-      ..addFlag('machine',
+      ..addFlag(
+        'machine',
         hide: !verboseHelp,
         negatable: false,
         help: 'Handle machine structured JSON command input and provide output '
-              'and progress in machine friendly format.',
+            'and progress in machine friendly format.',
       )
-      ..addFlag('hot',
+      ..addFlag(
+        'hot',
         defaultsTo: kHotReloadDefault,
-        help: 'Run with support for hot reloading. Only available for debug mode. Not available with "--trace-startup".',
+        help:
+            'Run with support for hot reloading. Only available for debug mode. Not available with "--trace-startup".',
       )
-      ..addFlag('resident',
+      ..addFlag(
+        'resident',
         defaultsTo: true,
         hide: !verboseHelp,
-        help: 'Stay resident after launching the application. Not available with "--trace-startup".',
+        help:
+            'Stay resident after launching the application. Not available with "--trace-startup".',
       )
-      ..addOption('pid-file',
+      ..addOption(
+        'pid-file',
         help: 'Specify a file to write the process ID to. '
-              'You can send SIGUSR1 to trigger a hot reload '
-              'and SIGUSR2 to trigger a hot restart. '
-              'The file is created when the signal handlers '
-              'are hooked and deleted when they are removed.',
-      )..addFlag(
+            'You can send SIGUSR1 to trigger a hot reload '
+            'and SIGUSR2 to trigger a hot restart. '
+            'The file is created when the signal handlers '
+            'are hooked and deleted when they are removed.',
+      )
+      ..addFlag(
         'report-ready',
-        help: 'Print "ready" to the console after handling a keyboard command.\n'
-              'This is primarily useful for tests and other automation, but consider '
-              'using "--machine" instead.',
+        help:
+            'Print "ready" to the console after handling a keyboard command.\n'
+            'This is primarily useful for tests and other automation, but consider '
+            'using "--machine" instead.',
         hide: !verboseHelp,
-      )..addFlag('benchmark',
+      )
+      ..addFlag(
+        'benchmark',
         negatable: false,
         hide: !verboseHelp,
-        help: 'Enable a benchmarking mode. This will run the given application, '
-              'measure the startup time and the app restart time, write the '
-              'results out to "refresh_benchmark.json", and exit. This flag is '
-              'intended for use in generating automated flutter benchmarks.',
+        help:
+            'Enable a benchmarking mode. This will run the given application, '
+            'measure the startup time and the app restart time, write the '
+            'results out to "refresh_benchmark.json", and exit. This flag is '
+            'intended for use in generating automated flutter benchmarks.',
       )
       // TODO(zanderso): Off by default with investigating whether this
       // is slower for certain use cases.
       // See: https://github.com/flutter/flutter/issues/49499
-      ..addFlag('fast-start',
+      ..addFlag(
+        'fast-start',
         help: 'Whether to quickly bootstrap applications with a minimal app. '
-              'Currently this is only supported on Android devices. This option '
-              'cannot be paired with "--${FlutterOptions.kUseApplicationBinary}".',
+            'Currently this is only supported on Android devices. This option '
+            'cannot be paired with "--${FlutterOptions.kUseApplicationBinary}".',
         hide: !verboseHelp,
       );
   }
@@ -442,7 +511,9 @@ class RunCommand extends RunCommandBase {
   final String name = 'run';
 
   @override
-  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : _deviceDeprecationBehavior;
+  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation')
+      ? DeprecationBehavior.ignore
+      : _deviceDeprecationBehavior;
   DeprecationBehavior _deviceDeprecationBehavior = DeprecationBehavior.none;
 
   @override
@@ -491,7 +562,8 @@ class RunCommand extends RunCommandBase {
   }
 
   @override
-  Future<analytics.Event> unifiedAnalyticsUsageValues(String commandPath) async {
+  Future<analytics.Event> unifiedAnalyticsUsageValues(
+      String commandPath) async {
     final AnalyticsUsageValuesRecord record = await _sharedAnalyticsUsageValues;
 
     return analytics.Event.commandUsageValues(
@@ -510,7 +582,8 @@ class RunCommand extends RunCommandBase {
     );
   }
 
-  late final Future<AnalyticsUsageValuesRecord> _sharedAnalyticsUsageValues = (() async {
+  late final Future<AnalyticsUsageValuesRecord> _sharedAnalyticsUsageValues =
+      (() async {
     String deviceType, deviceOsVersion;
     bool isEmulator;
     bool anyAndroidDevices = false;
@@ -538,7 +611,8 @@ class RunCommand extends RunCommandBase {
       isEmulator = false;
       for (final Device device in devices!) {
         final TargetPlatform platform = await device.targetPlatform;
-        anyAndroidDevices = anyAndroidDevices || (platform == TargetPlatform.android);
+        anyAndroidDevices =
+            anyAndroidDevices || (platform == TargetPlatform.android);
         anyIOSDevices = anyIOSDevices || (platform == TargetPlatform.ios);
         if (device is IOSDevice && device.isWirelesslyConnected) {
           anyWirelessIOSDevices = true;
@@ -560,7 +634,8 @@ class RunCommand extends RunCommandBase {
       final AndroidProject androidProject = FlutterProject.current().android;
       if (androidProject.existsSync()) {
         hostLanguage.add(androidProject.isKotlin ? 'kotlin' : 'java');
-        androidEmbeddingVersion = androidProject.getEmbeddingVersion().toString().split('.').last;
+        androidEmbeddingVersion =
+            androidProject.getEmbeddingVersion().toString().split('.').last;
       }
     }
     if (anyIOSDevices) {
@@ -569,7 +644,8 @@ class RunCommand extends RunCommandBase {
         final Iterable<File> swiftFiles = iosProject.hostAppRoot
             .listSync(recursive: true, followLinks: false)
             .whereType<File>()
-            .where((File file) => globals.fs.path.extension(file.path) == '.swift');
+            .where((File file) =>
+                globals.fs.path.extension(file.path) == '.swift');
         hostLanguage.add(swiftFiles.isNotEmpty ? 'swift' : 'objc');
       }
     }
@@ -607,7 +683,8 @@ class RunCommand extends RunCommandBase {
   }
 
   bool get stayResident => boolArg('resident');
-  bool get awaitFirstFrameWhenTracing => boolArg('await-first-frame-when-tracing');
+  bool get awaitFirstFrameWhenTracing =>
+      boolArg('await-first-frame-when-tracing');
 
   @override
   Future<void> validateCommand() async {
@@ -623,22 +700,26 @@ class RunCommand extends RunCommandBase {
     }
 
     if (devices!.length == 1 && devices!.first is MacOSDesignedForIPadDevice) {
-      throwToolExit('Mac Designed for iPad is currently not supported for flutter run -d.');
+      throwToolExit(
+          'Mac Designed for iPad is currently not supported for flutter run -d.');
     }
 
     if (globals.deviceManager!.hasSpecifiedAllDevices) {
-      devices?.removeWhere((Device device) => device is MacOSDesignedForIPadDevice);
+      devices?.removeWhere(
+          (Device device) => device is MacOSDesignedForIPadDevice);
     }
 
-    if (globals.deviceManager!.hasSpecifiedAllDevices && runningWithPrebuiltApplication) {
-      throwToolExit('Using "-d all" with "--${FlutterOptions.kUseApplicationBinary}" is not supported');
-    }
-
-    if (userIdentifier != null
-      && devices!.every((Device device) => device.platformType != PlatformType.android)) {
+    if (globals.deviceManager!.hasSpecifiedAllDevices &&
+        runningWithPrebuiltApplication) {
       throwToolExit(
-        '--${FlutterOptions.kDeviceUser} is only supported for Android. At least one Android device is required.'
-      );
+          'Using "-d all" with "--${FlutterOptions.kUseApplicationBinary}" is not supported');
+    }
+
+    if (userIdentifier != null &&
+        devices!.every(
+            (Device device) => device.platformType != PlatformType.android)) {
+      throwToolExit(
+          '--${FlutterOptions.kDeviceUser} is only supported for Android. At least one Android device is required.');
     }
 
     if (devices!.any((Device device) => device is AndroidDevice)) {
@@ -648,8 +729,8 @@ class RunCommand extends RunCommandBase {
     // Only support "web mode" with a single web device due to resident runner
     // refactoring required otherwise.
     webMode = featureFlags.isWebEnabled &&
-      devices!.length == 1  &&
-      await devices!.single.targetPlatform == TargetPlatform.web_javascript;
+        devices!.length == 1 &&
+        await devices!.single.targetPlatform == TargetPlatform.web_javascript;
 
     if (useWasm && !webMode) {
       throwToolExit('--wasm is only supported on the web platform');
@@ -664,14 +745,13 @@ class RunCommand extends RunCommandBase {
     }
 
     final String? flavor = stringArg('flavor');
-    final bool flavorsSupportedOnEveryDevice = devices!
-      .every((Device device) => device.supportsFlavors);
+    final bool flavorsSupportedOnEveryDevice =
+        devices!.every((Device device) => device.supportsFlavors);
     if (flavor != null && !flavorsSupportedOnEveryDevice) {
       globals.printWarning(
-        '--flavor is only supported for Android, macOS, and iOS devices. '
-        'Flavor-related features may not function properly and could '
-        'behave differently in a future release.'
-      );
+          '--flavor is only supported for Android, macOS, and iOS devices. '
+          'Flavor-related features may not function properly and could '
+          'behave differently in a future release.');
     }
   }
 
@@ -682,6 +762,7 @@ class RunCommand extends RunCommandBase {
     required String? applicationBinaryPath,
     required FlutterProject flutterProject,
   }) async {
+    final bool useImplicitPubspecResolution = globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution);
     if (hotMode && !webMode) {
       return HotRunner(
         flutterDevices,
@@ -697,6 +778,7 @@ class RunCommand extends RunCommandBase {
         analytics: globals.analytics,
         nativeAssetsYamlFile: stringArg(FlutterOptions.kNativeAssetsYamlFile),
         nativeAssetsBuilder: _nativeAssetsBuilder,
+        useImplicitPubspecResolution: useImplicitPubspecResolution,
       );
     } else if (webMode) {
       return webRunnerFactory!.createWebRunner(
@@ -710,6 +792,7 @@ class RunCommand extends RunCommandBase {
         analytics: globals.analytics,
         logger: globals.logger,
         systemClock: globals.systemClock,
+        useImplicitPubspecResolution: useImplicitPubspecResolution,
       );
     }
     return ColdRunner(
@@ -722,6 +805,7 @@ class RunCommand extends RunCommandBase {
           ? null
           : globals.fs.file(applicationBinaryPath),
       stayResident: stayResident,
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     );
   }
 
@@ -729,13 +813,16 @@ class RunCommand extends RunCommandBase {
   Daemon createMachineDaemon() {
     final Daemon daemon = Daemon(
       DaemonConnection(
-        daemonStreams: DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
+        daemonStreams:
+            DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
         logger: globals.logger,
       ),
       notifyingLogger: (globals.logger is NotifyingLogger)
-        ? globals.logger as NotifyingLogger
-        : NotifyingLogger(verbose: globals.logger.isVerbose, parent: globals.logger),
+          ? globals.logger as NotifyingLogger
+          : NotifyingLogger(
+              verbose: globals.logger.isVerbose, parent: globals.logger),
       logToStdout: true,
+      useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
     );
     return daemon;
   }
@@ -746,7 +833,8 @@ class RunCommand extends RunCommandBase {
     // Enable hot mode by default if `--no-hot` was not passed and we are in
     // debug mode.
     final bool hotMode = shouldUseHotMode(buildInfo);
-    final String? applicationBinaryPath = stringArg(FlutterOptions.kUseApplicationBinary);
+    final String? applicationBinaryPath =
+        stringArg(FlutterOptions.kUseApplicationBinary);
 
     if (boolArg('machine')) {
       if (devices!.length > 1) {
@@ -756,14 +844,19 @@ class RunCommand extends RunCommandBase {
       late AppInstance app;
       try {
         app = await daemon.appDomain.startApp(
-          devices!.first, globals.fs.currentDirectory.path, targetFile, route,
-          await createDebuggingOptions(webMode), hotMode,
+          devices!.first,
+          globals.fs.currentDirectory.path,
+          targetFile,
+          route,
+          await createDebuggingOptions(webMode),
+          hotMode,
           applicationBinary: applicationBinaryPath == null
               ? null
               : globals.fs.file(applicationBinaryPath),
           trackWidgetCreation: trackWidgetCreation,
           projectRootPath: stringArg('project-root'),
-          packagesFilePath: globalResults![FlutterGlobalOptions.kPackagesOption] as String?,
+          packagesFilePath:
+              globalResults![FlutterGlobalOptions.kPackagesOption] as String?,
           dillOutputPath: stringArg('output-dill'),
           userIdentifier: userIdentifier,
           nativeAssetsBuilder: _nativeAssetsBuilder,
@@ -794,7 +887,8 @@ class RunCommand extends RunCommandBase {
       }
       if (hotMode) {
         if (!device.supportsHotReload) {
-          throwToolExit('Hot reload is not supported by ${device.name}. Run with "--no-hot".');
+          throwToolExit(
+              'Hot reload is not supported by ${device.name}. Run with "--no-hot".');
         }
       }
     }
@@ -832,24 +926,22 @@ class RunCommand extends RunCommandBase {
 
     TerminalHandler? handler;
     // This callback can't throw.
-    unawaited(appStartedTimeRecorder.future.then<void>(
-      (_) {
-        appStartedTime = globals.systemClock.now();
-        if (stayResident) {
-          handler = TerminalHandler(
-            runner,
-            logger: globals.logger,
-            terminal: globals.terminal,
-            signals: globals.signals,
-            processInfo: globals.processInfo,
-            reportReady: boolArg('report-ready'),
-            pidFile: stringArg('pid-file'),
-          )
-            ..registerSignalHandlers()
-            ..setupTerminal();
-        }
+    unawaited(appStartedTimeRecorder.future.then<void>((_) {
+      appStartedTime = globals.systemClock.now();
+      if (stayResident) {
+        handler = TerminalHandler(
+          runner,
+          logger: globals.logger,
+          terminal: globals.terminal,
+          signals: globals.signals,
+          processInfo: globals.processInfo,
+          reportReady: boolArg('report-ready'),
+          pidFile: stringArg('pid-file'),
+        )
+          ..registerSignalHandlers()
+          ..setupTerminal();
       }
-    ));
+    }));
     try {
       final int? result = await runner.run(
         appStartedCompleter: appStartedTimeRecorder,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -35,9 +35,8 @@ import '../web/web_runner.dart';
 import 'daemon.dart';
 
 /// Shared logic between `flutter run` and `flutter drive` commands.
-abstract class RunCommandBase extends FlutterCommand
-    with DeviceBasedDevelopmentArtifacts {
-  RunCommandBase({required bool verboseHelp}) {
+abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
+  RunCommandBase({ required bool verboseHelp }) {
     addBuildModeFlags(verboseHelp: verboseHelp, defaultToRelease: false);
     usesDartDefineOption();
     usesFlavorOption();
@@ -47,133 +46,112 @@ abstract class RunCommandBase extends FlutterCommand
     addBundleSkSLPathOption(hide: !verboseHelp);
     usesApplicationBinaryOption();
     argParser
-      ..addFlag(
-        'trace-startup',
+      ..addFlag('trace-startup',
         negatable: false,
-        help:
-            'Trace application startup, then exit, saving the trace to a file. '
-            'By default, this will be saved in the "build" directory. If the '
-            'FLUTTER_TEST_OUTPUTS_DIR environment variable is set, the file '
-            'will be written there instead.',
+        help: 'Trace application startup, then exit, saving the trace to a file. '
+              'By default, this will be saved in the "build" directory. If the '
+              'FLUTTER_TEST_OUTPUTS_DIR environment variable is set, the file '
+              'will be written there instead.',
       )
-      ..addFlag(
-        'cache-startup-profile',
-        help:
-            'Caches the CPU profile collected before the first frame for startup '
-            'analysis.',
+      ..addFlag('cache-startup-profile',
+        help: 'Caches the CPU profile collected before the first frame for startup '
+              'analysis.',
       )
-      ..addFlag(
-        'verbose-system-logs',
+      ..addFlag('verbose-system-logs',
         negatable: false,
         help: 'Include verbose logging from the Flutter engine.',
       )
-      ..addFlag(
-        'cache-sksl',
+      ..addFlag('cache-sksl',
         negatable: false,
-        help:
-            'Cache the shader in the SkSL format instead of in binary or GLSL formats.',
+        help: 'Cache the shader in the SkSL format instead of in binary or GLSL formats.',
       )
-      ..addFlag(
-        'dump-skp-on-shader-compilation',
+      ..addFlag('dump-skp-on-shader-compilation',
         negatable: false,
-        help:
-            'Automatically dump the skp that triggers new shader compilations. '
-            'This is useful for writing custom ShaderWarmUp to reduce jank. '
-            'By default, this is not enabled as it introduces significant overhead. '
-            'This is only available in profile or debug builds.',
+        help: 'Automatically dump the skp that triggers new shader compilations. '
+              'This is useful for writing custom ShaderWarmUp to reduce jank. '
+              'By default, this is not enabled as it introduces significant overhead. '
+              'This is only available in profile or debug builds.',
       )
-      ..addFlag(
-        'purge-persistent-cache',
+      ..addFlag('purge-persistent-cache',
         negatable: false,
         help: 'Removes all existing persistent caches. This allows reproducing '
-            'shader compilation jank that normally only happens the first time '
-            'an app is run, or for reliable testing of compilation jank fixes '
-            '(e.g. shader warm-up).',
+              'shader compilation jank that normally only happens the first time '
+              'an app is run, or for reliable testing of compilation jank fixes '
+              '(e.g. shader warm-up).',
       )
-      ..addOption(
-        'route',
+      ..addOption('route',
         help: 'Which route to load when running the app.',
       )
-      ..addOption(
-        'vmservice-out-file',
+      ..addOption('vmservice-out-file',
         help: 'A file to write the attached vmservice URL to after an '
-            'application is started.',
+              'application is started.',
         valueHelp: 'project/example/out.txt',
         hide: !verboseHelp,
       )
       ..addFlag('disable-service-auth-codes',
-          negatable: false,
-          hide: !verboseHelp,
-          help:
-              '(deprecated) Allow connections to the VM service without using authentication codes. '
-              '(Not recommended! This can open your device to remote code execution attacks!)')
-      ..addFlag(
-        'start-paused',
+        negatable: false,
+        hide: !verboseHelp,
+        help: '(deprecated) Allow connections to the VM service without using authentication codes. '
+              '(Not recommended! This can open your device to remote code execution attacks!)'
+      )
+      ..addFlag('start-paused',
         defaultsTo: startPausedDefault,
         help: 'Start in a paused mode and wait for a debugger to connect.',
       )
       ..addOption('dart-flags',
-          hide: !verboseHelp,
-          help: 'Pass a list of comma separated flags to the Dart instance at '
+        hide: !verboseHelp,
+        help: 'Pass a list of comma separated flags to the Dart instance at '
               'application startup. Flags passed through this option must be '
               'present on the allowlist defined within the Flutter engine. If '
               'a disallowed flag is encountered, the process will be '
               'terminated immediately.\n\n'
               'This flag is not available on the stable channel and is only '
               'applied in debug and profile modes. This option should only '
-              'be used for experiments and should not be used by typical users.')
-      ..addFlag(
-        'endless-trace-buffer',
+              'be used for experiments and should not be used by typical users.'
+      )
+      ..addFlag('endless-trace-buffer',
         negatable: false,
         help: 'Enable tracing to an infinite buffer, instead of a ring buffer. '
-            'This is useful when recording large traces. To use an endless buffer to '
-            'record startup traces, combine this with "--trace-startup".',
+              'This is useful when recording large traces. To use an endless buffer to '
+              'record startup traces, combine this with "--trace-startup".',
       )
-      ..addFlag(
-        'trace-systrace',
+      ..addFlag('trace-systrace',
         negatable: false,
         help: 'Enable tracing to the system tracer. This is only useful on '
-            'platforms where such a tracer is available (Android, iOS, '
-            'macOS and Fuchsia).',
+              'platforms where such a tracer is available (Android, iOS, '
+              'macOS and Fuchsia).',
       )
-      ..addOption(
-        'trace-to-file',
+      ..addOption('trace-to-file',
         help: 'Write the timeline trace to a file at the specified path. The '
-            "file will be in Perfetto's proto format; it will be possible to "
-            "load the file into Perfetto's trace viewer.",
+              "file will be in Perfetto's proto format; it will be possible to "
+              "load the file into Perfetto's trace viewer.",
         valueHelp: 'path/to/trace.binpb',
       )
-      ..addFlag(
-        'trace-skia',
+      ..addFlag('trace-skia',
         negatable: false,
         help: 'Enable tracing of Skia code. This is useful when debugging '
-            'the raster thread (formerly known as the GPU thread). '
-            'By default, Flutter will not log Skia code, as it introduces significant '
-            'overhead that may affect recorded performance metrics in a misleading way.',
+              'the raster thread (formerly known as the GPU thread). '
+              'By default, Flutter will not log Skia code, as it introduces significant '
+              'overhead that may affect recorded performance metrics in a misleading way.',
       )
-      ..addOption(
-        'trace-allowlist',
+      ..addOption('trace-allowlist',
         hide: !verboseHelp,
         help: 'Filters out all trace events except those that are specified in '
-            'this comma separated list of allowed prefixes.',
+              'this comma separated list of allowed prefixes.',
         valueHelp: 'foo,bar',
       )
-      ..addOption(
-        'trace-skia-allowlist',
+      ..addOption('trace-skia-allowlist',
         hide: !verboseHelp,
-        help:
-            'Filters out all Skia trace events except those that are specified in '
-            'this comma separated list of allowed prefixes.',
+        help: 'Filters out all Skia trace events except those that are specified in '
+              'this comma separated list of allowed prefixes.',
         valueHelp: 'skia.gpu,skia.shaders',
       )
-      ..addFlag(
-        'enable-dart-profiling',
+      ..addFlag('enable-dart-profiling',
         defaultsTo: true,
         help: 'Whether the Dart VM sampling CPU profiler is enabled. This flag '
-            'is only meaningful in debug and profile builds.',
+              'is only meaningful in debug and profile builds.',
       )
-      ..addFlag(
-        'enable-software-rendering',
+      ..addFlag('enable-software-rendering',
         negatable: false,
         help: '(deprecated) Enable rendering using the Skia software backend. '
             'This is useful when testing Flutter on emulators. By default, '
@@ -182,30 +160,26 @@ abstract class RunCommandBase extends FlutterCommand
             'when using the Impeller rendering engine.',
         hide: !verboseHelp,
       )
-      ..addFlag(
-        'skia-deterministic-rendering',
+      ..addFlag('skia-deterministic-rendering',
         negatable: false,
-        help:
-            '(deprecated) When combined with "--enable-software-rendering", this should provide completely '
+        help: '(deprecated) When combined with "--enable-software-rendering", this should provide completely '
             'deterministic (i.e. reproducible) Skia rendering. This is useful for testing purposes '
             '(e.g. when comparing screenshots). This option is not supported '
             'when using the Impeller rendering engine.',
         hide: !verboseHelp,
       )
-      ..addMultiOption(
-        'dart-entrypoint-args',
+      ..addMultiOption('dart-entrypoint-args',
         abbr: 'a',
         help: 'Pass a list of arguments to the Dart entrypoint at application '
-            'startup. By default this is main(List<String> args). Specify '
-            'this option multiple times each with one argument to pass '
-            'multiple arguments to the Dart entrypoint. Currently this is '
-            'only supported on desktop platforms.',
+              'startup. By default this is main(List<String> args). Specify '
+              'this option multiple times each with one argument to pass '
+              'multiple arguments to the Dart entrypoint. Currently this is '
+              'only supported on desktop platforms.',
       )
-      ..addFlag(
-        'uninstall-first',
+      ..addFlag('uninstall-first',
         hide: !verboseHelp,
         help: 'Uninstall previous versions of the app on the device '
-            'before reinstalling. Currently only supported on iOS.',
+              'before reinstalling. Currently only supported on iOS.',
       )
       ..addFlag(
         FlutterOptions.kWebWasmFlag,
@@ -235,16 +209,13 @@ abstract class RunCommandBase extends FlutterCommand
   bool get traceStartup => boolArg('trace-startup');
   bool get enableDartProfiling => boolArg('enable-dart-profiling');
   bool get cacheSkSL => boolArg('cache-sksl');
-  bool get dumpSkpOnShaderCompilation =>
-      boolArg('dump-skp-on-shader-compilation');
+  bool get dumpSkpOnShaderCompilation => boolArg('dump-skp-on-shader-compilation');
   bool get purgePersistentCache => boolArg('purge-persistent-cache');
   bool get disableServiceAuthCodes => boolArg('disable-service-auth-codes');
   bool get cacheStartupProfile => boolArg('cache-startup-profile');
-  bool get runningWithPrebuiltApplication =>
-      argResults![FlutterOptions.kUseApplicationBinary] != null;
+  bool get runningWithPrebuiltApplication => argResults![FlutterOptions.kUseApplicationBinary] != null;
   bool get trackWidgetCreation => boolArg('track-widget-creation');
-  ImpellerStatus get enableImpeller =>
-      ImpellerStatus.fromBool(argResults!['enable-impeller'] as bool?);
+  ImpellerStatus get enableImpeller => ImpellerStatus.fromBool(argResults!['enable-impeller'] as bool?);
   bool get enableVulkanValidation => boolArg('enable-vulkan-validation');
   bool get uninstallFirst => boolArg('uninstall-first');
   bool get enableEmbedderApi => boolArg('enable-embedder-api');
@@ -264,19 +235,19 @@ abstract class RunCommandBase extends FlutterCommand
 
   bool get useWasm => boolArg(FlutterOptions.kWebWasmFlag);
 
-  WebRendererMode get webRenderer =>
-      WebRendererMode.fromCliOption(stringArg(FlutterOptions.kWebRendererFlag),
-          useWasm: useWasm);
+  WebRendererMode get webRenderer => WebRendererMode.fromCliOption(
+    stringArg(FlutterOptions.kWebRendererFlag),
+    useWasm: useWasm
+  );
 
   /// Create a debugging options instance for the current `run` or `drive` invocation.
   @visibleForTesting
   @protected
   Future<DebuggingOptions> createDebuggingOptions(bool webMode) async {
     final BuildInfo buildInfo = await getBuildInfo();
-    final int? webBrowserDebugPort = featureFlags.isWebEnabled &&
-            argResults!.wasParsed('web-browser-debug-port')
-        ? int.parse(stringArg('web-browser-debug-port')!)
-        : null;
+    final int? webBrowserDebugPort = featureFlags.isWebEnabled && argResults!.wasParsed('web-browser-debug-port')
+      ? int.parse(stringArg('web-browser-debug-port')!)
+      : null;
     final List<String> webBrowserFlags = featureFlags.isWebEnabled
         ? stringsArg(FlutterOptions.kWebBrowserFlag)
         : const <String>[];
@@ -291,21 +262,13 @@ abstract class RunCommandBase extends FlutterCommand
         dartEntrypointArgs: stringsArg('dart-entrypoint-args'),
         hostname: featureFlags.isWebEnabled ? stringArg('web-hostname') : '',
         port: featureFlags.isWebEnabled ? stringArg('web-port') : '',
-        tlsCertPath:
-            featureFlags.isWebEnabled ? stringArg('web-tls-cert-path') : null,
-        tlsCertKeyPath: featureFlags.isWebEnabled
-            ? stringArg('web-tls-cert-key-path')
-            : null,
-        webUseSseForDebugProxy: featureFlags.isWebEnabled &&
-            stringArg('web-server-debug-protocol') == 'sse',
-        webUseSseForDebugBackend: featureFlags.isWebEnabled &&
-            stringArg('web-server-debug-backend-protocol') == 'sse',
-        webUseSseForInjectedClient: featureFlags.isWebEnabled &&
-            stringArg('web-server-debug-injected-client-protocol') == 'sse',
-        webEnableExposeUrl:
-            featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
-        webRunHeadless:
-            featureFlags.isWebEnabled && boolArg('web-run-headless'),
+        tlsCertPath: featureFlags.isWebEnabled ? stringArg('web-tls-cert-path') : null,
+        tlsCertKeyPath: featureFlags.isWebEnabled ? stringArg('web-tls-cert-key-path') : null,
+        webUseSseForDebugProxy: featureFlags.isWebEnabled && stringArg('web-server-debug-protocol') == 'sse',
+        webUseSseForDebugBackend: featureFlags.isWebEnabled && stringArg('web-server-debug-backend-protocol') == 'sse',
+        webUseSseForInjectedClient: featureFlags.isWebEnabled && stringArg('web-server-debug-injected-client-protocol') == 'sse',
+        webEnableExposeUrl: featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
+        webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
         webHeaders: webHeaders,
@@ -328,14 +291,9 @@ abstract class RunCommandBase extends FlutterCommand
         enableDds: enableDds,
         dartEntrypointArgs: stringsArg('dart-entrypoint-args'),
         dartFlags: stringArg('dart-flags') ?? '',
-        useTestFonts: argParser.options.containsKey('use-test-fonts') &&
-            boolArg('use-test-fonts'),
-        enableSoftwareRendering:
-            argParser.options.containsKey('enable-software-rendering') &&
-                boolArg('enable-software-rendering'),
-        skiaDeterministicRendering:
-            argParser.options.containsKey('skia-deterministic-rendering') &&
-                boolArg('skia-deterministic-rendering'),
+        useTestFonts: argParser.options.containsKey('use-test-fonts') && boolArg('use-test-fonts'),
+        enableSoftwareRendering: argParser.options.containsKey('enable-software-rendering') && boolArg('enable-software-rendering'),
+        skiaDeterministicRendering: argParser.options.containsKey('skia-deterministic-rendering') && boolArg('skia-deterministic-rendering'),
         traceSkia: boolArg('trace-skia'),
         traceAllowlist: traceAllowlist,
         traceSkiaAllowlist: stringArg('trace-skia-allowlist'),
@@ -353,34 +311,24 @@ abstract class RunCommandBase extends FlutterCommand
         verboseSystemLogs: boolArg('verbose-system-logs'),
         hostname: featureFlags.isWebEnabled ? stringArg('web-hostname') : '',
         port: featureFlags.isWebEnabled ? stringArg('web-port') : '',
-        tlsCertPath:
-            featureFlags.isWebEnabled ? stringArg('web-tls-cert-path') : null,
-        tlsCertKeyPath: featureFlags.isWebEnabled
-            ? stringArg('web-tls-cert-key-path')
-            : null,
-        webUseSseForDebugProxy: featureFlags.isWebEnabled &&
-            stringArg('web-server-debug-protocol') == 'sse',
-        webUseSseForDebugBackend: featureFlags.isWebEnabled &&
-            stringArg('web-server-debug-backend-protocol') == 'sse',
-        webUseSseForInjectedClient: featureFlags.isWebEnabled &&
-            stringArg('web-server-debug-injected-client-protocol') == 'sse',
-        webEnableExposeUrl:
-            featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
-        webRunHeadless:
-            featureFlags.isWebEnabled && boolArg('web-run-headless'),
+        tlsCertPath: featureFlags.isWebEnabled ? stringArg('web-tls-cert-path') : null,
+        tlsCertKeyPath: featureFlags.isWebEnabled ? stringArg('web-tls-cert-key-path') : null,
+        webUseSseForDebugProxy: featureFlags.isWebEnabled && stringArg('web-server-debug-protocol') == 'sse',
+        webUseSseForDebugBackend: featureFlags.isWebEnabled && stringArg('web-server-debug-backend-protocol') == 'sse',
+        webUseSseForInjectedClient: featureFlags.isWebEnabled && stringArg('web-server-debug-injected-client-protocol') == 'sse',
+        webEnableExposeUrl: featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
+        webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
-        webEnableExpressionEvaluation: featureFlags.isWebEnabled &&
-            boolArg('web-enable-expression-evaluation'),
-        webLaunchUrl:
-            featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,
+        webEnableExpressionEvaluation: featureFlags.isWebEnabled && boolArg('web-enable-expression-evaluation'),
+        webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,
         webHeaders: webHeaders,
         webRenderer: webRenderer,
         webUseWasm: useWasm,
         vmserviceOutFile: stringArg('vmservice-out-file'),
-        fastStart: argParser.options.containsKey('fast-start') &&
-            boolArg('fast-start') &&
-            !runningWithPrebuiltApplication,
+        fastStart: argParser.options.containsKey('fast-start')
+          && boolArg('fast-start')
+          && !runningWithPrebuiltApplication,
         nullAssertions: boolArg('null-assertions'),
         nativeNullAssertions: boolArg('native-null-assertions'),
         enableImpeller: enableImpeller,
@@ -403,8 +351,8 @@ class RunCommand extends RunCommandBase {
   RunCommand({
     bool verboseHelp = false,
     HotRunnerNativeAssetsBuilder? nativeAssetsBuilder,
-  })  : _nativeAssetsBuilder = nativeAssetsBuilder,
-        super(verboseHelp: verboseHelp) {
+  }) : _nativeAssetsBuilder = nativeAssetsBuilder,
+       super(verboseHelp: verboseHelp) {
     requiresPubspecYaml();
     usesFilesystemOptions(hide: !verboseHelp);
     usesExtraDartFlagOptions(verboseHelp: verboseHelp);
@@ -419,88 +367,71 @@ class RunCommand extends RunCommandBase {
     addPublishPort(verboseHelp: verboseHelp);
     addIgnoreDeprecationOption();
     argParser
-      ..addFlag(
-        'await-first-frame-when-tracing',
+      ..addFlag('await-first-frame-when-tracing',
         defaultsTo: true,
-        help:
-            'Whether to wait for the first frame when tracing startup ("--trace-startup"), '
-            'or just dump the trace as soon as the application is running. The first frame '
-            'is detected by looking for a Timeline event with the name '
-            '"${Tracing.firstUsefulFrameEventName}". '
-            "By default, the widgets library's binding takes care of sending this event.",
+        help: 'Whether to wait for the first frame when tracing startup ("--trace-startup"), '
+              'or just dump the trace as soon as the application is running. The first frame '
+              'is detected by looking for a Timeline event with the name '
+              '"${Tracing.firstUsefulFrameEventName}". '
+              "By default, the widgets library's binding takes care of sending this event.",
       )
-      ..addFlag(
-        'use-test-fonts',
+      ..addFlag('use-test-fonts',
         help: 'Enable (and default to) the "Ahem" font. This is a special font '
-            'used in tests to remove any dependencies on the font metrics. It '
-            'is enabled when you use "flutter test". Set this flag when running '
-            'a test using "flutter run" for debugging purposes. This flag is '
-            'only available when running in debug mode.',
+              'used in tests to remove any dependencies on the font metrics. It '
+              'is enabled when you use "flutter test". Set this flag when running '
+              'a test using "flutter run" for debugging purposes. This flag is '
+              'only available when running in debug mode.',
       )
-      ..addFlag(
-        'build',
+      ..addFlag('build',
         defaultsTo: true,
         help: 'If necessary, build the app before running.',
       )
-      ..addOption(
-        'project-root',
+      ..addOption('project-root',
         hide: !verboseHelp,
         help: 'Specify the project root directory.',
       )
-      ..addFlag(
-        'machine',
+      ..addFlag('machine',
         hide: !verboseHelp,
         negatable: false,
         help: 'Handle machine structured JSON command input and provide output '
-            'and progress in machine friendly format.',
+              'and progress in machine friendly format.',
       )
-      ..addFlag(
-        'hot',
+      ..addFlag('hot',
         defaultsTo: kHotReloadDefault,
-        help:
-            'Run with support for hot reloading. Only available for debug mode. Not available with "--trace-startup".',
+        help: 'Run with support for hot reloading. Only available for debug mode. Not available with "--trace-startup".',
       )
-      ..addFlag(
-        'resident',
+      ..addFlag('resident',
         defaultsTo: true,
         hide: !verboseHelp,
-        help:
-            'Stay resident after launching the application. Not available with "--trace-startup".',
+        help: 'Stay resident after launching the application. Not available with "--trace-startup".',
       )
-      ..addOption(
-        'pid-file',
+      ..addOption('pid-file',
         help: 'Specify a file to write the process ID to. '
-            'You can send SIGUSR1 to trigger a hot reload '
-            'and SIGUSR2 to trigger a hot restart. '
-            'The file is created when the signal handlers '
-            'are hooked and deleted when they are removed.',
-      )
-      ..addFlag(
+              'You can send SIGUSR1 to trigger a hot reload '
+              'and SIGUSR2 to trigger a hot restart. '
+              'The file is created when the signal handlers '
+              'are hooked and deleted when they are removed.',
+      )..addFlag(
         'report-ready',
-        help:
-            'Print "ready" to the console after handling a keyboard command.\n'
-            'This is primarily useful for tests and other automation, but consider '
-            'using "--machine" instead.',
+        help: 'Print "ready" to the console after handling a keyboard command.\n'
+              'This is primarily useful for tests and other automation, but consider '
+              'using "--machine" instead.',
         hide: !verboseHelp,
-      )
-      ..addFlag(
-        'benchmark',
+      )..addFlag('benchmark',
         negatable: false,
         hide: !verboseHelp,
-        help:
-            'Enable a benchmarking mode. This will run the given application, '
-            'measure the startup time and the app restart time, write the '
-            'results out to "refresh_benchmark.json", and exit. This flag is '
-            'intended for use in generating automated flutter benchmarks.',
+        help: 'Enable a benchmarking mode. This will run the given application, '
+              'measure the startup time and the app restart time, write the '
+              'results out to "refresh_benchmark.json", and exit. This flag is '
+              'intended for use in generating automated flutter benchmarks.',
       )
       // TODO(zanderso): Off by default with investigating whether this
       // is slower for certain use cases.
       // See: https://github.com/flutter/flutter/issues/49499
-      ..addFlag(
-        'fast-start',
+      ..addFlag('fast-start',
         help: 'Whether to quickly bootstrap applications with a minimal app. '
-            'Currently this is only supported on Android devices. This option '
-            'cannot be paired with "--${FlutterOptions.kUseApplicationBinary}".',
+              'Currently this is only supported on Android devices. This option '
+              'cannot be paired with "--${FlutterOptions.kUseApplicationBinary}".',
         hide: !verboseHelp,
       );
   }
@@ -511,9 +442,7 @@ class RunCommand extends RunCommandBase {
   final String name = 'run';
 
   @override
-  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation')
-      ? DeprecationBehavior.ignore
-      : _deviceDeprecationBehavior;
+  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : _deviceDeprecationBehavior;
   DeprecationBehavior _deviceDeprecationBehavior = DeprecationBehavior.none;
 
   @override
@@ -562,8 +491,7 @@ class RunCommand extends RunCommandBase {
   }
 
   @override
-  Future<analytics.Event> unifiedAnalyticsUsageValues(
-      String commandPath) async {
+  Future<analytics.Event> unifiedAnalyticsUsageValues(String commandPath) async {
     final AnalyticsUsageValuesRecord record = await _sharedAnalyticsUsageValues;
 
     return analytics.Event.commandUsageValues(
@@ -582,8 +510,7 @@ class RunCommand extends RunCommandBase {
     );
   }
 
-  late final Future<AnalyticsUsageValuesRecord> _sharedAnalyticsUsageValues =
-      (() async {
+  late final Future<AnalyticsUsageValuesRecord> _sharedAnalyticsUsageValues = (() async {
     String deviceType, deviceOsVersion;
     bool isEmulator;
     bool anyAndroidDevices = false;
@@ -611,8 +538,7 @@ class RunCommand extends RunCommandBase {
       isEmulator = false;
       for (final Device device in devices!) {
         final TargetPlatform platform = await device.targetPlatform;
-        anyAndroidDevices =
-            anyAndroidDevices || (platform == TargetPlatform.android);
+        anyAndroidDevices = anyAndroidDevices || (platform == TargetPlatform.android);
         anyIOSDevices = anyIOSDevices || (platform == TargetPlatform.ios);
         if (device is IOSDevice && device.isWirelesslyConnected) {
           anyWirelessIOSDevices = true;
@@ -634,8 +560,7 @@ class RunCommand extends RunCommandBase {
       final AndroidProject androidProject = FlutterProject.current().android;
       if (androidProject.existsSync()) {
         hostLanguage.add(androidProject.isKotlin ? 'kotlin' : 'java');
-        androidEmbeddingVersion =
-            androidProject.getEmbeddingVersion().toString().split('.').last;
+        androidEmbeddingVersion = androidProject.getEmbeddingVersion().toString().split('.').last;
       }
     }
     if (anyIOSDevices) {
@@ -644,8 +569,7 @@ class RunCommand extends RunCommandBase {
         final Iterable<File> swiftFiles = iosProject.hostAppRoot
             .listSync(recursive: true, followLinks: false)
             .whereType<File>()
-            .where((File file) =>
-                globals.fs.path.extension(file.path) == '.swift');
+            .where((File file) => globals.fs.path.extension(file.path) == '.swift');
         hostLanguage.add(swiftFiles.isNotEmpty ? 'swift' : 'objc');
       }
     }
@@ -683,8 +607,7 @@ class RunCommand extends RunCommandBase {
   }
 
   bool get stayResident => boolArg('resident');
-  bool get awaitFirstFrameWhenTracing =>
-      boolArg('await-first-frame-when-tracing');
+  bool get awaitFirstFrameWhenTracing => boolArg('await-first-frame-when-tracing');
 
   @override
   Future<void> validateCommand() async {
@@ -700,26 +623,22 @@ class RunCommand extends RunCommandBase {
     }
 
     if (devices!.length == 1 && devices!.first is MacOSDesignedForIPadDevice) {
-      throwToolExit(
-          'Mac Designed for iPad is currently not supported for flutter run -d.');
+      throwToolExit('Mac Designed for iPad is currently not supported for flutter run -d.');
     }
 
     if (globals.deviceManager!.hasSpecifiedAllDevices) {
-      devices?.removeWhere(
-          (Device device) => device is MacOSDesignedForIPadDevice);
+      devices?.removeWhere((Device device) => device is MacOSDesignedForIPadDevice);
     }
 
-    if (globals.deviceManager!.hasSpecifiedAllDevices &&
-        runningWithPrebuiltApplication) {
-      throwToolExit(
-          'Using "-d all" with "--${FlutterOptions.kUseApplicationBinary}" is not supported');
+    if (globals.deviceManager!.hasSpecifiedAllDevices && runningWithPrebuiltApplication) {
+      throwToolExit('Using "-d all" with "--${FlutterOptions.kUseApplicationBinary}" is not supported');
     }
 
-    if (userIdentifier != null &&
-        devices!.every(
-            (Device device) => device.platformType != PlatformType.android)) {
+    if (userIdentifier != null
+      && devices!.every((Device device) => device.platformType != PlatformType.android)) {
       throwToolExit(
-          '--${FlutterOptions.kDeviceUser} is only supported for Android. At least one Android device is required.');
+        '--${FlutterOptions.kDeviceUser} is only supported for Android. At least one Android device is required.'
+      );
     }
 
     if (devices!.any((Device device) => device is AndroidDevice)) {
@@ -729,8 +648,8 @@ class RunCommand extends RunCommandBase {
     // Only support "web mode" with a single web device due to resident runner
     // refactoring required otherwise.
     webMode = featureFlags.isWebEnabled &&
-        devices!.length == 1 &&
-        await devices!.single.targetPlatform == TargetPlatform.web_javascript;
+      devices!.length == 1  &&
+      await devices!.single.targetPlatform == TargetPlatform.web_javascript;
 
     if (useWasm && !webMode) {
       throwToolExit('--wasm is only supported on the web platform');
@@ -745,13 +664,14 @@ class RunCommand extends RunCommandBase {
     }
 
     final String? flavor = stringArg('flavor');
-    final bool flavorsSupportedOnEveryDevice =
-        devices!.every((Device device) => device.supportsFlavors);
+    final bool flavorsSupportedOnEveryDevice = devices!
+      .every((Device device) => device.supportsFlavors);
     if (flavor != null && !flavorsSupportedOnEveryDevice) {
       globals.printWarning(
-          '--flavor is only supported for Android, macOS, and iOS devices. '
-          'Flavor-related features may not function properly and could '
-          'behave differently in a future release.');
+        '--flavor is only supported for Android, macOS, and iOS devices. '
+        'Flavor-related features may not function properly and could '
+        'behave differently in a future release.'
+      );
     }
   }
 
@@ -811,18 +731,17 @@ class RunCommand extends RunCommandBase {
 
   @visibleForTesting
   Daemon createMachineDaemon() {
+    final bool useImplicitPubspecResolution = globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution);
     final Daemon daemon = Daemon(
       DaemonConnection(
-        daemonStreams:
-            DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
+        daemonStreams: DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
         logger: globals.logger,
       ),
       notifyingLogger: (globals.logger is NotifyingLogger)
-          ? globals.logger as NotifyingLogger
-          : NotifyingLogger(
-              verbose: globals.logger.isVerbose, parent: globals.logger),
+        ? globals.logger as NotifyingLogger
+        : NotifyingLogger(verbose: globals.logger.isVerbose, parent: globals.logger),
       logToStdout: true,
-      useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     );
     return daemon;
   }
@@ -833,8 +752,7 @@ class RunCommand extends RunCommandBase {
     // Enable hot mode by default if `--no-hot` was not passed and we are in
     // debug mode.
     final bool hotMode = shouldUseHotMode(buildInfo);
-    final String? applicationBinaryPath =
-        stringArg(FlutterOptions.kUseApplicationBinary);
+    final String? applicationBinaryPath = stringArg(FlutterOptions.kUseApplicationBinary);
 
     if (boolArg('machine')) {
       if (devices!.length > 1) {
@@ -844,19 +762,14 @@ class RunCommand extends RunCommandBase {
       late AppInstance app;
       try {
         app = await daemon.appDomain.startApp(
-          devices!.first,
-          globals.fs.currentDirectory.path,
-          targetFile,
-          route,
-          await createDebuggingOptions(webMode),
-          hotMode,
+          devices!.first, globals.fs.currentDirectory.path, targetFile, route,
+          await createDebuggingOptions(webMode), hotMode,
           applicationBinary: applicationBinaryPath == null
               ? null
               : globals.fs.file(applicationBinaryPath),
           trackWidgetCreation: trackWidgetCreation,
           projectRootPath: stringArg('project-root'),
-          packagesFilePath:
-              globalResults![FlutterGlobalOptions.kPackagesOption] as String?,
+          packagesFilePath: globalResults![FlutterGlobalOptions.kPackagesOption] as String?,
           dillOutputPath: stringArg('output-dill'),
           userIdentifier: userIdentifier,
           nativeAssetsBuilder: _nativeAssetsBuilder,
@@ -887,8 +800,7 @@ class RunCommand extends RunCommandBase {
       }
       if (hotMode) {
         if (!device.supportsHotReload) {
-          throwToolExit(
-              'Hot reload is not supported by ${device.name}. Run with "--no-hot".');
+          throwToolExit('Hot reload is not supported by ${device.name}. Run with "--no-hot".');
         }
       }
     }
@@ -926,22 +838,24 @@ class RunCommand extends RunCommandBase {
 
     TerminalHandler? handler;
     // This callback can't throw.
-    unawaited(appStartedTimeRecorder.future.then<void>((_) {
-      appStartedTime = globals.systemClock.now();
-      if (stayResident) {
-        handler = TerminalHandler(
-          runner,
-          logger: globals.logger,
-          terminal: globals.terminal,
-          signals: globals.signals,
-          processInfo: globals.processInfo,
-          reportReady: boolArg('report-ready'),
-          pidFile: stringArg('pid-file'),
-        )
-          ..registerSignalHandlers()
-          ..setupTerminal();
+    unawaited(appStartedTimeRecorder.future.then<void>(
+      (_) {
+        appStartedTime = globals.systemClock.now();
+        if (stayResident) {
+          handler = TerminalHandler(
+            runner,
+            logger: globals.logger,
+            terminal: globals.terminal,
+            signals: globals.signals,
+            processInfo: globals.processInfo,
+            reportReady: boolArg('report-ready'),
+            pidFile: stringArg('pid-file'),
+          )
+            ..registerSignalHandlers()
+            ..setupTerminal();
+        }
       }
-    }));
+    ));
     try {
       final int? result = await runner.run(
         appStartedCompleter: appStartedTimeRecorder,

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -68,6 +68,7 @@ import 'windows/windows_workflow.dart';
 
 Future<T> runInContext<T>(
   FutureOr<T> Function() runner, {
+  bool useImplicitPubspecResolution = true,
   Map<Type, Generator>? overrides,
 }) async {
 
@@ -210,6 +211,7 @@ Future<T> runInContext<T>(
         operatingSystemUtils: globals.os,
         customDevicesConfig: globals.customDevicesConfig,
         nativeAssetsBuilder: globals.nativeAssetsBuilder,
+        useImplicitPubspecResolution: useImplicitPubspecResolution,
       ),
       DevtoolsLauncher: () => DevtoolsServerLauncher(
         processManager: globals.processManager,

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -440,8 +440,10 @@ class CustomDevice extends Device {
     required CustomDeviceConfig config,
     required super.logger,
     required ProcessManager processManager,
+    required bool useImplicitPubspecResolution,
   }) : _config = config,
        _logger = logger,
+       _useImplicitPubspecResolution = useImplicitPubspecResolution,
        _processManager = processManager,
        _processUtils = ProcessUtils(
          processManager: processManager,
@@ -469,6 +471,7 @@ class CustomDevice extends Device {
   final ProcessUtils _processUtils;
   final Map<ApplicationPackage, CustomDeviceAppSession> _sessions = <ApplicationPackage, CustomDeviceAppSession>{};
   final CustomDeviceLogReader _globalLogReader;
+  final bool _useImplicitPubspecResolution;
 
   @override
   final DevicePortForwarder portForwarder;
@@ -762,6 +765,7 @@ class CustomDevice extends Device {
         mainPath: mainPath,
         depfilePath: defaultDepfilePath,
         assetDirPath: assetBundleDir,
+        useImplicitPubspecResolution: _useImplicitPubspecResolution,
       );
 
       // if we have a post build step (needed for some embedders), execute it
@@ -822,15 +826,18 @@ class CustomDevices extends PollingDeviceDiscovery {
     required FeatureFlags featureFlags,
     required ProcessManager processManager,
     required Logger logger,
-    required CustomDevicesConfig config
+    required CustomDevicesConfig config,
+    required bool useImplicitPubspecResolution,
   }) : _customDeviceWorkflow = CustomDeviceWorkflow(
          featureFlags: featureFlags,
        ),
+       _useImplicitPubspecResolution = useImplicitPubspecResolution,
        _logger = logger,
        _processManager = processManager,
        _config = config,
        super('custom devices');
 
+  final bool _useImplicitPubspecResolution;
   final CustomDeviceWorkflow  _customDeviceWorkflow;
   final ProcessManager _processManager;
   final Logger _logger;
@@ -851,7 +858,8 @@ class CustomDevices extends PollingDeviceDiscovery {
         (CustomDeviceConfig config) => CustomDevice(
           config: config,
           logger: _logger,
-          processManager: _processManager
+          processManager: _processManager,
+          useImplicitPubspecResolution: _useImplicitPubspecResolution,
         )
       ).toList();
   }

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -28,17 +28,20 @@ class FlutterDriverFactory {
     required ProcessUtils processUtils,
     required String dartSdkPath,
     required DevtoolsLauncher devtoolsLauncher,
+    required bool useImplicitPubspecResolution,
   }) : _applicationPackageFactory = applicationPackageFactory,
        _logger = logger,
        _processUtils = processUtils,
        _dartSdkPath = dartSdkPath,
-       _devtoolsLauncher = devtoolsLauncher;
+       _devtoolsLauncher = devtoolsLauncher,
+       _useImplicitPubspecResolution = useImplicitPubspecResolution;
 
   final ApplicationPackageFactory _applicationPackageFactory;
   final Logger _logger;
   final ProcessUtils _processUtils;
   final String _dartSdkPath;
   final DevtoolsLauncher _devtoolsLauncher;
+  final bool _useImplicitPubspecResolution;
 
   /// Create a driver service for running `flutter drive`.
   DriverService createDriverService(bool web) {
@@ -47,6 +50,7 @@ class FlutterDriverFactory {
         logger: _logger,
         processUtils: _processUtils,
         dartSdkPath: _dartSdkPath,
+        useImplicitPubspecResolution: _useImplicitPubspecResolution,
       );
     }
     return FlutterDriverService(

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -30,13 +30,16 @@ class WebDriverService extends DriverService {
     required ProcessUtils processUtils,
     required String dartSdkPath,
     required Logger logger,
+    required bool useImplicitPubspecResolution,
   }) : _processUtils = processUtils,
        _dartSdkPath = dartSdkPath,
-       _logger = logger;
+       _logger = logger,
+       _useImplicitPubspecResolution = useImplicitPubspecResolution;
 
   final ProcessUtils _processUtils;
   final String _dartSdkPath;
   final Logger _logger;
+  final bool _useImplicitPubspecResolution;
 
   late ResidentRunner _residentRunner;
   Uri? _webUri;
@@ -94,6 +97,7 @@ class WebDriverService extends DriverService {
       analytics: globals.analytics,
       logger: _logger,
       systemClock: globals.systemClock,
+      useImplicitPubspecResolution: _useImplicitPubspecResolution,
     );
     final Completer<void> appStartedCompleter = Completer<void>.sync();
     final Future<int?> runFuture = _residentRunner.run(

--- a/packages/flutter_tools/lib/src/flutter_device_manager.dart
+++ b/packages/flutter_tools/lib/src/flutter_device_manager.dart
@@ -53,6 +53,7 @@ class FlutterDeviceManager extends DeviceManager {
     required WindowsWorkflow windowsWorkflow,
     required CustomDevicesConfig customDevicesConfig,
     required TestCompilerNativeAssetsBuilder? nativeAssetsBuilder,
+    required bool useImplicitPubspecResolution,
   }) : deviceDiscoverers =  <DeviceDiscovery>[
     AndroidDevices(
       logger: logger,
@@ -79,6 +80,7 @@ class FlutterDeviceManager extends DeviceManager {
       logger: logger,
       artifacts: artifacts,
       nativeAssetsBuilder: nativeAssetsBuilder,
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     ),
     MacOSDevices(
       processManager: processManager,
@@ -103,6 +105,7 @@ class FlutterDeviceManager extends DeviceManager {
       logger: logger,
       processManager: processManager,
       featureFlags: featureFlags,
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     ),
     LinuxDevices(
       platform: platform,
@@ -130,7 +133,8 @@ class FlutterDeviceManager extends DeviceManager {
       featureFlags: featureFlags,
       processManager: processManager,
       logger: logger,
-      config: customDevicesConfig
+      config: customDevicesConfig,
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     ),
   ];
 

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -78,10 +78,9 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
   }
 }
 
-const String kExitMessage =
-    'Failed to establish connection with the application '
-    'instance in Chrome.\nThis can happen if the websocket connection used by the '
-    'web tooling is unable to correctly establish a connection, for example due to a firewall.';
+const String kExitMessage = 'Failed to establish connection with the application '
+  'instance in Chrome.\nThis can happen if the websocket connection used by the '
+  'web tooling is unable to correctly establish a connection, for example due to a firewall.';
 
 class ResidentWebRunner extends ResidentRunner {
   ResidentWebRunner(
@@ -90,6 +89,7 @@ class ResidentWebRunner extends ResidentRunner {
     bool stayResident = true,
     bool machine = false,
     required this.flutterProject,
+    required bool useImplicitPubspecResolution,
     required DebuggingOptions debuggingOptions,
     required FileSystem fileSystem,
     required Logger logger,
@@ -99,15 +99,14 @@ class ResidentWebRunner extends ResidentRunner {
     UrlTunneller? urlTunneller,
     // TODO(bkonyi): remove when ready to serve DevTools from DDS.
     ResidentDevtoolsHandlerFactory devtoolsHandler = createDefaultHandler,
-    required bool useImplicitPubspecResolution,
-  })  : _fileSystem = fileSystem,
-        _logger = logger,
-        _systemClock = systemClock,
-        _usage = usage,
-        _analytics = analytics,
-        _urlTunneller = urlTunneller,
-        _useImplicitPubspecResolution = useImplicitPubspecResolution,
-        super(
+  }) : _fileSystem = fileSystem,
+       _logger = logger,
+       _systemClock = systemClock,
+       _usage = usage,
+       _analytics = analytics,
+       _urlTunneller = urlTunneller,
+       _useImplicitPubspecResolution = useImplicitPubspecResolution,
+       super(
           <FlutterDevice>[device],
           target: target ?? fileSystem.path.join('lib', 'main.dart'),
           debuggingOptions: debuggingOptions,
@@ -143,15 +142,13 @@ class ResidentWebRunner extends ResidentRunner {
 
   // Only non-wasm debug builds of the web support the service protocol.
   @override
-  bool get supportsServiceProtocol =>
-      !debuggingOptions.webUseWasm && isRunningDebug && deviceIsDebuggable;
+  bool get supportsServiceProtocol => !debuggingOptions.webUseWasm && isRunningDebug && deviceIsDebuggable;
 
   @override
   bool get debuggingEnabled => isRunningDebug && deviceIsDebuggable;
 
   /// WebServer device is debuggable when running with --start-paused.
-  bool get deviceIsDebuggable =>
-      device!.device is! WebServerDevice || debuggingOptions.startPaused;
+  bool get deviceIsDebuggable => device!.device is! WebServerDevice || debuggingOptions.startPaused;
 
   @override
   bool get supportsWriteSkSL => false;
@@ -239,8 +236,7 @@ class ResidentWebRunner extends ResidentRunner {
     );
     _logger.printStatus(message);
     const String quitMessage = 'To quit, press "q".';
-    _logger.printStatus(
-        'For a more detailed help message, press "h". $quitMessage');
+    _logger.printStatus('For a more detailed help message, press "h". $quitMessage');
     _logger.printStatus('');
     printDebuggerList();
   }
@@ -257,16 +253,13 @@ class ResidentWebRunner extends ResidentRunner {
     Completer<void>? appStartedCompleter,
     String? route,
   }) async {
-    final ApplicationPackage? package =
-        await ApplicationPackageFactory.instance!.getPackageForPlatform(
+    final ApplicationPackage? package = await ApplicationPackageFactory.instance!.getPackageForPlatform(
       TargetPlatform.web_javascript,
       buildInfo: debuggingOptions.buildInfo,
     );
     if (package == null) {
-      _logger.printStatus(
-          'This application is not configured to build on the web.');
-      _logger.printStatus(
-          'To add web support to a project, run `flutter create .`.');
+      _logger.printStatus('This application is not configured to build on the web.');
+      _logger.printStatus('To add web support to a project, run `flutter create .`.');
     }
     final String modeName = debuggingOptions.buildInfo.friendlyModeName;
     _logger.printStatus(
@@ -304,10 +297,10 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           return port;
         }
 
-        final ExpressionCompiler? expressionCompiler = debuggingOptions
-                .webEnableExpressionEvaluation
-            ? WebExpressionCompiler(device!.generator!, fileSystem: _fileSystem)
-            : null;
+        final ExpressionCompiler? expressionCompiler =
+          debuggingOptions.webEnableExpressionEvaluation
+              ? WebExpressionCompiler(device!.generator!, fileSystem: _fileSystem)
+              : null;
 
         device!.devFS = WebDevFS(
           hostname: debuggingOptions.hostname ?? 'localhost',
@@ -329,20 +322,17 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           nullAssertions: debuggingOptions.nullAssertions,
           nullSafetyMode: debuggingOptions.buildInfo.nullSafetyMode,
           nativeNullAssertions: debuggingOptions.nativeNullAssertions,
-          ddcModuleSystem:
-              debuggingOptions.buildInfo.ddcModuleFormat == DdcModuleFormat.ddc,
+          ddcModuleSystem: debuggingOptions.buildInfo.ddcModuleFormat == DdcModuleFormat.ddc,
           webRenderer: debuggingOptions.webRenderer,
           isWasm: debuggingOptions.webUseWasm,
           useLocalCanvasKit: debuggingOptions.buildInfo.useLocalCanvasKit,
           rootDirectory: fileSystem.directory(projectRootPath),
         );
         Uri url = await device!.devFS!.create();
-        if (debuggingOptions.tlsCertKeyPath != null &&
-            debuggingOptions.tlsCertPath != null) {
+        if (debuggingOptions.tlsCertKeyPath != null && debuggingOptions.tlsCertPath != null) {
           url = url.replace(scheme: 'https');
         }
-        if (debuggingOptions.buildInfo.isDebug &&
-            !debuggingOptions.webUseWasm) {
+        if (debuggingOptions.buildInfo.isDebug && !debuggingOptions.webUseWasm) {
           await runSourceGenerators();
           final UpdateFSReport report = await _updateDevFS(fullRestart: true);
           if (!report.success) {
@@ -376,7 +366,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           mainPath: target,
           debuggingOptions: debuggingOptions,
           platformArgs: <String, Object>{
-            'uri': url.toString(),
+             'uri': url.toString(),
           },
         );
         return attach(
@@ -413,9 +403,10 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   WebCompilerConfig get _compilerConfig {
     if (debuggingOptions.webUseWasm) {
       return WasmCompilerConfig(
-          optimizationLevel: 0,
-          stripWasm: false,
-          renderer: debuggingOptions.webRenderer);
+        optimizationLevel: 0,
+        stripWasm: false,
+        renderer: debuggingOptions.webRenderer
+      );
     }
     return JsCompilerConfig.run(
       nativeNullAssertions: debuggingOptions.nativeNullAssertions,
@@ -518,14 +509,14 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         overallTimeInMs: elapsed.inMilliseconds,
       ).send();
       _analytics.send(Event.hotRunnerInfo(
-          label: 'restart',
-          targetPlatform:
-              getNameForTargetPlatform(TargetPlatform.web_javascript),
-          sdkName: sdkName,
-          emulator: false,
-          fullRestart: true,
-          reason: reason,
-          overallTimeInMs: elapsed.inMilliseconds));
+        label: 'restart',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.web_javascript),
+        sdkName: sdkName,
+        emulator: false,
+        fullRestart: true,
+        reason: reason,
+        overallTimeInMs: elapsed.inMilliseconds
+      ));
     }
     return OperationResult.ok;
   }
@@ -533,19 +524,15 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   // Flutter web projects need to include a generated main entrypoint to call the
   // appropriate bootstrap method and inject plugins.
   // Keep this in sync with build_system/targets/web.dart.
-  Future<Uri> _generateEntrypoint(
-      Uri mainUri, PackageConfig? packageConfig) async {
-    File? result =
-        _generatedEntrypointDirectory?.childFile('web_entrypoint.dart');
+  Future<Uri> _generateEntrypoint(Uri mainUri, PackageConfig? packageConfig) async {
+    File? result = _generatedEntrypointDirectory?.childFile('web_entrypoint.dart');
     if (_generatedEntrypointDirectory == null) {
-      _generatedEntrypointDirectory ??= _fileSystem.systemTempDirectory
-          .createTempSync('flutter_tools.')
+      _generatedEntrypointDirectory ??= _fileSystem.systemTempDirectory.createTempSync('flutter_tools.')
         ..createSync();
       result = _generatedEntrypointDirectory!.childFile('web_entrypoint.dart');
 
       // Generates the generated_plugin_registrar
-      await injectBuildTimePluginFiles(flutterProject,
-          webPlatform: true, destination: _generatedEntrypointDirectory!);
+      await injectBuildTimePluginFiles(flutterProject, webPlatform: true, destination: _generatedEntrypointDirectory!);
       // The below works because `injectBuildTimePluginFiles` is configured to write
       // the web_plugin_registrant.dart file alongside the generated main.dart
       const String generatedImport = 'web_plugin_registrant.dart';
@@ -568,8 +555,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         Cache.flutterRoot!,
       );
 
-      final String entrypoint = main_dart.generateMainDartFile(
-        importedEntrypoint.toString(),
+      final String entrypoint = main_dart.generateMainDartFile(importedEntrypoint.toString(),
         languageVersion: languageVersion,
         pluginRegistrantEntrypoint: generatedImport,
       );
@@ -592,13 +578,12 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         return UpdateFSReport();
       }
     }
-    final InvalidationResult invalidationResult =
-        await projectFileInvalidator.findInvalidated(
+    final InvalidationResult invalidationResult = await projectFileInvalidator.findInvalidated(
       lastCompiled: device!.devFS!.lastCompiled,
       urisToMonitor: device!.devFS!.sources,
       packagesPath: packagesFilePath,
-      packageConfig: device!.devFS!.lastPackageConfig ??
-          debuggingOptions.buildInfo.packageConfig,
+      packageConfig: device!.devFS!.lastPackageConfig
+        ?? debuggingOptions.buildInfo.packageConfig,
     );
     final Status devFSStatus = _logger.startProgress(
       'Waiting for connection from debug service on ${device!.device!.name}...',
@@ -635,15 +620,16 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
     if (_chromiumLauncher != null) {
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
       final ChromeTab? chromeTab = await getChromeTabGuarded(
-          chrome.chromeConnection,
-          (ChromeTab chromeTab) {
-            return !chromeTab.url.startsWith('chrome-extension');
-          },
-          retryFor: const Duration(seconds: 5),
-          onIoError: (Object error, StackTrace stackTrace) {
-            // We were unable to unable to communicate with Chrome.
-            _logger.printError(error.toString(), stackTrace: stackTrace);
-          });
+        chrome.chromeConnection,
+        (ChromeTab chromeTab) {
+          return !chromeTab.url.startsWith('chrome-extension');
+        },
+        retryFor: const Duration(seconds: 5),
+        onIoError: (Object error, StackTrace stackTrace) {
+          // We were unable to unable to communicate with Chrome.
+          _logger.printError(error.toString(), stackTrace: stackTrace);
+        }
+      );
       if (chromeTab == null) {
         appFailedToStart();
         throwToolExit('Failed to connect to Chrome instance.');
@@ -653,11 +639,9 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
     Uri? websocketUri;
     if (supportsServiceProtocol) {
       final WebDevFS webDevFS = device!.devFS! as WebDevFS;
-      final bool useDebugExtension =
-          device!.device is WebServerDevice && debuggingOptions.startPaused;
+      final bool useDebugExtension = device!.device is WebServerDevice && debuggingOptions.startPaused;
       _connectionResult = await webDevFS.connect(useDebugExtension);
-      unawaited(_connectionResult!.debugConnection!.onDone
-          .whenComplete(_cleanupAndExit));
+      unawaited(_connectionResult!.debugConnection!.onDone.whenComplete(_cleanupAndExit));
 
       void onLogEvent(vmservice.Event event) {
         final String message = processVmServiceMessage(event);
@@ -711,8 +695,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         _connectionResult!.appConnection!.runMain();
       } else {
         late StreamSubscription<void> resumeSub;
-        resumeSub =
-            _vmService.service.onDebugEvent.listen((vmservice.Event event) {
+        resumeSub = _vmService.service.onDebugEvent.listen((vmservice.Event event) {
           if (event.type == vmservice.EventKind.kResume) {
             _connectionResult!.appConnection!.runMain();
             resumeSub.cancel();
@@ -780,6 +763,5 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
 Uri _httpUriFromWebsocketUri(Uri websocketUri) {
   const String wsPath = '/ws';
   final String path = websocketUri.path;
-  return websocketUri.replace(
-      scheme: 'http', path: path.substring(0, path.length - wsPath.length));
+  return websocketUri.replace(scheme: 'http', path: path.substring(0, path.length - wsPath.length));
 }

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -57,6 +57,7 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
     required SystemClock systemClock,
     required Usage usage,
     required Analytics analytics,
+    required bool useImplicitPubspecResolution,
     bool machine = false,
   }) {
     return ResidentWebRunner(
@@ -72,13 +73,15 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
       systemClock: systemClock,
       fileSystem: fileSystem,
       logger: logger,
+      useImplicitPubspecResolution: useImplicitPubspecResolution,
     );
   }
 }
 
-const String kExitMessage = 'Failed to establish connection with the application '
-  'instance in Chrome.\nThis can happen if the websocket connection used by the '
-  'web tooling is unable to correctly establish a connection, for example due to a firewall.';
+const String kExitMessage =
+    'Failed to establish connection with the application '
+    'instance in Chrome.\nThis can happen if the websocket connection used by the '
+    'web tooling is unable to correctly establish a connection, for example due to a firewall.';
 
 class ResidentWebRunner extends ResidentRunner {
   ResidentWebRunner(
@@ -96,19 +99,22 @@ class ResidentWebRunner extends ResidentRunner {
     UrlTunneller? urlTunneller,
     // TODO(bkonyi): remove when ready to serve DevTools from DDS.
     ResidentDevtoolsHandlerFactory devtoolsHandler = createDefaultHandler,
-  }) : _fileSystem = fileSystem,
-       _logger = logger,
-       _systemClock = systemClock,
-       _usage = usage,
-       _analytics = analytics,
-       _urlTunneller = urlTunneller,
-       super(
+    required bool useImplicitPubspecResolution,
+  })  : _fileSystem = fileSystem,
+        _logger = logger,
+        _systemClock = systemClock,
+        _usage = usage,
+        _analytics = analytics,
+        _urlTunneller = urlTunneller,
+        _useImplicitPubspecResolution = useImplicitPubspecResolution,
+        super(
           <FlutterDevice>[device],
           target: target ?? fileSystem.path.join('lib', 'main.dart'),
           debuggingOptions: debuggingOptions,
           stayResident: stayResident,
           machine: machine,
           devtoolsHandler: devtoolsHandler,
+          useImplicitPubspecResolution: useImplicitPubspecResolution,
         );
 
   final FileSystem _fileSystem;
@@ -117,6 +123,7 @@ class ResidentWebRunner extends ResidentRunner {
   final Usage _usage;
   final Analytics _analytics;
   final UrlTunneller? _urlTunneller;
+  final bool _useImplicitPubspecResolution;
 
   @override
   Logger get logger => _logger;
@@ -136,13 +143,15 @@ class ResidentWebRunner extends ResidentRunner {
 
   // Only non-wasm debug builds of the web support the service protocol.
   @override
-  bool get supportsServiceProtocol => !debuggingOptions.webUseWasm && isRunningDebug && deviceIsDebuggable;
+  bool get supportsServiceProtocol =>
+      !debuggingOptions.webUseWasm && isRunningDebug && deviceIsDebuggable;
 
   @override
   bool get debuggingEnabled => isRunningDebug && deviceIsDebuggable;
 
   /// WebServer device is debuggable when running with --start-paused.
-  bool get deviceIsDebuggable => device!.device is! WebServerDevice || debuggingOptions.startPaused;
+  bool get deviceIsDebuggable =>
+      device!.device is! WebServerDevice || debuggingOptions.startPaused;
 
   @override
   bool get supportsWriteSkSL => false;
@@ -230,7 +239,8 @@ class ResidentWebRunner extends ResidentRunner {
     );
     _logger.printStatus(message);
     const String quitMessage = 'To quit, press "q".';
-    _logger.printStatus('For a more detailed help message, press "h". $quitMessage');
+    _logger.printStatus(
+        'For a more detailed help message, press "h". $quitMessage');
     _logger.printStatus('');
     printDebuggerList();
   }
@@ -247,13 +257,16 @@ class ResidentWebRunner extends ResidentRunner {
     Completer<void>? appStartedCompleter,
     String? route,
   }) async {
-    final ApplicationPackage? package = await ApplicationPackageFactory.instance!.getPackageForPlatform(
+    final ApplicationPackage? package =
+        await ApplicationPackageFactory.instance!.getPackageForPlatform(
       TargetPlatform.web_javascript,
       buildInfo: debuggingOptions.buildInfo,
     );
     if (package == null) {
-      _logger.printStatus('This application is not configured to build on the web.');
-      _logger.printStatus('To add web support to a project, run `flutter create .`.');
+      _logger.printStatus(
+          'This application is not configured to build on the web.');
+      _logger.printStatus(
+          'To add web support to a project, run `flutter create .`.');
     }
     final String modeName = debuggingOptions.buildInfo.friendlyModeName;
     _logger.printStatus(
@@ -291,10 +304,10 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           return port;
         }
 
-        final ExpressionCompiler? expressionCompiler =
-          debuggingOptions.webEnableExpressionEvaluation
-              ? WebExpressionCompiler(device!.generator!, fileSystem: _fileSystem)
-              : null;
+        final ExpressionCompiler? expressionCompiler = debuggingOptions
+                .webEnableExpressionEvaluation
+            ? WebExpressionCompiler(device!.generator!, fileSystem: _fileSystem)
+            : null;
 
         device!.devFS = WebDevFS(
           hostname: debuggingOptions.hostname ?? 'localhost',
@@ -316,17 +329,20 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           nullAssertions: debuggingOptions.nullAssertions,
           nullSafetyMode: debuggingOptions.buildInfo.nullSafetyMode,
           nativeNullAssertions: debuggingOptions.nativeNullAssertions,
-          ddcModuleSystem: debuggingOptions.buildInfo.ddcModuleFormat == DdcModuleFormat.ddc,
+          ddcModuleSystem:
+              debuggingOptions.buildInfo.ddcModuleFormat == DdcModuleFormat.ddc,
           webRenderer: debuggingOptions.webRenderer,
           isWasm: debuggingOptions.webUseWasm,
           useLocalCanvasKit: debuggingOptions.buildInfo.useLocalCanvasKit,
           rootDirectory: fileSystem.directory(projectRootPath),
         );
         Uri url = await device!.devFS!.create();
-        if (debuggingOptions.tlsCertKeyPath != null && debuggingOptions.tlsCertPath != null) {
+        if (debuggingOptions.tlsCertKeyPath != null &&
+            debuggingOptions.tlsCertPath != null) {
           url = url.replace(scheme: 'https');
         }
-        if (debuggingOptions.buildInfo.isDebug && !debuggingOptions.webUseWasm) {
+        if (debuggingOptions.buildInfo.isDebug &&
+            !debuggingOptions.webUseWasm) {
           await runSourceGenerators();
           final UpdateFSReport report = await _updateDevFS(fullRestart: true);
           if (!report.success) {
@@ -345,6 +361,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
             flutterVersion: globals.flutterVersion,
             usage: globals.flutterUsage,
             analytics: globals.analytics,
+            useImplicitPubspecResolution: _useImplicitPubspecResolution,
           );
           await webBuilder.buildWeb(
             flutterProject,
@@ -359,7 +376,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           mainPath: target,
           debuggingOptions: debuggingOptions,
           platformArgs: <String, Object>{
-             'uri': url.toString(),
+            'uri': url.toString(),
           },
         );
         return attach(
@@ -396,10 +413,9 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   WebCompilerConfig get _compilerConfig {
     if (debuggingOptions.webUseWasm) {
       return WasmCompilerConfig(
-        optimizationLevel: 0,
-        stripWasm: false,
-        renderer: debuggingOptions.webRenderer
-      );
+          optimizationLevel: 0,
+          stripWasm: false,
+          renderer: debuggingOptions.webRenderer);
     }
     return JsCompilerConfig.run(
       nativeNullAssertions: debuggingOptions.nativeNullAssertions,
@@ -441,6 +457,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           flutterVersion: globals.flutterVersion,
           usage: globals.flutterUsage,
           analytics: globals.analytics,
+          useImplicitPubspecResolution: _useImplicitPubspecResolution,
         );
         await webBuilder.buildWeb(
           flutterProject,
@@ -501,14 +518,14 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         overallTimeInMs: elapsed.inMilliseconds,
       ).send();
       _analytics.send(Event.hotRunnerInfo(
-        label: 'restart',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.web_javascript),
-        sdkName: sdkName,
-        emulator: false,
-        fullRestart: true,
-        reason: reason,
-        overallTimeInMs: elapsed.inMilliseconds
-      ));
+          label: 'restart',
+          targetPlatform:
+              getNameForTargetPlatform(TargetPlatform.web_javascript),
+          sdkName: sdkName,
+          emulator: false,
+          fullRestart: true,
+          reason: reason,
+          overallTimeInMs: elapsed.inMilliseconds));
     }
     return OperationResult.ok;
   }
@@ -516,15 +533,19 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   // Flutter web projects need to include a generated main entrypoint to call the
   // appropriate bootstrap method and inject plugins.
   // Keep this in sync with build_system/targets/web.dart.
-  Future<Uri> _generateEntrypoint(Uri mainUri, PackageConfig? packageConfig) async {
-    File? result = _generatedEntrypointDirectory?.childFile('web_entrypoint.dart');
+  Future<Uri> _generateEntrypoint(
+      Uri mainUri, PackageConfig? packageConfig) async {
+    File? result =
+        _generatedEntrypointDirectory?.childFile('web_entrypoint.dart');
     if (_generatedEntrypointDirectory == null) {
-      _generatedEntrypointDirectory ??= _fileSystem.systemTempDirectory.createTempSync('flutter_tools.')
+      _generatedEntrypointDirectory ??= _fileSystem.systemTempDirectory
+          .createTempSync('flutter_tools.')
         ..createSync();
       result = _generatedEntrypointDirectory!.childFile('web_entrypoint.dart');
 
       // Generates the generated_plugin_registrar
-      await injectBuildTimePluginFiles(flutterProject, webPlatform: true, destination: _generatedEntrypointDirectory!);
+      await injectBuildTimePluginFiles(flutterProject,
+          webPlatform: true, destination: _generatedEntrypointDirectory!);
       // The below works because `injectBuildTimePluginFiles` is configured to write
       // the web_plugin_registrant.dart file alongside the generated main.dart
       const String generatedImport = 'web_plugin_registrant.dart';
@@ -547,7 +568,8 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         Cache.flutterRoot!,
       );
 
-      final String entrypoint = main_dart.generateMainDartFile(importedEntrypoint.toString(),
+      final String entrypoint = main_dart.generateMainDartFile(
+        importedEntrypoint.toString(),
         languageVersion: languageVersion,
         pluginRegistrantEntrypoint: generatedImport,
       );
@@ -570,12 +592,13 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         return UpdateFSReport();
       }
     }
-    final InvalidationResult invalidationResult = await projectFileInvalidator.findInvalidated(
+    final InvalidationResult invalidationResult =
+        await projectFileInvalidator.findInvalidated(
       lastCompiled: device!.devFS!.lastCompiled,
       urisToMonitor: device!.devFS!.sources,
       packagesPath: packagesFilePath,
-      packageConfig: device!.devFS!.lastPackageConfig
-        ?? debuggingOptions.buildInfo.packageConfig,
+      packageConfig: device!.devFS!.lastPackageConfig ??
+          debuggingOptions.buildInfo.packageConfig,
     );
     final Status devFSStatus = _logger.startProgress(
       'Waiting for connection from debug service on ${device!.device!.name}...',
@@ -612,16 +635,15 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
     if (_chromiumLauncher != null) {
       final Chromium chrome = await _chromiumLauncher!.connectedInstance;
       final ChromeTab? chromeTab = await getChromeTabGuarded(
-        chrome.chromeConnection,
-        (ChromeTab chromeTab) {
-          return !chromeTab.url.startsWith('chrome-extension');
-        },
-        retryFor: const Duration(seconds: 5),
-        onIoError: (Object error, StackTrace stackTrace) {
-          // We were unable to unable to communicate with Chrome.
-          _logger.printError(error.toString(), stackTrace: stackTrace);
-        }
-      );
+          chrome.chromeConnection,
+          (ChromeTab chromeTab) {
+            return !chromeTab.url.startsWith('chrome-extension');
+          },
+          retryFor: const Duration(seconds: 5),
+          onIoError: (Object error, StackTrace stackTrace) {
+            // We were unable to unable to communicate with Chrome.
+            _logger.printError(error.toString(), stackTrace: stackTrace);
+          });
       if (chromeTab == null) {
         appFailedToStart();
         throwToolExit('Failed to connect to Chrome instance.');
@@ -631,9 +653,11 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
     Uri? websocketUri;
     if (supportsServiceProtocol) {
       final WebDevFS webDevFS = device!.devFS! as WebDevFS;
-      final bool useDebugExtension = device!.device is WebServerDevice && debuggingOptions.startPaused;
+      final bool useDebugExtension =
+          device!.device is WebServerDevice && debuggingOptions.startPaused;
       _connectionResult = await webDevFS.connect(useDebugExtension);
-      unawaited(_connectionResult!.debugConnection!.onDone.whenComplete(_cleanupAndExit));
+      unawaited(_connectionResult!.debugConnection!.onDone
+          .whenComplete(_cleanupAndExit));
 
       void onLogEvent(vmservice.Event event) {
         final String message = processVmServiceMessage(event);
@@ -687,7 +711,8 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         _connectionResult!.appConnection!.runMain();
       } else {
         late StreamSubscription<void> resumeSub;
-        resumeSub = _vmService.service.onDebugEvent.listen((vmservice.Event event) {
+        resumeSub =
+            _vmService.service.onDebugEvent.listen((vmservice.Event event) {
           if (event.type == vmservice.EventKind.kResume) {
             _connectionResult!.appConnection!.runMain();
             resumeSub.cancel();
@@ -755,5 +780,6 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
 Uri _httpUriFromWebsocketUri(Uri websocketUri) {
   const String wsPath = '/ws';
   final String path = websocketUri.path;
-  return websocketUri.replace(scheme: 'http', path: path.substring(0, path.length - wsPath.length));
+  return websocketUri.replace(
+      scheme: 'http', path: path.substring(0, path.length - wsPath.length));
 }

--- a/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
+++ b/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
@@ -9,6 +9,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 import 'gen_l10n_types.dart';
 import 'language_subtag_registry.dart';
 
@@ -471,6 +472,7 @@ LocalizationOptions parseLocalizationsOptionsFromYAML({
   required File file,
   required Logger logger,
   required String defaultArbDir,
+  required bool defaultSyntheticPackage,
 }) {
   final String contents = file.readAsStringSync();
   if (contents.trim().isEmpty) {
@@ -497,7 +499,7 @@ LocalizationOptions parseLocalizationsOptionsFromYAML({
     headerFile: _tryReadUri(yamlNode, 'header-file', logger)?.path,
     useDeferredLoading: _tryReadBool(yamlNode, 'use-deferred-loading', logger),
     preferredSupportedLocales: _tryReadStringList(yamlNode, 'preferred-supported-locales', logger),
-    syntheticPackage: _tryReadBool(yamlNode, 'synthetic-package', logger),
+    syntheticPackage: _tryReadBool(yamlNode, 'synthetic-package', logger) ?? defaultSyntheticPackage,
     requiredResourceAttributes: _tryReadBool(yamlNode, 'required-resource-attributes', logger),
     nullableGetter: _tryReadBool(yamlNode, 'nullable-getter', logger),
     format: _tryReadBool(yamlNode, 'format', logger),
@@ -513,6 +515,15 @@ LocalizationOptions parseLocalizationsOptionsFromCommand({
   required FlutterCommand command,
   required String defaultArbDir,
 }) {
+  // TODO(matanlurey): Remove as part of https://github.com/flutter/flutter/issues/102983.
+  final bool syntheticPackage;
+  if (command.argResults!.wasParsed('synthetic-package')) {
+    // If provided explicitly, use the explicit value.
+    syntheticPackage = command.boolArg('synthetic-package');
+  } else {
+    // Otherwise, inherit from whatever the default of --implicit-pubspec-resolution is.
+    syntheticPackage = command.globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution);
+  }
   return LocalizationOptions(
     arbDir: command.stringArg('arb-dir') ?? defaultArbDir,
     outputDir: command.stringArg('output-dir'),
@@ -524,7 +535,7 @@ LocalizationOptions parseLocalizationsOptionsFromCommand({
     headerFile: command.stringArg('header-file'),
     useDeferredLoading: command.boolArg('use-deferred-loading'),
     genInputsAndOutputsList: command.stringArg('gen-inputs-and-outputs-list'),
-    syntheticPackage: command.boolArg('synthetic-package'),
+    syntheticPackage: syntheticPackage,
     projectDir: command.stringArg('project-dir'),
     requiredResourceAttributes: command.boolArg('required-resource-attributes'),
     nullableGetter: command.boolArg('nullable-getter'),

--- a/packages/flutter_tools/lib/src/preview_device.dart
+++ b/packages/flutter_tools/lib/src/preview_device.dart
@@ -37,12 +37,14 @@ class PreviewDeviceDiscovery extends PollingDeviceDiscovery {
     required Logger logger,
     required ProcessManager processManager,
     required FeatureFlags featureFlags,
+    required bool useImplicitPubspecResolution,
   }) : _artifacts = artifacts,
        _logger = logger,
        _processManager = processManager,
        _fileSystem = fileSystem,
        _platform = platform,
        _features = featureFlags,
+       _useImplicitPubspecResolution = useImplicitPubspecResolution,
        super('Flutter preview device');
 
   final Platform _platform;
@@ -51,6 +53,7 @@ class PreviewDeviceDiscovery extends PollingDeviceDiscovery {
   final ProcessManager _processManager;
   final FileSystem _fileSystem;
   final FeatureFlags _features;
+  final bool _useImplicitPubspecResolution;
 
   @override
   bool get canListAnything => _platform.isWindows;
@@ -75,6 +78,7 @@ class PreviewDeviceDiscovery extends PollingDeviceDiscovery {
       logger: _logger,
       processManager: _processManager,
       previewBinary: previewBinary,
+      useImplicitPubspecResolution: _useImplicitPubspecResolution,
     );
     return <Device>[
       if (_features.isPreviewDeviceEnabled)
@@ -99,6 +103,7 @@ class PreviewDevice extends Device {
     required FileSystem fileSystem,
     required Artifacts artifacts,
     required File previewBinary,
+    required bool useImplicitPubspecResolution,
     @visibleForTesting BundleBuilderFactory builderFactory = _defaultBundleBuilder,
   }) : _previewBinary = previewBinary,
        _processManager = processManager,
@@ -106,6 +111,7 @@ class PreviewDevice extends Device {
        _fileSystem = fileSystem,
        _bundleBuilderFactory = builderFactory,
        _artifacts = artifacts,
+       _useImplicitPubspecResolution = useImplicitPubspecResolution,
        super('preview', ephemeral: false, category: Category.desktop, platformType: PlatformType.windowsPreview);
 
   final ProcessManager _processManager;
@@ -114,6 +120,7 @@ class PreviewDevice extends Device {
   final BundleBuilderFactory _bundleBuilderFactory;
   final Artifacts _artifacts;
   final File _previewBinary;
+  final bool _useImplicitPubspecResolution;
 
   /// The set of plugins that are allowed to be used by Preview users.
   ///
@@ -184,6 +191,7 @@ class PreviewDevice extends Device {
         mainPath: mainPath,
         platform: TargetPlatform.windows_x64,
         assetDirPath: getAssetBuildDirectory(),
+        useImplicitPubspecResolution: _useImplicitPubspecResolution,
       );
       copyDirectory(_fileSystem.directory(
         getAssetBuildDirectory()),

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -53,27 +53,28 @@ class FlutterDevice {
     this.userIdentifier,
     required this.developmentShaderCompiler,
     this.developmentSceneImporter,
-  }) : generator = generator ?? ResidentCompiler(
-         globals.artifacts!.getArtifactPath(
-           Artifact.flutterPatchedSdkPath,
-           platform: targetPlatform,
-           mode: buildInfo.mode,
-         ),
-         buildMode: buildInfo.mode,
-         trackWidgetCreation: buildInfo.trackWidgetCreation,
-         fileSystemRoots: buildInfo.fileSystemRoots,
-         fileSystemScheme: buildInfo.fileSystemScheme,
-         targetModel: targetModel,
-         dartDefines: buildInfo.dartDefines,
-         packagesPath: buildInfo.packageConfigPath,
-         frontendServerStarterPath: buildInfo.frontendServerStarterPath,
-         extraFrontEndOptions: buildInfo.extraFrontEndOptions,
-         artifacts: globals.artifacts!,
-         processManager: globals.processManager,
-         logger: globals.logger,
-         platform: globals.platform,
-         fileSystem: globals.fs,
-       );
+  }) : generator = generator ??
+            ResidentCompiler(
+              globals.artifacts!.getArtifactPath(
+                Artifact.flutterPatchedSdkPath,
+                platform: targetPlatform,
+                mode: buildInfo.mode,
+              ),
+              buildMode: buildInfo.mode,
+              trackWidgetCreation: buildInfo.trackWidgetCreation,
+              fileSystemRoots: buildInfo.fileSystemRoots,
+              fileSystemScheme: buildInfo.fileSystemScheme,
+              targetModel: targetModel,
+              dartDefines: buildInfo.dartDefines,
+              packagesPath: buildInfo.packageConfigPath,
+              frontendServerStarterPath: buildInfo.frontendServerStarterPath,
+              extraFrontEndOptions: buildInfo.extraFrontEndOptions,
+              artifacts: globals.artifacts!,
+              processManager: globals.processManager,
+              logger: globals.logger,
+              platform: globals.platform,
+              fileSystem: globals.fs,
+            );
 
   /// Create a [FlutterDevice] with optional code generation enabled.
   static Future<FlutterDevice> create(
@@ -120,7 +121,8 @@ class FlutterDevice {
     if (targetPlatform == TargetPlatform.web_javascript) {
       // TODO(zanderso): consistently provide these flags across platforms.
       final String platformDillName;
-      final List<String> extraFrontEndOptions = List<String>.of(buildInfo.extraFrontEndOptions);
+      final List<String> extraFrontEndOptions =
+          List<String>.of(buildInfo.extraFrontEndOptions);
       switch (buildInfo.nullSafetyMode) {
         case NullSafetyMode.unsound:
           platformDillName = 'ddc_outline.dill';
@@ -140,7 +142,9 @@ class FlutterDevice {
       }
 
       final String platformDillPath = globals.fs.path.join(
-        globals.artifacts!.getHostArtifact(HostArtifact.webPlatformKernelFolder).path,
+        globals.artifacts!
+            .getHostArtifact(HostArtifact.webPlatformKernelFolder)
+            .path,
         platformDillName,
       );
 
@@ -152,19 +156,24 @@ class FlutterDevice {
         // Override the filesystem scheme so that the frontend_server can find
         // the generated entrypoint code.
         fileSystemScheme: 'org-dartlang-app',
-        initializeFromDill: buildInfo.initializeFromDill ?? getDefaultCachedKernelPath(
-          trackWidgetCreation: buildInfo.trackWidgetCreation,
-          dartDefines: buildInfo.dartDefines,
-          extraFrontEndOptions: extraFrontEndOptions,
-        ),
-        assumeInitializeFromDillUpToDate: buildInfo.assumeInitializeFromDillUpToDate,
+        initializeFromDill: buildInfo.initializeFromDill ??
+            getDefaultCachedKernelPath(
+              trackWidgetCreation: buildInfo.trackWidgetCreation,
+              dartDefines: buildInfo.dartDefines,
+              extraFrontEndOptions: extraFrontEndOptions,
+            ),
+        assumeInitializeFromDillUpToDate:
+            buildInfo.assumeInitializeFromDillUpToDate,
         targetModel: TargetModel.dartdevc,
         frontendServerStarterPath: buildInfo.frontendServerStarterPath,
         extraFrontEndOptions: extraFrontEndOptions,
         platformDill: globals.fs.file(platformDillPath).absolute.uri.toString(),
         dartDefines: buildInfo.dartDefines,
-        librariesSpec: globals.fs.file(globals.artifacts!
-          .getHostArtifact(HostArtifact.flutterWebLibrariesJson)).uri.toString(),
+        librariesSpec: globals.fs
+            .file(globals.artifacts!
+                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+            .uri
+            .toString(),
         packagesPath: buildInfo.packageConfigPath,
         artifacts: globals.artifacts!,
         processManager: globals.processManager,
@@ -192,12 +201,14 @@ class FlutterDevice {
         dartDefines: buildInfo.dartDefines,
         frontendServerStarterPath: buildInfo.frontendServerStarterPath,
         extraFrontEndOptions: extraFrontEndOptions,
-        initializeFromDill: buildInfo.initializeFromDill ?? getDefaultCachedKernelPath(
-          trackWidgetCreation: buildInfo.trackWidgetCreation,
-          dartDefines: buildInfo.dartDefines,
-          extraFrontEndOptions: extraFrontEndOptions,
-        ),
-        assumeInitializeFromDillUpToDate: buildInfo.assumeInitializeFromDillUpToDate,
+        initializeFromDill: buildInfo.initializeFromDill ??
+            getDefaultCachedKernelPath(
+              trackWidgetCreation: buildInfo.trackWidgetCreation,
+              dartDefines: buildInfo.dartDefines,
+              extraFrontEndOptions: extraFrontEndOptions,
+            ),
+        assumeInitializeFromDillUpToDate:
+            buildInfo.assumeInitializeFromDillUpToDate,
         packagesPath: buildInfo.packageConfigPath,
         artifacts: globals.artifacts!,
         processManager: globals.processManager,
@@ -269,21 +280,27 @@ class FlutterDevice {
       FlutterVmService? service;
       if (debuggingOptions.enableDds) {
         void handleError(Exception e, StackTrace st) {
-          globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $e');
+          globals.printTrace(
+              'Fail to connect to service protocol: $vmServiceUri: $e');
           if (!completer.isCompleted) {
-            completer.completeError('failed to connect to $vmServiceUri $e', st);
+            completer.completeError(
+                'failed to connect to $vmServiceUri $e', st);
           }
         }
+
         // First check if the VM service is actually listening on vmServiceUri as
         // this may not be the case when scraping logcat for URIs. If this URI is
         // from an old application instance, we shouldn't try and start DDS.
         try {
-          service = await connectToVmService(vmServiceUri!, logger: globals.logger);
+          service =
+              await connectToVmService(vmServiceUri!, logger: globals.logger);
           await service.dispose();
         } on Exception catch (exception) {
-          globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $exception');
+          globals.printTrace(
+              'Fail to connect to service protocol: $vmServiceUri: $exception');
           if (!completer.isCompleted && !_isListeningForVmServiceUri!) {
-            completer.completeError('failed to connect to $vmServiceUri $exception');
+            completer
+                .completeError('failed to connect to $vmServiceUri $exception');
           }
           return;
         }
@@ -298,7 +315,8 @@ class FlutterDevice {
           );
         } on DartDevelopmentServiceException catch (e, st) {
           if (!allowExistingDdsInstance ||
-              (e.errorCode != DartDevelopmentServiceException.existingDdsInstanceError)) {
+              (e.errorCode !=
+                  DartDevelopmentServiceException.existingDdsInstanceError)) {
             handleError(e, st);
             return;
           } else {
@@ -316,34 +334,38 @@ class FlutterDevice {
       // shuts down, including after an error. If `done` completes before `connectToVmService`,
       // something went wrong that caused DDS to shutdown early.
       try {
-        service = await Future.any<dynamic>(
-          <Future<dynamic>>[
-            connectToVmService(
-              debuggingOptions.enableDds ? (device!.dds.uri ?? vmServiceUri!): vmServiceUri!,
-              reloadSources: reloadSources,
-              restart: restart,
-              compileExpression: compileExpression,
-              getSkSLMethod: getSkSLMethod,
-              flutterProject: FlutterProject.current(),
-              printStructuredErrorLogMethod: printStructuredErrorLogMethod,
-              device: device,
-              logger: globals.logger,
-            ),
-            if (!existingDds)
-              device!.dds.done.whenComplete(() => throw Exception('DDS shut down too early')),
-          ]
-        ) as FlutterVmService?;
+        service = await Future.any<dynamic>(<Future<dynamic>>[
+          connectToVmService(
+            debuggingOptions.enableDds
+                ? (device!.dds.uri ?? vmServiceUri!)
+                : vmServiceUri!,
+            reloadSources: reloadSources,
+            restart: restart,
+            compileExpression: compileExpression,
+            getSkSLMethod: getSkSLMethod,
+            flutterProject: FlutterProject.current(),
+            printStructuredErrorLogMethod: printStructuredErrorLogMethod,
+            device: device,
+            logger: globals.logger,
+          ),
+          if (!existingDds)
+            device!.dds.done
+                .whenComplete(() => throw Exception('DDS shut down too early')),
+        ]) as FlutterVmService?;
       } on Exception catch (exception) {
-        globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $exception');
+        globals.printTrace(
+            'Fail to connect to service protocol: $vmServiceUri: $exception');
         if (!completer.isCompleted && !_isListeningForVmServiceUri!) {
-          completer.completeError('failed to connect to $vmServiceUri $exception');
+          completer
+              .completeError('failed to connect to $vmServiceUri $exception');
         }
         return;
       }
       if (completer.isCompleted) {
         return;
       }
-      globals.printTrace('Successfully connected to service protocol: $vmServiceUri');
+      globals.printTrace(
+          'Successfully connected to service protocol: $vmServiceUri');
 
       vmService = service;
       (await device!.getLogReader(app: package)).connectedVMService = vmService;
@@ -354,7 +376,8 @@ class FlutterDevice {
     }, onDone: () {
       _isListeningForVmServiceUri = false;
       if (!completer.isCompleted && !isWaitingForVm) {
-        completer.completeError(Exception('connection to device ended too early'));
+        completer
+            .completeError(Exception('connection to device ended too early'));
       }
     });
     _isListeningForVmServiceUri = true;
@@ -395,10 +418,12 @@ class FlutterDevice {
     }
     final Stream<String> logStream;
     if (device is IOSDevice) {
-      logStream = (device! as IOSDevice).getLogReader(
-        app: package as IOSApp?,
-        usingCISystem: debuggingOptions.usingCISystem,
-      ).logLines;
+      logStream = (device! as IOSDevice)
+          .getLogReader(
+            app: package as IOSApp?,
+            usingCISystem: debuggingOptions.usingCISystem,
+          )
+          .logLines;
     } else {
       logStream = (await device!.getLogReader(app: package)).logLines;
     }
@@ -440,7 +465,8 @@ class FlutterDevice {
     String? route,
   }) async {
     final bool prebuiltMode = hotRunner.applicationBinary != null;
-    final String modeName = hotRunner.debuggingOptions.buildInfo.friendlyModeName;
+    final String modeName =
+        hotRunner.debuggingOptions.buildInfo.friendlyModeName;
     globals.printStatus(
       'Launching ${getDisplayPath(hotRunner.mainPath, globals.fs)} '
       'on ${device!.name} in $modeName mode...',
@@ -456,7 +482,8 @@ class FlutterDevice {
 
     if (applicationPackage == null) {
       String message = 'No application found for $targetPlatform.';
-      final String? hint = await getMissingPackageHintForPlatform(targetPlatform);
+      final String? hint =
+          await getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null) {
         message += '\n$hint';
       }
@@ -488,13 +515,10 @@ class FlutterDevice {
       return 2;
     }
     if (result.hasVmService) {
-      vmServiceUris = Stream<Uri?>
-        .value(result.vmServiceUri)
-        .asBroadcastStream();
+      vmServiceUris =
+          Stream<Uri?>.value(result.vmServiceUri).asBroadcastStream();
     } else {
-      vmServiceUris = const Stream<Uri>
-        .empty()
-        .asBroadcastStream();
+      vmServiceUris = const Stream<Uri>.empty().asBroadcastStream();
     }
     return 0;
   }
@@ -513,7 +537,8 @@ class FlutterDevice {
 
     if (applicationPackage == null) {
       String message = 'No application found for $targetPlatform.';
-      final String? hint = await getMissingPackageHintForPlatform(targetPlatform);
+      final String? hint =
+          await getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null) {
         message += '\n$hint';
       }
@@ -523,7 +548,8 @@ class FlutterDevice {
 
     devFSWriter = device!.createDevFSWriter(applicationPackage, userIdentifier);
 
-    final String modeName = coldRunner.debuggingOptions.buildInfo.friendlyModeName;
+    final String modeName =
+        coldRunner.debuggingOptions.buildInfo.friendlyModeName;
     final bool prebuiltMode = coldRunner.applicationBinary != null;
     globals.printStatus(
       'Launching ${getDisplayPath(coldRunner.mainPath, globals.fs)} '
@@ -551,13 +577,10 @@ class FlutterDevice {
       return 2;
     }
     if (result.hasVmService) {
-      vmServiceUris = Stream<Uri?>
-        .value(result.vmServiceUri)
-        .asBroadcastStream();
+      vmServiceUris =
+          Stream<Uri?>.value(result.vmServiceUri).asBroadcastStream();
     } else {
-      vmServiceUris = const Stream<Uri>
-        .empty()
-        .asBroadcastStream();
+      vmServiceUris = const Stream<Uri>.empty().asBroadcastStream();
     }
     return 0;
   }
@@ -661,16 +684,22 @@ abstract class ResidentHandlers {
   FileSystem? get fileSystem;
 
   /// Called to print help to the terminal.
-  void printHelp({ required bool details });
+  void printHelp({required bool details});
 
   /// Perform a hot reload or hot restart of all attached applications.
   ///
   /// If [fullRestart] is true, a hot restart is performed. Otherwise a hot reload
   /// is run instead. On web devices, this only performs a hot restart regardless of
   /// the value of [fullRestart].
-  Future<OperationResult> restart({ bool fullRestart = false, bool pause = false, String? reason }) {
-    final String mode = isRunningProfile ? 'profile' :isRunningRelease ? 'release' : 'this';
-    throw Exception('${fullRestart ? 'Restart' : 'Reload'} is not supported in $mode mode');
+  Future<OperationResult> restart(
+      {bool fullRestart = false, bool pause = false, String? reason}) {
+    final String mode = isRunningProfile
+        ? 'profile'
+        : isRunningRelease
+            ? 'release'
+            : 'this';
+    throw Exception(
+        '${fullRestart ? 'Restart' : 'Reload'} is not supported in $mode mode');
   }
 
   /// Dump the application's current widget tree to the terminal.
@@ -679,7 +708,8 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         final String data = await device.vmService!.flutterDebugDumpApp(
           isolateId: view.uiIsolate!.id!,
@@ -696,7 +726,8 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         final String data = await device.vmService!.flutterDebugDumpRenderTree(
           isolateId: view.uiIsolate!.id!,
@@ -713,7 +744,8 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         final String data = await device.vmService!.flutterDebugDumpLayerTree(
           isolateId: view.uiIsolate!.id!,
@@ -729,7 +761,8 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         final String data = await device.vmService!.flutterDebugDumpFocusTree(
           isolateId: view.uiIsolate!.id!,
@@ -748,9 +781,11 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
-        final String data = await device.vmService!.flutterDebugDumpSemanticsTreeInTraversalOrder(
+        final String data = await device.vmService!
+            .flutterDebugDumpSemanticsTreeInTraversalOrder(
           isolateId: view.uiIsolate!.id!,
         );
         logger.printStatus(data);
@@ -767,9 +802,11 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
-        final String data = await device.vmService!.flutterDebugDumpSemanticsTreeInInverseHitTestOrder(
+        final String data = await device.vmService!
+            .flutterDebugDumpSemanticsTreeInInverseHitTestOrder(
           isolateId: view.uiIsolate!.id!,
         );
         logger.printStatus(data);
@@ -784,7 +821,8 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterToggleDebugPaintSizeEnabled(
           isolateId: view.uiIsolate!.id!,
@@ -821,7 +859,8 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterToggleWidgetInspector(
           isolateId: view.uiIsolate!.id!,
@@ -837,7 +876,8 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterToggleInvertOversizedImages(
           isolateId: view.uiIsolate!.id!,
@@ -853,7 +893,8 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterToggleProfileWidgetBuilds(
           isolateId: view.uiIsolate!.id!,
@@ -868,8 +909,10 @@ abstract class ResidentHandlers {
     if (!supportsServiceProtocol) {
       return false;
     }
-    final List<FlutterView> views = await flutterDevices.first!.vmService!.getFlutterViews();
-    final Brightness? current = await flutterDevices.first!.vmService!.flutterBrightnessOverride(
+    final List<FlutterView> views =
+        await flutterDevices.first!.vmService!.getFlutterViews();
+    final Brightness? current =
+        await flutterDevices.first!.vmService!.flutterBrightnessOverride(
       isolateId: views.first.uiIsolate!.id!,
     );
     final Brightness next = switch (current) {
@@ -877,7 +920,8 @@ abstract class ResidentHandlers {
       Brightness.dark || null => Brightness.light,
     };
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterBrightnessOverride(
           isolateId: view.uiIsolate!.id!,
@@ -894,14 +938,16 @@ abstract class ResidentHandlers {
     if (!supportsServiceProtocol || !isRunningDebug) {
       return false;
     }
-    final List<FlutterView> views = await flutterDevices.first!.vmService!.getFlutterViews();
-    final String from = await flutterDevices
-      .first!.vmService!.flutterPlatformOverride(
-        isolateId: views.first.uiIsolate!.id!,
-      );
+    final List<FlutterView> views =
+        await flutterDevices.first!.vmService!.getFlutterViews();
+    final String from =
+        await flutterDevices.first!.vmService!.flutterPlatformOverride(
+      isolateId: views.first.uiIsolate!.id!,
+    );
     final String to = nextPlatform(from);
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterPlatformOverride(
           platform: to,
@@ -959,7 +1005,8 @@ abstract class ResidentHandlers {
     try {
       bool result;
       if (device.device!.supportsScreenshot) {
-        result = await _toggleDebugBanner(device, () => device.device!.takeScreenshot(outputFile));
+        result = await _toggleDebugBanner(
+            device, () => device.device!.takeScreenshot(outputFile));
       } else {
         result = await _takeVmServiceScreenshot(device, outputFile);
       }
@@ -977,23 +1024,26 @@ abstract class ResidentHandlers {
     }
   }
 
-  Future<bool> _takeVmServiceScreenshot(FlutterDevice device, File outputFile) async {
+  Future<bool> _takeVmServiceScreenshot(
+      FlutterDevice device, File outputFile) async {
     if (device.targetPlatform != TargetPlatform.web_javascript) {
       return false;
     }
     assert(supportsServiceProtocol);
 
     return _toggleDebugBanner(device, () async {
-      final vm_service.Response? response =  await device.vmService!.callMethodWrapper('ext.dwds.screenshot');
+      final vm_service.Response? response =
+          await device.vmService!.callMethodWrapper('ext.dwds.screenshot');
       if (response == null) {
-       throw Exception('Failed to take screenshot');
+        throw Exception('Failed to take screenshot');
       }
       final String data = response.json!['data'] as String;
       outputFile.writeAsBytesSync(base64.decode(data));
     });
   }
 
-  Future<bool> _toggleDebugBanner(FlutterDevice device, Future<void> Function() cb) async {
+  Future<bool> _toggleDebugBanner(
+      FlutterDevice device, Future<void> Function() cb) async {
     List<FlutterView> views = <FlutterView>[];
     if (supportsServiceProtocol) {
       views = await device.vmService!.getFlutterViews();
@@ -1009,10 +1059,12 @@ abstract class ResidentHandlers {
         }
         return true;
       } on vm_service.RPCError catch (error) {
-        logger.printError('Error communicating with Flutter on the device: $error');
+        logger.printError(
+            'Error communicating with Flutter on the device: $error');
         return false;
       }
     }
+
     if (!await setDebugBanner(false)) {
       return false;
     }
@@ -1026,7 +1078,6 @@ abstract class ResidentHandlers {
     }
     return succeeded;
   }
-
 
   /// Remove sigusr signal handlers.
   Future<void> cleanupAfterSignal();
@@ -1053,31 +1104,34 @@ abstract class ResidentRunner extends ResidentHandlers {
     this.flutterDevices, {
     required this.target,
     required this.debuggingOptions,
+    required bool useImplicitPubspecResolution,
     String? projectRootPath,
     this.stayResident = true,
     this.hotMode = true,
     String? dillOutputPath,
     this.machine = false,
     ResidentDevtoolsHandlerFactory devtoolsHandler = createDefaultHandler,
-  }) : mainPath = globals.fs.file(target).absolute.path,
-       packagesFilePath = debuggingOptions.buildInfo.packageConfigPath,
-       projectRootPath = projectRootPath ?? globals.fs.currentDirectory.path,
-       _dillOutputPath = dillOutputPath,
-       artifactDirectory = dillOutputPath == null
-          ? globals.fs.systemTempDirectory.createTempSync('flutter_tool.')
-          : globals.fs.file(dillOutputPath).parent,
-       assetBundle = AssetBundleFactory.instance.createBundle(),
-       commandHelp = CommandHelp(
-         logger: globals.logger,
-         terminal: globals.terminal,
-         platform: globals.platform,
-         outputPreferences: globals.outputPreferences,
-       ) {
+  })  : mainPath = globals.fs.file(target).absolute.path,
+        packagesFilePath = debuggingOptions.buildInfo.packageConfigPath,
+        projectRootPath = projectRootPath ?? globals.fs.currentDirectory.path,
+        _dillOutputPath = dillOutputPath,
+        _useImplicitPubspecResolution = useImplicitPubspecResolution,
+        artifactDirectory = dillOutputPath == null
+            ? globals.fs.systemTempDirectory.createTempSync('flutter_tool.')
+            : globals.fs.file(dillOutputPath).parent,
+        assetBundle = AssetBundleFactory.instance.createBundle(),
+        commandHelp = CommandHelp(
+          logger: globals.logger,
+          terminal: globals.terminal,
+          platform: globals.platform,
+          outputPreferences: globals.outputPreferences,
+        ) {
     if (!artifactDirectory.existsSync()) {
       artifactDirectory.createSync(recursive: true);
     }
     // TODO(bkonyi): remove when ready to serve DevTools from DDS.
-    _residentDevtoolsHandler = devtoolsHandler(DevtoolsLauncher.instance, this, globals.logger);
+    _residentDevtoolsHandler =
+        devtoolsHandler(DevtoolsLauncher.instance, this, globals.logger);
   }
 
   @override
@@ -1095,19 +1149,22 @@ abstract class ResidentRunner extends ResidentHandlers {
   @override
   final bool stayResident;
   final String? _dillOutputPath;
+
   /// The parent location of the incremental artifacts.
   final Directory artifactDirectory;
   final String packagesFilePath;
   final String projectRootPath;
   final String mainPath;
   final AssetBundle assetBundle;
+  final bool _useImplicitPubspecResolution;
 
   final CommandHelp commandHelp;
   final bool machine;
 
   // TODO(bkonyi): remove when ready to serve DevTools from DDS.
   @override
-  ResidentDevtoolsHandler? get residentDevtoolsHandler => _residentDevtoolsHandler;
+  ResidentDevtoolsHandler? get residentDevtoolsHandler =>
+      _residentDevtoolsHandler;
   ResidentDevtoolsHandler? _residentDevtoolsHandler;
 
   bool _exited = false;
@@ -1125,7 +1182,9 @@ abstract class ResidentRunner extends ResidentHandlers {
     });
   }
 
-  String get dillOutputPath => _dillOutputPath ?? globals.fs.path.join(artifactDirectory.path, 'app.dill');
+  String get dillOutputPath =>
+      _dillOutputPath ??
+      globals.fs.path.join(artifactDirectory.path, 'app.dill');
   String getReloadPath({
     bool fullRestart = false,
     required bool swap,
@@ -1139,10 +1198,12 @@ abstract class ResidentRunner extends ResidentHandlers {
   bool get debuggingEnabled => debuggingOptions.debuggingEnabled;
 
   @override
-  bool get isRunningDebug => !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isDebug;
+  bool get isRunningDebug =>
+      !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isDebug;
 
   @override
-  bool get isRunningProfile => !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isProfile;
+  bool get isRunningProfile =>
+      !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isProfile;
 
   @override
   bool get isRunningRelease => debuggingOptions.buildInfo.isRelease;
@@ -1153,7 +1214,8 @@ abstract class ResidentRunner extends ResidentHandlers {
   @override
   bool get supportsWriteSkSL => supportsServiceProtocol;
 
-  bool get trackWidgetCreation => debuggingOptions.buildInfo.trackWidgetCreation;
+  bool get trackWidgetCreation =>
+      debuggingOptions.buildInfo.trackWidgetCreation;
 
   /// True if the shared Dart plugin registry (which is different than the one
   /// used for web) should be generated during source generation.
@@ -1171,9 +1233,10 @@ abstract class ResidentRunner extends ResidentHandlers {
 
   @override
   bool get supportsRestart {
-    return isRunningDebug && flutterDevices.every((FlutterDevice? device) {
-      return device!.device!.supportsHotRestart;
-    });
+    return isRunningDebug &&
+        flutterDevices.every((FlutterDevice? device) {
+          return device!.device!.supportsHotRestart;
+        });
   }
 
   @override
@@ -1221,6 +1284,7 @@ abstract class ResidentRunner extends ResidentHandlers {
         // Needed for Dart plugin registry generation.
         kTargetFile: mainPath,
       },
+      useImplicitPubspecResolution: _useImplicitPubspecResolution,
     );
 
     final CompositeTarget compositeTarget = CompositeTarget(<Target>[
@@ -1234,12 +1298,12 @@ abstract class ResidentRunner extends ResidentHandlers {
       _lastBuild,
     );
     if (!_lastBuild!.success) {
-      for (final ExceptionMeasurement exceptionMeasurement in _lastBuild!.exceptions.values) {
+      for (final ExceptionMeasurement exceptionMeasurement
+          in _lastBuild!.exceptions.values) {
         globals.printError(
           exceptionMeasurement.exception.toString(),
-          stackTrace: globals.logger.isVerbose
-            ? exceptionMeasurement.stackTrace
-            : null,
+          stackTrace:
+              globals.logger.isVerbose ? exceptionMeasurement.stackTrace : null,
         );
       }
     }
@@ -1250,12 +1314,15 @@ abstract class ResidentRunner extends ResidentHandlers {
   void writeVmServiceFile() {
     if (debuggingOptions.vmserviceOutFile != null) {
       try {
-        final String address = flutterDevices.first.vmService!.wsAddress.toString();
-        final File vmserviceOutFile = globals.fs.file(debuggingOptions.vmserviceOutFile);
+        final String address =
+            flutterDevices.first.vmService!.wsAddress.toString();
+        final File vmserviceOutFile =
+            globals.fs.file(debuggingOptions.vmserviceOutFile);
         vmserviceOutFile.createSync(recursive: true);
         vmserviceOutFile.writeAsStringSync(address);
       } on FileSystemException {
-        globals.printError('Failed to write vmservice-out-file at ${debuggingOptions.vmserviceOutFile}');
+        globals.printError(
+            'Failed to write vmservice-out-file at ${debuggingOptions.vmserviceOutFile}');
       }
     }
   }
@@ -1282,9 +1349,8 @@ abstract class ResidentRunner extends ResidentHandlers {
   }
 
   Future<void> stopEchoingDeviceLog() async {
-    await Future.wait<void>(
-      flutterDevices.map<Future<void>>((FlutterDevice? device) => device!.stopEchoingDeviceLog())
-    );
+    await Future.wait<void>(flutterDevices.map<Future<void>>(
+        (FlutterDevice? device) => device!.stopEchoingDeviceLog()));
   }
 
   void shutdownDartDevelopmentService() {
@@ -1306,10 +1372,7 @@ abstract class ResidentRunner extends ResidentHandlers {
         dartDefines: debuggingOptions.buildInfo.dartDefines,
         extraFrontEndOptions: debuggingOptions.buildInfo.extraFrontEndOptions,
       );
-      globals.fs
-          .file(copyPath)
-          .parent
-          .createSync(recursive: true);
+      globals.fs.file(copyPath).parent.createSync(recursive: true);
       outputDill.copySync(copyPath);
     }
   }
@@ -1319,7 +1382,8 @@ abstract class ResidentRunner extends ResidentHandlers {
       final Map<String, Object?>? json = event.extensionData?.data;
       if (json != null && json.containsKey('renderedErrorText')) {
         final int errorsSinceReload;
-        if (json.containsKey('errorsSinceReload') && json['errorsSinceReload'] is int) {
+        if (json.containsKey('errorsSinceReload') &&
+            json['errorsSinceReload'] is int) {
           errorsSinceReload = json['errorsSinceReload']! as int;
         } else {
           errorsSinceReload = 0;
@@ -1334,7 +1398,8 @@ abstract class ResidentRunner extends ResidentHandlers {
           globals.printStatus('');
         }
       } else {
-        globals.printError('Received an invalid ${globals.logger.terminal.bolden("Flutter.Error")} message from app: $json');
+        globals.printError(
+            'Received an invalid ${globals.logger.terminal.bolden("Flutter.Error")} message from app: $json');
       }
     }
   }
@@ -1373,10 +1438,12 @@ abstract class ResidentRunner extends ResidentHandlers {
       // This hooks up callbacks for when the connection stops in the future.
       // We don't want to wait for them. We don't handle errors in those callbacks'
       // futures either because they just print to logger and is not critical.
-      unawaited(device.vmService!.service.onDone.then<void>(
-        _serviceProtocolDone,
-        onError: _serviceProtocolError,
-      ).whenComplete(_serviceDisconnected));
+      unawaited(device.vmService!.service.onDone
+          .then<void>(
+            _serviceProtocolDone,
+            onError: _serviceProtocolError,
+          )
+          .whenComplete(_serviceDisconnected));
     }
   }
 
@@ -1385,7 +1452,8 @@ abstract class ResidentRunner extends ResidentHandlers {
   }
 
   Future<void> _serviceProtocolError(Object error, StackTrace stack) {
-    globals.printTrace('Service protocol connection closed with an error: $error\n$stack');
+    globals.printTrace(
+        'Service protocol connection closed with an error: $error\n$stack');
     return Future<void>.error(error, stack);
   }
 
@@ -1403,11 +1471,13 @@ abstract class ResidentRunner extends ResidentHandlers {
 
   Future<void> enableObservatory() async {
     assert(debuggingOptions.serveObservatory);
-    final List<Future<vm_service.Response?>> serveObservatoryRequests = <Future<vm_service.Response?>>[
+    final List<Future<vm_service.Response?>> serveObservatoryRequests =
+        <Future<vm_service.Response?>>[
       for (final FlutterDevice? device in flutterDevices)
         if (device != null)
           // Notify the VM service if the user wants Observatory to be served.
-          device.vmService?.callMethodWrapper('_serveObservatory') ?? Future<vm_service.Response?>.value(),
+          device.vmService?.callMethodWrapper('_serveObservatory') ??
+              Future<vm_service.Response?>.value(),
     ];
     try {
       await Future.wait(serveObservatoryRequests);
@@ -1456,9 +1526,11 @@ abstract class ResidentRunner extends ResidentHandlers {
   bool get reportedDebuggers => _reportedDebuggers;
   bool _reportedDebuggers = false;
 
-  void printDebuggerList({bool includeVmService = true, bool includeDevtools = true}) {
+  void printDebuggerList(
+      {bool includeVmService = true, bool includeDevtools = true}) {
     // TODO(bkonyi): update this logic when ready to serve DevTools from DDS.
-    final DevToolsServerAddress? devToolsServerAddress = residentDevtoolsHandler!.activeDevToolsServer;
+    final DevToolsServerAddress? devToolsServerAddress =
+        residentDevtoolsHandler!.activeDevToolsServer;
     if (!residentDevtoolsHandler!.readyToAnnounce) {
       includeDevtools = false;
     }
@@ -1478,11 +1550,14 @@ abstract class ResidentRunner extends ResidentHandlers {
         if (_residentDevtoolsHandler!.printDtdUri) {
           final Uri? dtdUri = residentDevtoolsHandler!.dtdUri;
           if (dtdUri != null) {
-            globals.printStatus('The Dart Tooling Daemon is available at: $dtdUri\n');
+            globals.printStatus(
+                'The Dart Tooling Daemon is available at: $dtdUri\n');
           }
         }
         final Uri? uri = devToolsServerAddress!.uri?.replace(
-          queryParameters: <String, dynamic>{'uri': '${device.vmService!.httpAddress}'},
+          queryParameters: <String, dynamic>{
+            'uri': '${device.vmService!.httpAddress}'
+          },
         );
         if (uri != null) {
           globals.printStatus(
@@ -1497,7 +1572,8 @@ abstract class ResidentRunner extends ResidentHandlers {
 
   void printHelpDetails() {
     commandHelp.v.print();
-    if (flutterDevices.any((FlutterDevice? d) => d!.device!.supportsScreenshot)) {
+    if (flutterDevices
+        .any((FlutterDevice? d) => d!.device!.supportsScreenshot)) {
       commandHelp.s.print();
     }
     if (supportsServiceProtocol) {
@@ -1537,7 +1613,10 @@ abstract class ResidentRunner extends ResidentHandlers {
 }
 
 class OperationResult {
-  OperationResult(this.code, this.message, { this.fatal = false, this.updateFSReport, this.extraTimings = const <OperationResultExtraTiming>[] });
+  OperationResult(this.code, this.message,
+      {this.fatal = false,
+      this.updateFSReport,
+      this.extraTimings = const <OperationResultExtraTiming>[]});
 
   /// The result of the operation; a non-zero code indicates a failure.
   final int code;
@@ -1568,14 +1647,16 @@ class OperationResultExtraTiming {
   final int timeInMs;
 }
 
-Future<String?> getMissingPackageHintForPlatform(TargetPlatform platform) async {
+Future<String?> getMissingPackageHintForPlatform(
+    TargetPlatform platform) async {
   switch (platform) {
     case TargetPlatform.android_arm:
     case TargetPlatform.android_arm64:
     case TargetPlatform.android_x64:
     case TargetPlatform.android_x86:
       final FlutterProject project = FlutterProject.current();
-      final String manifestPath = globals.fs.path.relative(project.android.appManifestFile.path);
+      final String manifestPath =
+          globals.fs.path.relative(project.android.appManifestFile.path);
       return 'Is your project missing an $manifestPath?\nConsider running "flutter create ." to create one.';
     case TargetPlatform.ios:
       return 'Is your project missing an ios/Runner/Info.plist?\nConsider running "flutter create ." to create one.';
@@ -1595,19 +1676,20 @@ Future<String?> getMissingPackageHintForPlatform(TargetPlatform platform) async 
 
 /// Redirects terminal commands to the correct resident runner methods.
 class TerminalHandler {
-  TerminalHandler(this.residentRunner, {
+  TerminalHandler(
+    this.residentRunner, {
     required Logger logger,
     required Terminal terminal,
     required Signals signals,
     required io.ProcessInfo processInfo,
     required bool reportReady,
     String? pidFile,
-  }) : _logger = logger,
-       _terminal = terminal,
-       _signals = signals,
-       _processInfo = processInfo,
-       _reportReady = reportReady,
-       _pidFile = pidFile;
+  })  : _logger = logger,
+        _terminal = terminal,
+        _signals = signals,
+        _processInfo = processInfo,
+        _reportReady = reportReady,
+        _pidFile = pidFile;
 
   final Logger _logger;
   final Terminal _terminal;
@@ -1637,7 +1719,8 @@ class TerminalHandler {
     subscription = _terminal.keystrokes.listen(processTerminalInput);
   }
 
-  final Map<io.ProcessSignal, Object> _signalTokens = <io.ProcessSignal, Object>{};
+  final Map<io.ProcessSignal, Object> _signalTokens =
+      <io.ProcessSignal, Object>{};
 
   void _addSignalHandler(io.ProcessSignal signal, SignalHandler handler) {
     _signalTokens[signal] = _signals.addHandler(signal, handler);
@@ -1647,7 +1730,8 @@ class TerminalHandler {
     assert(residentRunner.stayResident);
     _addSignalHandler(io.ProcessSignal.sigint, _cleanUp);
     _addSignalHandler(io.ProcessSignal.sigterm, _cleanUp);
-    if (residentRunner.supportsServiceProtocol && residentRunner.supportsRestart) {
+    if (residentRunner.supportsServiceProtocol &&
+        residentRunner.supportsRestart) {
       _addSignalHandler(io.ProcessSignal.sigusr1, _handleSignal);
       _addSignalHandler(io.ProcessSignal.sigusr2, _handleSignal);
       if (_pidFile != null) {
@@ -1665,11 +1749,13 @@ class TerminalHandler {
         _logger.printTrace('Deleting pid file (${_actualPidFile!.path}).');
         _actualPidFile!.deleteSync();
       } on FileSystemException catch (error) {
-        _logger.printWarning('Failed to delete pid file (${_actualPidFile!.path}): ${error.message}');
+        _logger.printWarning(
+            'Failed to delete pid file (${_actualPidFile!.path}): ${error.message}');
       }
       _actualPidFile = null;
     }
-    for (final MapEntry<io.ProcessSignal, Object> entry in _signalTokens.entries) {
+    for (final MapEntry<io.ProcessSignal, Object> entry
+        in _signalTokens.entries) {
       _signals.removeHandler(entry.key, entry.value);
     }
     _signalTokens.clear();
@@ -1735,7 +1821,8 @@ class TerminalHandler {
           throwToolExit(result.message);
         }
         if (!result.isOk) {
-          _logger.printStatus('Try again after fixing the above error(s).', emphasis: true);
+          _logger.printStatus('Try again after fixing the above error(s).',
+              emphasis: true);
         }
         return true;
       case 'R':
@@ -1743,12 +1830,14 @@ class TerminalHandler {
         if (!residentRunner.supportsRestart || !residentRunner.hotMode) {
           return false;
         }
-        final OperationResult result = await residentRunner.restart(fullRestart: true);
+        final OperationResult result =
+            await residentRunner.restart(fullRestart: true);
         if (result.fatal) {
           throwToolExit(result.message);
         }
         if (!result.isOk) {
-          _logger.printStatus('Try again after fixing the above error(s).', emphasis: true);
+          _logger.printStatus('Try again after fixing the above error(s).',
+              emphasis: true);
         }
         return true;
       case 's':
@@ -1765,7 +1854,8 @@ class TerminalHandler {
         return residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
       case 'v':
       case 'V':
-        return residentRunner.residentDevtoolsHandler!.launchDevToolsInBrowser(flutterDevices: residentRunner.flutterDevices);
+        return residentRunner.residentDevtoolsHandler!.launchDevToolsInBrowser(
+            flutterDevices: residentRunner.flutterDevices);
       case 'w':
       case 'W':
         return residentRunner.debugDumpApp();
@@ -1777,15 +1867,17 @@ class TerminalHandler {
     // When terminal doesn't support line mode, '\n' can sneak into the input.
     command = command.trim();
     if (_processingUserRequest) {
-      _logger.printTrace('Ignoring terminal input: "$command" because we are busy.');
+      _logger.printTrace(
+          'Ignoring terminal input: "$command" because we are busy.');
       return;
     }
     _processingUserRequest = true;
     try {
       lastReceivedCommand = command;
       await _commonTerminalInputHandler(command);
-    // Catch all exception since this is doing cleanup and rethrowing.
-    } catch (error, st) { // ignore: avoid_catches_without_on_clauses
+      // Catch all exception since this is doing cleanup and rethrowing.
+    } catch (error, st) {
+      // ignore: avoid_catches_without_on_clauses
       // Don't print stack traces for known error types.
       if (error is! ToolExit) {
         _logger.printError('$error\n$st');
@@ -1824,7 +1916,7 @@ class TerminalHandler {
 }
 
 class DebugConnectionInfo {
-  DebugConnectionInfo({ this.httpUri, this.wsUri, this.baseUri });
+  DebugConnectionInfo({this.httpUri, this.wsUri, this.baseUri});
 
   final Uri? httpUri;
   final Uri? wsUri;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -53,28 +53,27 @@ class FlutterDevice {
     this.userIdentifier,
     required this.developmentShaderCompiler,
     this.developmentSceneImporter,
-  }) : generator = generator ??
-            ResidentCompiler(
-              globals.artifacts!.getArtifactPath(
-                Artifact.flutterPatchedSdkPath,
-                platform: targetPlatform,
-                mode: buildInfo.mode,
-              ),
-              buildMode: buildInfo.mode,
-              trackWidgetCreation: buildInfo.trackWidgetCreation,
-              fileSystemRoots: buildInfo.fileSystemRoots,
-              fileSystemScheme: buildInfo.fileSystemScheme,
-              targetModel: targetModel,
-              dartDefines: buildInfo.dartDefines,
-              packagesPath: buildInfo.packageConfigPath,
-              frontendServerStarterPath: buildInfo.frontendServerStarterPath,
-              extraFrontEndOptions: buildInfo.extraFrontEndOptions,
-              artifacts: globals.artifacts!,
-              processManager: globals.processManager,
-              logger: globals.logger,
-              platform: globals.platform,
-              fileSystem: globals.fs,
-            );
+  }) : generator = generator ?? ResidentCompiler(
+         globals.artifacts!.getArtifactPath(
+           Artifact.flutterPatchedSdkPath,
+           platform: targetPlatform,
+           mode: buildInfo.mode,
+         ),
+         buildMode: buildInfo.mode,
+         trackWidgetCreation: buildInfo.trackWidgetCreation,
+         fileSystemRoots: buildInfo.fileSystemRoots,
+         fileSystemScheme: buildInfo.fileSystemScheme,
+         targetModel: targetModel,
+         dartDefines: buildInfo.dartDefines,
+         packagesPath: buildInfo.packageConfigPath,
+         frontendServerStarterPath: buildInfo.frontendServerStarterPath,
+         extraFrontEndOptions: buildInfo.extraFrontEndOptions,
+         artifacts: globals.artifacts!,
+         processManager: globals.processManager,
+         logger: globals.logger,
+         platform: globals.platform,
+         fileSystem: globals.fs,
+       );
 
   /// Create a [FlutterDevice] with optional code generation enabled.
   static Future<FlutterDevice> create(
@@ -121,8 +120,7 @@ class FlutterDevice {
     if (targetPlatform == TargetPlatform.web_javascript) {
       // TODO(zanderso): consistently provide these flags across platforms.
       final String platformDillName;
-      final List<String> extraFrontEndOptions =
-          List<String>.of(buildInfo.extraFrontEndOptions);
+      final List<String> extraFrontEndOptions = List<String>.of(buildInfo.extraFrontEndOptions);
       switch (buildInfo.nullSafetyMode) {
         case NullSafetyMode.unsound:
           platformDillName = 'ddc_outline.dill';
@@ -142,9 +140,7 @@ class FlutterDevice {
       }
 
       final String platformDillPath = globals.fs.path.join(
-        globals.artifacts!
-            .getHostArtifact(HostArtifact.webPlatformKernelFolder)
-            .path,
+        globals.artifacts!.getHostArtifact(HostArtifact.webPlatformKernelFolder).path,
         platformDillName,
       );
 
@@ -156,24 +152,19 @@ class FlutterDevice {
         // Override the filesystem scheme so that the frontend_server can find
         // the generated entrypoint code.
         fileSystemScheme: 'org-dartlang-app',
-        initializeFromDill: buildInfo.initializeFromDill ??
-            getDefaultCachedKernelPath(
-              trackWidgetCreation: buildInfo.trackWidgetCreation,
-              dartDefines: buildInfo.dartDefines,
-              extraFrontEndOptions: extraFrontEndOptions,
-            ),
-        assumeInitializeFromDillUpToDate:
-            buildInfo.assumeInitializeFromDillUpToDate,
+        initializeFromDill: buildInfo.initializeFromDill ?? getDefaultCachedKernelPath(
+          trackWidgetCreation: buildInfo.trackWidgetCreation,
+          dartDefines: buildInfo.dartDefines,
+          extraFrontEndOptions: extraFrontEndOptions,
+        ),
+        assumeInitializeFromDillUpToDate: buildInfo.assumeInitializeFromDillUpToDate,
         targetModel: TargetModel.dartdevc,
         frontendServerStarterPath: buildInfo.frontendServerStarterPath,
         extraFrontEndOptions: extraFrontEndOptions,
         platformDill: globals.fs.file(platformDillPath).absolute.uri.toString(),
         dartDefines: buildInfo.dartDefines,
-        librariesSpec: globals.fs
-            .file(globals.artifacts!
-                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-            .uri
-            .toString(),
+        librariesSpec: globals.fs.file(globals.artifacts!
+          .getHostArtifact(HostArtifact.flutterWebLibrariesJson)).uri.toString(),
         packagesPath: buildInfo.packageConfigPath,
         artifacts: globals.artifacts!,
         processManager: globals.processManager,
@@ -201,14 +192,12 @@ class FlutterDevice {
         dartDefines: buildInfo.dartDefines,
         frontendServerStarterPath: buildInfo.frontendServerStarterPath,
         extraFrontEndOptions: extraFrontEndOptions,
-        initializeFromDill: buildInfo.initializeFromDill ??
-            getDefaultCachedKernelPath(
-              trackWidgetCreation: buildInfo.trackWidgetCreation,
-              dartDefines: buildInfo.dartDefines,
-              extraFrontEndOptions: extraFrontEndOptions,
-            ),
-        assumeInitializeFromDillUpToDate:
-            buildInfo.assumeInitializeFromDillUpToDate,
+        initializeFromDill: buildInfo.initializeFromDill ?? getDefaultCachedKernelPath(
+          trackWidgetCreation: buildInfo.trackWidgetCreation,
+          dartDefines: buildInfo.dartDefines,
+          extraFrontEndOptions: extraFrontEndOptions,
+        ),
+        assumeInitializeFromDillUpToDate: buildInfo.assumeInitializeFromDillUpToDate,
         packagesPath: buildInfo.packageConfigPath,
         artifacts: globals.artifacts!,
         processManager: globals.processManager,
@@ -280,27 +269,21 @@ class FlutterDevice {
       FlutterVmService? service;
       if (debuggingOptions.enableDds) {
         void handleError(Exception e, StackTrace st) {
-          globals.printTrace(
-              'Fail to connect to service protocol: $vmServiceUri: $e');
+          globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $e');
           if (!completer.isCompleted) {
-            completer.completeError(
-                'failed to connect to $vmServiceUri $e', st);
+            completer.completeError('failed to connect to $vmServiceUri $e', st);
           }
         }
-
         // First check if the VM service is actually listening on vmServiceUri as
         // this may not be the case when scraping logcat for URIs. If this URI is
         // from an old application instance, we shouldn't try and start DDS.
         try {
-          service =
-              await connectToVmService(vmServiceUri!, logger: globals.logger);
+          service = await connectToVmService(vmServiceUri!, logger: globals.logger);
           await service.dispose();
         } on Exception catch (exception) {
-          globals.printTrace(
-              'Fail to connect to service protocol: $vmServiceUri: $exception');
+          globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $exception');
           if (!completer.isCompleted && !_isListeningForVmServiceUri!) {
-            completer
-                .completeError('failed to connect to $vmServiceUri $exception');
+            completer.completeError('failed to connect to $vmServiceUri $exception');
           }
           return;
         }
@@ -315,8 +298,7 @@ class FlutterDevice {
           );
         } on DartDevelopmentServiceException catch (e, st) {
           if (!allowExistingDdsInstance ||
-              (e.errorCode !=
-                  DartDevelopmentServiceException.existingDdsInstanceError)) {
+              (e.errorCode != DartDevelopmentServiceException.existingDdsInstanceError)) {
             handleError(e, st);
             return;
           } else {
@@ -334,38 +316,34 @@ class FlutterDevice {
       // shuts down, including after an error. If `done` completes before `connectToVmService`,
       // something went wrong that caused DDS to shutdown early.
       try {
-        service = await Future.any<dynamic>(<Future<dynamic>>[
-          connectToVmService(
-            debuggingOptions.enableDds
-                ? (device!.dds.uri ?? vmServiceUri!)
-                : vmServiceUri!,
-            reloadSources: reloadSources,
-            restart: restart,
-            compileExpression: compileExpression,
-            getSkSLMethod: getSkSLMethod,
-            flutterProject: FlutterProject.current(),
-            printStructuredErrorLogMethod: printStructuredErrorLogMethod,
-            device: device,
-            logger: globals.logger,
-          ),
-          if (!existingDds)
-            device!.dds.done
-                .whenComplete(() => throw Exception('DDS shut down too early')),
-        ]) as FlutterVmService?;
+        service = await Future.any<dynamic>(
+          <Future<dynamic>>[
+            connectToVmService(
+              debuggingOptions.enableDds ? (device!.dds.uri ?? vmServiceUri!): vmServiceUri!,
+              reloadSources: reloadSources,
+              restart: restart,
+              compileExpression: compileExpression,
+              getSkSLMethod: getSkSLMethod,
+              flutterProject: FlutterProject.current(),
+              printStructuredErrorLogMethod: printStructuredErrorLogMethod,
+              device: device,
+              logger: globals.logger,
+            ),
+            if (!existingDds)
+              device!.dds.done.whenComplete(() => throw Exception('DDS shut down too early')),
+          ]
+        ) as FlutterVmService?;
       } on Exception catch (exception) {
-        globals.printTrace(
-            'Fail to connect to service protocol: $vmServiceUri: $exception');
+        globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $exception');
         if (!completer.isCompleted && !_isListeningForVmServiceUri!) {
-          completer
-              .completeError('failed to connect to $vmServiceUri $exception');
+          completer.completeError('failed to connect to $vmServiceUri $exception');
         }
         return;
       }
       if (completer.isCompleted) {
         return;
       }
-      globals.printTrace(
-          'Successfully connected to service protocol: $vmServiceUri');
+      globals.printTrace('Successfully connected to service protocol: $vmServiceUri');
 
       vmService = service;
       (await device!.getLogReader(app: package)).connectedVMService = vmService;
@@ -376,8 +354,7 @@ class FlutterDevice {
     }, onDone: () {
       _isListeningForVmServiceUri = false;
       if (!completer.isCompleted && !isWaitingForVm) {
-        completer
-            .completeError(Exception('connection to device ended too early'));
+        completer.completeError(Exception('connection to device ended too early'));
       }
     });
     _isListeningForVmServiceUri = true;
@@ -418,12 +395,10 @@ class FlutterDevice {
     }
     final Stream<String> logStream;
     if (device is IOSDevice) {
-      logStream = (device! as IOSDevice)
-          .getLogReader(
-            app: package as IOSApp?,
-            usingCISystem: debuggingOptions.usingCISystem,
-          )
-          .logLines;
+      logStream = (device! as IOSDevice).getLogReader(
+        app: package as IOSApp?,
+        usingCISystem: debuggingOptions.usingCISystem,
+      ).logLines;
     } else {
       logStream = (await device!.getLogReader(app: package)).logLines;
     }
@@ -465,8 +440,7 @@ class FlutterDevice {
     String? route,
   }) async {
     final bool prebuiltMode = hotRunner.applicationBinary != null;
-    final String modeName =
-        hotRunner.debuggingOptions.buildInfo.friendlyModeName;
+    final String modeName = hotRunner.debuggingOptions.buildInfo.friendlyModeName;
     globals.printStatus(
       'Launching ${getDisplayPath(hotRunner.mainPath, globals.fs)} '
       'on ${device!.name} in $modeName mode...',
@@ -482,8 +456,7 @@ class FlutterDevice {
 
     if (applicationPackage == null) {
       String message = 'No application found for $targetPlatform.';
-      final String? hint =
-          await getMissingPackageHintForPlatform(targetPlatform);
+      final String? hint = await getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null) {
         message += '\n$hint';
       }
@@ -515,10 +488,13 @@ class FlutterDevice {
       return 2;
     }
     if (result.hasVmService) {
-      vmServiceUris =
-          Stream<Uri?>.value(result.vmServiceUri).asBroadcastStream();
+      vmServiceUris = Stream<Uri?>
+        .value(result.vmServiceUri)
+        .asBroadcastStream();
     } else {
-      vmServiceUris = const Stream<Uri>.empty().asBroadcastStream();
+      vmServiceUris = const Stream<Uri>
+        .empty()
+        .asBroadcastStream();
     }
     return 0;
   }
@@ -537,8 +513,7 @@ class FlutterDevice {
 
     if (applicationPackage == null) {
       String message = 'No application found for $targetPlatform.';
-      final String? hint =
-          await getMissingPackageHintForPlatform(targetPlatform);
+      final String? hint = await getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null) {
         message += '\n$hint';
       }
@@ -548,8 +523,7 @@ class FlutterDevice {
 
     devFSWriter = device!.createDevFSWriter(applicationPackage, userIdentifier);
 
-    final String modeName =
-        coldRunner.debuggingOptions.buildInfo.friendlyModeName;
+    final String modeName = coldRunner.debuggingOptions.buildInfo.friendlyModeName;
     final bool prebuiltMode = coldRunner.applicationBinary != null;
     globals.printStatus(
       'Launching ${getDisplayPath(coldRunner.mainPath, globals.fs)} '
@@ -577,10 +551,13 @@ class FlutterDevice {
       return 2;
     }
     if (result.hasVmService) {
-      vmServiceUris =
-          Stream<Uri?>.value(result.vmServiceUri).asBroadcastStream();
+      vmServiceUris = Stream<Uri?>
+        .value(result.vmServiceUri)
+        .asBroadcastStream();
     } else {
-      vmServiceUris = const Stream<Uri>.empty().asBroadcastStream();
+      vmServiceUris = const Stream<Uri>
+        .empty()
+        .asBroadcastStream();
     }
     return 0;
   }
@@ -684,22 +661,16 @@ abstract class ResidentHandlers {
   FileSystem? get fileSystem;
 
   /// Called to print help to the terminal.
-  void printHelp({required bool details});
+  void printHelp({ required bool details });
 
   /// Perform a hot reload or hot restart of all attached applications.
   ///
   /// If [fullRestart] is true, a hot restart is performed. Otherwise a hot reload
   /// is run instead. On web devices, this only performs a hot restart regardless of
   /// the value of [fullRestart].
-  Future<OperationResult> restart(
-      {bool fullRestart = false, bool pause = false, String? reason}) {
-    final String mode = isRunningProfile
-        ? 'profile'
-        : isRunningRelease
-            ? 'release'
-            : 'this';
-    throw Exception(
-        '${fullRestart ? 'Restart' : 'Reload'} is not supported in $mode mode');
+  Future<OperationResult> restart({ bool fullRestart = false, bool pause = false, String? reason }) {
+    final String mode = isRunningProfile ? 'profile' :isRunningRelease ? 'release' : 'this';
+    throw Exception('${fullRestart ? 'Restart' : 'Reload'} is not supported in $mode mode');
   }
 
   /// Dump the application's current widget tree to the terminal.
@@ -708,8 +679,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         final String data = await device.vmService!.flutterDebugDumpApp(
           isolateId: view.uiIsolate!.id!,
@@ -726,8 +696,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         final String data = await device.vmService!.flutterDebugDumpRenderTree(
           isolateId: view.uiIsolate!.id!,
@@ -744,8 +713,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         final String data = await device.vmService!.flutterDebugDumpLayerTree(
           isolateId: view.uiIsolate!.id!,
@@ -761,8 +729,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         final String data = await device.vmService!.flutterDebugDumpFocusTree(
           isolateId: view.uiIsolate!.id!,
@@ -781,11 +748,9 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
-        final String data = await device.vmService!
-            .flutterDebugDumpSemanticsTreeInTraversalOrder(
+        final String data = await device.vmService!.flutterDebugDumpSemanticsTreeInTraversalOrder(
           isolateId: view.uiIsolate!.id!,
         );
         logger.printStatus(data);
@@ -802,11 +767,9 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
-        final String data = await device.vmService!
-            .flutterDebugDumpSemanticsTreeInInverseHitTestOrder(
+        final String data = await device.vmService!.flutterDebugDumpSemanticsTreeInInverseHitTestOrder(
           isolateId: view.uiIsolate!.id!,
         );
         logger.printStatus(data);
@@ -821,8 +784,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterToggleDebugPaintSizeEnabled(
           isolateId: view.uiIsolate!.id!,
@@ -859,8 +821,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterToggleWidgetInspector(
           isolateId: view.uiIsolate!.id!,
@@ -876,8 +837,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterToggleInvertOversizedImages(
           isolateId: view.uiIsolate!.id!,
@@ -893,8 +853,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterToggleProfileWidgetBuilds(
           isolateId: view.uiIsolate!.id!,
@@ -909,10 +868,8 @@ abstract class ResidentHandlers {
     if (!supportsServiceProtocol) {
       return false;
     }
-    final List<FlutterView> views =
-        await flutterDevices.first!.vmService!.getFlutterViews();
-    final Brightness? current =
-        await flutterDevices.first!.vmService!.flutterBrightnessOverride(
+    final List<FlutterView> views = await flutterDevices.first!.vmService!.getFlutterViews();
+    final Brightness? current = await flutterDevices.first!.vmService!.flutterBrightnessOverride(
       isolateId: views.first.uiIsolate!.id!,
     );
     final Brightness next = switch (current) {
@@ -920,8 +877,7 @@ abstract class ResidentHandlers {
       Brightness.dark || null => Brightness.light,
     };
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterBrightnessOverride(
           isolateId: view.uiIsolate!.id!,
@@ -938,16 +894,14 @@ abstract class ResidentHandlers {
     if (!supportsServiceProtocol || !isRunningDebug) {
       return false;
     }
-    final List<FlutterView> views =
-        await flutterDevices.first!.vmService!.getFlutterViews();
-    final String from =
-        await flutterDevices.first!.vmService!.flutterPlatformOverride(
-      isolateId: views.first.uiIsolate!.id!,
-    );
+    final List<FlutterView> views = await flutterDevices.first!.vmService!.getFlutterViews();
+    final String from = await flutterDevices
+      .first!.vmService!.flutterPlatformOverride(
+        isolateId: views.first.uiIsolate!.id!,
+      );
     final String to = nextPlatform(from);
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         await device.vmService!.flutterPlatformOverride(
           platform: to,
@@ -1005,8 +959,7 @@ abstract class ResidentHandlers {
     try {
       bool result;
       if (device.device!.supportsScreenshot) {
-        result = await _toggleDebugBanner(
-            device, () => device.device!.takeScreenshot(outputFile));
+        result = await _toggleDebugBanner(device, () => device.device!.takeScreenshot(outputFile));
       } else {
         result = await _takeVmServiceScreenshot(device, outputFile);
       }
@@ -1024,26 +977,23 @@ abstract class ResidentHandlers {
     }
   }
 
-  Future<bool> _takeVmServiceScreenshot(
-      FlutterDevice device, File outputFile) async {
+  Future<bool> _takeVmServiceScreenshot(FlutterDevice device, File outputFile) async {
     if (device.targetPlatform != TargetPlatform.web_javascript) {
       return false;
     }
     assert(supportsServiceProtocol);
 
     return _toggleDebugBanner(device, () async {
-      final vm_service.Response? response =
-          await device.vmService!.callMethodWrapper('ext.dwds.screenshot');
+      final vm_service.Response? response =  await device.vmService!.callMethodWrapper('ext.dwds.screenshot');
       if (response == null) {
-        throw Exception('Failed to take screenshot');
+       throw Exception('Failed to take screenshot');
       }
       final String data = response.json!['data'] as String;
       outputFile.writeAsBytesSync(base64.decode(data));
     });
   }
 
-  Future<bool> _toggleDebugBanner(
-      FlutterDevice device, Future<void> Function() cb) async {
+  Future<bool> _toggleDebugBanner(FlutterDevice device, Future<void> Function() cb) async {
     List<FlutterView> views = <FlutterView>[];
     if (supportsServiceProtocol) {
       views = await device.vmService!.getFlutterViews();
@@ -1059,12 +1009,10 @@ abstract class ResidentHandlers {
         }
         return true;
       } on vm_service.RPCError catch (error) {
-        logger.printError(
-            'Error communicating with Flutter on the device: $error');
+        logger.printError('Error communicating with Flutter on the device: $error');
         return false;
       }
     }
-
     if (!await setDebugBanner(false)) {
       return false;
     }
@@ -1078,6 +1026,7 @@ abstract class ResidentHandlers {
     }
     return succeeded;
   }
+
 
   /// Remove sigusr signal handlers.
   Future<void> cleanupAfterSignal();
@@ -1111,27 +1060,26 @@ abstract class ResidentRunner extends ResidentHandlers {
     String? dillOutputPath,
     this.machine = false,
     ResidentDevtoolsHandlerFactory devtoolsHandler = createDefaultHandler,
-  })  : mainPath = globals.fs.file(target).absolute.path,
-        packagesFilePath = debuggingOptions.buildInfo.packageConfigPath,
-        projectRootPath = projectRootPath ?? globals.fs.currentDirectory.path,
-        _dillOutputPath = dillOutputPath,
-        _useImplicitPubspecResolution = useImplicitPubspecResolution,
-        artifactDirectory = dillOutputPath == null
-            ? globals.fs.systemTempDirectory.createTempSync('flutter_tool.')
-            : globals.fs.file(dillOutputPath).parent,
-        assetBundle = AssetBundleFactory.instance.createBundle(),
-        commandHelp = CommandHelp(
-          logger: globals.logger,
-          terminal: globals.terminal,
-          platform: globals.platform,
-          outputPreferences: globals.outputPreferences,
-        ) {
+  }) : mainPath = globals.fs.file(target).absolute.path,
+       packagesFilePath = debuggingOptions.buildInfo.packageConfigPath,
+       projectRootPath = projectRootPath ?? globals.fs.currentDirectory.path,
+       _dillOutputPath = dillOutputPath,
+       _useImplicitPubspecResolution = useImplicitPubspecResolution,
+       artifactDirectory = dillOutputPath == null
+          ? globals.fs.systemTempDirectory.createTempSync('flutter_tool.')
+          : globals.fs.file(dillOutputPath).parent,
+       assetBundle = AssetBundleFactory.instance.createBundle(),
+       commandHelp = CommandHelp(
+         logger: globals.logger,
+         terminal: globals.terminal,
+         platform: globals.platform,
+         outputPreferences: globals.outputPreferences,
+       ) {
     if (!artifactDirectory.existsSync()) {
       artifactDirectory.createSync(recursive: true);
     }
     // TODO(bkonyi): remove when ready to serve DevTools from DDS.
-    _residentDevtoolsHandler =
-        devtoolsHandler(DevtoolsLauncher.instance, this, globals.logger);
+    _residentDevtoolsHandler = devtoolsHandler(DevtoolsLauncher.instance, this, globals.logger);
   }
 
   @override
@@ -1149,22 +1097,20 @@ abstract class ResidentRunner extends ResidentHandlers {
   @override
   final bool stayResident;
   final String? _dillOutputPath;
-
+  final bool _useImplicitPubspecResolution;
   /// The parent location of the incremental artifacts.
   final Directory artifactDirectory;
   final String packagesFilePath;
   final String projectRootPath;
   final String mainPath;
   final AssetBundle assetBundle;
-  final bool _useImplicitPubspecResolution;
 
   final CommandHelp commandHelp;
   final bool machine;
 
   // TODO(bkonyi): remove when ready to serve DevTools from DDS.
   @override
-  ResidentDevtoolsHandler? get residentDevtoolsHandler =>
-      _residentDevtoolsHandler;
+  ResidentDevtoolsHandler? get residentDevtoolsHandler => _residentDevtoolsHandler;
   ResidentDevtoolsHandler? _residentDevtoolsHandler;
 
   bool _exited = false;
@@ -1182,9 +1128,7 @@ abstract class ResidentRunner extends ResidentHandlers {
     });
   }
 
-  String get dillOutputPath =>
-      _dillOutputPath ??
-      globals.fs.path.join(artifactDirectory.path, 'app.dill');
+  String get dillOutputPath => _dillOutputPath ?? globals.fs.path.join(artifactDirectory.path, 'app.dill');
   String getReloadPath({
     bool fullRestart = false,
     required bool swap,
@@ -1198,12 +1142,10 @@ abstract class ResidentRunner extends ResidentHandlers {
   bool get debuggingEnabled => debuggingOptions.debuggingEnabled;
 
   @override
-  bool get isRunningDebug =>
-      !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isDebug;
+  bool get isRunningDebug => !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isDebug;
 
   @override
-  bool get isRunningProfile =>
-      !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isProfile;
+  bool get isRunningProfile => !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isProfile;
 
   @override
   bool get isRunningRelease => debuggingOptions.buildInfo.isRelease;
@@ -1214,8 +1156,7 @@ abstract class ResidentRunner extends ResidentHandlers {
   @override
   bool get supportsWriteSkSL => supportsServiceProtocol;
 
-  bool get trackWidgetCreation =>
-      debuggingOptions.buildInfo.trackWidgetCreation;
+  bool get trackWidgetCreation => debuggingOptions.buildInfo.trackWidgetCreation;
 
   /// True if the shared Dart plugin registry (which is different than the one
   /// used for web) should be generated during source generation.
@@ -1233,10 +1174,9 @@ abstract class ResidentRunner extends ResidentHandlers {
 
   @override
   bool get supportsRestart {
-    return isRunningDebug &&
-        flutterDevices.every((FlutterDevice? device) {
-          return device!.device!.supportsHotRestart;
-        });
+    return isRunningDebug && flutterDevices.every((FlutterDevice? device) {
+      return device!.device!.supportsHotRestart;
+    });
   }
 
   @override
@@ -1298,12 +1238,12 @@ abstract class ResidentRunner extends ResidentHandlers {
       _lastBuild,
     );
     if (!_lastBuild!.success) {
-      for (final ExceptionMeasurement exceptionMeasurement
-          in _lastBuild!.exceptions.values) {
+      for (final ExceptionMeasurement exceptionMeasurement in _lastBuild!.exceptions.values) {
         globals.printError(
           exceptionMeasurement.exception.toString(),
-          stackTrace:
-              globals.logger.isVerbose ? exceptionMeasurement.stackTrace : null,
+          stackTrace: globals.logger.isVerbose
+            ? exceptionMeasurement.stackTrace
+            : null,
         );
       }
     }
@@ -1314,15 +1254,12 @@ abstract class ResidentRunner extends ResidentHandlers {
   void writeVmServiceFile() {
     if (debuggingOptions.vmserviceOutFile != null) {
       try {
-        final String address =
-            flutterDevices.first.vmService!.wsAddress.toString();
-        final File vmserviceOutFile =
-            globals.fs.file(debuggingOptions.vmserviceOutFile);
+        final String address = flutterDevices.first.vmService!.wsAddress.toString();
+        final File vmserviceOutFile = globals.fs.file(debuggingOptions.vmserviceOutFile);
         vmserviceOutFile.createSync(recursive: true);
         vmserviceOutFile.writeAsStringSync(address);
       } on FileSystemException {
-        globals.printError(
-            'Failed to write vmservice-out-file at ${debuggingOptions.vmserviceOutFile}');
+        globals.printError('Failed to write vmservice-out-file at ${debuggingOptions.vmserviceOutFile}');
       }
     }
   }
@@ -1349,8 +1286,9 @@ abstract class ResidentRunner extends ResidentHandlers {
   }
 
   Future<void> stopEchoingDeviceLog() async {
-    await Future.wait<void>(flutterDevices.map<Future<void>>(
-        (FlutterDevice? device) => device!.stopEchoingDeviceLog()));
+    await Future.wait<void>(
+      flutterDevices.map<Future<void>>((FlutterDevice? device) => device!.stopEchoingDeviceLog())
+    );
   }
 
   void shutdownDartDevelopmentService() {
@@ -1372,7 +1310,10 @@ abstract class ResidentRunner extends ResidentHandlers {
         dartDefines: debuggingOptions.buildInfo.dartDefines,
         extraFrontEndOptions: debuggingOptions.buildInfo.extraFrontEndOptions,
       );
-      globals.fs.file(copyPath).parent.createSync(recursive: true);
+      globals.fs
+          .file(copyPath)
+          .parent
+          .createSync(recursive: true);
       outputDill.copySync(copyPath);
     }
   }
@@ -1382,8 +1323,7 @@ abstract class ResidentRunner extends ResidentHandlers {
       final Map<String, Object?>? json = event.extensionData?.data;
       if (json != null && json.containsKey('renderedErrorText')) {
         final int errorsSinceReload;
-        if (json.containsKey('errorsSinceReload') &&
-            json['errorsSinceReload'] is int) {
+        if (json.containsKey('errorsSinceReload') && json['errorsSinceReload'] is int) {
           errorsSinceReload = json['errorsSinceReload']! as int;
         } else {
           errorsSinceReload = 0;
@@ -1398,8 +1338,7 @@ abstract class ResidentRunner extends ResidentHandlers {
           globals.printStatus('');
         }
       } else {
-        globals.printError(
-            'Received an invalid ${globals.logger.terminal.bolden("Flutter.Error")} message from app: $json');
+        globals.printError('Received an invalid ${globals.logger.terminal.bolden("Flutter.Error")} message from app: $json');
       }
     }
   }
@@ -1438,12 +1377,10 @@ abstract class ResidentRunner extends ResidentHandlers {
       // This hooks up callbacks for when the connection stops in the future.
       // We don't want to wait for them. We don't handle errors in those callbacks'
       // futures either because they just print to logger and is not critical.
-      unawaited(device.vmService!.service.onDone
-          .then<void>(
-            _serviceProtocolDone,
-            onError: _serviceProtocolError,
-          )
-          .whenComplete(_serviceDisconnected));
+      unawaited(device.vmService!.service.onDone.then<void>(
+        _serviceProtocolDone,
+        onError: _serviceProtocolError,
+      ).whenComplete(_serviceDisconnected));
     }
   }
 
@@ -1452,8 +1389,7 @@ abstract class ResidentRunner extends ResidentHandlers {
   }
 
   Future<void> _serviceProtocolError(Object error, StackTrace stack) {
-    globals.printTrace(
-        'Service protocol connection closed with an error: $error\n$stack');
+    globals.printTrace('Service protocol connection closed with an error: $error\n$stack');
     return Future<void>.error(error, stack);
   }
 
@@ -1471,13 +1407,11 @@ abstract class ResidentRunner extends ResidentHandlers {
 
   Future<void> enableObservatory() async {
     assert(debuggingOptions.serveObservatory);
-    final List<Future<vm_service.Response?>> serveObservatoryRequests =
-        <Future<vm_service.Response?>>[
+    final List<Future<vm_service.Response?>> serveObservatoryRequests = <Future<vm_service.Response?>>[
       for (final FlutterDevice? device in flutterDevices)
         if (device != null)
           // Notify the VM service if the user wants Observatory to be served.
-          device.vmService?.callMethodWrapper('_serveObservatory') ??
-              Future<vm_service.Response?>.value(),
+          device.vmService?.callMethodWrapper('_serveObservatory') ?? Future<vm_service.Response?>.value(),
     ];
     try {
       await Future.wait(serveObservatoryRequests);
@@ -1526,11 +1460,9 @@ abstract class ResidentRunner extends ResidentHandlers {
   bool get reportedDebuggers => _reportedDebuggers;
   bool _reportedDebuggers = false;
 
-  void printDebuggerList(
-      {bool includeVmService = true, bool includeDevtools = true}) {
+  void printDebuggerList({bool includeVmService = true, bool includeDevtools = true}) {
     // TODO(bkonyi): update this logic when ready to serve DevTools from DDS.
-    final DevToolsServerAddress? devToolsServerAddress =
-        residentDevtoolsHandler!.activeDevToolsServer;
+    final DevToolsServerAddress? devToolsServerAddress = residentDevtoolsHandler!.activeDevToolsServer;
     if (!residentDevtoolsHandler!.readyToAnnounce) {
       includeDevtools = false;
     }
@@ -1550,14 +1482,11 @@ abstract class ResidentRunner extends ResidentHandlers {
         if (_residentDevtoolsHandler!.printDtdUri) {
           final Uri? dtdUri = residentDevtoolsHandler!.dtdUri;
           if (dtdUri != null) {
-            globals.printStatus(
-                'The Dart Tooling Daemon is available at: $dtdUri\n');
+            globals.printStatus('The Dart Tooling Daemon is available at: $dtdUri\n');
           }
         }
         final Uri? uri = devToolsServerAddress!.uri?.replace(
-          queryParameters: <String, dynamic>{
-            'uri': '${device.vmService!.httpAddress}'
-          },
+          queryParameters: <String, dynamic>{'uri': '${device.vmService!.httpAddress}'},
         );
         if (uri != null) {
           globals.printStatus(
@@ -1572,8 +1501,7 @@ abstract class ResidentRunner extends ResidentHandlers {
 
   void printHelpDetails() {
     commandHelp.v.print();
-    if (flutterDevices
-        .any((FlutterDevice? d) => d!.device!.supportsScreenshot)) {
+    if (flutterDevices.any((FlutterDevice? d) => d!.device!.supportsScreenshot)) {
       commandHelp.s.print();
     }
     if (supportsServiceProtocol) {
@@ -1613,10 +1541,7 @@ abstract class ResidentRunner extends ResidentHandlers {
 }
 
 class OperationResult {
-  OperationResult(this.code, this.message,
-      {this.fatal = false,
-      this.updateFSReport,
-      this.extraTimings = const <OperationResultExtraTiming>[]});
+  OperationResult(this.code, this.message, { this.fatal = false, this.updateFSReport, this.extraTimings = const <OperationResultExtraTiming>[] });
 
   /// The result of the operation; a non-zero code indicates a failure.
   final int code;
@@ -1647,16 +1572,14 @@ class OperationResultExtraTiming {
   final int timeInMs;
 }
 
-Future<String?> getMissingPackageHintForPlatform(
-    TargetPlatform platform) async {
+Future<String?> getMissingPackageHintForPlatform(TargetPlatform platform) async {
   switch (platform) {
     case TargetPlatform.android_arm:
     case TargetPlatform.android_arm64:
     case TargetPlatform.android_x64:
     case TargetPlatform.android_x86:
       final FlutterProject project = FlutterProject.current();
-      final String manifestPath =
-          globals.fs.path.relative(project.android.appManifestFile.path);
+      final String manifestPath = globals.fs.path.relative(project.android.appManifestFile.path);
       return 'Is your project missing an $manifestPath?\nConsider running "flutter create ." to create one.';
     case TargetPlatform.ios:
       return 'Is your project missing an ios/Runner/Info.plist?\nConsider running "flutter create ." to create one.';
@@ -1676,20 +1599,19 @@ Future<String?> getMissingPackageHintForPlatform(
 
 /// Redirects terminal commands to the correct resident runner methods.
 class TerminalHandler {
-  TerminalHandler(
-    this.residentRunner, {
+  TerminalHandler(this.residentRunner, {
     required Logger logger,
     required Terminal terminal,
     required Signals signals,
     required io.ProcessInfo processInfo,
     required bool reportReady,
     String? pidFile,
-  })  : _logger = logger,
-        _terminal = terminal,
-        _signals = signals,
-        _processInfo = processInfo,
-        _reportReady = reportReady,
-        _pidFile = pidFile;
+  }) : _logger = logger,
+       _terminal = terminal,
+       _signals = signals,
+       _processInfo = processInfo,
+       _reportReady = reportReady,
+       _pidFile = pidFile;
 
   final Logger _logger;
   final Terminal _terminal;
@@ -1719,8 +1641,7 @@ class TerminalHandler {
     subscription = _terminal.keystrokes.listen(processTerminalInput);
   }
 
-  final Map<io.ProcessSignal, Object> _signalTokens =
-      <io.ProcessSignal, Object>{};
+  final Map<io.ProcessSignal, Object> _signalTokens = <io.ProcessSignal, Object>{};
 
   void _addSignalHandler(io.ProcessSignal signal, SignalHandler handler) {
     _signalTokens[signal] = _signals.addHandler(signal, handler);
@@ -1730,8 +1651,7 @@ class TerminalHandler {
     assert(residentRunner.stayResident);
     _addSignalHandler(io.ProcessSignal.sigint, _cleanUp);
     _addSignalHandler(io.ProcessSignal.sigterm, _cleanUp);
-    if (residentRunner.supportsServiceProtocol &&
-        residentRunner.supportsRestart) {
+    if (residentRunner.supportsServiceProtocol && residentRunner.supportsRestart) {
       _addSignalHandler(io.ProcessSignal.sigusr1, _handleSignal);
       _addSignalHandler(io.ProcessSignal.sigusr2, _handleSignal);
       if (_pidFile != null) {
@@ -1749,13 +1669,11 @@ class TerminalHandler {
         _logger.printTrace('Deleting pid file (${_actualPidFile!.path}).');
         _actualPidFile!.deleteSync();
       } on FileSystemException catch (error) {
-        _logger.printWarning(
-            'Failed to delete pid file (${_actualPidFile!.path}): ${error.message}');
+        _logger.printWarning('Failed to delete pid file (${_actualPidFile!.path}): ${error.message}');
       }
       _actualPidFile = null;
     }
-    for (final MapEntry<io.ProcessSignal, Object> entry
-        in _signalTokens.entries) {
+    for (final MapEntry<io.ProcessSignal, Object> entry in _signalTokens.entries) {
       _signals.removeHandler(entry.key, entry.value);
     }
     _signalTokens.clear();
@@ -1821,8 +1739,7 @@ class TerminalHandler {
           throwToolExit(result.message);
         }
         if (!result.isOk) {
-          _logger.printStatus('Try again after fixing the above error(s).',
-              emphasis: true);
+          _logger.printStatus('Try again after fixing the above error(s).', emphasis: true);
         }
         return true;
       case 'R':
@@ -1830,14 +1747,12 @@ class TerminalHandler {
         if (!residentRunner.supportsRestart || !residentRunner.hotMode) {
           return false;
         }
-        final OperationResult result =
-            await residentRunner.restart(fullRestart: true);
+        final OperationResult result = await residentRunner.restart(fullRestart: true);
         if (result.fatal) {
           throwToolExit(result.message);
         }
         if (!result.isOk) {
-          _logger.printStatus('Try again after fixing the above error(s).',
-              emphasis: true);
+          _logger.printStatus('Try again after fixing the above error(s).', emphasis: true);
         }
         return true;
       case 's':
@@ -1854,8 +1769,7 @@ class TerminalHandler {
         return residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
       case 'v':
       case 'V':
-        return residentRunner.residentDevtoolsHandler!.launchDevToolsInBrowser(
-            flutterDevices: residentRunner.flutterDevices);
+        return residentRunner.residentDevtoolsHandler!.launchDevToolsInBrowser(flutterDevices: residentRunner.flutterDevices);
       case 'w':
       case 'W':
         return residentRunner.debugDumpApp();
@@ -1867,17 +1781,15 @@ class TerminalHandler {
     // When terminal doesn't support line mode, '\n' can sneak into the input.
     command = command.trim();
     if (_processingUserRequest) {
-      _logger.printTrace(
-          'Ignoring terminal input: "$command" because we are busy.');
+      _logger.printTrace('Ignoring terminal input: "$command" because we are busy.');
       return;
     }
     _processingUserRequest = true;
     try {
       lastReceivedCommand = command;
       await _commonTerminalInputHandler(command);
-      // Catch all exception since this is doing cleanup and rethrowing.
-    } catch (error, st) {
-      // ignore: avoid_catches_without_on_clauses
+    // Catch all exception since this is doing cleanup and rethrowing.
+    } catch (error, st) { // ignore: avoid_catches_without_on_clauses
       // Don't print stack traces for known error types.
       if (error is! ToolExit) {
         _logger.printError('$error\n$st');
@@ -1916,7 +1828,7 @@ class TerminalHandler {
 }
 
 class DebugConnectionInfo {
-  DebugConnectionInfo({this.httpUri, this.wsUri, this.baseUri});
+  DebugConnectionInfo({ this.httpUri, this.wsUri, this.baseUri });
 
   final Uri? httpUri;
   final Uri? wsUri;

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -18,6 +18,7 @@ class ColdRunner extends ResidentRunner {
     super.flutterDevices, {
     required super.target,
     required super.debuggingOptions,
+    required super.useImplicitPubspecResolution,
     this.traceStartup = false,
     this.awaitFirstFrameWhenTracing = true,
     this.applicationBinary,

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -26,13 +26,11 @@ import 'reporting/reporting.dart';
 import 'resident_runner.dart';
 import 'vmservice.dart';
 
-ProjectFileInvalidator get projectFileInvalidator =>
-    context.get<ProjectFileInvalidator>() ??
-    ProjectFileInvalidator(
-      fileSystem: globals.fs,
-      platform: globals.platform,
-      logger: globals.logger,
-    );
+ProjectFileInvalidator get projectFileInvalidator => context.get<ProjectFileInvalidator>() ?? ProjectFileInvalidator(
+  fileSystem: globals.fs,
+  platform: globals.platform,
+  logger: globals.logger,
+);
 
 HotRunnerConfig? get hotRunnerConfig => context.get<HotRunnerConfig>();
 
@@ -73,8 +71,7 @@ class DeviceReloadReport {
   DeviceReloadReport(this.device, this.reports);
 
   FlutterDevice? device;
-  List<vm_service.ReloadReport>
-      reports; // List has one report per Flutter view.
+  List<vm_service.ReloadReport> reports; // List has one report per Flutter view.
 }
 
 class HotRunner extends ResidentRunner {
@@ -185,9 +182,9 @@ class HotRunner extends ResidentRunner {
     }
   }
 
-  Future<void> _restartService({bool pause = false}) async {
+  Future<void> _restartService({ bool pause = false }) async {
     final OperationResult result =
-        await restart(fullRestart: true, pause: pause);
+      await restart(fullRestart: true, pause: pause);
     if (!result.isOk) {
       throw vm_service.RPCError(
         'Unable to restart',
@@ -212,18 +209,10 @@ class HotRunner extends ResidentRunner {
   ) async {
     for (final FlutterDevice? device in flutterDevices) {
       if (device!.generator != null) {
-        final CompilerOutput? compilerOutput = await device.generator!
-            .compileExpression(
-                expression,
-                definitions,
-                definitionTypes,
-                typeDefinitions,
-                typeBounds,
-                typeDefaults,
-                libraryUri,
-                klass,
-                method,
-                isStatic);
+        final CompilerOutput? compilerOutput =
+            await device.generator!.compileExpression(expression, definitions,
+                definitionTypes, typeDefinitions, typeBounds, typeDefaults,
+                libraryUri, klass, method, isStatic);
         if (compilerOutput != null && compilerOutput.expressionData != null) {
           return base64.encode(compilerOutput.expressionData!);
         }
@@ -249,9 +238,8 @@ class HotRunner extends ResidentRunner {
         getSkSLMethod: writeSkSL,
         allowExistingDdsInstance: allowExistingDdsInstance,
       );
-      // Catches all exceptions, non-Exception objects are rethrown.
-    } catch (error) {
-      // ignore: avoid_catches_without_on_clauses
+    // Catches all exceptions, non-Exception objects are rethrown.
+    } catch (error) { // ignore: avoid_catches_without_on_clauses
       if (error is! Exception && error is! String) {
         rethrow;
       }
@@ -275,7 +263,9 @@ class HotRunner extends ResidentRunner {
 
     for (final FlutterDevice? device in flutterDevices) {
       await device!.tryInitLogReader();
-      device.developmentShaderCompiler.configureCompiler(device.targetPlatform);
+      device
+        .developmentShaderCompiler
+        .configureCompiler(device.targetPlatform);
     }
     try {
       final List<Uri?> baseUris = await _initDevFS();
@@ -295,8 +285,7 @@ class HotRunner extends ResidentRunner {
     }
 
     final Stopwatch initialUpdateDevFSsTimer = Stopwatch()..start();
-    final UpdateFSReport devfsResult =
-        await _updateDevFS(fullRestart: needsFullRestart);
+    final UpdateFSReport devfsResult = await _updateDevFS(fullRestart: needsFullRestart);
     _addBenchmarkData(
       'hotReloadInitialDevFSSyncMilliseconds',
       initialUpdateDevFSsTimer.elapsed.inMilliseconds,
@@ -406,37 +395,35 @@ class HotRunner extends ResidentRunner {
       await runSourceGenerators();
       if (device!.generator != null) {
         final Stopwatch compileTimer = Stopwatch()..start();
-        startupTasks.add(device.generator!
-            .recompile(
-          mainFile.uri,
-          <Uri>[],
-          // When running without a provided applicationBinary, the tool will
-          // simultaneously run the initial frontend_server compilation and
-          // the native build step. If there is a Dart compilation error, it
-          // should only be displayed once.
-          suppressErrors: applicationBinary == null,
-          checkDartPluginRegistry: true,
-          dartPluginRegistrant: FlutterProject.current().dartPluginRegistrant,
-          outputPath: dillOutputPath,
-          packageConfig: debuggingOptions.buildInfo.packageConfig,
-          projectRootPath: FlutterProject.current().directory.absolute.path,
-          fs: globals.fs,
-          nativeAssetsYaml: nativeAssetsYaml,
-        )
-            .then((CompilerOutput? output) {
-          compileTimer.stop();
-          totalCompileTime += compileTimer.elapsed;
-          return output?.errorCount == 0;
-        }));
+        startupTasks.add(
+          device.generator!.recompile(
+            mainFile.uri,
+            <Uri>[],
+            // When running without a provided applicationBinary, the tool will
+            // simultaneously run the initial frontend_server compilation and
+            // the native build step. If there is a Dart compilation error, it
+            // should only be displayed once.
+            suppressErrors: applicationBinary == null,
+            checkDartPluginRegistry: true,
+            dartPluginRegistrant: FlutterProject.current().dartPluginRegistrant,
+            outputPath: dillOutputPath,
+            packageConfig: debuggingOptions.buildInfo.packageConfig,
+            projectRootPath: FlutterProject.current().directory.absolute.path,
+            fs: globals.fs,
+            nativeAssetsYaml: nativeAssetsYaml,
+          ).then((CompilerOutput? output) {
+            compileTimer.stop();
+            totalCompileTime += compileTimer.elapsed;
+            return output?.errorCount == 0;
+          })
+        );
       }
 
       final Stopwatch launchAppTimer = Stopwatch()..start();
-      startupTasks.add(device
-          .runHot(
+      startupTasks.add(device.runHot(
         hotRunner: this,
         route: route,
-      )
-          .then((int result) {
+      ).then((int result) {
         totalLaunchAppTime += launchAppTimer.elapsed;
         return result == 0;
       }));
@@ -497,7 +484,7 @@ class HotRunner extends ResidentRunner {
     ];
   }
 
-  Future<UpdateFSReport> _updateDevFS({bool fullRestart = false}) async {
+  Future<UpdateFSReport> _updateDevFS({ bool fullRestart = false }) async {
     final bool isFirstUpload = !assetBundle.wasBuiltOnce();
     final bool rebuildBundle = assetBundle.needsBuild();
     if (rebuildBundle) {
@@ -511,26 +498,25 @@ class HotRunner extends ResidentRunner {
       }
     }
 
-    final Stopwatch findInvalidationTimer =
-        _stopwatchFactory.createStopwatch('updateDevFS')..start();
+    final Stopwatch findInvalidationTimer = _stopwatchFactory.createStopwatch('updateDevFS')..start();
     final DevFS devFS = flutterDevices[0].devFS!;
-    final InvalidationResult invalidationResult =
-        await projectFileInvalidator.findInvalidated(
+    final InvalidationResult invalidationResult = await projectFileInvalidator.findInvalidated(
       lastCompiled: devFS.lastCompiled,
       urisToMonitor: devFS.sources,
       packagesPath: packagesFilePath,
       asyncScanning: hotRunnerConfig!.asyncScanning,
-      packageConfig:
-          devFS.lastPackageConfig ?? debuggingOptions.buildInfo.packageConfig,
+      packageConfig: devFS.lastPackageConfig
+          ?? debuggingOptions.buildInfo.packageConfig,
     );
     findInvalidationTimer.stop();
     final File entrypointFile = globals.fs.file(mainPath);
     if (!entrypointFile.existsSync()) {
       globals.printError(
-          'The entrypoint file (i.e. the file with main()) ${entrypointFile.path} '
-          'cannot be found. Moving or renaming this file will prevent changes to '
-          'its contents from being discovered during hot reload/restart until '
-          'flutter is restarted or the file is restored.');
+        'The entrypoint file (i.e. the file with main()) ${entrypointFile.path} '
+        'cannot be found. Moving or renaming this file will prevent changes to '
+        'its contents from being discovered during hot reload/restart until '
+        'flutter is restarted or the file is restored.'
+      );
     }
     final UpdateFSReport results = UpdateFSReport(
       success: true,
@@ -574,15 +560,14 @@ class HotRunner extends ResidentRunner {
       if (device.devFS != null) {
         // Cleanup the devFS, but don't wait indefinitely.
         // We ignore any errors, because it's not clear what we would do anyway.
-        futures.add(
-          device.devFS!
-              .destroy()
-              .timeout(const Duration(milliseconds: 250))
-              .then<void>((Object? _) {},
-                  onError: (Object? error, StackTrace stackTrace) {
-            globals.printTrace(
-                'Ignored error while cleaning up DevFS: $error\n$stackTrace');
-          }),
+        futures.add(device.devFS!.destroy()
+          .timeout(const Duration(milliseconds: 250))
+          .then<void>(
+            (Object? _) {},
+            onError: (Object? error, StackTrace stackTrace) {
+              globals.printTrace('Ignored error while cleaning up DevFS: $error\n$stackTrace');
+            }
+          ),
         );
       }
       device.devFS = null;
@@ -609,12 +594,12 @@ class HotRunner extends ResidentRunner {
   Future<void> _launchFromDevFS() async {
     final List<Future<void>> futures = <Future<void>>[];
     for (final FlutterDevice? device in flutterDevices) {
-      final Uri deviceEntryUri = device!.devFS!.baseUri!
-          .resolve(_swap ? 'main.dart.swap.dill' : 'main.dart.dill');
-      final Uri deviceAssetsDirectoryUri = device.devFS!.baseUri!
-          .resolveUri(globals.fs.path.toUri(getAssetBuildDirectory()));
-      futures
-          .add(_launchInView(device, deviceEntryUri, deviceAssetsDirectoryUri));
+      final Uri deviceEntryUri = device!.devFS!.baseUri!.resolve(_swap ? 'main.dart.swap.dill' : 'main.dart.dill');
+      final Uri deviceAssetsDirectoryUri = device.devFS!.baseUri!.resolveUri(
+        globals.fs.path.toUri(getAssetBuildDirectory()));
+      futures.add(_launchInView(device,
+                          deviceEntryUri,
+                          deviceAssetsDirectoryUri));
     }
     await Future.wait(futures);
   }
@@ -649,16 +634,15 @@ class HotRunner extends ResidentRunner {
     final List<Future<void>> operations = <Future<void>>[];
     for (final FlutterDevice? device in flutterDevices) {
       final Set<String?> uiIsolatesIds = <String?>{};
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         if (view.uiIsolate == null) {
           continue;
         }
         uiIsolatesIds.add(view.uiIsolate!.id);
         // Reload the isolate.
-        final Future<vm_service.Isolate?> reloadIsolate =
-            device.vmService!.getIsolateOrNull(view.uiIsolate!.id!);
+        final Future<vm_service.Isolate?> reloadIsolate = device.vmService!
+          .getIsolateOrNull(view.uiIsolate!.id!);
         operations.add(reloadIsolate.then((vm_service.Isolate? isolate) async {
           if ((isolate != null) && isPauseEvent(isolate.pauseEvent!.kind!)) {
             // The embedder requires that the isolate is unpaused, because the
@@ -673,14 +657,11 @@ class HotRunner extends ResidentRunner {
             // These settings to not need restoring as Hot Restart results in
             // new isolates, which will be configured by the editor as they are
             // started.
-            final List<Future<void>> breakpointAndExceptionRemoval =
-                <Future<void>>[
+            final List<Future<void>> breakpointAndExceptionRemoval = <Future<void>>[
               device.vmService!.service.setIsolatePauseMode(isolate.id!,
-                  exceptionPauseMode: vm_service.ExceptionPauseMode.kNone),
-              for (final vm_service.Breakpoint breakpoint
-                  in isolate.breakpoints!)
-                device.vmService!.service
-                    .removeBreakpoint(isolate.id!, breakpoint.id!),
+                exceptionPauseMode: vm_service.ExceptionPauseMode.kNone),
+              for (final vm_service.Breakpoint breakpoint in isolate.breakpoints!)
+                device.vmService!.service.removeBreakpoint(isolate.id!, breakpoint.id!),
             ];
             await Future.wait(breakpointAndExceptionRemoval);
             await device.vmService!.service.resume(view.uiIsolate!.id!);
@@ -697,12 +678,11 @@ class HotRunner extends ResidentRunner {
           continue;
         }
         operations.add(
-          device.vmService!.service
-              .kill(isolateRef.id!)
-              // Since we never check the value of this Future, only await its
-              // completion, make its type nullable so we can return null when
-              // catching errors.
-              .then<vm_service.Success?>(
+          device.vmService!.service.kill(isolateRef.id!)
+          // Since we never check the value of this Future, only await its
+          // completion, make its type nullable so we can return null when
+          // catching errors.
+          .then<vm_service.Success?>(
             (vm_service.Success success) => success,
             onError: (Object error, StackTrace stackTrace) {
               if (error is vm_service.SentinelException ||
@@ -724,10 +704,9 @@ class HotRunner extends ResidentRunner {
     globals.printTrace('Finished waiting on operations.');
     await _launchFromDevFS();
     restartTimer.stop();
-    globals.printTrace(
-        'Hot restart performed in ${getElapsedAsMilliseconds(restartTimer.elapsed)}.');
-    _addBenchmarkData(
-        'hotRestartMillisecondsToFrame', restartTimer.elapsed.inMilliseconds);
+    globals.printTrace('Hot restart performed in ${getElapsedAsMilliseconds(restartTimer.elapsed)}.');
+    _addBenchmarkData('hotRestartMillisecondsToFrame',
+        restartTimer.elapsed.inMilliseconds);
 
     // Send timing analytics.
     final Duration elapsedDuration = restartTimer.elapsed;
@@ -739,7 +718,7 @@ class HotRunner extends ResidentRunner {
     ));
 
     // Toggle the main dill name after successfully uploading.
-    _swap = !_swap;
+    _swap =! _swap;
 
     return OperationResult(
       OperationResult.ok.code,
@@ -760,8 +739,7 @@ class HotRunner extends ResidentRunner {
       }
       return false;
     }
-    final ReloadReportContents contents =
-        ReloadReportContents.fromReloadReport(reloadReport);
+    final ReloadReportContents contents = ReloadReportContents.fromReloadReport(reloadReport);
     if (!reloadReport.success!) {
       if (printErrors) {
         globals.printError('Hot reload was rejected:');
@@ -799,8 +777,7 @@ class HotRunner extends ResidentRunner {
         silent: silent,
       );
       if (!silent) {
-        globals.printStatus(
-            'Restarted application in ${getElapsedAsMilliseconds(timer.elapsed)}.');
+        globals.printStatus('Restarted application in ${getElapsedAsMilliseconds(timer.elapsed)}.');
       }
       // TODO(bkonyi): remove when ready to serve DevTools from DDS.
       unawaited(residentDevtoolsHandler!.hotRestart(flutterDevices));
@@ -821,11 +798,9 @@ class HotRunner extends ResidentRunner {
       if (!silent) {
         if (result.extraTimings.isNotEmpty) {
           final String extraTimingsString = result.extraTimings
-              .map((OperationResultExtraTiming e) =>
-                  '${e.description}: ${e.timeInMs} ms')
-              .join(', ');
-          globals.printStatus(
-              '${result.message} in $elapsed ($extraTimingsString).');
+            .map((OperationResultExtraTiming e) => '${e.description}: ${e.timeInMs} ms')
+            .join(', ');
+          globals.printStatus('${result.message} in $elapsed ($extraTimingsString).');
         } else {
           globals.printStatus('${result.message} in $elapsed.');
         }
@@ -854,8 +829,7 @@ class HotRunner extends ResidentRunner {
     OperationResult result;
     String? restartEvent;
     try {
-      final Stopwatch restartTimer =
-          _stopwatchFactory.createStopwatch('fullRestartHelper')..start();
+      final Stopwatch restartTimer = _stopwatchFactory.createStopwatch('fullRestartHelper')..start();
       if ((await hotRunnerConfig!.setupHotRestart()) != true) {
         return OperationResult(1, 'setupHotRestart failed');
       }
@@ -864,8 +838,7 @@ class HotRunner extends ResidentRunner {
       if (!result.isOk) {
         restartEvent = 'restart-failed';
       } else {
-        HotEvent(
-          'restart',
+        HotEvent('restart',
           targetPlatform: targetPlatform!,
           sdkName: sdkName!,
           emulator: emulator!,
@@ -873,14 +846,10 @@ class HotRunner extends ResidentRunner {
           reason: reason,
           overallTimeInMs: restartTimer.elapsed.inMilliseconds,
           syncedBytes: result.updateFSReport?.syncedBytes,
-          invalidatedSourcesCount:
-              result.updateFSReport?.invalidatedSourcesCount,
-          transferTimeInMs:
-              result.updateFSReport?.transferDuration.inMilliseconds,
-          compileTimeInMs:
-              result.updateFSReport?.compileDuration.inMilliseconds,
-          findInvalidatedTimeInMs:
-              result.updateFSReport?.findInvalidatedDuration.inMilliseconds,
+          invalidatedSourcesCount: result.updateFSReport?.invalidatedSourcesCount,
+          transferTimeInMs: result.updateFSReport?.transferDuration.inMilliseconds,
+          compileTimeInMs: result.updateFSReport?.compileDuration.inMilliseconds,
+          findInvalidatedTimeInMs: result.updateFSReport?.findInvalidatedDuration.inMilliseconds,
           scannedSourcesCount: result.updateFSReport?.scannedSourcesCount,
         ).send();
         _analytics.send(Event.hotRunnerInfo(
@@ -892,31 +861,24 @@ class HotRunner extends ResidentRunner {
           reason: reason,
           overallTimeInMs: restartTimer.elapsed.inMilliseconds,
           syncedBytes: result.updateFSReport?.syncedBytes,
-          invalidatedSourcesCount:
-              result.updateFSReport?.invalidatedSourcesCount,
-          transferTimeInMs:
-              result.updateFSReport?.transferDuration.inMilliseconds,
-          compileTimeInMs:
-              result.updateFSReport?.compileDuration.inMilliseconds,
-          findInvalidatedTimeInMs:
-              result.updateFSReport?.findInvalidatedDuration.inMilliseconds,
+          invalidatedSourcesCount: result.updateFSReport?.invalidatedSourcesCount,
+          transferTimeInMs: result.updateFSReport?.transferDuration.inMilliseconds,
+          compileTimeInMs: result.updateFSReport?.compileDuration.inMilliseconds,
+          findInvalidatedTimeInMs: result.updateFSReport?.findInvalidatedDuration.inMilliseconds,
           scannedSourcesCount: result.updateFSReport?.scannedSourcesCount,
         ));
       }
     } on vm_service.SentinelException catch (err, st) {
       restartEvent = 'exception';
-      return OperationResult(1, 'hot restart failed to complete: $err\n$st',
-          fatal: true);
-    } on vm_service.RPCError catch (err, st) {
+      return OperationResult(1, 'hot restart failed to complete: $err\n$st', fatal: true);
+    } on vm_service.RPCError  catch (err, st) {
       restartEvent = 'exception';
-      return OperationResult(1, 'hot restart failed to complete: $err\n$st',
-          fatal: true);
+      return OperationResult(1, 'hot restart failed to complete: $err\n$st', fatal: true);
     } finally {
       // The `restartEvent` variable will be null if restart succeeded. We will
       // only handle the case when it failed here.
       if (restartEvent != null) {
-        HotEvent(
-          restartEvent,
+        HotEvent(restartEvent,
           targetPlatform: targetPlatform!,
           sdkName: sdkName!,
           emulator: emulator!,
@@ -969,13 +931,11 @@ class HotRunner extends ResidentRunner {
       int errorCode = 1;
       if (error.code == kIsolateReloadBarred) {
         errorCode = error.code;
-        errorMessage =
-            'Unable to hot reload application due to an unrecoverable error in '
-            'the source code. Please address the error and then use "R" to '
-            'restart the app.\n'
-            '${error.message} (error code: ${error.code})';
-        HotEvent(
-          'reload-barred',
+        errorMessage = 'Unable to hot reload application due to an unrecoverable error in '
+                      'the source code. Please address the error and then use "R" to '
+                      'restart the app.\n'
+                      '${error.message} (error code: ${error.code})';
+        HotEvent('reload-barred',
           targetPlatform: targetPlatform!,
           sdkName: sdkName!,
           emulator: emulator!,
@@ -991,8 +951,7 @@ class HotRunner extends ResidentRunner {
           reason: reason,
         ));
       } else {
-        HotEvent(
-          'exception',
+        HotEvent('exception',
           targetPlatform: targetPlatform!,
           sdkName: sdkName!,
           emulator: emulator!,
@@ -1023,48 +982,40 @@ class HotRunner extends ResidentRunner {
     String? reason,
     void Function(String message)? onSlow,
   }) async {
-    final Map<FlutterDevice?, List<FlutterView>> viewCache =
-        <FlutterDevice?, List<FlutterView>>{};
+    final Map<FlutterDevice?, List<FlutterView>> viewCache = <FlutterDevice?, List<FlutterView>>{};
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views =
-          await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
       viewCache[device] = views;
       for (final FlutterView view in views) {
         if (view.uiIsolate == null) {
-          return OperationResult(2, 'Application isolate not found',
-              fatal: true);
+          return OperationResult(2, 'Application isolate not found', fatal: true);
         }
       }
     }
 
-    final Stopwatch reloadTimer =
-        _stopwatchFactory.createStopwatch('reloadSources:reload')..start();
+    final Stopwatch reloadTimer = _stopwatchFactory.createStopwatch('reloadSources:reload')..start();
     if ((await hotRunnerConfig!.setupHotReload()) != true) {
       return OperationResult(1, 'setupHotReload failed');
     }
     final Stopwatch devFSTimer = Stopwatch()..start();
     UpdateFSReport updatedDevFS;
     try {
-      updatedDevFS = await _updateDevFS();
+      updatedDevFS= await _updateDevFS();
     } finally {
       hotRunnerConfig!.updateDevFSComplete();
     }
     // Record time it took to synchronize to DevFS.
     bool shouldReportReloadTime = true;
-    _addBenchmarkData(
-        'hotReloadDevFSSyncMilliseconds', devFSTimer.elapsed.inMilliseconds);
+    _addBenchmarkData('hotReloadDevFSSyncMilliseconds', devFSTimer.elapsed.inMilliseconds);
     if (!updatedDevFS.success) {
       return OperationResult(1, 'DevFS synchronization failed');
     }
 
-    final List<OperationResultExtraTiming> extraTimings =
-        <OperationResultExtraTiming>[];
-    extraTimings.add(OperationResultExtraTiming(
-        'compile', updatedDevFS.compileDuration.inMilliseconds));
+    final List<OperationResultExtraTiming> extraTimings = <OperationResultExtraTiming>[];
+    extraTimings.add(OperationResultExtraTiming('compile', updatedDevFS.compileDuration.inMilliseconds));
 
     String reloadMessage = 'Reloaded 0 libraries';
-    final Stopwatch reloadVMTimer =
-        _stopwatchFactory.createStopwatch('reloadSources:vm')..start();
+    final Stopwatch reloadVMTimer = _stopwatchFactory.createStopwatch('reloadSources:vm')..start();
     final Map<String, Object?> firstReloadDetails = <String, Object?>{};
     if (updatedDevFS.invalidatedSourcesCount > 0) {
       final OperationResult result = await _reloadSourcesHelper(
@@ -1087,13 +1038,11 @@ class HotRunner extends ResidentRunner {
       _addBenchmarkData('hotReloadVMReloadMilliseconds', 0);
     }
     reloadVMTimer.stop();
-    extraTimings.add(OperationResultExtraTiming(
-        'reload', reloadVMTimer.elapsedMilliseconds));
+    extraTimings.add(OperationResultExtraTiming('reload', reloadVMTimer.elapsedMilliseconds));
 
     await evictDirtyAssets();
 
-    final Stopwatch reassembleTimer =
-        _stopwatchFactory.createStopwatch('reloadSources:reassemble')..start();
+    final Stopwatch reassembleTimer = _stopwatchFactory.createStopwatch('reloadSources:reassemble')..start();
 
     final ReassembleResult reassembleResult = await _reassembleHelper(
       flutterDevices,
@@ -1107,10 +1056,8 @@ class HotRunner extends ResidentRunner {
     }
     // Record time it took for Flutter to reassemble the application.
     reassembleTimer.stop();
-    _addBenchmarkData('hotReloadFlutterReassembleMilliseconds',
-        reassembleTimer.elapsed.inMilliseconds);
-    extraTimings.add(OperationResultExtraTiming(
-        'reassemble', reassembleTimer.elapsedMilliseconds));
+    _addBenchmarkData('hotReloadFlutterReassembleMilliseconds', reassembleTimer.elapsed.inMilliseconds);
+    extraTimings.add(OperationResultExtraTiming('reassemble', reassembleTimer.elapsedMilliseconds));
 
     reloadTimer.stop();
     final Duration reloadDuration = reloadTimer.elapsed;
@@ -1121,8 +1068,7 @@ class HotRunner extends ResidentRunner {
     // many libraries were affected by the hot reload request.
     // Relation of [invalidatedSourcesCount] to [syncedLibraryCount] should help
     // understand sync/transfer "overhead" of updating this number of source files.
-    HotEvent(
-      'reload',
+    HotEvent('reload',
       targetPlatform: targetPlatform!,
       sdkName: sdkName!,
       emulator: emulator!,
@@ -1130,18 +1076,14 @@ class HotRunner extends ResidentRunner {
       reason: reason,
       overallTimeInMs: reloadInMs,
       finalLibraryCount: firstReloadDetails['finalLibraryCount'] as int? ?? 0,
-      syncedLibraryCount:
-          firstReloadDetails['receivedLibraryCount'] as int? ?? 0,
-      syncedClassesCount:
-          firstReloadDetails['receivedClassesCount'] as int? ?? 0,
-      syncedProceduresCount:
-          firstReloadDetails['receivedProceduresCount'] as int? ?? 0,
+      syncedLibraryCount: firstReloadDetails['receivedLibraryCount'] as int? ?? 0,
+      syncedClassesCount: firstReloadDetails['receivedClassesCount'] as int? ?? 0,
+      syncedProceduresCount: firstReloadDetails['receivedProceduresCount'] as int? ?? 0,
       syncedBytes: updatedDevFS.syncedBytes,
       invalidatedSourcesCount: updatedDevFS.invalidatedSourcesCount,
       transferTimeInMs: updatedDevFS.transferDuration.inMilliseconds,
       compileTimeInMs: updatedDevFS.compileDuration.inMilliseconds,
-      findInvalidatedTimeInMs:
-          updatedDevFS.findInvalidatedDuration.inMilliseconds,
+      findInvalidatedTimeInMs: updatedDevFS.findInvalidatedDuration.inMilliseconds,
       scannedSourcesCount: updatedDevFS.scannedSourcesCount,
       reassembleTimeInMs: reassembleTimer.elapsed.inMilliseconds,
       reloadVMTimeInMs: reloadVMTimer.elapsed.inMilliseconds,
@@ -1155,33 +1097,26 @@ class HotRunner extends ResidentRunner {
       reason: reason,
       overallTimeInMs: reloadInMs,
       finalLibraryCount: firstReloadDetails['finalLibraryCount'] as int? ?? 0,
-      syncedLibraryCount:
-          firstReloadDetails['receivedLibraryCount'] as int? ?? 0,
-      syncedClassesCount:
-          firstReloadDetails['receivedClassesCount'] as int? ?? 0,
-      syncedProceduresCount:
-          firstReloadDetails['receivedProceduresCount'] as int? ?? 0,
+      syncedLibraryCount: firstReloadDetails['receivedLibraryCount'] as int? ?? 0,
+      syncedClassesCount: firstReloadDetails['receivedClassesCount'] as int? ?? 0,
+      syncedProceduresCount: firstReloadDetails['receivedProceduresCount'] as int? ?? 0,
       syncedBytes: updatedDevFS.syncedBytes,
       invalidatedSourcesCount: updatedDevFS.invalidatedSourcesCount,
       transferTimeInMs: updatedDevFS.transferDuration.inMilliseconds,
       compileTimeInMs: updatedDevFS.compileDuration.inMilliseconds,
-      findInvalidatedTimeInMs:
-          updatedDevFS.findInvalidatedDuration.inMilliseconds,
+      findInvalidatedTimeInMs: updatedDevFS.findInvalidatedDuration.inMilliseconds,
       scannedSourcesCount: updatedDevFS.scannedSourcesCount,
       reassembleTimeInMs: reassembleTimer.elapsed.inMilliseconds,
       reloadVMTimeInMs: reloadVMTimer.elapsed.inMilliseconds,
     ));
 
     if (shouldReportReloadTime) {
-      globals.printTrace(
-          'Hot reload performed in ${getElapsedAsMilliseconds(reloadDuration)}.');
+      globals.printTrace('Hot reload performed in ${getElapsedAsMilliseconds(reloadDuration)}.');
       // Record complete time it took for the reload.
       _addBenchmarkData('hotReloadMillisecondsToFrame', reloadInMs);
     }
     // Only report timings if we reloaded a single view without any errors.
-    if ((reassembleResult.reassembleViews.length == 1) &&
-        !reassembleResult.failedReassemble &&
-        shouldReportReloadTime) {
+    if ((reassembleResult.reassembleViews.length == 1) && !reassembleResult.failedReassemble && shouldReportReloadTime) {
       globals.flutterUsage.sendTiming('hot', 'reload', reloadDuration);
       _analytics.send(Event.timing(
         workflow: 'hot',
@@ -1190,13 +1125,14 @@ class HotRunner extends ResidentRunner {
       ));
     }
     return OperationResult(
-        reassembleResult.failedReassemble ? 1 : OperationResult.ok.code,
-        reloadMessage,
-        extraTimings: extraTimings);
+      reassembleResult.failedReassemble ? 1 : OperationResult.ok.code,
+      reloadMessage,
+      extraTimings: extraTimings
+    );
   }
 
   @override
-  void printHelp({required bool details}) {
+  void printHelp({ required bool details }) {
     globals.printStatus('Flutter run key commands.');
     commandHelp.r.print();
     if (supportsRestart) {
@@ -1213,7 +1149,7 @@ class HotRunner extends ResidentRunner {
     }
     commandHelp.c.print();
     commandHelp.q.print();
-    if (debuggingOptions.buildInfo.nullSafetyMode != NullSafetyMode.sound) {
+    if (debuggingOptions.buildInfo.nullSafetyMode !=  NullSafetyMode.sound) {
       globals.printStatus('');
       globals.printStatus(
         'Running without sound null safety ⚠️',
@@ -1240,15 +1176,15 @@ class HotRunner extends ResidentRunner {
 
       // If this is the first time we update the assets, make sure to call the setAssetDirectory
       if (!device.devFS!.hasSetAssetDirectory) {
-        final Uri deviceAssetsDirectoryUri = device.devFS!.baseUri!
-            .resolveUri(globals.fs.path.toUri(getAssetBuildDirectory()));
+        final Uri deviceAssetsDirectoryUri = device.devFS!.baseUri!.resolveUri(globals.fs.path.toUri(getAssetBuildDirectory()));
         await Future.wait<void>(views.map<Future<void>>(
-            (FlutterView view) => device.vmService!.setAssetDirectory(
-                  assetsDirectory: deviceAssetsDirectoryUri,
-                  uiIsolateId: view.uiIsolate!.id,
-                  viewId: view.id,
-                  windows: device.targetPlatform == TargetPlatform.windows_x64,
-                )));
+          (FlutterView view) => device.vmService!.setAssetDirectory(
+            assetsDirectory: deviceAssetsDirectoryUri,
+            uiIsolateId: view.uiIsolate!.id,
+            viewId: view.id,
+            windows: device.targetPlatform == TargetPlatform.windows_x64,
+          )
+        ));
         for (final FlutterView view in views) {
           globals.printTrace('Set asset directory in $view.');
         }
@@ -1262,28 +1198,37 @@ class HotRunner extends ResidentRunner {
 
       if (device.devFS!.didUpdateFontManifest) {
         futures.add(device.vmService!.reloadAssetFonts(
-          isolateId: views.first.uiIsolate!.id!,
-          viewId: views.first.id,
+            isolateId: views.first.uiIsolate!.id!,
+            viewId: views.first.id,
         ));
       }
 
       for (final String assetPath in device.devFS!.assetPathsToEvict) {
-        futures.add(device.vmService!.flutterEvictAsset(
-          assetPath,
-          isolateId: views.first.uiIsolate!.id!,
-        ));
+        futures.add(
+          device.vmService!
+            .flutterEvictAsset(
+              assetPath,
+              isolateId: views.first.uiIsolate!.id!,
+            )
+        );
       }
       for (final String assetPath in device.devFS!.shaderPathsToEvict) {
-        futures.add(device.vmService!.flutterEvictShader(
-          assetPath,
-          isolateId: views.first.uiIsolate!.id!,
-        ));
+        futures.add(
+          device.vmService!
+            .flutterEvictShader(
+              assetPath,
+              isolateId: views.first.uiIsolate!.id!,
+            )
+        );
       }
       for (final String assetPath in device.devFS!.scenePathsToEvict) {
-        futures.add(device.vmService!.flutterEvictScene(
-          assetPath,
-          isolateId: views.first.uiIsolate!.id!,
-        ));
+        futures.add(
+          device.vmService!
+            .flutterEvictScene(
+              assetPath,
+              isolateId: views.first.uiIsolate!.id!,
+            )
+        );
       }
       device.devFS!.assetPathsToEvict.clear();
       device.devFS!.shaderPathsToEvict.clear();
@@ -1349,12 +1294,10 @@ Future<OperationResult> defaultReloadSourcesHelper(
 ) async {
   final Stopwatch vmReloadTimer = Stopwatch()..start();
   const String entryPath = 'main.dart.incremental.dill';
-  final List<Future<DeviceReloadReport?>> allReportsFutures =
-      <Future<DeviceReloadReport?>>[];
+  final List<Future<DeviceReloadReport?>> allReportsFutures = <Future<DeviceReloadReport?>>[];
 
   for (final FlutterDevice? device in flutterDevices) {
-    final List<Future<vm_service.ReloadReport>> reportFutures =
-        await _reloadDeviceSources(
+    final List<Future<vm_service.ReloadReport>> reportFutures = await _reloadDeviceSources(
       device!,
       entryPath,
       pause: pause,
@@ -1376,14 +1319,11 @@ Future<OperationResult> defaultReloadSourcesHelper(
       },
     ));
   }
-  final Iterable<DeviceReloadReport> reports =
-      (await Future.wait(allReportsFutures)).whereType<DeviceReloadReport>();
-  final vm_service.ReloadReport? reloadReport =
-      reports.isEmpty ? null : reports.first.reports[0];
+  final Iterable<DeviceReloadReport> reports = (await Future.wait(allReportsFutures)).whereType<DeviceReloadReport>();
+  final vm_service.ReloadReport? reloadReport = reports.isEmpty ? null : reports.first.reports[0];
   if (reloadReport == null || !HotRunner.validateReloadReport(reloadReport)) {
     // Reload failed.
-    HotEvent(
-      'reload-reject',
+    HotEvent('reload-reject',
       targetPlatform: targetPlatform!,
       sdkName: sdkName!,
       emulator: emulator!,
@@ -1405,27 +1345,21 @@ Future<OperationResult> defaultReloadSourcesHelper(
     if (reloadReport == null) {
       return OperationResult(1, 'No Dart isolates found');
     }
-    final ReloadReportContents contents =
-        ReloadReportContents.fromReloadReport(reloadReport);
-    return OperationResult(
-        1, 'Reload rejected: ${contents.notices.join("\n")}');
+    final ReloadReportContents contents = ReloadReportContents.fromReloadReport(reloadReport);
+    return OperationResult(1, 'Reload rejected: ${contents.notices.join("\n")}');
   }
   // Collect stats only from the first device. If/when run -d all is
   // refactored, we'll probably need to send one hot reload/restart event
   // per device to analytics.
   firstReloadDetails.addAll(castStringKeyedMap(reloadReport.json!['details'])!);
-  final Map<String, dynamic> details =
-      reloadReport.json!['details'] as Map<String, dynamic>;
+  final Map<String, dynamic> details = reloadReport.json!['details'] as Map<String, dynamic>;
   final int? loadedLibraryCount = details['loadedLibraryCount'] as int?;
   final int? finalLibraryCount = details['finalLibraryCount'] as int?;
-  globals.printTrace(
-      'reloaded $loadedLibraryCount of $finalLibraryCount libraries');
+  globals.printTrace('reloaded $loadedLibraryCount of $finalLibraryCount libraries');
   // reloadMessage = 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries';
   // Record time it took for the VM to reload the sources.
-  hotRunner._addBenchmarkData(
-      'hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
-  return OperationResult(
-      0, 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries');
+  hotRunner._addBenchmarkData('hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
+  return OperationResult(0, 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries');
 }
 
 Future<List<Future<vm_service.ReloadReport>>> _reloadDeviceSources(
@@ -1433,8 +1367,8 @@ Future<List<Future<vm_service.ReloadReport>>> _reloadDeviceSources(
   String entryPath, {
   bool? pause = false,
 }) async {
-  final String deviceEntryUri =
-      device.devFS!.baseUri!.resolve(entryPath).toString();
+  final String deviceEntryUri = device.devFS!.baseUri!
+    .resolve(entryPath).toString();
   final vm_service.VM vm = await device.vmService!.service.getVM();
   return <Future<vm_service.ReloadReport>>[
     for (final vm_service.IsolateRef isolateRef in vm.isolates!)
@@ -1454,8 +1388,7 @@ void _resetDevFSCompileTime(List<FlutterDevice?> flutterDevices) {
 
 @visibleForTesting
 class ReassembleResult {
-  ReassembleResult(
-      this.reassembleViews, this.failedReassemble, this.shouldReportReloadTime);
+  ReassembleResult(this.reassembleViews, this.failedReassemble, this.shouldReportReloadTime);
   final Map<FlutterView?, FlutterVmService?> reassembleViews;
   final bool failedReassemble;
   final bool shouldReportReloadTime;
@@ -1475,8 +1408,7 @@ Future<ReassembleResult> _defaultReassembleHelper(
   String reloadMessage,
 ) async {
   // Check if any isolates are paused and reassemble those that aren't.
-  final Map<FlutterView, FlutterVmService?> reassembleViews =
-      <FlutterView, FlutterVmService?>{};
+  final Map<FlutterView, FlutterVmService?> reassembleViews = <FlutterView, FlutterVmService?>{};
   final List<Future<void>> reassembleFutures = <Future<void>>[];
   String? serviceEventKind;
   int pausedIsolatesFound = 0;
@@ -1488,10 +1420,10 @@ Future<ReassembleResult> _defaultReassembleHelper(
       // Check if the isolate is paused, and if so, don't reassemble. Ignore the
       // PostPauseEvent event - the client requesting the pause will resume the app.
       final vm_service.Event? pauseEvent = await device!.vmService!
-          .getIsolatePauseEventOrNull(view.uiIsolate!.id!);
-      if (pauseEvent != null &&
-          isPauseEvent(pauseEvent.kind!) &&
-          pauseEvent.kind != vm_service.EventKind.kPausePostRequest) {
+        .getIsolatePauseEventOrNull(view.uiIsolate!.id!);
+      if (pauseEvent != null
+        && isPauseEvent(pauseEvent.kind!)
+        && pauseEvent.kind != vm_service.EventKind.kPausePostRequest) {
         pausedIsolatesFound += 1;
         if (serviceEventKind == null) {
           serviceEventKind = pauseEvent.kind;
@@ -1512,8 +1444,7 @@ Future<ReassembleResult> _defaultReassembleHelper(
               return Future<Object?>.error(error, stackTrace);
             }
             failedReassemble = true;
-            globals.printError(
-                'Reassembling ${view.uiIsolate!.name} failed: $error\n$stackTrace');
+            globals.printError('Reassembling ${view.uiIsolate!.name} failed: $error\n$stackTrace');
           },
         ));
       }
@@ -1521,37 +1452,32 @@ Future<ReassembleResult> _defaultReassembleHelper(
   }
   if (pausedIsolatesFound > 0) {
     if (onSlow != null) {
-      onSlow(
-          '${_describePausedIsolates(pausedIsolatesFound, serviceEventKind!)}; interface might not update.');
+      onSlow('${_describePausedIsolates(pausedIsolatesFound, serviceEventKind!)}; interface might not update.');
     }
     if (reassembleViews.isEmpty) {
-      globals
-          .printTrace('Skipping reassemble because all isolates are paused.');
-      return ReassembleResult(
-          reassembleViews, failedReassemble, shouldReportReloadTime);
+      globals.printTrace('Skipping reassemble because all isolates are paused.');
+      return ReassembleResult(reassembleViews, failedReassemble, shouldReportReloadTime);
     }
   }
   assert(reassembleViews.isNotEmpty);
 
   globals.printTrace('Reassembling application');
 
-  final Future<void> reassembleFuture =
-      Future.wait<void>(reassembleFutures).then((void _) => null);
+  final Future<void> reassembleFuture = Future.wait<void>(reassembleFutures).then((void _) => null);
   await reassembleFuture.timeout(
     const Duration(seconds: 2),
     onTimeout: () async {
       if (pausedIsolatesFound > 0) {
         shouldReportReloadTime = false;
-        return; // probably no point waiting, they're probably deadlocked and we've already warned.
+        return ; // probably no point waiting, they're probably deadlocked and we've already warned.
       }
       // Check if any isolate is newly paused.
-      globals.printTrace(
-          'This is taking a long time; will now check for paused isolates.');
+      globals.printTrace('This is taking a long time; will now check for paused isolates.');
       int postReloadPausedIsolatesFound = 0;
       String? serviceEventKind;
       for (final FlutterView view in reassembleViews.keys) {
         final vm_service.Event? pauseEvent = await reassembleViews[view]!
-            .getIsolatePauseEventOrNull(view.uiIsolate!.id!);
+          .getIsolatePauseEventOrNull(view.uiIsolate!.id!);
         if (pauseEvent != null && isPauseEvent(pauseEvent.kind!)) {
           postReloadPausedIsolatesFound += 1;
           if (serviceEventKind == null) {
@@ -1561,26 +1487,22 @@ Future<ReassembleResult> _defaultReassembleHelper(
           }
         }
       }
-      globals.printTrace(
-          'Found $postReloadPausedIsolatesFound newly paused isolate(s).');
+      globals.printTrace('Found $postReloadPausedIsolatesFound newly paused isolate(s).');
       if (postReloadPausedIsolatesFound == 0) {
         await reassembleFuture; // must just be taking a long time... keep waiting!
         return;
       }
       shouldReportReloadTime = false;
       if (onSlow != null) {
-        onSlow(
-            '${_describePausedIsolates(postReloadPausedIsolatesFound, serviceEventKind!)}.');
+        onSlow('${_describePausedIsolates(postReloadPausedIsolatesFound, serviceEventKind!)}.');
       }
       return;
     },
   );
-  return ReassembleResult(
-      reassembleViews, failedReassemble, shouldReportReloadTime);
+  return ReassembleResult(reassembleViews, failedReassemble, shouldReportReloadTime);
 }
 
-String _describePausedIsolates(
-    int pausedIsolatesFound, String serviceEventKind) {
+String _describePausedIsolates(int pausedIsolatesFound, String serviceEventKind) {
   assert(pausedIsolatesFound > 0);
   final StringBuffer message = StringBuffer();
   bool plural;
@@ -1592,18 +1514,14 @@ String _describePausedIsolates(
     plural = true;
   }
   message.write(switch (serviceEventKind) {
-    vm_service.EventKind.kPauseStart =>
-      'paused (probably due to --start-paused)',
-    vm_service.EventKind.kPauseExit =>
-      'paused because ${plural ? 'they have' : 'it has'} terminated',
-    vm_service.EventKind.kPauseBreakpoint =>
-      'paused in the debugger on a breakpoint',
+    vm_service.EventKind.kPauseStart       => 'paused (probably due to --start-paused)',
+    vm_service.EventKind.kPauseExit        => 'paused because ${ plural ? 'they have' : 'it has' } terminated',
+    vm_service.EventKind.kPauseBreakpoint  => 'paused in the debugger on a breakpoint',
     vm_service.EventKind.kPauseInterrupted => 'paused due in the debugger',
-    vm_service.EventKind.kPauseException =>
-      'paused in the debugger after an exception was thrown',
+    vm_service.EventKind.kPauseException   => 'paused in the debugger after an exception was thrown',
     vm_service.EventKind.kPausePostRequest => 'paused',
     '' => 'paused for various reasons',
-    _ => 'paused',
+    _  => 'paused',
   });
   return message.toString();
 }
@@ -1626,9 +1544,9 @@ class ProjectFileInvalidator {
     required FileSystem fileSystem,
     required Platform platform,
     required Logger logger,
-  })  : _fileSystem = fileSystem,
-        _platform = platform,
-        _logger = logger;
+  }): _fileSystem = fileSystem,
+      _platform = platform,
+      _logger = logger;
 
   final FileSystem _fileSystem;
   final Platform _platform;
@@ -1652,6 +1570,7 @@ class ProjectFileInvalidator {
     required PackageConfig packageConfig,
     bool asyncScanning = false,
   }) async {
+
     if (lastCompiled == null) {
       // Initial load.
       assert(urisToMonitor.isEmpty);
@@ -1673,18 +1592,18 @@ class ProjectFileInvalidator {
       final List<Future<void>> waitList = <Future<void>>[];
       for (final Uri uri in urisToScan) {
         waitList.add(pool.withResource<void>(
-            // Calling fs.stat() is more performant than fs.file().stat(), but
-            // uri.toFilePath() does not work with MultiRootFileSystem.
-            () => (uri.hasScheme && uri.scheme != 'file'
-                        ? _fileSystem.file(uri).stat()
-                        : _fileSystem
-                            .stat(uri.toFilePath(windows: _platform.isWindows)))
-                    .then((FileStat stat) {
-                  final DateTime updatedAt = stat.modified;
-                  if (updatedAt.isAfter(lastCompiled)) {
-                    invalidatedFiles.add(uri);
-                  }
-                })));
+          // Calling fs.stat() is more performant than fs.file().stat(), but
+          // uri.toFilePath() does not work with MultiRootFileSystem.
+          () => (uri.hasScheme && uri.scheme != 'file'
+            ? _fileSystem.file(uri).stat()
+            :  _fileSystem.stat(uri.toFilePath(windows: _platform.isWindows)))
+            .then((FileStat stat) {
+              final DateTime updatedAt = stat.modified;
+              if (updatedAt.isAfter(lastCompiled)) {
+                invalidatedFiles.add(uri);
+              }
+            })
+        ));
       }
       await Future.wait<void>(waitList);
     } else {
@@ -1692,10 +1611,8 @@ class ProjectFileInvalidator {
         // Calling fs.statSync() is more performant than fs.file().statSync(), but
         // uri.toFilePath() does not work with MultiRootFileSystem.
         final DateTime updatedAt = uri.hasScheme && uri.scheme != 'file'
-            ? _fileSystem.file(uri).statSync().modified
-            : _fileSystem
-                .statSync(uri.toFilePath(windows: _platform.isWindows))
-                .modified;
+          ? _fileSystem.file(uri).statSync().modified
+          : _fileSystem.statSync(uri.toFilePath(windows: _platform.isWindows)).modified;
         if (updatedAt.isAfter(lastCompiled)) {
           invalidatedFiles.add(uri);
         }
@@ -1722,15 +1639,14 @@ class ProjectFileInvalidator {
   }
 
   bool _isNotInPubCache(Uri uri) {
-    return !(_platform.isWindows && uri.path.contains(_pubCachePathWindows)) &&
-        !uri.path.contains(_pubCachePathLinuxAndMac);
+    return !(_platform.isWindows && uri.path.contains(_pubCachePathWindows))
+        && !uri.path.contains(_pubCachePathLinuxAndMac);
   }
 }
 
 /// Additional serialization logic for a hot reload response.
 class ReloadReportContents {
-  factory ReloadReportContents.fromReloadReport(
-      vm_service.ReloadReport report) {
+  factory ReloadReportContents.fromReloadReport(vm_service.ReloadReport report) {
     final List<ReasonForCancelling> reasons = <ReasonForCancelling>[];
     final Object? notices = report.json!['notices'];
     if (notices is! List<dynamic>) {
@@ -1743,8 +1659,8 @@ class ReloadReportContents {
       final Map<String, dynamic> notice = obj;
       reasons.add(ReasonForCancelling(
         message: notice['message'] is String
-            ? notice['message'] as String?
-            : 'Unknown Error',
+          ? notice['message'] as String?
+          : 'Unknown Error',
       ));
     }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -26,11 +26,13 @@ import 'reporting/reporting.dart';
 import 'resident_runner.dart';
 import 'vmservice.dart';
 
-ProjectFileInvalidator get projectFileInvalidator => context.get<ProjectFileInvalidator>() ?? ProjectFileInvalidator(
-  fileSystem: globals.fs,
-  platform: globals.platform,
-  logger: globals.logger,
-);
+ProjectFileInvalidator get projectFileInvalidator =>
+    context.get<ProjectFileInvalidator>() ??
+    ProjectFileInvalidator(
+      fileSystem: globals.fs,
+      platform: globals.platform,
+      logger: globals.logger,
+    );
 
 HotRunnerConfig? get hotRunnerConfig => context.get<HotRunnerConfig>();
 
@@ -71,7 +73,8 @@ class DeviceReloadReport {
   DeviceReloadReport(this.device, this.reports);
 
   FlutterDevice? device;
-  List<vm_service.ReloadReport> reports; // List has one report per Flutter view.
+  List<vm_service.ReloadReport>
+      reports; // List has one report per Flutter view.
 }
 
 class HotRunner extends ResidentRunner {
@@ -79,6 +82,7 @@ class HotRunner extends ResidentRunner {
     super.flutterDevices, {
     required super.target,
     required super.debuggingOptions,
+    required super.useImplicitPubspecResolution,
     this.benchmarkMode = false,
     this.applicationBinary,
     this.hostIsIde = false,
@@ -181,9 +185,9 @@ class HotRunner extends ResidentRunner {
     }
   }
 
-  Future<void> _restartService({ bool pause = false }) async {
+  Future<void> _restartService({bool pause = false}) async {
     final OperationResult result =
-      await restart(fullRestart: true, pause: pause);
+        await restart(fullRestart: true, pause: pause);
     if (!result.isOk) {
       throw vm_service.RPCError(
         'Unable to restart',
@@ -208,10 +212,18 @@ class HotRunner extends ResidentRunner {
   ) async {
     for (final FlutterDevice? device in flutterDevices) {
       if (device!.generator != null) {
-        final CompilerOutput? compilerOutput =
-            await device.generator!.compileExpression(expression, definitions,
-                definitionTypes, typeDefinitions, typeBounds, typeDefaults,
-                libraryUri, klass, method, isStatic);
+        final CompilerOutput? compilerOutput = await device.generator!
+            .compileExpression(
+                expression,
+                definitions,
+                definitionTypes,
+                typeDefinitions,
+                typeBounds,
+                typeDefaults,
+                libraryUri,
+                klass,
+                method,
+                isStatic);
         if (compilerOutput != null && compilerOutput.expressionData != null) {
           return base64.encode(compilerOutput.expressionData!);
         }
@@ -237,8 +249,9 @@ class HotRunner extends ResidentRunner {
         getSkSLMethod: writeSkSL,
         allowExistingDdsInstance: allowExistingDdsInstance,
       );
-    // Catches all exceptions, non-Exception objects are rethrown.
-    } catch (error) { // ignore: avoid_catches_without_on_clauses
+      // Catches all exceptions, non-Exception objects are rethrown.
+    } catch (error) {
+      // ignore: avoid_catches_without_on_clauses
       if (error is! Exception && error is! String) {
         rethrow;
       }
@@ -262,9 +275,7 @@ class HotRunner extends ResidentRunner {
 
     for (final FlutterDevice? device in flutterDevices) {
       await device!.tryInitLogReader();
-      device
-        .developmentShaderCompiler
-        .configureCompiler(device.targetPlatform);
+      device.developmentShaderCompiler.configureCompiler(device.targetPlatform);
     }
     try {
       final List<Uri?> baseUris = await _initDevFS();
@@ -284,7 +295,8 @@ class HotRunner extends ResidentRunner {
     }
 
     final Stopwatch initialUpdateDevFSsTimer = Stopwatch()..start();
-    final UpdateFSReport devfsResult = await _updateDevFS(fullRestart: needsFullRestart);
+    final UpdateFSReport devfsResult =
+        await _updateDevFS(fullRestart: needsFullRestart);
     _addBenchmarkData(
       'hotReloadInitialDevFSSyncMilliseconds',
       initialUpdateDevFSsTimer.elapsed.inMilliseconds,
@@ -394,35 +406,37 @@ class HotRunner extends ResidentRunner {
       await runSourceGenerators();
       if (device!.generator != null) {
         final Stopwatch compileTimer = Stopwatch()..start();
-        startupTasks.add(
-          device.generator!.recompile(
-            mainFile.uri,
-            <Uri>[],
-            // When running without a provided applicationBinary, the tool will
-            // simultaneously run the initial frontend_server compilation and
-            // the native build step. If there is a Dart compilation error, it
-            // should only be displayed once.
-            suppressErrors: applicationBinary == null,
-            checkDartPluginRegistry: true,
-            dartPluginRegistrant: FlutterProject.current().dartPluginRegistrant,
-            outputPath: dillOutputPath,
-            packageConfig: debuggingOptions.buildInfo.packageConfig,
-            projectRootPath: FlutterProject.current().directory.absolute.path,
-            fs: globals.fs,
-            nativeAssetsYaml: nativeAssetsYaml,
-          ).then((CompilerOutput? output) {
-            compileTimer.stop();
-            totalCompileTime += compileTimer.elapsed;
-            return output?.errorCount == 0;
-          })
-        );
+        startupTasks.add(device.generator!
+            .recompile(
+          mainFile.uri,
+          <Uri>[],
+          // When running without a provided applicationBinary, the tool will
+          // simultaneously run the initial frontend_server compilation and
+          // the native build step. If there is a Dart compilation error, it
+          // should only be displayed once.
+          suppressErrors: applicationBinary == null,
+          checkDartPluginRegistry: true,
+          dartPluginRegistrant: FlutterProject.current().dartPluginRegistrant,
+          outputPath: dillOutputPath,
+          packageConfig: debuggingOptions.buildInfo.packageConfig,
+          projectRootPath: FlutterProject.current().directory.absolute.path,
+          fs: globals.fs,
+          nativeAssetsYaml: nativeAssetsYaml,
+        )
+            .then((CompilerOutput? output) {
+          compileTimer.stop();
+          totalCompileTime += compileTimer.elapsed;
+          return output?.errorCount == 0;
+        }));
       }
 
       final Stopwatch launchAppTimer = Stopwatch()..start();
-      startupTasks.add(device.runHot(
+      startupTasks.add(device
+          .runHot(
         hotRunner: this,
         route: route,
-      ).then((int result) {
+      )
+          .then((int result) {
         totalLaunchAppTime += launchAppTimer.elapsed;
         return result == 0;
       }));
@@ -483,7 +497,7 @@ class HotRunner extends ResidentRunner {
     ];
   }
 
-  Future<UpdateFSReport> _updateDevFS({ bool fullRestart = false }) async {
+  Future<UpdateFSReport> _updateDevFS({bool fullRestart = false}) async {
     final bool isFirstUpload = !assetBundle.wasBuiltOnce();
     final bool rebuildBundle = assetBundle.needsBuild();
     if (rebuildBundle) {
@@ -497,25 +511,26 @@ class HotRunner extends ResidentRunner {
       }
     }
 
-    final Stopwatch findInvalidationTimer = _stopwatchFactory.createStopwatch('updateDevFS')..start();
+    final Stopwatch findInvalidationTimer =
+        _stopwatchFactory.createStopwatch('updateDevFS')..start();
     final DevFS devFS = flutterDevices[0].devFS!;
-    final InvalidationResult invalidationResult = await projectFileInvalidator.findInvalidated(
+    final InvalidationResult invalidationResult =
+        await projectFileInvalidator.findInvalidated(
       lastCompiled: devFS.lastCompiled,
       urisToMonitor: devFS.sources,
       packagesPath: packagesFilePath,
       asyncScanning: hotRunnerConfig!.asyncScanning,
-      packageConfig: devFS.lastPackageConfig
-          ?? debuggingOptions.buildInfo.packageConfig,
+      packageConfig:
+          devFS.lastPackageConfig ?? debuggingOptions.buildInfo.packageConfig,
     );
     findInvalidationTimer.stop();
     final File entrypointFile = globals.fs.file(mainPath);
     if (!entrypointFile.existsSync()) {
       globals.printError(
-        'The entrypoint file (i.e. the file with main()) ${entrypointFile.path} '
-        'cannot be found. Moving or renaming this file will prevent changes to '
-        'its contents from being discovered during hot reload/restart until '
-        'flutter is restarted or the file is restored.'
-      );
+          'The entrypoint file (i.e. the file with main()) ${entrypointFile.path} '
+          'cannot be found. Moving or renaming this file will prevent changes to '
+          'its contents from being discovered during hot reload/restart until '
+          'flutter is restarted or the file is restored.');
     }
     final UpdateFSReport results = UpdateFSReport(
       success: true,
@@ -559,14 +574,15 @@ class HotRunner extends ResidentRunner {
       if (device.devFS != null) {
         // Cleanup the devFS, but don't wait indefinitely.
         // We ignore any errors, because it's not clear what we would do anyway.
-        futures.add(device.devFS!.destroy()
-          .timeout(const Duration(milliseconds: 250))
-          .then<void>(
-            (Object? _) {},
-            onError: (Object? error, StackTrace stackTrace) {
-              globals.printTrace('Ignored error while cleaning up DevFS: $error\n$stackTrace');
-            }
-          ),
+        futures.add(
+          device.devFS!
+              .destroy()
+              .timeout(const Duration(milliseconds: 250))
+              .then<void>((Object? _) {},
+                  onError: (Object? error, StackTrace stackTrace) {
+            globals.printTrace(
+                'Ignored error while cleaning up DevFS: $error\n$stackTrace');
+          }),
         );
       }
       device.devFS = null;
@@ -593,12 +609,12 @@ class HotRunner extends ResidentRunner {
   Future<void> _launchFromDevFS() async {
     final List<Future<void>> futures = <Future<void>>[];
     for (final FlutterDevice? device in flutterDevices) {
-      final Uri deviceEntryUri = device!.devFS!.baseUri!.resolve(_swap ? 'main.dart.swap.dill' : 'main.dart.dill');
-      final Uri deviceAssetsDirectoryUri = device.devFS!.baseUri!.resolveUri(
-        globals.fs.path.toUri(getAssetBuildDirectory()));
-      futures.add(_launchInView(device,
-                          deviceEntryUri,
-                          deviceAssetsDirectoryUri));
+      final Uri deviceEntryUri = device!.devFS!.baseUri!
+          .resolve(_swap ? 'main.dart.swap.dill' : 'main.dart.dill');
+      final Uri deviceAssetsDirectoryUri = device.devFS!.baseUri!
+          .resolveUri(globals.fs.path.toUri(getAssetBuildDirectory()));
+      futures
+          .add(_launchInView(device, deviceEntryUri, deviceAssetsDirectoryUri));
     }
     await Future.wait(futures);
   }
@@ -633,15 +649,16 @@ class HotRunner extends ResidentRunner {
     final List<Future<void>> operations = <Future<void>>[];
     for (final FlutterDevice? device in flutterDevices) {
       final Set<String?> uiIsolatesIds = <String?>{};
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       for (final FlutterView view in views) {
         if (view.uiIsolate == null) {
           continue;
         }
         uiIsolatesIds.add(view.uiIsolate!.id);
         // Reload the isolate.
-        final Future<vm_service.Isolate?> reloadIsolate = device.vmService!
-          .getIsolateOrNull(view.uiIsolate!.id!);
+        final Future<vm_service.Isolate?> reloadIsolate =
+            device.vmService!.getIsolateOrNull(view.uiIsolate!.id!);
         operations.add(reloadIsolate.then((vm_service.Isolate? isolate) async {
           if ((isolate != null) && isPauseEvent(isolate.pauseEvent!.kind!)) {
             // The embedder requires that the isolate is unpaused, because the
@@ -656,11 +673,14 @@ class HotRunner extends ResidentRunner {
             // These settings to not need restoring as Hot Restart results in
             // new isolates, which will be configured by the editor as they are
             // started.
-            final List<Future<void>> breakpointAndExceptionRemoval = <Future<void>>[
+            final List<Future<void>> breakpointAndExceptionRemoval =
+                <Future<void>>[
               device.vmService!.service.setIsolatePauseMode(isolate.id!,
-                exceptionPauseMode: vm_service.ExceptionPauseMode.kNone),
-              for (final vm_service.Breakpoint breakpoint in isolate.breakpoints!)
-                device.vmService!.service.removeBreakpoint(isolate.id!, breakpoint.id!),
+                  exceptionPauseMode: vm_service.ExceptionPauseMode.kNone),
+              for (final vm_service.Breakpoint breakpoint
+                  in isolate.breakpoints!)
+                device.vmService!.service
+                    .removeBreakpoint(isolate.id!, breakpoint.id!),
             ];
             await Future.wait(breakpointAndExceptionRemoval);
             await device.vmService!.service.resume(view.uiIsolate!.id!);
@@ -677,11 +697,12 @@ class HotRunner extends ResidentRunner {
           continue;
         }
         operations.add(
-          device.vmService!.service.kill(isolateRef.id!)
-          // Since we never check the value of this Future, only await its
-          // completion, make its type nullable so we can return null when
-          // catching errors.
-          .then<vm_service.Success?>(
+          device.vmService!.service
+              .kill(isolateRef.id!)
+              // Since we never check the value of this Future, only await its
+              // completion, make its type nullable so we can return null when
+              // catching errors.
+              .then<vm_service.Success?>(
             (vm_service.Success success) => success,
             onError: (Object error, StackTrace stackTrace) {
               if (error is vm_service.SentinelException ||
@@ -703,9 +724,10 @@ class HotRunner extends ResidentRunner {
     globals.printTrace('Finished waiting on operations.');
     await _launchFromDevFS();
     restartTimer.stop();
-    globals.printTrace('Hot restart performed in ${getElapsedAsMilliseconds(restartTimer.elapsed)}.');
-    _addBenchmarkData('hotRestartMillisecondsToFrame',
-        restartTimer.elapsed.inMilliseconds);
+    globals.printTrace(
+        'Hot restart performed in ${getElapsedAsMilliseconds(restartTimer.elapsed)}.');
+    _addBenchmarkData(
+        'hotRestartMillisecondsToFrame', restartTimer.elapsed.inMilliseconds);
 
     // Send timing analytics.
     final Duration elapsedDuration = restartTimer.elapsed;
@@ -717,7 +739,7 @@ class HotRunner extends ResidentRunner {
     ));
 
     // Toggle the main dill name after successfully uploading.
-    _swap =! _swap;
+    _swap = !_swap;
 
     return OperationResult(
       OperationResult.ok.code,
@@ -738,7 +760,8 @@ class HotRunner extends ResidentRunner {
       }
       return false;
     }
-    final ReloadReportContents contents = ReloadReportContents.fromReloadReport(reloadReport);
+    final ReloadReportContents contents =
+        ReloadReportContents.fromReloadReport(reloadReport);
     if (!reloadReport.success!) {
       if (printErrors) {
         globals.printError('Hot reload was rejected:');
@@ -776,7 +799,8 @@ class HotRunner extends ResidentRunner {
         silent: silent,
       );
       if (!silent) {
-        globals.printStatus('Restarted application in ${getElapsedAsMilliseconds(timer.elapsed)}.');
+        globals.printStatus(
+            'Restarted application in ${getElapsedAsMilliseconds(timer.elapsed)}.');
       }
       // TODO(bkonyi): remove when ready to serve DevTools from DDS.
       unawaited(residentDevtoolsHandler!.hotRestart(flutterDevices));
@@ -797,9 +821,11 @@ class HotRunner extends ResidentRunner {
       if (!silent) {
         if (result.extraTimings.isNotEmpty) {
           final String extraTimingsString = result.extraTimings
-            .map((OperationResultExtraTiming e) => '${e.description}: ${e.timeInMs} ms')
-            .join(', ');
-          globals.printStatus('${result.message} in $elapsed ($extraTimingsString).');
+              .map((OperationResultExtraTiming e) =>
+                  '${e.description}: ${e.timeInMs} ms')
+              .join(', ');
+          globals.printStatus(
+              '${result.message} in $elapsed ($extraTimingsString).');
         } else {
           globals.printStatus('${result.message} in $elapsed.');
         }
@@ -828,7 +854,8 @@ class HotRunner extends ResidentRunner {
     OperationResult result;
     String? restartEvent;
     try {
-      final Stopwatch restartTimer = _stopwatchFactory.createStopwatch('fullRestartHelper')..start();
+      final Stopwatch restartTimer =
+          _stopwatchFactory.createStopwatch('fullRestartHelper')..start();
       if ((await hotRunnerConfig!.setupHotRestart()) != true) {
         return OperationResult(1, 'setupHotRestart failed');
       }
@@ -837,7 +864,8 @@ class HotRunner extends ResidentRunner {
       if (!result.isOk) {
         restartEvent = 'restart-failed';
       } else {
-        HotEvent('restart',
+        HotEvent(
+          'restart',
           targetPlatform: targetPlatform!,
           sdkName: sdkName!,
           emulator: emulator!,
@@ -845,10 +873,14 @@ class HotRunner extends ResidentRunner {
           reason: reason,
           overallTimeInMs: restartTimer.elapsed.inMilliseconds,
           syncedBytes: result.updateFSReport?.syncedBytes,
-          invalidatedSourcesCount: result.updateFSReport?.invalidatedSourcesCount,
-          transferTimeInMs: result.updateFSReport?.transferDuration.inMilliseconds,
-          compileTimeInMs: result.updateFSReport?.compileDuration.inMilliseconds,
-          findInvalidatedTimeInMs: result.updateFSReport?.findInvalidatedDuration.inMilliseconds,
+          invalidatedSourcesCount:
+              result.updateFSReport?.invalidatedSourcesCount,
+          transferTimeInMs:
+              result.updateFSReport?.transferDuration.inMilliseconds,
+          compileTimeInMs:
+              result.updateFSReport?.compileDuration.inMilliseconds,
+          findInvalidatedTimeInMs:
+              result.updateFSReport?.findInvalidatedDuration.inMilliseconds,
           scannedSourcesCount: result.updateFSReport?.scannedSourcesCount,
         ).send();
         _analytics.send(Event.hotRunnerInfo(
@@ -860,24 +892,31 @@ class HotRunner extends ResidentRunner {
           reason: reason,
           overallTimeInMs: restartTimer.elapsed.inMilliseconds,
           syncedBytes: result.updateFSReport?.syncedBytes,
-          invalidatedSourcesCount: result.updateFSReport?.invalidatedSourcesCount,
-          transferTimeInMs: result.updateFSReport?.transferDuration.inMilliseconds,
-          compileTimeInMs: result.updateFSReport?.compileDuration.inMilliseconds,
-          findInvalidatedTimeInMs: result.updateFSReport?.findInvalidatedDuration.inMilliseconds,
+          invalidatedSourcesCount:
+              result.updateFSReport?.invalidatedSourcesCount,
+          transferTimeInMs:
+              result.updateFSReport?.transferDuration.inMilliseconds,
+          compileTimeInMs:
+              result.updateFSReport?.compileDuration.inMilliseconds,
+          findInvalidatedTimeInMs:
+              result.updateFSReport?.findInvalidatedDuration.inMilliseconds,
           scannedSourcesCount: result.updateFSReport?.scannedSourcesCount,
         ));
       }
     } on vm_service.SentinelException catch (err, st) {
       restartEvent = 'exception';
-      return OperationResult(1, 'hot restart failed to complete: $err\n$st', fatal: true);
-    } on vm_service.RPCError  catch (err, st) {
+      return OperationResult(1, 'hot restart failed to complete: $err\n$st',
+          fatal: true);
+    } on vm_service.RPCError catch (err, st) {
       restartEvent = 'exception';
-      return OperationResult(1, 'hot restart failed to complete: $err\n$st', fatal: true);
+      return OperationResult(1, 'hot restart failed to complete: $err\n$st',
+          fatal: true);
     } finally {
       // The `restartEvent` variable will be null if restart succeeded. We will
       // only handle the case when it failed here.
       if (restartEvent != null) {
-        HotEvent(restartEvent,
+        HotEvent(
+          restartEvent,
           targetPlatform: targetPlatform!,
           sdkName: sdkName!,
           emulator: emulator!,
@@ -930,11 +969,13 @@ class HotRunner extends ResidentRunner {
       int errorCode = 1;
       if (error.code == kIsolateReloadBarred) {
         errorCode = error.code;
-        errorMessage = 'Unable to hot reload application due to an unrecoverable error in '
-                      'the source code. Please address the error and then use "R" to '
-                      'restart the app.\n'
-                      '${error.message} (error code: ${error.code})';
-        HotEvent('reload-barred',
+        errorMessage =
+            'Unable to hot reload application due to an unrecoverable error in '
+            'the source code. Please address the error and then use "R" to '
+            'restart the app.\n'
+            '${error.message} (error code: ${error.code})';
+        HotEvent(
+          'reload-barred',
           targetPlatform: targetPlatform!,
           sdkName: sdkName!,
           emulator: emulator!,
@@ -950,7 +991,8 @@ class HotRunner extends ResidentRunner {
           reason: reason,
         ));
       } else {
-        HotEvent('exception',
+        HotEvent(
+          'exception',
           targetPlatform: targetPlatform!,
           sdkName: sdkName!,
           emulator: emulator!,
@@ -981,40 +1023,48 @@ class HotRunner extends ResidentRunner {
     String? reason,
     void Function(String message)? onSlow,
   }) async {
-    final Map<FlutterDevice?, List<FlutterView>> viewCache = <FlutterDevice?, List<FlutterView>>{};
+    final Map<FlutterDevice?, List<FlutterView>> viewCache =
+        <FlutterDevice?, List<FlutterView>>{};
     for (final FlutterDevice? device in flutterDevices) {
-      final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      final List<FlutterView> views =
+          await device!.vmService!.getFlutterViews();
       viewCache[device] = views;
       for (final FlutterView view in views) {
         if (view.uiIsolate == null) {
-          return OperationResult(2, 'Application isolate not found', fatal: true);
+          return OperationResult(2, 'Application isolate not found',
+              fatal: true);
         }
       }
     }
 
-    final Stopwatch reloadTimer = _stopwatchFactory.createStopwatch('reloadSources:reload')..start();
+    final Stopwatch reloadTimer =
+        _stopwatchFactory.createStopwatch('reloadSources:reload')..start();
     if ((await hotRunnerConfig!.setupHotReload()) != true) {
       return OperationResult(1, 'setupHotReload failed');
     }
     final Stopwatch devFSTimer = Stopwatch()..start();
     UpdateFSReport updatedDevFS;
     try {
-      updatedDevFS= await _updateDevFS();
+      updatedDevFS = await _updateDevFS();
     } finally {
       hotRunnerConfig!.updateDevFSComplete();
     }
     // Record time it took to synchronize to DevFS.
     bool shouldReportReloadTime = true;
-    _addBenchmarkData('hotReloadDevFSSyncMilliseconds', devFSTimer.elapsed.inMilliseconds);
+    _addBenchmarkData(
+        'hotReloadDevFSSyncMilliseconds', devFSTimer.elapsed.inMilliseconds);
     if (!updatedDevFS.success) {
       return OperationResult(1, 'DevFS synchronization failed');
     }
 
-    final List<OperationResultExtraTiming> extraTimings = <OperationResultExtraTiming>[];
-    extraTimings.add(OperationResultExtraTiming('compile', updatedDevFS.compileDuration.inMilliseconds));
+    final List<OperationResultExtraTiming> extraTimings =
+        <OperationResultExtraTiming>[];
+    extraTimings.add(OperationResultExtraTiming(
+        'compile', updatedDevFS.compileDuration.inMilliseconds));
 
     String reloadMessage = 'Reloaded 0 libraries';
-    final Stopwatch reloadVMTimer = _stopwatchFactory.createStopwatch('reloadSources:vm')..start();
+    final Stopwatch reloadVMTimer =
+        _stopwatchFactory.createStopwatch('reloadSources:vm')..start();
     final Map<String, Object?> firstReloadDetails = <String, Object?>{};
     if (updatedDevFS.invalidatedSourcesCount > 0) {
       final OperationResult result = await _reloadSourcesHelper(
@@ -1037,11 +1087,13 @@ class HotRunner extends ResidentRunner {
       _addBenchmarkData('hotReloadVMReloadMilliseconds', 0);
     }
     reloadVMTimer.stop();
-    extraTimings.add(OperationResultExtraTiming('reload', reloadVMTimer.elapsedMilliseconds));
+    extraTimings.add(OperationResultExtraTiming(
+        'reload', reloadVMTimer.elapsedMilliseconds));
 
     await evictDirtyAssets();
 
-    final Stopwatch reassembleTimer = _stopwatchFactory.createStopwatch('reloadSources:reassemble')..start();
+    final Stopwatch reassembleTimer =
+        _stopwatchFactory.createStopwatch('reloadSources:reassemble')..start();
 
     final ReassembleResult reassembleResult = await _reassembleHelper(
       flutterDevices,
@@ -1055,8 +1107,10 @@ class HotRunner extends ResidentRunner {
     }
     // Record time it took for Flutter to reassemble the application.
     reassembleTimer.stop();
-    _addBenchmarkData('hotReloadFlutterReassembleMilliseconds', reassembleTimer.elapsed.inMilliseconds);
-    extraTimings.add(OperationResultExtraTiming('reassemble', reassembleTimer.elapsedMilliseconds));
+    _addBenchmarkData('hotReloadFlutterReassembleMilliseconds',
+        reassembleTimer.elapsed.inMilliseconds);
+    extraTimings.add(OperationResultExtraTiming(
+        'reassemble', reassembleTimer.elapsedMilliseconds));
 
     reloadTimer.stop();
     final Duration reloadDuration = reloadTimer.elapsed;
@@ -1067,7 +1121,8 @@ class HotRunner extends ResidentRunner {
     // many libraries were affected by the hot reload request.
     // Relation of [invalidatedSourcesCount] to [syncedLibraryCount] should help
     // understand sync/transfer "overhead" of updating this number of source files.
-    HotEvent('reload',
+    HotEvent(
+      'reload',
       targetPlatform: targetPlatform!,
       sdkName: sdkName!,
       emulator: emulator!,
@@ -1075,14 +1130,18 @@ class HotRunner extends ResidentRunner {
       reason: reason,
       overallTimeInMs: reloadInMs,
       finalLibraryCount: firstReloadDetails['finalLibraryCount'] as int? ?? 0,
-      syncedLibraryCount: firstReloadDetails['receivedLibraryCount'] as int? ?? 0,
-      syncedClassesCount: firstReloadDetails['receivedClassesCount'] as int? ?? 0,
-      syncedProceduresCount: firstReloadDetails['receivedProceduresCount'] as int? ?? 0,
+      syncedLibraryCount:
+          firstReloadDetails['receivedLibraryCount'] as int? ?? 0,
+      syncedClassesCount:
+          firstReloadDetails['receivedClassesCount'] as int? ?? 0,
+      syncedProceduresCount:
+          firstReloadDetails['receivedProceduresCount'] as int? ?? 0,
       syncedBytes: updatedDevFS.syncedBytes,
       invalidatedSourcesCount: updatedDevFS.invalidatedSourcesCount,
       transferTimeInMs: updatedDevFS.transferDuration.inMilliseconds,
       compileTimeInMs: updatedDevFS.compileDuration.inMilliseconds,
-      findInvalidatedTimeInMs: updatedDevFS.findInvalidatedDuration.inMilliseconds,
+      findInvalidatedTimeInMs:
+          updatedDevFS.findInvalidatedDuration.inMilliseconds,
       scannedSourcesCount: updatedDevFS.scannedSourcesCount,
       reassembleTimeInMs: reassembleTimer.elapsed.inMilliseconds,
       reloadVMTimeInMs: reloadVMTimer.elapsed.inMilliseconds,
@@ -1096,26 +1155,33 @@ class HotRunner extends ResidentRunner {
       reason: reason,
       overallTimeInMs: reloadInMs,
       finalLibraryCount: firstReloadDetails['finalLibraryCount'] as int? ?? 0,
-      syncedLibraryCount: firstReloadDetails['receivedLibraryCount'] as int? ?? 0,
-      syncedClassesCount: firstReloadDetails['receivedClassesCount'] as int? ?? 0,
-      syncedProceduresCount: firstReloadDetails['receivedProceduresCount'] as int? ?? 0,
+      syncedLibraryCount:
+          firstReloadDetails['receivedLibraryCount'] as int? ?? 0,
+      syncedClassesCount:
+          firstReloadDetails['receivedClassesCount'] as int? ?? 0,
+      syncedProceduresCount:
+          firstReloadDetails['receivedProceduresCount'] as int? ?? 0,
       syncedBytes: updatedDevFS.syncedBytes,
       invalidatedSourcesCount: updatedDevFS.invalidatedSourcesCount,
       transferTimeInMs: updatedDevFS.transferDuration.inMilliseconds,
       compileTimeInMs: updatedDevFS.compileDuration.inMilliseconds,
-      findInvalidatedTimeInMs: updatedDevFS.findInvalidatedDuration.inMilliseconds,
+      findInvalidatedTimeInMs:
+          updatedDevFS.findInvalidatedDuration.inMilliseconds,
       scannedSourcesCount: updatedDevFS.scannedSourcesCount,
       reassembleTimeInMs: reassembleTimer.elapsed.inMilliseconds,
       reloadVMTimeInMs: reloadVMTimer.elapsed.inMilliseconds,
     ));
 
     if (shouldReportReloadTime) {
-      globals.printTrace('Hot reload performed in ${getElapsedAsMilliseconds(reloadDuration)}.');
+      globals.printTrace(
+          'Hot reload performed in ${getElapsedAsMilliseconds(reloadDuration)}.');
       // Record complete time it took for the reload.
       _addBenchmarkData('hotReloadMillisecondsToFrame', reloadInMs);
     }
     // Only report timings if we reloaded a single view without any errors.
-    if ((reassembleResult.reassembleViews.length == 1) && !reassembleResult.failedReassemble && shouldReportReloadTime) {
+    if ((reassembleResult.reassembleViews.length == 1) &&
+        !reassembleResult.failedReassemble &&
+        shouldReportReloadTime) {
       globals.flutterUsage.sendTiming('hot', 'reload', reloadDuration);
       _analytics.send(Event.timing(
         workflow: 'hot',
@@ -1124,14 +1190,13 @@ class HotRunner extends ResidentRunner {
       ));
     }
     return OperationResult(
-      reassembleResult.failedReassemble ? 1 : OperationResult.ok.code,
-      reloadMessage,
-      extraTimings: extraTimings
-    );
+        reassembleResult.failedReassemble ? 1 : OperationResult.ok.code,
+        reloadMessage,
+        extraTimings: extraTimings);
   }
 
   @override
-  void printHelp({ required bool details }) {
+  void printHelp({required bool details}) {
     globals.printStatus('Flutter run key commands.');
     commandHelp.r.print();
     if (supportsRestart) {
@@ -1148,7 +1213,7 @@ class HotRunner extends ResidentRunner {
     }
     commandHelp.c.print();
     commandHelp.q.print();
-    if (debuggingOptions.buildInfo.nullSafetyMode !=  NullSafetyMode.sound) {
+    if (debuggingOptions.buildInfo.nullSafetyMode != NullSafetyMode.sound) {
       globals.printStatus('');
       globals.printStatus(
         'Running without sound null safety ⚠️',
@@ -1175,15 +1240,15 @@ class HotRunner extends ResidentRunner {
 
       // If this is the first time we update the assets, make sure to call the setAssetDirectory
       if (!device.devFS!.hasSetAssetDirectory) {
-        final Uri deviceAssetsDirectoryUri = device.devFS!.baseUri!.resolveUri(globals.fs.path.toUri(getAssetBuildDirectory()));
+        final Uri deviceAssetsDirectoryUri = device.devFS!.baseUri!
+            .resolveUri(globals.fs.path.toUri(getAssetBuildDirectory()));
         await Future.wait<void>(views.map<Future<void>>(
-          (FlutterView view) => device.vmService!.setAssetDirectory(
-            assetsDirectory: deviceAssetsDirectoryUri,
-            uiIsolateId: view.uiIsolate!.id,
-            viewId: view.id,
-            windows: device.targetPlatform == TargetPlatform.windows_x64,
-          )
-        ));
+            (FlutterView view) => device.vmService!.setAssetDirectory(
+                  assetsDirectory: deviceAssetsDirectoryUri,
+                  uiIsolateId: view.uiIsolate!.id,
+                  viewId: view.id,
+                  windows: device.targetPlatform == TargetPlatform.windows_x64,
+                )));
         for (final FlutterView view in views) {
           globals.printTrace('Set asset directory in $view.');
         }
@@ -1197,37 +1262,28 @@ class HotRunner extends ResidentRunner {
 
       if (device.devFS!.didUpdateFontManifest) {
         futures.add(device.vmService!.reloadAssetFonts(
-            isolateId: views.first.uiIsolate!.id!,
-            viewId: views.first.id,
+          isolateId: views.first.uiIsolate!.id!,
+          viewId: views.first.id,
         ));
       }
 
       for (final String assetPath in device.devFS!.assetPathsToEvict) {
-        futures.add(
-          device.vmService!
-            .flutterEvictAsset(
-              assetPath,
-              isolateId: views.first.uiIsolate!.id!,
-            )
-        );
+        futures.add(device.vmService!.flutterEvictAsset(
+          assetPath,
+          isolateId: views.first.uiIsolate!.id!,
+        ));
       }
       for (final String assetPath in device.devFS!.shaderPathsToEvict) {
-        futures.add(
-          device.vmService!
-            .flutterEvictShader(
-              assetPath,
-              isolateId: views.first.uiIsolate!.id!,
-            )
-        );
+        futures.add(device.vmService!.flutterEvictShader(
+          assetPath,
+          isolateId: views.first.uiIsolate!.id!,
+        ));
       }
       for (final String assetPath in device.devFS!.scenePathsToEvict) {
-        futures.add(
-          device.vmService!
-            .flutterEvictScene(
-              assetPath,
-              isolateId: views.first.uiIsolate!.id!,
-            )
-        );
+        futures.add(device.vmService!.flutterEvictScene(
+          assetPath,
+          isolateId: views.first.uiIsolate!.id!,
+        ));
       }
       device.devFS!.assetPathsToEvict.clear();
       device.devFS!.shaderPathsToEvict.clear();
@@ -1293,10 +1349,12 @@ Future<OperationResult> defaultReloadSourcesHelper(
 ) async {
   final Stopwatch vmReloadTimer = Stopwatch()..start();
   const String entryPath = 'main.dart.incremental.dill';
-  final List<Future<DeviceReloadReport?>> allReportsFutures = <Future<DeviceReloadReport?>>[];
+  final List<Future<DeviceReloadReport?>> allReportsFutures =
+      <Future<DeviceReloadReport?>>[];
 
   for (final FlutterDevice? device in flutterDevices) {
-    final List<Future<vm_service.ReloadReport>> reportFutures = await _reloadDeviceSources(
+    final List<Future<vm_service.ReloadReport>> reportFutures =
+        await _reloadDeviceSources(
       device!,
       entryPath,
       pause: pause,
@@ -1318,11 +1376,14 @@ Future<OperationResult> defaultReloadSourcesHelper(
       },
     ));
   }
-  final Iterable<DeviceReloadReport> reports = (await Future.wait(allReportsFutures)).whereType<DeviceReloadReport>();
-  final vm_service.ReloadReport? reloadReport = reports.isEmpty ? null : reports.first.reports[0];
+  final Iterable<DeviceReloadReport> reports =
+      (await Future.wait(allReportsFutures)).whereType<DeviceReloadReport>();
+  final vm_service.ReloadReport? reloadReport =
+      reports.isEmpty ? null : reports.first.reports[0];
   if (reloadReport == null || !HotRunner.validateReloadReport(reloadReport)) {
     // Reload failed.
-    HotEvent('reload-reject',
+    HotEvent(
+      'reload-reject',
       targetPlatform: targetPlatform!,
       sdkName: sdkName!,
       emulator: emulator!,
@@ -1344,21 +1405,27 @@ Future<OperationResult> defaultReloadSourcesHelper(
     if (reloadReport == null) {
       return OperationResult(1, 'No Dart isolates found');
     }
-    final ReloadReportContents contents = ReloadReportContents.fromReloadReport(reloadReport);
-    return OperationResult(1, 'Reload rejected: ${contents.notices.join("\n")}');
+    final ReloadReportContents contents =
+        ReloadReportContents.fromReloadReport(reloadReport);
+    return OperationResult(
+        1, 'Reload rejected: ${contents.notices.join("\n")}');
   }
   // Collect stats only from the first device. If/when run -d all is
   // refactored, we'll probably need to send one hot reload/restart event
   // per device to analytics.
   firstReloadDetails.addAll(castStringKeyedMap(reloadReport.json!['details'])!);
-  final Map<String, dynamic> details = reloadReport.json!['details'] as Map<String, dynamic>;
+  final Map<String, dynamic> details =
+      reloadReport.json!['details'] as Map<String, dynamic>;
   final int? loadedLibraryCount = details['loadedLibraryCount'] as int?;
   final int? finalLibraryCount = details['finalLibraryCount'] as int?;
-  globals.printTrace('reloaded $loadedLibraryCount of $finalLibraryCount libraries');
+  globals.printTrace(
+      'reloaded $loadedLibraryCount of $finalLibraryCount libraries');
   // reloadMessage = 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries';
   // Record time it took for the VM to reload the sources.
-  hotRunner._addBenchmarkData('hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
-  return OperationResult(0, 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries');
+  hotRunner._addBenchmarkData(
+      'hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
+  return OperationResult(
+      0, 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries');
 }
 
 Future<List<Future<vm_service.ReloadReport>>> _reloadDeviceSources(
@@ -1366,8 +1433,8 @@ Future<List<Future<vm_service.ReloadReport>>> _reloadDeviceSources(
   String entryPath, {
   bool? pause = false,
 }) async {
-  final String deviceEntryUri = device.devFS!.baseUri!
-    .resolve(entryPath).toString();
+  final String deviceEntryUri =
+      device.devFS!.baseUri!.resolve(entryPath).toString();
   final vm_service.VM vm = await device.vmService!.service.getVM();
   return <Future<vm_service.ReloadReport>>[
     for (final vm_service.IsolateRef isolateRef in vm.isolates!)
@@ -1387,7 +1454,8 @@ void _resetDevFSCompileTime(List<FlutterDevice?> flutterDevices) {
 
 @visibleForTesting
 class ReassembleResult {
-  ReassembleResult(this.reassembleViews, this.failedReassemble, this.shouldReportReloadTime);
+  ReassembleResult(
+      this.reassembleViews, this.failedReassemble, this.shouldReportReloadTime);
   final Map<FlutterView?, FlutterVmService?> reassembleViews;
   final bool failedReassemble;
   final bool shouldReportReloadTime;
@@ -1407,7 +1475,8 @@ Future<ReassembleResult> _defaultReassembleHelper(
   String reloadMessage,
 ) async {
   // Check if any isolates are paused and reassemble those that aren't.
-  final Map<FlutterView, FlutterVmService?> reassembleViews = <FlutterView, FlutterVmService?>{};
+  final Map<FlutterView, FlutterVmService?> reassembleViews =
+      <FlutterView, FlutterVmService?>{};
   final List<Future<void>> reassembleFutures = <Future<void>>[];
   String? serviceEventKind;
   int pausedIsolatesFound = 0;
@@ -1419,10 +1488,10 @@ Future<ReassembleResult> _defaultReassembleHelper(
       // Check if the isolate is paused, and if so, don't reassemble. Ignore the
       // PostPauseEvent event - the client requesting the pause will resume the app.
       final vm_service.Event? pauseEvent = await device!.vmService!
-        .getIsolatePauseEventOrNull(view.uiIsolate!.id!);
-      if (pauseEvent != null
-        && isPauseEvent(pauseEvent.kind!)
-        && pauseEvent.kind != vm_service.EventKind.kPausePostRequest) {
+          .getIsolatePauseEventOrNull(view.uiIsolate!.id!);
+      if (pauseEvent != null &&
+          isPauseEvent(pauseEvent.kind!) &&
+          pauseEvent.kind != vm_service.EventKind.kPausePostRequest) {
         pausedIsolatesFound += 1;
         if (serviceEventKind == null) {
           serviceEventKind = pauseEvent.kind;
@@ -1443,7 +1512,8 @@ Future<ReassembleResult> _defaultReassembleHelper(
               return Future<Object?>.error(error, stackTrace);
             }
             failedReassemble = true;
-            globals.printError('Reassembling ${view.uiIsolate!.name} failed: $error\n$stackTrace');
+            globals.printError(
+                'Reassembling ${view.uiIsolate!.name} failed: $error\n$stackTrace');
           },
         ));
       }
@@ -1451,32 +1521,37 @@ Future<ReassembleResult> _defaultReassembleHelper(
   }
   if (pausedIsolatesFound > 0) {
     if (onSlow != null) {
-      onSlow('${_describePausedIsolates(pausedIsolatesFound, serviceEventKind!)}; interface might not update.');
+      onSlow(
+          '${_describePausedIsolates(pausedIsolatesFound, serviceEventKind!)}; interface might not update.');
     }
     if (reassembleViews.isEmpty) {
-      globals.printTrace('Skipping reassemble because all isolates are paused.');
-      return ReassembleResult(reassembleViews, failedReassemble, shouldReportReloadTime);
+      globals
+          .printTrace('Skipping reassemble because all isolates are paused.');
+      return ReassembleResult(
+          reassembleViews, failedReassemble, shouldReportReloadTime);
     }
   }
   assert(reassembleViews.isNotEmpty);
 
   globals.printTrace('Reassembling application');
 
-  final Future<void> reassembleFuture = Future.wait<void>(reassembleFutures).then((void _) => null);
+  final Future<void> reassembleFuture =
+      Future.wait<void>(reassembleFutures).then((void _) => null);
   await reassembleFuture.timeout(
     const Duration(seconds: 2),
     onTimeout: () async {
       if (pausedIsolatesFound > 0) {
         shouldReportReloadTime = false;
-        return ; // probably no point waiting, they're probably deadlocked and we've already warned.
+        return; // probably no point waiting, they're probably deadlocked and we've already warned.
       }
       // Check if any isolate is newly paused.
-      globals.printTrace('This is taking a long time; will now check for paused isolates.');
+      globals.printTrace(
+          'This is taking a long time; will now check for paused isolates.');
       int postReloadPausedIsolatesFound = 0;
       String? serviceEventKind;
       for (final FlutterView view in reassembleViews.keys) {
         final vm_service.Event? pauseEvent = await reassembleViews[view]!
-          .getIsolatePauseEventOrNull(view.uiIsolate!.id!);
+            .getIsolatePauseEventOrNull(view.uiIsolate!.id!);
         if (pauseEvent != null && isPauseEvent(pauseEvent.kind!)) {
           postReloadPausedIsolatesFound += 1;
           if (serviceEventKind == null) {
@@ -1486,22 +1561,26 @@ Future<ReassembleResult> _defaultReassembleHelper(
           }
         }
       }
-      globals.printTrace('Found $postReloadPausedIsolatesFound newly paused isolate(s).');
+      globals.printTrace(
+          'Found $postReloadPausedIsolatesFound newly paused isolate(s).');
       if (postReloadPausedIsolatesFound == 0) {
         await reassembleFuture; // must just be taking a long time... keep waiting!
         return;
       }
       shouldReportReloadTime = false;
       if (onSlow != null) {
-        onSlow('${_describePausedIsolates(postReloadPausedIsolatesFound, serviceEventKind!)}.');
+        onSlow(
+            '${_describePausedIsolates(postReloadPausedIsolatesFound, serviceEventKind!)}.');
       }
       return;
     },
   );
-  return ReassembleResult(reassembleViews, failedReassemble, shouldReportReloadTime);
+  return ReassembleResult(
+      reassembleViews, failedReassemble, shouldReportReloadTime);
 }
 
-String _describePausedIsolates(int pausedIsolatesFound, String serviceEventKind) {
+String _describePausedIsolates(
+    int pausedIsolatesFound, String serviceEventKind) {
   assert(pausedIsolatesFound > 0);
   final StringBuffer message = StringBuffer();
   bool plural;
@@ -1513,14 +1592,18 @@ String _describePausedIsolates(int pausedIsolatesFound, String serviceEventKind)
     plural = true;
   }
   message.write(switch (serviceEventKind) {
-    vm_service.EventKind.kPauseStart       => 'paused (probably due to --start-paused)',
-    vm_service.EventKind.kPauseExit        => 'paused because ${ plural ? 'they have' : 'it has' } terminated',
-    vm_service.EventKind.kPauseBreakpoint  => 'paused in the debugger on a breakpoint',
+    vm_service.EventKind.kPauseStart =>
+      'paused (probably due to --start-paused)',
+    vm_service.EventKind.kPauseExit =>
+      'paused because ${plural ? 'they have' : 'it has'} terminated',
+    vm_service.EventKind.kPauseBreakpoint =>
+      'paused in the debugger on a breakpoint',
     vm_service.EventKind.kPauseInterrupted => 'paused due in the debugger',
-    vm_service.EventKind.kPauseException   => 'paused in the debugger after an exception was thrown',
+    vm_service.EventKind.kPauseException =>
+      'paused in the debugger after an exception was thrown',
     vm_service.EventKind.kPausePostRequest => 'paused',
     '' => 'paused for various reasons',
-    _  => 'paused',
+    _ => 'paused',
   });
   return message.toString();
 }
@@ -1543,9 +1626,9 @@ class ProjectFileInvalidator {
     required FileSystem fileSystem,
     required Platform platform,
     required Logger logger,
-  }): _fileSystem = fileSystem,
-      _platform = platform,
-      _logger = logger;
+  })  : _fileSystem = fileSystem,
+        _platform = platform,
+        _logger = logger;
 
   final FileSystem _fileSystem;
   final Platform _platform;
@@ -1569,7 +1652,6 @@ class ProjectFileInvalidator {
     required PackageConfig packageConfig,
     bool asyncScanning = false,
   }) async {
-
     if (lastCompiled == null) {
       // Initial load.
       assert(urisToMonitor.isEmpty);
@@ -1591,18 +1673,18 @@ class ProjectFileInvalidator {
       final List<Future<void>> waitList = <Future<void>>[];
       for (final Uri uri in urisToScan) {
         waitList.add(pool.withResource<void>(
-          // Calling fs.stat() is more performant than fs.file().stat(), but
-          // uri.toFilePath() does not work with MultiRootFileSystem.
-          () => (uri.hasScheme && uri.scheme != 'file'
-            ? _fileSystem.file(uri).stat()
-            :  _fileSystem.stat(uri.toFilePath(windows: _platform.isWindows)))
-            .then((FileStat stat) {
-              final DateTime updatedAt = stat.modified;
-              if (updatedAt.isAfter(lastCompiled)) {
-                invalidatedFiles.add(uri);
-              }
-            })
-        ));
+            // Calling fs.stat() is more performant than fs.file().stat(), but
+            // uri.toFilePath() does not work with MultiRootFileSystem.
+            () => (uri.hasScheme && uri.scheme != 'file'
+                        ? _fileSystem.file(uri).stat()
+                        : _fileSystem
+                            .stat(uri.toFilePath(windows: _platform.isWindows)))
+                    .then((FileStat stat) {
+                  final DateTime updatedAt = stat.modified;
+                  if (updatedAt.isAfter(lastCompiled)) {
+                    invalidatedFiles.add(uri);
+                  }
+                })));
       }
       await Future.wait<void>(waitList);
     } else {
@@ -1610,8 +1692,10 @@ class ProjectFileInvalidator {
         // Calling fs.statSync() is more performant than fs.file().statSync(), but
         // uri.toFilePath() does not work with MultiRootFileSystem.
         final DateTime updatedAt = uri.hasScheme && uri.scheme != 'file'
-          ? _fileSystem.file(uri).statSync().modified
-          : _fileSystem.statSync(uri.toFilePath(windows: _platform.isWindows)).modified;
+            ? _fileSystem.file(uri).statSync().modified
+            : _fileSystem
+                .statSync(uri.toFilePath(windows: _platform.isWindows))
+                .modified;
         if (updatedAt.isAfter(lastCompiled)) {
           invalidatedFiles.add(uri);
         }
@@ -1638,14 +1722,15 @@ class ProjectFileInvalidator {
   }
 
   bool _isNotInPubCache(Uri uri) {
-    return !(_platform.isWindows && uri.path.contains(_pubCachePathWindows))
-        && !uri.path.contains(_pubCachePathLinuxAndMac);
+    return !(_platform.isWindows && uri.path.contains(_pubCachePathWindows)) &&
+        !uri.path.contains(_pubCachePathLinuxAndMac);
   }
 }
 
 /// Additional serialization logic for a hot reload response.
 class ReloadReportContents {
-  factory ReloadReportContents.fromReloadReport(vm_service.ReloadReport report) {
+  factory ReloadReportContents.fromReloadReport(
+      vm_service.ReloadReport report) {
     final List<ReasonForCancelling> reasons = <ReasonForCancelling>[];
     final Object? notices = report.json!['notices'];
     if (notices is! List<dynamic>) {
@@ -1658,8 +1743,8 @@ class ReloadReportContents {
       final Map<String, dynamic> notice = obj;
       reasons.add(ReasonForCancelling(
         message: notice['message'] is String
-          ? notice['message'] as String?
-          : 'Unknown Error',
+            ? notice['message'] as String?
+            : 'Unknown Error',
       ));
     }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1770,6 +1770,7 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
         projectDir: project.directory,
         packageConfigPath: packageConfigPath(),
         generateDartPluginRegistry: true,
+        useImplicitPubspecResolution: globalResults!.flag(FlutterGlobalOptions.kImplicitPubspecResolution),
       );
 
       await pub.get(

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -51,6 +51,7 @@ class FlutterTesterDevice extends Device {
     required super.logger,
     required FileSystem fileSystem,
     required Artifacts artifacts,
+    required bool useImplicitPubspecResolution,
     TestCompilerNativeAssetsBuilder? nativeAssetsBuilder,
   }) : _processManager = processManager,
        _flutterVersion = flutterVersion,
@@ -58,6 +59,7 @@ class FlutterTesterDevice extends Device {
        _fileSystem = fileSystem,
       _artifacts = artifacts,
       _nativeAssetsBuilder = nativeAssetsBuilder,
+      _useImplicitPubspecResolution = useImplicitPubspecResolution,
        super(
         platformType: null,
         category: null,
@@ -70,6 +72,7 @@ class FlutterTesterDevice extends Device {
   final FileSystem _fileSystem;
   final Artifacts _artifacts;
   final TestCompilerNativeAssetsBuilder? _nativeAssetsBuilder;
+  final bool _useImplicitPubspecResolution;
 
   Process? _process;
   final DevicePortForwarder _portForwarder = const NoOpDevicePortForwarder();
@@ -164,6 +167,7 @@ class FlutterTesterDevice extends Device {
       applicationKernelFilePath: applicationKernelFilePath,
       platform: TargetPlatform.tester,
       assetDirPath: assetDirectory.path,
+      useImplicitPubspecResolution: _useImplicitPubspecResolution,
     );
 
     final List<String> command = <String>[
@@ -265,6 +269,7 @@ class FlutterTesterDevices extends PollingDeviceDiscovery {
     required ProcessManager processManager,
     required Logger logger,
     required FlutterVersion flutterVersion,
+    required bool useImplicitPubspecResolution,
     TestCompilerNativeAssetsBuilder? nativeAssetsBuilder,
   }) : _testerDevice = FlutterTesterDevice(
         kTesterDeviceId,
@@ -274,6 +279,7 @@ class FlutterTesterDevices extends PollingDeviceDiscovery {
         logger: logger,
         flutterVersion: flutterVersion,
         nativeAssetsBuilder: nativeAssetsBuilder,
+        useImplicitPubspecResolution: useImplicitPubspecResolution,
       ),
        super('Flutter tester');
 

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -46,13 +46,15 @@ class WebBuilder {
     required Analytics analytics,
     required FlutterVersion flutterVersion,
     required FileSystem fileSystem,
+    required bool useImplicitPubspecResolution,
   })  : _logger = logger,
         _processManager = processManager,
         _buildSystem = buildSystem,
         _flutterUsage = usage,
         _analytics = analytics,
         _flutterVersion = flutterVersion,
-        _fileSystem = fileSystem;
+        _fileSystem = fileSystem,
+        _useImplicitPubspecResolution = useImplicitPubspecResolution;
 
   final Logger _logger;
   final ProcessManager _processManager;
@@ -61,6 +63,7 @@ class WebBuilder {
   final Analytics _analytics;
   final FlutterVersion _flutterVersion;
   final FileSystem _fileSystem;
+  final bool _useImplicitPubspecResolution;
 
   Future<void> buildWeb(
     FlutterProject flutterProject,
@@ -116,6 +119,7 @@ class WebBuilder {
             // Web uses a different Dart plugin registry.
             // https://github.com/flutter/flutter/issues/80406
             generateDartPluginRegistry: false,
+            useImplicitPubspecResolution: _useImplicitPubspecResolution,
           ));
       if (!result.success) {
         for (final ExceptionMeasurement measurement in result.exceptions.values) {

--- a/packages/flutter_tools/lib/src/web/web_runner.dart
+++ b/packages/flutter_tools/lib/src/web/web_runner.dart
@@ -33,6 +33,7 @@ abstract class WebRunnerFactory {
     required SystemClock systemClock,
     required Usage usage,
     required Analytics analytics,
+    required bool useImplicitPubspecResolution,
     bool machine = false,
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -1260,6 +1260,7 @@ class FakeHotRunnerFactory extends Fake implements HotRunnerFactory {
     Analytics? analytics,
     String? nativeAssetsYamlFile,
     HotRunnerNativeAssetsBuilder? nativeAssetsBuilder,
+    required bool useImplicitPubspecResolution,
   }) {
     if (_artifactTester != null) {
       for (final FlutterDevice device in devices) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -99,6 +99,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'daemon.version'}));
       final DaemonMessage response = await daemonStreams.outputs.stream.firstWhere(_notEvent);
@@ -111,6 +112,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       // Use the flutter_gallery project which has a known set of supported platforms.
       final String projectPath = globals.fs.path.join(getFlutterRoot(), 'dev', 'integration_tests', 'flutter_gallery');
@@ -215,6 +217,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       globals.printError('daemon.logMessage test');
       final DaemonMessage response = await daemonStreams.outputs.stream.firstWhere((DaemonMessage message) {
@@ -233,6 +236,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       globals.printWarning('daemon.logMessage test');
       final DaemonMessage response = await daemonStreams.outputs.stream.firstWhere((DaemonMessage message) {
@@ -253,6 +257,7 @@ void main() {
           daemonConnection,
           notifyingLogger: notifyingLogger,
           logToStdout: true,
+          useImplicitPubspecResolution: true,
         );
         globals.printStatus('daemon.logMessage test');
         return Future<void>.value();
@@ -269,6 +274,7 @@ void main() {
           daemonConnection,
           notifyingLogger: notifyingLogger,
           logToStdout: true,
+          useImplicitPubspecResolution: true,
         );
         globals.printBox('This is the box message', title: 'Sample title');
         return Future<void>.value();
@@ -283,6 +289,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       notifyingLogger.notifyVerbose = false;
       globals.printTrace('daemon.logMessage test 1');
@@ -304,6 +311,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       expect(notifyingLogger.notifyVerbose, false);
 
@@ -322,6 +330,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       notifyingLogger.notifyVerbose = false;
 
@@ -340,6 +349,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'daemon.shutdown'}));
       return daemon.onExit.then<void>((int code) async {
@@ -352,6 +362,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
 
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'app.restart'}));
@@ -364,6 +375,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
 
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{
@@ -382,6 +394,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
 
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'app.stop'}));
@@ -394,6 +407,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'device.getDevices'}));
       final DaemonMessage response = await daemonStreams.outputs.stream.firstWhere(_notEvent);
@@ -405,6 +419,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
@@ -421,6 +436,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
 
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
@@ -434,6 +450,7 @@ void main() {
         previewBinary: fs.file(r'preview_device.exe'),
         artifacts: Artifacts.test(fileSystem: fs),
         builderFactory: () => throw UnimplementedError('TODO implement builder factory'),
+        useImplicitPubspecResolution: true,
       ));
 
       final List<Map<String, Object?>> names = <Map<String, Object?>>[];
@@ -504,6 +521,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'device.discoverDevices'}));
       final DaemonMessage response = await daemonStreams.outputs.stream.firstWhere(_notEvent);
@@ -515,6 +533,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
@@ -532,6 +551,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
@@ -556,6 +576,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
@@ -607,6 +628,7 @@ void main() {
         daemon = Daemon(
           daemonConnection,
           notifyingLogger: notifyingLogger,
+          useImplicitPubspecResolution: true,
         );
         final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
         daemon.deviceDomain.addDeviceDiscoverer(discoverer);
@@ -673,6 +695,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
@@ -732,6 +755,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       final FakePollingDeviceDiscovery discoverer1 = FakePollingDeviceDiscovery();
       discoverer1.diagnostics = <String>['fake diagnostic 1', 'fake diagnostic 2'];
@@ -757,6 +781,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
 
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'emulator.launch'}));
@@ -769,6 +794,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       final Map<String, Object?> params = <String, Object?>{'emulatorId': 'device', 'coldBoot': 1};
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'emulator.launch', 'params': params}));
@@ -781,6 +807,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'emulator.getEmulators'}));
       final DaemonMessage response = await daemonStreams.outputs.stream.firstWhere(_notEvent);
@@ -795,6 +822,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
 
       // Respond to any requests from the daemon to expose a URL.
@@ -814,6 +842,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
 
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'devtools.serve'}));
@@ -830,6 +859,7 @@ void main() {
       daemon = Daemon(
         daemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
 
       daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'devtools.serve'}));
@@ -860,6 +890,7 @@ void main() {
         daemon = Daemon(
           daemonConnection,
           notifyingLogger: notifyingLogger,
+          useImplicitPubspecResolution: true,
         );
         daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'proxy.connect', 'params': <String, Object?>{'port': 123}}));
 
@@ -920,6 +951,7 @@ void main() {
         daemon = Daemon(
           daemonConnection,
           notifyingLogger: notifyingLogger,
+          useImplicitPubspecResolution: true,
         );
         daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'proxy.connect', 'params': <String, Object?>{'port': 123}}));
 
@@ -940,6 +972,7 @@ void main() {
         daemon = Daemon(
           daemonConnection,
           notifyingLogger: notifyingLogger,
+          useImplicitPubspecResolution: true,
         );
         daemonStreams.inputs.add(DaemonMessage(<String, Object?>{'id': 0, 'method': 'proxy.connect', 'params': <String, Object?>{'port': 123}}));
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
@@ -64,7 +64,7 @@ void main() {
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('not using synthetic packages', () async {
+  testUsingContext('not using synthetic packages (explicitly)', () async {
     final Directory l10nDirectory = fileSystem.directory(
       fileSystem.path.join('lib', 'l10n'),
     );
@@ -99,6 +99,46 @@ flutter:
     expect(l10nDirectory.existsSync(), true);
     expect(l10nDirectory.childFile('app_localizations_en.dart').existsSync(), true);
     expect(l10nDirectory.childFile('app_localizations.dart').existsSync(), true);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('not using synthetic packages (due to --no-implicit-pubspec-resolution)', () async {
+    final Directory l10nDirectory = fileSystem.directory(
+      fileSystem.path.join('lib', 'l10n'),
+    );
+    final File arbFile = l10nDirectory.childFile(
+      'app_en.arb',
+    )..createSync(recursive: true);
+
+    arbFile.writeAsStringSync('''
+{
+  "helloWorld": "Hello, World!",
+  "@helloWorld": {
+    "description": "Sample description"
+  }
+}''');
+    fileSystem.file('pubspec.yaml').writeAsStringSync('''
+flutter:
+  generate: true''');
+
+    final GenerateLocalizationsCommand command = GenerateLocalizationsCommand(
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: processManager,
+    );
+    await createTestCommandRunner(command).run(<String>[
+      '--no-implicit-pubspec-resolution',
+      'gen-l10n',
+    ]);
+
+    expect(l10nDirectory.existsSync(), true);
+    expect(l10nDirectory.childFile('app_localizations_en.dart').existsSync(),
+        true);
+    expect(
+        l10nDirectory.childFile('app_localizations.dart').existsSync(), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/commands.shard/hermetic/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/proxied_devices_test.dart
@@ -71,6 +71,7 @@ void main() {
       daemon = Daemon(
         serverDaemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       fakeDevice = FakeAndroidDevice();
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
@@ -92,6 +93,7 @@ void main() {
       daemon = Daemon(
         serverDaemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       fakeDevice = FakeAndroidDevice();
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
@@ -114,6 +116,7 @@ void main() {
       daemon = Daemon(
         serverDaemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       fakeDevice = FakeAndroidDevice();
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
@@ -144,6 +147,7 @@ void main() {
       daemon = Daemon(
         serverDaemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       fakeDevice = FakeAndroidDevice();
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
@@ -197,6 +201,7 @@ void main() {
       daemon = Daemon(
         serverDaemonConnection,
         notifyingLogger: notifyingLogger,
+        useImplicitPubspecResolution: true,
       );
       fakeDevice = FakeAndroidDevice();
       final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1584,14 +1584,14 @@ class DaemonCapturingRunCommand extends RunCommand {
   @override
   Daemon createMachineDaemon() {
     daemon = super.createMachineDaemon();
-    appDomain = daemon.appDomain = CapturingAppDomain(daemon);
+    appDomain = daemon.appDomain = CapturingAppDomain(daemon, useImplicitPubspecResolution: true);
     daemon.registerDomain(appDomain);
     return daemon;
   }
 }
 
 class CapturingAppDomain extends AppDomain {
-  CapturingAppDomain(super.daemon);
+  CapturingAppDomain(super.daemon, {required super.useImplicitPubspecResolution});
 
   String? userIdentifier;
   bool? enableDevTools;

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -544,5 +544,6 @@ class FakeBundleBuilder extends Fake implements BundleBuilder {
     String? assetDirPath,
     bool buildNativeAssets = true,
     @visibleForTesting BuildSystem? buildSystem,
+    required bool useImplicitPubspecResolution,
   }) async {}
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
@@ -53,6 +53,7 @@ nullable-getter: false
       file: configFile,
       logger: BufferLogger.test(),
       defaultArbDir: fileSystem.path.join('lib', 'l10n'),
+      defaultSyntheticPackage: true,
     );
 
     expect(options.arbDir, Uri.parse('arb').path);
@@ -79,6 +80,7 @@ preferred-supported-locales: ['en_US', 'de']
       file: configFile,
       logger: BufferLogger.test(),
       defaultArbDir: fileSystem.path.join('lib', 'l10n'),
+      defaultSyntheticPackage: true,
     );
 
     expect(options.preferredSupportedLocales, <String>['en_US', 'de']);
@@ -97,6 +99,7 @@ use-deferred-loading: string
         file: configFile,
         logger: BufferLogger.test(),
         defaultArbDir: fileSystem.path.join('lib', 'l10n'),
+        defaultSyntheticPackage: true,
       ),
       throwsException,
     );
@@ -113,6 +116,7 @@ template-arb-file: {name}_en.arb
         file: configFile,
         logger: BufferLogger.test(),
         defaultArbDir: fileSystem.path.join('lib', 'l10n'),
+        defaultSyntheticPackage: true,
       ),
       throwsToolExit(),
     );

--- a/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
@@ -70,6 +70,65 @@ nullable-getter: false
     expect(options.nullableGetter, false);
   });
 
+  testWithoutContext(
+      'parseLocalizationsOptions uses defaultSyntheticPackage = true', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File configFile = fileSystem.file('l10n.yaml')..writeAsStringSync('''
+arb-dir: arb
+template-arb-file: example.arb
+output-localization-file: bar
+untranslated-messages-file: untranslated
+output-class: Foo
+header-file: header
+header: HEADER
+use-deferred-loading: true
+preferred-supported-locales: en_US
+# Intentionally omitted
+# synthetic-package: ...
+required-resource-attributes: false
+nullable-getter: false
+''');
+
+    final LocalizationOptions options = parseLocalizationsOptionsFromYAML(
+      file: configFile,
+      logger: BufferLogger.test(),
+      defaultArbDir: fileSystem.path.join('lib', 'l10n'),
+      defaultSyntheticPackage: true,
+    );
+
+    expect(options.syntheticPackage, true);
+  });
+
+  testWithoutContext(
+      'parseLocalizationsOptions uses defaultSyntheticPackage = false',
+      () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File configFile = fileSystem.file('l10n.yaml')..writeAsStringSync('''
+arb-dir: arb
+template-arb-file: example.arb
+output-localization-file: bar
+untranslated-messages-file: untranslated
+output-class: Foo
+header-file: header
+header: HEADER
+use-deferred-loading: true
+preferred-supported-locales: en_US
+# Intentionally omitted
+# synthetic-package: ...
+required-resource-attributes: false
+nullable-getter: false
+''');
+
+    final LocalizationOptions options = parseLocalizationsOptionsFromYAML(
+      file: configFile,
+      logger: BufferLogger.test(),
+      defaultArbDir: fileSystem.path.join('lib', 'l10n'),
+      defaultSyntheticPackage: false,
+    );
+
+    expect(options.syntheticPackage, false);
+  });
+
   testWithoutContext('parseLocalizationsOptions handles preferredSupportedLocales as list', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final File configFile = fileSystem.file('l10n.yaml')..writeAsStringSync('''

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -47,7 +47,8 @@ void main() {
       mainPath: globals.fs.path.join('lib', 'main.dart'),
       assetDirPath: 'example',
       depfilePath: 'example.d',
-      buildSystem: buildSystem
+      buildSystem: buildSystem,
+      useImplicitPubspecResolution: true,
     );
     expect(globals.fs.file(globals.fs.path.join('example', 'kernel_blob.bin')).existsSync(), true);
     expect(globals.fs.file(globals.fs.path.join('example', 'LICENSE')).existsSync(), true);
@@ -136,7 +137,8 @@ void main() {
         mainPath: 'lib/main.dart',
         assetDirPath: 'example',
         depfilePath: 'example.d',
-        buildSystem: TestBuildSystem.all(BuildResult(success: false))
+        buildSystem: TestBuildSystem.all(BuildResult(success: false)),
+        useImplicitPubspecResolution: true,
       ),
       throwsToolExit()
     );
@@ -181,7 +183,8 @@ void main() {
       mainPath: mainPath,
       assetDirPath: assetDirPath,
       depfilePath: depfilePath,
-      buildSystem: buildSystem
+      buildSystem: buildSystem,
+      useImplicitPubspecResolution: true,
     );
 
     expect(env, isNotNull);

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -23,9 +23,8 @@ import '../src/common.dart';
 import '../src/context.dart';
 
 void main() {
-  testUsingContext(
-      'Exits with code 2 when HttpException is thrown '
-      'during VM service connection', () async {
+  testUsingContext('Exits with code 2 when HttpException is thrown '
+    'during VM service connection', () async {
     final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
     final FakeDevice device = FakeDevice()
       ..supportsHotReload = true
@@ -35,14 +34,12 @@ void main() {
       TestFlutterDevice(
         device: device,
         generator: residentCompiler,
-        exception: const HttpException(
-            'Connection closed before full header was received, '
+        exception: const HttpException('Connection closed before full header was received, '
             'uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
       ),
     ];
 
-    final int exitCode = await ColdRunner(
-      devices,
+    final int exitCode = await ColdRunner(devices,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       target: 'main.dart',
       useImplicitPubspecResolution: true,
@@ -57,13 +54,9 @@ void main() {
       final FakeFlutterDevice flutterDevice1 = FakeFlutterDevice(device1);
       final FakeFlutterDevice flutterDevice2 = FakeFlutterDevice(device2);
 
-      final List<FlutterDevice> devices = <FlutterDevice>[
-        flutterDevice1,
-        flutterDevice2
-      ];
+      final List<FlutterDevice> devices = <FlutterDevice>[flutterDevice1, flutterDevice2];
 
-      await ColdRunner(
-        devices,
+      await ColdRunner(devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
         target: 'main.dart',
         useImplicitPubspecResolution: true,
@@ -117,12 +110,7 @@ void main() {
       ).run();
 
       expect(result, 0);
-      expect(
-          memoryFileSystem
-              .directory(getBuildDirectory())
-              .childFile('start_up_info.json')
-              .existsSync(),
-          true);
+      expect(memoryFileSystem.directory(getBuildDirectory()).childFile('start_up_info.json').existsSync(), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -130,8 +118,7 @@ void main() {
     });
 
     testUsingContext('with traceStartup, env variable', () async {
-      fakePlatform.environment[kFlutterTestOutputsDirEnvName] =
-          'test_output_dir';
+      fakePlatform.environment[kFlutterTestOutputsDirEnvName] = 'test_output_dir';
 
       final FakeDevice device = FakeDevice();
       final FakeFlutterDevice flutterDevice = FakeFlutterDevice(device);
@@ -147,12 +134,7 @@ void main() {
       ).run();
 
       expect(result, 0);
-      expect(
-          memoryFileSystem
-              .directory('test_output_dir')
-              .childFile('start_up_info.json')
-              .existsSync(),
-          true);
+      expect(memoryFileSystem.directory('test_output_dir').childFile('start_up_info.json').existsSync(), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -188,7 +170,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   }
 
   @override
-  Future<void> tryInitLogReader() async {}
+  Future<void> tryInitLogReader() async { }
 }
 
 class FakeDevice extends Fake implements Device {
@@ -223,10 +205,7 @@ class TestFlutterDevice extends FlutterDevice {
     required Device device,
     required this.exception,
     required ResidentCompiler generator,
-  }) : super(device,
-            buildInfo: BuildInfo.debug,
-            generator: generator,
-            developmentShaderCompiler: const FakeShaderCompiler());
+  })  : super(device, buildInfo: BuildInfo.debug, generator: generator, developmentShaderCompiler: const FakeShaderCompiler());
 
   /// The exception to throw when the connect method is called.
   final Exception exception;
@@ -247,23 +226,19 @@ class TestFlutterDevice extends FlutterDevice {
   }
 }
 
-class FakeResidentCompiler extends Fake implements ResidentCompiler {}
+class FakeResidentCompiler extends Fake implements ResidentCompiler { }
 
 class FakeFlutterVmService extends Fake implements FlutterVmService {
   @override
   VmService get service => FakeVmService();
 
   @override
-  Future<List<FlutterView>> getFlutterViews(
-      {bool returnEarly = false,
-      Duration delay = const Duration(milliseconds: 50)}) async {
+  Future<List<FlutterView>> getFlutterViews({bool returnEarly = false, Duration delay = const Duration(milliseconds: 50)}) async {
     return <FlutterView>[];
   }
 
   @override
-  Future<bool> flutterAlreadyPaintedFirstUsefulFrame(
-          {String? isolateId}) async =>
-      true;
+  Future<bool> flutterAlreadyPaintedFirstUsefulFrame({String? isolateId}) async => true;
 
   @override
   Future<Response?> getTimeline() async {
@@ -296,8 +271,7 @@ class FakeVmService extends Fake implements VmService {
   @override
   Stream<Event> get onExtensionEvent {
     return Stream<Event>.fromIterable(<Event>[
-      Event(
-          kind: 'Extension', extensionKind: 'Flutter.FirstFrame', timestamp: 1),
+      Event(kind: 'Extension', extensionKind: 'Flutter.FirstFrame', timestamp: 1),
     ]);
   }
 }
@@ -306,7 +280,7 @@ class FakeShaderCompiler implements DevelopmentShaderCompiler {
   const FakeShaderCompiler();
 
   @override
-  void configureCompiler(TargetPlatform? platform) {}
+  void configureCompiler(TargetPlatform? platform) { }
 
   @override
   Future<DevFSContent> recompileShader(DevFSContent inputShader) {

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -23,8 +23,9 @@ import '../src/common.dart';
 import '../src/context.dart';
 
 void main() {
-  testUsingContext('Exits with code 2 when HttpException is thrown '
-    'during VM service connection', () async {
+  testUsingContext(
+      'Exits with code 2 when HttpException is thrown '
+      'during VM service connection', () async {
     final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
     final FakeDevice device = FakeDevice()
       ..supportsHotReload = true
@@ -34,14 +35,17 @@ void main() {
       TestFlutterDevice(
         device: device,
         generator: residentCompiler,
-        exception: const HttpException('Connection closed before full header was received, '
+        exception: const HttpException(
+            'Connection closed before full header was received, '
             'uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
       ),
     ];
 
-    final int exitCode = await ColdRunner(devices,
+    final int exitCode = await ColdRunner(
+      devices,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       target: 'main.dart',
+      useImplicitPubspecResolution: true,
     ).attach();
     expect(exitCode, 2);
   });
@@ -53,11 +57,16 @@ void main() {
       final FakeFlutterDevice flutterDevice1 = FakeFlutterDevice(device1);
       final FakeFlutterDevice flutterDevice2 = FakeFlutterDevice(device2);
 
-      final List<FlutterDevice> devices = <FlutterDevice>[flutterDevice1, flutterDevice2];
+      final List<FlutterDevice> devices = <FlutterDevice>[
+        flutterDevice1,
+        flutterDevice2
+      ];
 
-      await ColdRunner(devices,
+      await ColdRunner(
+        devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
         target: 'main.dart',
+        useImplicitPubspecResolution: true,
       ).cleanupAtFinish();
 
       expect(flutterDevice1.stopEchoingDeviceLogCount, 1);
@@ -87,6 +96,7 @@ void main() {
         applicationBinary: applicationBinary,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
         target: 'main.dart',
+        useImplicitPubspecResolution: true,
       ).run();
 
       expect(result, 1);
@@ -103,10 +113,16 @@ void main() {
         debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
         target: 'main.dart',
         traceStartup: true,
+        useImplicitPubspecResolution: true,
       ).run();
 
       expect(result, 0);
-      expect(memoryFileSystem.directory(getBuildDirectory()).childFile('start_up_info.json').existsSync(), true);
+      expect(
+          memoryFileSystem
+              .directory(getBuildDirectory())
+              .childFile('start_up_info.json')
+              .existsSync(),
+          true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -114,7 +130,8 @@ void main() {
     });
 
     testUsingContext('with traceStartup, env variable', () async {
-      fakePlatform.environment[kFlutterTestOutputsDirEnvName] = 'test_output_dir';
+      fakePlatform.environment[kFlutterTestOutputsDirEnvName] =
+          'test_output_dir';
 
       final FakeDevice device = FakeDevice();
       final FakeFlutterDevice flutterDevice = FakeFlutterDevice(device);
@@ -126,10 +143,16 @@ void main() {
         debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
         target: 'main.dart',
         traceStartup: true,
+        useImplicitPubspecResolution: true,
       ).run();
 
       expect(result, 0);
-      expect(memoryFileSystem.directory('test_output_dir').childFile('start_up_info.json').existsSync(), true);
+      expect(
+          memoryFileSystem
+              .directory('test_output_dir')
+              .childFile('start_up_info.json')
+              .existsSync(),
+          true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -165,7 +188,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   }
 
   @override
-  Future<void> tryInitLogReader() async { }
+  Future<void> tryInitLogReader() async {}
 }
 
 class FakeDevice extends Fake implements Device {
@@ -200,7 +223,10 @@ class TestFlutterDevice extends FlutterDevice {
     required Device device,
     required this.exception,
     required ResidentCompiler generator,
-  })  : super(device, buildInfo: BuildInfo.debug, generator: generator, developmentShaderCompiler: const FakeShaderCompiler());
+  }) : super(device,
+            buildInfo: BuildInfo.debug,
+            generator: generator,
+            developmentShaderCompiler: const FakeShaderCompiler());
 
   /// The exception to throw when the connect method is called.
   final Exception exception;
@@ -221,19 +247,23 @@ class TestFlutterDevice extends FlutterDevice {
   }
 }
 
-class FakeResidentCompiler extends Fake implements ResidentCompiler { }
+class FakeResidentCompiler extends Fake implements ResidentCompiler {}
 
 class FakeFlutterVmService extends Fake implements FlutterVmService {
   @override
   VmService get service => FakeVmService();
 
   @override
-  Future<List<FlutterView>> getFlutterViews({bool returnEarly = false, Duration delay = const Duration(milliseconds: 50)}) async {
+  Future<List<FlutterView>> getFlutterViews(
+      {bool returnEarly = false,
+      Duration delay = const Duration(milliseconds: 50)}) async {
     return <FlutterView>[];
   }
 
   @override
-  Future<bool> flutterAlreadyPaintedFirstUsefulFrame({String? isolateId}) async => true;
+  Future<bool> flutterAlreadyPaintedFirstUsefulFrame(
+          {String? isolateId}) async =>
+      true;
 
   @override
   Future<Response?> getTimeline() async {
@@ -266,7 +296,8 @@ class FakeVmService extends Fake implements VmService {
   @override
   Stream<Event> get onExtensionEvent {
     return Stream<Event>.fromIterable(<Event>[
-      Event(kind: 'Extension', extensionKind: 'Flutter.FirstFrame', timestamp: 1),
+      Event(
+          kind: 'Extension', extensionKind: 'Flutter.FirstFrame', timestamp: 1),
     ]);
   }
 }
@@ -275,7 +306,7 @@ class FakeShaderCompiler implements DevelopmentShaderCompiler {
   const FakeShaderCompiler();
 
   @override
-  void configureCompiler(TargetPlatform? platform) { }
+  void configureCompiler(TargetPlatform? platform) {}
 
   @override
   Future<DevFSContent> recompileShader(DevFSContent inputShader) {

--- a/packages/flutter_tools/test/general.shard/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/daemon_test.dart
@@ -29,6 +29,7 @@ void main() {
         bindPorts.add(port);
         return socket;
       },
+      useImplicitPubspecResolution: true,
     );
     await server.run();
     expect(bindCalledTimes, 1);
@@ -56,6 +57,7 @@ void main() {
         }
         return socket;
       },
+      useImplicitPubspecResolution: true,
     );
     await server.run();
     expect(bindCalledTimes, 2);

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -122,7 +122,8 @@ void main() {
       final CustomDevice device = CustomDevice(
         config: testConfig,
         processManager: FakeProcessManager.any(),
-        logger: BufferLogger.test()
+        logger: BufferLogger.test(),
+        useImplicitPubspecResolution: true,
       );
 
       final PrebuiltLinuxApp linuxApp = PrebuiltLinuxApp(executable: 'foo');
@@ -165,7 +166,8 @@ void main() {
         fileSystem: fs,
         directory: dir,
         logger: BufferLogger.test()
-      )
+      ),
+      useImplicitPubspecResolution: true,
     ).devices(), <Device>[]);
   });
 
@@ -183,7 +185,8 @@ void main() {
         fileSystem: fs,
         directory: dir,
         logger: BufferLogger.test()
-      )
+      ),
+      useImplicitPubspecResolution: true,
     ).devices(), <Device>[]);
   });
 
@@ -207,7 +210,8 @@ void main() {
           fileSystem: fs,
           directory: dir,
           logger: BufferLogger.test()
-        )
+        ),
+        useImplicitPubspecResolution: true,
       ).devices(),
       hasLength(1)
     );
@@ -236,6 +240,7 @@ void main() {
         directory: dir,
         logger: BufferLogger.test(),
       ),
+      useImplicitPubspecResolution: true,
     );
 
     final List<Device> discoveredDevices = await discovery.discoverDevices();
@@ -265,6 +270,7 @@ void main() {
         directory: dir,
         logger: BufferLogger.test(),
       ),
+      useImplicitPubspecResolution: true,
     );
 
     expect(await discovery.discoverDevices(), hasLength(0));
@@ -289,6 +295,7 @@ void main() {
         directory: dir,
         logger: BufferLogger.test(),
       ),
+      useImplicitPubspecResolution: true,
     );
 
     expect(await discovery.discoverDevices(), hasLength(0));
@@ -308,6 +315,7 @@ void main() {
       config: testConfig,
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.any(),
+      useImplicitPubspecResolution: true,
     ).isSupportedForProject(flutterProject), true);
   });
 
@@ -317,12 +325,13 @@ void main() {
       bool bothCommandsWereExecuted = false;
 
       final CustomDevice device = CustomDevice(
-          config: testConfig,
-          logger: BufferLogger.test(),
-          processManager: FakeProcessManager.list(<FakeCommand>[
-            FakeCommand(command: testConfig.uninstallCommand),
-            FakeCommand(command: testConfig.installCommand, onRun: (_) => bothCommandsWereExecuted = true),
-          ])
+        config: testConfig,
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(command: testConfig.uninstallCommand),
+          FakeCommand(command: testConfig.installCommand, onRun: (_) => bothCommandsWereExecuted = true),
+        ]),
+        useImplicitPubspecResolution: true,
       );
 
       expect(await device.installApp(PrebuiltLinuxApp(executable: 'exe')), true);
@@ -384,7 +393,8 @@ void main() {
       device: CustomDevice(
         config: testConfig,
         logger: BufferLogger.test(),
-        processManager: processManager
+        processManager: processManager,
+        useImplicitPubspecResolution: true,
       ),
       appPackage: PrebuiltLinuxApp(executable: 'testexecutable'),
       logger: BufferLogger.test(),
@@ -421,7 +431,8 @@ void main() {
       device: CustomDevice(
         config: testConfigNonForwarding,
         logger: BufferLogger.test(),
-        processManager: processManager
+        processManager: processManager,
+        useImplicitPubspecResolution: true,
       ),
       appPackage: PrebuiltLinuxApp(executable: 'testexecutable'),
       logger: BufferLogger.test(),
@@ -486,7 +497,8 @@ void main() {
           fileSystem: fs,
           directory: configFileDir,
           logger: BufferLogger.test()
-        )
+        ),
+        useImplicitPubspecResolution: true,
       );
 
       final List<Device> devices = await customDevices.discoverDevices();
@@ -535,7 +547,8 @@ void main() {
     final CustomDevice device = CustomDevice(
       config: testConfig,
       logger: BufferLogger.test(),
-      processManager: processManager
+      processManager: processManager,
+      useImplicitPubspecResolution: true,
     );
 
     expect(device.supportsScreenshot, true);
@@ -563,7 +576,8 @@ void main() {
           explicitScreenshotCommand: true
         ),
         logger: BufferLogger.test(),
-        processManager: processManager
+        processManager: processManager,
+      useImplicitPubspecResolution: true,
     );
 
     expect(device.supportsScreenshot, false);
@@ -581,7 +595,8 @@ void main() {
         platform: TargetPlatform.linux_x64
       ),
       logger: BufferLogger.test(),
-      processManager: FakeProcessManager.empty()
+      processManager: FakeProcessManager.empty(),
+      useImplicitPubspecResolution: true,
     );
 
     expect(await device.targetPlatform, TargetPlatform.linux_x64);
@@ -649,6 +664,7 @@ class FakeBundleBuilder extends Fake implements BundleBuilder {
     String? assetDirPath,
     Uri? nativeAssets,
     bool buildNativeAssets = true,
+    required bool useImplicitPubspecResolution,
     @visibleForTesting BuildSystem? buildSystem
   }) async {}
 }

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -318,6 +318,7 @@ class FakeWebRunnerFactory implements WebRunnerFactory {
     Usage? usage,
     Analytics? analytics,
     bool machine = false,
+    required bool useImplicitPubspecResolution,
   }) {
     expect(stayResident, isTrue);
     return FakeResidentRunner(
@@ -381,6 +382,7 @@ WebDriverService setUpDriverService() {
       processManager: FakeProcessManager.any(),
     ),
     dartSdkPath: 'dart',
+    useImplicitPubspecResolution: true,
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -26,84 +26,116 @@ import 'hot_shared.dart';
 void main() {
   group('validateReloadReport', () {
     testUsingContext('invalid', () async {
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': false,
-        'details': <String, dynamic>{},
-      })), false);
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': false,
-        'details': <String, dynamic>{
-          'notices': <Map<String, dynamic>>[
-          ],
-        },
-      })), false);
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': false,
-        'details': <String, dynamic>{
-          'notices': <String, dynamic>{
-            'message': 'error',
-          },
-        },
-      })), false);
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': false,
-        'details': <String, dynamic>{
-          'notices': <Map<String, dynamic>>[],
-        },
-      })), false);
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': false,
-        'details': <String, dynamic>{
-          'notices': <Map<String, dynamic>>[
-            <String, dynamic>{'message': false},
-          ],
-        },
-      })), false);
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': false,
-        'details': <String, dynamic>{
-          'notices': <Map<String, dynamic>>[
-            <String, dynamic>{'message': <String>['error']},
-          ],
-        },
-      })), false);
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': false,
-        'details': <String, dynamic>{
-          'notices': <Map<String, dynamic>>[
-            <String, dynamic>{'message': 'error'},
-            <String, dynamic>{'message': <String>['error']},
-          ],
-        },
-      })), false);
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': false,
-        'details': <String, dynamic>{
-          'notices': <Map<String, dynamic>>[
-            <String, dynamic>{'message': 'error'},
-          ],
-        },
-      })), false);
-      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
-        'type': 'ReloadReport',
-        'success': true,
-      })), true);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': false,
+            'details': <String, dynamic>{},
+          })),
+          false);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': false,
+            'details': <String, dynamic>{
+              'notices': <Map<String, dynamic>>[],
+            },
+          })),
+          false);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': false,
+            'details': <String, dynamic>{
+              'notices': <String, dynamic>{
+                'message': 'error',
+              },
+            },
+          })),
+          false);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': false,
+            'details': <String, dynamic>{
+              'notices': <Map<String, dynamic>>[],
+            },
+          })),
+          false);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': false,
+            'details': <String, dynamic>{
+              'notices': <Map<String, dynamic>>[
+                <String, dynamic>{'message': false},
+              ],
+            },
+          })),
+          false);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': false,
+            'details': <String, dynamic>{
+              'notices': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'message': <String>['error']
+                },
+              ],
+            },
+          })),
+          false);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': false,
+            'details': <String, dynamic>{
+              'notices': <Map<String, dynamic>>[
+                <String, dynamic>{'message': 'error'},
+                <String, dynamic>{
+                  'message': <String>['error']
+                },
+              ],
+            },
+          })),
+          false);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': false,
+            'details': <String, dynamic>{
+              'notices': <Map<String, dynamic>>[
+                <String, dynamic>{'message': 'error'},
+              ],
+            },
+          })),
+          false);
+      expect(
+          HotRunner.validateReloadReport(
+              vm_service.ReloadReport.parse(<String, dynamic>{
+            'type': 'ReloadReport',
+            'success': true,
+          })),
+          true);
     });
 
-    testWithoutContext('ReasonForCancelling toString has a hint for specific errors', () {
+    testWithoutContext(
+        'ReasonForCancelling toString has a hint for specific errors', () {
       final ReasonForCancelling reasonForCancelling = ReasonForCancelling(
         message: 'Const class cannot remove fields',
       );
 
-      expect(reasonForCancelling.toString(), contains('Try performing a hot restart instead.'));
+      expect(reasonForCancelling.toString(),
+          contains('Try performing a hot restart instead.'));
     });
   });
 
@@ -150,6 +182,7 @@ void main() {
           target: 'main.dart',
           devtoolsHandler: createNoOpHandler,
           analytics: fakeAnalytics,
+          useImplicitPubspecResolution: true,
         ).restart(fullRestart: true);
         expect(result.isOk, false);
         expect(result.message, 'setupHotRestart failed');
@@ -181,17 +214,19 @@ void main() {
           debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
           target: 'main.dart',
           devtoolsHandler: createNoOpHandler,
+          useImplicitPubspecResolution: true,
           reassembleHelper: (
             List<FlutterDevice?> flutterDevices,
             Map<FlutterDevice?, List<FlutterView>> viewCache,
             void Function(String message)? onSlow,
             String reloadMessage,
-          ) async => ReassembleResult(
-              <FlutterView?, FlutterVmService?>{null: null},
-              false,
-              true,
-            ),
-            analytics: fakeAnalytics,
+          ) async =>
+              ReassembleResult(
+            <FlutterView?, FlutterVmService?>{null: null},
+            false,
+            true,
+          ),
+          analytics: fakeAnalytics,
         ).restart();
         expect(result.isOk, false);
         expect(result.message, 'setupHotReload failed');
@@ -223,13 +258,17 @@ void main() {
 ''');
         final FakeDevice device = FakeDevice();
         final List<FlutterDevice> devices = <FlutterDevice>[
-          FlutterDevice(device, generator: residentCompiler, buildInfo: BuildInfo.debug, developmentShaderCompiler: const FakeShaderCompiler()),
+          FlutterDevice(device,
+              generator: residentCompiler,
+              buildInfo: BuildInfo.debug,
+              developmentShaderCompiler: const FakeShaderCompiler()),
         ];
         await HotRunner(
           devices,
           debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
           target: 'main.dart',
           analytics: fakeAnalytics,
+          useImplicitPubspecResolution: true,
         ).cleanupAfterSignal();
         expect(shutdownTestingConfig.shutdownHookCalled, true);
       }, overrides: <Type, Generator>{
@@ -251,13 +290,17 @@ void main() {
 ''');
         final FakeDevice device = FakeDevice();
         final List<FlutterDevice> devices = <FlutterDevice>[
-          FlutterDevice(device, generator: residentCompiler, buildInfo: BuildInfo.debug, developmentShaderCompiler: const FakeShaderCompiler()),
+          FlutterDevice(device,
+              generator: residentCompiler,
+              buildInfo: BuildInfo.debug,
+              developmentShaderCompiler: const FakeShaderCompiler()),
         ];
         await HotRunner(
           devices,
           debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
           target: 'main.dart',
           analytics: fakeAnalytics,
+          useImplicitPubspecResolution: true,
         ).preExit();
         expect(shutdownTestingConfig.shutdownHookCalled, true);
       }, overrides: <Type, Generator>{
@@ -276,30 +319,36 @@ void main() {
           successfulHotRestartSetup: true,
         );
       });
-      testUsingContext('correctly tracks time spent for analytics for hot restart', () async {
+      testUsingContext(
+          'correctly tracks time spent for analytics for hot restart',
+          () async {
         final FakeDevice device = FakeDevice();
         final FakeFlutterDevice fakeFlutterDevice = FakeFlutterDevice(device);
         final List<FlutterDevice> devices = <FlutterDevice>[
           fakeFlutterDevice,
         ];
 
-        fakeFlutterDevice.updateDevFSReportCallback = () async => UpdateFSReport(
-          success: true,
-          invalidatedSourcesCount: 2,
-          syncedBytes: 4,
-          scannedSourcesCount: 8,
-          compileDuration: const Duration(seconds: 16),
-          transferDuration: const Duration(seconds: 32),
-        );
+        fakeFlutterDevice.updateDevFSReportCallback =
+            () async => UpdateFSReport(
+                  success: true,
+                  invalidatedSourcesCount: 2,
+                  syncedBytes: 4,
+                  scannedSourcesCount: 8,
+                  compileDuration: const Duration(seconds: 16),
+                  transferDuration: const Duration(seconds: 32),
+                );
 
         final FakeStopwatchFactory fakeStopwatchFactory = FakeStopwatchFactory(
           stopwatches: <String, Stopwatch>{
-            'fullRestartHelper': FakeStopwatch()..elapsed = const Duration(seconds: 64),
-            'updateDevFS': FakeStopwatch()..elapsed = const Duration(seconds: 128),
+            'fullRestartHelper': FakeStopwatch()
+              ..elapsed = const Duration(seconds: 64),
+            'updateDevFS': FakeStopwatch()
+              ..elapsed = const Duration(seconds: 128),
           },
         );
 
-        (fakeFlutterDevice.devFS! as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
+        (fakeFlutterDevice.devFS! as FakeDevFs).baseUri =
+            Uri.parse('file:///base_uri');
 
         final OperationResult result = await HotRunner(
           devices,
@@ -308,41 +357,42 @@ void main() {
           devtoolsHandler: createNoOpHandler,
           stopwatchFactory: fakeStopwatchFactory,
           analytics: fakeAnalytics,
+          useImplicitPubspecResolution: true,
         ).restart(fullRestart: true);
 
         expect(result.isOk, true);
         expect(testUsage.events, <TestUsageEvent>[
-          const TestUsageEvent('hot', 'restart', parameters: CustomDimensions(
-            hotEventTargetPlatform: 'flutter-tester',
-            hotEventSdkName: 'Tester',
-            hotEventEmulator: false,
-            hotEventFullRestart: true,
-            hotEventOverallTimeInMs: 64000,
-            hotEventSyncedBytes: 4,
-            hotEventInvalidatedSourcesCount: 2,
-            hotEventTransferTimeInMs: 32000,
-            hotEventCompileTimeInMs: 16000,
-            hotEventFindInvalidatedTimeInMs: 128000,
-            hotEventScannedSourcesCount: 8,
-          )),
+          const TestUsageEvent('hot', 'restart',
+              parameters: CustomDimensions(
+                hotEventTargetPlatform: 'flutter-tester',
+                hotEventSdkName: 'Tester',
+                hotEventEmulator: false,
+                hotEventFullRestart: true,
+                hotEventOverallTimeInMs: 64000,
+                hotEventSyncedBytes: 4,
+                hotEventInvalidatedSourcesCount: 2,
+                hotEventTransferTimeInMs: 32000,
+                hotEventCompileTimeInMs: 16000,
+                hotEventFindInvalidatedTimeInMs: 128000,
+                hotEventScannedSourcesCount: 8,
+              )),
         ]);
 
-        expect(fakeAnalytics.sentEvents, contains(
-          Event.hotRunnerInfo(
-            label: 'restart',
-            targetPlatform: 'flutter-tester',
-            sdkName: 'Tester',
-            emulator: false,
-            fullRestart: true,
-            syncedBytes: 4,
-            invalidatedSourcesCount: 2,
-            transferTimeInMs: 32000,
-            overallTimeInMs: 64000,
-            compileTimeInMs: 16000,
-            findInvalidatedTimeInMs: 128000,
-            scannedSourcesCount: 8
-          )
-        ));
+        expect(
+            fakeAnalytics.sentEvents,
+            contains(Event.hotRunnerInfo(
+                label: 'restart',
+                targetPlatform: 'flutter-tester',
+                sdkName: 'Tester',
+                emulator: false,
+                fullRestart: true,
+                syncedBytes: 4,
+                invalidatedSourcesCount: 2,
+                transferTimeInMs: 32000,
+                overallTimeInMs: 64000,
+                compileTimeInMs: 16000,
+                findInvalidatedTimeInMs: 128000,
+                scannedSourcesCount: 8)));
         expect(testingConfig.updateDevFSCompleteCalled, true);
       }, overrides: <Type, Generator>{
         HotRunnerConfig: () => testingConfig,
@@ -361,32 +411,39 @@ void main() {
           successfulHotReloadSetup: true,
         );
       });
-      testUsingContext('correctly tracks time spent for analytics for hot reload', () async {
+      testUsingContext(
+          'correctly tracks time spent for analytics for hot reload', () async {
         final FakeDevice device = FakeDevice();
         final FakeFlutterDevice fakeFlutterDevice = FakeFlutterDevice(device);
         final List<FlutterDevice> devices = <FlutterDevice>[
           fakeFlutterDevice,
         ];
 
-        fakeFlutterDevice.updateDevFSReportCallback = () async => UpdateFSReport(
-          success: true,
-          invalidatedSourcesCount: 6,
-          syncedBytes: 8,
-          scannedSourcesCount: 16,
-          compileDuration: const Duration(seconds: 16),
-          transferDuration: const Duration(seconds: 32),
-        );
+        fakeFlutterDevice.updateDevFSReportCallback =
+            () async => UpdateFSReport(
+                  success: true,
+                  invalidatedSourcesCount: 6,
+                  syncedBytes: 8,
+                  scannedSourcesCount: 16,
+                  compileDuration: const Duration(seconds: 16),
+                  transferDuration: const Duration(seconds: 32),
+                );
 
         final FakeStopwatchFactory fakeStopwatchFactory = FakeStopwatchFactory(
           stopwatches: <String, Stopwatch>{
-            'updateDevFS': FakeStopwatch()..elapsed = const Duration(seconds: 64),
-            'reloadSources:reload': FakeStopwatch()..elapsed = const Duration(seconds: 128),
-            'reloadSources:reassemble': FakeStopwatch()..elapsed = const Duration(seconds: 256),
-            'reloadSources:vm': FakeStopwatch()..elapsed = const Duration(seconds: 512),
+            'updateDevFS': FakeStopwatch()
+              ..elapsed = const Duration(seconds: 64),
+            'reloadSources:reload': FakeStopwatch()
+              ..elapsed = const Duration(seconds: 128),
+            'reloadSources:reassemble': FakeStopwatch()
+              ..elapsed = const Duration(seconds: 256),
+            'reloadSources:vm': FakeStopwatch()
+              ..elapsed = const Duration(seconds: 512),
           },
         );
 
-        (fakeFlutterDevice.devFS! as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
+        (fakeFlutterDevice.devFS! as FakeDevFs).baseUri =
+            Uri.parse('file:///base_uri');
 
         final OperationResult result = await HotRunner(
           devices,
@@ -395,6 +452,7 @@ void main() {
           devtoolsHandler: createNoOpHandler,
           stopwatchFactory: fakeStopwatchFactory,
           analytics: fakeAnalytics,
+          useImplicitPubspecResolution: true,
           reloadSourcesHelper: (
             HotRunner hotRunner,
             List<FlutterDevice?> flutterDevices,
@@ -418,57 +476,60 @@ void main() {
             Map<FlutterDevice?, List<FlutterView>> viewCache,
             void Function(String message)? onSlow,
             String reloadMessage,
-          ) async => ReassembleResult(
-              <FlutterView?, FlutterVmService?>{null: null},
-              false,
-              true,
-            ),
+          ) async =>
+              ReassembleResult(
+            <FlutterView?, FlutterVmService?>{null: null},
+            false,
+            true,
+          ),
         ).restart();
 
         expect(result.isOk, true);
         expect(testUsage.events, <TestUsageEvent>[
-          const TestUsageEvent('hot', 'reload', parameters: CustomDimensions(
-            hotEventFinalLibraryCount: 2,
-            hotEventSyncedLibraryCount: 3,
-            hotEventSyncedClassesCount: 4,
-            hotEventSyncedProceduresCount: 5,
-            hotEventSyncedBytes: 8,
-            hotEventInvalidatedSourcesCount: 6,
-            hotEventTransferTimeInMs: 32000,
-            hotEventOverallTimeInMs: 128000,
-            hotEventTargetPlatform: 'flutter-tester',
-            hotEventSdkName: 'Tester',
-            hotEventEmulator: false,
-            hotEventFullRestart: false,
-            hotEventCompileTimeInMs: 16000,
-            hotEventFindInvalidatedTimeInMs: 64000,
-            hotEventScannedSourcesCount: 16,
-            hotEventReassembleTimeInMs: 256000,
-            hotEventReloadVMTimeInMs: 512000,
-          )),
+          const TestUsageEvent('hot', 'reload',
+              parameters: CustomDimensions(
+                hotEventFinalLibraryCount: 2,
+                hotEventSyncedLibraryCount: 3,
+                hotEventSyncedClassesCount: 4,
+                hotEventSyncedProceduresCount: 5,
+                hotEventSyncedBytes: 8,
+                hotEventInvalidatedSourcesCount: 6,
+                hotEventTransferTimeInMs: 32000,
+                hotEventOverallTimeInMs: 128000,
+                hotEventTargetPlatform: 'flutter-tester',
+                hotEventSdkName: 'Tester',
+                hotEventEmulator: false,
+                hotEventFullRestart: false,
+                hotEventCompileTimeInMs: 16000,
+                hotEventFindInvalidatedTimeInMs: 64000,
+                hotEventScannedSourcesCount: 16,
+                hotEventReassembleTimeInMs: 256000,
+                hotEventReloadVMTimeInMs: 512000,
+              )),
         ]);
-        expect(fakeAnalytics.sentEvents, contains(
-          Event.hotRunnerInfo(
-            label: 'reload',
-            targetPlatform: 'flutter-tester',
-            sdkName: 'Tester',
-            emulator: false,
-            fullRestart: false,
-            finalLibraryCount: 2,
-            syncedLibraryCount: 3,
-            syncedClassesCount: 4,
-            syncedProceduresCount: 5,
-            syncedBytes: 8,
-            invalidatedSourcesCount: 6,
-            transferTimeInMs: 32000,
-            overallTimeInMs: 128000,
-            compileTimeInMs: 16000,
-            findInvalidatedTimeInMs: 64000,
-            scannedSourcesCount: 16,
-            reassembleTimeInMs: 256000,
-            reloadVMTimeInMs: 512000
-          ),
-        ));
+        expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.hotRunnerInfo(
+                  label: 'reload',
+                  targetPlatform: 'flutter-tester',
+                  sdkName: 'Tester',
+                  emulator: false,
+                  fullRestart: false,
+                  finalLibraryCount: 2,
+                  syncedLibraryCount: 3,
+                  syncedClassesCount: 4,
+                  syncedProceduresCount: 5,
+                  syncedBytes: 8,
+                  invalidatedSourcesCount: 6,
+                  transferTimeInMs: 32000,
+                  overallTimeInMs: 128000,
+                  compileTimeInMs: 16000,
+                  findInvalidatedTimeInMs: 64000,
+                  scannedSourcesCount: 16,
+                  reassembleTimeInMs: 256000,
+                  reloadVMTimeInMs: 512000),
+            ));
         expect(testingConfig.updateDevFSCompleteCalled, true);
       }, overrides: <Type, Generator>{
         HotRunnerConfig: () => testingConfig,
@@ -493,7 +554,8 @@ void main() {
         final List<FlutterDevice> devices = <FlutterDevice>[
           fakeFlutterDevice,
         ];
-        fakeFlutterDevice.updateDevFSReportCallback = () async => throw Exception('updateDevFS failed');
+        fakeFlutterDevice.updateDevFSReportCallback =
+            () async => throw Exception('updateDevFS failed');
 
         final HotRunner runner = HotRunner(
           devices,
@@ -501,9 +563,13 @@ void main() {
           target: 'main.dart',
           devtoolsHandler: createNoOpHandler,
           analytics: fakeAnalytics,
+          useImplicitPubspecResolution: true,
         );
 
-        await expectLater(runner.restart(fullRestart: true), throwsA(isA<Exception>().having((Exception e) => e.toString(), 'message', 'Exception: updateDevFS failed')));
+        await expectLater(
+            runner.restart(fullRestart: true),
+            throwsA(isA<Exception>().having((Exception e) => e.toString(),
+                'message', 'Exception: updateDevFS failed')));
         expect(testingConfig.updateDevFSCompleteCalled, true);
       }, overrides: <Type, Generator>{
         HotRunnerConfig: () => testingConfig,
@@ -528,7 +594,8 @@ void main() {
         final List<FlutterDevice> devices = <FlutterDevice>[
           fakeFlutterDevice,
         ];
-        fakeFlutterDevice.updateDevFSReportCallback = () async => throw Exception('updateDevFS failed');
+        fakeFlutterDevice.updateDevFSReportCallback =
+            () async => throw Exception('updateDevFS failed');
 
         final HotRunner runner = HotRunner(
           devices,
@@ -536,9 +603,13 @@ void main() {
           target: 'main.dart',
           devtoolsHandler: createNoOpHandler,
           analytics: fakeAnalytics,
+          useImplicitPubspecResolution: true,
         );
 
-        await expectLater(runner.restart(), throwsA(isA<Exception>().having((Exception e) => e.toString(), 'message', 'Exception: updateDevFS failed')));
+        await expectLater(
+            runner.restart(),
+            throwsA(isA<Exception>().having((Exception e) => e.toString(),
+                'message', 'Exception: updateDevFS failed')));
         expect(testingConfig.updateDevFSCompleteCalled, true);
       }, overrides: <Type, Generator>{
         HotRunnerConfig: () => testingConfig,
@@ -563,11 +634,12 @@ void main() {
       );
     });
 
-    testUsingContext('Exits with code 2 when HttpException is thrown '
-      'during VM service connection', () async {
+    testUsingContext(
+        'Exits with code 2 when HttpException is thrown '
+        'during VM service connection', () async {
       fileSystem.directory('.dart_tool').childFile('package_config.json')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": []
@@ -580,15 +652,18 @@ void main() {
         TestFlutterDevice(
           device: device,
           generator: residentCompiler,
-          exception: const HttpException('Connection closed before full header was received, '
+          exception: const HttpException(
+              'Connection closed before full header was received, '
               'uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
         ),
       ];
 
-      final int exitCode = await HotRunner(devices,
+      final int exitCode = await HotRunner(
+        devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
         target: 'main.dart',
         analytics: fakeAnalytics,
+        useImplicitPubspecResolution: true,
       ).attach(needsFullRestart: false);
       expect(exitCode, 2);
     }, overrides: <Type, Generator>{
@@ -623,10 +698,12 @@ void main() {
         flutterDevice2,
       ];
 
-      await HotRunner(devices,
+      await HotRunner(
+        devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
         target: 'main.dart',
         analytics: fakeAnalytics,
+        useImplicitPubspecResolution: true,
       ).cleanupAtFinish();
 
       expect(device1.disposed, true);

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -26,116 +26,84 @@ import 'hot_shared.dart';
 void main() {
   group('validateReloadReport', () {
     testUsingContext('invalid', () async {
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': false,
-            'details': <String, dynamic>{},
-          })),
-          false);
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': false,
-            'details': <String, dynamic>{
-              'notices': <Map<String, dynamic>>[],
-            },
-          })),
-          false);
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': false,
-            'details': <String, dynamic>{
-              'notices': <String, dynamic>{
-                'message': 'error',
-              },
-            },
-          })),
-          false);
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': false,
-            'details': <String, dynamic>{
-              'notices': <Map<String, dynamic>>[],
-            },
-          })),
-          false);
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': false,
-            'details': <String, dynamic>{
-              'notices': <Map<String, dynamic>>[
-                <String, dynamic>{'message': false},
-              ],
-            },
-          })),
-          false);
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': false,
-            'details': <String, dynamic>{
-              'notices': <Map<String, dynamic>>[
-                <String, dynamic>{
-                  'message': <String>['error']
-                },
-              ],
-            },
-          })),
-          false);
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': false,
-            'details': <String, dynamic>{
-              'notices': <Map<String, dynamic>>[
-                <String, dynamic>{'message': 'error'},
-                <String, dynamic>{
-                  'message': <String>['error']
-                },
-              ],
-            },
-          })),
-          false);
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': false,
-            'details': <String, dynamic>{
-              'notices': <Map<String, dynamic>>[
-                <String, dynamic>{'message': 'error'},
-              ],
-            },
-          })),
-          false);
-      expect(
-          HotRunner.validateReloadReport(
-              vm_service.ReloadReport.parse(<String, dynamic>{
-            'type': 'ReloadReport',
-            'success': true,
-          })),
-          true);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': false,
+        'details': <String, dynamic>{},
+      })), false);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': false,
+        'details': <String, dynamic>{
+          'notices': <Map<String, dynamic>>[
+          ],
+        },
+      })), false);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': false,
+        'details': <String, dynamic>{
+          'notices': <String, dynamic>{
+            'message': 'error',
+          },
+        },
+      })), false);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': false,
+        'details': <String, dynamic>{
+          'notices': <Map<String, dynamic>>[],
+        },
+      })), false);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': false,
+        'details': <String, dynamic>{
+          'notices': <Map<String, dynamic>>[
+            <String, dynamic>{'message': false},
+          ],
+        },
+      })), false);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': false,
+        'details': <String, dynamic>{
+          'notices': <Map<String, dynamic>>[
+            <String, dynamic>{'message': <String>['error']},
+          ],
+        },
+      })), false);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': false,
+        'details': <String, dynamic>{
+          'notices': <Map<String, dynamic>>[
+            <String, dynamic>{'message': 'error'},
+            <String, dynamic>{'message': <String>['error']},
+          ],
+        },
+      })), false);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': false,
+        'details': <String, dynamic>{
+          'notices': <Map<String, dynamic>>[
+            <String, dynamic>{'message': 'error'},
+          ],
+        },
+      })), false);
+      expect(HotRunner.validateReloadReport(vm_service.ReloadReport.parse(<String, dynamic>{
+        'type': 'ReloadReport',
+        'success': true,
+      })), true);
     });
 
-    testWithoutContext(
-        'ReasonForCancelling toString has a hint for specific errors', () {
+    testWithoutContext('ReasonForCancelling toString has a hint for specific errors', () {
       final ReasonForCancelling reasonForCancelling = ReasonForCancelling(
         message: 'Const class cannot remove fields',
       );
 
-      expect(reasonForCancelling.toString(),
-          contains('Try performing a hot restart instead.'));
+      expect(reasonForCancelling.toString(), contains('Try performing a hot restart instead.'));
     });
   });
 
@@ -181,8 +149,8 @@ void main() {
           debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
           target: 'main.dart',
           devtoolsHandler: createNoOpHandler,
-          analytics: fakeAnalytics,
           useImplicitPubspecResolution: true,
+          analytics: fakeAnalytics,
         ).restart(fullRestart: true);
         expect(result.isOk, false);
         expect(result.message, 'setupHotRestart failed');
@@ -220,13 +188,12 @@ void main() {
             Map<FlutterDevice?, List<FlutterView>> viewCache,
             void Function(String message)? onSlow,
             String reloadMessage,
-          ) async =>
-              ReassembleResult(
-            <FlutterView?, FlutterVmService?>{null: null},
-            false,
-            true,
-          ),
-          analytics: fakeAnalytics,
+          ) async => ReassembleResult(
+              <FlutterView?, FlutterVmService?>{null: null},
+              false,
+              true,
+            ),
+            analytics: fakeAnalytics,
         ).restart();
         expect(result.isOk, false);
         expect(result.message, 'setupHotReload failed');
@@ -258,10 +225,7 @@ void main() {
 ''');
         final FakeDevice device = FakeDevice();
         final List<FlutterDevice> devices = <FlutterDevice>[
-          FlutterDevice(device,
-              generator: residentCompiler,
-              buildInfo: BuildInfo.debug,
-              developmentShaderCompiler: const FakeShaderCompiler()),
+          FlutterDevice(device, generator: residentCompiler, buildInfo: BuildInfo.debug, developmentShaderCompiler: const FakeShaderCompiler()),
         ];
         await HotRunner(
           devices,
@@ -290,10 +254,7 @@ void main() {
 ''');
         final FakeDevice device = FakeDevice();
         final List<FlutterDevice> devices = <FlutterDevice>[
-          FlutterDevice(device,
-              generator: residentCompiler,
-              buildInfo: BuildInfo.debug,
-              developmentShaderCompiler: const FakeShaderCompiler()),
+          FlutterDevice(device, generator: residentCompiler, buildInfo: BuildInfo.debug, developmentShaderCompiler: const FakeShaderCompiler()),
         ];
         await HotRunner(
           devices,
@@ -319,36 +280,30 @@ void main() {
           successfulHotRestartSetup: true,
         );
       });
-      testUsingContext(
-          'correctly tracks time spent for analytics for hot restart',
-          () async {
+      testUsingContext('correctly tracks time spent for analytics for hot restart', () async {
         final FakeDevice device = FakeDevice();
         final FakeFlutterDevice fakeFlutterDevice = FakeFlutterDevice(device);
         final List<FlutterDevice> devices = <FlutterDevice>[
           fakeFlutterDevice,
         ];
 
-        fakeFlutterDevice.updateDevFSReportCallback =
-            () async => UpdateFSReport(
-                  success: true,
-                  invalidatedSourcesCount: 2,
-                  syncedBytes: 4,
-                  scannedSourcesCount: 8,
-                  compileDuration: const Duration(seconds: 16),
-                  transferDuration: const Duration(seconds: 32),
-                );
+        fakeFlutterDevice.updateDevFSReportCallback = () async => UpdateFSReport(
+          success: true,
+          invalidatedSourcesCount: 2,
+          syncedBytes: 4,
+          scannedSourcesCount: 8,
+          compileDuration: const Duration(seconds: 16),
+          transferDuration: const Duration(seconds: 32),
+        );
 
         final FakeStopwatchFactory fakeStopwatchFactory = FakeStopwatchFactory(
           stopwatches: <String, Stopwatch>{
-            'fullRestartHelper': FakeStopwatch()
-              ..elapsed = const Duration(seconds: 64),
-            'updateDevFS': FakeStopwatch()
-              ..elapsed = const Duration(seconds: 128),
+            'fullRestartHelper': FakeStopwatch()..elapsed = const Duration(seconds: 64),
+            'updateDevFS': FakeStopwatch()..elapsed = const Duration(seconds: 128),
           },
         );
 
-        (fakeFlutterDevice.devFS! as FakeDevFs).baseUri =
-            Uri.parse('file:///base_uri');
+        (fakeFlutterDevice.devFS! as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
 
         final OperationResult result = await HotRunner(
           devices,
@@ -362,37 +317,37 @@ void main() {
 
         expect(result.isOk, true);
         expect(testUsage.events, <TestUsageEvent>[
-          const TestUsageEvent('hot', 'restart',
-              parameters: CustomDimensions(
-                hotEventTargetPlatform: 'flutter-tester',
-                hotEventSdkName: 'Tester',
-                hotEventEmulator: false,
-                hotEventFullRestart: true,
-                hotEventOverallTimeInMs: 64000,
-                hotEventSyncedBytes: 4,
-                hotEventInvalidatedSourcesCount: 2,
-                hotEventTransferTimeInMs: 32000,
-                hotEventCompileTimeInMs: 16000,
-                hotEventFindInvalidatedTimeInMs: 128000,
-                hotEventScannedSourcesCount: 8,
-              )),
+          const TestUsageEvent('hot', 'restart', parameters: CustomDimensions(
+            hotEventTargetPlatform: 'flutter-tester',
+            hotEventSdkName: 'Tester',
+            hotEventEmulator: false,
+            hotEventFullRestart: true,
+            hotEventOverallTimeInMs: 64000,
+            hotEventSyncedBytes: 4,
+            hotEventInvalidatedSourcesCount: 2,
+            hotEventTransferTimeInMs: 32000,
+            hotEventCompileTimeInMs: 16000,
+            hotEventFindInvalidatedTimeInMs: 128000,
+            hotEventScannedSourcesCount: 8,
+          )),
         ]);
 
-        expect(
-            fakeAnalytics.sentEvents,
-            contains(Event.hotRunnerInfo(
-                label: 'restart',
-                targetPlatform: 'flutter-tester',
-                sdkName: 'Tester',
-                emulator: false,
-                fullRestart: true,
-                syncedBytes: 4,
-                invalidatedSourcesCount: 2,
-                transferTimeInMs: 32000,
-                overallTimeInMs: 64000,
-                compileTimeInMs: 16000,
-                findInvalidatedTimeInMs: 128000,
-                scannedSourcesCount: 8)));
+        expect(fakeAnalytics.sentEvents, contains(
+          Event.hotRunnerInfo(
+            label: 'restart',
+            targetPlatform: 'flutter-tester',
+            sdkName: 'Tester',
+            emulator: false,
+            fullRestart: true,
+            syncedBytes: 4,
+            invalidatedSourcesCount: 2,
+            transferTimeInMs: 32000,
+            overallTimeInMs: 64000,
+            compileTimeInMs: 16000,
+            findInvalidatedTimeInMs: 128000,
+            scannedSourcesCount: 8
+          )
+        ));
         expect(testingConfig.updateDevFSCompleteCalled, true);
       }, overrides: <Type, Generator>{
         HotRunnerConfig: () => testingConfig,
@@ -411,39 +366,32 @@ void main() {
           successfulHotReloadSetup: true,
         );
       });
-      testUsingContext(
-          'correctly tracks time spent for analytics for hot reload', () async {
+      testUsingContext('correctly tracks time spent for analytics for hot reload', () async {
         final FakeDevice device = FakeDevice();
         final FakeFlutterDevice fakeFlutterDevice = FakeFlutterDevice(device);
         final List<FlutterDevice> devices = <FlutterDevice>[
           fakeFlutterDevice,
         ];
 
-        fakeFlutterDevice.updateDevFSReportCallback =
-            () async => UpdateFSReport(
-                  success: true,
-                  invalidatedSourcesCount: 6,
-                  syncedBytes: 8,
-                  scannedSourcesCount: 16,
-                  compileDuration: const Duration(seconds: 16),
-                  transferDuration: const Duration(seconds: 32),
-                );
+        fakeFlutterDevice.updateDevFSReportCallback = () async => UpdateFSReport(
+          success: true,
+          invalidatedSourcesCount: 6,
+          syncedBytes: 8,
+          scannedSourcesCount: 16,
+          compileDuration: const Duration(seconds: 16),
+          transferDuration: const Duration(seconds: 32),
+        );
 
         final FakeStopwatchFactory fakeStopwatchFactory = FakeStopwatchFactory(
           stopwatches: <String, Stopwatch>{
-            'updateDevFS': FakeStopwatch()
-              ..elapsed = const Duration(seconds: 64),
-            'reloadSources:reload': FakeStopwatch()
-              ..elapsed = const Duration(seconds: 128),
-            'reloadSources:reassemble': FakeStopwatch()
-              ..elapsed = const Duration(seconds: 256),
-            'reloadSources:vm': FakeStopwatch()
-              ..elapsed = const Duration(seconds: 512),
+            'updateDevFS': FakeStopwatch()..elapsed = const Duration(seconds: 64),
+            'reloadSources:reload': FakeStopwatch()..elapsed = const Duration(seconds: 128),
+            'reloadSources:reassemble': FakeStopwatch()..elapsed = const Duration(seconds: 256),
+            'reloadSources:vm': FakeStopwatch()..elapsed = const Duration(seconds: 512),
           },
         );
 
-        (fakeFlutterDevice.devFS! as FakeDevFs).baseUri =
-            Uri.parse('file:///base_uri');
+        (fakeFlutterDevice.devFS! as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
 
         final OperationResult result = await HotRunner(
           devices,
@@ -476,60 +424,57 @@ void main() {
             Map<FlutterDevice?, List<FlutterView>> viewCache,
             void Function(String message)? onSlow,
             String reloadMessage,
-          ) async =>
-              ReassembleResult(
-            <FlutterView?, FlutterVmService?>{null: null},
-            false,
-            true,
-          ),
+          ) async => ReassembleResult(
+              <FlutterView?, FlutterVmService?>{null: null},
+              false,
+              true,
+            ),
         ).restart();
 
         expect(result.isOk, true);
         expect(testUsage.events, <TestUsageEvent>[
-          const TestUsageEvent('hot', 'reload',
-              parameters: CustomDimensions(
-                hotEventFinalLibraryCount: 2,
-                hotEventSyncedLibraryCount: 3,
-                hotEventSyncedClassesCount: 4,
-                hotEventSyncedProceduresCount: 5,
-                hotEventSyncedBytes: 8,
-                hotEventInvalidatedSourcesCount: 6,
-                hotEventTransferTimeInMs: 32000,
-                hotEventOverallTimeInMs: 128000,
-                hotEventTargetPlatform: 'flutter-tester',
-                hotEventSdkName: 'Tester',
-                hotEventEmulator: false,
-                hotEventFullRestart: false,
-                hotEventCompileTimeInMs: 16000,
-                hotEventFindInvalidatedTimeInMs: 64000,
-                hotEventScannedSourcesCount: 16,
-                hotEventReassembleTimeInMs: 256000,
-                hotEventReloadVMTimeInMs: 512000,
-              )),
+          const TestUsageEvent('hot', 'reload', parameters: CustomDimensions(
+            hotEventFinalLibraryCount: 2,
+            hotEventSyncedLibraryCount: 3,
+            hotEventSyncedClassesCount: 4,
+            hotEventSyncedProceduresCount: 5,
+            hotEventSyncedBytes: 8,
+            hotEventInvalidatedSourcesCount: 6,
+            hotEventTransferTimeInMs: 32000,
+            hotEventOverallTimeInMs: 128000,
+            hotEventTargetPlatform: 'flutter-tester',
+            hotEventSdkName: 'Tester',
+            hotEventEmulator: false,
+            hotEventFullRestart: false,
+            hotEventCompileTimeInMs: 16000,
+            hotEventFindInvalidatedTimeInMs: 64000,
+            hotEventScannedSourcesCount: 16,
+            hotEventReassembleTimeInMs: 256000,
+            hotEventReloadVMTimeInMs: 512000,
+          )),
         ]);
-        expect(
-            fakeAnalytics.sentEvents,
-            contains(
-              Event.hotRunnerInfo(
-                  label: 'reload',
-                  targetPlatform: 'flutter-tester',
-                  sdkName: 'Tester',
-                  emulator: false,
-                  fullRestart: false,
-                  finalLibraryCount: 2,
-                  syncedLibraryCount: 3,
-                  syncedClassesCount: 4,
-                  syncedProceduresCount: 5,
-                  syncedBytes: 8,
-                  invalidatedSourcesCount: 6,
-                  transferTimeInMs: 32000,
-                  overallTimeInMs: 128000,
-                  compileTimeInMs: 16000,
-                  findInvalidatedTimeInMs: 64000,
-                  scannedSourcesCount: 16,
-                  reassembleTimeInMs: 256000,
-                  reloadVMTimeInMs: 512000),
-            ));
+        expect(fakeAnalytics.sentEvents, contains(
+          Event.hotRunnerInfo(
+            label: 'reload',
+            targetPlatform: 'flutter-tester',
+            sdkName: 'Tester',
+            emulator: false,
+            fullRestart: false,
+            finalLibraryCount: 2,
+            syncedLibraryCount: 3,
+            syncedClassesCount: 4,
+            syncedProceduresCount: 5,
+            syncedBytes: 8,
+            invalidatedSourcesCount: 6,
+            transferTimeInMs: 32000,
+            overallTimeInMs: 128000,
+            compileTimeInMs: 16000,
+            findInvalidatedTimeInMs: 64000,
+            scannedSourcesCount: 16,
+            reassembleTimeInMs: 256000,
+            reloadVMTimeInMs: 512000
+          ),
+        ));
         expect(testingConfig.updateDevFSCompleteCalled, true);
       }, overrides: <Type, Generator>{
         HotRunnerConfig: () => testingConfig,
@@ -554,8 +499,7 @@ void main() {
         final List<FlutterDevice> devices = <FlutterDevice>[
           fakeFlutterDevice,
         ];
-        fakeFlutterDevice.updateDevFSReportCallback =
-            () async => throw Exception('updateDevFS failed');
+        fakeFlutterDevice.updateDevFSReportCallback = () async => throw Exception('updateDevFS failed');
 
         final HotRunner runner = HotRunner(
           devices,
@@ -566,10 +510,7 @@ void main() {
           useImplicitPubspecResolution: true,
         );
 
-        await expectLater(
-            runner.restart(fullRestart: true),
-            throwsA(isA<Exception>().having((Exception e) => e.toString(),
-                'message', 'Exception: updateDevFS failed')));
+        await expectLater(runner.restart(fullRestart: true), throwsA(isA<Exception>().having((Exception e) => e.toString(), 'message', 'Exception: updateDevFS failed')));
         expect(testingConfig.updateDevFSCompleteCalled, true);
       }, overrides: <Type, Generator>{
         HotRunnerConfig: () => testingConfig,
@@ -594,8 +535,7 @@ void main() {
         final List<FlutterDevice> devices = <FlutterDevice>[
           fakeFlutterDevice,
         ];
-        fakeFlutterDevice.updateDevFSReportCallback =
-            () async => throw Exception('updateDevFS failed');
+        fakeFlutterDevice.updateDevFSReportCallback = () async => throw Exception('updateDevFS failed');
 
         final HotRunner runner = HotRunner(
           devices,
@@ -606,10 +546,7 @@ void main() {
           useImplicitPubspecResolution: true,
         );
 
-        await expectLater(
-            runner.restart(),
-            throwsA(isA<Exception>().having((Exception e) => e.toString(),
-                'message', 'Exception: updateDevFS failed')));
+        await expectLater(runner.restart(), throwsA(isA<Exception>().having((Exception e) => e.toString(), 'message', 'Exception: updateDevFS failed')));
         expect(testingConfig.updateDevFSCompleteCalled, true);
       }, overrides: <Type, Generator>{
         HotRunnerConfig: () => testingConfig,
@@ -634,12 +571,11 @@ void main() {
       );
     });
 
-    testUsingContext(
-        'Exits with code 2 when HttpException is thrown '
-        'during VM service connection', () async {
+    testUsingContext('Exits with code 2 when HttpException is thrown '
+      'during VM service connection', () async {
       fileSystem.directory('.dart_tool').childFile('package_config.json')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('''
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": []
@@ -652,14 +588,12 @@ void main() {
         TestFlutterDevice(
           device: device,
           generator: residentCompiler,
-          exception: const HttpException(
-              'Connection closed before full header was received, '
+          exception: const HttpException('Connection closed before full header was received, '
               'uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
         ),
       ];
 
-      final int exitCode = await HotRunner(
-        devices,
+      final int exitCode = await HotRunner(devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
         target: 'main.dart',
         analytics: fakeAnalytics,
@@ -698,8 +632,7 @@ void main() {
         flutterDevice2,
       ];
 
-      await HotRunner(
-        devices,
+      await HotRunner(devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
         target: 'main.dart',
         analytics: fakeAnalytics,

--- a/packages/flutter_tools/test/general.shard/isolated/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/hot_test.dart
@@ -13,8 +13,7 @@ import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/resident_devtools_handler.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
-import 'package:native_assets_cli/native_assets_cli_internal.dart'
-    hide Target;
+import 'package:native_assets_cli/native_assets_cli_internal.dart' hide Target;
 import 'package:package_config/package_config.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
@@ -48,17 +47,19 @@ void main() {
       ];
 
       fakeFlutterDevice.updateDevFSReportCallback = () async => UpdateFSReport(
-        success: true,
-        invalidatedSourcesCount: 6,
-        syncedBytes: 8,
-        scannedSourcesCount: 16,
-        compileDuration: const Duration(seconds: 16),
-        transferDuration: const Duration(seconds: 32),
-      );
+            success: true,
+            invalidatedSourcesCount: 6,
+            syncedBytes: 8,
+            scannedSourcesCount: 16,
+            compileDuration: const Duration(seconds: 16),
+            transferDuration: const Duration(seconds: 32),
+          );
 
-      (fakeFlutterDevice.devFS! as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
+      (fakeFlutterDevice.devFS! as FakeDevFs).baseUri =
+          Uri.parse('file:///base_uri');
 
-      final FakeFlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner(
+      final FakeFlutterNativeAssetsBuildRunner buildRunner =
+          FakeFlutterNativeAssetsBuildRunner(
         packagesWithNativeAssetsResult: <Package>[
           Package('bar', fileSystem.currentDirectory.uri),
         ],
@@ -89,6 +90,7 @@ void main() {
         devtoolsHandler: createNoOpHandler,
         nativeAssetsBuilder: FakeHotRunnerNativeAssetsBuilder(buildRunner),
         analytics: fakeAnalytics,
+        useImplicitPubspecResolution: true,
       );
       final OperationResult result = await hotRunner.restart(fullRestart: true);
       expect(result.isOk, true);
@@ -105,28 +107,32 @@ void main() {
       FileSystem: () => fileSystem,
       Platform: () => FakePlatform(),
       ProcessManager: () => FakeProcessManager.empty(),
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+      FeatureFlags: () =>
+          TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
     });
 
     testUsingContext('native assets run unsupported', () async {
-      final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.fuchsia_arm64);
+      final FakeDevice device =
+          FakeDevice(targetPlatform: TargetPlatform.fuchsia_arm64);
       final FakeFlutterDevice fakeFlutterDevice = FakeFlutterDevice(device);
       final List<FlutterDevice> devices = <FlutterDevice>[
         fakeFlutterDevice,
       ];
 
       fakeFlutterDevice.updateDevFSReportCallback = () async => UpdateFSReport(
-        success: true,
-        invalidatedSourcesCount: 6,
-        syncedBytes: 8,
-        scannedSourcesCount: 16,
-        compileDuration: const Duration(seconds: 16),
-        transferDuration: const Duration(seconds: 32),
-      );
+            success: true,
+            invalidatedSourcesCount: 6,
+            syncedBytes: 8,
+            scannedSourcesCount: 16,
+            compileDuration: const Duration(seconds: 16),
+            transferDuration: const Duration(seconds: 32),
+          );
 
-      (fakeFlutterDevice.devFS! as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
+      (fakeFlutterDevice.devFS! as FakeDevFs).baseUri =
+          Uri.parse('file:///base_uri');
 
-      final FakeFlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner(
+      final FakeFlutterNativeAssetsBuildRunner buildRunner =
+          FakeFlutterNativeAssetsBuildRunner(
         packagesWithNativeAssetsResult: <Package>[
           Package('bar', fileSystem.currentDirectory.uri),
         ],
@@ -157,23 +163,23 @@ void main() {
         devtoolsHandler: createNoOpHandler,
         nativeAssetsBuilder: FakeHotRunnerNativeAssetsBuilder(buildRunner),
         analytics: fakeAnalytics,
+        useImplicitPubspecResolution: true,
       );
       expect(
-        () => hotRunner.run(),
-        throwsToolExit( message:
-          'Package(s) bar require the native assets feature. '
-          'This feature has not yet been implemented for `TargetPlatform.fuchsia_arm64`. '
-          'For more info see https://github.com/flutter/flutter/issues/129757.',
-        )
-      );
-
+          () => hotRunner.run(),
+          throwsToolExit(
+            message: 'Package(s) bar require the native assets feature. '
+                'This feature has not yet been implemented for `TargetPlatform.fuchsia_arm64`. '
+                'For more info see https://github.com/flutter/flutter/issues/129757.',
+          ));
     }, overrides: <Type, Generator>{
       HotRunnerConfig: () => testingConfig,
       Artifacts: () => Artifacts.test(),
       FileSystem: () => fileSystem,
       Platform: () => FakePlatform(),
       ProcessManager: () => FakeProcessManager.empty(),
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+      FeatureFlags: () =>
+          TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/isolated/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/hot_test.dart
@@ -13,7 +13,8 @@ import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/resident_devtools_handler.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
-import 'package:native_assets_cli/native_assets_cli_internal.dart' hide Target;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide Target;
 import 'package:package_config/package_config.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
@@ -47,19 +48,17 @@ void main() {
       ];
 
       fakeFlutterDevice.updateDevFSReportCallback = () async => UpdateFSReport(
-            success: true,
-            invalidatedSourcesCount: 6,
-            syncedBytes: 8,
-            scannedSourcesCount: 16,
-            compileDuration: const Duration(seconds: 16),
-            transferDuration: const Duration(seconds: 32),
-          );
+        success: true,
+        invalidatedSourcesCount: 6,
+        syncedBytes: 8,
+        scannedSourcesCount: 16,
+        compileDuration: const Duration(seconds: 16),
+        transferDuration: const Duration(seconds: 32),
+      );
 
-      (fakeFlutterDevice.devFS! as FakeDevFs).baseUri =
-          Uri.parse('file:///base_uri');
+      (fakeFlutterDevice.devFS! as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
 
-      final FakeFlutterNativeAssetsBuildRunner buildRunner =
-          FakeFlutterNativeAssetsBuildRunner(
+      final FakeFlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner(
         packagesWithNativeAssetsResult: <Package>[
           Package('bar', fileSystem.currentDirectory.uri),
         ],
@@ -107,32 +106,28 @@ void main() {
       FileSystem: () => fileSystem,
       Platform: () => FakePlatform(),
       ProcessManager: () => FakeProcessManager.empty(),
-      FeatureFlags: () =>
-          TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
     });
 
     testUsingContext('native assets run unsupported', () async {
-      final FakeDevice device =
-          FakeDevice(targetPlatform: TargetPlatform.fuchsia_arm64);
+      final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.fuchsia_arm64);
       final FakeFlutterDevice fakeFlutterDevice = FakeFlutterDevice(device);
       final List<FlutterDevice> devices = <FlutterDevice>[
         fakeFlutterDevice,
       ];
 
       fakeFlutterDevice.updateDevFSReportCallback = () async => UpdateFSReport(
-            success: true,
-            invalidatedSourcesCount: 6,
-            syncedBytes: 8,
-            scannedSourcesCount: 16,
-            compileDuration: const Duration(seconds: 16),
-            transferDuration: const Duration(seconds: 32),
-          );
+        success: true,
+        invalidatedSourcesCount: 6,
+        syncedBytes: 8,
+        scannedSourcesCount: 16,
+        compileDuration: const Duration(seconds: 16),
+        transferDuration: const Duration(seconds: 32),
+      );
 
-      (fakeFlutterDevice.devFS! as FakeDevFs).baseUri =
-          Uri.parse('file:///base_uri');
+      (fakeFlutterDevice.devFS! as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
 
-      final FakeFlutterNativeAssetsBuildRunner buildRunner =
-          FakeFlutterNativeAssetsBuildRunner(
+      final FakeFlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner(
         packagesWithNativeAssetsResult: <Package>[
           Package('bar', fileSystem.currentDirectory.uri),
         ],
@@ -166,20 +161,21 @@ void main() {
         useImplicitPubspecResolution: true,
       );
       expect(
-          () => hotRunner.run(),
-          throwsToolExit(
-            message: 'Package(s) bar require the native assets feature. '
-                'This feature has not yet been implemented for `TargetPlatform.fuchsia_arm64`. '
-                'For more info see https://github.com/flutter/flutter/issues/129757.',
-          ));
+        () => hotRunner.run(),
+        throwsToolExit( message:
+          'Package(s) bar require the native assets feature. '
+          'This feature has not yet been implemented for `TargetPlatform.fuchsia_arm64`. '
+          'For more info see https://github.com/flutter/flutter/issues/129757.',
+        )
+      );
+
     }, overrides: <Type, Generator>{
       HotRunnerConfig: () => testingConfig,
       Artifacts: () => Artifacts.test(),
       FileSystem: () => fileSystem,
       Platform: () => FakePlatform(),
       ProcessManager: () => FakeProcessManager.empty(),
-      FeatureFlags: () =>
-          TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/isolated/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/resident_runner_test.dart
@@ -36,61 +36,66 @@ void main() {
   testUsingContext(
       'use the nativeAssetsYamlFile when provided',
       () => testbed.run(() async {
-        final FakeDevice device = FakeDevice(
-          targetPlatform: TargetPlatform.darwin,
-          sdkNameAndVersion: 'Macos',
-        );
-        final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
-        final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
-          ..testUri = testUri
-          ..vmServiceHost = (() => fakeVmServiceHost)
-          ..device = device
-          ..fakeDevFS = devFS
-          ..targetPlatform = TargetPlatform.darwin
-          ..generator = residentCompiler;
+            final FakeDevice device = FakeDevice(
+              targetPlatform: TargetPlatform.darwin,
+              sdkNameAndVersion: 'Macos',
+            );
+            final FakeResidentCompiler residentCompiler =
+                FakeResidentCompiler();
+            final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+              ..testUri = testUri
+              ..vmServiceHost = (() => fakeVmServiceHost)
+              ..device = device
+              ..fakeDevFS = devFS
+              ..targetPlatform = TargetPlatform.darwin
+              ..generator = residentCompiler;
 
-        fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-          listViews,
-          listViews,
-        ]);
-        globals.fs
-            .file(globals.fs.path.join('lib', 'main.dart'))
-            .createSync(recursive: true);
-        final FakeFlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner();
-        final HotRunner residentRunner = HotRunner(
-          <FlutterDevice>[
-            flutterDevice,
-          ],
-          stayResident: false,
-          debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-            BuildMode.debug,
-            '',
-            treeShakeIcons: false,
-            trackWidgetCreation: true,
-            packageConfigPath: '.dart_tool/package_config.json'
-          )),
-          target: 'main.dart',
-          devtoolsHandler: createNoOpHandler,
-          nativeAssetsBuilder: FakeHotRunnerNativeAssetsBuilder(buildRunner),
-          analytics: FakeAnalytics(),
-          nativeAssetsYamlFile: 'foo.yaml',
-        );
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            final FakeFlutterNativeAssetsBuildRunner buildRunner =
+                FakeFlutterNativeAssetsBuildRunner();
+            final HotRunner residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                  BuildMode.debug, '',
+                  treeShakeIcons: false,
+                  trackWidgetCreation: true,
+                  packageConfigPath: '.dart_tool/package_config.json')),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              nativeAssetsBuilder:
+                  FakeHotRunnerNativeAssetsBuilder(buildRunner),
+              analytics: FakeAnalytics(),
+              nativeAssetsYamlFile: 'foo.yaml',
+              useImplicitPubspecResolution: true,
+            );
 
-        final int result = await residentRunner.run();
-        expect(result, 0);
+            final int result = await residentRunner.run();
+            expect(result, 0);
 
-        expect(buildRunner.buildInvocations, 0);
-        expect(buildRunner.buildDryRunInvocations, 0);
-        expect(buildRunner.linkInvocations, 0);
-        expect(buildRunner.hasPackageConfigInvocations, 0);
-        expect(buildRunner.packagesWithNativeAssetsInvocations, 0);
+            expect(buildRunner.buildInvocations, 0);
+            expect(buildRunner.buildDryRunInvocations, 0);
+            expect(buildRunner.linkInvocations, 0);
+            expect(buildRunner.hasPackageConfigInvocations, 0);
+            expect(buildRunner.packagesWithNativeAssetsInvocations, 0);
 
-        expect(residentCompiler.recompileCalled, true);
-        expect(residentCompiler.receivedNativeAssetsYaml, globals.fs.path.toUri('foo.yaml'));
-      }),
+            expect(residentCompiler.recompileCalled, true);
+            expect(residentCompiler.receivedNativeAssetsYaml,
+                globals.fs.path.toUri('foo.yaml'));
+          }),
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+        FeatureFlags: () =>
+            TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
       });
 }
 

--- a/packages/flutter_tools/test/general.shard/isolated/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/resident_runner_test.dart
@@ -36,66 +36,62 @@ void main() {
   testUsingContext(
       'use the nativeAssetsYamlFile when provided',
       () => testbed.run(() async {
-            final FakeDevice device = FakeDevice(
-              targetPlatform: TargetPlatform.darwin,
-              sdkNameAndVersion: 'Macos',
-            );
-            final FakeResidentCompiler residentCompiler =
-                FakeResidentCompiler();
-            final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
-              ..testUri = testUri
-              ..vmServiceHost = (() => fakeVmServiceHost)
-              ..device = device
-              ..fakeDevFS = devFS
-              ..targetPlatform = TargetPlatform.darwin
-              ..generator = residentCompiler;
+        final FakeDevice device = FakeDevice(
+          targetPlatform: TargetPlatform.darwin,
+          sdkNameAndVersion: 'Macos',
+        );
+        final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
+        final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+          ..testUri = testUri
+          ..vmServiceHost = (() => fakeVmServiceHost)
+          ..device = device
+          ..fakeDevFS = devFS
+          ..targetPlatform = TargetPlatform.darwin
+          ..generator = residentCompiler;
 
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            final FakeFlutterNativeAssetsBuildRunner buildRunner =
-                FakeFlutterNativeAssetsBuildRunner();
-            final HotRunner residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                  BuildMode.debug, '',
-                  treeShakeIcons: false,
-                  trackWidgetCreation: true,
-                  packageConfigPath: '.dart_tool/package_config.json')),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              nativeAssetsBuilder:
-                  FakeHotRunnerNativeAssetsBuilder(buildRunner),
-              analytics: FakeAnalytics(),
-              nativeAssetsYamlFile: 'foo.yaml',
-              useImplicitPubspecResolution: true,
-            );
+        fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+          listViews,
+          listViews,
+        ]);
+        globals.fs
+            .file(globals.fs.path.join('lib', 'main.dart'))
+            .createSync(recursive: true);
+        final FakeFlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner();
+        final HotRunner residentRunner = HotRunner(
+          <FlutterDevice>[
+            flutterDevice,
+          ],
+          stayResident: false,
+          debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+            BuildMode.debug,
+            '',
+            treeShakeIcons: false,
+            trackWidgetCreation: true,
+            packageConfigPath: '.dart_tool/package_config.json'
+          )),
+          target: 'main.dart',
+          devtoolsHandler: createNoOpHandler,
+          nativeAssetsBuilder: FakeHotRunnerNativeAssetsBuilder(buildRunner),
+          analytics: FakeAnalytics(),
+          nativeAssetsYamlFile: 'foo.yaml',
+          useImplicitPubspecResolution: true,
+        );
 
-            final int result = await residentRunner.run();
-            expect(result, 0);
+        final int result = await residentRunner.run();
+        expect(result, 0);
 
-            expect(buildRunner.buildInvocations, 0);
-            expect(buildRunner.buildDryRunInvocations, 0);
-            expect(buildRunner.linkInvocations, 0);
-            expect(buildRunner.hasPackageConfigInvocations, 0);
-            expect(buildRunner.packagesWithNativeAssetsInvocations, 0);
+        expect(buildRunner.buildInvocations, 0);
+        expect(buildRunner.buildDryRunInvocations, 0);
+        expect(buildRunner.linkInvocations, 0);
+        expect(buildRunner.hasPackageConfigInvocations, 0);
+        expect(buildRunner.packagesWithNativeAssetsInvocations, 0);
 
-            expect(residentCompiler.recompileCalled, true);
-            expect(residentCompiler.receivedNativeAssetsYaml,
-                globals.fs.path.toUri('foo.yaml'));
-          }),
+        expect(residentCompiler.recompileCalled, true);
+        expect(residentCompiler.receivedNativeAssetsYaml, globals.fs.path.toUri('foo.yaml'));
+      }),
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () =>
-            TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
       });
 }
 

--- a/packages/flutter_tools/test/general.shard/preview_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/preview_device_test.dart
@@ -49,6 +49,7 @@ void main() {
       processManager: FakeProcessManager.any(),
       previewBinary: previewBinary,
       logger: BufferLogger.test(),
+      useImplicitPubspecResolution: true,
     );
 
     expect(await device.isLocalEmulator, false);
@@ -84,6 +85,7 @@ void main() {
       ]),
       logger: logger,
       builderFactory: () => FakeBundleBuilder(fs),
+      useImplicitPubspecResolution: true,
     );
     final Directory previewDeviceCacheDir = fs
       .directory('Artifact.windowsDesktopPath.TargetPlatform.windows_x64.debug')
@@ -121,6 +123,7 @@ void main() {
         processManager: processManager,
         platform: linuxPlatform,
         featureFlags: featureFlags,
+        useImplicitPubspecResolution: true,
       );
 
       final List<Device> devices = await discovery.devices();
@@ -136,6 +139,7 @@ void main() {
         processManager: processManager,
         platform: macPlatform,
         featureFlags: featureFlags,
+        useImplicitPubspecResolution: true,
       );
 
       final List<Device> devices = await discovery.devices();
@@ -153,6 +157,7 @@ void main() {
         processManager: processManager,
         platform: windowsPlatform,
         featureFlags: featureFlags,
+        useImplicitPubspecResolution: true,
       );
 
       final List<Device> devices = await discovery.devices();
@@ -170,6 +175,7 @@ void main() {
         processManager: processManager,
         platform: windowsPlatform,
         featureFlags: featureFlags,
+        useImplicitPubspecResolution: true,
       );
 
       final List<Device> devices = await discovery.devices();
@@ -197,7 +203,8 @@ class FakeBundleBuilder extends Fake implements BundleBuilder {
     String? depfilePath,
     String? assetDirPath,
     bool buildNativeAssets = true,
-    @visibleForTesting BuildSystem? buildSystem
+    @visibleForTesting BuildSystem? buildSystem,
+    required bool useImplicitPubspecResolution,
   }) async {
     final Directory assetDirectory = fileSystem
       .directory(assetDirPath)

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -50,23 +50,26 @@ void main() {
   FakeVmServiceHost? fakeVmServiceHost;
 
   setUp(() {
-    testbed = Testbed(setup: () {
-      globals.fs.file(globals.fs.path.join('build', 'app.dill'))
-        ..createSync(recursive: true)
-        ..writeAsStringSync('ABC');
-      residentRunner = HotRunner(
-        <FlutterDevice>[
-          flutterDevice,
-        ],
-        stayResident: false,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-        target: 'main.dart',
-        analytics: fakeAnalytics,
-        devtoolsHandler: createNoOpHandler,
-      );
-    }, overrides: <Type, Generator>{
-      Analytics: () => FakeAnalytics(),
-    });
+    testbed = Testbed(
+        setup: () {
+          globals.fs.file(globals.fs.path.join('build', 'app.dill'))
+            ..createSync(recursive: true)
+            ..writeAsStringSync('ABC');
+          residentRunner = HotRunner(
+            <FlutterDevice>[
+              flutterDevice,
+            ],
+            stayResident: false,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            target: 'main.dart',
+            analytics: fakeAnalytics,
+            devtoolsHandler: createNoOpHandler,
+            useImplicitPubspecResolution: true,
+          );
+        },
+        overrides: <Type, Generator>{
+          Analytics: () => FakeAnalytics(),
+        });
     device = FakeDevice();
     devFS = FakeDevFS();
     flutterDevice = FakeFlutterDevice()
@@ -76,1041 +79,1190 @@ void main() {
       ..fakeDevFS = devFS;
   });
 
-  testUsingContext('ResidentRunner can attach to device successfully', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    final Future<int?> result = residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    );
-    final Future<DebugConnectionInfo> connectionInfo = futureConnectionInfo.future;
+  testUsingContext(
+      'ResidentRunner can attach to device successfully',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            final Future<int?> result = residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            );
+            final Future<DebugConnectionInfo> connectionInfo =
+                futureConnectionInfo.future;
 
-    expect(await result, 0);
-    expect(futureConnectionInfo.isCompleted, true);
-    expect((await connectionInfo).baseUri, 'foo://bar');
-    expect(futureAppStart.isCompleted, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+            expect(await result, 0);
+            expect(futureConnectionInfo.isCompleted, true);
+            expect((await connectionInfo).baseUri, 'foo://bar');
+            expect(futureAppStart.isCompleted, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-  testUsingContext('ResidentRunner suppresses errors for the initial compilation', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-      ..nextOutput = const CompilerOutput('foo', 0 ,<Uri>[]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: globals.analytics,
-    );
-    flutterDevice.generator = residentCompiler;
+  testUsingContext(
+      'ResidentRunner suppresses errors for the initial compilation',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+              ..nextOutput = const CompilerOutput('foo', 0, <Uri>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.generator = residentCompiler;
 
-    expect(await residentRunner.run(), 0);
-    expect(residentCompiler.didSuppressErrors, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
-
-  // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext('ResidentRunner calls appFailedToStart if initial compilation fails', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: globals.analytics,
-    );
-    flutterDevice.generator = residentCompiler;
-
-    expect(await residentRunner.run(), 1);
-    // Completing this future ensures that the daemon can exit correctly.
-    expect(await residentRunner.waitForAppToFinish(), 1);
-  }));
+            expect(await residentRunner.run(), 0);
+            expect(residentCompiler.didSuppressErrors, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext('ResidentRunner calls appFailedToStart if initial compilation fails - cold mode', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-    flutterDevice.runColdCode = 1;
+  testUsingContext(
+      'ResidentRunner calls appFailedToStart if initial compilation fails',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+              ..nextOutput = const CompilerOutput('foo', 1, <Uri>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.generator = residentCompiler;
 
-    expect(await residentRunner.run(), 1);
-    // Completing this future ensures that the daemon can exit correctly.
-    expect(await residentRunner.waitForAppToFinish(), 1);
-  }));
+            expect(await residentRunner.run(), 1);
+            // Completing this future ensures that the daemon can exit correctly.
+            expect(await residentRunner.waitForAppToFinish(), 1);
+          }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext('ResidentRunner calls appFailedToStart if exception is thrown - cold mode', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-    flutterDevice.runColdError = Exception('BAD STUFF');
+  testUsingContext(
+      'ResidentRunner calls appFailedToStart if initial compilation fails - cold mode',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.runColdCode = 1;
 
+            expect(await residentRunner.run(), 1);
+            // Completing this future ensures that the daemon can exit correctly.
+            expect(await residentRunner.waitForAppToFinish(), 1);
+          }));
 
-    expect(await residentRunner.run(), 1);
-    // Completing this future ensures that the daemon can exit correctly.
-    expect(await residentRunner.waitForAppToFinish(), 1);
-  }));
+  // Regression test for https://github.com/flutter/flutter/issues/60613
+  testUsingContext(
+      'ResidentRunner calls appFailedToStart if exception is thrown - cold mode',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.runColdError = Exception('BAD STUFF');
 
-  testUsingContext('ResidentRunner does not suppressErrors if running with an applicationBinary', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-      ..nextOutput = const CompilerOutput('foo', 0 ,<Uri>[]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      applicationBinary: globals.fs.file('app-debug.apk'),
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: globals.analytics,
-    );
-    flutterDevice.generator = residentCompiler;
+            expect(await residentRunner.run(), 1);
+            // Completing this future ensures that the daemon can exit correctly.
+            expect(await residentRunner.waitForAppToFinish(), 1);
+          }));
 
-    expect(await residentRunner.run(), 0);
-    expect(residentCompiler.didSuppressErrors, false);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner does not suppressErrors if running with an applicationBinary',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+              ..nextOutput = const CompilerOutput('foo', 0, <Uri>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              applicationBinary: globals.fs.file('app-debug.apk'),
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.generator = residentCompiler;
 
-  testUsingContext('ResidentRunner can attach to device successfully with --fast-start', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        }
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        }
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        )
-      ),
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(
-        BuildInfo.debug,
-        fastStart: true,
-        startPaused: true,
-      ),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: globals.analytics,
-    );
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    final Future<int?> result = residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    );
-    final Future<DebugConnectionInfo> connectionInfo = futureConnectionInfo.future;
+            expect(await residentRunner.run(), 0);
+            expect(residentCompiler.didSuppressErrors, false);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    expect(await result, 0);
-    expect(futureConnectionInfo.isCompleted, true);
-    expect((await connectionInfo).baseUri, 'foo://bar');
-    expect(futureAppStart.isCompleted, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner can attach to device successfully with --fast-start',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                  method: 'streamListen',
+                  args: <String, Object>{
+                    'streamId': 'Isolate',
+                  }),
+              FakeVmServiceRequest(
+                  method: kRunInViewMethod,
+                  args: <String, Object>{
+                    'viewId': fakeFlutterView.id,
+                    'mainScript': 'main.dart.dill',
+                    'assetDirectory': 'build/flutter_assets',
+                  }),
+              FakeVmServiceStreamResponse(
+                  streamId: 'Isolate',
+                  event: vm_service.Event(
+                    timestamp: 0,
+                    kind: vm_service.EventKind.kIsolateRunnable,
+                  )),
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(
+                BuildInfo.debug,
+                fastStart: true,
+                startPaused: true,
+              ),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              useImplicitPubspecResolution: true,
+            );
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            final Future<int?> result = residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            );
+            final Future<DebugConnectionInfo> connectionInfo =
+                futureConnectionInfo.future;
 
-  testUsingContext('ResidentRunner can handle an RPC exception from hot reload', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
+            expect(await result, 0);
+            expect(futureConnectionInfo.isCompleted, true);
+            expect((await connectionInfo).baseUri, 'foo://bar');
+            expect(futureAppStart.isCompleted, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, true);
-    expect(result.code, 1);
-    expect((globals.flutterUsage as TestUsage).events, contains(
-      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
-        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        hotEventSdkName: 'Android',
-        hotEventEmulator: false,
-        hotEventFullRestart: false,
-      )),
-    ));
-    expect((globals.analytics as FakeAnalytics).sentEvents, contains(
-      Event.hotRunnerInfo(
-        label: 'exception',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        sdkName: 'Android',
-        emulator: false,
-        fullRestart: false,
-      ),
-    ));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+  testUsingContext(
+      'ResidentRunner can handle an RPC exception from hot reload',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.reportError =
+                vm_service.RPCError('something bad happened', 666, '');
 
-  testUsingContext('ResidentRunner fails its operation if the device initialization is not complete', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.fakeDevFS = null;
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, true);
+            expect(result.code, 1);
+            expect(
+                (globals.flutterUsage as TestUsage).events,
+                contains(
+                  TestUsageEvent('hot', 'exception',
+                      parameters: CustomDimensions(
+                        hotEventTargetPlatform: getNameForTargetPlatform(
+                            TargetPlatform.android_arm),
+                        hotEventSdkName: 'Android',
+                        hotEventEmulator: false,
+                        hotEventFullRestart: false,
+                      )),
+                ));
+            expect(
+                (globals.analytics as FakeAnalytics).sentEvents,
+                contains(
+                  Event.hotRunnerInfo(
+                    label: 'exception',
+                    targetPlatform:
+                        getNameForTargetPlatform(TargetPlatform.android_arm),
+                    sdkName: 'Android',
+                    emulator: false,
+                    fullRestart: false,
+                  ),
+                ));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, false);
-    expect(result.code, 1);
-    expect(result.message, contains('Device initialization has not completed.'));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner fails its operation if the device initialization is not complete',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.fakeDevFS = null;
 
-  testUsingContext('ResidentRunner can handle an reload-barred exception from hot reload', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.reportError = vm_service.RPCError('something bad happened', kIsolateReloadBarred, '');
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, false);
+            expect(result.code, 1);
+            expect(result.message,
+                contains('Device initialization has not completed.'));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, true);
-    expect(result.code, kIsolateReloadBarred);
-    expect(result.message, contains('Unable to hot reload application due to an unrecoverable error'));
+  testUsingContext(
+      'ResidentRunner can handle an reload-barred exception from hot reload',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.reportError = vm_service.RPCError(
+                'something bad happened', kIsolateReloadBarred, '');
 
-    expect((globals.flutterUsage as TestUsage).events, contains(
-      TestUsageEvent('hot', 'reload-barred', parameters: CustomDimensions(
-        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        hotEventSdkName: 'Android',
-        hotEventEmulator: false,
-        hotEventFullRestart: false,
-      )),
-    ));
-    expect(fakeAnalytics.sentEvents, contains(
-      Event.hotRunnerInfo(
-        label: 'reload-barred',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        sdkName: 'Android',
-        emulator: false,
-        fullRestart: false,
-      )
-    ));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, true);
+            expect(result.code, kIsolateReloadBarred);
+            expect(
+                result.message,
+                contains(
+                    'Unable to hot reload application due to an unrecoverable error'));
 
-  testUsingContext('ResidentRunner reports hot reload event with null safety analytics', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      target: 'main.dart',
-      debuggingOptions: DebuggingOptions.enabled(
-        const BuildInfo(
-          BuildMode.debug, '', treeShakeIcons: false, extraFrontEndOptions: <String>[
-          '--enable-experiment=non-nullable',
-          ],
-          packageConfigPath: '.dart_tool/package_config.json',
-        ),
-        enableDevTools: false,
-      ),
-      analytics: fakeAnalytics,
-    );
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
+            expect(
+                (globals.flutterUsage as TestUsage).events,
+                contains(
+                  TestUsageEvent('hot', 'reload-barred',
+                      parameters: CustomDimensions(
+                        hotEventTargetPlatform: getNameForTargetPlatform(
+                            TargetPlatform.android_arm),
+                        hotEventSdkName: 'Android',
+                        hotEventEmulator: false,
+                        hotEventFullRestart: false,
+                      )),
+                ));
+            expect(
+                fakeAnalytics.sentEvents,
+                contains(Event.hotRunnerInfo(
+                  label: 'reload-barred',
+                  targetPlatform:
+                      getNameForTargetPlatform(TargetPlatform.android_arm),
+                  sdkName: 'Android',
+                  emulator: false,
+                  fullRestart: false,
+                )));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, true);
-    expect(result.code, 1);
+  testUsingContext(
+      'ResidentRunner reports hot reload event with null safety analytics',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              target: 'main.dart',
+              debuggingOptions: DebuggingOptions.enabled(
+                const BuildInfo(
+                  BuildMode.debug,
+                  '',
+                  treeShakeIcons: false,
+                  extraFrontEndOptions: <String>[
+                    '--enable-experiment=non-nullable',
+                  ],
+                  packageConfigPath: '.dart_tool/package_config.json',
+                ),
+                enableDevTools: false,
+              ),
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.reportError =
+                vm_service.RPCError('something bad happened', 666, '');
 
-    expect((globals.flutterUsage as TestUsage).events, contains(
-      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
-        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        hotEventSdkName: 'Android',
-        hotEventEmulator: false,
-        hotEventFullRestart: false,
-      )),
-    ));
-    expect(fakeAnalytics.sentEvents, contains(
-      Event.hotRunnerInfo(
-        label: 'exception',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        sdkName: 'Android',
-        emulator: false,
-        fullRestart: false,
-      )
-    ));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, true);
+            expect(result.code, 1);
 
-  testUsingContext('ResidentRunner does not reload sources if no sources changed', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolatePauseEvent',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedEvent.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.report =  UpdateFSReport(success: true);
+            expect(
+                (globals.flutterUsage as TestUsage).events,
+                contains(
+                  TestUsageEvent('hot', 'exception',
+                      parameters: CustomDimensions(
+                        hotEventTargetPlatform: getNameForTargetPlatform(
+                            TargetPlatform.android_arm),
+                        hotEventSdkName: 'Android',
+                        hotEventEmulator: false,
+                        hotEventFullRestart: false,
+                      )),
+                ));
+            expect(
+                fakeAnalytics.sentEvents,
+                contains(Event.hotRunnerInfo(
+                  label: 'exception',
+                  targetPlatform:
+                      getNameForTargetPlatform(TargetPlatform.android_arm),
+                  sdkName: 'Android',
+                  emulator: false,
+                  fullRestart: false,
+                )));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-    final OperationResult result = await residentRunner.restart();
+  testUsingContext(
+      'ResidentRunner does not reload sources if no sources changed',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolatePauseEvent',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedEvent.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.report = UpdateFSReport(success: true);
 
-    expect(result.code, 0);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+            final OperationResult result = await residentRunner.restart();
 
-  testUsingContext('ResidentRunner reports error with missing entrypoint file', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{
-          'isolates': <Object>[
-            fakeUnpausedIsolate.toJson(),
-          ],
-        })!.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: kReloadSourcesServiceName,
-        args: <String, Object>{
-          'isolateId': '1',
-          'pause': false,
-          'rootLibUri': 'main.dart.incremental.dill',
-        },
-        jsonResponse: <String, Object>{
-          'type': 'ReloadReport',
-          'success': true,
-          'details': <String, Object>{
-            'loadedLibraryCount': 1,
-          },
-        },
-      ),
-      FakeVmServiceRequest(
-        method: 'getIsolatePauseEvent',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedEvent.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.report =  UpdateFSReport(success: true, invalidatedSourcesCount: 1);
+            expect(result.code, 0);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
+  testUsingContext(
+      'ResidentRunner reports error with missing entrypoint file',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{
+                  'isolates': <Object>[
+                    fakeUnpausedIsolate.toJson(),
+                  ],
+                })!.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                method: kReloadSourcesServiceName,
+                args: <String, Object>{
+                  'isolateId': '1',
+                  'pause': false,
+                  'rootLibUri': 'main.dart.incremental.dill',
+                },
+                jsonResponse: <String, Object>{
+                  'type': 'ReloadReport',
+                  'success': true,
+                  'details': <String, Object>{
+                    'loadedLibraryCount': 1,
+                  },
+                },
+              ),
+              FakeVmServiceRequest(
+                method: 'getIsolatePauseEvent',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedEvent.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.report =
+                UpdateFSReport(success: true, invalidatedSourcesCount: 1);
 
-    expect(globals.fs.file(globals.fs.path.join('lib', 'main.dart')), isNot(exists));
-    expect(testLogger.errorText, contains('The entrypoint file (i.e. the file with main())'));
-    expect(result.fatal, false);
-    expect(result.code, 0);
-  }));
+            final OperationResult result = await residentRunner.restart();
 
-   testUsingContext('ResidentRunner resets compilation time on reload reject', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{
-          'isolates': <Object>[
-            fakeUnpausedIsolate.toJson(),
-          ],
-        })!.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: kReloadSourcesServiceName,
-        args: <String, Object>{
-          'isolateId': '1',
-          'pause': false,
-          'rootLibUri': 'main.dart.incremental.dill',
-        },
-        jsonResponse: <String, Object>{
-          'type': 'ReloadReport',
-          'success': false,
-          'notices': <Object>[
-            <String, Object>{
-              'message': 'Failed to hot reload',
-            },
-          ],
-          'details': <String, Object>{},
-        },
-      ),
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.report =  UpdateFSReport(success: true, invalidatedSourcesCount: 1);
+            expect(globals.fs.file(globals.fs.path.join('lib', 'main.dart')),
+                isNot(exists));
+            expect(testLogger.errorText,
+                contains('The entrypoint file (i.e. the file with main())'));
+            expect(result.fatal, false);
+            expect(result.code, 0);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
+  testUsingContext(
+      'ResidentRunner resets compilation time on reload reject',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{
+                  'isolates': <Object>[
+                    fakeUnpausedIsolate.toJson(),
+                  ],
+                })!.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                method: kReloadSourcesServiceName,
+                args: <String, Object>{
+                  'isolateId': '1',
+                  'pause': false,
+                  'rootLibUri': 'main.dart.incremental.dill',
+                },
+                jsonResponse: <String, Object>{
+                  'type': 'ReloadReport',
+                  'success': false,
+                  'notices': <Object>[
+                    <String, Object>{
+                      'message': 'Failed to hot reload',
+                    },
+                  ],
+                  'details': <String, Object>{},
+                },
+              ),
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.report =
+                UpdateFSReport(success: true, invalidatedSourcesCount: 1);
 
-    expect(result.fatal, false);
-    expect(result.message, contains('Reload rejected: Failed to hot reload')); // contains error message from reload report.
-    expect(result.code, 1);
-    expect(devFS.lastCompiled, null);
-  }));
+            final OperationResult result = await residentRunner.restart();
 
-  testUsingContext('ResidentRunner can send target platform to analytics from hot reload', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{
-          'isolates': <Object>[
-            fakeUnpausedIsolate.toJson(),
-          ],
-        })!.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: kReloadSourcesServiceName,
-        args: <String, Object>{
-          'isolateId': '1',
-          'pause': false,
-          'rootLibUri': 'main.dart.incremental.dill',
-        },
-        jsonResponse: <String, Object>{
-          'type': 'ReloadReport',
-          'success': true,
-          'details': <String, Object>{
-            'loadedLibraryCount': 1,
-          },
-        },
-      ),
-      FakeVmServiceRequest(
-        method: 'getIsolatePauseEvent',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedEvent.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
+            expect(result.fatal, false);
+            expect(
+                result.message,
+                contains(
+                    'Reload rejected: Failed to hot reload')); // contains error message from reload report.
+            expect(result.code, 1);
+            expect(devFS.lastCompiled, null);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, false);
-    expect(result.code, 0);
+  testUsingContext(
+      'ResidentRunner can send target platform to analytics from hot reload',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{
+                  'isolates': <Object>[
+                    fakeUnpausedIsolate.toJson(),
+                  ],
+                })!.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                method: kReloadSourcesServiceName,
+                args: <String, Object>{
+                  'isolateId': '1',
+                  'pause': false,
+                  'rootLibUri': 'main.dart.incremental.dill',
+                },
+                jsonResponse: <String, Object>{
+                  'type': 'ReloadReport',
+                  'success': true,
+                  'details': <String, Object>{
+                    'loadedLibraryCount': 1,
+                  },
+                },
+              ),
+              FakeVmServiceRequest(
+                method: 'getIsolatePauseEvent',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedEvent.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
 
-    final TestUsageEvent event = (globals.flutterUsage as TestUsage).events.first;
-    expect(event.category, 'hot');
-    expect(event.parameter, 'reload');
-    expect(event.parameters?.hotEventTargetPlatform, getNameForTargetPlatform(TargetPlatform.android_arm));
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, false);
+            expect(result.code, 0);
 
-    final Event newEvent = fakeAnalytics.sentEvents.first;
-    expect(newEvent.eventName.label, 'hot_runner_info');
-    expect(newEvent.eventData['label'], 'reload');
-    expect(newEvent.eventData['targetPlatform'], getNameForTargetPlatform(TargetPlatform.android_arm));
+            final TestUsageEvent event =
+                (globals.flutterUsage as TestUsage).events.first;
+            expect(event.category, 'hot');
+            expect(event.parameter, 'reload');
+            expect(event.parameters?.hotEventTargetPlatform,
+                getNameForTargetPlatform(TargetPlatform.android_arm));
 
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+            final Event newEvent = fakeAnalytics.sentEvents.first;
+            expect(newEvent.eventName.label, 'hot_runner_info');
+            expect(newEvent.eventData['label'], 'reload');
+            expect(newEvent.eventData['targetPlatform'],
+                getNameForTargetPlatform(TargetPlatform.android_arm));
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-  testUsingContext('ResidentRunner reports hot reload time details', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: fakeVM.toJson(),
-      ),
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: fakeVM.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: kReloadSourcesServiceName,
-        args: <String, Object>{
-          'isolateId': '1',
-          'pause': false,
-          'rootLibUri': 'main.dart.incremental.dill',
-        },
-        jsonResponse: <String, Object>{
-          'type': 'ReloadReport',
-          'success': true,
-          'details': <String, Object>{
-            'loadedLibraryCount': 1,
-            'finalLibraryCount': 42,
-          },
-        },
-      ),
-      FakeVmServiceRequest(
-        method: 'getIsolatePauseEvent',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedEvent.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    final FakeDelegateFlutterDevice flutterDevice = FakeDelegateFlutterDevice(
-      device,
-      BuildInfo.debug,
-      FakeResidentCompiler(),
-      devFS,
-    )..vmService = fakeVmServiceHost!.vmService;
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    devFS.nextUpdateReport = UpdateFSReport(
-      success: true,
-      invalidatedSourcesCount: 1,
-    );
+  testUsingContext(
+      'ResidentRunner reports hot reload time details',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: fakeVM.toJson(),
+              ),
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: fakeVM.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                method: kReloadSourcesServiceName,
+                args: <String, Object>{
+                  'isolateId': '1',
+                  'pause': false,
+                  'rootLibUri': 'main.dart.incremental.dill',
+                },
+                jsonResponse: <String, Object>{
+                  'type': 'ReloadReport',
+                  'success': true,
+                  'details': <String, Object>{
+                    'loadedLibraryCount': 1,
+                    'finalLibraryCount': 42,
+                  },
+                },
+              ),
+              FakeVmServiceRequest(
+                method: 'getIsolatePauseEvent',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedEvent.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            final FakeDelegateFlutterDevice flutterDevice =
+                FakeDelegateFlutterDevice(
+              device,
+              BuildInfo.debug,
+              FakeResidentCompiler(),
+              devFS,
+            )..vmService = fakeVmServiceHost!.vmService;
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            devFS.nextUpdateReport = UpdateFSReport(
+              success: true,
+              invalidatedSourcesCount: 1,
+            );
 
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
 
-    await futureAppStart.future;
-    await residentRunner.restart();
+            await futureAppStart.future;
+            await residentRunner.restart();
 
-    // The actual test: Expect to have compile, reload and reassemble times.
-    expect(
-        testLogger.statusText,
-        contains(RegExp(r'Reloaded 1 of 42 libraries in \d+ms '
-            r'\(compile: \d+ ms, reload: \d+ ms, reassemble: \d+ ms\)\.')));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem.test(),
-    Platform: () => FakePlatform(),
-    ProjectFileInvalidator: () => FakeProjectFileInvalidator(),
-    Usage: () => TestUsage(),
-  }));
+            // The actual test: Expect to have compile, reload and reassemble times.
+            expect(
+                testLogger.statusText,
+                contains(RegExp(r'Reloaded 1 of 42 libraries in \d+ms '
+                    r'\(compile: \d+ ms, reload: \d+ ms, reassemble: \d+ ms\)\.')));
+          }, overrides: <Type, Generator>{
+            FileSystem: () => MemoryFileSystem.test(),
+            Platform: () => FakePlatform(),
+            ProjectFileInvalidator: () => FakeProjectFileInvalidator(),
+            Usage: () => TestUsage(),
+          }));
 
-  testUsingContext('ResidentRunner can send target platform to analytics from full restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        )
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
+  testUsingContext(
+      'ResidentRunner can send target platform to analytics from full restart',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                  streamId: 'Isolate',
+                  event: vm_service.Event(
+                    timestamp: 0,
+                    kind: vm_service.EventKind.kIsolateRunnable,
+                  )),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
 
-    final OperationResult result = await residentRunner.restart(fullRestart: true);
-    expect(result.fatal, false);
-    expect(result.code, 0);
+            final OperationResult result =
+                await residentRunner.restart(fullRestart: true);
+            expect(result.fatal, false);
+            expect(result.code, 0);
 
-    final TestUsageEvent event = (globals.flutterUsage as TestUsage).events.first;
-    expect(event.category, 'hot');
-    expect(event.parameter, 'restart');
-    expect(event.parameters?.hotEventTargetPlatform, getNameForTargetPlatform(TargetPlatform.android_arm));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+            final TestUsageEvent event =
+                (globals.flutterUsage as TestUsage).events.first;
+            expect(event.category, 'hot');
+            expect(event.parameter, 'restart');
+            expect(event.parameters?.hotEventTargetPlatform,
+                getNameForTargetPlatform(TargetPlatform.android_arm));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
 
-    // Parse out the event of interest since we may have timing events with
-    // the new analytics package
-    final List<Event> newEventList = fakeAnalytics.sentEvents.where((Event e) => e.eventName.label == 'hot_runner_info').toList();
-    expect(newEventList, hasLength(1));
-    final Event newEvent = newEventList.first;
-    expect(newEvent.eventName.label, 'hot_runner_info');
-    expect(newEvent.eventData['label'], 'restart');
-    expect(newEvent.eventData['targetPlatform'], getNameForTargetPlatform(TargetPlatform.android_arm));
+            // Parse out the event of interest since we may have timing events with
+            // the new analytics package
+            final List<Event> newEventList = fakeAnalytics.sentEvents
+                .where((Event e) => e.eventName.label == 'hot_runner_info')
+                .toList();
+            expect(newEventList, hasLength(1));
+            final Event newEvent = newEventList.first;
+            expect(newEvent.eventName.label, 'hot_runner_info');
+            expect(newEvent.eventData['label'], 'restart');
+            expect(newEvent.eventData['targetPlatform'],
+                getNameForTargetPlatform(TargetPlatform.android_arm));
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+  testUsingContext(
+      'ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakePausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                  method: 'setIsolatePauseMode',
+                  args: <String, String>{
+                    'isolateId': '1',
+                    'exceptionPauseMode': 'None',
+                  }),
+              const FakeVmServiceRequest(
+                  method: 'removeBreakpoint',
+                  args: <String, String>{
+                    'isolateId': '1',
+                    'breakpointId': 'test-breakpoint',
+                  }),
+              const FakeVmServiceRequest(
+                  method: 'resume',
+                  args: <String, String>{
+                    'isolateId': '1',
+                  }),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                streamId: 'Isolate',
+                event: vm_service.Event(
+                  timestamp: 0,
+                  kind: vm_service.EventKind.kIsolateRunnable,
+                ),
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
 
-  testUsingContext('ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakePausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: 'setIsolatePauseMode',
-        args: <String, String>{
-          'isolateId': '1',
-          'exceptionPauseMode': 'None',
-        }
-      ),
-      const FakeVmServiceRequest(
-        method: 'removeBreakpoint',
-        args: <String, String>{
-          'isolateId': '1',
-          'breakpointId': 'test-breakpoint',
-        }
-      ),
-      const FakeVmServiceRequest(
-        method: 'resume',
-        args: <String, String>{
-          'isolateId': '1',
-        }
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        ),
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
+            final OperationResult result =
+                await residentRunner.restart(fullRestart: true);
 
-    final OperationResult result = await residentRunner.restart(fullRestart: true);
+            expect(result.isOk, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    expect(result.isOk, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner will alternative the name of the dill file uploaded for a hot restart',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                streamId: 'Isolate',
+                event: vm_service.Event(
+                  timestamp: 0,
+                  kind: vm_service.EventKind.kIsolateRunnable,
+                ),
+              ),
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.swap.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                streamId: 'Isolate',
+                event: vm_service.Event(
+                  timestamp: 0,
+                  kind: vm_service.EventKind.kIsolateRunnable,
+                ),
+              ),
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                streamId: 'Isolate',
+                event: vm_service.Event(
+                  timestamp: 0,
+                  kind: vm_service.EventKind.kIsolateRunnable,
+                ),
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
 
-  testUsingContext('ResidentRunner will alternative the name of the dill file uploaded for a hot restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        ),
-      ),
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.swap.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        ),
-      ),
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        ),
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
+            await residentRunner.restart(fullRestart: true);
+            await residentRunner.restart(fullRestart: true);
+            await residentRunner.restart(fullRestart: true);
 
-    await residentRunner.restart(fullRestart: true);
-    await residentRunner.restart(fullRestart: true);
-    await residentRunner.restart(fullRestart: true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner Can handle an RPC exception from hot restart',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.reportError =
+                vm_service.RPCError('something bad happened', 666, '');
 
-  testUsingContext('ResidentRunner Can handle an RPC exception from hot restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
+            final OperationResult result =
+                await residentRunner.restart(fullRestart: true);
+            expect(result.fatal, true);
+            expect(result.code, 1);
 
-    final OperationResult result = await residentRunner.restart(fullRestart: true);
-    expect(result.fatal, true);
-    expect(result.code, 1);
+            expect(
+                (globals.flutterUsage as TestUsage).events,
+                contains(
+                  TestUsageEvent('hot', 'exception',
+                      parameters: CustomDimensions(
+                        hotEventTargetPlatform: getNameForTargetPlatform(
+                            TargetPlatform.android_arm),
+                        hotEventSdkName: 'Android',
+                        hotEventEmulator: false,
+                        hotEventFullRestart: true,
+                      )),
+                ));
+            expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.hotRunnerInfo(
+                    label: 'exception',
+                    targetPlatform:
+                        getNameForTargetPlatform(TargetPlatform.android_arm),
+                    sdkName: 'Android',
+                    emulator: false,
+                    fullRestart: true,
+                  ),
+                ));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-    expect((globals.flutterUsage as TestUsage).events, contains(
-      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
-        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        hotEventSdkName: 'Android',
-        hotEventEmulator: false,
-        hotEventFullRestart: true,
-      )),
-    ));
-    expect(fakeAnalytics.sentEvents, contains(
-      Event.hotRunnerInfo(
-        label: 'exception',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        sdkName: 'Android',
-        emulator: false,
-        fullRestart: true,
-      ),
-    ));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+  testUsingContext(
+      'ResidentRunner uses temp directory when there is no output dill path',
+      () => testbed.run(() {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            expect(residentRunner.artifactDirectory.path,
+                contains('flutter_tool.'));
 
-  testUsingContext('ResidentRunner uses temp directory when there is no output dill path', () => testbed.run(() {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    expect(residentRunner.artifactDirectory.path, contains('flutter_tool.'));
+            final ResidentRunner otherRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            expect(otherRunner.artifactDirectory.path, contains('foobar'));
+          }));
 
-    final ResidentRunner otherRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    expect(otherRunner.artifactDirectory.path, contains('foobar'));
-  }));
+  testUsingContext(
+      'ResidentRunner deletes artifact directory on preExit',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            residentRunner.artifactDirectory.childFile('app.dill').createSync();
+            await residentRunner.preExit();
 
-  testUsingContext('ResidentRunner deletes artifact directory on preExit', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    residentRunner.artifactDirectory.childFile('app.dill').createSync();
-    await residentRunner.preExit();
+            expect(residentRunner.artifactDirectory, isNot(exists));
+          }));
 
-    expect(residentRunner.artifactDirectory, isNot(exists));
-  }));
-
-  testUsingContext('ResidentRunner can run source generation', () => testbed.run(() async {
-    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
+  testUsingContext(
+      'ResidentRunner can run source generation',
+      () => testbed.run(() async {
+            final File arbFile = globals.fs
+                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+              ..createSync(recursive: true);
+            arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-    globals.fs.file('l10n.yaml').createSync();
-    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
+            globals.fs.file('l10n.yaml').createSync();
+            globals.fs
+                .file('pubspec.yaml')
+                .writeAsStringSync('flutter:\n  generate: true\n');
 
-    // Create necessary files for [DartPluginRegistrantTarget]
-    final File packageConfig = globals.fs.directory('.dart_tool')
-        .childFile('package_config.json');
-    packageConfig.createSync(recursive: true);
-    packageConfig.writeAsStringSync('''
+            // Create necessary files for [DartPluginRegistrantTarget]
+            final File packageConfig = globals.fs
+                .directory('.dart_tool')
+                .childFile('package_config.json');
+            packageConfig.createSync(recursive: true);
+            packageConfig.writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": [
@@ -1123,27 +1275,34 @@ void main() {
   ]
 }
 ''');
-    // Start from an empty dart_plugin_registrant.dart file.
-    globals.fs.directory('.dart_tool').childDirectory('flutter_build').childFile('dart_plugin_registrant.dart').createSync(recursive: true);
+            // Start from an empty dart_plugin_registrant.dart file.
+            globals.fs
+                .directory('.dart_tool')
+                .childDirectory('flutter_build')
+                .childFile('dart_plugin_registrant.dart')
+                .createSync(recursive: true);
 
-    await residentRunner.runSourceGenerators();
+            await residentRunner.runSourceGenerators();
 
-    expect(testLogger.errorText, isEmpty);
-    expect(testLogger.statusText, isEmpty);
-  }));
+            expect(testLogger.errorText, isEmpty);
+            expect(testLogger.statusText, isEmpty);
+          }));
 
-  testUsingContext('generated main uses correct target', () => testbed.run(() async {
-    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
+  testUsingContext(
+      'generated main uses correct target',
+      () => testbed.run(() async {
+            final File arbFile = globals.fs
+                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+              ..createSync(recursive: true);
+            arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-    globals.fs.file('l10n.yaml').createSync();
-    globals.fs.file('pubspec.yaml').writeAsStringSync('''
+            globals.fs.file('l10n.yaml').createSync();
+            globals.fs.file('pubspec.yaml').writeAsStringSync('''
 flutter:
   generate: true
 
@@ -1153,12 +1312,13 @@ dependencies:
   path_provider_linux: 1.0.0
 ''');
 
-    // Create necessary files for [DartPluginRegistrantTarget], including a
-    // plugin that will trigger generation.
-    final File packageConfig = globals.fs.directory('.dart_tool')
-        .childFile('package_config.json');
-    packageConfig.createSync(recursive: true);
-    packageConfig.writeAsStringSync('''
+            // Create necessary files for [DartPluginRegistrantTarget], including a
+            // plugin that will trigger generation.
+            final File packageConfig = globals.fs
+                .directory('.dart_tool')
+                .childFile('package_config.json');
+            packageConfig.createSync(recursive: true);
+            packageConfig.writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": [
@@ -1171,10 +1331,11 @@ dependencies:
   ]
 }
 ''');
-    final Directory fakePluginDir = globals.fs.directory('path_provider_linux');
-    final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
-    pluginPubspec.createSync(recursive: true);
-    pluginPubspec.writeAsStringSync('''
+            final Directory fakePluginDir =
+                globals.fs.directory('path_provider_linux');
+            final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
+            pluginPubspec.createSync(recursive: true);
+            pluginPubspec.writeAsStringSync('''
 name: path_provider_linux
 
 flutter:
@@ -1185,594 +1346,739 @@ flutter:
         dartPluginClass: PathProviderLinux
 ''');
 
-    residentRunner = HotRunner(
-        <FlutterDevice>[
-          flutterDevice,
-        ],
-        stayResident: false,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-        target: 'custom_main.dart',
-        devtoolsHandler: createNoOpHandler,
-        analytics: fakeAnalytics,
-      );
-    await residentRunner.runSourceGenerators();
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'custom_main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            await residentRunner.runSourceGenerators();
 
-    final File generatedMain = globals.fs.directory('.dart_tool')
-        .childDirectory('flutter_build')
-        .childFile('dart_plugin_registrant.dart');
+            final File generatedMain = globals.fs
+                .directory('.dart_tool')
+                .childDirectory('flutter_build')
+                .childFile('dart_plugin_registrant.dart');
 
-    expect(generatedMain.existsSync(), isTrue);
-    expect(testLogger.errorText, isEmpty);
-    expect(testLogger.statusText, isEmpty);
-  }));
+            expect(generatedMain.existsSync(), isTrue);
+            expect(testLogger.errorText, isEmpty);
+            expect(testLogger.statusText, isEmpty);
+          }));
 
-  testUsingContext('ResidentRunner can run source generation - generation fails', () => testbed.run(() async {
-    // Intentionally define arb file with wrong name. generate_localizations defaults
-    // to app_en.arb.
-    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'foo.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
+  testUsingContext(
+      'ResidentRunner can run source generation - generation fails',
+      () => testbed.run(() async {
+            // Intentionally define arb file with wrong name. generate_localizations defaults
+            // to app_en.arb.
+            final File arbFile = globals.fs
+                .file(globals.fs.path.join('lib', 'l10n', 'foo.arb'))
+              ..createSync(recursive: true);
+            arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-    globals.fs.file('l10n.yaml').createSync();
-    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
+            globals.fs.file('l10n.yaml').createSync();
+            globals.fs
+                .file('pubspec.yaml')
+                .writeAsStringSync('flutter:\n  generate: true\n');
 
-    await residentRunner.runSourceGenerators();
+            await residentRunner.runSourceGenerators();
 
-    expect(testLogger.errorText, contains('Error'));
-    expect(testLogger.statusText, isEmpty);
-  }));
+            expect(testLogger.errorText, contains('Error'));
+            expect(testLogger.statusText, isEmpty);
+          }));
 
-  testUsingContext('ResidentRunner generates files when l10n.yaml exists', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
+  testUsingContext(
+      'ResidentRunner generates files when l10n.yaml exists',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            final File arbFile = globals.fs
+                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+              ..createSync(recursive: true);
+            arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-    globals.fs.file('l10n.yaml').createSync();
-    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
+            globals.fs.file('l10n.yaml').createSync();
+            globals.fs
+                .file('pubspec.yaml')
+                .writeAsStringSync('flutter:\n  generate: true\n');
 
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+              ..nextOutput = const CompilerOutput('foo', 1, <Uri>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.generator = residentCompiler;
+
+            await residentRunner.run();
+
+            final File generatedLocalizationsFile = globals.fs
+                .directory('.dart_tool')
+                .childDirectory('flutter_gen')
+                .childDirectory('gen_l10n')
+                .childFile('app_localizations.dart');
+            expect(generatedLocalizationsFile.existsSync(), isTrue);
+
+            // Completing this future ensures that the daemon can exit correctly.
+            expect(await residentRunner.waitForAppToFinish(), 1);
+          }));
+
+  testUsingContext(
+      'ResidentRunner printHelpDetails hot runner',
+      () => testbed.run(() {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
+            residentRunner.printHelp(details: true);
+
+            final CommandHelp commandHelp = residentRunner.commandHelp;
+
+            // supports service protocol
+            expect(residentRunner.supportsServiceProtocol, true);
+            // isRunningDebug
+            expect(residentRunner.isRunningDebug, true);
+            // does support SkSL
+            expect(residentRunner.supportsWriteSkSL, true);
+            // commands
+            expect(
+                testLogger.statusText,
+                equals(<dynamic>[
+                  'Flutter run key commands.',
+                  commandHelp.r,
+                  commandHelp.R,
+                  commandHelp.v,
+                  commandHelp.s,
+                  commandHelp.w,
+                  commandHelp.t,
+                  commandHelp.L,
+                  commandHelp.f,
+                  commandHelp.S,
+                  commandHelp.U,
+                  commandHelp.i,
+                  commandHelp.p,
+                  commandHelp.I,
+                  commandHelp.o,
+                  commandHelp.b,
+                  commandHelp.P,
+                  commandHelp.a,
+                  commandHelp.M,
+                  commandHelp.g,
+                  commandHelp.hWithDetails,
+                  commandHelp.c,
+                  commandHelp.q,
+                  '',
+                  'A Dart VM Service on FakeDevice is available at: null',
+                  '',
+                ].join('\n')));
+          }));
+
+  testUsingContext(
+      'ResidentRunner printHelp hot runner',
+      () => testbed.run(() {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
+            residentRunner.printHelp(details: false);
+
+            final CommandHelp commandHelp = residentRunner.commandHelp;
+
+            // supports service protocol
+            expect(residentRunner.supportsServiceProtocol, true);
+            // isRunningDebug
+            expect(residentRunner.isRunningDebug, true);
+            // does support SkSL
+            expect(residentRunner.supportsWriteSkSL, true);
+            // commands
+            expect(
+                testLogger.statusText,
+                equals(<dynamic>[
+                  'Flutter run key commands.',
+                  commandHelp.r,
+                  commandHelp.R,
+                  commandHelp.hWithoutDetails,
+                  commandHelp.c,
+                  commandHelp.q,
+                  '',
+                  'A Dart VM Service on FakeDevice is available at: null',
+                  '',
+                ].join('\n')));
+          }));
+
+  testUsingContext(
+      'ResidentRunner printHelpDetails cold runner',
+      () => testbed.run(() {
+            fakeVmServiceHost = null;
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.printHelp(details: true);
+
+            final CommandHelp commandHelp = residentRunner.commandHelp;
+
+            // does not supports service protocol
+            expect(residentRunner.supportsServiceProtocol, false);
+            // isRunningDebug
+            expect(residentRunner.isRunningDebug, false);
+            // does support SkSL
+            expect(residentRunner.supportsWriteSkSL, false);
+            // commands
+            expect(
+                testLogger.statusText,
+                equals(<dynamic>[
+                  'Flutter run key commands.',
+                  commandHelp.v,
+                  commandHelp.s,
+                  commandHelp.hWithDetails,
+                  commandHelp.c,
+                  commandHelp.q,
+                  '',
+                ].join('\n')));
+          }));
+
+  testUsingContext(
+      'ResidentRunner printHelp cold runner',
+      () => testbed.run(() {
+            fakeVmServiceHost = null;
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.printHelp(details: false);
+
+            final CommandHelp commandHelp = residentRunner.commandHelp;
+
+            // does not supports service protocol
+            expect(residentRunner.supportsServiceProtocol, false);
+            // isRunningDebug
+            expect(residentRunner.isRunningDebug, false);
+            // does support SkSL
+            expect(residentRunner.supportsWriteSkSL, false);
+            // commands
+            expect(
+                testLogger.statusText,
+                equals(<dynamic>[
+                  'Flutter run key commands.',
+                  commandHelp.hWithoutDetails,
+                  commandHelp.c,
+                  commandHelp.q,
+                  '',
+                ].join('\n')));
+          }));
+
+  testUsingContext(
+      'ResidentRunner handles writeSkSL returning no data',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              FakeVmServiceRequest(
+                  method: kGetSkSLsMethod,
+                  args: <String, Object>{
+                    'viewId': fakeFlutterView.id,
+                  },
+                  jsonResponse: <String, Object>{
+                    'SkSLs': <String, Object>{},
+                  }),
+            ]);
+            await residentRunner.writeSkSL();
+
+            expect(testLogger.statusText, contains('No data was received'));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
+
+  testUsingContext(
+      'ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              FakeVmServiceRequest(
+                method: kGetSkSLsMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                },
+                jsonResponse: <String, Object>{
+                  'SkSLs': <String, Object>{
+                    'A': 'B',
+                  },
+                },
+              ),
+            ]);
+            await residentRunner.writeSkSL();
+
+            expect(testLogger.statusText, contains('flutter_01.sksl.json'));
+            expect(globals.fs.file('flutter_01.sksl.json'), exists);
+            expect(
+                json.decode(
+                    globals.fs.file('flutter_01.sksl.json').readAsStringSync()),
+                <String, Object>{
+                  'platform': 'android',
+                  'name': 'FakeDevice',
+                  'engineRevision': 'abcdefg',
+                  'data': <String, Object>{'A': 'B'},
+                });
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            FileSystemUtils: () => FileSystemUtils(
+                  fileSystem: globals.fs,
+                  platform: globals.platform,
+                ),
+            FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg'),
+          }));
+
+  testUsingContext(
+      'ResidentRunner ignores DevtoolsLauncher when attaching with enableDevTools: false - cold mode',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile,
+                  vmserviceOutFile: 'foo', enableDevTools: false),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubspecResolution: true,
+            );
+
+            final Future<int?> result = residentRunner.attach();
+            expect(await result, 0);
+          }));
+
+  testUsingContext(
+      'FlutterDevice can exit from a release mode isolate with no VmService',
+      () => testbed.run(() async {
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+            );
+
+            await flutterDevice.exitApps();
+
+            expect(device.appStopped, true);
+          }));
+
+  testUsingContext(
+      'FlutterDevice will exit an un-paused isolate using stopApp',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+            );
+            flutterDevice.vmService = fakeVmServiceHost!.vmService;
+
+            final Future<void> exitFuture = flutterDevice.exitApps();
+
+            await expectLater(exitFuture, completes);
+            expect(device.appStopped, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
+
+  testUsingContext(
+      'HotRunner writes vm service file when providing debugging option',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
+                  vmserviceOutFile: 'foo'),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+
+            await residentRunner.run();
+
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+            expect(await globals.fs.file('foo').readAsString(),
+                testUri.toString());
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                null,
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(globals.fs.path.join('build', 'cache.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup with dart defines',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                '',
+                treeShakeIcons: false,
+                dartDefines: <String>['a', 'b'],
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(globals.fs.path.join(
+                        'build', '187ef4436122d1cc2f40dc2b92f0eba0.cache.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup with null safety',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                '',
+                treeShakeIcons: false,
+                extraFrontEndOptions: <String>[
+                  '--enable-experiment=non-nullable'
+                ],
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(globals.fs.path.join('build', 'cache.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup with track-widget-creation',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(
+                        globals.fs.path.join('build', 'cache.dill.track.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner does not copy app.dill if a dillOutputPath is given',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              dillOutputPath: 'test',
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(globals.fs.file(globals.fs.path.join('build', 'cache.dill')),
+                isNot(exists));
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup with --track-widget-creation',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                '',
+                treeShakeIcons: false,
+                trackWidgetCreation: true,
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(
+                        globals.fs.path.join('build', 'cache.dill.track.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner calls device dispose',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+
+            await residentRunner.run();
+            expect(device.disposed, true);
+          }));
+
+  testUsingContext(
+      'HotRunner handles failure to write vmservice file',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
+                  vmserviceOutFile: 'foo'),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+
+            await residentRunner.run();
+
+            expect(testLogger.errorText,
+                contains('Failed to write vmservice-out-file at foo'));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            FileSystem: () =>
+                ThrowingForwardingFileSystem(MemoryFileSystem.test()),
+          }));
+
+  testUsingContext(
+      'ColdRunner writes vm service file when providing debugging option',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile,
+                  vmserviceOutFile: 'foo'),
+              devtoolsHandler: createNoOpHandler,
+              target: 'main.dart',
+              useImplicitPubspecResolution: true,
+            );
+
+            await residentRunner.run();
+
+            expect(await globals.fs.file('foo').readAsString(),
+                testUri.toString());
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
+
+  testUsingContext(
+      'FlutterDevice uses dartdevc configuration when targeting web', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    flutterDevice.generator = residentCompiler;
-
-    await residentRunner.run();
-
-    final File generatedLocalizationsFile = globals.fs.directory('.dart_tool')
-      .childDirectory('flutter_gen')
-      .childDirectory('gen_l10n')
-      .childFile('app_localizations.dart');
-    expect(generatedLocalizationsFile.existsSync(), isTrue);
-
-    // Completing this future ensures that the daemon can exit correctly.
-    expect(await residentRunner.waitForAppToFinish(), 1);
-  }));
-
-  testUsingContext('ResidentRunner printHelpDetails hot runner', () => testbed.run(() {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
-    residentRunner.printHelp(details: true);
-
-    final CommandHelp commandHelp = residentRunner.commandHelp;
-
-    // supports service protocol
-    expect(residentRunner.supportsServiceProtocol, true);
-    // isRunningDebug
-    expect(residentRunner.isRunningDebug, true);
-    // does support SkSL
-    expect(residentRunner.supportsWriteSkSL, true);
-    // commands
-    expect(testLogger.statusText, equals(
-        <dynamic>[
-          'Flutter run key commands.',
-          commandHelp.r,
-          commandHelp.R,
-          commandHelp.v,
-          commandHelp.s,
-          commandHelp.w,
-          commandHelp.t,
-          commandHelp.L,
-          commandHelp.f,
-          commandHelp.S,
-          commandHelp.U,
-          commandHelp.i,
-          commandHelp.p,
-          commandHelp.I,
-          commandHelp.o,
-          commandHelp.b,
-          commandHelp.P,
-          commandHelp.a,
-          commandHelp.M,
-          commandHelp.g,
-          commandHelp.hWithDetails,
-          commandHelp.c,
-          commandHelp.q,
-          '',
-          'A Dart VM Service on FakeDevice is available at: null',
-          '',
-        ].join('\n')
-    ));
-  }));
-
-  testUsingContext('ResidentRunner printHelp hot runner', () => testbed.run(() {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
-    residentRunner.printHelp(details: false);
-
-    final CommandHelp commandHelp = residentRunner.commandHelp;
-
-    // supports service protocol
-    expect(residentRunner.supportsServiceProtocol, true);
-    // isRunningDebug
-    expect(residentRunner.isRunningDebug, true);
-    // does support SkSL
-    expect(residentRunner.supportsWriteSkSL, true);
-    // commands
-    expect(testLogger.statusText, equals(
-        <dynamic>[
-          'Flutter run key commands.',
-          commandHelp.r,
-          commandHelp.R,
-          commandHelp.hWithoutDetails,
-          commandHelp.c,
-          commandHelp.q,
-          '',
-          'A Dart VM Service on FakeDevice is available at: null',
-          '',
-        ].join('\n')
-    ));
-  }));
-
-  testUsingContext('ResidentRunner printHelpDetails cold runner', () => testbed.run(() {
-    fakeVmServiceHost = null;
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-    residentRunner.printHelp(details: true);
-
-    final CommandHelp commandHelp = residentRunner.commandHelp;
-
-    // does not supports service protocol
-    expect(residentRunner.supportsServiceProtocol, false);
-    // isRunningDebug
-    expect(residentRunner.isRunningDebug, false);
-    // does support SkSL
-    expect(residentRunner.supportsWriteSkSL, false);
-    // commands
-    expect(testLogger.statusText, equals(
-        <dynamic>[
-          'Flutter run key commands.',
-          commandHelp.v,
-          commandHelp.s,
-          commandHelp.hWithDetails,
-          commandHelp.c,
-          commandHelp.q,
-          '',
-        ].join('\n')
-    ));
-  }));
-
-  testUsingContext('ResidentRunner printHelp cold runner', () => testbed.run(() {
-    fakeVmServiceHost = null;
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-    residentRunner.printHelp(details: false);
-
-    final CommandHelp commandHelp = residentRunner.commandHelp;
-
-    // does not supports service protocol
-    expect(residentRunner.supportsServiceProtocol, false);
-    // isRunningDebug
-    expect(residentRunner.isRunningDebug, false);
-    // does support SkSL
-    expect(residentRunner.supportsWriteSkSL, false);
-    // commands
-    expect(testLogger.statusText, equals(
-        <dynamic>[
-          'Flutter run key commands.',
-          commandHelp.hWithoutDetails,
-          commandHelp.c,
-          commandHelp.q,
-          '',
-        ].join('\n')
-    ));
-  }));
-
-  testUsingContext('ResidentRunner handles writeSkSL returning no data', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      FakeVmServiceRequest(
-        method: kGetSkSLsMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-        },
-        jsonResponse: <String, Object>{
-          'SkSLs': <String, Object>{},
-        }
-      ),
-    ]);
-    await residentRunner.writeSkSL();
-
-    expect(testLogger.statusText, contains('No data was received'));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
-
-  testUsingContext('ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      FakeVmServiceRequest(
-        method: kGetSkSLsMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-        },
-        jsonResponse: <String, Object>{
-          'SkSLs': <String, Object>{
-            'A': 'B',
-          },
-        },
-      ),
-    ]);
-    await residentRunner.writeSkSL();
-
-    expect(testLogger.statusText, contains('flutter_01.sksl.json'));
-    expect(globals.fs.file('flutter_01.sksl.json'), exists);
-    expect(json.decode(globals.fs.file('flutter_01.sksl.json').readAsStringSync()), <String, Object>{
-      'platform': 'android',
-      'name': 'FakeDevice',
-      'engineRevision': 'abcdefg',
-      'data': <String, Object>{'A': 'B'},
-    });
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    FileSystemUtils: () => FileSystemUtils(
-      fileSystem: globals.fs,
-      platform: globals.platform,
-    ),
-    FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg'),
-  }));
-
-  testUsingContext('ResidentRunner ignores DevtoolsLauncher when attaching with enableDevTools: false - cold mode', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo', enableDevTools: false),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-
-    final Future<int?> result = residentRunner.attach();
-    expect(await result, 0);
-  }));
-
-  testUsingContext('FlutterDevice can exit from a release mode isolate with no VmService', () => testbed.run(() async {
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-    );
-
-    await flutterDevice.exitApps();
-
-    expect(device.appStopped, true);
-  }));
-
-  testUsingContext('FlutterDevice will exit an un-paused isolate using stopApp', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-    );
-    flutterDevice.vmService = fakeVmServiceHost!.vmService;
-
-    final Future<void> exitFuture = flutterDevice.exitApps();
-
-    await expectLater(exitFuture, completes);
-    expect(device.appStopped, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
-
-  testUsingContext('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-
-    await residentRunner.run();
-
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-    expect(await globals.fs.file('foo').readAsString(), testUri.toString());
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(
-        const BuildInfo(
-          BuildMode.debug,
-          null,
-          treeShakeIcons: false,
-          packageConfigPath: '.dart_tool/package_config.json',
-        )
-      ),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup with dart defines', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(
-        const BuildInfo(
-          BuildMode.debug,
-          '',
-          treeShakeIcons: false,
-          dartDefines: <String>['a', 'b'],
-          packageConfigPath: '.dart_tool/package_config.json',
-        )
-      ),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join(
-      'build', '187ef4436122d1cc2f40dc2b92f0eba0.cache.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup with null safety', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(
-        const BuildInfo(
-          BuildMode.debug,
-          '',
-          treeShakeIcons: false,
-          extraFrontEndOptions: <String>['--enable-experiment=non-nullable'],
-          packageConfigPath: '.dart_tool/package_config.json',
-        )
-      ),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join(
-      'build', 'cache.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup with track-widget-creation', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join(
-      'build', 'cache.dill.track.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner does not copy app.dill if a dillOutputPath is given', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      dillOutputPath: 'test',
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(globals.fs.file(globals.fs.path.join('build', 'cache.dill')), isNot(exists));
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup with --track-widget-creation', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        trackWidgetCreation: true,
-        packageConfigPath: '.dart_tool/package_config.json',
-      )),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill.track.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner calls device dispose', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-
-    await residentRunner.run();
-    expect(device.disposed, true);
-  }));
-
-  testUsingContext('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-
-    await residentRunner.run();
-
-    expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem.test()),
-  }));
-
-  testUsingContext('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo'),
-      devtoolsHandler: createNoOpHandler,
-      target: 'main.dart',
-    );
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file('foo').readAsString(), testUri.toString());
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
-
-  testUsingContext('FlutterDevice uses dartdevc configuration when targeting web', () async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final FakeDevice device =
+        FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -1783,28 +2089,40 @@ flutter:
       ),
       target: null,
       platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+    ))
+            .generator as DefaultResidentCompiler?;
 
-    expect(residentCompiler!.initializeFromDill,
-      globals.fs.path.join(getBuildDirectory(), 'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'));
-    expect(residentCompiler.librariesSpec,
-      globals.fs.file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-        .uri.toString());
+    expect(
+        residentCompiler!.initializeFromDill,
+        globals.fs.path.join(getBuildDirectory(),
+            'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'));
+    expect(
+        residentCompiler.librariesSpec,
+        globals.fs
+            .file(globals.artifacts!
+                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+            .uri
+            .toString());
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
-      '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill');
+        '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
+    expect(residentCompiler.platformDill,
+        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected', () async {
+  testUsingContext(
+      'FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+    final FakeDevice device =
+        FakeDevice(targetPlatform: TargetPlatform.web_javascript);
 
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -1815,29 +2133,38 @@ flutter:
       ),
       target: null,
       platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+    ))
+            .generator as DefaultResidentCompiler?;
 
-    expect(residentCompiler!.initializeFromDill,
-      globals.fs.path.join(getBuildDirectory(), '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
-    expect(residentCompiler.librariesSpec,
-      globals.fs.file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-        .uri.toString());
+    expect(
+        residentCompiler!.initializeFromDill,
+        globals.fs.path.join(getBuildDirectory(),
+            '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
+    expect(
+        residentCompiler.librariesSpec,
+        globals.fs
+            .file(globals.artifacts!
+                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+            .uri
+            .toString());
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
-      '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill');
+        '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
+    expect(residentCompiler.platformDill,
+        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice passes alternative-invalidation-strategy flag', () async {
+  testUsingContext(
+      'FlutterDevice passes alternative-invalidation-strategy flag', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -1846,22 +2173,27 @@ flutter:
         extraFrontEndOptions: <String>[],
         packageConfigPath: '.dart_tool/package_config.json',
       ),
-      target: null, platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+      target: null,
+      platform: FakePlatform(),
+    ))
+            .generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.extraFrontEndOptions,
-      contains('--enable-experiment=alternative-invalidation-strategy'));
+        contains('--enable-experiment=alternative-invalidation-strategy'));
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice passes initializeFromDill parameter if specified', () async {
+  testUsingContext(
+      'FlutterDevice passes initializeFromDill parameter if specified',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -1871,8 +2203,10 @@ flutter:
         initializeFromDill: '/foo/bar.dill',
         packageConfigPath: '.dart_tool/package_config.json',
       ),
-      target: null, platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+      target: null,
+      platform: FakePlatform(),
+    ))
+            .generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.initializeFromDill, '/foo/bar.dill');
     expect(residentCompiler.assumeInitializeFromDillUpToDate, false);
@@ -1882,22 +2216,24 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-   testUsingContext('FlutterDevice passes assumeInitializeFromDillUpToDate parameter if specified', () async {
+  testUsingContext(
+      'FlutterDevice passes assumeInitializeFromDillUpToDate parameter if specified',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
-      buildInfo: const BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        extraFrontEndOptions: <String>[],
-        assumeInitializeFromDillUpToDate: true,
-        packageConfigPath: '.dart_tool/package_config.json'
-      ),
-      target: null, platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+      buildInfo: const BuildInfo(BuildMode.debug, '',
+          treeShakeIcons: false,
+          extraFrontEndOptions: <String>[],
+          assumeInitializeFromDillUpToDate: true,
+          packageConfigPath: '.dart_tool/package_config.json'),
+      target: null,
+      platform: FakePlatform(),
+    ))
+            .generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.assumeInitializeFromDillUpToDate, true);
   }, overrides: <Type, Generator>{
@@ -1906,30 +2242,35 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice passes frontendServerStarterPath parameter if specified', () async {
+  testUsingContext(
+      'FlutterDevice passes frontendServerStarterPath parameter if specified',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
-      buildInfo: const BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        frontendServerStarterPath: '/foo/bar/frontend_server_starter.dart',
-        packageConfigPath: '.dart_tool/package_config.json'
-      ),
-      target: null, platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+      buildInfo: const BuildInfo(BuildMode.debug, '',
+          treeShakeIcons: false,
+          frontendServerStarterPath: '/foo/bar/frontend_server_starter.dart',
+          packageConfigPath: '.dart_tool/package_config.json'),
+      target: null,
+      platform: FakePlatform(),
+    ))
+            .generator as DefaultResidentCompiler?;
 
-    expect(residentCompiler!.frontendServerStarterPath, '/foo/bar/frontend_server_starter.dart');
+    expect(residentCompiler!.frontendServerStarterPath,
+        '/foo/bar/frontend_server_starter.dart');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection', () async {
+  testUsingContext(
+      'FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         const FakeVmServiceRequest(
@@ -1966,160 +2307,189 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('Uses existing DDS URI from exception field', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice()
-      ..dds = DartDevelopmentService(logger: testLogger);
-    ddsLauncherCallback = ({
-      required Uri remoteVmServiceUri,
-      Uri? serviceUri,
-      bool enableAuthCodes = true,
-      bool serveDevTools = false,
-      Uri? devToolsServerAddress,
-      bool enableServicePortFallback = false,
-      List<String> cachedUserTags = const <String>[],
-      String? dartExecutable,
-      String? google3WorkspaceRoot,
-    }) {
-      throw DartDevelopmentServiceException.existingDdsInstance(
-        'Existing DDS at http://localhost/existingDdsInMessage.',
-        ddsUri: Uri.parse('http://localhost/existingDdsInField'),
-      );
-    };
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-      vmServiceUris: Stream<Uri>.value(testUri),
-    );
-    final Completer<void> done = Completer<void>();
-    unawaited(runZonedGuarded(
-      () => flutterDevice.connect(
-        allowExistingDdsInstance: true,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      ).then((_) => done.complete()),
-      (_, __) => done.complete(),
-    ));
-    await done.future;
-    expect(device.dds.uri, Uri.parse('http://localhost/existingDdsInField'));
-  }, overrides: <Type, Generator>{
-    VMServiceConnector: () => (Uri httpUri, {
-      ReloadSources? reloadSources,
-      Restart? restart,
-      CompileExpression? compileExpression,
-      GetSkSLMethod? getSkSLMethod,
-      FlutterProject? flutterProject,
-    PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-      io.CompressionOptions? compression,
-      Device? device,
-      required Logger logger,
-    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
-  }));
+  testUsingContext(
+      'Uses existing DDS URI from exception field',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final FakeDevice device = FakeDevice()
+              ..dds = DartDevelopmentService(logger: testLogger);
+            ddsLauncherCallback = ({
+              required Uri remoteVmServiceUri,
+              Uri? serviceUri,
+              bool enableAuthCodes = true,
+              bool serveDevTools = false,
+              Uri? devToolsServerAddress,
+              bool enableServicePortFallback = false,
+              List<String> cachedUserTags = const <String>[],
+              String? dartExecutable,
+              String? google3WorkspaceRoot,
+            }) {
+              throw DartDevelopmentServiceException.existingDdsInstance(
+                'Existing DDS at http://localhost/existingDdsInMessage.',
+                ddsUri: Uri.parse('http://localhost/existingDdsInField'),
+              );
+            };
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+              vmServiceUris: Stream<Uri>.value(testUri),
+            );
+            final Completer<void> done = Completer<void>();
+            unawaited(runZonedGuarded(
+              () => flutterDevice
+                  .connect(
+                    allowExistingDdsInstance: true,
+                    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+                  )
+                  .then((_) => done.complete()),
+              (_, __) => done.complete(),
+            ));
+            await done.future;
+            expect(device.dds.uri,
+                Uri.parse('http://localhost/existingDdsInField'));
+          }, overrides: <Type, Generator>{
+            VMServiceConnector: () => (
+                  Uri httpUri, {
+                  ReloadSources? reloadSources,
+                  Restart? restart,
+                  CompileExpression? compileExpression,
+                  GetSkSLMethod? getSkSLMethod,
+                  FlutterProject? flutterProject,
+                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+                  io.CompressionOptions? compression,
+                  Device? device,
+                  required Logger logger,
+                }) async =>
+                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
+                        .vmService,
+          }));
 
-  testUsingContext('Host VM service ipv6 defaults', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice()
-      ..dds = DartDevelopmentService(logger: testLogger);
-    final Completer<void>done = Completer<void>();
-    ddsLauncherCallback = ({
-        required Uri remoteVmServiceUri,
-        Uri? serviceUri,
-        bool enableAuthCodes = true,
-        bool serveDevTools = false,
-        Uri? devToolsServerAddress,
-        bool enableServicePortFallback = false,
-        List<String> cachedUserTags = const <String>[],
-        String? dartExecutable,
-        String? google3WorkspaceRoot,
-      }) async {
-      expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
-      expect(enableAuthCodes, isFalse);
-      expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
-      expect(cachedUserTags, isEmpty);
-      done.complete();
-      return FakeDartDevelopmentServiceLauncher(uri: remoteVmServiceUri);
-    };
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-      vmServiceUris: Stream<Uri>.value(testUri),
-    );
-    await flutterDevice.connect(
-      allowExistingDdsInstance: true,
-      debuggingOptions: DebuggingOptions.enabled(
-        BuildInfo.debug, disableServiceAuthCodes: true, ipv6: true,
-      )
-    );
-    await done.future;
-  }, overrides: <Type, Generator>{
-    VMServiceConnector: () => (Uri httpUri, {
-      ReloadSources? reloadSources,
-      Restart? restart,
-      CompileExpression? compileExpression,
-      GetSkSLMethod? getSkSLMethod,
-      FlutterProject? flutterProject,
-      PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-      io.CompressionOptions? compression,
-      Device? device,
-      required Logger logger,
-    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
-  }));
+  testUsingContext(
+      'Host VM service ipv6 defaults',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final FakeDevice device = FakeDevice()
+              ..dds = DartDevelopmentService(logger: testLogger);
+            final Completer<void> done = Completer<void>();
+            ddsLauncherCallback = ({
+              required Uri remoteVmServiceUri,
+              Uri? serviceUri,
+              bool enableAuthCodes = true,
+              bool serveDevTools = false,
+              Uri? devToolsServerAddress,
+              bool enableServicePortFallback = false,
+              List<String> cachedUserTags = const <String>[],
+              String? dartExecutable,
+              String? google3WorkspaceRoot,
+            }) async {
+              expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
+              expect(enableAuthCodes, isFalse);
+              expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
+              expect(cachedUserTags, isEmpty);
+              done.complete();
+              return FakeDartDevelopmentServiceLauncher(
+                  uri: remoteVmServiceUri);
+            };
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+              vmServiceUris: Stream<Uri>.value(testUri),
+            );
+            await flutterDevice.connect(
+                allowExistingDdsInstance: true,
+                debuggingOptions: DebuggingOptions.enabled(
+                  BuildInfo.debug,
+                  disableServiceAuthCodes: true,
+                  ipv6: true,
+                ));
+            await done.future;
+          }, overrides: <Type, Generator>{
+            VMServiceConnector: () => (
+                  Uri httpUri, {
+                  ReloadSources? reloadSources,
+                  Restart? restart,
+                  CompileExpression? compileExpression,
+                  GetSkSLMethod? getSkSLMethod,
+                  FlutterProject? flutterProject,
+                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+                  io.CompressionOptions? compression,
+                  Device? device,
+                  required Logger logger,
+                }) async =>
+                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
+                        .vmService,
+          }));
 
-  testUsingContext('Failed DDS start outputs error message', () => testbed.run(() async {
-    // See https://github.com/flutter/flutter/issues/72385 for context.
-    final FakeDevice device = FakeDevice()
-      ..dds = DartDevelopmentService(logger: testLogger);
-    ddsLauncherCallback = ({
-        required Uri remoteVmServiceUri,
-        Uri? serviceUri,
-        bool enableAuthCodes = true,
-        bool serveDevTools = false,
-        Uri? devToolsServerAddress,
-        bool enableServicePortFallback = false,
-        List<String> cachedUserTags = const <String>[],
-        String? dartExecutable,
-        String? google3WorkspaceRoot,
-      }) {
-      expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
-      expect(enableAuthCodes, isTrue);
-      expect(serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
-      expect(cachedUserTags, isEmpty);
-      throw FakeDartDevelopmentServiceException(message: 'No URI');
-    };
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-      vmServiceUris: Stream<Uri>.value(testUri),
-    );
-    bool caught = false;
-    final Completer<void>done = Completer<void>();
-    runZonedGuarded(() {
-      flutterDevice.connect(
-        allowExistingDdsInstance: true,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, enableDevTools: false),
-      ).then((_) => done.complete());
-    }, (Object e, StackTrace st) {
-      expect(e, isA<StateError>());
-      expect((e as StateError).message, contains('No URI'));
-      expect(testLogger.errorText, contains(
-        'DDS has failed to start and there is not an existing DDS instance',
-      ));
-      done.complete();
-      caught = true;
-    });
-    await done.future;
-    if (!caught) {
-      fail('Expected a StateError to be thrown.');
-    }
-  }, overrides: <Type, Generator>{
-    VMServiceConnector: () => (Uri httpUri, {
-      ReloadSources? reloadSources,
-      Restart? restart,
-      CompileExpression? compileExpression,
-      GetSkSLMethod? getSkSLMethod,
-      FlutterProject? flutterProject,
-      PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-      io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
-      Device? device,
-      required Logger logger,
-    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
-  }));
+  testUsingContext(
+      'Failed DDS start outputs error message',
+      () => testbed.run(() async {
+            // See https://github.com/flutter/flutter/issues/72385 for context.
+            final FakeDevice device = FakeDevice()
+              ..dds = DartDevelopmentService(logger: testLogger);
+            ddsLauncherCallback = ({
+              required Uri remoteVmServiceUri,
+              Uri? serviceUri,
+              bool enableAuthCodes = true,
+              bool serveDevTools = false,
+              Uri? devToolsServerAddress,
+              bool enableServicePortFallback = false,
+              List<String> cachedUserTags = const <String>[],
+              String? dartExecutable,
+              String? google3WorkspaceRoot,
+            }) {
+              expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
+              expect(enableAuthCodes, isTrue);
+              expect(
+                  serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
+              expect(cachedUserTags, isEmpty);
+              throw FakeDartDevelopmentServiceException(message: 'No URI');
+            };
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+              vmServiceUris: Stream<Uri>.value(testUri),
+            );
+            bool caught = false;
+            final Completer<void> done = Completer<void>();
+            runZonedGuarded(() {
+              flutterDevice
+                  .connect(
+                    allowExistingDdsInstance: true,
+                    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
+                        enableDevTools: false),
+                  )
+                  .then((_) => done.complete());
+            }, (Object e, StackTrace st) {
+              expect(e, isA<StateError>());
+              expect((e as StateError).message, contains('No URI'));
+              expect(
+                  testLogger.errorText,
+                  contains(
+                    'DDS has failed to start and there is not an existing DDS instance',
+                  ));
+              done.complete();
+              caught = true;
+            });
+            await done.future;
+            if (!caught) {
+              fail('Expected a StateError to be thrown.');
+            }
+          }, overrides: <Type, Generator>{
+            VMServiceConnector: () => (
+                  Uri httpUri, {
+                  ReloadSources? reloadSources,
+                  Restart? restart,
+                  CompileExpression? compileExpression,
+                  GetSkSLMethod? getSkSLMethod,
+                  FlutterProject? flutterProject,
+                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+                  io.CompressionOptions compression =
+                      io.CompressionOptions.compressionDefault,
+                  Device? device,
+                  required Logger logger,
+                }) async =>
+                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
+                        .vmService,
+          }));
 
   testUsingContext('nextPlatform moves through expected platforms', () {
     expect(nextPlatform('android'), 'iOS');
@@ -2132,166 +2502,199 @@ flutter:
   });
 
   // TODO(bkonyi): remove when ready to serve DevTools from DDS.
-  testUsingContext('cleanupAtFinish shuts down resident devtools handler', () => testbed.run(() async {
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    await residentRunner.cleanupAtFinish();
+  testUsingContext(
+      'cleanupAtFinish shuts down resident devtools handler',
+      () => testbed.run(() async {
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
+                  vmserviceOutFile: 'foo'),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            await residentRunner.cleanupAtFinish();
 
-    expect((residentRunner.residentDevtoolsHandler! as NoOpDevtoolsHandler).wasShutdown, true);
-  }));
+            expect(
+                (residentRunner.residentDevtoolsHandler! as NoOpDevtoolsHandler)
+                    .wasShutdown,
+                true);
+          }));
 
-  testUsingContext('HotRunner sets asset directory when first evict assets', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      setAssetBundlePath,
-      evict,
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
+  testUsingContext(
+      'HotRunner sets asset directory when first evict assets',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              setAssetBundlePath,
+              evict,
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
 
-    (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{'asset'};
+            (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{
+              'asset'
+            };
 
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, isFalse);
-    await (residentRunner as HotRunner).evictDirtyAssets();
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, isTrue);
-    expect(fakeVmServiceHost!.hasRemainingExpectations, isFalse);
-  }));
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, isFalse);
+            await (residentRunner as HotRunner).evictDirtyAssets();
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, isTrue);
+            expect(fakeVmServiceHost!.hasRemainingExpectations, isFalse);
+          }));
 
-  testUsingContext('HotRunner sets asset directory when first evict shaders', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      setAssetBundlePath,
-      evictShader,
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
+  testUsingContext(
+      'HotRunner sets asset directory when first evict shaders',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              setAssetBundlePath,
+              evictShader,
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
 
-    (flutterDevice.devFS! as FakeDevFS).shaderPathsToEvict = <String>{'foo.frag'};
+            (flutterDevice.devFS! as FakeDevFS).shaderPathsToEvict = <String>{
+              'foo.frag'
+            };
 
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-    await (residentRunner as HotRunner).evictDirtyAssets();
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
-    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-  }));
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+            await (residentRunner as HotRunner).evictDirtyAssets();
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
+            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+          }));
 
-  testUsingContext('HotRunner does not sets asset directory when no assets to evict', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
+  testUsingContext(
+      'HotRunner does not sets asset directory when no assets to evict',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
 
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-    await (residentRunner as HotRunner).evictDirtyAssets();
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-  }));
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+            await (residentRunner as HotRunner).evictDirtyAssets();
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+          }));
 
-  testUsingContext('HotRunner does not set asset directory if it has been set before', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      evict,
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
+  testUsingContext(
+      'HotRunner does not set asset directory if it has been set before',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              evict,
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
 
-    (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{'asset'};
-    flutterDevice.devFS!.hasSetAssetDirectory = true;
+            (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{
+              'asset'
+            };
+            flutterDevice.devFS!.hasSetAssetDirectory = true;
 
-    await (residentRunner as HotRunner).evictDirtyAssets();
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
-    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-  }));
+            await (residentRunner as HotRunner).evictDirtyAssets();
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
+            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+          }));
 
   testUsingContext(
       'use the nativeAssetsYamlFile when provided',
       () => testbed.run(() async {
-        final FakeDevice device = FakeDevice(
-          targetPlatform: TargetPlatform.darwin,
-          sdkNameAndVersion: 'Macos',
-        );
-        final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
-        final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
-          ..testUri = testUri
-          ..vmServiceHost = (() => fakeVmServiceHost)
-          ..device = device
-          ..fakeDevFS = devFS
-          ..targetPlatform = TargetPlatform.darwin
-          ..generator = residentCompiler;
+            final FakeDevice device = FakeDevice(
+              targetPlatform: TargetPlatform.darwin,
+              sdkNameAndVersion: 'Macos',
+            );
+            final FakeResidentCompiler residentCompiler =
+                FakeResidentCompiler();
+            final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+              ..testUri = testUri
+              ..vmServiceHost = (() => fakeVmServiceHost)
+              ..device = device
+              ..fakeDevFS = devFS
+              ..targetPlatform = TargetPlatform.darwin
+              ..generator = residentCompiler;
 
-        fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-          listViews,
-          listViews,
-        ]);
-        globals.fs
-            .file(globals.fs.path.join('lib', 'main.dart'))
-            .createSync(recursive: true);
-        residentRunner = HotRunner(
-          <FlutterDevice>[
-            flutterDevice,
-          ],
-          stayResident: false,
-          debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-            BuildMode.debug,
-            '',
-            treeShakeIcons: false,
-            trackWidgetCreation: true,
-            packageConfigPath: '.dart_tool/package_config.json',
-          )),
-          target: 'main.dart',
-          devtoolsHandler: createNoOpHandler,
-          analytics: globals.analytics,
-          nativeAssetsYamlFile: 'foo.yaml',
-        );
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                '',
+                treeShakeIcons: false,
+                trackWidgetCreation: true,
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              nativeAssetsYamlFile: 'foo.yaml',
+              useImplicitPubspecResolution: true,
+            );
 
-        final int? result = await residentRunner.run();
-        expect(result, 0);
+            final int? result = await residentRunner.run();
+            expect(result, 0);
 
-        expect(residentCompiler.recompileCalled, true);
-        expect(residentCompiler.receivedNativeAssetsYaml, globals.fs.path.toUri('foo.yaml'));
-      }),
+            expect(residentCompiler.recompileCalled, true);
+            expect(residentCompiler.receivedNativeAssetsYaml,
+                globals.fs.path.toUri('foo.yaml'));
+          }),
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+        FeatureFlags: () =>
+            TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
       });
 }
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -50,23 +50,26 @@ void main() {
   FakeVmServiceHost? fakeVmServiceHost;
 
   setUp(() {
-    testbed = Testbed(setup: () {
-      globals.fs.file(globals.fs.path.join('build', 'app.dill'))
-        ..createSync(recursive: true)
-        ..writeAsStringSync('ABC');
-      residentRunner = HotRunner(
-        <FlutterDevice>[
-          flutterDevice,
-        ],
-        stayResident: false,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-        target: 'main.dart',
-        analytics: fakeAnalytics,
-        devtoolsHandler: createNoOpHandler,
-      );
-    }, overrides: <Type, Generator>{
-      Analytics: () => FakeAnalytics(),
-    });
+    testbed = Testbed(
+        setup: () {
+          globals.fs.file(globals.fs.path.join('build', 'app.dill'))
+            ..createSync(recursive: true)
+            ..writeAsStringSync('ABC');
+          residentRunner = HotRunner(
+            <FlutterDevice>[
+              flutterDevice,
+            ],
+            stayResident: false,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            target: 'main.dart',
+            analytics: fakeAnalytics,
+            devtoolsHandler: createNoOpHandler,
+            useImplicitPubspecResolution: true,
+          );
+        },
+        overrides: <Type, Generator>{
+          Analytics: () => FakeAnalytics(),
+        });
     device = FakeDevice();
     devFS = FakeDevFS();
     flutterDevice = FakeFlutterDevice()
@@ -76,1041 +79,1190 @@ void main() {
       ..fakeDevFS = devFS;
   });
 
-  testUsingContext('ResidentRunner can attach to device successfully', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    final Future<int?> result = residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    );
-    final Future<DebugConnectionInfo> connectionInfo = futureConnectionInfo.future;
+  testUsingContext(
+      'ResidentRunner can attach to device successfully',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            final Future<int?> result = residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            );
+            final Future<DebugConnectionInfo> connectionInfo =
+                futureConnectionInfo.future;
 
-    expect(await result, 0);
-    expect(futureConnectionInfo.isCompleted, true);
-    expect((await connectionInfo).baseUri, 'foo://bar');
-    expect(futureAppStart.isCompleted, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+            expect(await result, 0);
+            expect(futureConnectionInfo.isCompleted, true);
+            expect((await connectionInfo).baseUri, 'foo://bar');
+            expect(futureAppStart.isCompleted, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-  testUsingContext('ResidentRunner suppresses errors for the initial compilation', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-      ..nextOutput = const CompilerOutput('foo', 0 ,<Uri>[]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: globals.analytics,
-    );
-    flutterDevice.generator = residentCompiler;
+  testUsingContext(
+      'ResidentRunner suppresses errors for the initial compilation',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+              ..nextOutput = const CompilerOutput('foo', 0, <Uri>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.generator = residentCompiler;
 
-    expect(await residentRunner.run(), 0);
-    expect(residentCompiler.didSuppressErrors, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
-
-  // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext('ResidentRunner calls appFailedToStart if initial compilation fails', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: globals.analytics,
-    );
-    flutterDevice.generator = residentCompiler;
-
-    expect(await residentRunner.run(), 1);
-    // Completing this future ensures that the daemon can exit correctly.
-    expect(await residentRunner.waitForAppToFinish(), 1);
-  }));
+            expect(await residentRunner.run(), 0);
+            expect(residentCompiler.didSuppressErrors, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext('ResidentRunner calls appFailedToStart if initial compilation fails - cold mode', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-    flutterDevice.runColdCode = 1;
+  testUsingContext(
+      'ResidentRunner calls appFailedToStart if initial compilation fails',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+              ..nextOutput = const CompilerOutput('foo', 1, <Uri>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.generator = residentCompiler;
 
-    expect(await residentRunner.run(), 1);
-    // Completing this future ensures that the daemon can exit correctly.
-    expect(await residentRunner.waitForAppToFinish(), 1);
-  }));
+            expect(await residentRunner.run(), 1);
+            // Completing this future ensures that the daemon can exit correctly.
+            expect(await residentRunner.waitForAppToFinish(), 1);
+          }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext('ResidentRunner calls appFailedToStart if exception is thrown - cold mode', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-    flutterDevice.runColdError = Exception('BAD STUFF');
+  testUsingContext(
+      'ResidentRunner calls appFailedToStart if initial compilation fails - cold mode',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubpsecResolution: true,
+            );
+            flutterDevice.runColdCode = 1;
 
+            expect(await residentRunner.run(), 1);
+            // Completing this future ensures that the daemon can exit correctly.
+            expect(await residentRunner.waitForAppToFinish(), 1);
+          }));
 
-    expect(await residentRunner.run(), 1);
-    // Completing this future ensures that the daemon can exit correctly.
-    expect(await residentRunner.waitForAppToFinish(), 1);
-  }));
+  // Regression test for https://github.com/flutter/flutter/issues/60613
+  testUsingContext(
+      'ResidentRunner calls appFailedToStart if exception is thrown - cold mode',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubpsecResolution: true,
+            );
+            flutterDevice.runColdError = Exception('BAD STUFF');
 
-  testUsingContext('ResidentRunner does not suppressErrors if running with an applicationBinary', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-      ..nextOutput = const CompilerOutput('foo', 0 ,<Uri>[]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      applicationBinary: globals.fs.file('app-debug.apk'),
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: globals.analytics,
-    );
-    flutterDevice.generator = residentCompiler;
+            expect(await residentRunner.run(), 1);
+            // Completing this future ensures that the daemon can exit correctly.
+            expect(await residentRunner.waitForAppToFinish(), 1);
+          }));
 
-    expect(await residentRunner.run(), 0);
-    expect(residentCompiler.didSuppressErrors, false);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner does not suppressErrors if running with an applicationBinary',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+              ..nextOutput = const CompilerOutput('foo', 0, <Uri>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              applicationBinary: globals.fs.file('app-debug.apk'),
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.generator = residentCompiler;
 
-  testUsingContext('ResidentRunner can attach to device successfully with --fast-start', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        }
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        }
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        )
-      ),
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(
-        BuildInfo.debug,
-        fastStart: true,
-        startPaused: true,
-      ),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: globals.analytics,
-    );
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    final Future<int?> result = residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    );
-    final Future<DebugConnectionInfo> connectionInfo = futureConnectionInfo.future;
+            expect(await residentRunner.run(), 0);
+            expect(residentCompiler.didSuppressErrors, false);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    expect(await result, 0);
-    expect(futureConnectionInfo.isCompleted, true);
-    expect((await connectionInfo).baseUri, 'foo://bar');
-    expect(futureAppStart.isCompleted, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner can attach to device successfully with --fast-start',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                  method: 'streamListen',
+                  args: <String, Object>{
+                    'streamId': 'Isolate',
+                  }),
+              FakeVmServiceRequest(
+                  method: kRunInViewMethod,
+                  args: <String, Object>{
+                    'viewId': fakeFlutterView.id,
+                    'mainScript': 'main.dart.dill',
+                    'assetDirectory': 'build/flutter_assets',
+                  }),
+              FakeVmServiceStreamResponse(
+                  streamId: 'Isolate',
+                  event: vm_service.Event(
+                    timestamp: 0,
+                    kind: vm_service.EventKind.kIsolateRunnable,
+                  )),
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(
+                BuildInfo.debug,
+                fastStart: true,
+                startPaused: true,
+              ),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              useImplicitPubspecResolution: true,
+            );
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            final Future<int?> result = residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            );
+            final Future<DebugConnectionInfo> connectionInfo =
+                futureConnectionInfo.future;
 
-  testUsingContext('ResidentRunner can handle an RPC exception from hot reload', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
+            expect(await result, 0);
+            expect(futureConnectionInfo.isCompleted, true);
+            expect((await connectionInfo).baseUri, 'foo://bar');
+            expect(futureAppStart.isCompleted, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, true);
-    expect(result.code, 1);
-    expect((globals.flutterUsage as TestUsage).events, contains(
-      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
-        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        hotEventSdkName: 'Android',
-        hotEventEmulator: false,
-        hotEventFullRestart: false,
-      )),
-    ));
-    expect((globals.analytics as FakeAnalytics).sentEvents, contains(
-      Event.hotRunnerInfo(
-        label: 'exception',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        sdkName: 'Android',
-        emulator: false,
-        fullRestart: false,
-      ),
-    ));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+  testUsingContext(
+      'ResidentRunner can handle an RPC exception from hot reload',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.reportError =
+                vm_service.RPCError('something bad happened', 666, '');
 
-  testUsingContext('ResidentRunner fails its operation if the device initialization is not complete', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.fakeDevFS = null;
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, true);
+            expect(result.code, 1);
+            expect(
+                (globals.flutterUsage as TestUsage).events,
+                contains(
+                  TestUsageEvent('hot', 'exception',
+                      parameters: CustomDimensions(
+                        hotEventTargetPlatform: getNameForTargetPlatform(
+                            TargetPlatform.android_arm),
+                        hotEventSdkName: 'Android',
+                        hotEventEmulator: false,
+                        hotEventFullRestart: false,
+                      )),
+                ));
+            expect(
+                (globals.analytics as FakeAnalytics).sentEvents,
+                contains(
+                  Event.hotRunnerInfo(
+                    label: 'exception',
+                    targetPlatform:
+                        getNameForTargetPlatform(TargetPlatform.android_arm),
+                    sdkName: 'Android',
+                    emulator: false,
+                    fullRestart: false,
+                  ),
+                ));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, false);
-    expect(result.code, 1);
-    expect(result.message, contains('Device initialization has not completed.'));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner fails its operation if the device initialization is not complete',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.fakeDevFS = null;
 
-  testUsingContext('ResidentRunner can handle an reload-barred exception from hot reload', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.reportError = vm_service.RPCError('something bad happened', kIsolateReloadBarred, '');
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, false);
+            expect(result.code, 1);
+            expect(result.message,
+                contains('Device initialization has not completed.'));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, true);
-    expect(result.code, kIsolateReloadBarred);
-    expect(result.message, contains('Unable to hot reload application due to an unrecoverable error'));
+  testUsingContext(
+      'ResidentRunner can handle an reload-barred exception from hot reload',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.reportError = vm_service.RPCError(
+                'something bad happened', kIsolateReloadBarred, '');
 
-    expect((globals.flutterUsage as TestUsage).events, contains(
-      TestUsageEvent('hot', 'reload-barred', parameters: CustomDimensions(
-        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        hotEventSdkName: 'Android',
-        hotEventEmulator: false,
-        hotEventFullRestart: false,
-      )),
-    ));
-    expect(fakeAnalytics.sentEvents, contains(
-      Event.hotRunnerInfo(
-        label: 'reload-barred',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        sdkName: 'Android',
-        emulator: false,
-        fullRestart: false,
-      )
-    ));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, true);
+            expect(result.code, kIsolateReloadBarred);
+            expect(
+                result.message,
+                contains(
+                    'Unable to hot reload application due to an unrecoverable error'));
 
-  testUsingContext('ResidentRunner reports hot reload event with null safety analytics', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      target: 'main.dart',
-      debuggingOptions: DebuggingOptions.enabled(
-        const BuildInfo(
-          BuildMode.debug, '', treeShakeIcons: false, extraFrontEndOptions: <String>[
-          '--enable-experiment=non-nullable',
-          ],
-          packageConfigPath: '.dart_tool/package_config.json',
-        ),
-        enableDevTools: false,
-      ),
-      analytics: fakeAnalytics,
-    );
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
+            expect(
+                (globals.flutterUsage as TestUsage).events,
+                contains(
+                  TestUsageEvent('hot', 'reload-barred',
+                      parameters: CustomDimensions(
+                        hotEventTargetPlatform: getNameForTargetPlatform(
+                            TargetPlatform.android_arm),
+                        hotEventSdkName: 'Android',
+                        hotEventEmulator: false,
+                        hotEventFullRestart: false,
+                      )),
+                ));
+            expect(
+                fakeAnalytics.sentEvents,
+                contains(Event.hotRunnerInfo(
+                  label: 'reload-barred',
+                  targetPlatform:
+                      getNameForTargetPlatform(TargetPlatform.android_arm),
+                  sdkName: 'Android',
+                  emulator: false,
+                  fullRestart: false,
+                )));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, true);
-    expect(result.code, 1);
+  testUsingContext(
+      'ResidentRunner reports hot reload event with null safety analytics',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              target: 'main.dart',
+              debuggingOptions: DebuggingOptions.enabled(
+                const BuildInfo(
+                  BuildMode.debug,
+                  '',
+                  treeShakeIcons: false,
+                  extraFrontEndOptions: <String>[
+                    '--enable-experiment=non-nullable',
+                  ],
+                  packageConfigPath: '.dart_tool/package_config.json',
+                ),
+                enableDevTools: false,
+              ),
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.reportError =
+                vm_service.RPCError('something bad happened', 666, '');
 
-    expect((globals.flutterUsage as TestUsage).events, contains(
-      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
-        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        hotEventSdkName: 'Android',
-        hotEventEmulator: false,
-        hotEventFullRestart: false,
-      )),
-    ));
-    expect(fakeAnalytics.sentEvents, contains(
-      Event.hotRunnerInfo(
-        label: 'exception',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        sdkName: 'Android',
-        emulator: false,
-        fullRestart: false,
-      )
-    ));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, true);
+            expect(result.code, 1);
 
-  testUsingContext('ResidentRunner does not reload sources if no sources changed', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolatePauseEvent',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedEvent.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.report =  UpdateFSReport(success: true);
+            expect(
+                (globals.flutterUsage as TestUsage).events,
+                contains(
+                  TestUsageEvent('hot', 'exception',
+                      parameters: CustomDimensions(
+                        hotEventTargetPlatform: getNameForTargetPlatform(
+                            TargetPlatform.android_arm),
+                        hotEventSdkName: 'Android',
+                        hotEventEmulator: false,
+                        hotEventFullRestart: false,
+                      )),
+                ));
+            expect(
+                fakeAnalytics.sentEvents,
+                contains(Event.hotRunnerInfo(
+                  label: 'exception',
+                  targetPlatform:
+                      getNameForTargetPlatform(TargetPlatform.android_arm),
+                  sdkName: 'Android',
+                  emulator: false,
+                  fullRestart: false,
+                )));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-    final OperationResult result = await residentRunner.restart();
+  testUsingContext(
+      'ResidentRunner does not reload sources if no sources changed',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolatePauseEvent',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedEvent.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.report = UpdateFSReport(success: true);
 
-    expect(result.code, 0);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+            final OperationResult result = await residentRunner.restart();
 
-  testUsingContext('ResidentRunner reports error with missing entrypoint file', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{
-          'isolates': <Object>[
-            fakeUnpausedIsolate.toJson(),
-          ],
-        })!.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: kReloadSourcesServiceName,
-        args: <String, Object>{
-          'isolateId': '1',
-          'pause': false,
-          'rootLibUri': 'main.dart.incremental.dill',
-        },
-        jsonResponse: <String, Object>{
-          'type': 'ReloadReport',
-          'success': true,
-          'details': <String, Object>{
-            'loadedLibraryCount': 1,
-          },
-        },
-      ),
-      FakeVmServiceRequest(
-        method: 'getIsolatePauseEvent',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedEvent.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.report =  UpdateFSReport(success: true, invalidatedSourcesCount: 1);
+            expect(result.code, 0);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
+  testUsingContext(
+      'ResidentRunner reports error with missing entrypoint file',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{
+                  'isolates': <Object>[
+                    fakeUnpausedIsolate.toJson(),
+                  ],
+                })!.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                method: kReloadSourcesServiceName,
+                args: <String, Object>{
+                  'isolateId': '1',
+                  'pause': false,
+                  'rootLibUri': 'main.dart.incremental.dill',
+                },
+                jsonResponse: <String, Object>{
+                  'type': 'ReloadReport',
+                  'success': true,
+                  'details': <String, Object>{
+                    'loadedLibraryCount': 1,
+                  },
+                },
+              ),
+              FakeVmServiceRequest(
+                method: 'getIsolatePauseEvent',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedEvent.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.report =
+                UpdateFSReport(success: true, invalidatedSourcesCount: 1);
 
-    expect(globals.fs.file(globals.fs.path.join('lib', 'main.dart')), isNot(exists));
-    expect(testLogger.errorText, contains('The entrypoint file (i.e. the file with main())'));
-    expect(result.fatal, false);
-    expect(result.code, 0);
-  }));
+            final OperationResult result = await residentRunner.restart();
 
-   testUsingContext('ResidentRunner resets compilation time on reload reject', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{
-          'isolates': <Object>[
-            fakeUnpausedIsolate.toJson(),
-          ],
-        })!.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: kReloadSourcesServiceName,
-        args: <String, Object>{
-          'isolateId': '1',
-          'pause': false,
-          'rootLibUri': 'main.dart.incremental.dill',
-        },
-        jsonResponse: <String, Object>{
-          'type': 'ReloadReport',
-          'success': false,
-          'notices': <Object>[
-            <String, Object>{
-              'message': 'Failed to hot reload',
-            },
-          ],
-          'details': <String, Object>{},
-        },
-      ),
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.report =  UpdateFSReport(success: true, invalidatedSourcesCount: 1);
+            expect(globals.fs.file(globals.fs.path.join('lib', 'main.dart')),
+                isNot(exists));
+            expect(testLogger.errorText,
+                contains('The entrypoint file (i.e. the file with main())'));
+            expect(result.fatal, false);
+            expect(result.code, 0);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
+  testUsingContext(
+      'ResidentRunner resets compilation time on reload reject',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{
+                  'isolates': <Object>[
+                    fakeUnpausedIsolate.toJson(),
+                  ],
+                })!.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                method: kReloadSourcesServiceName,
+                args: <String, Object>{
+                  'isolateId': '1',
+                  'pause': false,
+                  'rootLibUri': 'main.dart.incremental.dill',
+                },
+                jsonResponse: <String, Object>{
+                  'type': 'ReloadReport',
+                  'success': false,
+                  'notices': <Object>[
+                    <String, Object>{
+                      'message': 'Failed to hot reload',
+                    },
+                  ],
+                  'details': <String, Object>{},
+                },
+              ),
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.report =
+                UpdateFSReport(success: true, invalidatedSourcesCount: 1);
 
-    expect(result.fatal, false);
-    expect(result.message, contains('Reload rejected: Failed to hot reload')); // contains error message from reload report.
-    expect(result.code, 1);
-    expect(devFS.lastCompiled, null);
-  }));
+            final OperationResult result = await residentRunner.restart();
 
-  testUsingContext('ResidentRunner can send target platform to analytics from hot reload', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{
-          'isolates': <Object>[
-            fakeUnpausedIsolate.toJson(),
-          ],
-        })!.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: kReloadSourcesServiceName,
-        args: <String, Object>{
-          'isolateId': '1',
-          'pause': false,
-          'rootLibUri': 'main.dart.incremental.dill',
-        },
-        jsonResponse: <String, Object>{
-          'type': 'ReloadReport',
-          'success': true,
-          'details': <String, Object>{
-            'loadedLibraryCount': 1,
-          },
-        },
-      ),
-      FakeVmServiceRequest(
-        method: 'getIsolatePauseEvent',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedEvent.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
+            expect(result.fatal, false);
+            expect(
+                result.message,
+                contains(
+                    'Reload rejected: Failed to hot reload')); // contains error message from reload report.
+            expect(result.code, 1);
+            expect(devFS.lastCompiled, null);
+          }));
 
-    final OperationResult result = await residentRunner.restart();
-    expect(result.fatal, false);
-    expect(result.code, 0);
+  testUsingContext(
+      'ResidentRunner can send target platform to analytics from hot reload',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{
+                  'isolates': <Object>[
+                    fakeUnpausedIsolate.toJson(),
+                  ],
+                })!.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                method: kReloadSourcesServiceName,
+                args: <String, Object>{
+                  'isolateId': '1',
+                  'pause': false,
+                  'rootLibUri': 'main.dart.incremental.dill',
+                },
+                jsonResponse: <String, Object>{
+                  'type': 'ReloadReport',
+                  'success': true,
+                  'details': <String, Object>{
+                    'loadedLibraryCount': 1,
+                  },
+                },
+              ),
+              FakeVmServiceRequest(
+                method: 'getIsolatePauseEvent',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedEvent.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
 
-    final TestUsageEvent event = (globals.flutterUsage as TestUsage).events.first;
-    expect(event.category, 'hot');
-    expect(event.parameter, 'reload');
-    expect(event.parameters?.hotEventTargetPlatform, getNameForTargetPlatform(TargetPlatform.android_arm));
+            final OperationResult result = await residentRunner.restart();
+            expect(result.fatal, false);
+            expect(result.code, 0);
 
-    final Event newEvent = fakeAnalytics.sentEvents.first;
-    expect(newEvent.eventName.label, 'hot_runner_info');
-    expect(newEvent.eventData['label'], 'reload');
-    expect(newEvent.eventData['targetPlatform'], getNameForTargetPlatform(TargetPlatform.android_arm));
+            final TestUsageEvent event =
+                (globals.flutterUsage as TestUsage).events.first;
+            expect(event.category, 'hot');
+            expect(event.parameter, 'reload');
+            expect(event.parameters?.hotEventTargetPlatform,
+                getNameForTargetPlatform(TargetPlatform.android_arm));
 
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+            final Event newEvent = fakeAnalytics.sentEvents.first;
+            expect(newEvent.eventName.label, 'hot_runner_info');
+            expect(newEvent.eventData['label'], 'reload');
+            expect(newEvent.eventData['targetPlatform'],
+                getNameForTargetPlatform(TargetPlatform.android_arm));
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-  testUsingContext('ResidentRunner reports hot reload time details', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: fakeVM.toJson(),
-      ),
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: fakeVM.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: kReloadSourcesServiceName,
-        args: <String, Object>{
-          'isolateId': '1',
-          'pause': false,
-          'rootLibUri': 'main.dart.incremental.dill',
-        },
-        jsonResponse: <String, Object>{
-          'type': 'ReloadReport',
-          'success': true,
-          'details': <String, Object>{
-            'loadedLibraryCount': 1,
-            'finalLibraryCount': 42,
-          },
-        },
-      ),
-      FakeVmServiceRequest(
-        method: 'getIsolatePauseEvent',
-        args: <String, Object>{
-          'isolateId': '1',
-        },
-        jsonResponse: fakeUnpausedEvent.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'ext.flutter.reassemble',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-      ),
-    ]);
-    final FakeDelegateFlutterDevice flutterDevice = FakeDelegateFlutterDevice(
-      device,
-      BuildInfo.debug,
-      FakeResidentCompiler(),
-      devFS,
-    )..vmService = fakeVmServiceHost!.vmService;
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    devFS.nextUpdateReport = UpdateFSReport(
-      success: true,
-      invalidatedSourcesCount: 1,
-    );
+  testUsingContext(
+      'ResidentRunner reports hot reload time details',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: fakeVM.toJson(),
+              ),
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: fakeVM.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                method: kReloadSourcesServiceName,
+                args: <String, Object>{
+                  'isolateId': '1',
+                  'pause': false,
+                  'rootLibUri': 'main.dart.incremental.dill',
+                },
+                jsonResponse: <String, Object>{
+                  'type': 'ReloadReport',
+                  'success': true,
+                  'details': <String, Object>{
+                    'loadedLibraryCount': 1,
+                    'finalLibraryCount': 42,
+                  },
+                },
+              ),
+              FakeVmServiceRequest(
+                method: 'getIsolatePauseEvent',
+                args: <String, Object>{
+                  'isolateId': '1',
+                },
+                jsonResponse: fakeUnpausedEvent.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'ext.flutter.reassemble',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+              ),
+            ]);
+            final FakeDelegateFlutterDevice flutterDevice =
+                FakeDelegateFlutterDevice(
+              device,
+              BuildInfo.debug,
+              FakeResidentCompiler(),
+              devFS,
+            )..vmService = fakeVmServiceHost!.vmService;
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            devFS.nextUpdateReport = UpdateFSReport(
+              success: true,
+              invalidatedSourcesCount: 1,
+            );
 
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
 
-    await futureAppStart.future;
-    await residentRunner.restart();
+            await futureAppStart.future;
+            await residentRunner.restart();
 
-    // The actual test: Expect to have compile, reload and reassemble times.
-    expect(
-        testLogger.statusText,
-        contains(RegExp(r'Reloaded 1 of 42 libraries in \d+ms '
-            r'\(compile: \d+ ms, reload: \d+ ms, reassemble: \d+ ms\)\.')));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem.test(),
-    Platform: () => FakePlatform(),
-    ProjectFileInvalidator: () => FakeProjectFileInvalidator(),
-    Usage: () => TestUsage(),
-  }));
+            // The actual test: Expect to have compile, reload and reassemble times.
+            expect(
+                testLogger.statusText,
+                contains(RegExp(r'Reloaded 1 of 42 libraries in \d+ms '
+                    r'\(compile: \d+ ms, reload: \d+ ms, reassemble: \d+ ms\)\.')));
+          }, overrides: <Type, Generator>{
+            FileSystem: () => MemoryFileSystem.test(),
+            Platform: () => FakePlatform(),
+            ProjectFileInvalidator: () => FakeProjectFileInvalidator(),
+            Usage: () => TestUsage(),
+          }));
 
-  testUsingContext('ResidentRunner can send target platform to analytics from full restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        )
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
+  testUsingContext(
+      'ResidentRunner can send target platform to analytics from full restart',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                  streamId: 'Isolate',
+                  event: vm_service.Event(
+                    timestamp: 0,
+                    kind: vm_service.EventKind.kIsolateRunnable,
+                  )),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
 
-    final OperationResult result = await residentRunner.restart(fullRestart: true);
-    expect(result.fatal, false);
-    expect(result.code, 0);
+            final OperationResult result =
+                await residentRunner.restart(fullRestart: true);
+            expect(result.fatal, false);
+            expect(result.code, 0);
 
-    final TestUsageEvent event = (globals.flutterUsage as TestUsage).events.first;
-    expect(event.category, 'hot');
-    expect(event.parameter, 'restart');
-    expect(event.parameters?.hotEventTargetPlatform, getNameForTargetPlatform(TargetPlatform.android_arm));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+            final TestUsageEvent event =
+                (globals.flutterUsage as TestUsage).events.first;
+            expect(event.category, 'hot');
+            expect(event.parameter, 'restart');
+            expect(event.parameters?.hotEventTargetPlatform,
+                getNameForTargetPlatform(TargetPlatform.android_arm));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
 
-    // Parse out the event of interest since we may have timing events with
-    // the new analytics package
-    final List<Event> newEventList = fakeAnalytics.sentEvents.where((Event e) => e.eventName.label == 'hot_runner_info').toList();
-    expect(newEventList, hasLength(1));
-    final Event newEvent = newEventList.first;
-    expect(newEvent.eventName.label, 'hot_runner_info');
-    expect(newEvent.eventData['label'], 'restart');
-    expect(newEvent.eventData['targetPlatform'], getNameForTargetPlatform(TargetPlatform.android_arm));
+            // Parse out the event of interest since we may have timing events with
+            // the new analytics package
+            final List<Event> newEventList = fakeAnalytics.sentEvents
+                .where((Event e) => e.eventName.label == 'hot_runner_info')
+                .toList();
+            expect(newEventList, hasLength(1));
+            final Event newEvent = newEventList.first;
+            expect(newEvent.eventName.label, 'hot_runner_info');
+            expect(newEvent.eventData['label'], 'restart');
+            expect(newEvent.eventData['targetPlatform'],
+                getNameForTargetPlatform(TargetPlatform.android_arm));
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+  testUsingContext(
+      'ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakePausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              const FakeVmServiceRequest(
+                  method: 'setIsolatePauseMode',
+                  args: <String, String>{
+                    'isolateId': '1',
+                    'exceptionPauseMode': 'None',
+                  }),
+              const FakeVmServiceRequest(
+                  method: 'removeBreakpoint',
+                  args: <String, String>{
+                    'isolateId': '1',
+                    'breakpointId': 'test-breakpoint',
+                  }),
+              const FakeVmServiceRequest(
+                  method: 'resume',
+                  args: <String, String>{
+                    'isolateId': '1',
+                  }),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                streamId: 'Isolate',
+                event: vm_service.Event(
+                  timestamp: 0,
+                  kind: vm_service.EventKind.kIsolateRunnable,
+                ),
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
 
-  testUsingContext('ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakePausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      const FakeVmServiceRequest(
-        method: 'setIsolatePauseMode',
-        args: <String, String>{
-          'isolateId': '1',
-          'exceptionPauseMode': 'None',
-        }
-      ),
-      const FakeVmServiceRequest(
-        method: 'removeBreakpoint',
-        args: <String, String>{
-          'isolateId': '1',
-          'breakpointId': 'test-breakpoint',
-        }
-      ),
-      const FakeVmServiceRequest(
-        method: 'resume',
-        args: <String, String>{
-          'isolateId': '1',
-        }
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        ),
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
+            final OperationResult result =
+                await residentRunner.restart(fullRestart: true);
 
-    final OperationResult result = await residentRunner.restart(fullRestart: true);
+            expect(result.isOk, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    expect(result.isOk, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner will alternative the name of the dill file uploaded for a hot restart',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                streamId: 'Isolate',
+                event: vm_service.Event(
+                  timestamp: 0,
+                  kind: vm_service.EventKind.kIsolateRunnable,
+                ),
+              ),
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.swap.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                streamId: 'Isolate',
+                event: vm_service.Event(
+                  timestamp: 0,
+                  kind: vm_service.EventKind.kIsolateRunnable,
+                ),
+              ),
+              listViews,
+              FakeVmServiceRequest(
+                method: 'getIsolate',
+                args: <String, Object?>{
+                  'isolateId': fakeUnpausedIsolate.id,
+                },
+                jsonResponse: fakeUnpausedIsolate.toJson(),
+              ),
+              FakeVmServiceRequest(
+                method: 'getVM',
+                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+              ),
+              listViews,
+              const FakeVmServiceRequest(
+                method: 'streamListen',
+                args: <String, Object>{
+                  'streamId': 'Isolate',
+                },
+              ),
+              FakeVmServiceRequest(
+                method: kRunInViewMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                  'mainScript': 'main.dart.dill',
+                  'assetDirectory': 'build/flutter_assets',
+                },
+              ),
+              FakeVmServiceStreamResponse(
+                streamId: 'Isolate',
+                event: vm_service.Event(
+                  timestamp: 0,
+                  kind: vm_service.EventKind.kIsolateRunnable,
+                ),
+              ),
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
 
-  testUsingContext('ResidentRunner will alternative the name of the dill file uploaded for a hot restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        ),
-      ),
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.swap.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        ),
-      ),
-      listViews,
-      FakeVmServiceRequest(
-        method: 'getIsolate',
-        args: <String, Object?>{
-          'isolateId': fakeUnpausedIsolate.id,
-        },
-        jsonResponse: fakeUnpausedIsolate.toJson(),
-      ),
-      FakeVmServiceRequest(
-        method: 'getVM',
-        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-      ),
-      listViews,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate',
-        },
-      ),
-      FakeVmServiceRequest(
-        method: kRunInViewMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-          'mainScript': 'main.dart.dill',
-          'assetDirectory': 'build/flutter_assets',
-        },
-      ),
-      FakeVmServiceStreamResponse(
-        streamId: 'Isolate',
-        event: vm_service.Event(
-          timestamp: 0,
-          kind: vm_service.EventKind.kIsolateRunnable,
-        ),
-      ),
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
+            await residentRunner.restart(fullRestart: true);
+            await residentRunner.restart(fullRestart: true);
+            await residentRunner.restart(fullRestart: true);
 
-    await residentRunner.restart(fullRestart: true);
-    await residentRunner.restart(fullRestart: true);
-    await residentRunner.restart(fullRestart: true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
 
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
+  testUsingContext(
+      'ResidentRunner Can handle an RPC exception from hot restart',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            final Completer<DebugConnectionInfo> futureConnectionInfo =
+                Completer<DebugConnectionInfo>.sync();
+            final Completer<void> futureAppStart = Completer<void>.sync();
+            unawaited(residentRunner.attach(
+              appStartedCompleter: futureAppStart,
+              connectionInfoCompleter: futureConnectionInfo,
+            ));
+            await futureAppStart.future;
+            flutterDevice.reportError =
+                vm_service.RPCError('something bad happened', 666, '');
 
-  testUsingContext('ResidentRunner Can handle an RPC exception from hot restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
-    final Completer<void> futureAppStart = Completer<void>.sync();
-    unawaited(residentRunner.attach(
-      appStartedCompleter: futureAppStart,
-      connectionInfoCompleter: futureConnectionInfo,
-    ));
-    await futureAppStart.future;
-    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
+            final OperationResult result =
+                await residentRunner.restart(fullRestart: true);
+            expect(result.fatal, true);
+            expect(result.code, 1);
 
-    final OperationResult result = await residentRunner.restart(fullRestart: true);
-    expect(result.fatal, true);
-    expect(result.code, 1);
+            expect(
+                (globals.flutterUsage as TestUsage).events,
+                contains(
+                  TestUsageEvent('hot', 'exception',
+                      parameters: CustomDimensions(
+                        hotEventTargetPlatform: getNameForTargetPlatform(
+                            TargetPlatform.android_arm),
+                        hotEventSdkName: 'Android',
+                        hotEventEmulator: false,
+                        hotEventFullRestart: true,
+                      )),
+                ));
+            expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.hotRunnerInfo(
+                    label: 'exception',
+                    targetPlatform:
+                        getNameForTargetPlatform(TargetPlatform.android_arm),
+                    sdkName: 'Android',
+                    emulator: false,
+                    fullRestart: true,
+                  ),
+                ));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            Usage: () => TestUsage(),
+          }));
 
-    expect((globals.flutterUsage as TestUsage).events, contains(
-      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
-        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        hotEventSdkName: 'Android',
-        hotEventEmulator: false,
-        hotEventFullRestart: true,
-      )),
-    ));
-    expect(fakeAnalytics.sentEvents, contains(
-      Event.hotRunnerInfo(
-        label: 'exception',
-        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
-        sdkName: 'Android',
-        emulator: false,
-        fullRestart: true,
-      ),
-    ));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => TestUsage(),
-  }));
+  testUsingContext(
+      'ResidentRunner uses temp directory when there is no output dill path',
+      () => testbed.run(() {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            expect(residentRunner.artifactDirectory.path,
+                contains('flutter_tool.'));
 
-  testUsingContext('ResidentRunner uses temp directory when there is no output dill path', () => testbed.run(() {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    expect(residentRunner.artifactDirectory.path, contains('flutter_tool.'));
+            final ResidentRunner otherRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            expect(otherRunner.artifactDirectory.path, contains('foobar'));
+          }));
 
-    final ResidentRunner otherRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    expect(otherRunner.artifactDirectory.path, contains('foobar'));
-  }));
+  testUsingContext(
+      'ResidentRunner deletes artifact directory on preExit',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            residentRunner.artifactDirectory.childFile('app.dill').createSync();
+            await residentRunner.preExit();
 
-  testUsingContext('ResidentRunner deletes artifact directory on preExit', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    residentRunner.artifactDirectory.childFile('app.dill').createSync();
-    await residentRunner.preExit();
+            expect(residentRunner.artifactDirectory, isNot(exists));
+          }));
 
-    expect(residentRunner.artifactDirectory, isNot(exists));
-  }));
-
-  testUsingContext('ResidentRunner can run source generation', () => testbed.run(() async {
-    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
+  testUsingContext(
+      'ResidentRunner can run source generation',
+      () => testbed.run(() async {
+            final File arbFile = globals.fs
+                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+              ..createSync(recursive: true);
+            arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-    globals.fs.file('l10n.yaml').createSync();
-    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
+            globals.fs.file('l10n.yaml').createSync();
+            globals.fs
+                .file('pubspec.yaml')
+                .writeAsStringSync('flutter:\n  generate: true\n');
 
-    // Create necessary files for [DartPluginRegistrantTarget]
-    final File packageConfig = globals.fs.directory('.dart_tool')
-        .childFile('package_config.json');
-    packageConfig.createSync(recursive: true);
-    packageConfig.writeAsStringSync('''
+            // Create necessary files for [DartPluginRegistrantTarget]
+            final File packageConfig = globals.fs
+                .directory('.dart_tool')
+                .childFile('package_config.json');
+            packageConfig.createSync(recursive: true);
+            packageConfig.writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": [
@@ -1123,27 +1275,34 @@ void main() {
   ]
 }
 ''');
-    // Start from an empty dart_plugin_registrant.dart file.
-    globals.fs.directory('.dart_tool').childDirectory('flutter_build').childFile('dart_plugin_registrant.dart').createSync(recursive: true);
+            // Start from an empty dart_plugin_registrant.dart file.
+            globals.fs
+                .directory('.dart_tool')
+                .childDirectory('flutter_build')
+                .childFile('dart_plugin_registrant.dart')
+                .createSync(recursive: true);
 
-    await residentRunner.runSourceGenerators();
+            await residentRunner.runSourceGenerators();
 
-    expect(testLogger.errorText, isEmpty);
-    expect(testLogger.statusText, isEmpty);
-  }));
+            expect(testLogger.errorText, isEmpty);
+            expect(testLogger.statusText, isEmpty);
+          }));
 
-  testUsingContext('generated main uses correct target', () => testbed.run(() async {
-    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
+  testUsingContext(
+      'generated main uses correct target',
+      () => testbed.run(() async {
+            final File arbFile = globals.fs
+                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+              ..createSync(recursive: true);
+            arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-    globals.fs.file('l10n.yaml').createSync();
-    globals.fs.file('pubspec.yaml').writeAsStringSync('''
+            globals.fs.file('l10n.yaml').createSync();
+            globals.fs.file('pubspec.yaml').writeAsStringSync('''
 flutter:
   generate: true
 
@@ -1153,12 +1312,13 @@ dependencies:
   path_provider_linux: 1.0.0
 ''');
 
-    // Create necessary files for [DartPluginRegistrantTarget], including a
-    // plugin that will trigger generation.
-    final File packageConfig = globals.fs.directory('.dart_tool')
-        .childFile('package_config.json');
-    packageConfig.createSync(recursive: true);
-    packageConfig.writeAsStringSync('''
+            // Create necessary files for [DartPluginRegistrantTarget], including a
+            // plugin that will trigger generation.
+            final File packageConfig = globals.fs
+                .directory('.dart_tool')
+                .childFile('package_config.json');
+            packageConfig.createSync(recursive: true);
+            packageConfig.writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": [
@@ -1171,10 +1331,11 @@ dependencies:
   ]
 }
 ''');
-    final Directory fakePluginDir = globals.fs.directory('path_provider_linux');
-    final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
-    pluginPubspec.createSync(recursive: true);
-    pluginPubspec.writeAsStringSync('''
+            final Directory fakePluginDir =
+                globals.fs.directory('path_provider_linux');
+            final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
+            pluginPubspec.createSync(recursive: true);
+            pluginPubspec.writeAsStringSync('''
 name: path_provider_linux
 
 flutter:
@@ -1185,594 +1346,739 @@ flutter:
         dartPluginClass: PathProviderLinux
 ''');
 
-    residentRunner = HotRunner(
-        <FlutterDevice>[
-          flutterDevice,
-        ],
-        stayResident: false,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-        target: 'custom_main.dart',
-        devtoolsHandler: createNoOpHandler,
-        analytics: fakeAnalytics,
-      );
-    await residentRunner.runSourceGenerators();
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'custom_main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            await residentRunner.runSourceGenerators();
 
-    final File generatedMain = globals.fs.directory('.dart_tool')
-        .childDirectory('flutter_build')
-        .childFile('dart_plugin_registrant.dart');
+            final File generatedMain = globals.fs
+                .directory('.dart_tool')
+                .childDirectory('flutter_build')
+                .childFile('dart_plugin_registrant.dart');
 
-    expect(generatedMain.existsSync(), isTrue);
-    expect(testLogger.errorText, isEmpty);
-    expect(testLogger.statusText, isEmpty);
-  }));
+            expect(generatedMain.existsSync(), isTrue);
+            expect(testLogger.errorText, isEmpty);
+            expect(testLogger.statusText, isEmpty);
+          }));
 
-  testUsingContext('ResidentRunner can run source generation - generation fails', () => testbed.run(() async {
-    // Intentionally define arb file with wrong name. generate_localizations defaults
-    // to app_en.arb.
-    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'foo.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
+  testUsingContext(
+      'ResidentRunner can run source generation - generation fails',
+      () => testbed.run(() async {
+            // Intentionally define arb file with wrong name. generate_localizations defaults
+            // to app_en.arb.
+            final File arbFile = globals.fs
+                .file(globals.fs.path.join('lib', 'l10n', 'foo.arb'))
+              ..createSync(recursive: true);
+            arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-    globals.fs.file('l10n.yaml').createSync();
-    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
+            globals.fs.file('l10n.yaml').createSync();
+            globals.fs
+                .file('pubspec.yaml')
+                .writeAsStringSync('flutter:\n  generate: true\n');
 
-    await residentRunner.runSourceGenerators();
+            await residentRunner.runSourceGenerators();
 
-    expect(testLogger.errorText, contains('Error'));
-    expect(testLogger.statusText, isEmpty);
-  }));
+            expect(testLogger.errorText, contains('Error'));
+            expect(testLogger.statusText, isEmpty);
+          }));
 
-  testUsingContext('ResidentRunner generates files when l10n.yaml exists', () => testbed.run(() async {
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-      .createSync(recursive: true);
-    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
+  testUsingContext(
+      'ResidentRunner generates files when l10n.yaml exists',
+      () => testbed.run(() async {
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            final File arbFile = globals.fs
+                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+              ..createSync(recursive: true);
+            arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-    globals.fs.file('l10n.yaml').createSync();
-    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
+            globals.fs.file('l10n.yaml').createSync();
+            globals.fs
+                .file('pubspec.yaml')
+                .writeAsStringSync('flutter:\n  generate: true\n');
 
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+              ..nextOutput = const CompilerOutput('foo', 1, <Uri>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            flutterDevice.generator = residentCompiler;
+
+            await residentRunner.run();
+
+            final File generatedLocalizationsFile = globals.fs
+                .directory('.dart_tool')
+                .childDirectory('flutter_gen')
+                .childDirectory('gen_l10n')
+                .childFile('app_localizations.dart');
+            expect(generatedLocalizationsFile.existsSync(), isTrue);
+
+            // Completing this future ensures that the daemon can exit correctly.
+            expect(await residentRunner.waitForAppToFinish(), 1);
+          }));
+
+  testUsingContext(
+      'ResidentRunner printHelpDetails hot runner',
+      () => testbed.run(() {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
+            residentRunner.printHelp(details: true);
+
+            final CommandHelp commandHelp = residentRunner.commandHelp;
+
+            // supports service protocol
+            expect(residentRunner.supportsServiceProtocol, true);
+            // isRunningDebug
+            expect(residentRunner.isRunningDebug, true);
+            // does support SkSL
+            expect(residentRunner.supportsWriteSkSL, true);
+            // commands
+            expect(
+                testLogger.statusText,
+                equals(<dynamic>[
+                  'Flutter run key commands.',
+                  commandHelp.r,
+                  commandHelp.R,
+                  commandHelp.v,
+                  commandHelp.s,
+                  commandHelp.w,
+                  commandHelp.t,
+                  commandHelp.L,
+                  commandHelp.f,
+                  commandHelp.S,
+                  commandHelp.U,
+                  commandHelp.i,
+                  commandHelp.p,
+                  commandHelp.I,
+                  commandHelp.o,
+                  commandHelp.b,
+                  commandHelp.P,
+                  commandHelp.a,
+                  commandHelp.M,
+                  commandHelp.g,
+                  commandHelp.hWithDetails,
+                  commandHelp.c,
+                  commandHelp.q,
+                  '',
+                  'A Dart VM Service on FakeDevice is available at: null',
+                  '',
+                ].join('\n')));
+          }));
+
+  testUsingContext(
+      'ResidentRunner printHelp hot runner',
+      () => testbed.run(() {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
+            residentRunner.printHelp(details: false);
+
+            final CommandHelp commandHelp = residentRunner.commandHelp;
+
+            // supports service protocol
+            expect(residentRunner.supportsServiceProtocol, true);
+            // isRunningDebug
+            expect(residentRunner.isRunningDebug, true);
+            // does support SkSL
+            expect(residentRunner.supportsWriteSkSL, true);
+            // commands
+            expect(
+                testLogger.statusText,
+                equals(<dynamic>[
+                  'Flutter run key commands.',
+                  commandHelp.r,
+                  commandHelp.R,
+                  commandHelp.hWithoutDetails,
+                  commandHelp.c,
+                  commandHelp.q,
+                  '',
+                  'A Dart VM Service on FakeDevice is available at: null',
+                  '',
+                ].join('\n')));
+          }));
+
+  testUsingContext(
+      'ResidentRunner printHelpDetails cold runner',
+      () => testbed.run(() {
+            fakeVmServiceHost = null;
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubpsecResolution: true,
+            );
+            residentRunner.printHelp(details: true);
+
+            final CommandHelp commandHelp = residentRunner.commandHelp;
+
+            // does not supports service protocol
+            expect(residentRunner.supportsServiceProtocol, false);
+            // isRunningDebug
+            expect(residentRunner.isRunningDebug, false);
+            // does support SkSL
+            expect(residentRunner.supportsWriteSkSL, false);
+            // commands
+            expect(
+                testLogger.statusText,
+                equals(<dynamic>[
+                  'Flutter run key commands.',
+                  commandHelp.v,
+                  commandHelp.s,
+                  commandHelp.hWithDetails,
+                  commandHelp.c,
+                  commandHelp.q,
+                  '',
+                ].join('\n')));
+          }));
+
+  testUsingContext(
+      'ResidentRunner printHelp cold runner',
+      () => testbed.run(() {
+            fakeVmServiceHost = null;
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubpsecResolution: true,
+            );
+            residentRunner.printHelp(details: false);
+
+            final CommandHelp commandHelp = residentRunner.commandHelp;
+
+            // does not supports service protocol
+            expect(residentRunner.supportsServiceProtocol, false);
+            // isRunningDebug
+            expect(residentRunner.isRunningDebug, false);
+            // does support SkSL
+            expect(residentRunner.supportsWriteSkSL, false);
+            // commands
+            expect(
+                testLogger.statusText,
+                equals(<dynamic>[
+                  'Flutter run key commands.',
+                  commandHelp.hWithoutDetails,
+                  commandHelp.c,
+                  commandHelp.q,
+                  '',
+                ].join('\n')));
+          }));
+
+  testUsingContext(
+      'ResidentRunner handles writeSkSL returning no data',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              FakeVmServiceRequest(
+                  method: kGetSkSLsMethod,
+                  args: <String, Object>{
+                    'viewId': fakeFlutterView.id,
+                  },
+                  jsonResponse: <String, Object>{
+                    'SkSLs': <String, Object>{},
+                  }),
+            ]);
+            await residentRunner.writeSkSL();
+
+            expect(testLogger.statusText, contains('No data was received'));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
+
+  testUsingContext(
+      'ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              FakeVmServiceRequest(
+                method: kGetSkSLsMethod,
+                args: <String, Object>{
+                  'viewId': fakeFlutterView.id,
+                },
+                jsonResponse: <String, Object>{
+                  'SkSLs': <String, Object>{
+                    'A': 'B',
+                  },
+                },
+              ),
+            ]);
+            await residentRunner.writeSkSL();
+
+            expect(testLogger.statusText, contains('flutter_01.sksl.json'));
+            expect(globals.fs.file('flutter_01.sksl.json'), exists);
+            expect(
+                json.decode(
+                    globals.fs.file('flutter_01.sksl.json').readAsStringSync()),
+                <String, Object>{
+                  'platform': 'android',
+                  'name': 'FakeDevice',
+                  'engineRevision': 'abcdefg',
+                  'data': <String, Object>{'A': 'B'},
+                });
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            FileSystemUtils: () => FileSystemUtils(
+                  fileSystem: globals.fs,
+                  platform: globals.platform,
+                ),
+            FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg'),
+          }));
+
+  testUsingContext(
+      'ResidentRunner ignores DevtoolsLauncher when attaching with enableDevTools: false - cold mode',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile,
+                  vmserviceOutFile: 'foo', enableDevTools: false),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              useImplicitPubpsecResolution: true,
+            );
+
+            final Future<int?> result = residentRunner.attach();
+            expect(await result, 0);
+          }));
+
+  testUsingContext(
+      'FlutterDevice can exit from a release mode isolate with no VmService',
+      () => testbed.run(() async {
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+            );
+
+            await flutterDevice.exitApps();
+
+            expect(device.appStopped, true);
+          }));
+
+  testUsingContext(
+      'FlutterDevice will exit an un-paused isolate using stopApp',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+            );
+            flutterDevice.vmService = fakeVmServiceHost!.vmService;
+
+            final Future<void> exitFuture = flutterDevice.exitApps();
+
+            await expectLater(exitFuture, completes);
+            expect(device.appStopped, true);
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
+
+  testUsingContext(
+      'HotRunner writes vm service file when providing debugging option',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
+                  vmserviceOutFile: 'foo'),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+
+            await residentRunner.run();
+
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+            expect(await globals.fs.file('foo').readAsString(),
+                testUri.toString());
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                null,
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(globals.fs.path.join('build', 'cache.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup with dart defines',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                '',
+                treeShakeIcons: false,
+                dartDefines: <String>['a', 'b'],
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(globals.fs.path.join(
+                        'build', '187ef4436122d1cc2f40dc2b92f0eba0.cache.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup with null safety',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                '',
+                treeShakeIcons: false,
+                extraFrontEndOptions: <String>[
+                  '--enable-experiment=non-nullable'
+                ],
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(globals.fs.path.join('build', 'cache.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup with track-widget-creation',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(
+                        globals.fs.path.join('build', 'cache.dill.track.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner does not copy app.dill if a dillOutputPath is given',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              dillOutputPath: 'test',
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(globals.fs.file(globals.fs.path.join('build', 'cache.dill')),
+                isNot(exists));
+          }));
+
+  testUsingContext(
+      'HotRunner copies compiled app.dill to cache during startup with --track-widget-creation',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                '',
+                treeShakeIcons: false,
+                trackWidgetCreation: true,
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            residentRunner.artifactDirectory
+                .childFile('app.dill')
+                .writeAsStringSync('ABC');
+
+            await residentRunner.run();
+
+            expect(
+                await globals.fs
+                    .file(
+                        globals.fs.path.join('build', 'cache.dill.track.dill'))
+                    .readAsString(),
+                'ABC');
+          }));
+
+  testUsingContext(
+      'HotRunner calls device dispose',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+
+            await residentRunner.run();
+            expect(device.disposed, true);
+          }));
+
+  testUsingContext(
+      'HotRunner handles failure to write vmservice file',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
+                  vmserviceOutFile: 'foo'),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+
+            await residentRunner.run();
+
+            expect(testLogger.errorText,
+                contains('Failed to write vmservice-out-file at foo'));
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }, overrides: <Type, Generator>{
+            FileSystem: () =>
+                ThrowingForwardingFileSystem(MemoryFileSystem.test()),
+          }));
+
+  testUsingContext(
+      'ColdRunner writes vm service file when providing debugging option',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+            ], wsAddress: testUri);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = ColdRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile,
+                  vmserviceOutFile: 'foo'),
+              devtoolsHandler: createNoOpHandler,
+              target: 'main.dart',
+              useImplicitPubpsecResolution: true,
+            );
+
+            await residentRunner.run();
+
+            expect(await globals.fs.file('foo').readAsString(),
+                testUri.toString());
+            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+          }));
+
+  testUsingContext(
+      'FlutterDevice uses dartdevc configuration when targeting web', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    flutterDevice.generator = residentCompiler;
-
-    await residentRunner.run();
-
-    final File generatedLocalizationsFile = globals.fs.directory('.dart_tool')
-      .childDirectory('flutter_gen')
-      .childDirectory('gen_l10n')
-      .childFile('app_localizations.dart');
-    expect(generatedLocalizationsFile.existsSync(), isTrue);
-
-    // Completing this future ensures that the daemon can exit correctly.
-    expect(await residentRunner.waitForAppToFinish(), 1);
-  }));
-
-  testUsingContext('ResidentRunner printHelpDetails hot runner', () => testbed.run(() {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
-    residentRunner.printHelp(details: true);
-
-    final CommandHelp commandHelp = residentRunner.commandHelp;
-
-    // supports service protocol
-    expect(residentRunner.supportsServiceProtocol, true);
-    // isRunningDebug
-    expect(residentRunner.isRunningDebug, true);
-    // does support SkSL
-    expect(residentRunner.supportsWriteSkSL, true);
-    // commands
-    expect(testLogger.statusText, equals(
-        <dynamic>[
-          'Flutter run key commands.',
-          commandHelp.r,
-          commandHelp.R,
-          commandHelp.v,
-          commandHelp.s,
-          commandHelp.w,
-          commandHelp.t,
-          commandHelp.L,
-          commandHelp.f,
-          commandHelp.S,
-          commandHelp.U,
-          commandHelp.i,
-          commandHelp.p,
-          commandHelp.I,
-          commandHelp.o,
-          commandHelp.b,
-          commandHelp.P,
-          commandHelp.a,
-          commandHelp.M,
-          commandHelp.g,
-          commandHelp.hWithDetails,
-          commandHelp.c,
-          commandHelp.q,
-          '',
-          'A Dart VM Service on FakeDevice is available at: null',
-          '',
-        ].join('\n')
-    ));
-  }));
-
-  testUsingContext('ResidentRunner printHelp hot runner', () => testbed.run(() {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
-    residentRunner.printHelp(details: false);
-
-    final CommandHelp commandHelp = residentRunner.commandHelp;
-
-    // supports service protocol
-    expect(residentRunner.supportsServiceProtocol, true);
-    // isRunningDebug
-    expect(residentRunner.isRunningDebug, true);
-    // does support SkSL
-    expect(residentRunner.supportsWriteSkSL, true);
-    // commands
-    expect(testLogger.statusText, equals(
-        <dynamic>[
-          'Flutter run key commands.',
-          commandHelp.r,
-          commandHelp.R,
-          commandHelp.hWithoutDetails,
-          commandHelp.c,
-          commandHelp.q,
-          '',
-          'A Dart VM Service on FakeDevice is available at: null',
-          '',
-        ].join('\n')
-    ));
-  }));
-
-  testUsingContext('ResidentRunner printHelpDetails cold runner', () => testbed.run(() {
-    fakeVmServiceHost = null;
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-    residentRunner.printHelp(details: true);
-
-    final CommandHelp commandHelp = residentRunner.commandHelp;
-
-    // does not supports service protocol
-    expect(residentRunner.supportsServiceProtocol, false);
-    // isRunningDebug
-    expect(residentRunner.isRunningDebug, false);
-    // does support SkSL
-    expect(residentRunner.supportsWriteSkSL, false);
-    // commands
-    expect(testLogger.statusText, equals(
-        <dynamic>[
-          'Flutter run key commands.',
-          commandHelp.v,
-          commandHelp.s,
-          commandHelp.hWithDetails,
-          commandHelp.c,
-          commandHelp.q,
-          '',
-        ].join('\n')
-    ));
-  }));
-
-  testUsingContext('ResidentRunner printHelp cold runner', () => testbed.run(() {
-    fakeVmServiceHost = null;
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-    residentRunner.printHelp(details: false);
-
-    final CommandHelp commandHelp = residentRunner.commandHelp;
-
-    // does not supports service protocol
-    expect(residentRunner.supportsServiceProtocol, false);
-    // isRunningDebug
-    expect(residentRunner.isRunningDebug, false);
-    // does support SkSL
-    expect(residentRunner.supportsWriteSkSL, false);
-    // commands
-    expect(testLogger.statusText, equals(
-        <dynamic>[
-          'Flutter run key commands.',
-          commandHelp.hWithoutDetails,
-          commandHelp.c,
-          commandHelp.q,
-          '',
-        ].join('\n')
-    ));
-  }));
-
-  testUsingContext('ResidentRunner handles writeSkSL returning no data', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      FakeVmServiceRequest(
-        method: kGetSkSLsMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-        },
-        jsonResponse: <String, Object>{
-          'SkSLs': <String, Object>{},
-        }
-      ),
-    ]);
-    await residentRunner.writeSkSL();
-
-    expect(testLogger.statusText, contains('No data was received'));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
-
-  testUsingContext('ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      FakeVmServiceRequest(
-        method: kGetSkSLsMethod,
-        args: <String, Object>{
-          'viewId': fakeFlutterView.id,
-        },
-        jsonResponse: <String, Object>{
-          'SkSLs': <String, Object>{
-            'A': 'B',
-          },
-        },
-      ),
-    ]);
-    await residentRunner.writeSkSL();
-
-    expect(testLogger.statusText, contains('flutter_01.sksl.json'));
-    expect(globals.fs.file('flutter_01.sksl.json'), exists);
-    expect(json.decode(globals.fs.file('flutter_01.sksl.json').readAsStringSync()), <String, Object>{
-      'platform': 'android',
-      'name': 'FakeDevice',
-      'engineRevision': 'abcdefg',
-      'data': <String, Object>{'A': 'B'},
-    });
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    FileSystemUtils: () => FileSystemUtils(
-      fileSystem: globals.fs,
-      platform: globals.platform,
-    ),
-    FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg'),
-  }));
-
-  testUsingContext('ResidentRunner ignores DevtoolsLauncher when attaching with enableDevTools: false - cold mode', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo', enableDevTools: false),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-    );
-
-    final Future<int?> result = residentRunner.attach();
-    expect(await result, 0);
-  }));
-
-  testUsingContext('FlutterDevice can exit from a release mode isolate with no VmService', () => testbed.run(() async {
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-    );
-
-    await flutterDevice.exitApps();
-
-    expect(device.appStopped, true);
-  }));
-
-  testUsingContext('FlutterDevice will exit an un-paused isolate using stopApp', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-    );
-    flutterDevice.vmService = fakeVmServiceHost!.vmService;
-
-    final Future<void> exitFuture = flutterDevice.exitApps();
-
-    await expectLater(exitFuture, completes);
-    expect(device.appStopped, true);
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
-
-  testUsingContext('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-
-    await residentRunner.run();
-
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-    expect(await globals.fs.file('foo').readAsString(), testUri.toString());
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(
-        const BuildInfo(
-          BuildMode.debug,
-          null,
-          treeShakeIcons: false,
-          packageConfigPath: '.dart_tool/package_config.json',
-        )
-      ),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup with dart defines', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(
-        const BuildInfo(
-          BuildMode.debug,
-          '',
-          treeShakeIcons: false,
-          dartDefines: <String>['a', 'b'],
-          packageConfigPath: '.dart_tool/package_config.json',
-        )
-      ),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join(
-      'build', '187ef4436122d1cc2f40dc2b92f0eba0.cache.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup with null safety', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(
-        const BuildInfo(
-          BuildMode.debug,
-          '',
-          treeShakeIcons: false,
-          extraFrontEndOptions: <String>['--enable-experiment=non-nullable'],
-          packageConfigPath: '.dart_tool/package_config.json',
-        )
-      ),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join(
-      'build', 'cache.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup with track-widget-creation', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join(
-      'build', 'cache.dill.track.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner does not copy app.dill if a dillOutputPath is given', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      dillOutputPath: 'test',
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(globals.fs.file(globals.fs.path.join('build', 'cache.dill')), isNot(exists));
-  }));
-
-  testUsingContext('HotRunner copies compiled app.dill to cache during startup with --track-widget-creation', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        trackWidgetCreation: true,
-        packageConfigPath: '.dart_tool/package_config.json',
-      )),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill.track.dill')).readAsString(), 'ABC');
-  }));
-
-  testUsingContext('HotRunner calls device dispose', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-
-    await residentRunner.run();
-    expect(device.disposed, true);
-  }));
-
-  testUsingContext('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-
-    await residentRunner.run();
-
-    expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }, overrides: <Type, Generator>{
-    FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem.test()),
-  }));
-
-  testUsingContext('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-    ], wsAddress: testUri);
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    residentRunner = ColdRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo'),
-      devtoolsHandler: createNoOpHandler,
-      target: 'main.dart',
-    );
-
-    await residentRunner.run();
-
-    expect(await globals.fs.file('foo').readAsString(), testUri.toString());
-    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-  }));
-
-  testUsingContext('FlutterDevice uses dartdevc configuration when targeting web', () async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final FakeDevice device =
+        FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -1783,28 +2089,40 @@ flutter:
       ),
       target: null,
       platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+    ))
+            .generator as DefaultResidentCompiler?;
 
-    expect(residentCompiler!.initializeFromDill,
-      globals.fs.path.join(getBuildDirectory(), 'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'));
-    expect(residentCompiler.librariesSpec,
-      globals.fs.file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-        .uri.toString());
+    expect(
+        residentCompiler!.initializeFromDill,
+        globals.fs.path.join(getBuildDirectory(),
+            'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'));
+    expect(
+        residentCompiler.librariesSpec,
+        globals.fs
+            .file(globals.artifacts!
+                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+            .uri
+            .toString());
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
-      '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill');
+        '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
+    expect(residentCompiler.platformDill,
+        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected', () async {
+  testUsingContext(
+      'FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+    final FakeDevice device =
+        FakeDevice(targetPlatform: TargetPlatform.web_javascript);
 
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -1815,29 +2133,38 @@ flutter:
       ),
       target: null,
       platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+    ))
+            .generator as DefaultResidentCompiler?;
 
-    expect(residentCompiler!.initializeFromDill,
-      globals.fs.path.join(getBuildDirectory(), '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
-    expect(residentCompiler.librariesSpec,
-      globals.fs.file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-        .uri.toString());
+    expect(
+        residentCompiler!.initializeFromDill,
+        globals.fs.path.join(getBuildDirectory(),
+            '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
+    expect(
+        residentCompiler.librariesSpec,
+        globals.fs
+            .file(globals.artifacts!
+                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+            .uri
+            .toString());
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
-      '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill');
+        '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
+    expect(residentCompiler.platformDill,
+        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice passes alternative-invalidation-strategy flag', () async {
+  testUsingContext(
+      'FlutterDevice passes alternative-invalidation-strategy flag', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -1846,22 +2173,27 @@ flutter:
         extraFrontEndOptions: <String>[],
         packageConfigPath: '.dart_tool/package_config.json',
       ),
-      target: null, platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+      target: null,
+      platform: FakePlatform(),
+    ))
+            .generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.extraFrontEndOptions,
-      contains('--enable-experiment=alternative-invalidation-strategy'));
+        contains('--enable-experiment=alternative-invalidation-strategy'));
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice passes initializeFromDill parameter if specified', () async {
+  testUsingContext(
+      'FlutterDevice passes initializeFromDill parameter if specified',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -1871,8 +2203,10 @@ flutter:
         initializeFromDill: '/foo/bar.dill',
         packageConfigPath: '.dart_tool/package_config.json',
       ),
-      target: null, platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+      target: null,
+      platform: FakePlatform(),
+    ))
+            .generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.initializeFromDill, '/foo/bar.dill');
     expect(residentCompiler.assumeInitializeFromDillUpToDate, false);
@@ -1882,22 +2216,24 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-   testUsingContext('FlutterDevice passes assumeInitializeFromDillUpToDate parameter if specified', () async {
+  testUsingContext(
+      'FlutterDevice passes assumeInitializeFromDillUpToDate parameter if specified',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
-      buildInfo: const BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        extraFrontEndOptions: <String>[],
-        assumeInitializeFromDillUpToDate: true,
-        packageConfigPath: '.dart_tool/package_config.json'
-      ),
-      target: null, platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+      buildInfo: const BuildInfo(BuildMode.debug, '',
+          treeShakeIcons: false,
+          extraFrontEndOptions: <String>[],
+          assumeInitializeFromDillUpToDate: true,
+          packageConfigPath: '.dart_tool/package_config.json'),
+      target: null,
+      platform: FakePlatform(),
+    ))
+            .generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.assumeInitializeFromDillUpToDate, true);
   }, overrides: <Type, Generator>{
@@ -1906,30 +2242,35 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice passes frontendServerStarterPath parameter if specified', () async {
+  testUsingContext(
+      'FlutterDevice passes frontendServerStarterPath parameter if specified',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler =
+        (await FlutterDevice.create(
       device,
-      buildInfo: const BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        frontendServerStarterPath: '/foo/bar/frontend_server_starter.dart',
-        packageConfigPath: '.dart_tool/package_config.json'
-      ),
-      target: null, platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
+      buildInfo: const BuildInfo(BuildMode.debug, '',
+          treeShakeIcons: false,
+          frontendServerStarterPath: '/foo/bar/frontend_server_starter.dart',
+          packageConfigPath: '.dart_tool/package_config.json'),
+      target: null,
+      platform: FakePlatform(),
+    ))
+            .generator as DefaultResidentCompiler?;
 
-    expect(residentCompiler!.frontendServerStarterPath, '/foo/bar/frontend_server_starter.dart');
+    expect(residentCompiler!.frontendServerStarterPath,
+        '/foo/bar/frontend_server_starter.dart');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection', () async {
+  testUsingContext(
+      'FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection',
+      () async {
     fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         const FakeVmServiceRequest(
@@ -1966,160 +2307,189 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('Uses existing DDS URI from exception field', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice()
-      ..dds = DartDevelopmentService(logger: testLogger);
-    ddsLauncherCallback = ({
-      required Uri remoteVmServiceUri,
-      Uri? serviceUri,
-      bool enableAuthCodes = true,
-      bool serveDevTools = false,
-      Uri? devToolsServerAddress,
-      bool enableServicePortFallback = false,
-      List<String> cachedUserTags = const <String>[],
-      String? dartExecutable,
-      String? google3WorkspaceRoot,
-    }) {
-      throw DartDevelopmentServiceException.existingDdsInstance(
-        'Existing DDS at http://localhost/existingDdsInMessage.',
-        ddsUri: Uri.parse('http://localhost/existingDdsInField'),
-      );
-    };
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-      vmServiceUris: Stream<Uri>.value(testUri),
-    );
-    final Completer<void> done = Completer<void>();
-    unawaited(runZonedGuarded(
-      () => flutterDevice.connect(
-        allowExistingDdsInstance: true,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      ).then((_) => done.complete()),
-      (_, __) => done.complete(),
-    ));
-    await done.future;
-    expect(device.dds.uri, Uri.parse('http://localhost/existingDdsInField'));
-  }, overrides: <Type, Generator>{
-    VMServiceConnector: () => (Uri httpUri, {
-      ReloadSources? reloadSources,
-      Restart? restart,
-      CompileExpression? compileExpression,
-      GetSkSLMethod? getSkSLMethod,
-      FlutterProject? flutterProject,
-    PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-      io.CompressionOptions? compression,
-      Device? device,
-      required Logger logger,
-    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
-  }));
+  testUsingContext(
+      'Uses existing DDS URI from exception field',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final FakeDevice device = FakeDevice()
+              ..dds = DartDevelopmentService(logger: testLogger);
+            ddsLauncherCallback = ({
+              required Uri remoteVmServiceUri,
+              Uri? serviceUri,
+              bool enableAuthCodes = true,
+              bool serveDevTools = false,
+              Uri? devToolsServerAddress,
+              bool enableServicePortFallback = false,
+              List<String> cachedUserTags = const <String>[],
+              String? dartExecutable,
+              String? google3WorkspaceRoot,
+            }) {
+              throw DartDevelopmentServiceException.existingDdsInstance(
+                'Existing DDS at http://localhost/existingDdsInMessage.',
+                ddsUri: Uri.parse('http://localhost/existingDdsInField'),
+              );
+            };
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+              vmServiceUris: Stream<Uri>.value(testUri),
+            );
+            final Completer<void> done = Completer<void>();
+            unawaited(runZonedGuarded(
+              () => flutterDevice
+                  .connect(
+                    allowExistingDdsInstance: true,
+                    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+                  )
+                  .then((_) => done.complete()),
+              (_, __) => done.complete(),
+            ));
+            await done.future;
+            expect(device.dds.uri,
+                Uri.parse('http://localhost/existingDdsInField'));
+          }, overrides: <Type, Generator>{
+            VMServiceConnector: () => (
+                  Uri httpUri, {
+                  ReloadSources? reloadSources,
+                  Restart? restart,
+                  CompileExpression? compileExpression,
+                  GetSkSLMethod? getSkSLMethod,
+                  FlutterProject? flutterProject,
+                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+                  io.CompressionOptions? compression,
+                  Device? device,
+                  required Logger logger,
+                }) async =>
+                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
+                        .vmService,
+          }));
 
-  testUsingContext('Host VM service ipv6 defaults', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice()
-      ..dds = DartDevelopmentService(logger: testLogger);
-    final Completer<void>done = Completer<void>();
-    ddsLauncherCallback = ({
-        required Uri remoteVmServiceUri,
-        Uri? serviceUri,
-        bool enableAuthCodes = true,
-        bool serveDevTools = false,
-        Uri? devToolsServerAddress,
-        bool enableServicePortFallback = false,
-        List<String> cachedUserTags = const <String>[],
-        String? dartExecutable,
-        String? google3WorkspaceRoot,
-      }) async {
-      expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
-      expect(enableAuthCodes, isFalse);
-      expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
-      expect(cachedUserTags, isEmpty);
-      done.complete();
-      return FakeDartDevelopmentServiceLauncher(uri: remoteVmServiceUri);
-    };
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-      vmServiceUris: Stream<Uri>.value(testUri),
-    );
-    await flutterDevice.connect(
-      allowExistingDdsInstance: true,
-      debuggingOptions: DebuggingOptions.enabled(
-        BuildInfo.debug, disableServiceAuthCodes: true, ipv6: true,
-      )
-    );
-    await done.future;
-  }, overrides: <Type, Generator>{
-    VMServiceConnector: () => (Uri httpUri, {
-      ReloadSources? reloadSources,
-      Restart? restart,
-      CompileExpression? compileExpression,
-      GetSkSLMethod? getSkSLMethod,
-      FlutterProject? flutterProject,
-      PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-      io.CompressionOptions? compression,
-      Device? device,
-      required Logger logger,
-    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
-  }));
+  testUsingContext(
+      'Host VM service ipv6 defaults',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            final FakeDevice device = FakeDevice()
+              ..dds = DartDevelopmentService(logger: testLogger);
+            final Completer<void> done = Completer<void>();
+            ddsLauncherCallback = ({
+              required Uri remoteVmServiceUri,
+              Uri? serviceUri,
+              bool enableAuthCodes = true,
+              bool serveDevTools = false,
+              Uri? devToolsServerAddress,
+              bool enableServicePortFallback = false,
+              List<String> cachedUserTags = const <String>[],
+              String? dartExecutable,
+              String? google3WorkspaceRoot,
+            }) async {
+              expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
+              expect(enableAuthCodes, isFalse);
+              expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
+              expect(cachedUserTags, isEmpty);
+              done.complete();
+              return FakeDartDevelopmentServiceLauncher(
+                  uri: remoteVmServiceUri);
+            };
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+              vmServiceUris: Stream<Uri>.value(testUri),
+            );
+            await flutterDevice.connect(
+                allowExistingDdsInstance: true,
+                debuggingOptions: DebuggingOptions.enabled(
+                  BuildInfo.debug,
+                  disableServiceAuthCodes: true,
+                  ipv6: true,
+                ));
+            await done.future;
+          }, overrides: <Type, Generator>{
+            VMServiceConnector: () => (
+                  Uri httpUri, {
+                  ReloadSources? reloadSources,
+                  Restart? restart,
+                  CompileExpression? compileExpression,
+                  GetSkSLMethod? getSkSLMethod,
+                  FlutterProject? flutterProject,
+                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+                  io.CompressionOptions? compression,
+                  Device? device,
+                  required Logger logger,
+                }) async =>
+                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
+                        .vmService,
+          }));
 
-  testUsingContext('Failed DDS start outputs error message', () => testbed.run(() async {
-    // See https://github.com/flutter/flutter/issues/72385 for context.
-    final FakeDevice device = FakeDevice()
-      ..dds = DartDevelopmentService(logger: testLogger);
-    ddsLauncherCallback = ({
-        required Uri remoteVmServiceUri,
-        Uri? serviceUri,
-        bool enableAuthCodes = true,
-        bool serveDevTools = false,
-        Uri? devToolsServerAddress,
-        bool enableServicePortFallback = false,
-        List<String> cachedUserTags = const <String>[],
-        String? dartExecutable,
-        String? google3WorkspaceRoot,
-      }) {
-      expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
-      expect(enableAuthCodes, isTrue);
-      expect(serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
-      expect(cachedUserTags, isEmpty);
-      throw FakeDartDevelopmentServiceException(message: 'No URI');
-    };
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      device,
-      vmServiceUris: Stream<Uri>.value(testUri),
-    );
-    bool caught = false;
-    final Completer<void>done = Completer<void>();
-    runZonedGuarded(() {
-      flutterDevice.connect(
-        allowExistingDdsInstance: true,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, enableDevTools: false),
-      ).then((_) => done.complete());
-    }, (Object e, StackTrace st) {
-      expect(e, isA<StateError>());
-      expect((e as StateError).message, contains('No URI'));
-      expect(testLogger.errorText, contains(
-        'DDS has failed to start and there is not an existing DDS instance',
-      ));
-      done.complete();
-      caught = true;
-    });
-    await done.future;
-    if (!caught) {
-      fail('Expected a StateError to be thrown.');
-    }
-  }, overrides: <Type, Generator>{
-    VMServiceConnector: () => (Uri httpUri, {
-      ReloadSources? reloadSources,
-      Restart? restart,
-      CompileExpression? compileExpression,
-      GetSkSLMethod? getSkSLMethod,
-      FlutterProject? flutterProject,
-      PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-      io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
-      Device? device,
-      required Logger logger,
-    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
-  }));
+  testUsingContext(
+      'Failed DDS start outputs error message',
+      () => testbed.run(() async {
+            // See https://github.com/flutter/flutter/issues/72385 for context.
+            final FakeDevice device = FakeDevice()
+              ..dds = DartDevelopmentService(logger: testLogger);
+            ddsLauncherCallback = ({
+              required Uri remoteVmServiceUri,
+              Uri? serviceUri,
+              bool enableAuthCodes = true,
+              bool serveDevTools = false,
+              Uri? devToolsServerAddress,
+              bool enableServicePortFallback = false,
+              List<String> cachedUserTags = const <String>[],
+              String? dartExecutable,
+              String? google3WorkspaceRoot,
+            }) {
+              expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
+              expect(enableAuthCodes, isTrue);
+              expect(
+                  serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
+              expect(cachedUserTags, isEmpty);
+              throw FakeDartDevelopmentServiceException(message: 'No URI');
+            };
+            final TestFlutterDevice flutterDevice = TestFlutterDevice(
+              device,
+              vmServiceUris: Stream<Uri>.value(testUri),
+            );
+            bool caught = false;
+            final Completer<void> done = Completer<void>();
+            runZonedGuarded(() {
+              flutterDevice
+                  .connect(
+                    allowExistingDdsInstance: true,
+                    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
+                        enableDevTools: false),
+                  )
+                  .then((_) => done.complete());
+            }, (Object e, StackTrace st) {
+              expect(e, isA<StateError>());
+              expect((e as StateError).message, contains('No URI'));
+              expect(
+                  testLogger.errorText,
+                  contains(
+                    'DDS has failed to start and there is not an existing DDS instance',
+                  ));
+              done.complete();
+              caught = true;
+            });
+            await done.future;
+            if (!caught) {
+              fail('Expected a StateError to be thrown.');
+            }
+          }, overrides: <Type, Generator>{
+            VMServiceConnector: () => (
+                  Uri httpUri, {
+                  ReloadSources? reloadSources,
+                  Restart? restart,
+                  CompileExpression? compileExpression,
+                  GetSkSLMethod? getSkSLMethod,
+                  FlutterProject? flutterProject,
+                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+                  io.CompressionOptions compression =
+                      io.CompressionOptions.compressionDefault,
+                  Device? device,
+                  required Logger logger,
+                }) async =>
+                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
+                        .vmService,
+          }));
 
   testUsingContext('nextPlatform moves through expected platforms', () {
     expect(nextPlatform('android'), 'iOS');
@@ -2132,166 +2502,199 @@ flutter:
   });
 
   // TODO(bkonyi): remove when ready to serve DevTools from DDS.
-  testUsingContext('cleanupAtFinish shuts down resident devtools handler', () => testbed.run(() async {
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
-    await residentRunner.cleanupAtFinish();
+  testUsingContext(
+      'cleanupAtFinish shuts down resident devtools handler',
+      () => testbed.run(() async {
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
+                  vmserviceOutFile: 'foo'),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
+            await residentRunner.cleanupAtFinish();
 
-    expect((residentRunner.residentDevtoolsHandler! as NoOpDevtoolsHandler).wasShutdown, true);
-  }));
+            expect(
+                (residentRunner.residentDevtoolsHandler! as NoOpDevtoolsHandler)
+                    .wasShutdown,
+                true);
+          }));
 
-  testUsingContext('HotRunner sets asset directory when first evict assets', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      setAssetBundlePath,
-      evict,
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
+  testUsingContext(
+      'HotRunner sets asset directory when first evict assets',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              setAssetBundlePath,
+              evict,
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
 
-    (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{'asset'};
+            (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{
+              'asset'
+            };
 
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, isFalse);
-    await (residentRunner as HotRunner).evictDirtyAssets();
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, isTrue);
-    expect(fakeVmServiceHost!.hasRemainingExpectations, isFalse);
-  }));
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, isFalse);
+            await (residentRunner as HotRunner).evictDirtyAssets();
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, isTrue);
+            expect(fakeVmServiceHost!.hasRemainingExpectations, isFalse);
+          }));
 
-  testUsingContext('HotRunner sets asset directory when first evict shaders', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      setAssetBundlePath,
-      evictShader,
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
+  testUsingContext(
+      'HotRunner sets asset directory when first evict shaders',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              setAssetBundlePath,
+              evictShader,
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
 
-    (flutterDevice.devFS! as FakeDevFS).shaderPathsToEvict = <String>{'foo.frag'};
+            (flutterDevice.devFS! as FakeDevFS).shaderPathsToEvict = <String>{
+              'foo.frag'
+            };
 
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-    await (residentRunner as HotRunner).evictDirtyAssets();
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
-    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-  }));
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+            await (residentRunner as HotRunner).evictDirtyAssets();
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
+            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+          }));
 
-  testUsingContext('HotRunner does not sets asset directory when no assets to evict', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
+  testUsingContext(
+      'HotRunner does not sets asset directory when no assets to evict',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
 
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-    await (residentRunner as HotRunner).evictDirtyAssets();
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-  }));
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+            await (residentRunner as HotRunner).evictDirtyAssets();
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+          }));
 
-  testUsingContext('HotRunner does not set asset directory if it has been set before', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      evict,
-    ]);
-    residentRunner = HotRunner(
-      <FlutterDevice>[
-        flutterDevice,
-      ],
-      stayResident: false,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      target: 'main.dart',
-      devtoolsHandler: createNoOpHandler,
-      analytics: fakeAnalytics,
-    );
+  testUsingContext(
+      'HotRunner does not set asset directory if it has been set before',
+      () => testbed.run(() async {
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              evict,
+            ]);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: fakeAnalytics,
+              useImplicitPubspecResolution: true,
+            );
 
-    (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{'asset'};
-    flutterDevice.devFS!.hasSetAssetDirectory = true;
+            (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{
+              'asset'
+            };
+            flutterDevice.devFS!.hasSetAssetDirectory = true;
 
-    await (residentRunner as HotRunner).evictDirtyAssets();
-    expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
-    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-  }));
+            await (residentRunner as HotRunner).evictDirtyAssets();
+            expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
+            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+          }));
 
   testUsingContext(
       'use the nativeAssetsYamlFile when provided',
       () => testbed.run(() async {
-        final FakeDevice device = FakeDevice(
-          targetPlatform: TargetPlatform.darwin,
-          sdkNameAndVersion: 'Macos',
-        );
-        final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
-        final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
-          ..testUri = testUri
-          ..vmServiceHost = (() => fakeVmServiceHost)
-          ..device = device
-          ..fakeDevFS = devFS
-          ..targetPlatform = TargetPlatform.darwin
-          ..generator = residentCompiler;
+            final FakeDevice device = FakeDevice(
+              targetPlatform: TargetPlatform.darwin,
+              sdkNameAndVersion: 'Macos',
+            );
+            final FakeResidentCompiler residentCompiler =
+                FakeResidentCompiler();
+            final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+              ..testUri = testUri
+              ..vmServiceHost = (() => fakeVmServiceHost)
+              ..device = device
+              ..fakeDevFS = devFS
+              ..targetPlatform = TargetPlatform.darwin
+              ..generator = residentCompiler;
 
-        fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-          listViews,
-          listViews,
-        ]);
-        globals.fs
-            .file(globals.fs.path.join('lib', 'main.dart'))
-            .createSync(recursive: true);
-        residentRunner = HotRunner(
-          <FlutterDevice>[
-            flutterDevice,
-          ],
-          stayResident: false,
-          debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-            BuildMode.debug,
-            '',
-            treeShakeIcons: false,
-            trackWidgetCreation: true,
-            packageConfigPath: '.dart_tool/package_config.json',
-          )),
-          target: 'main.dart',
-          devtoolsHandler: createNoOpHandler,
-          analytics: globals.analytics,
-          nativeAssetsYamlFile: 'foo.yaml',
-        );
+            fakeVmServiceHost =
+                FakeVmServiceHost(requests: <VmServiceExpectation>[
+              listViews,
+              listViews,
+            ]);
+            globals.fs
+                .file(globals.fs.path.join('lib', 'main.dart'))
+                .createSync(recursive: true);
+            residentRunner = HotRunner(
+              <FlutterDevice>[
+                flutterDevice,
+              ],
+              stayResident: false,
+              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+                BuildMode.debug,
+                '',
+                treeShakeIcons: false,
+                trackWidgetCreation: true,
+                packageConfigPath: '.dart_tool/package_config.json',
+              )),
+              target: 'main.dart',
+              devtoolsHandler: createNoOpHandler,
+              analytics: globals.analytics,
+              nativeAssetsYamlFile: 'foo.yaml',
+              useImplicitPubspecResolution: true,
+            );
 
-        final int? result = await residentRunner.run();
-        expect(result, 0);
+            final int? result = await residentRunner.run();
+            expect(result, 0);
 
-        expect(residentCompiler.recompileCalled, true);
-        expect(residentCompiler.receivedNativeAssetsYaml, globals.fs.path.toUri('foo.yaml'));
-      }),
+            expect(residentCompiler.recompileCalled, true);
+            expect(residentCompiler.receivedNativeAssetsYaml,
+                globals.fs.path.toUri('foo.yaml'));
+          }),
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+        FeatureFlags: () =>
+            TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
       });
 }
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -50,26 +50,24 @@ void main() {
   FakeVmServiceHost? fakeVmServiceHost;
 
   setUp(() {
-    testbed = Testbed(
-        setup: () {
-          globals.fs.file(globals.fs.path.join('build', 'app.dill'))
-            ..createSync(recursive: true)
-            ..writeAsStringSync('ABC');
-          residentRunner = HotRunner(
-            <FlutterDevice>[
-              flutterDevice,
-            ],
-            stayResident: false,
-            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-            target: 'main.dart',
-            analytics: fakeAnalytics,
-            devtoolsHandler: createNoOpHandler,
-            useImplicitPubspecResolution: true,
-          );
-        },
-        overrides: <Type, Generator>{
-          Analytics: () => FakeAnalytics(),
-        });
+    testbed = Testbed(setup: () {
+      globals.fs.file(globals.fs.path.join('build', 'app.dill'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('ABC');
+      residentRunner = HotRunner(
+        <FlutterDevice>[
+          flutterDevice,
+        ],
+        stayResident: false,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'main.dart',
+        analytics: fakeAnalytics,
+        devtoolsHandler: createNoOpHandler,
+        useImplicitPubspecResolution: true,
+      );
+    }, overrides: <Type, Generator>{
+      Analytics: () => FakeAnalytics(),
+    });
     device = FakeDevice();
     devFS = FakeDevFS();
     flutterDevice = FakeFlutterDevice()
@@ -79,1190 +77,1051 @@ void main() {
       ..fakeDevFS = devFS;
   });
 
-  testUsingContext(
-      'ResidentRunner can attach to device successfully',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            final Future<int?> result = residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            );
-            final Future<DebugConnectionInfo> connectionInfo =
-                futureConnectionInfo.future;
+  testUsingContext('ResidentRunner can attach to device successfully', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    final Future<int?> result = residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    );
+    final Future<DebugConnectionInfo> connectionInfo = futureConnectionInfo.future;
 
-            expect(await result, 0);
-            expect(futureConnectionInfo.isCompleted, true);
-            expect((await connectionInfo).baseUri, 'foo://bar');
-            expect(futureAppStart.isCompleted, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+    expect(await result, 0);
+    expect(futureConnectionInfo.isCompleted, true);
+    expect((await connectionInfo).baseUri, 'foo://bar');
+    expect(futureAppStart.isCompleted, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'ResidentRunner suppresses errors for the initial compilation',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-              ..nextOutput = const CompilerOutput('foo', 0, <Uri>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.generator = residentCompiler;
+  testUsingContext('ResidentRunner suppresses errors for the initial compilation', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 0 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: globals.analytics,
+      useImplicitPubspecResolution: true,
+    );
+    flutterDevice.generator = residentCompiler;
 
-            expect(await residentRunner.run(), 0);
-            expect(residentCompiler.didSuppressErrors, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+    expect(await residentRunner.run(), 0);
+    expect(residentCompiler.didSuppressErrors, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext(
-      'ResidentRunner calls appFailedToStart if initial compilation fails',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-              ..nextOutput = const CompilerOutput('foo', 1, <Uri>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.generator = residentCompiler;
+  testUsingContext('ResidentRunner calls appFailedToStart if initial compilation fails', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: globals.analytics,
+      useImplicitPubspecResolution: true,
+    );
+    flutterDevice.generator = residentCompiler;
 
-            expect(await residentRunner.run(), 1);
-            // Completing this future ensures that the daemon can exit correctly.
-            expect(await residentRunner.waitForAppToFinish(), 1);
-          }));
+    expect(await residentRunner.run(), 1);
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
+  }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext(
-      'ResidentRunner calls appFailedToStart if initial compilation fails - cold mode',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.runColdCode = 1;
+  testUsingContext('ResidentRunner calls appFailedToStart if initial compilation fails - cold mode', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
+    );
+    flutterDevice.runColdCode = 1;
 
-            expect(await residentRunner.run(), 1);
-            // Completing this future ensures that the daemon can exit correctly.
-            expect(await residentRunner.waitForAppToFinish(), 1);
-          }));
+    expect(await residentRunner.run(), 1);
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
+  }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext(
-      'ResidentRunner calls appFailedToStart if exception is thrown - cold mode',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.runColdError = Exception('BAD STUFF');
+  testUsingContext('ResidentRunner calls appFailedToStart if exception is thrown - cold mode', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
+    );
+    flutterDevice.runColdError = Exception('BAD STUFF');
 
-            expect(await residentRunner.run(), 1);
-            // Completing this future ensures that the daemon can exit correctly.
-            expect(await residentRunner.waitForAppToFinish(), 1);
-          }));
 
-  testUsingContext(
-      'ResidentRunner does not suppressErrors if running with an applicationBinary',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-              ..nextOutput = const CompilerOutput('foo', 0, <Uri>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              applicationBinary: globals.fs.file('app-debug.apk'),
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.generator = residentCompiler;
+    expect(await residentRunner.run(), 1);
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
+  }));
 
-            expect(await residentRunner.run(), 0);
-            expect(residentCompiler.didSuppressErrors, false);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+  testUsingContext('ResidentRunner does not suppressErrors if running with an applicationBinary', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 0 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      applicationBinary: globals.fs.file('app-debug.apk'),
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: globals.analytics,
+      useImplicitPubspecResolution: true,
+    );
+    flutterDevice.generator = residentCompiler;
 
-  testUsingContext(
-      'ResidentRunner can attach to device successfully with --fast-start',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                  method: 'streamListen',
-                  args: <String, Object>{
-                    'streamId': 'Isolate',
-                  }),
-              FakeVmServiceRequest(
-                  method: kRunInViewMethod,
-                  args: <String, Object>{
-                    'viewId': fakeFlutterView.id,
-                    'mainScript': 'main.dart.dill',
-                    'assetDirectory': 'build/flutter_assets',
-                  }),
-              FakeVmServiceStreamResponse(
-                  streamId: 'Isolate',
-                  event: vm_service.Event(
-                    timestamp: 0,
-                    kind: vm_service.EventKind.kIsolateRunnable,
-                  )),
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(
-                BuildInfo.debug,
-                fastStart: true,
-                startPaused: true,
-              ),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              useImplicitPubspecResolution: true,
-            );
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            final Future<int?> result = residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            );
-            final Future<DebugConnectionInfo> connectionInfo =
-                futureConnectionInfo.future;
+    expect(await residentRunner.run(), 0);
+    expect(residentCompiler.didSuppressErrors, false);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-            expect(await result, 0);
-            expect(futureConnectionInfo.isCompleted, true);
-            expect((await connectionInfo).baseUri, 'foo://bar');
-            expect(futureAppStart.isCompleted, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+  testUsingContext('ResidentRunner can attach to device successfully with --fast-start', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        }
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        }
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        )
+      ),
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(
+        BuildInfo.debug,
+        fastStart: true,
+        startPaused: true,
+      ),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: globals.analytics,
+      useImplicitPubspecResolution: true,
+    );
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    final Future<int?> result = residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    );
+    final Future<DebugConnectionInfo> connectionInfo = futureConnectionInfo.future;
 
-  testUsingContext(
-      'ResidentRunner can handle an RPC exception from hot reload',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.reportError =
-                vm_service.RPCError('something bad happened', 666, '');
+    expect(await result, 0);
+    expect(futureConnectionInfo.isCompleted, true);
+    expect((await connectionInfo).baseUri, 'foo://bar');
+    expect(futureAppStart.isCompleted, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, true);
-            expect(result.code, 1);
-            expect(
-                (globals.flutterUsage as TestUsage).events,
-                contains(
-                  TestUsageEvent('hot', 'exception',
-                      parameters: CustomDimensions(
-                        hotEventTargetPlatform: getNameForTargetPlatform(
-                            TargetPlatform.android_arm),
-                        hotEventSdkName: 'Android',
-                        hotEventEmulator: false,
-                        hotEventFullRestart: false,
-                      )),
-                ));
-            expect(
-                (globals.analytics as FakeAnalytics).sentEvents,
-                contains(
-                  Event.hotRunnerInfo(
-                    label: 'exception',
-                    targetPlatform:
-                        getNameForTargetPlatform(TargetPlatform.android_arm),
-                    sdkName: 'Android',
-                    emulator: false,
-                    fullRestart: false,
-                  ),
-                ));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+  testUsingContext('ResidentRunner can handle an RPC exception from hot reload', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
 
-  testUsingContext(
-      'ResidentRunner fails its operation if the device initialization is not complete',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.fakeDevFS = null;
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, true);
+    expect(result.code, 1);
+    expect((globals.flutterUsage as TestUsage).events, contains(
+      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
+        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        hotEventSdkName: 'Android',
+        hotEventEmulator: false,
+        hotEventFullRestart: false,
+      )),
+    ));
+    expect((globals.analytics as FakeAnalytics).sentEvents, contains(
+      Event.hotRunnerInfo(
+        label: 'exception',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        sdkName: 'Android',
+        emulator: false,
+        fullRestart: false,
+      ),
+    ));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, false);
-            expect(result.code, 1);
-            expect(result.message,
-                contains('Device initialization has not completed.'));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+  testUsingContext('ResidentRunner fails its operation if the device initialization is not complete', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.fakeDevFS = null;
 
-  testUsingContext(
-      'ResidentRunner can handle an reload-barred exception from hot reload',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.reportError = vm_service.RPCError(
-                'something bad happened', kIsolateReloadBarred, '');
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, false);
+    expect(result.code, 1);
+    expect(result.message, contains('Device initialization has not completed.'));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, true);
-            expect(result.code, kIsolateReloadBarred);
-            expect(
-                result.message,
-                contains(
-                    'Unable to hot reload application due to an unrecoverable error'));
+  testUsingContext('ResidentRunner can handle an reload-barred exception from hot reload', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.reportError = vm_service.RPCError('something bad happened', kIsolateReloadBarred, '');
 
-            expect(
-                (globals.flutterUsage as TestUsage).events,
-                contains(
-                  TestUsageEvent('hot', 'reload-barred',
-                      parameters: CustomDimensions(
-                        hotEventTargetPlatform: getNameForTargetPlatform(
-                            TargetPlatform.android_arm),
-                        hotEventSdkName: 'Android',
-                        hotEventEmulator: false,
-                        hotEventFullRestart: false,
-                      )),
-                ));
-            expect(
-                fakeAnalytics.sentEvents,
-                contains(Event.hotRunnerInfo(
-                  label: 'reload-barred',
-                  targetPlatform:
-                      getNameForTargetPlatform(TargetPlatform.android_arm),
-                  sdkName: 'Android',
-                  emulator: false,
-                  fullRestart: false,
-                )));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, true);
+    expect(result.code, kIsolateReloadBarred);
+    expect(result.message, contains('Unable to hot reload application due to an unrecoverable error'));
 
-  testUsingContext(
-      'ResidentRunner reports hot reload event with null safety analytics',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              target: 'main.dart',
-              debuggingOptions: DebuggingOptions.enabled(
-                const BuildInfo(
-                  BuildMode.debug,
-                  '',
-                  treeShakeIcons: false,
-                  extraFrontEndOptions: <String>[
-                    '--enable-experiment=non-nullable',
-                  ],
-                  packageConfigPath: '.dart_tool/package_config.json',
-                ),
-                enableDevTools: false,
-              ),
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.reportError =
-                vm_service.RPCError('something bad happened', 666, '');
+    expect((globals.flutterUsage as TestUsage).events, contains(
+      TestUsageEvent('hot', 'reload-barred', parameters: CustomDimensions(
+        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        hotEventSdkName: 'Android',
+        hotEventEmulator: false,
+        hotEventFullRestart: false,
+      )),
+    ));
+    expect(fakeAnalytics.sentEvents, contains(
+      Event.hotRunnerInfo(
+        label: 'reload-barred',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        sdkName: 'Android',
+        emulator: false,
+        fullRestart: false,
+      )
+    ));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, true);
-            expect(result.code, 1);
+  testUsingContext('ResidentRunner reports hot reload event with null safety analytics', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      target: 'main.dart',
+      debuggingOptions: DebuggingOptions.enabled(
+        const BuildInfo(
+          BuildMode.debug, '', treeShakeIcons: false, extraFrontEndOptions: <String>[
+          '--enable-experiment=non-nullable',
+          ],
+          packageConfigPath: '.dart_tool/package_config.json',
+        ),
+        enableDevTools: false,
+      ),
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
 
-            expect(
-                (globals.flutterUsage as TestUsage).events,
-                contains(
-                  TestUsageEvent('hot', 'exception',
-                      parameters: CustomDimensions(
-                        hotEventTargetPlatform: getNameForTargetPlatform(
-                            TargetPlatform.android_arm),
-                        hotEventSdkName: 'Android',
-                        hotEventEmulator: false,
-                        hotEventFullRestart: false,
-                      )),
-                ));
-            expect(
-                fakeAnalytics.sentEvents,
-                contains(Event.hotRunnerInfo(
-                  label: 'exception',
-                  targetPlatform:
-                      getNameForTargetPlatform(TargetPlatform.android_arm),
-                  sdkName: 'Android',
-                  emulator: false,
-                  fullRestart: false,
-                )));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, true);
+    expect(result.code, 1);
 
-  testUsingContext(
-      'ResidentRunner does not reload sources if no sources changed',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolatePauseEvent',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedEvent.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.report = UpdateFSReport(success: true);
+    expect((globals.flutterUsage as TestUsage).events, contains(
+      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
+        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        hotEventSdkName: 'Android',
+        hotEventEmulator: false,
+        hotEventFullRestart: false,
+      )),
+    ));
+    expect(fakeAnalytics.sentEvents, contains(
+      Event.hotRunnerInfo(
+        label: 'exception',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        sdkName: 'Android',
+        emulator: false,
+        fullRestart: false,
+      )
+    ));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            final OperationResult result = await residentRunner.restart();
+  testUsingContext('ResidentRunner does not reload sources if no sources changed', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolatePauseEvent',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedEvent.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.report =  UpdateFSReport(success: true);
 
-            expect(result.code, 0);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+    final OperationResult result = await residentRunner.restart();
 
-  testUsingContext(
-      'ResidentRunner reports error with missing entrypoint file',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{
-                  'isolates': <Object>[
-                    fakeUnpausedIsolate.toJson(),
-                  ],
-                })!.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                method: kReloadSourcesServiceName,
-                args: <String, Object>{
-                  'isolateId': '1',
-                  'pause': false,
-                  'rootLibUri': 'main.dart.incremental.dill',
-                },
-                jsonResponse: <String, Object>{
-                  'type': 'ReloadReport',
-                  'success': true,
-                  'details': <String, Object>{
-                    'loadedLibraryCount': 1,
-                  },
-                },
-              ),
-              FakeVmServiceRequest(
-                method: 'getIsolatePauseEvent',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedEvent.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.report =
-                UpdateFSReport(success: true, invalidatedSourcesCount: 1);
+    expect(result.code, 0);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
+  testUsingContext('ResidentRunner reports error with missing entrypoint file', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{
+          'isolates': <Object>[
+            fakeUnpausedIsolate.toJson(),
+          ],
+        })!.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: kReloadSourcesServiceName,
+        args: <String, Object>{
+          'isolateId': '1',
+          'pause': false,
+          'rootLibUri': 'main.dart.incremental.dill',
+        },
+        jsonResponse: <String, Object>{
+          'type': 'ReloadReport',
+          'success': true,
+          'details': <String, Object>{
+            'loadedLibraryCount': 1,
+          },
+        },
+      ),
+      FakeVmServiceRequest(
+        method: 'getIsolatePauseEvent',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedEvent.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.report =  UpdateFSReport(success: true, invalidatedSourcesCount: 1);
 
-            expect(globals.fs.file(globals.fs.path.join('lib', 'main.dart')),
-                isNot(exists));
-            expect(testLogger.errorText,
-                contains('The entrypoint file (i.e. the file with main())'));
-            expect(result.fatal, false);
-            expect(result.code, 0);
-          }));
+    final OperationResult result = await residentRunner.restart();
 
-  testUsingContext(
-      'ResidentRunner resets compilation time on reload reject',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{
-                  'isolates': <Object>[
-                    fakeUnpausedIsolate.toJson(),
-                  ],
-                })!.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                method: kReloadSourcesServiceName,
-                args: <String, Object>{
-                  'isolateId': '1',
-                  'pause': false,
-                  'rootLibUri': 'main.dart.incremental.dill',
-                },
-                jsonResponse: <String, Object>{
-                  'type': 'ReloadReport',
-                  'success': false,
-                  'notices': <Object>[
-                    <String, Object>{
-                      'message': 'Failed to hot reload',
-                    },
-                  ],
-                  'details': <String, Object>{},
-                },
-              ),
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.report =
-                UpdateFSReport(success: true, invalidatedSourcesCount: 1);
+    expect(globals.fs.file(globals.fs.path.join('lib', 'main.dart')), isNot(exists));
+    expect(testLogger.errorText, contains('The entrypoint file (i.e. the file with main())'));
+    expect(result.fatal, false);
+    expect(result.code, 0);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
+   testUsingContext('ResidentRunner resets compilation time on reload reject', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{
+          'isolates': <Object>[
+            fakeUnpausedIsolate.toJson(),
+          ],
+        })!.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: kReloadSourcesServiceName,
+        args: <String, Object>{
+          'isolateId': '1',
+          'pause': false,
+          'rootLibUri': 'main.dart.incremental.dill',
+        },
+        jsonResponse: <String, Object>{
+          'type': 'ReloadReport',
+          'success': false,
+          'notices': <Object>[
+            <String, Object>{
+              'message': 'Failed to hot reload',
+            },
+          ],
+          'details': <String, Object>{},
+        },
+      ),
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.report =  UpdateFSReport(success: true, invalidatedSourcesCount: 1);
 
-            expect(result.fatal, false);
-            expect(
-                result.message,
-                contains(
-                    'Reload rejected: Failed to hot reload')); // contains error message from reload report.
-            expect(result.code, 1);
-            expect(devFS.lastCompiled, null);
-          }));
+    final OperationResult result = await residentRunner.restart();
 
-  testUsingContext(
-      'ResidentRunner can send target platform to analytics from hot reload',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{
-                  'isolates': <Object>[
-                    fakeUnpausedIsolate.toJson(),
-                  ],
-                })!.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                method: kReloadSourcesServiceName,
-                args: <String, Object>{
-                  'isolateId': '1',
-                  'pause': false,
-                  'rootLibUri': 'main.dart.incremental.dill',
-                },
-                jsonResponse: <String, Object>{
-                  'type': 'ReloadReport',
-                  'success': true,
-                  'details': <String, Object>{
-                    'loadedLibraryCount': 1,
-                  },
-                },
-              ),
-              FakeVmServiceRequest(
-                method: 'getIsolatePauseEvent',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedEvent.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
+    expect(result.fatal, false);
+    expect(result.message, contains('Reload rejected: Failed to hot reload')); // contains error message from reload report.
+    expect(result.code, 1);
+    expect(devFS.lastCompiled, null);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, false);
-            expect(result.code, 0);
+  testUsingContext('ResidentRunner can send target platform to analytics from hot reload', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{
+          'isolates': <Object>[
+            fakeUnpausedIsolate.toJson(),
+          ],
+        })!.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: kReloadSourcesServiceName,
+        args: <String, Object>{
+          'isolateId': '1',
+          'pause': false,
+          'rootLibUri': 'main.dart.incremental.dill',
+        },
+        jsonResponse: <String, Object>{
+          'type': 'ReloadReport',
+          'success': true,
+          'details': <String, Object>{
+            'loadedLibraryCount': 1,
+          },
+        },
+      ),
+      FakeVmServiceRequest(
+        method: 'getIsolatePauseEvent',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedEvent.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
 
-            final TestUsageEvent event =
-                (globals.flutterUsage as TestUsage).events.first;
-            expect(event.category, 'hot');
-            expect(event.parameter, 'reload');
-            expect(event.parameters?.hotEventTargetPlatform,
-                getNameForTargetPlatform(TargetPlatform.android_arm));
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, false);
+    expect(result.code, 0);
 
-            final Event newEvent = fakeAnalytics.sentEvents.first;
-            expect(newEvent.eventName.label, 'hot_runner_info');
-            expect(newEvent.eventData['label'], 'reload');
-            expect(newEvent.eventData['targetPlatform'],
-                getNameForTargetPlatform(TargetPlatform.android_arm));
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    final TestUsageEvent event = (globals.flutterUsage as TestUsage).events.first;
+    expect(event.category, 'hot');
+    expect(event.parameter, 'reload');
+    expect(event.parameters?.hotEventTargetPlatform, getNameForTargetPlatform(TargetPlatform.android_arm));
 
-  testUsingContext(
-      'ResidentRunner reports hot reload time details',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: fakeVM.toJson(),
-              ),
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: fakeVM.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                method: kReloadSourcesServiceName,
-                args: <String, Object>{
-                  'isolateId': '1',
-                  'pause': false,
-                  'rootLibUri': 'main.dart.incremental.dill',
-                },
-                jsonResponse: <String, Object>{
-                  'type': 'ReloadReport',
-                  'success': true,
-                  'details': <String, Object>{
-                    'loadedLibraryCount': 1,
-                    'finalLibraryCount': 42,
-                  },
-                },
-              ),
-              FakeVmServiceRequest(
-                method: 'getIsolatePauseEvent',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedEvent.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            final FakeDelegateFlutterDevice flutterDevice =
-                FakeDelegateFlutterDevice(
-              device,
-              BuildInfo.debug,
-              FakeResidentCompiler(),
-              devFS,
-            )..vmService = fakeVmServiceHost!.vmService;
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            devFS.nextUpdateReport = UpdateFSReport(
-              success: true,
-              invalidatedSourcesCount: 1,
-            );
+    final Event newEvent = fakeAnalytics.sentEvents.first;
+    expect(newEvent.eventName.label, 'hot_runner_info');
+    expect(newEvent.eventData['label'], 'reload');
+    expect(newEvent.eventData['targetPlatform'], getNameForTargetPlatform(TargetPlatform.android_arm));
 
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            await futureAppStart.future;
-            await residentRunner.restart();
+  testUsingContext('ResidentRunner reports hot reload time details', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: fakeVM.toJson(),
+      ),
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: fakeVM.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: kReloadSourcesServiceName,
+        args: <String, Object>{
+          'isolateId': '1',
+          'pause': false,
+          'rootLibUri': 'main.dart.incremental.dill',
+        },
+        jsonResponse: <String, Object>{
+          'type': 'ReloadReport',
+          'success': true,
+          'details': <String, Object>{
+            'loadedLibraryCount': 1,
+            'finalLibraryCount': 42,
+          },
+        },
+      ),
+      FakeVmServiceRequest(
+        method: 'getIsolatePauseEvent',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedEvent.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    final FakeDelegateFlutterDevice flutterDevice = FakeDelegateFlutterDevice(
+      device,
+      BuildInfo.debug,
+      FakeResidentCompiler(),
+      devFS,
+    )..vmService = fakeVmServiceHost!.vmService;
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    devFS.nextUpdateReport = UpdateFSReport(
+      success: true,
+      invalidatedSourcesCount: 1,
+    );
 
-            // The actual test: Expect to have compile, reload and reassemble times.
-            expect(
-                testLogger.statusText,
-                contains(RegExp(r'Reloaded 1 of 42 libraries in \d+ms '
-                    r'\(compile: \d+ ms, reload: \d+ ms, reassemble: \d+ ms\)\.')));
-          }, overrides: <Type, Generator>{
-            FileSystem: () => MemoryFileSystem.test(),
-            Platform: () => FakePlatform(),
-            ProjectFileInvalidator: () => FakeProjectFileInvalidator(),
-            Usage: () => TestUsage(),
-          }));
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
 
-  testUsingContext(
-      'ResidentRunner can send target platform to analytics from full restart',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                  streamId: 'Isolate',
-                  event: vm_service.Event(
-                    timestamp: 0,
-                    kind: vm_service.EventKind.kIsolateRunnable,
-                  )),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
+    await futureAppStart.future;
+    await residentRunner.restart();
 
-            final OperationResult result =
-                await residentRunner.restart(fullRestart: true);
-            expect(result.fatal, false);
-            expect(result.code, 0);
+    // The actual test: Expect to have compile, reload and reassemble times.
+    expect(
+        testLogger.statusText,
+        contains(RegExp(r'Reloaded 1 of 42 libraries in \d+ms '
+            r'\(compile: \d+ ms, reload: \d+ ms, reassemble: \d+ ms\)\.')));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem.test(),
+    Platform: () => FakePlatform(),
+    ProjectFileInvalidator: () => FakeProjectFileInvalidator(),
+    Usage: () => TestUsage(),
+  }));
 
-            final TestUsageEvent event =
-                (globals.flutterUsage as TestUsage).events.first;
-            expect(event.category, 'hot');
-            expect(event.parameter, 'restart');
-            expect(event.parameters?.hotEventTargetPlatform,
-                getNameForTargetPlatform(TargetPlatform.android_arm));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  testUsingContext('ResidentRunner can send target platform to analytics from full restart', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        )
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
 
-            // Parse out the event of interest since we may have timing events with
-            // the new analytics package
-            final List<Event> newEventList = fakeAnalytics.sentEvents
-                .where((Event e) => e.eventName.label == 'hot_runner_info')
-                .toList();
-            expect(newEventList, hasLength(1));
-            final Event newEvent = newEventList.first;
-            expect(newEvent.eventName.label, 'hot_runner_info');
-            expect(newEvent.eventData['label'], 'restart');
-            expect(newEvent.eventData['targetPlatform'],
-                getNameForTargetPlatform(TargetPlatform.android_arm));
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    final OperationResult result = await residentRunner.restart(fullRestart: true);
+    expect(result.fatal, false);
+    expect(result.code, 0);
 
-  testUsingContext(
-      'ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakePausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                  method: 'setIsolatePauseMode',
-                  args: <String, String>{
-                    'isolateId': '1',
-                    'exceptionPauseMode': 'None',
-                  }),
-              const FakeVmServiceRequest(
-                  method: 'removeBreakpoint',
-                  args: <String, String>{
-                    'isolateId': '1',
-                    'breakpointId': 'test-breakpoint',
-                  }),
-              const FakeVmServiceRequest(
-                  method: 'resume',
-                  args: <String, String>{
-                    'isolateId': '1',
-                  }),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                streamId: 'Isolate',
-                event: vm_service.Event(
-                  timestamp: 0,
-                  kind: vm_service.EventKind.kIsolateRunnable,
-                ),
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
+    final TestUsageEvent event = (globals.flutterUsage as TestUsage).events.first;
+    expect(event.category, 'hot');
+    expect(event.parameter, 'restart');
+    expect(event.parameters?.hotEventTargetPlatform, getNameForTargetPlatform(TargetPlatform.android_arm));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
 
-            final OperationResult result =
-                await residentRunner.restart(fullRestart: true);
+    // Parse out the event of interest since we may have timing events with
+    // the new analytics package
+    final List<Event> newEventList = fakeAnalytics.sentEvents.where((Event e) => e.eventName.label == 'hot_runner_info').toList();
+    expect(newEventList, hasLength(1));
+    final Event newEvent = newEventList.first;
+    expect(newEvent.eventName.label, 'hot_runner_info');
+    expect(newEvent.eventData['label'], 'restart');
+    expect(newEvent.eventData['targetPlatform'], getNameForTargetPlatform(TargetPlatform.android_arm));
 
-            expect(result.isOk, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-  testUsingContext(
-      'ResidentRunner will alternative the name of the dill file uploaded for a hot restart',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                streamId: 'Isolate',
-                event: vm_service.Event(
-                  timestamp: 0,
-                  kind: vm_service.EventKind.kIsolateRunnable,
-                ),
-              ),
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.swap.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                streamId: 'Isolate',
-                event: vm_service.Event(
-                  timestamp: 0,
-                  kind: vm_service.EventKind.kIsolateRunnable,
-                ),
-              ),
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                streamId: 'Isolate',
-                event: vm_service.Event(
-                  timestamp: 0,
-                  kind: vm_service.EventKind.kIsolateRunnable,
-                ),
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
+  testUsingContext('ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakePausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: 'setIsolatePauseMode',
+        args: <String, String>{
+          'isolateId': '1',
+          'exceptionPauseMode': 'None',
+        }
+      ),
+      const FakeVmServiceRequest(
+        method: 'removeBreakpoint',
+        args: <String, String>{
+          'isolateId': '1',
+          'breakpointId': 'test-breakpoint',
+        }
+      ),
+      const FakeVmServiceRequest(
+        method: 'resume',
+        args: <String, String>{
+          'isolateId': '1',
+        }
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        ),
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
 
-            await residentRunner.restart(fullRestart: true);
-            await residentRunner.restart(fullRestart: true);
-            await residentRunner.restart(fullRestart: true);
+    final OperationResult result = await residentRunner.restart(fullRestart: true);
 
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+    expect(result.isOk, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'ResidentRunner Can handle an RPC exception from hot restart',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.reportError =
-                vm_service.RPCError('something bad happened', 666, '');
+  testUsingContext('ResidentRunner will alternative the name of the dill file uploaded for a hot restart', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        ),
+      ),
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.swap.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        ),
+      ),
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        ),
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
 
-            final OperationResult result =
-                await residentRunner.restart(fullRestart: true);
-            expect(result.fatal, true);
-            expect(result.code, 1);
+    await residentRunner.restart(fullRestart: true);
+    await residentRunner.restart(fullRestart: true);
+    await residentRunner.restart(fullRestart: true);
 
-            expect(
-                (globals.flutterUsage as TestUsage).events,
-                contains(
-                  TestUsageEvent('hot', 'exception',
-                      parameters: CustomDimensions(
-                        hotEventTargetPlatform: getNameForTargetPlatform(
-                            TargetPlatform.android_arm),
-                        hotEventSdkName: 'Android',
-                        hotEventEmulator: false,
-                        hotEventFullRestart: true,
-                      )),
-                ));
-            expect(
-                fakeAnalytics.sentEvents,
-                contains(
-                  Event.hotRunnerInfo(
-                    label: 'exception',
-                    targetPlatform:
-                        getNameForTargetPlatform(TargetPlatform.android_arm),
-                    sdkName: 'Android',
-                    emulator: false,
-                    fullRestart: true,
-                  ),
-                ));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'ResidentRunner uses temp directory when there is no output dill path',
-      () => testbed.run(() {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            expect(residentRunner.artifactDirectory.path,
-                contains('flutter_tool.'));
+  testUsingContext('ResidentRunner Can handle an RPC exception from hot restart', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
 
-            final ResidentRunner otherRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            expect(otherRunner.artifactDirectory.path, contains('foobar'));
-          }));
+    final OperationResult result = await residentRunner.restart(fullRestart: true);
+    expect(result.fatal, true);
+    expect(result.code, 1);
 
-  testUsingContext(
-      'ResidentRunner deletes artifact directory on preExit',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            residentRunner.artifactDirectory.childFile('app.dill').createSync();
-            await residentRunner.preExit();
+    expect((globals.flutterUsage as TestUsage).events, contains(
+      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
+        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        hotEventSdkName: 'Android',
+        hotEventEmulator: false,
+        hotEventFullRestart: true,
+      )),
+    ));
+    expect(fakeAnalytics.sentEvents, contains(
+      Event.hotRunnerInfo(
+        label: 'exception',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        sdkName: 'Android',
+        emulator: false,
+        fullRestart: true,
+      ),
+    ));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            expect(residentRunner.artifactDirectory, isNot(exists));
-          }));
+  testUsingContext('ResidentRunner uses temp directory when there is no output dill path', () => testbed.run(() {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    expect(residentRunner.artifactDirectory.path, contains('flutter_tool.'));
 
-  testUsingContext(
-      'ResidentRunner can run source generation',
-      () => testbed.run(() async {
-            final File arbFile = globals.fs
-                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-              ..createSync(recursive: true);
-            arbFile.writeAsStringSync('''
+    final ResidentRunner otherRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    expect(otherRunner.artifactDirectory.path, contains('foobar'));
+  }));
+
+  testUsingContext('ResidentRunner deletes artifact directory on preExit', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner.artifactDirectory.childFile('app.dill').createSync();
+    await residentRunner.preExit();
+
+    expect(residentRunner.artifactDirectory, isNot(exists));
+  }));
+
+  testUsingContext('ResidentRunner can run source generation', () => testbed.run(() async {
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-            globals.fs.file('l10n.yaml').createSync();
-            globals.fs
-                .file('pubspec.yaml')
-                .writeAsStringSync('flutter:\n  generate: true\n');
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
 
-            // Create necessary files for [DartPluginRegistrantTarget]
-            final File packageConfig = globals.fs
-                .directory('.dart_tool')
-                .childFile('package_config.json');
-            packageConfig.createSync(recursive: true);
-            packageConfig.writeAsStringSync('''
+    // Create necessary files for [DartPluginRegistrantTarget]
+    final File packageConfig = globals.fs.directory('.dart_tool')
+        .childFile('package_config.json');
+    packageConfig.createSync(recursive: true);
+    packageConfig.writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": [
@@ -1275,34 +1134,27 @@ void main() {
   ]
 }
 ''');
-            // Start from an empty dart_plugin_registrant.dart file.
-            globals.fs
-                .directory('.dart_tool')
-                .childDirectory('flutter_build')
-                .childFile('dart_plugin_registrant.dart')
-                .createSync(recursive: true);
+    // Start from an empty dart_plugin_registrant.dart file.
+    globals.fs.directory('.dart_tool').childDirectory('flutter_build').childFile('dart_plugin_registrant.dart').createSync(recursive: true);
 
-            await residentRunner.runSourceGenerators();
+    await residentRunner.runSourceGenerators();
 
-            expect(testLogger.errorText, isEmpty);
-            expect(testLogger.statusText, isEmpty);
-          }));
+    expect(testLogger.errorText, isEmpty);
+    expect(testLogger.statusText, isEmpty);
+  }));
 
-  testUsingContext(
-      'generated main uses correct target',
-      () => testbed.run(() async {
-            final File arbFile = globals.fs
-                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-              ..createSync(recursive: true);
-            arbFile.writeAsStringSync('''
+  testUsingContext('generated main uses correct target', () => testbed.run(() async {
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-            globals.fs.file('l10n.yaml').createSync();
-            globals.fs.file('pubspec.yaml').writeAsStringSync('''
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('''
 flutter:
   generate: true
 
@@ -1312,13 +1164,12 @@ dependencies:
   path_provider_linux: 1.0.0
 ''');
 
-            // Create necessary files for [DartPluginRegistrantTarget], including a
-            // plugin that will trigger generation.
-            final File packageConfig = globals.fs
-                .directory('.dart_tool')
-                .childFile('package_config.json');
-            packageConfig.createSync(recursive: true);
-            packageConfig.writeAsStringSync('''
+    // Create necessary files for [DartPluginRegistrantTarget], including a
+    // plugin that will trigger generation.
+    final File packageConfig = globals.fs.directory('.dart_tool')
+        .childFile('package_config.json');
+    packageConfig.createSync(recursive: true);
+    packageConfig.writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": [
@@ -1331,11 +1182,10 @@ dependencies:
   ]
 }
 ''');
-            final Directory fakePluginDir =
-                globals.fs.directory('path_provider_linux');
-            final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
-            pluginPubspec.createSync(recursive: true);
-            pluginPubspec.writeAsStringSync('''
+    final Directory fakePluginDir = globals.fs.directory('path_provider_linux');
+    final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
+    pluginPubspec.createSync(recursive: true);
+    pluginPubspec.writeAsStringSync('''
 name: path_provider_linux
 
 flutter:
@@ -1346,739 +1196,609 @@ flutter:
         dartPluginClass: PathProviderLinux
 ''');
 
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'custom_main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            await residentRunner.runSourceGenerators();
+    residentRunner = HotRunner(
+        <FlutterDevice>[
+          flutterDevice,
+        ],
+        stayResident: false,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'custom_main.dart',
+        devtoolsHandler: createNoOpHandler,
+        analytics: fakeAnalytics,
+        useImplicitPubspecResolution: true,
+      );
+    await residentRunner.runSourceGenerators();
 
-            final File generatedMain = globals.fs
-                .directory('.dart_tool')
-                .childDirectory('flutter_build')
-                .childFile('dart_plugin_registrant.dart');
+    final File generatedMain = globals.fs.directory('.dart_tool')
+        .childDirectory('flutter_build')
+        .childFile('dart_plugin_registrant.dart');
 
-            expect(generatedMain.existsSync(), isTrue);
-            expect(testLogger.errorText, isEmpty);
-            expect(testLogger.statusText, isEmpty);
-          }));
+    expect(generatedMain.existsSync(), isTrue);
+    expect(testLogger.errorText, isEmpty);
+    expect(testLogger.statusText, isEmpty);
+  }));
 
-  testUsingContext(
-      'ResidentRunner can run source generation - generation fails',
-      () => testbed.run(() async {
-            // Intentionally define arb file with wrong name. generate_localizations defaults
-            // to app_en.arb.
-            final File arbFile = globals.fs
-                .file(globals.fs.path.join('lib', 'l10n', 'foo.arb'))
-              ..createSync(recursive: true);
-            arbFile.writeAsStringSync('''
+  testUsingContext('ResidentRunner can run source generation - generation fails', () => testbed.run(() async {
+    // Intentionally define arb file with wrong name. generate_localizations defaults
+    // to app_en.arb.
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'foo.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-            globals.fs.file('l10n.yaml').createSync();
-            globals.fs
-                .file('pubspec.yaml')
-                .writeAsStringSync('flutter:\n  generate: true\n');
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
 
-            await residentRunner.runSourceGenerators();
+    await residentRunner.runSourceGenerators();
 
-            expect(testLogger.errorText, contains('Error'));
-            expect(testLogger.statusText, isEmpty);
-          }));
+    expect(testLogger.errorText, contains('Error'));
+    expect(testLogger.statusText, isEmpty);
+  }));
 
-  testUsingContext(
-      'ResidentRunner generates files when l10n.yaml exists',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            final File arbFile = globals.fs
-                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-              ..createSync(recursive: true);
-            arbFile.writeAsStringSync('''
+  testUsingContext('ResidentRunner generates files when l10n.yaml exists', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-            globals.fs.file('l10n.yaml').createSync();
-            globals.fs
-                .file('pubspec.yaml')
-                .writeAsStringSync('flutter:\n  generate: true\n');
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
 
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-              ..nextOutput = const CompilerOutput('foo', 1, <Uri>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.generator = residentCompiler;
-
-            await residentRunner.run();
-
-            final File generatedLocalizationsFile = globals.fs
-                .directory('.dart_tool')
-                .childDirectory('flutter_gen')
-                .childDirectory('gen_l10n')
-                .childFile('app_localizations.dart');
-            expect(generatedLocalizationsFile.existsSync(), isTrue);
-
-            // Completing this future ensures that the daemon can exit correctly.
-            expect(await residentRunner.waitForAppToFinish(), 1);
-          }));
-
-  testUsingContext(
-      'ResidentRunner printHelpDetails hot runner',
-      () => testbed.run(() {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
-            residentRunner.printHelp(details: true);
-
-            final CommandHelp commandHelp = residentRunner.commandHelp;
-
-            // supports service protocol
-            expect(residentRunner.supportsServiceProtocol, true);
-            // isRunningDebug
-            expect(residentRunner.isRunningDebug, true);
-            // does support SkSL
-            expect(residentRunner.supportsWriteSkSL, true);
-            // commands
-            expect(
-                testLogger.statusText,
-                equals(<dynamic>[
-                  'Flutter run key commands.',
-                  commandHelp.r,
-                  commandHelp.R,
-                  commandHelp.v,
-                  commandHelp.s,
-                  commandHelp.w,
-                  commandHelp.t,
-                  commandHelp.L,
-                  commandHelp.f,
-                  commandHelp.S,
-                  commandHelp.U,
-                  commandHelp.i,
-                  commandHelp.p,
-                  commandHelp.I,
-                  commandHelp.o,
-                  commandHelp.b,
-                  commandHelp.P,
-                  commandHelp.a,
-                  commandHelp.M,
-                  commandHelp.g,
-                  commandHelp.hWithDetails,
-                  commandHelp.c,
-                  commandHelp.q,
-                  '',
-                  'A Dart VM Service on FakeDevice is available at: null',
-                  '',
-                ].join('\n')));
-          }));
-
-  testUsingContext(
-      'ResidentRunner printHelp hot runner',
-      () => testbed.run(() {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
-            residentRunner.printHelp(details: false);
-
-            final CommandHelp commandHelp = residentRunner.commandHelp;
-
-            // supports service protocol
-            expect(residentRunner.supportsServiceProtocol, true);
-            // isRunningDebug
-            expect(residentRunner.isRunningDebug, true);
-            // does support SkSL
-            expect(residentRunner.supportsWriteSkSL, true);
-            // commands
-            expect(
-                testLogger.statusText,
-                equals(<dynamic>[
-                  'Flutter run key commands.',
-                  commandHelp.r,
-                  commandHelp.R,
-                  commandHelp.hWithoutDetails,
-                  commandHelp.c,
-                  commandHelp.q,
-                  '',
-                  'A Dart VM Service on FakeDevice is available at: null',
-                  '',
-                ].join('\n')));
-          }));
-
-  testUsingContext(
-      'ResidentRunner printHelpDetails cold runner',
-      () => testbed.run(() {
-            fakeVmServiceHost = null;
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.printHelp(details: true);
-
-            final CommandHelp commandHelp = residentRunner.commandHelp;
-
-            // does not supports service protocol
-            expect(residentRunner.supportsServiceProtocol, false);
-            // isRunningDebug
-            expect(residentRunner.isRunningDebug, false);
-            // does support SkSL
-            expect(residentRunner.supportsWriteSkSL, false);
-            // commands
-            expect(
-                testLogger.statusText,
-                equals(<dynamic>[
-                  'Flutter run key commands.',
-                  commandHelp.v,
-                  commandHelp.s,
-                  commandHelp.hWithDetails,
-                  commandHelp.c,
-                  commandHelp.q,
-                  '',
-                ].join('\n')));
-          }));
-
-  testUsingContext(
-      'ResidentRunner printHelp cold runner',
-      () => testbed.run(() {
-            fakeVmServiceHost = null;
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.printHelp(details: false);
-
-            final CommandHelp commandHelp = residentRunner.commandHelp;
-
-            // does not supports service protocol
-            expect(residentRunner.supportsServiceProtocol, false);
-            // isRunningDebug
-            expect(residentRunner.isRunningDebug, false);
-            // does support SkSL
-            expect(residentRunner.supportsWriteSkSL, false);
-            // commands
-            expect(
-                testLogger.statusText,
-                equals(<dynamic>[
-                  'Flutter run key commands.',
-                  commandHelp.hWithoutDetails,
-                  commandHelp.c,
-                  commandHelp.q,
-                  '',
-                ].join('\n')));
-          }));
-
-  testUsingContext(
-      'ResidentRunner handles writeSkSL returning no data',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              FakeVmServiceRequest(
-                  method: kGetSkSLsMethod,
-                  args: <String, Object>{
-                    'viewId': fakeFlutterView.id,
-                  },
-                  jsonResponse: <String, Object>{
-                    'SkSLs': <String, Object>{},
-                  }),
-            ]);
-            await residentRunner.writeSkSL();
-
-            expect(testLogger.statusText, contains('No data was received'));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
-
-  testUsingContext(
-      'ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              FakeVmServiceRequest(
-                method: kGetSkSLsMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                },
-                jsonResponse: <String, Object>{
-                  'SkSLs': <String, Object>{
-                    'A': 'B',
-                  },
-                },
-              ),
-            ]);
-            await residentRunner.writeSkSL();
-
-            expect(testLogger.statusText, contains('flutter_01.sksl.json'));
-            expect(globals.fs.file('flutter_01.sksl.json'), exists);
-            expect(
-                json.decode(
-                    globals.fs.file('flutter_01.sksl.json').readAsStringSync()),
-                <String, Object>{
-                  'platform': 'android',
-                  'name': 'FakeDevice',
-                  'engineRevision': 'abcdefg',
-                  'data': <String, Object>{'A': 'B'},
-                });
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            FileSystemUtils: () => FileSystemUtils(
-                  fileSystem: globals.fs,
-                  platform: globals.platform,
-                ),
-            FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg'),
-          }));
-
-  testUsingContext(
-      'ResidentRunner ignores DevtoolsLauncher when attaching with enableDevTools: false - cold mode',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile,
-                  vmserviceOutFile: 'foo', enableDevTools: false),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubspecResolution: true,
-            );
-
-            final Future<int?> result = residentRunner.attach();
-            expect(await result, 0);
-          }));
-
-  testUsingContext(
-      'FlutterDevice can exit from a release mode isolate with no VmService',
-      () => testbed.run(() async {
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-            );
-
-            await flutterDevice.exitApps();
-
-            expect(device.appStopped, true);
-          }));
-
-  testUsingContext(
-      'FlutterDevice will exit an un-paused isolate using stopApp',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-            );
-            flutterDevice.vmService = fakeVmServiceHost!.vmService;
-
-            final Future<void> exitFuture = flutterDevice.exitApps();
-
-            await expectLater(exitFuture, completes);
-            expect(device.appStopped, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
-
-  testUsingContext(
-      'HotRunner writes vm service file when providing debugging option',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
-                  vmserviceOutFile: 'foo'),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-
-            await residentRunner.run();
-
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-            expect(await globals.fs.file('foo').readAsString(),
-                testUri.toString());
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(globals.fs.path.join('build', 'cache.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup with dart defines',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                '',
-                treeShakeIcons: false,
-                dartDefines: <String>['a', 'b'],
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(globals.fs.path.join(
-                        'build', '187ef4436122d1cc2f40dc2b92f0eba0.cache.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup with null safety',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                '',
-                treeShakeIcons: false,
-                extraFrontEndOptions: <String>[
-                  '--enable-experiment=non-nullable'
-                ],
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(globals.fs.path.join('build', 'cache.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup with track-widget-creation',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(
-                        globals.fs.path.join('build', 'cache.dill.track.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner does not copy app.dill if a dillOutputPath is given',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              dillOutputPath: 'test',
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(globals.fs.file(globals.fs.path.join('build', 'cache.dill')),
-                isNot(exists));
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup with --track-widget-creation',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                '',
-                treeShakeIcons: false,
-                trackWidgetCreation: true,
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(
-                        globals.fs.path.join('build', 'cache.dill.track.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner calls device dispose',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-
-            await residentRunner.run();
-            expect(device.disposed, true);
-          }));
-
-  testUsingContext(
-      'HotRunner handles failure to write vmservice file',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
-                  vmserviceOutFile: 'foo'),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-
-            await residentRunner.run();
-
-            expect(testLogger.errorText,
-                contains('Failed to write vmservice-out-file at foo'));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            FileSystem: () =>
-                ThrowingForwardingFileSystem(MemoryFileSystem.test()),
-          }));
-
-  testUsingContext(
-      'ColdRunner writes vm service file when providing debugging option',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile,
-                  vmserviceOutFile: 'foo'),
-              devtoolsHandler: createNoOpHandler,
-              target: 'main.dart',
-              useImplicitPubspecResolution: true,
-            );
-
-            await residentRunner.run();
-
-            expect(await globals.fs.file('foo').readAsString(),
-                testUri.toString());
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
-
-  testUsingContext(
-      'FlutterDevice uses dartdevc configuration when targeting web', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device =
-        FakeDevice(targetPlatform: TargetPlatform.web_javascript);
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    flutterDevice.generator = residentCompiler;
+
+    await residentRunner.run();
+
+    final File generatedLocalizationsFile = globals.fs.directory('.dart_tool')
+      .childDirectory('flutter_gen')
+      .childDirectory('gen_l10n')
+      .childFile('app_localizations.dart');
+    expect(generatedLocalizationsFile.existsSync(), isTrue);
+
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
+  }));
+
+  testUsingContext('ResidentRunner printHelpDetails hot runner', () => testbed.run(() {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
+    residentRunner.printHelp(details: true);
+
+    final CommandHelp commandHelp = residentRunner.commandHelp;
+
+    // supports service protocol
+    expect(residentRunner.supportsServiceProtocol, true);
+    // isRunningDebug
+    expect(residentRunner.isRunningDebug, true);
+    // does support SkSL
+    expect(residentRunner.supportsWriteSkSL, true);
+    // commands
+    expect(testLogger.statusText, equals(
+        <dynamic>[
+          'Flutter run key commands.',
+          commandHelp.r,
+          commandHelp.R,
+          commandHelp.v,
+          commandHelp.s,
+          commandHelp.w,
+          commandHelp.t,
+          commandHelp.L,
+          commandHelp.f,
+          commandHelp.S,
+          commandHelp.U,
+          commandHelp.i,
+          commandHelp.p,
+          commandHelp.I,
+          commandHelp.o,
+          commandHelp.b,
+          commandHelp.P,
+          commandHelp.a,
+          commandHelp.M,
+          commandHelp.g,
+          commandHelp.hWithDetails,
+          commandHelp.c,
+          commandHelp.q,
+          '',
+          'A Dart VM Service on FakeDevice is available at: null',
+          '',
+        ].join('\n')
+    ));
+  }));
+
+  testUsingContext('ResidentRunner printHelp hot runner', () => testbed.run(() {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
+    residentRunner.printHelp(details: false);
+
+    final CommandHelp commandHelp = residentRunner.commandHelp;
+
+    // supports service protocol
+    expect(residentRunner.supportsServiceProtocol, true);
+    // isRunningDebug
+    expect(residentRunner.isRunningDebug, true);
+    // does support SkSL
+    expect(residentRunner.supportsWriteSkSL, true);
+    // commands
+    expect(testLogger.statusText, equals(
+        <dynamic>[
+          'Flutter run key commands.',
+          commandHelp.r,
+          commandHelp.R,
+          commandHelp.hWithoutDetails,
+          commandHelp.c,
+          commandHelp.q,
+          '',
+          'A Dart VM Service on FakeDevice is available at: null',
+          '',
+        ].join('\n')
+    ));
+  }));
+
+  testUsingContext('ResidentRunner printHelpDetails cold runner', () => testbed.run(() {
+    fakeVmServiceHost = null;
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
+    );
+    residentRunner.printHelp(details: true);
+
+    final CommandHelp commandHelp = residentRunner.commandHelp;
+
+    // does not supports service protocol
+    expect(residentRunner.supportsServiceProtocol, false);
+    // isRunningDebug
+    expect(residentRunner.isRunningDebug, false);
+    // does support SkSL
+    expect(residentRunner.supportsWriteSkSL, false);
+    // commands
+    expect(testLogger.statusText, equals(
+        <dynamic>[
+          'Flutter run key commands.',
+          commandHelp.v,
+          commandHelp.s,
+          commandHelp.hWithDetails,
+          commandHelp.c,
+          commandHelp.q,
+          '',
+        ].join('\n')
+    ));
+  }));
+
+  testUsingContext('ResidentRunner printHelp cold runner', () => testbed.run(() {
+    fakeVmServiceHost = null;
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
+    );
+    residentRunner.printHelp(details: false);
+
+    final CommandHelp commandHelp = residentRunner.commandHelp;
+
+    // does not supports service protocol
+    expect(residentRunner.supportsServiceProtocol, false);
+    // isRunningDebug
+    expect(residentRunner.isRunningDebug, false);
+    // does support SkSL
+    expect(residentRunner.supportsWriteSkSL, false);
+    // commands
+    expect(testLogger.statusText, equals(
+        <dynamic>[
+          'Flutter run key commands.',
+          commandHelp.hWithoutDetails,
+          commandHelp.c,
+          commandHelp.q,
+          '',
+        ].join('\n')
+    ));
+  }));
+
+  testUsingContext('ResidentRunner handles writeSkSL returning no data', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      FakeVmServiceRequest(
+        method: kGetSkSLsMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+        },
+        jsonResponse: <String, Object>{
+          'SkSLs': <String, Object>{},
+        }
+      ),
+    ]);
+    await residentRunner.writeSkSL();
+
+    expect(testLogger.statusText, contains('No data was received'));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
+
+  testUsingContext('ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      FakeVmServiceRequest(
+        method: kGetSkSLsMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+        },
+        jsonResponse: <String, Object>{
+          'SkSLs': <String, Object>{
+            'A': 'B',
+          },
+        },
+      ),
+    ]);
+    await residentRunner.writeSkSL();
+
+    expect(testLogger.statusText, contains('flutter_01.sksl.json'));
+    expect(globals.fs.file('flutter_01.sksl.json'), exists);
+    expect(json.decode(globals.fs.file('flutter_01.sksl.json').readAsStringSync()), <String, Object>{
+      'platform': 'android',
+      'name': 'FakeDevice',
+      'engineRevision': 'abcdefg',
+      'data': <String, Object>{'A': 'B'},
+    });
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    FileSystemUtils: () => FileSystemUtils(
+      fileSystem: globals.fs,
+      platform: globals.platform,
+    ),
+    FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg'),
+  }));
+
+  testUsingContext('ResidentRunner ignores DevtoolsLauncher when attaching with enableDevTools: false - cold mode', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo', enableDevTools: false),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
+    );
+
+    final Future<int?> result = residentRunner.attach();
+    expect(await result, 0);
+  }));
+
+  testUsingContext('FlutterDevice can exit from a release mode isolate with no VmService', () => testbed.run(() async {
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+    );
+
+    await flutterDevice.exitApps();
+
+    expect(device.appStopped, true);
+  }));
+
+  testUsingContext('FlutterDevice will exit an un-paused isolate using stopApp', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+    );
+    flutterDevice.vmService = fakeVmServiceHost!.vmService;
+
+    final Future<void> exitFuture = flutterDevice.exitApps();
+
+    await expectLater(exitFuture, completes);
+    expect(device.appStopped, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
+
+  testUsingContext('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+
+    await residentRunner.run();
+
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+    expect(await globals.fs.file('foo').readAsString(), testUri.toString());
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(
+        const BuildInfo(
+          BuildMode.debug,
+          null,
+          treeShakeIcons: false,
+          packageConfigPath: '.dart_tool/package_config.json',
+        )
+      ),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with dart defines', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(
+        const BuildInfo(
+          BuildMode.debug,
+          '',
+          treeShakeIcons: false,
+          dartDefines: <String>['a', 'b'],
+          packageConfigPath: '.dart_tool/package_config.json',
+        )
+      ),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join(
+      'build', '187ef4436122d1cc2f40dc2b92f0eba0.cache.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with null safety', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(
+        const BuildInfo(
+          BuildMode.debug,
+          '',
+          treeShakeIcons: false,
+          extraFrontEndOptions: <String>['--enable-experiment=non-nullable'],
+          packageConfigPath: '.dart_tool/package_config.json',
+        )
+      ),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join(
+      'build', 'cache.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with track-widget-creation', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join(
+      'build', 'cache.dill.track.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner does not copy app.dill if a dillOutputPath is given', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      dillOutputPath: 'test',
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(globals.fs.file(globals.fs.path.join('build', 'cache.dill')), isNot(exists));
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with --track-widget-creation', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+        trackWidgetCreation: true,
+        packageConfigPath: '.dart_tool/package_config.json',
+      )),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill.track.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner calls device dispose', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+
+    await residentRunner.run();
+    expect(device.disposed, true);
+  }));
+
+  testUsingContext('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+
+    await residentRunner.run();
+
+    expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem.test()),
+  }));
+
+  testUsingContext('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo'),
+      devtoolsHandler: createNoOpHandler,
+      target: 'main.dart',
+      useImplicitPubspecResolution: true,
+    );
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file('foo').readAsString(), testUri.toString());
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
+
+  testUsingContext('FlutterDevice uses dartdevc configuration when targeting web', () async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -2089,40 +1809,28 @@ flutter:
       ),
       target: null,
       platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+    )).generator as DefaultResidentCompiler?;
 
-    expect(
-        residentCompiler!.initializeFromDill,
-        globals.fs.path.join(getBuildDirectory(),
-            'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'));
-    expect(
-        residentCompiler.librariesSpec,
-        globals.fs
-            .file(globals.artifacts!
-                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-            .uri
-            .toString());
+    expect(residentCompiler!.initializeFromDill,
+      globals.fs.path.join(getBuildDirectory(), 'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'));
+    expect(residentCompiler.librariesSpec,
+      globals.fs.file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+        .uri.toString());
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
-        '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill,
-        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill');
+      '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
+    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected',
-      () async {
+  testUsingContext('FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device =
-        FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -2133,38 +1841,29 @@ flutter:
       ),
       target: null,
       platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+    )).generator as DefaultResidentCompiler?;
 
-    expect(
-        residentCompiler!.initializeFromDill,
-        globals.fs.path.join(getBuildDirectory(),
-            '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
-    expect(
-        residentCompiler.librariesSpec,
-        globals.fs
-            .file(globals.artifacts!
-                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-            .uri
-            .toString());
+    expect(residentCompiler!.initializeFromDill,
+      globals.fs.path.join(getBuildDirectory(), '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
+    expect(residentCompiler.librariesSpec,
+      globals.fs.file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+        .uri.toString());
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
-        '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill,
-        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill');
+      '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
+    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice passes alternative-invalidation-strategy flag', () async {
+  testUsingContext('FlutterDevice passes alternative-invalidation-strategy flag', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -2173,27 +1872,22 @@ flutter:
         extraFrontEndOptions: <String>[],
         packageConfigPath: '.dart_tool/package_config.json',
       ),
-      target: null,
-      platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+      target: null, platform: FakePlatform(),
+    )).generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.extraFrontEndOptions,
-        contains('--enable-experiment=alternative-invalidation-strategy'));
+      contains('--enable-experiment=alternative-invalidation-strategy'));
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice passes initializeFromDill parameter if specified',
-      () async {
+  testUsingContext('FlutterDevice passes initializeFromDill parameter if specified', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -2203,10 +1897,8 @@ flutter:
         initializeFromDill: '/foo/bar.dill',
         packageConfigPath: '.dart_tool/package_config.json',
       ),
-      target: null,
-      platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+      target: null, platform: FakePlatform(),
+    )).generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.initializeFromDill, '/foo/bar.dill');
     expect(residentCompiler.assumeInitializeFromDillUpToDate, false);
@@ -2216,24 +1908,22 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice passes assumeInitializeFromDillUpToDate parameter if specified',
-      () async {
+   testUsingContext('FlutterDevice passes assumeInitializeFromDillUpToDate parameter if specified', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
-      buildInfo: const BuildInfo(BuildMode.debug, '',
-          treeShakeIcons: false,
-          extraFrontEndOptions: <String>[],
-          assumeInitializeFromDillUpToDate: true,
-          packageConfigPath: '.dart_tool/package_config.json'),
-      target: null,
-      platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+      buildInfo: const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+        extraFrontEndOptions: <String>[],
+        assumeInitializeFromDillUpToDate: true,
+        packageConfigPath: '.dart_tool/package_config.json'
+      ),
+      target: null, platform: FakePlatform(),
+    )).generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.assumeInitializeFromDillUpToDate, true);
   }, overrides: <Type, Generator>{
@@ -2242,35 +1932,30 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice passes frontendServerStarterPath parameter if specified',
-      () async {
+  testUsingContext('FlutterDevice passes frontendServerStarterPath parameter if specified', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
-      buildInfo: const BuildInfo(BuildMode.debug, '',
-          treeShakeIcons: false,
-          frontendServerStarterPath: '/foo/bar/frontend_server_starter.dart',
-          packageConfigPath: '.dart_tool/package_config.json'),
-      target: null,
-      platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+      buildInfo: const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+        frontendServerStarterPath: '/foo/bar/frontend_server_starter.dart',
+        packageConfigPath: '.dart_tool/package_config.json'
+      ),
+      target: null, platform: FakePlatform(),
+    )).generator as DefaultResidentCompiler?;
 
-    expect(residentCompiler!.frontendServerStarterPath,
-        '/foo/bar/frontend_server_starter.dart');
+    expect(residentCompiler!.frontendServerStarterPath, '/foo/bar/frontend_server_starter.dart');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection',
-      () async {
+  testUsingContext('FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection', () async {
     fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         const FakeVmServiceRequest(
@@ -2307,189 +1992,160 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'Uses existing DDS URI from exception field',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final FakeDevice device = FakeDevice()
-              ..dds = DartDevelopmentService(logger: testLogger);
-            ddsLauncherCallback = ({
-              required Uri remoteVmServiceUri,
-              Uri? serviceUri,
-              bool enableAuthCodes = true,
-              bool serveDevTools = false,
-              Uri? devToolsServerAddress,
-              bool enableServicePortFallback = false,
-              List<String> cachedUserTags = const <String>[],
-              String? dartExecutable,
-              String? google3WorkspaceRoot,
-            }) {
-              throw DartDevelopmentServiceException.existingDdsInstance(
-                'Existing DDS at http://localhost/existingDdsInMessage.',
-                ddsUri: Uri.parse('http://localhost/existingDdsInField'),
-              );
-            };
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-              vmServiceUris: Stream<Uri>.value(testUri),
-            );
-            final Completer<void> done = Completer<void>();
-            unawaited(runZonedGuarded(
-              () => flutterDevice
-                  .connect(
-                    allowExistingDdsInstance: true,
-                    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-                  )
-                  .then((_) => done.complete()),
-              (_, __) => done.complete(),
-            ));
-            await done.future;
-            expect(device.dds.uri,
-                Uri.parse('http://localhost/existingDdsInField'));
-          }, overrides: <Type, Generator>{
-            VMServiceConnector: () => (
-                  Uri httpUri, {
-                  ReloadSources? reloadSources,
-                  Restart? restart,
-                  CompileExpression? compileExpression,
-                  GetSkSLMethod? getSkSLMethod,
-                  FlutterProject? flutterProject,
-                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-                  io.CompressionOptions? compression,
-                  Device? device,
-                  required Logger logger,
-                }) async =>
-                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
-                        .vmService,
-          }));
+  testUsingContext('Uses existing DDS URI from exception field', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeDevice device = FakeDevice()
+      ..dds = DartDevelopmentService(logger: testLogger);
+    ddsLauncherCallback = ({
+      required Uri remoteVmServiceUri,
+      Uri? serviceUri,
+      bool enableAuthCodes = true,
+      bool serveDevTools = false,
+      Uri? devToolsServerAddress,
+      bool enableServicePortFallback = false,
+      List<String> cachedUserTags = const <String>[],
+      String? dartExecutable,
+      String? google3WorkspaceRoot,
+    }) {
+      throw DartDevelopmentServiceException.existingDdsInstance(
+        'Existing DDS at http://localhost/existingDdsInMessage.',
+        ddsUri: Uri.parse('http://localhost/existingDdsInField'),
+      );
+    };
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+      vmServiceUris: Stream<Uri>.value(testUri),
+    );
+    final Completer<void> done = Completer<void>();
+    unawaited(runZonedGuarded(
+      () => flutterDevice.connect(
+        allowExistingDdsInstance: true,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ).then((_) => done.complete()),
+      (_, __) => done.complete(),
+    ));
+    await done.future;
+    expect(device.dds.uri, Uri.parse('http://localhost/existingDdsInField'));
+  }, overrides: <Type, Generator>{
+    VMServiceConnector: () => (Uri httpUri, {
+      ReloadSources? reloadSources,
+      Restart? restart,
+      CompileExpression? compileExpression,
+      GetSkSLMethod? getSkSLMethod,
+      FlutterProject? flutterProject,
+    PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+      io.CompressionOptions? compression,
+      Device? device,
+      required Logger logger,
+    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
+  }));
 
-  testUsingContext(
-      'Host VM service ipv6 defaults',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final FakeDevice device = FakeDevice()
-              ..dds = DartDevelopmentService(logger: testLogger);
-            final Completer<void> done = Completer<void>();
-            ddsLauncherCallback = ({
-              required Uri remoteVmServiceUri,
-              Uri? serviceUri,
-              bool enableAuthCodes = true,
-              bool serveDevTools = false,
-              Uri? devToolsServerAddress,
-              bool enableServicePortFallback = false,
-              List<String> cachedUserTags = const <String>[],
-              String? dartExecutable,
-              String? google3WorkspaceRoot,
-            }) async {
-              expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
-              expect(enableAuthCodes, isFalse);
-              expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
-              expect(cachedUserTags, isEmpty);
-              done.complete();
-              return FakeDartDevelopmentServiceLauncher(
-                  uri: remoteVmServiceUri);
-            };
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-              vmServiceUris: Stream<Uri>.value(testUri),
-            );
-            await flutterDevice.connect(
-                allowExistingDdsInstance: true,
-                debuggingOptions: DebuggingOptions.enabled(
-                  BuildInfo.debug,
-                  disableServiceAuthCodes: true,
-                  ipv6: true,
-                ));
-            await done.future;
-          }, overrides: <Type, Generator>{
-            VMServiceConnector: () => (
-                  Uri httpUri, {
-                  ReloadSources? reloadSources,
-                  Restart? restart,
-                  CompileExpression? compileExpression,
-                  GetSkSLMethod? getSkSLMethod,
-                  FlutterProject? flutterProject,
-                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-                  io.CompressionOptions? compression,
-                  Device? device,
-                  required Logger logger,
-                }) async =>
-                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
-                        .vmService,
-          }));
+  testUsingContext('Host VM service ipv6 defaults', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeDevice device = FakeDevice()
+      ..dds = DartDevelopmentService(logger: testLogger);
+    final Completer<void>done = Completer<void>();
+    ddsLauncherCallback = ({
+        required Uri remoteVmServiceUri,
+        Uri? serviceUri,
+        bool enableAuthCodes = true,
+        bool serveDevTools = false,
+        Uri? devToolsServerAddress,
+        bool enableServicePortFallback = false,
+        List<String> cachedUserTags = const <String>[],
+        String? dartExecutable,
+        String? google3WorkspaceRoot,
+      }) async {
+      expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
+      expect(enableAuthCodes, isFalse);
+      expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
+      expect(cachedUserTags, isEmpty);
+      done.complete();
+      return FakeDartDevelopmentServiceLauncher(uri: remoteVmServiceUri);
+    };
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+      vmServiceUris: Stream<Uri>.value(testUri),
+    );
+    await flutterDevice.connect(
+      allowExistingDdsInstance: true,
+      debuggingOptions: DebuggingOptions.enabled(
+        BuildInfo.debug, disableServiceAuthCodes: true, ipv6: true,
+      )
+    );
+    await done.future;
+  }, overrides: <Type, Generator>{
+    VMServiceConnector: () => (Uri httpUri, {
+      ReloadSources? reloadSources,
+      Restart? restart,
+      CompileExpression? compileExpression,
+      GetSkSLMethod? getSkSLMethod,
+      FlutterProject? flutterProject,
+      PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+      io.CompressionOptions? compression,
+      Device? device,
+      required Logger logger,
+    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
+  }));
 
-  testUsingContext(
-      'Failed DDS start outputs error message',
-      () => testbed.run(() async {
-            // See https://github.com/flutter/flutter/issues/72385 for context.
-            final FakeDevice device = FakeDevice()
-              ..dds = DartDevelopmentService(logger: testLogger);
-            ddsLauncherCallback = ({
-              required Uri remoteVmServiceUri,
-              Uri? serviceUri,
-              bool enableAuthCodes = true,
-              bool serveDevTools = false,
-              Uri? devToolsServerAddress,
-              bool enableServicePortFallback = false,
-              List<String> cachedUserTags = const <String>[],
-              String? dartExecutable,
-              String? google3WorkspaceRoot,
-            }) {
-              expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
-              expect(enableAuthCodes, isTrue);
-              expect(
-                  serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
-              expect(cachedUserTags, isEmpty);
-              throw FakeDartDevelopmentServiceException(message: 'No URI');
-            };
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-              vmServiceUris: Stream<Uri>.value(testUri),
-            );
-            bool caught = false;
-            final Completer<void> done = Completer<void>();
-            runZonedGuarded(() {
-              flutterDevice
-                  .connect(
-                    allowExistingDdsInstance: true,
-                    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
-                        enableDevTools: false),
-                  )
-                  .then((_) => done.complete());
-            }, (Object e, StackTrace st) {
-              expect(e, isA<StateError>());
-              expect((e as StateError).message, contains('No URI'));
-              expect(
-                  testLogger.errorText,
-                  contains(
-                    'DDS has failed to start and there is not an existing DDS instance',
-                  ));
-              done.complete();
-              caught = true;
-            });
-            await done.future;
-            if (!caught) {
-              fail('Expected a StateError to be thrown.');
-            }
-          }, overrides: <Type, Generator>{
-            VMServiceConnector: () => (
-                  Uri httpUri, {
-                  ReloadSources? reloadSources,
-                  Restart? restart,
-                  CompileExpression? compileExpression,
-                  GetSkSLMethod? getSkSLMethod,
-                  FlutterProject? flutterProject,
-                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-                  io.CompressionOptions compression =
-                      io.CompressionOptions.compressionDefault,
-                  Device? device,
-                  required Logger logger,
-                }) async =>
-                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
-                        .vmService,
-          }));
+  testUsingContext('Failed DDS start outputs error message', () => testbed.run(() async {
+    // See https://github.com/flutter/flutter/issues/72385 for context.
+    final FakeDevice device = FakeDevice()
+      ..dds = DartDevelopmentService(logger: testLogger);
+    ddsLauncherCallback = ({
+        required Uri remoteVmServiceUri,
+        Uri? serviceUri,
+        bool enableAuthCodes = true,
+        bool serveDevTools = false,
+        Uri? devToolsServerAddress,
+        bool enableServicePortFallback = false,
+        List<String> cachedUserTags = const <String>[],
+        String? dartExecutable,
+        String? google3WorkspaceRoot,
+      }) {
+      expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
+      expect(enableAuthCodes, isTrue);
+      expect(serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
+      expect(cachedUserTags, isEmpty);
+      throw FakeDartDevelopmentServiceException(message: 'No URI');
+    };
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+      vmServiceUris: Stream<Uri>.value(testUri),
+    );
+    bool caught = false;
+    final Completer<void>done = Completer<void>();
+    runZonedGuarded(() {
+      flutterDevice.connect(
+        allowExistingDdsInstance: true,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, enableDevTools: false),
+      ).then((_) => done.complete());
+    }, (Object e, StackTrace st) {
+      expect(e, isA<StateError>());
+      expect((e as StateError).message, contains('No URI'));
+      expect(testLogger.errorText, contains(
+        'DDS has failed to start and there is not an existing DDS instance',
+      ));
+      done.complete();
+      caught = true;
+    });
+    await done.future;
+    if (!caught) {
+      fail('Expected a StateError to be thrown.');
+    }
+  }, overrides: <Type, Generator>{
+    VMServiceConnector: () => (Uri httpUri, {
+      ReloadSources? reloadSources,
+      Restart? restart,
+      CompileExpression? compileExpression,
+      GetSkSLMethod? getSkSLMethod,
+      FlutterProject? flutterProject,
+      PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+      io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
+      Device? device,
+      required Logger logger,
+    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
+  }));
 
   testUsingContext('nextPlatform moves through expected platforms', () {
     expect(nextPlatform('android'), 'iOS');
@@ -2502,199 +2158,172 @@ flutter:
   });
 
   // TODO(bkonyi): remove when ready to serve DevTools from DDS.
-  testUsingContext(
-      'cleanupAtFinish shuts down resident devtools handler',
-      () => testbed.run(() async {
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
-                  vmserviceOutFile: 'foo'),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            await residentRunner.cleanupAtFinish();
+  testUsingContext('cleanupAtFinish shuts down resident devtools handler', () => testbed.run(() async {
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
+    await residentRunner.cleanupAtFinish();
 
-            expect(
-                (residentRunner.residentDevtoolsHandler! as NoOpDevtoolsHandler)
-                    .wasShutdown,
-                true);
-          }));
+    expect((residentRunner.residentDevtoolsHandler! as NoOpDevtoolsHandler).wasShutdown, true);
+  }));
 
-  testUsingContext(
-      'HotRunner sets asset directory when first evict assets',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              setAssetBundlePath,
-              evict,
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
+  testUsingContext('HotRunner sets asset directory when first evict assets', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      setAssetBundlePath,
+      evict,
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
 
-            (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{
-              'asset'
-            };
+    (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{'asset'};
 
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, isFalse);
-            await (residentRunner as HotRunner).evictDirtyAssets();
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, isTrue);
-            expect(fakeVmServiceHost!.hasRemainingExpectations, isFalse);
-          }));
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, isFalse);
+    await (residentRunner as HotRunner).evictDirtyAssets();
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, isTrue);
+    expect(fakeVmServiceHost!.hasRemainingExpectations, isFalse);
+  }));
 
-  testUsingContext(
-      'HotRunner sets asset directory when first evict shaders',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              setAssetBundlePath,
-              evictShader,
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
+  testUsingContext('HotRunner sets asset directory when first evict shaders', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      setAssetBundlePath,
+      evictShader,
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
 
-            (flutterDevice.devFS! as FakeDevFS).shaderPathsToEvict = <String>{
-              'foo.frag'
-            };
+    (flutterDevice.devFS! as FakeDevFS).shaderPathsToEvict = <String>{'foo.frag'};
 
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-            await (residentRunner as HotRunner).evictDirtyAssets();
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
-            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-          }));
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+    await (residentRunner as HotRunner).evictDirtyAssets();
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
+    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'HotRunner does not sets asset directory when no assets to evict',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
+  testUsingContext('HotRunner does not sets asset directory when no assets to evict', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
 
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-            await (residentRunner as HotRunner).evictDirtyAssets();
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-          }));
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+    await (residentRunner as HotRunner).evictDirtyAssets();
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'HotRunner does not set asset directory if it has been set before',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              evict,
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
+  testUsingContext('HotRunner does not set asset directory if it has been set before', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      evict,
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
+    );
 
-            (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{
-              'asset'
-            };
-            flutterDevice.devFS!.hasSetAssetDirectory = true;
+    (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{'asset'};
+    flutterDevice.devFS!.hasSetAssetDirectory = true;
 
-            await (residentRunner as HotRunner).evictDirtyAssets();
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
-            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-          }));
+    await (residentRunner as HotRunner).evictDirtyAssets();
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
+    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+  }));
 
   testUsingContext(
       'use the nativeAssetsYamlFile when provided',
       () => testbed.run(() async {
-            final FakeDevice device = FakeDevice(
-              targetPlatform: TargetPlatform.darwin,
-              sdkNameAndVersion: 'Macos',
-            );
-            final FakeResidentCompiler residentCompiler =
-                FakeResidentCompiler();
-            final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
-              ..testUri = testUri
-              ..vmServiceHost = (() => fakeVmServiceHost)
-              ..device = device
-              ..fakeDevFS = devFS
-              ..targetPlatform = TargetPlatform.darwin
-              ..generator = residentCompiler;
+        final FakeDevice device = FakeDevice(
+          targetPlatform: TargetPlatform.darwin,
+          sdkNameAndVersion: 'Macos',
+        );
+        final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
+        final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+          ..testUri = testUri
+          ..vmServiceHost = (() => fakeVmServiceHost)
+          ..device = device
+          ..fakeDevFS = devFS
+          ..targetPlatform = TargetPlatform.darwin
+          ..generator = residentCompiler;
 
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                '',
-                treeShakeIcons: false,
-                trackWidgetCreation: true,
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              nativeAssetsYamlFile: 'foo.yaml',
-              useImplicitPubspecResolution: true,
-            );
+        fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+          listViews,
+          listViews,
+        ]);
+        globals.fs
+            .file(globals.fs.path.join('lib', 'main.dart'))
+            .createSync(recursive: true);
+        residentRunner = HotRunner(
+          <FlutterDevice>[
+            flutterDevice,
+          ],
+          stayResident: false,
+          debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+            BuildMode.debug,
+            '',
+            treeShakeIcons: false,
+            trackWidgetCreation: true,
+            packageConfigPath: '.dart_tool/package_config.json',
+          )),
+          target: 'main.dart',
+          devtoolsHandler: createNoOpHandler,
+          analytics: globals.analytics,
+          nativeAssetsYamlFile: 'foo.yaml',
+          useImplicitPubspecResolution: true,
+        );
 
-            final int? result = await residentRunner.run();
-            expect(result, 0);
+        final int? result = await residentRunner.run();
+        expect(result, 0);
 
-            expect(residentCompiler.recompileCalled, true);
-            expect(residentCompiler.receivedNativeAssetsYaml,
-                globals.fs.path.toUri('foo.yaml'));
-          }),
+        expect(residentCompiler.recompileCalled, true);
+        expect(residentCompiler.receivedNativeAssetsYaml, globals.fs.path.toUri('foo.yaml'));
+      }),
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () =>
-            TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
       });
 }
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -50,26 +50,23 @@ void main() {
   FakeVmServiceHost? fakeVmServiceHost;
 
   setUp(() {
-    testbed = Testbed(
-        setup: () {
-          globals.fs.file(globals.fs.path.join('build', 'app.dill'))
-            ..createSync(recursive: true)
-            ..writeAsStringSync('ABC');
-          residentRunner = HotRunner(
-            <FlutterDevice>[
-              flutterDevice,
-            ],
-            stayResident: false,
-            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-            target: 'main.dart',
-            analytics: fakeAnalytics,
-            devtoolsHandler: createNoOpHandler,
-            useImplicitPubspecResolution: true,
-          );
-        },
-        overrides: <Type, Generator>{
-          Analytics: () => FakeAnalytics(),
-        });
+    testbed = Testbed(setup: () {
+      globals.fs.file(globals.fs.path.join('build', 'app.dill'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('ABC');
+      residentRunner = HotRunner(
+        <FlutterDevice>[
+          flutterDevice,
+        ],
+        stayResident: false,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'main.dart',
+        analytics: fakeAnalytics,
+        devtoolsHandler: createNoOpHandler,
+      );
+    }, overrides: <Type, Generator>{
+      Analytics: () => FakeAnalytics(),
+    });
     device = FakeDevice();
     devFS = FakeDevFS();
     flutterDevice = FakeFlutterDevice()
@@ -79,1190 +76,1041 @@ void main() {
       ..fakeDevFS = devFS;
   });
 
-  testUsingContext(
-      'ResidentRunner can attach to device successfully',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            final Future<int?> result = residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            );
-            final Future<DebugConnectionInfo> connectionInfo =
-                futureConnectionInfo.future;
+  testUsingContext('ResidentRunner can attach to device successfully', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    final Future<int?> result = residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    );
+    final Future<DebugConnectionInfo> connectionInfo = futureConnectionInfo.future;
 
-            expect(await result, 0);
-            expect(futureConnectionInfo.isCompleted, true);
-            expect((await connectionInfo).baseUri, 'foo://bar');
-            expect(futureAppStart.isCompleted, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+    expect(await result, 0);
+    expect(futureConnectionInfo.isCompleted, true);
+    expect((await connectionInfo).baseUri, 'foo://bar');
+    expect(futureAppStart.isCompleted, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'ResidentRunner suppresses errors for the initial compilation',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-              ..nextOutput = const CompilerOutput('foo', 0, <Uri>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.generator = residentCompiler;
+  testUsingContext('ResidentRunner suppresses errors for the initial compilation', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 0 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: globals.analytics,
+    );
+    flutterDevice.generator = residentCompiler;
 
-            expect(await residentRunner.run(), 0);
-            expect(residentCompiler.didSuppressErrors, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+    expect(await residentRunner.run(), 0);
+    expect(residentCompiler.didSuppressErrors, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext(
-      'ResidentRunner calls appFailedToStart if initial compilation fails',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-              ..nextOutput = const CompilerOutput('foo', 1, <Uri>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.generator = residentCompiler;
+  testUsingContext('ResidentRunner calls appFailedToStart if initial compilation fails', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: globals.analytics,
+    );
+    flutterDevice.generator = residentCompiler;
 
-            expect(await residentRunner.run(), 1);
-            // Completing this future ensures that the daemon can exit correctly.
-            expect(await residentRunner.waitForAppToFinish(), 1);
-          }));
+    expect(await residentRunner.run(), 1);
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
+  }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext(
-      'ResidentRunner calls appFailedToStart if initial compilation fails - cold mode',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubpsecResolution: true,
-            );
-            flutterDevice.runColdCode = 1;
+  testUsingContext('ResidentRunner calls appFailedToStart if initial compilation fails - cold mode', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+    );
+    flutterDevice.runColdCode = 1;
 
-            expect(await residentRunner.run(), 1);
-            // Completing this future ensures that the daemon can exit correctly.
-            expect(await residentRunner.waitForAppToFinish(), 1);
-          }));
+    expect(await residentRunner.run(), 1);
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
+  }));
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
-  testUsingContext(
-      'ResidentRunner calls appFailedToStart if exception is thrown - cold mode',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubpsecResolution: true,
-            );
-            flutterDevice.runColdError = Exception('BAD STUFF');
+  testUsingContext('ResidentRunner calls appFailedToStart if exception is thrown - cold mode', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+    );
+    flutterDevice.runColdError = Exception('BAD STUFF');
 
-            expect(await residentRunner.run(), 1);
-            // Completing this future ensures that the daemon can exit correctly.
-            expect(await residentRunner.waitForAppToFinish(), 1);
-          }));
 
-  testUsingContext(
-      'ResidentRunner does not suppressErrors if running with an applicationBinary',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-              ..nextOutput = const CompilerOutput('foo', 0, <Uri>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              applicationBinary: globals.fs.file('app-debug.apk'),
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.generator = residentCompiler;
+    expect(await residentRunner.run(), 1);
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
+  }));
 
-            expect(await residentRunner.run(), 0);
-            expect(residentCompiler.didSuppressErrors, false);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+  testUsingContext('ResidentRunner does not suppressErrors if running with an applicationBinary', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 0 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      applicationBinary: globals.fs.file('app-debug.apk'),
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: globals.analytics,
+    );
+    flutterDevice.generator = residentCompiler;
 
-  testUsingContext(
-      'ResidentRunner can attach to device successfully with --fast-start',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                  method: 'streamListen',
-                  args: <String, Object>{
-                    'streamId': 'Isolate',
-                  }),
-              FakeVmServiceRequest(
-                  method: kRunInViewMethod,
-                  args: <String, Object>{
-                    'viewId': fakeFlutterView.id,
-                    'mainScript': 'main.dart.dill',
-                    'assetDirectory': 'build/flutter_assets',
-                  }),
-              FakeVmServiceStreamResponse(
-                  streamId: 'Isolate',
-                  event: vm_service.Event(
-                    timestamp: 0,
-                    kind: vm_service.EventKind.kIsolateRunnable,
-                  )),
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(
-                BuildInfo.debug,
-                fastStart: true,
-                startPaused: true,
-              ),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              useImplicitPubspecResolution: true,
-            );
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            final Future<int?> result = residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            );
-            final Future<DebugConnectionInfo> connectionInfo =
-                futureConnectionInfo.future;
+    expect(await residentRunner.run(), 0);
+    expect(residentCompiler.didSuppressErrors, false);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-            expect(await result, 0);
-            expect(futureConnectionInfo.isCompleted, true);
-            expect((await connectionInfo).baseUri, 'foo://bar');
-            expect(futureAppStart.isCompleted, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+  testUsingContext('ResidentRunner can attach to device successfully with --fast-start', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        }
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        }
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        )
+      ),
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(
+        BuildInfo.debug,
+        fastStart: true,
+        startPaused: true,
+      ),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: globals.analytics,
+    );
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    final Future<int?> result = residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    );
+    final Future<DebugConnectionInfo> connectionInfo = futureConnectionInfo.future;
 
-  testUsingContext(
-      'ResidentRunner can handle an RPC exception from hot reload',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.reportError =
-                vm_service.RPCError('something bad happened', 666, '');
+    expect(await result, 0);
+    expect(futureConnectionInfo.isCompleted, true);
+    expect((await connectionInfo).baseUri, 'foo://bar');
+    expect(futureAppStart.isCompleted, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, true);
-            expect(result.code, 1);
-            expect(
-                (globals.flutterUsage as TestUsage).events,
-                contains(
-                  TestUsageEvent('hot', 'exception',
-                      parameters: CustomDimensions(
-                        hotEventTargetPlatform: getNameForTargetPlatform(
-                            TargetPlatform.android_arm),
-                        hotEventSdkName: 'Android',
-                        hotEventEmulator: false,
-                        hotEventFullRestart: false,
-                      )),
-                ));
-            expect(
-                (globals.analytics as FakeAnalytics).sentEvents,
-                contains(
-                  Event.hotRunnerInfo(
-                    label: 'exception',
-                    targetPlatform:
-                        getNameForTargetPlatform(TargetPlatform.android_arm),
-                    sdkName: 'Android',
-                    emulator: false,
-                    fullRestart: false,
-                  ),
-                ));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+  testUsingContext('ResidentRunner can handle an RPC exception from hot reload', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
 
-  testUsingContext(
-      'ResidentRunner fails its operation if the device initialization is not complete',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.fakeDevFS = null;
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, true);
+    expect(result.code, 1);
+    expect((globals.flutterUsage as TestUsage).events, contains(
+      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
+        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        hotEventSdkName: 'Android',
+        hotEventEmulator: false,
+        hotEventFullRestart: false,
+      )),
+    ));
+    expect((globals.analytics as FakeAnalytics).sentEvents, contains(
+      Event.hotRunnerInfo(
+        label: 'exception',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        sdkName: 'Android',
+        emulator: false,
+        fullRestart: false,
+      ),
+    ));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, false);
-            expect(result.code, 1);
-            expect(result.message,
-                contains('Device initialization has not completed.'));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+  testUsingContext('ResidentRunner fails its operation if the device initialization is not complete', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.fakeDevFS = null;
 
-  testUsingContext(
-      'ResidentRunner can handle an reload-barred exception from hot reload',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.reportError = vm_service.RPCError(
-                'something bad happened', kIsolateReloadBarred, '');
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, false);
+    expect(result.code, 1);
+    expect(result.message, contains('Device initialization has not completed.'));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, true);
-            expect(result.code, kIsolateReloadBarred);
-            expect(
-                result.message,
-                contains(
-                    'Unable to hot reload application due to an unrecoverable error'));
+  testUsingContext('ResidentRunner can handle an reload-barred exception from hot reload', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.reportError = vm_service.RPCError('something bad happened', kIsolateReloadBarred, '');
 
-            expect(
-                (globals.flutterUsage as TestUsage).events,
-                contains(
-                  TestUsageEvent('hot', 'reload-barred',
-                      parameters: CustomDimensions(
-                        hotEventTargetPlatform: getNameForTargetPlatform(
-                            TargetPlatform.android_arm),
-                        hotEventSdkName: 'Android',
-                        hotEventEmulator: false,
-                        hotEventFullRestart: false,
-                      )),
-                ));
-            expect(
-                fakeAnalytics.sentEvents,
-                contains(Event.hotRunnerInfo(
-                  label: 'reload-barred',
-                  targetPlatform:
-                      getNameForTargetPlatform(TargetPlatform.android_arm),
-                  sdkName: 'Android',
-                  emulator: false,
-                  fullRestart: false,
-                )));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, true);
+    expect(result.code, kIsolateReloadBarred);
+    expect(result.message, contains('Unable to hot reload application due to an unrecoverable error'));
 
-  testUsingContext(
-      'ResidentRunner reports hot reload event with null safety analytics',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              target: 'main.dart',
-              debuggingOptions: DebuggingOptions.enabled(
-                const BuildInfo(
-                  BuildMode.debug,
-                  '',
-                  treeShakeIcons: false,
-                  extraFrontEndOptions: <String>[
-                    '--enable-experiment=non-nullable',
-                  ],
-                  packageConfigPath: '.dart_tool/package_config.json',
-                ),
-                enableDevTools: false,
-              ),
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.reportError =
-                vm_service.RPCError('something bad happened', 666, '');
+    expect((globals.flutterUsage as TestUsage).events, contains(
+      TestUsageEvent('hot', 'reload-barred', parameters: CustomDimensions(
+        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        hotEventSdkName: 'Android',
+        hotEventEmulator: false,
+        hotEventFullRestart: false,
+      )),
+    ));
+    expect(fakeAnalytics.sentEvents, contains(
+      Event.hotRunnerInfo(
+        label: 'reload-barred',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        sdkName: 'Android',
+        emulator: false,
+        fullRestart: false,
+      )
+    ));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, true);
-            expect(result.code, 1);
+  testUsingContext('ResidentRunner reports hot reload event with null safety analytics', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      target: 'main.dart',
+      debuggingOptions: DebuggingOptions.enabled(
+        const BuildInfo(
+          BuildMode.debug, '', treeShakeIcons: false, extraFrontEndOptions: <String>[
+          '--enable-experiment=non-nullable',
+          ],
+          packageConfigPath: '.dart_tool/package_config.json',
+        ),
+        enableDevTools: false,
+      ),
+      analytics: fakeAnalytics,
+    );
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
 
-            expect(
-                (globals.flutterUsage as TestUsage).events,
-                contains(
-                  TestUsageEvent('hot', 'exception',
-                      parameters: CustomDimensions(
-                        hotEventTargetPlatform: getNameForTargetPlatform(
-                            TargetPlatform.android_arm),
-                        hotEventSdkName: 'Android',
-                        hotEventEmulator: false,
-                        hotEventFullRestart: false,
-                      )),
-                ));
-            expect(
-                fakeAnalytics.sentEvents,
-                contains(Event.hotRunnerInfo(
-                  label: 'exception',
-                  targetPlatform:
-                      getNameForTargetPlatform(TargetPlatform.android_arm),
-                  sdkName: 'Android',
-                  emulator: false,
-                  fullRestart: false,
-                )));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, true);
+    expect(result.code, 1);
 
-  testUsingContext(
-      'ResidentRunner does not reload sources if no sources changed',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolatePauseEvent',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedEvent.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.report = UpdateFSReport(success: true);
+    expect((globals.flutterUsage as TestUsage).events, contains(
+      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
+        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        hotEventSdkName: 'Android',
+        hotEventEmulator: false,
+        hotEventFullRestart: false,
+      )),
+    ));
+    expect(fakeAnalytics.sentEvents, contains(
+      Event.hotRunnerInfo(
+        label: 'exception',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        sdkName: 'Android',
+        emulator: false,
+        fullRestart: false,
+      )
+    ));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            final OperationResult result = await residentRunner.restart();
+  testUsingContext('ResidentRunner does not reload sources if no sources changed', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolatePauseEvent',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedEvent.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.report =  UpdateFSReport(success: true);
 
-            expect(result.code, 0);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+    final OperationResult result = await residentRunner.restart();
 
-  testUsingContext(
-      'ResidentRunner reports error with missing entrypoint file',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{
-                  'isolates': <Object>[
-                    fakeUnpausedIsolate.toJson(),
-                  ],
-                })!.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                method: kReloadSourcesServiceName,
-                args: <String, Object>{
-                  'isolateId': '1',
-                  'pause': false,
-                  'rootLibUri': 'main.dart.incremental.dill',
-                },
-                jsonResponse: <String, Object>{
-                  'type': 'ReloadReport',
-                  'success': true,
-                  'details': <String, Object>{
-                    'loadedLibraryCount': 1,
-                  },
-                },
-              ),
-              FakeVmServiceRequest(
-                method: 'getIsolatePauseEvent',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedEvent.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.report =
-                UpdateFSReport(success: true, invalidatedSourcesCount: 1);
+    expect(result.code, 0);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
+  testUsingContext('ResidentRunner reports error with missing entrypoint file', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{
+          'isolates': <Object>[
+            fakeUnpausedIsolate.toJson(),
+          ],
+        })!.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: kReloadSourcesServiceName,
+        args: <String, Object>{
+          'isolateId': '1',
+          'pause': false,
+          'rootLibUri': 'main.dart.incremental.dill',
+        },
+        jsonResponse: <String, Object>{
+          'type': 'ReloadReport',
+          'success': true,
+          'details': <String, Object>{
+            'loadedLibraryCount': 1,
+          },
+        },
+      ),
+      FakeVmServiceRequest(
+        method: 'getIsolatePauseEvent',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedEvent.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.report =  UpdateFSReport(success: true, invalidatedSourcesCount: 1);
 
-            expect(globals.fs.file(globals.fs.path.join('lib', 'main.dart')),
-                isNot(exists));
-            expect(testLogger.errorText,
-                contains('The entrypoint file (i.e. the file with main())'));
-            expect(result.fatal, false);
-            expect(result.code, 0);
-          }));
+    final OperationResult result = await residentRunner.restart();
 
-  testUsingContext(
-      'ResidentRunner resets compilation time on reload reject',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{
-                  'isolates': <Object>[
-                    fakeUnpausedIsolate.toJson(),
-                  ],
-                })!.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                method: kReloadSourcesServiceName,
-                args: <String, Object>{
-                  'isolateId': '1',
-                  'pause': false,
-                  'rootLibUri': 'main.dart.incremental.dill',
-                },
-                jsonResponse: <String, Object>{
-                  'type': 'ReloadReport',
-                  'success': false,
-                  'notices': <Object>[
-                    <String, Object>{
-                      'message': 'Failed to hot reload',
-                    },
-                  ],
-                  'details': <String, Object>{},
-                },
-              ),
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.report =
-                UpdateFSReport(success: true, invalidatedSourcesCount: 1);
+    expect(globals.fs.file(globals.fs.path.join('lib', 'main.dart')), isNot(exists));
+    expect(testLogger.errorText, contains('The entrypoint file (i.e. the file with main())'));
+    expect(result.fatal, false);
+    expect(result.code, 0);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
+   testUsingContext('ResidentRunner resets compilation time on reload reject', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{
+          'isolates': <Object>[
+            fakeUnpausedIsolate.toJson(),
+          ],
+        })!.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: kReloadSourcesServiceName,
+        args: <String, Object>{
+          'isolateId': '1',
+          'pause': false,
+          'rootLibUri': 'main.dart.incremental.dill',
+        },
+        jsonResponse: <String, Object>{
+          'type': 'ReloadReport',
+          'success': false,
+          'notices': <Object>[
+            <String, Object>{
+              'message': 'Failed to hot reload',
+            },
+          ],
+          'details': <String, Object>{},
+        },
+      ),
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.report =  UpdateFSReport(success: true, invalidatedSourcesCount: 1);
 
-            expect(result.fatal, false);
-            expect(
-                result.message,
-                contains(
-                    'Reload rejected: Failed to hot reload')); // contains error message from reload report.
-            expect(result.code, 1);
-            expect(devFS.lastCompiled, null);
-          }));
+    final OperationResult result = await residentRunner.restart();
 
-  testUsingContext(
-      'ResidentRunner can send target platform to analytics from hot reload',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{
-                  'isolates': <Object>[
-                    fakeUnpausedIsolate.toJson(),
-                  ],
-                })!.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                method: kReloadSourcesServiceName,
-                args: <String, Object>{
-                  'isolateId': '1',
-                  'pause': false,
-                  'rootLibUri': 'main.dart.incremental.dill',
-                },
-                jsonResponse: <String, Object>{
-                  'type': 'ReloadReport',
-                  'success': true,
-                  'details': <String, Object>{
-                    'loadedLibraryCount': 1,
-                  },
-                },
-              ),
-              FakeVmServiceRequest(
-                method: 'getIsolatePauseEvent',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedEvent.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
+    expect(result.fatal, false);
+    expect(result.message, contains('Reload rejected: Failed to hot reload')); // contains error message from reload report.
+    expect(result.code, 1);
+    expect(devFS.lastCompiled, null);
+  }));
 
-            final OperationResult result = await residentRunner.restart();
-            expect(result.fatal, false);
-            expect(result.code, 0);
+  testUsingContext('ResidentRunner can send target platform to analytics from hot reload', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{
+          'isolates': <Object>[
+            fakeUnpausedIsolate.toJson(),
+          ],
+        })!.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: kReloadSourcesServiceName,
+        args: <String, Object>{
+          'isolateId': '1',
+          'pause': false,
+          'rootLibUri': 'main.dart.incremental.dill',
+        },
+        jsonResponse: <String, Object>{
+          'type': 'ReloadReport',
+          'success': true,
+          'details': <String, Object>{
+            'loadedLibraryCount': 1,
+          },
+        },
+      ),
+      FakeVmServiceRequest(
+        method: 'getIsolatePauseEvent',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedEvent.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
 
-            final TestUsageEvent event =
-                (globals.flutterUsage as TestUsage).events.first;
-            expect(event.category, 'hot');
-            expect(event.parameter, 'reload');
-            expect(event.parameters?.hotEventTargetPlatform,
-                getNameForTargetPlatform(TargetPlatform.android_arm));
+    final OperationResult result = await residentRunner.restart();
+    expect(result.fatal, false);
+    expect(result.code, 0);
 
-            final Event newEvent = fakeAnalytics.sentEvents.first;
-            expect(newEvent.eventName.label, 'hot_runner_info');
-            expect(newEvent.eventData['label'], 'reload');
-            expect(newEvent.eventData['targetPlatform'],
-                getNameForTargetPlatform(TargetPlatform.android_arm));
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    final TestUsageEvent event = (globals.flutterUsage as TestUsage).events.first;
+    expect(event.category, 'hot');
+    expect(event.parameter, 'reload');
+    expect(event.parameters?.hotEventTargetPlatform, getNameForTargetPlatform(TargetPlatform.android_arm));
 
-  testUsingContext(
-      'ResidentRunner reports hot reload time details',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: fakeVM.toJson(),
-              ),
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: fakeVM.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                method: kReloadSourcesServiceName,
-                args: <String, Object>{
-                  'isolateId': '1',
-                  'pause': false,
-                  'rootLibUri': 'main.dart.incremental.dill',
-                },
-                jsonResponse: <String, Object>{
-                  'type': 'ReloadReport',
-                  'success': true,
-                  'details': <String, Object>{
-                    'loadedLibraryCount': 1,
-                    'finalLibraryCount': 42,
-                  },
-                },
-              ),
-              FakeVmServiceRequest(
-                method: 'getIsolatePauseEvent',
-                args: <String, Object>{
-                  'isolateId': '1',
-                },
-                jsonResponse: fakeUnpausedEvent.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'ext.flutter.reassemble',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-              ),
-            ]);
-            final FakeDelegateFlutterDevice flutterDevice =
-                FakeDelegateFlutterDevice(
-              device,
-              BuildInfo.debug,
-              FakeResidentCompiler(),
-              devFS,
-            )..vmService = fakeVmServiceHost!.vmService;
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            devFS.nextUpdateReport = UpdateFSReport(
-              success: true,
-              invalidatedSourcesCount: 1,
-            );
+    final Event newEvent = fakeAnalytics.sentEvents.first;
+    expect(newEvent.eventName.label, 'hot_runner_info');
+    expect(newEvent.eventData['label'], 'reload');
+    expect(newEvent.eventData['targetPlatform'], getNameForTargetPlatform(TargetPlatform.android_arm));
 
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            await futureAppStart.future;
-            await residentRunner.restart();
+  testUsingContext('ResidentRunner reports hot reload time details', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: fakeVM.toJson(),
+      ),
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: fakeVM.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: kReloadSourcesServiceName,
+        args: <String, Object>{
+          'isolateId': '1',
+          'pause': false,
+          'rootLibUri': 'main.dart.incremental.dill',
+        },
+        jsonResponse: <String, Object>{
+          'type': 'ReloadReport',
+          'success': true,
+          'details': <String, Object>{
+            'loadedLibraryCount': 1,
+            'finalLibraryCount': 42,
+          },
+        },
+      ),
+      FakeVmServiceRequest(
+        method: 'getIsolatePauseEvent',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedEvent.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    final FakeDelegateFlutterDevice flutterDevice = FakeDelegateFlutterDevice(
+      device,
+      BuildInfo.debug,
+      FakeResidentCompiler(),
+      devFS,
+    )..vmService = fakeVmServiceHost!.vmService;
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    devFS.nextUpdateReport = UpdateFSReport(
+      success: true,
+      invalidatedSourcesCount: 1,
+    );
 
-            // The actual test: Expect to have compile, reload and reassemble times.
-            expect(
-                testLogger.statusText,
-                contains(RegExp(r'Reloaded 1 of 42 libraries in \d+ms '
-                    r'\(compile: \d+ ms, reload: \d+ ms, reassemble: \d+ ms\)\.')));
-          }, overrides: <Type, Generator>{
-            FileSystem: () => MemoryFileSystem.test(),
-            Platform: () => FakePlatform(),
-            ProjectFileInvalidator: () => FakeProjectFileInvalidator(),
-            Usage: () => TestUsage(),
-          }));
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
 
-  testUsingContext(
-      'ResidentRunner can send target platform to analytics from full restart',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                  streamId: 'Isolate',
-                  event: vm_service.Event(
-                    timestamp: 0,
-                    kind: vm_service.EventKind.kIsolateRunnable,
-                  )),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
+    await futureAppStart.future;
+    await residentRunner.restart();
 
-            final OperationResult result =
-                await residentRunner.restart(fullRestart: true);
-            expect(result.fatal, false);
-            expect(result.code, 0);
+    // The actual test: Expect to have compile, reload and reassemble times.
+    expect(
+        testLogger.statusText,
+        contains(RegExp(r'Reloaded 1 of 42 libraries in \d+ms '
+            r'\(compile: \d+ ms, reload: \d+ ms, reassemble: \d+ ms\)\.')));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem.test(),
+    Platform: () => FakePlatform(),
+    ProjectFileInvalidator: () => FakeProjectFileInvalidator(),
+    Usage: () => TestUsage(),
+  }));
 
-            final TestUsageEvent event =
-                (globals.flutterUsage as TestUsage).events.first;
-            expect(event.category, 'hot');
-            expect(event.parameter, 'restart');
-            expect(event.parameters?.hotEventTargetPlatform,
-                getNameForTargetPlatform(TargetPlatform.android_arm));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  testUsingContext('ResidentRunner can send target platform to analytics from full restart', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        )
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
 
-            // Parse out the event of interest since we may have timing events with
-            // the new analytics package
-            final List<Event> newEventList = fakeAnalytics.sentEvents
-                .where((Event e) => e.eventName.label == 'hot_runner_info')
-                .toList();
-            expect(newEventList, hasLength(1));
-            final Event newEvent = newEventList.first;
-            expect(newEvent.eventName.label, 'hot_runner_info');
-            expect(newEvent.eventData['label'], 'restart');
-            expect(newEvent.eventData['targetPlatform'],
-                getNameForTargetPlatform(TargetPlatform.android_arm));
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    final OperationResult result = await residentRunner.restart(fullRestart: true);
+    expect(result.fatal, false);
+    expect(result.code, 0);
 
-  testUsingContext(
-      'ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakePausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              const FakeVmServiceRequest(
-                  method: 'setIsolatePauseMode',
-                  args: <String, String>{
-                    'isolateId': '1',
-                    'exceptionPauseMode': 'None',
-                  }),
-              const FakeVmServiceRequest(
-                  method: 'removeBreakpoint',
-                  args: <String, String>{
-                    'isolateId': '1',
-                    'breakpointId': 'test-breakpoint',
-                  }),
-              const FakeVmServiceRequest(
-                  method: 'resume',
-                  args: <String, String>{
-                    'isolateId': '1',
-                  }),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                streamId: 'Isolate',
-                event: vm_service.Event(
-                  timestamp: 0,
-                  kind: vm_service.EventKind.kIsolateRunnable,
-                ),
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
+    final TestUsageEvent event = (globals.flutterUsage as TestUsage).events.first;
+    expect(event.category, 'hot');
+    expect(event.parameter, 'restart');
+    expect(event.parameters?.hotEventTargetPlatform, getNameForTargetPlatform(TargetPlatform.android_arm));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
 
-            final OperationResult result =
-                await residentRunner.restart(fullRestart: true);
+    // Parse out the event of interest since we may have timing events with
+    // the new analytics package
+    final List<Event> newEventList = fakeAnalytics.sentEvents.where((Event e) => e.eventName.label == 'hot_runner_info').toList();
+    expect(newEventList, hasLength(1));
+    final Event newEvent = newEventList.first;
+    expect(newEvent.eventName.label, 'hot_runner_info');
+    expect(newEvent.eventData['label'], 'restart');
+    expect(newEvent.eventData['targetPlatform'], getNameForTargetPlatform(TargetPlatform.android_arm));
 
-            expect(result.isOk, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-  testUsingContext(
-      'ResidentRunner will alternative the name of the dill file uploaded for a hot restart',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                streamId: 'Isolate',
-                event: vm_service.Event(
-                  timestamp: 0,
-                  kind: vm_service.EventKind.kIsolateRunnable,
-                ),
-              ),
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.swap.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                streamId: 'Isolate',
-                event: vm_service.Event(
-                  timestamp: 0,
-                  kind: vm_service.EventKind.kIsolateRunnable,
-                ),
-              ),
-              listViews,
-              FakeVmServiceRequest(
-                method: 'getIsolate',
-                args: <String, Object?>{
-                  'isolateId': fakeUnpausedIsolate.id,
-                },
-                jsonResponse: fakeUnpausedIsolate.toJson(),
-              ),
-              FakeVmServiceRequest(
-                method: 'getVM',
-                jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
-              ),
-              listViews,
-              const FakeVmServiceRequest(
-                method: 'streamListen',
-                args: <String, Object>{
-                  'streamId': 'Isolate',
-                },
-              ),
-              FakeVmServiceRequest(
-                method: kRunInViewMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                  'mainScript': 'main.dart.dill',
-                  'assetDirectory': 'build/flutter_assets',
-                },
-              ),
-              FakeVmServiceStreamResponse(
-                streamId: 'Isolate',
-                event: vm_service.Event(
-                  timestamp: 0,
-                  kind: vm_service.EventKind.kIsolateRunnable,
-                ),
-              ),
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
+  testUsingContext('ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakePausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: 'setIsolatePauseMode',
+        args: <String, String>{
+          'isolateId': '1',
+          'exceptionPauseMode': 'None',
+        }
+      ),
+      const FakeVmServiceRequest(
+        method: 'removeBreakpoint',
+        args: <String, String>{
+          'isolateId': '1',
+          'breakpointId': 'test-breakpoint',
+        }
+      ),
+      const FakeVmServiceRequest(
+        method: 'resume',
+        args: <String, String>{
+          'isolateId': '1',
+        }
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        ),
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
 
-            await residentRunner.restart(fullRestart: true);
-            await residentRunner.restart(fullRestart: true);
-            await residentRunner.restart(fullRestart: true);
+    final OperationResult result = await residentRunner.restart(fullRestart: true);
 
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
+    expect(result.isOk, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'ResidentRunner Can handle an RPC exception from hot restart',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            final Completer<DebugConnectionInfo> futureConnectionInfo =
-                Completer<DebugConnectionInfo>.sync();
-            final Completer<void> futureAppStart = Completer<void>.sync();
-            unawaited(residentRunner.attach(
-              appStartedCompleter: futureAppStart,
-              connectionInfoCompleter: futureConnectionInfo,
-            ));
-            await futureAppStart.future;
-            flutterDevice.reportError =
-                vm_service.RPCError('something bad happened', 666, '');
+  testUsingContext('ResidentRunner will alternative the name of the dill file uploaded for a hot restart', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        ),
+      ),
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.swap.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        ),
+      ),
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object?>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'getVM',
+        jsonResponse: vm_service.VM.parse(<String, Object>{})!.toJson(),
+      ),
+      listViews,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate',
+        },
+      ),
+      FakeVmServiceRequest(
+        method: kRunInViewMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+          'mainScript': 'main.dart.dill',
+          'assetDirectory': 'build/flutter_assets',
+        },
+      ),
+      FakeVmServiceStreamResponse(
+        streamId: 'Isolate',
+        event: vm_service.Event(
+          timestamp: 0,
+          kind: vm_service.EventKind.kIsolateRunnable,
+        ),
+      ),
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
 
-            final OperationResult result =
-                await residentRunner.restart(fullRestart: true);
-            expect(result.fatal, true);
-            expect(result.code, 1);
+    await residentRunner.restart(fullRestart: true);
+    await residentRunner.restart(fullRestart: true);
+    await residentRunner.restart(fullRestart: true);
 
-            expect(
-                (globals.flutterUsage as TestUsage).events,
-                contains(
-                  TestUsageEvent('hot', 'exception',
-                      parameters: CustomDimensions(
-                        hotEventTargetPlatform: getNameForTargetPlatform(
-                            TargetPlatform.android_arm),
-                        hotEventSdkName: 'Android',
-                        hotEventEmulator: false,
-                        hotEventFullRestart: true,
-                      )),
-                ));
-            expect(
-                fakeAnalytics.sentEvents,
-                contains(
-                  Event.hotRunnerInfo(
-                    label: 'exception',
-                    targetPlatform:
-                        getNameForTargetPlatform(TargetPlatform.android_arm),
-                    sdkName: 'Android',
-                    emulator: false,
-                    fullRestart: true,
-                  ),
-                ));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            Usage: () => TestUsage(),
-          }));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'ResidentRunner uses temp directory when there is no output dill path',
-      () => testbed.run(() {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            expect(residentRunner.artifactDirectory.path,
-                contains('flutter_tool.'));
+  testUsingContext('ResidentRunner Can handle an RPC exception from hot restart', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    final Completer<DebugConnectionInfo> futureConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> futureAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: futureAppStart,
+      connectionInfoCompleter: futureConnectionInfo,
+    ));
+    await futureAppStart.future;
+    flutterDevice.reportError = vm_service.RPCError('something bad happened', 666, '');
 
-            final ResidentRunner otherRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            expect(otherRunner.artifactDirectory.path, contains('foobar'));
-          }));
+    final OperationResult result = await residentRunner.restart(fullRestart: true);
+    expect(result.fatal, true);
+    expect(result.code, 1);
 
-  testUsingContext(
-      'ResidentRunner deletes artifact directory on preExit',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            residentRunner.artifactDirectory.childFile('app.dill').createSync();
-            await residentRunner.preExit();
+    expect((globals.flutterUsage as TestUsage).events, contains(
+      TestUsageEvent('hot', 'exception', parameters: CustomDimensions(
+        hotEventTargetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        hotEventSdkName: 'Android',
+        hotEventEmulator: false,
+        hotEventFullRestart: true,
+      )),
+    ));
+    expect(fakeAnalytics.sentEvents, contains(
+      Event.hotRunnerInfo(
+        label: 'exception',
+        targetPlatform: getNameForTargetPlatform(TargetPlatform.android_arm),
+        sdkName: 'Android',
+        emulator: false,
+        fullRestart: true,
+      ),
+    ));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => TestUsage(),
+  }));
 
-            expect(residentRunner.artifactDirectory, isNot(exists));
-          }));
+  testUsingContext('ResidentRunner uses temp directory when there is no output dill path', () => testbed.run(() {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    expect(residentRunner.artifactDirectory.path, contains('flutter_tool.'));
 
-  testUsingContext(
-      'ResidentRunner can run source generation',
-      () => testbed.run(() async {
-            final File arbFile = globals.fs
-                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-              ..createSync(recursive: true);
-            arbFile.writeAsStringSync('''
+    final ResidentRunner otherRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    expect(otherRunner.artifactDirectory.path, contains('foobar'));
+  }));
+
+  testUsingContext('ResidentRunner deletes artifact directory on preExit', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner.artifactDirectory.childFile('app.dill').createSync();
+    await residentRunner.preExit();
+
+    expect(residentRunner.artifactDirectory, isNot(exists));
+  }));
+
+  testUsingContext('ResidentRunner can run source generation', () => testbed.run(() async {
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-            globals.fs.file('l10n.yaml').createSync();
-            globals.fs
-                .file('pubspec.yaml')
-                .writeAsStringSync('flutter:\n  generate: true\n');
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
 
-            // Create necessary files for [DartPluginRegistrantTarget]
-            final File packageConfig = globals.fs
-                .directory('.dart_tool')
-                .childFile('package_config.json');
-            packageConfig.createSync(recursive: true);
-            packageConfig.writeAsStringSync('''
+    // Create necessary files for [DartPluginRegistrantTarget]
+    final File packageConfig = globals.fs.directory('.dart_tool')
+        .childFile('package_config.json');
+    packageConfig.createSync(recursive: true);
+    packageConfig.writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": [
@@ -1275,34 +1123,27 @@ void main() {
   ]
 }
 ''');
-            // Start from an empty dart_plugin_registrant.dart file.
-            globals.fs
-                .directory('.dart_tool')
-                .childDirectory('flutter_build')
-                .childFile('dart_plugin_registrant.dart')
-                .createSync(recursive: true);
+    // Start from an empty dart_plugin_registrant.dart file.
+    globals.fs.directory('.dart_tool').childDirectory('flutter_build').childFile('dart_plugin_registrant.dart').createSync(recursive: true);
 
-            await residentRunner.runSourceGenerators();
+    await residentRunner.runSourceGenerators();
 
-            expect(testLogger.errorText, isEmpty);
-            expect(testLogger.statusText, isEmpty);
-          }));
+    expect(testLogger.errorText, isEmpty);
+    expect(testLogger.statusText, isEmpty);
+  }));
 
-  testUsingContext(
-      'generated main uses correct target',
-      () => testbed.run(() async {
-            final File arbFile = globals.fs
-                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-              ..createSync(recursive: true);
-            arbFile.writeAsStringSync('''
+  testUsingContext('generated main uses correct target', () => testbed.run(() async {
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-            globals.fs.file('l10n.yaml').createSync();
-            globals.fs.file('pubspec.yaml').writeAsStringSync('''
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('''
 flutter:
   generate: true
 
@@ -1312,13 +1153,12 @@ dependencies:
   path_provider_linux: 1.0.0
 ''');
 
-            // Create necessary files for [DartPluginRegistrantTarget], including a
-            // plugin that will trigger generation.
-            final File packageConfig = globals.fs
-                .directory('.dart_tool')
-                .childFile('package_config.json');
-            packageConfig.createSync(recursive: true);
-            packageConfig.writeAsStringSync('''
+    // Create necessary files for [DartPluginRegistrantTarget], including a
+    // plugin that will trigger generation.
+    final File packageConfig = globals.fs.directory('.dart_tool')
+        .childFile('package_config.json');
+    packageConfig.createSync(recursive: true);
+    packageConfig.writeAsStringSync('''
 {
   "configVersion": 2,
   "packages": [
@@ -1331,11 +1171,10 @@ dependencies:
   ]
 }
 ''');
-            final Directory fakePluginDir =
-                globals.fs.directory('path_provider_linux');
-            final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
-            pluginPubspec.createSync(recursive: true);
-            pluginPubspec.writeAsStringSync('''
+    final Directory fakePluginDir = globals.fs.directory('path_provider_linux');
+    final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
+    pluginPubspec.createSync(recursive: true);
+    pluginPubspec.writeAsStringSync('''
 name: path_provider_linux
 
 flutter:
@@ -1346,739 +1185,594 @@ flutter:
         dartPluginClass: PathProviderLinux
 ''');
 
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'custom_main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            await residentRunner.runSourceGenerators();
+    residentRunner = HotRunner(
+        <FlutterDevice>[
+          flutterDevice,
+        ],
+        stayResident: false,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'custom_main.dart',
+        devtoolsHandler: createNoOpHandler,
+        analytics: fakeAnalytics,
+      );
+    await residentRunner.runSourceGenerators();
 
-            final File generatedMain = globals.fs
-                .directory('.dart_tool')
-                .childDirectory('flutter_build')
-                .childFile('dart_plugin_registrant.dart');
+    final File generatedMain = globals.fs.directory('.dart_tool')
+        .childDirectory('flutter_build')
+        .childFile('dart_plugin_registrant.dart');
 
-            expect(generatedMain.existsSync(), isTrue);
-            expect(testLogger.errorText, isEmpty);
-            expect(testLogger.statusText, isEmpty);
-          }));
+    expect(generatedMain.existsSync(), isTrue);
+    expect(testLogger.errorText, isEmpty);
+    expect(testLogger.statusText, isEmpty);
+  }));
 
-  testUsingContext(
-      'ResidentRunner can run source generation - generation fails',
-      () => testbed.run(() async {
-            // Intentionally define arb file with wrong name. generate_localizations defaults
-            // to app_en.arb.
-            final File arbFile = globals.fs
-                .file(globals.fs.path.join('lib', 'l10n', 'foo.arb'))
-              ..createSync(recursive: true);
-            arbFile.writeAsStringSync('''
+  testUsingContext('ResidentRunner can run source generation - generation fails', () => testbed.run(() async {
+    // Intentionally define arb file with wrong name. generate_localizations defaults
+    // to app_en.arb.
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'foo.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-            globals.fs.file('l10n.yaml').createSync();
-            globals.fs
-                .file('pubspec.yaml')
-                .writeAsStringSync('flutter:\n  generate: true\n');
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
 
-            await residentRunner.runSourceGenerators();
+    await residentRunner.runSourceGenerators();
 
-            expect(testLogger.errorText, contains('Error'));
-            expect(testLogger.statusText, isEmpty);
-          }));
+    expect(testLogger.errorText, contains('Error'));
+    expect(testLogger.statusText, isEmpty);
+  }));
 
-  testUsingContext(
-      'ResidentRunner generates files when l10n.yaml exists',
-      () => testbed.run(() async {
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            final File arbFile = globals.fs
-                .file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-              ..createSync(recursive: true);
-            arbFile.writeAsStringSync('''
+  testUsingContext('ResidentRunner generates files when l10n.yaml exists', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-            globals.fs.file('l10n.yaml').createSync();
-            globals.fs
-                .file('pubspec.yaml')
-                .writeAsStringSync('flutter:\n  generate: true\n');
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
 
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
-              ..nextOutput = const CompilerOutput('foo', 1, <Uri>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            flutterDevice.generator = residentCompiler;
-
-            await residentRunner.run();
-
-            final File generatedLocalizationsFile = globals.fs
-                .directory('.dart_tool')
-                .childDirectory('flutter_gen')
-                .childDirectory('gen_l10n')
-                .childFile('app_localizations.dart');
-            expect(generatedLocalizationsFile.existsSync(), isTrue);
-
-            // Completing this future ensures that the daemon can exit correctly.
-            expect(await residentRunner.waitForAppToFinish(), 1);
-          }));
-
-  testUsingContext(
-      'ResidentRunner printHelpDetails hot runner',
-      () => testbed.run(() {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
-            residentRunner.printHelp(details: true);
-
-            final CommandHelp commandHelp = residentRunner.commandHelp;
-
-            // supports service protocol
-            expect(residentRunner.supportsServiceProtocol, true);
-            // isRunningDebug
-            expect(residentRunner.isRunningDebug, true);
-            // does support SkSL
-            expect(residentRunner.supportsWriteSkSL, true);
-            // commands
-            expect(
-                testLogger.statusText,
-                equals(<dynamic>[
-                  'Flutter run key commands.',
-                  commandHelp.r,
-                  commandHelp.R,
-                  commandHelp.v,
-                  commandHelp.s,
-                  commandHelp.w,
-                  commandHelp.t,
-                  commandHelp.L,
-                  commandHelp.f,
-                  commandHelp.S,
-                  commandHelp.U,
-                  commandHelp.i,
-                  commandHelp.p,
-                  commandHelp.I,
-                  commandHelp.o,
-                  commandHelp.b,
-                  commandHelp.P,
-                  commandHelp.a,
-                  commandHelp.M,
-                  commandHelp.g,
-                  commandHelp.hWithDetails,
-                  commandHelp.c,
-                  commandHelp.q,
-                  '',
-                  'A Dart VM Service on FakeDevice is available at: null',
-                  '',
-                ].join('\n')));
-          }));
-
-  testUsingContext(
-      'ResidentRunner printHelp hot runner',
-      () => testbed.run(() {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
-            residentRunner.printHelp(details: false);
-
-            final CommandHelp commandHelp = residentRunner.commandHelp;
-
-            // supports service protocol
-            expect(residentRunner.supportsServiceProtocol, true);
-            // isRunningDebug
-            expect(residentRunner.isRunningDebug, true);
-            // does support SkSL
-            expect(residentRunner.supportsWriteSkSL, true);
-            // commands
-            expect(
-                testLogger.statusText,
-                equals(<dynamic>[
-                  'Flutter run key commands.',
-                  commandHelp.r,
-                  commandHelp.R,
-                  commandHelp.hWithoutDetails,
-                  commandHelp.c,
-                  commandHelp.q,
-                  '',
-                  'A Dart VM Service on FakeDevice is available at: null',
-                  '',
-                ].join('\n')));
-          }));
-
-  testUsingContext(
-      'ResidentRunner printHelpDetails cold runner',
-      () => testbed.run(() {
-            fakeVmServiceHost = null;
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubpsecResolution: true,
-            );
-            residentRunner.printHelp(details: true);
-
-            final CommandHelp commandHelp = residentRunner.commandHelp;
-
-            // does not supports service protocol
-            expect(residentRunner.supportsServiceProtocol, false);
-            // isRunningDebug
-            expect(residentRunner.isRunningDebug, false);
-            // does support SkSL
-            expect(residentRunner.supportsWriteSkSL, false);
-            // commands
-            expect(
-                testLogger.statusText,
-                equals(<dynamic>[
-                  'Flutter run key commands.',
-                  commandHelp.v,
-                  commandHelp.s,
-                  commandHelp.hWithDetails,
-                  commandHelp.c,
-                  commandHelp.q,
-                  '',
-                ].join('\n')));
-          }));
-
-  testUsingContext(
-      'ResidentRunner printHelp cold runner',
-      () => testbed.run(() {
-            fakeVmServiceHost = null;
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubpsecResolution: true,
-            );
-            residentRunner.printHelp(details: false);
-
-            final CommandHelp commandHelp = residentRunner.commandHelp;
-
-            // does not supports service protocol
-            expect(residentRunner.supportsServiceProtocol, false);
-            // isRunningDebug
-            expect(residentRunner.isRunningDebug, false);
-            // does support SkSL
-            expect(residentRunner.supportsWriteSkSL, false);
-            // commands
-            expect(
-                testLogger.statusText,
-                equals(<dynamic>[
-                  'Flutter run key commands.',
-                  commandHelp.hWithoutDetails,
-                  commandHelp.c,
-                  commandHelp.q,
-                  '',
-                ].join('\n')));
-          }));
-
-  testUsingContext(
-      'ResidentRunner handles writeSkSL returning no data',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              FakeVmServiceRequest(
-                  method: kGetSkSLsMethod,
-                  args: <String, Object>{
-                    'viewId': fakeFlutterView.id,
-                  },
-                  jsonResponse: <String, Object>{
-                    'SkSLs': <String, Object>{},
-                  }),
-            ]);
-            await residentRunner.writeSkSL();
-
-            expect(testLogger.statusText, contains('No data was received'));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
-
-  testUsingContext(
-      'ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              FakeVmServiceRequest(
-                method: kGetSkSLsMethod,
-                args: <String, Object>{
-                  'viewId': fakeFlutterView.id,
-                },
-                jsonResponse: <String, Object>{
-                  'SkSLs': <String, Object>{
-                    'A': 'B',
-                  },
-                },
-              ),
-            ]);
-            await residentRunner.writeSkSL();
-
-            expect(testLogger.statusText, contains('flutter_01.sksl.json'));
-            expect(globals.fs.file('flutter_01.sksl.json'), exists);
-            expect(
-                json.decode(
-                    globals.fs.file('flutter_01.sksl.json').readAsStringSync()),
-                <String, Object>{
-                  'platform': 'android',
-                  'name': 'FakeDevice',
-                  'engineRevision': 'abcdefg',
-                  'data': <String, Object>{'A': 'B'},
-                });
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            FileSystemUtils: () => FileSystemUtils(
-                  fileSystem: globals.fs,
-                  platform: globals.platform,
-                ),
-            FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg'),
-          }));
-
-  testUsingContext(
-      'ResidentRunner ignores DevtoolsLauncher when attaching with enableDevTools: false - cold mode',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile,
-                  vmserviceOutFile: 'foo', enableDevTools: false),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              useImplicitPubpsecResolution: true,
-            );
-
-            final Future<int?> result = residentRunner.attach();
-            expect(await result, 0);
-          }));
-
-  testUsingContext(
-      'FlutterDevice can exit from a release mode isolate with no VmService',
-      () => testbed.run(() async {
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-            );
-
-            await flutterDevice.exitApps();
-
-            expect(device.appStopped, true);
-          }));
-
-  testUsingContext(
-      'FlutterDevice will exit an un-paused isolate using stopApp',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-            );
-            flutterDevice.vmService = fakeVmServiceHost!.vmService;
-
-            final Future<void> exitFuture = flutterDevice.exitApps();
-
-            await expectLater(exitFuture, completes);
-            expect(device.appStopped, true);
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
-
-  testUsingContext(
-      'HotRunner writes vm service file when providing debugging option',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
-                  vmserviceOutFile: 'foo'),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-
-            await residentRunner.run();
-
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-            expect(await globals.fs.file('foo').readAsString(),
-                testUri.toString());
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(globals.fs.path.join('build', 'cache.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup with dart defines',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                '',
-                treeShakeIcons: false,
-                dartDefines: <String>['a', 'b'],
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(globals.fs.path.join(
-                        'build', '187ef4436122d1cc2f40dc2b92f0eba0.cache.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup with null safety',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                '',
-                treeShakeIcons: false,
-                extraFrontEndOptions: <String>[
-                  '--enable-experiment=non-nullable'
-                ],
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(globals.fs.path.join('build', 'cache.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup with track-widget-creation',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(
-                        globals.fs.path.join('build', 'cache.dill.track.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner does not copy app.dill if a dillOutputPath is given',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              dillOutputPath: 'test',
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(globals.fs.file(globals.fs.path.join('build', 'cache.dill')),
-                isNot(exists));
-          }));
-
-  testUsingContext(
-      'HotRunner copies compiled app.dill to cache during startup with --track-widget-creation',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                '',
-                treeShakeIcons: false,
-                trackWidgetCreation: true,
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            residentRunner.artifactDirectory
-                .childFile('app.dill')
-                .writeAsStringSync('ABC');
-
-            await residentRunner.run();
-
-            expect(
-                await globals.fs
-                    .file(
-                        globals.fs.path.join('build', 'cache.dill.track.dill'))
-                    .readAsString(),
-                'ABC');
-          }));
-
-  testUsingContext(
-      'HotRunner calls device dispose',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-
-            await residentRunner.run();
-            expect(device.disposed, true);
-          }));
-
-  testUsingContext(
-      'HotRunner handles failure to write vmservice file',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
-                  vmserviceOutFile: 'foo'),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-
-            await residentRunner.run();
-
-            expect(testLogger.errorText,
-                contains('Failed to write vmservice-out-file at foo'));
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }, overrides: <Type, Generator>{
-            FileSystem: () =>
-                ThrowingForwardingFileSystem(MemoryFileSystem.test()),
-          }));
-
-  testUsingContext(
-      'ColdRunner writes vm service file when providing debugging option',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-            ], wsAddress: testUri);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = ColdRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile,
-                  vmserviceOutFile: 'foo'),
-              devtoolsHandler: createNoOpHandler,
-              target: 'main.dart',
-              useImplicitPubpsecResolution: true,
-            );
-
-            await residentRunner.run();
-
-            expect(await globals.fs.file('foo').readAsString(),
-                testUri.toString());
-            expect(fakeVmServiceHost?.hasRemainingExpectations, false);
-          }));
-
-  testUsingContext(
-      'FlutterDevice uses dartdevc configuration when targeting web', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device =
-        FakeDevice(targetPlatform: TargetPlatform.web_javascript);
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    flutterDevice.generator = residentCompiler;
+
+    await residentRunner.run();
+
+    final File generatedLocalizationsFile = globals.fs.directory('.dart_tool')
+      .childDirectory('flutter_gen')
+      .childDirectory('gen_l10n')
+      .childFile('app_localizations.dart');
+    expect(generatedLocalizationsFile.existsSync(), isTrue);
+
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
+  }));
+
+  testUsingContext('ResidentRunner printHelpDetails hot runner', () => testbed.run(() {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
+    residentRunner.printHelp(details: true);
+
+    final CommandHelp commandHelp = residentRunner.commandHelp;
+
+    // supports service protocol
+    expect(residentRunner.supportsServiceProtocol, true);
+    // isRunningDebug
+    expect(residentRunner.isRunningDebug, true);
+    // does support SkSL
+    expect(residentRunner.supportsWriteSkSL, true);
+    // commands
+    expect(testLogger.statusText, equals(
+        <dynamic>[
+          'Flutter run key commands.',
+          commandHelp.r,
+          commandHelp.R,
+          commandHelp.v,
+          commandHelp.s,
+          commandHelp.w,
+          commandHelp.t,
+          commandHelp.L,
+          commandHelp.f,
+          commandHelp.S,
+          commandHelp.U,
+          commandHelp.i,
+          commandHelp.p,
+          commandHelp.I,
+          commandHelp.o,
+          commandHelp.b,
+          commandHelp.P,
+          commandHelp.a,
+          commandHelp.M,
+          commandHelp.g,
+          commandHelp.hWithDetails,
+          commandHelp.c,
+          commandHelp.q,
+          '',
+          'A Dart VM Service on FakeDevice is available at: null',
+          '',
+        ].join('\n')
+    ));
+  }));
+
+  testUsingContext('ResidentRunner printHelp hot runner', () => testbed.run(() {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
+    residentRunner.printHelp(details: false);
+
+    final CommandHelp commandHelp = residentRunner.commandHelp;
+
+    // supports service protocol
+    expect(residentRunner.supportsServiceProtocol, true);
+    // isRunningDebug
+    expect(residentRunner.isRunningDebug, true);
+    // does support SkSL
+    expect(residentRunner.supportsWriteSkSL, true);
+    // commands
+    expect(testLogger.statusText, equals(
+        <dynamic>[
+          'Flutter run key commands.',
+          commandHelp.r,
+          commandHelp.R,
+          commandHelp.hWithoutDetails,
+          commandHelp.c,
+          commandHelp.q,
+          '',
+          'A Dart VM Service on FakeDevice is available at: null',
+          '',
+        ].join('\n')
+    ));
+  }));
+
+  testUsingContext('ResidentRunner printHelpDetails cold runner', () => testbed.run(() {
+    fakeVmServiceHost = null;
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+    );
+    residentRunner.printHelp(details: true);
+
+    final CommandHelp commandHelp = residentRunner.commandHelp;
+
+    // does not supports service protocol
+    expect(residentRunner.supportsServiceProtocol, false);
+    // isRunningDebug
+    expect(residentRunner.isRunningDebug, false);
+    // does support SkSL
+    expect(residentRunner.supportsWriteSkSL, false);
+    // commands
+    expect(testLogger.statusText, equals(
+        <dynamic>[
+          'Flutter run key commands.',
+          commandHelp.v,
+          commandHelp.s,
+          commandHelp.hWithDetails,
+          commandHelp.c,
+          commandHelp.q,
+          '',
+        ].join('\n')
+    ));
+  }));
+
+  testUsingContext('ResidentRunner printHelp cold runner', () => testbed.run(() {
+    fakeVmServiceHost = null;
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+    );
+    residentRunner.printHelp(details: false);
+
+    final CommandHelp commandHelp = residentRunner.commandHelp;
+
+    // does not supports service protocol
+    expect(residentRunner.supportsServiceProtocol, false);
+    // isRunningDebug
+    expect(residentRunner.isRunningDebug, false);
+    // does support SkSL
+    expect(residentRunner.supportsWriteSkSL, false);
+    // commands
+    expect(testLogger.statusText, equals(
+        <dynamic>[
+          'Flutter run key commands.',
+          commandHelp.hWithoutDetails,
+          commandHelp.c,
+          commandHelp.q,
+          '',
+        ].join('\n')
+    ));
+  }));
+
+  testUsingContext('ResidentRunner handles writeSkSL returning no data', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      FakeVmServiceRequest(
+        method: kGetSkSLsMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+        },
+        jsonResponse: <String, Object>{
+          'SkSLs': <String, Object>{},
+        }
+      ),
+    ]);
+    await residentRunner.writeSkSL();
+
+    expect(testLogger.statusText, contains('No data was received'));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
+
+  testUsingContext('ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      FakeVmServiceRequest(
+        method: kGetSkSLsMethod,
+        args: <String, Object>{
+          'viewId': fakeFlutterView.id,
+        },
+        jsonResponse: <String, Object>{
+          'SkSLs': <String, Object>{
+            'A': 'B',
+          },
+        },
+      ),
+    ]);
+    await residentRunner.writeSkSL();
+
+    expect(testLogger.statusText, contains('flutter_01.sksl.json'));
+    expect(globals.fs.file('flutter_01.sksl.json'), exists);
+    expect(json.decode(globals.fs.file('flutter_01.sksl.json').readAsStringSync()), <String, Object>{
+      'platform': 'android',
+      'name': 'FakeDevice',
+      'engineRevision': 'abcdefg',
+      'data': <String, Object>{'A': 'B'},
+    });
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    FileSystemUtils: () => FileSystemUtils(
+      fileSystem: globals.fs,
+      platform: globals.platform,
+    ),
+    FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg'),
+  }));
+
+  testUsingContext('ResidentRunner ignores DevtoolsLauncher when attaching with enableDevTools: false - cold mode', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo', enableDevTools: false),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+    );
+
+    final Future<int?> result = residentRunner.attach();
+    expect(await result, 0);
+  }));
+
+  testUsingContext('FlutterDevice can exit from a release mode isolate with no VmService', () => testbed.run(() async {
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+    );
+
+    await flutterDevice.exitApps();
+
+    expect(device.appStopped, true);
+  }));
+
+  testUsingContext('FlutterDevice will exit an un-paused isolate using stopApp', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+    );
+    flutterDevice.vmService = fakeVmServiceHost!.vmService;
+
+    final Future<void> exitFuture = flutterDevice.exitApps();
+
+    await expectLater(exitFuture, completes);
+    expect(device.appStopped, true);
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
+
+  testUsingContext('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+
+    await residentRunner.run();
+
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+    expect(await globals.fs.file('foo').readAsString(), testUri.toString());
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(
+        const BuildInfo(
+          BuildMode.debug,
+          null,
+          treeShakeIcons: false,
+          packageConfigPath: '.dart_tool/package_config.json',
+        )
+      ),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with dart defines', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(
+        const BuildInfo(
+          BuildMode.debug,
+          '',
+          treeShakeIcons: false,
+          dartDefines: <String>['a', 'b'],
+          packageConfigPath: '.dart_tool/package_config.json',
+        )
+      ),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join(
+      'build', '187ef4436122d1cc2f40dc2b92f0eba0.cache.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with null safety', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(
+        const BuildInfo(
+          BuildMode.debug,
+          '',
+          treeShakeIcons: false,
+          extraFrontEndOptions: <String>['--enable-experiment=non-nullable'],
+          packageConfigPath: '.dart_tool/package_config.json',
+        )
+      ),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join(
+      'build', 'cache.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with track-widget-creation', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join(
+      'build', 'cache.dill.track.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner does not copy app.dill if a dillOutputPath is given', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      dillOutputPath: 'test',
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(globals.fs.file(globals.fs.path.join('build', 'cache.dill')), isNot(exists));
+  }));
+
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with --track-widget-creation', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+        trackWidgetCreation: true,
+        packageConfigPath: '.dart_tool/package_config.json',
+      )),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill.track.dill')).readAsString(), 'ABC');
+  }));
+
+  testUsingContext('HotRunner calls device dispose', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+
+    await residentRunner.run();
+    expect(device.disposed, true);
+  }));
+
+  testUsingContext('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+
+    await residentRunner.run();
+
+    expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem.test()),
+  }));
+
+  testUsingContext('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+    ], wsAddress: testUri);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = ColdRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo'),
+      devtoolsHandler: createNoOpHandler,
+      target: 'main.dart',
+    );
+
+    await residentRunner.run();
+
+    expect(await globals.fs.file('foo').readAsString(), testUri.toString());
+    expect(fakeVmServiceHost?.hasRemainingExpectations, false);
+  }));
+
+  testUsingContext('FlutterDevice uses dartdevc configuration when targeting web', () async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -2089,40 +1783,28 @@ flutter:
       ),
       target: null,
       platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+    )).generator as DefaultResidentCompiler?;
 
-    expect(
-        residentCompiler!.initializeFromDill,
-        globals.fs.path.join(getBuildDirectory(),
-            'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'));
-    expect(
-        residentCompiler.librariesSpec,
-        globals.fs
-            .file(globals.artifacts!
-                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-            .uri
-            .toString());
+    expect(residentCompiler!.initializeFromDill,
+      globals.fs.path.join(getBuildDirectory(), 'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'));
+    expect(residentCompiler.librariesSpec,
+      globals.fs.file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+        .uri.toString());
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
-        '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill,
-        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill');
+      '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
+    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected',
-      () async {
+  testUsingContext('FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device =
-        FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -2133,38 +1815,29 @@ flutter:
       ),
       target: null,
       platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+    )).generator as DefaultResidentCompiler?;
 
-    expect(
-        residentCompiler!.initializeFromDill,
-        globals.fs.path.join(getBuildDirectory(),
-            '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
-    expect(
-        residentCompiler.librariesSpec,
-        globals.fs
-            .file(globals.artifacts!
-                .getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-            .uri
-            .toString());
+    expect(residentCompiler!.initializeFromDill,
+      globals.fs.path.join(getBuildDirectory(), '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
+    expect(residentCompiler.librariesSpec,
+      globals.fs.file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
+        .uri.toString());
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
-        '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill,
-        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill');
+      '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
+    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice passes alternative-invalidation-strategy flag', () async {
+  testUsingContext('FlutterDevice passes alternative-invalidation-strategy flag', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -2173,27 +1846,22 @@ flutter:
         extraFrontEndOptions: <String>[],
         packageConfigPath: '.dart_tool/package_config.json',
       ),
-      target: null,
-      platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+      target: null, platform: FakePlatform(),
+    )).generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.extraFrontEndOptions,
-        contains('--enable-experiment=alternative-invalidation-strategy'));
+      contains('--enable-experiment=alternative-invalidation-strategy'));
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice passes initializeFromDill parameter if specified',
-      () async {
+  testUsingContext('FlutterDevice passes initializeFromDill parameter if specified', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
       buildInfo: const BuildInfo(
         BuildMode.debug,
@@ -2203,10 +1871,8 @@ flutter:
         initializeFromDill: '/foo/bar.dill',
         packageConfigPath: '.dart_tool/package_config.json',
       ),
-      target: null,
-      platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+      target: null, platform: FakePlatform(),
+    )).generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.initializeFromDill, '/foo/bar.dill');
     expect(residentCompiler.assumeInitializeFromDillUpToDate, false);
@@ -2216,24 +1882,22 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice passes assumeInitializeFromDillUpToDate parameter if specified',
-      () async {
+   testUsingContext('FlutterDevice passes assumeInitializeFromDillUpToDate parameter if specified', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
-      buildInfo: const BuildInfo(BuildMode.debug, '',
-          treeShakeIcons: false,
-          extraFrontEndOptions: <String>[],
-          assumeInitializeFromDillUpToDate: true,
-          packageConfigPath: '.dart_tool/package_config.json'),
-      target: null,
-      platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+      buildInfo: const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+        extraFrontEndOptions: <String>[],
+        assumeInitializeFromDillUpToDate: true,
+        packageConfigPath: '.dart_tool/package_config.json'
+      ),
+      target: null, platform: FakePlatform(),
+    )).generator as DefaultResidentCompiler?;
 
     expect(residentCompiler!.assumeInitializeFromDillUpToDate, true);
   }, overrides: <Type, Generator>{
@@ -2242,35 +1906,30 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice passes frontendServerStarterPath parameter if specified',
-      () async {
+  testUsingContext('FlutterDevice passes frontendServerStarterPath parameter if specified', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice();
 
-    final DefaultResidentCompiler? residentCompiler =
-        (await FlutterDevice.create(
+    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
       device,
-      buildInfo: const BuildInfo(BuildMode.debug, '',
-          treeShakeIcons: false,
-          frontendServerStarterPath: '/foo/bar/frontend_server_starter.dart',
-          packageConfigPath: '.dart_tool/package_config.json'),
-      target: null,
-      platform: FakePlatform(),
-    ))
-            .generator as DefaultResidentCompiler?;
+      buildInfo: const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+        frontendServerStarterPath: '/foo/bar/frontend_server_starter.dart',
+        packageConfigPath: '.dart_tool/package_config.json'
+      ),
+      target: null, platform: FakePlatform(),
+    )).generator as DefaultResidentCompiler?;
 
-    expect(residentCompiler!.frontendServerStarterPath,
-        '/foo/bar/frontend_server_starter.dart');
+    expect(residentCompiler!.frontendServerStarterPath, '/foo/bar/frontend_server_starter.dart');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection',
-      () async {
+  testUsingContext('FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection', () async {
     fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         const FakeVmServiceRequest(
@@ -2307,189 +1966,160 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext(
-      'Uses existing DDS URI from exception field',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final FakeDevice device = FakeDevice()
-              ..dds = DartDevelopmentService(logger: testLogger);
-            ddsLauncherCallback = ({
-              required Uri remoteVmServiceUri,
-              Uri? serviceUri,
-              bool enableAuthCodes = true,
-              bool serveDevTools = false,
-              Uri? devToolsServerAddress,
-              bool enableServicePortFallback = false,
-              List<String> cachedUserTags = const <String>[],
-              String? dartExecutable,
-              String? google3WorkspaceRoot,
-            }) {
-              throw DartDevelopmentServiceException.existingDdsInstance(
-                'Existing DDS at http://localhost/existingDdsInMessage.',
-                ddsUri: Uri.parse('http://localhost/existingDdsInField'),
-              );
-            };
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-              vmServiceUris: Stream<Uri>.value(testUri),
-            );
-            final Completer<void> done = Completer<void>();
-            unawaited(runZonedGuarded(
-              () => flutterDevice
-                  .connect(
-                    allowExistingDdsInstance: true,
-                    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-                  )
-                  .then((_) => done.complete()),
-              (_, __) => done.complete(),
-            ));
-            await done.future;
-            expect(device.dds.uri,
-                Uri.parse('http://localhost/existingDdsInField'));
-          }, overrides: <Type, Generator>{
-            VMServiceConnector: () => (
-                  Uri httpUri, {
-                  ReloadSources? reloadSources,
-                  Restart? restart,
-                  CompileExpression? compileExpression,
-                  GetSkSLMethod? getSkSLMethod,
-                  FlutterProject? flutterProject,
-                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-                  io.CompressionOptions? compression,
-                  Device? device,
-                  required Logger logger,
-                }) async =>
-                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
-                        .vmService,
-          }));
+  testUsingContext('Uses existing DDS URI from exception field', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeDevice device = FakeDevice()
+      ..dds = DartDevelopmentService(logger: testLogger);
+    ddsLauncherCallback = ({
+      required Uri remoteVmServiceUri,
+      Uri? serviceUri,
+      bool enableAuthCodes = true,
+      bool serveDevTools = false,
+      Uri? devToolsServerAddress,
+      bool enableServicePortFallback = false,
+      List<String> cachedUserTags = const <String>[],
+      String? dartExecutable,
+      String? google3WorkspaceRoot,
+    }) {
+      throw DartDevelopmentServiceException.existingDdsInstance(
+        'Existing DDS at http://localhost/existingDdsInMessage.',
+        ddsUri: Uri.parse('http://localhost/existingDdsInField'),
+      );
+    };
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+      vmServiceUris: Stream<Uri>.value(testUri),
+    );
+    final Completer<void> done = Completer<void>();
+    unawaited(runZonedGuarded(
+      () => flutterDevice.connect(
+        allowExistingDdsInstance: true,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ).then((_) => done.complete()),
+      (_, __) => done.complete(),
+    ));
+    await done.future;
+    expect(device.dds.uri, Uri.parse('http://localhost/existingDdsInField'));
+  }, overrides: <Type, Generator>{
+    VMServiceConnector: () => (Uri httpUri, {
+      ReloadSources? reloadSources,
+      Restart? restart,
+      CompileExpression? compileExpression,
+      GetSkSLMethod? getSkSLMethod,
+      FlutterProject? flutterProject,
+    PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+      io.CompressionOptions? compression,
+      Device? device,
+      required Logger logger,
+    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
+  }));
 
-  testUsingContext(
-      'Host VM service ipv6 defaults',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            final FakeDevice device = FakeDevice()
-              ..dds = DartDevelopmentService(logger: testLogger);
-            final Completer<void> done = Completer<void>();
-            ddsLauncherCallback = ({
-              required Uri remoteVmServiceUri,
-              Uri? serviceUri,
-              bool enableAuthCodes = true,
-              bool serveDevTools = false,
-              Uri? devToolsServerAddress,
-              bool enableServicePortFallback = false,
-              List<String> cachedUserTags = const <String>[],
-              String? dartExecutable,
-              String? google3WorkspaceRoot,
-            }) async {
-              expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
-              expect(enableAuthCodes, isFalse);
-              expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
-              expect(cachedUserTags, isEmpty);
-              done.complete();
-              return FakeDartDevelopmentServiceLauncher(
-                  uri: remoteVmServiceUri);
-            };
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-              vmServiceUris: Stream<Uri>.value(testUri),
-            );
-            await flutterDevice.connect(
-                allowExistingDdsInstance: true,
-                debuggingOptions: DebuggingOptions.enabled(
-                  BuildInfo.debug,
-                  disableServiceAuthCodes: true,
-                  ipv6: true,
-                ));
-            await done.future;
-          }, overrides: <Type, Generator>{
-            VMServiceConnector: () => (
-                  Uri httpUri, {
-                  ReloadSources? reloadSources,
-                  Restart? restart,
-                  CompileExpression? compileExpression,
-                  GetSkSLMethod? getSkSLMethod,
-                  FlutterProject? flutterProject,
-                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-                  io.CompressionOptions? compression,
-                  Device? device,
-                  required Logger logger,
-                }) async =>
-                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
-                        .vmService,
-          }));
+  testUsingContext('Host VM service ipv6 defaults', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeDevice device = FakeDevice()
+      ..dds = DartDevelopmentService(logger: testLogger);
+    final Completer<void>done = Completer<void>();
+    ddsLauncherCallback = ({
+        required Uri remoteVmServiceUri,
+        Uri? serviceUri,
+        bool enableAuthCodes = true,
+        bool serveDevTools = false,
+        Uri? devToolsServerAddress,
+        bool enableServicePortFallback = false,
+        List<String> cachedUserTags = const <String>[],
+        String? dartExecutable,
+        String? google3WorkspaceRoot,
+      }) async {
+      expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
+      expect(enableAuthCodes, isFalse);
+      expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
+      expect(cachedUserTags, isEmpty);
+      done.complete();
+      return FakeDartDevelopmentServiceLauncher(uri: remoteVmServiceUri);
+    };
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+      vmServiceUris: Stream<Uri>.value(testUri),
+    );
+    await flutterDevice.connect(
+      allowExistingDdsInstance: true,
+      debuggingOptions: DebuggingOptions.enabled(
+        BuildInfo.debug, disableServiceAuthCodes: true, ipv6: true,
+      )
+    );
+    await done.future;
+  }, overrides: <Type, Generator>{
+    VMServiceConnector: () => (Uri httpUri, {
+      ReloadSources? reloadSources,
+      Restart? restart,
+      CompileExpression? compileExpression,
+      GetSkSLMethod? getSkSLMethod,
+      FlutterProject? flutterProject,
+      PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+      io.CompressionOptions? compression,
+      Device? device,
+      required Logger logger,
+    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
+  }));
 
-  testUsingContext(
-      'Failed DDS start outputs error message',
-      () => testbed.run(() async {
-            // See https://github.com/flutter/flutter/issues/72385 for context.
-            final FakeDevice device = FakeDevice()
-              ..dds = DartDevelopmentService(logger: testLogger);
-            ddsLauncherCallback = ({
-              required Uri remoteVmServiceUri,
-              Uri? serviceUri,
-              bool enableAuthCodes = true,
-              bool serveDevTools = false,
-              Uri? devToolsServerAddress,
-              bool enableServicePortFallback = false,
-              List<String> cachedUserTags = const <String>[],
-              String? dartExecutable,
-              String? google3WorkspaceRoot,
-            }) {
-              expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
-              expect(enableAuthCodes, isTrue);
-              expect(
-                  serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
-              expect(cachedUserTags, isEmpty);
-              throw FakeDartDevelopmentServiceException(message: 'No URI');
-            };
-            final TestFlutterDevice flutterDevice = TestFlutterDevice(
-              device,
-              vmServiceUris: Stream<Uri>.value(testUri),
-            );
-            bool caught = false;
-            final Completer<void> done = Completer<void>();
-            runZonedGuarded(() {
-              flutterDevice
-                  .connect(
-                    allowExistingDdsInstance: true,
-                    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
-                        enableDevTools: false),
-                  )
-                  .then((_) => done.complete());
-            }, (Object e, StackTrace st) {
-              expect(e, isA<StateError>());
-              expect((e as StateError).message, contains('No URI'));
-              expect(
-                  testLogger.errorText,
-                  contains(
-                    'DDS has failed to start and there is not an existing DDS instance',
-                  ));
-              done.complete();
-              caught = true;
-            });
-            await done.future;
-            if (!caught) {
-              fail('Expected a StateError to be thrown.');
-            }
-          }, overrides: <Type, Generator>{
-            VMServiceConnector: () => (
-                  Uri httpUri, {
-                  ReloadSources? reloadSources,
-                  Restart? restart,
-                  CompileExpression? compileExpression,
-                  GetSkSLMethod? getSkSLMethod,
-                  FlutterProject? flutterProject,
-                  PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
-                  io.CompressionOptions compression =
-                      io.CompressionOptions.compressionDefault,
-                  Device? device,
-                  required Logger logger,
-                }) async =>
-                    FakeVmServiceHost(requests: <VmServiceExpectation>[])
-                        .vmService,
-          }));
+  testUsingContext('Failed DDS start outputs error message', () => testbed.run(() async {
+    // See https://github.com/flutter/flutter/issues/72385 for context.
+    final FakeDevice device = FakeDevice()
+      ..dds = DartDevelopmentService(logger: testLogger);
+    ddsLauncherCallback = ({
+        required Uri remoteVmServiceUri,
+        Uri? serviceUri,
+        bool enableAuthCodes = true,
+        bool serveDevTools = false,
+        Uri? devToolsServerAddress,
+        bool enableServicePortFallback = false,
+        List<String> cachedUserTags = const <String>[],
+        String? dartExecutable,
+        String? google3WorkspaceRoot,
+      }) {
+      expect(remoteVmServiceUri, Uri(scheme: 'foo', host: 'bar'));
+      expect(enableAuthCodes, isTrue);
+      expect(serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
+      expect(cachedUserTags, isEmpty);
+      throw FakeDartDevelopmentServiceException(message: 'No URI');
+    };
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      device,
+      vmServiceUris: Stream<Uri>.value(testUri),
+    );
+    bool caught = false;
+    final Completer<void>done = Completer<void>();
+    runZonedGuarded(() {
+      flutterDevice.connect(
+        allowExistingDdsInstance: true,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, enableDevTools: false),
+      ).then((_) => done.complete());
+    }, (Object e, StackTrace st) {
+      expect(e, isA<StateError>());
+      expect((e as StateError).message, contains('No URI'));
+      expect(testLogger.errorText, contains(
+        'DDS has failed to start and there is not an existing DDS instance',
+      ));
+      done.complete();
+      caught = true;
+    });
+    await done.future;
+    if (!caught) {
+      fail('Expected a StateError to be thrown.');
+    }
+  }, overrides: <Type, Generator>{
+    VMServiceConnector: () => (Uri httpUri, {
+      ReloadSources? reloadSources,
+      Restart? restart,
+      CompileExpression? compileExpression,
+      GetSkSLMethod? getSkSLMethod,
+      FlutterProject? flutterProject,
+      PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+      io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
+      Device? device,
+      required Logger logger,
+    }) async => FakeVmServiceHost(requests: <VmServiceExpectation>[]).vmService,
+  }));
 
   testUsingContext('nextPlatform moves through expected platforms', () {
     expect(nextPlatform('android'), 'iOS');
@@ -2502,199 +2132,166 @@ flutter:
   });
 
   // TODO(bkonyi): remove when ready to serve DevTools from DDS.
-  testUsingContext(
-      'cleanupAtFinish shuts down resident devtools handler',
-      () => testbed.run(() async {
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug,
-                  vmserviceOutFile: 'foo'),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
-            await residentRunner.cleanupAtFinish();
+  testUsingContext('cleanupAtFinish shuts down resident devtools handler', () => testbed.run(() async {
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
+    await residentRunner.cleanupAtFinish();
 
-            expect(
-                (residentRunner.residentDevtoolsHandler! as NoOpDevtoolsHandler)
-                    .wasShutdown,
-                true);
-          }));
+    expect((residentRunner.residentDevtoolsHandler! as NoOpDevtoolsHandler).wasShutdown, true);
+  }));
 
-  testUsingContext(
-      'HotRunner sets asset directory when first evict assets',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              setAssetBundlePath,
-              evict,
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
+  testUsingContext('HotRunner sets asset directory when first evict assets', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      setAssetBundlePath,
+      evict,
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
 
-            (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{
-              'asset'
-            };
+    (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{'asset'};
 
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, isFalse);
-            await (residentRunner as HotRunner).evictDirtyAssets();
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, isTrue);
-            expect(fakeVmServiceHost!.hasRemainingExpectations, isFalse);
-          }));
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, isFalse);
+    await (residentRunner as HotRunner).evictDirtyAssets();
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, isTrue);
+    expect(fakeVmServiceHost!.hasRemainingExpectations, isFalse);
+  }));
 
-  testUsingContext(
-      'HotRunner sets asset directory when first evict shaders',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              setAssetBundlePath,
-              evictShader,
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
+  testUsingContext('HotRunner sets asset directory when first evict shaders', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      setAssetBundlePath,
+      evictShader,
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
 
-            (flutterDevice.devFS! as FakeDevFS).shaderPathsToEvict = <String>{
-              'foo.frag'
-            };
+    (flutterDevice.devFS! as FakeDevFS).shaderPathsToEvict = <String>{'foo.frag'};
 
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-            await (residentRunner as HotRunner).evictDirtyAssets();
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
-            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-          }));
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+    await (residentRunner as HotRunner).evictDirtyAssets();
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
+    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'HotRunner does not sets asset directory when no assets to evict',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
+  testUsingContext('HotRunner does not sets asset directory when no assets to evict', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
 
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-            await (residentRunner as HotRunner).evictDirtyAssets();
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
-            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-          }));
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+    await (residentRunner as HotRunner).evictDirtyAssets();
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, false);
+    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+  }));
 
-  testUsingContext(
-      'HotRunner does not set asset directory if it has been set before',
-      () => testbed.run(() async {
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              evict,
-            ]);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: fakeAnalytics,
-              useImplicitPubspecResolution: true,
-            );
+  testUsingContext('HotRunner does not set asset directory if it has been set before', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      evict,
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+      analytics: fakeAnalytics,
+    );
 
-            (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{
-              'asset'
-            };
-            flutterDevice.devFS!.hasSetAssetDirectory = true;
+    (flutterDevice.devFS! as FakeDevFS).assetPathsToEvict = <String>{'asset'};
+    flutterDevice.devFS!.hasSetAssetDirectory = true;
 
-            await (residentRunner as HotRunner).evictDirtyAssets();
-            expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
-            expect(fakeVmServiceHost!.hasRemainingExpectations, false);
-          }));
+    await (residentRunner as HotRunner).evictDirtyAssets();
+    expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
+    expect(fakeVmServiceHost!.hasRemainingExpectations, false);
+  }));
 
   testUsingContext(
       'use the nativeAssetsYamlFile when provided',
       () => testbed.run(() async {
-            final FakeDevice device = FakeDevice(
-              targetPlatform: TargetPlatform.darwin,
-              sdkNameAndVersion: 'Macos',
-            );
-            final FakeResidentCompiler residentCompiler =
-                FakeResidentCompiler();
-            final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
-              ..testUri = testUri
-              ..vmServiceHost = (() => fakeVmServiceHost)
-              ..device = device
-              ..fakeDevFS = devFS
-              ..targetPlatform = TargetPlatform.darwin
-              ..generator = residentCompiler;
+        final FakeDevice device = FakeDevice(
+          targetPlatform: TargetPlatform.darwin,
+          sdkNameAndVersion: 'Macos',
+        );
+        final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
+        final FakeFlutterDevice flutterDevice = FakeFlutterDevice()
+          ..testUri = testUri
+          ..vmServiceHost = (() => fakeVmServiceHost)
+          ..device = device
+          ..fakeDevFS = devFS
+          ..targetPlatform = TargetPlatform.darwin
+          ..generator = residentCompiler;
 
-            fakeVmServiceHost =
-                FakeVmServiceHost(requests: <VmServiceExpectation>[
-              listViews,
-              listViews,
-            ]);
-            globals.fs
-                .file(globals.fs.path.join('lib', 'main.dart'))
-                .createSync(recursive: true);
-            residentRunner = HotRunner(
-              <FlutterDevice>[
-                flutterDevice,
-              ],
-              stayResident: false,
-              debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
-                BuildMode.debug,
-                '',
-                treeShakeIcons: false,
-                trackWidgetCreation: true,
-                packageConfigPath: '.dart_tool/package_config.json',
-              )),
-              target: 'main.dart',
-              devtoolsHandler: createNoOpHandler,
-              analytics: globals.analytics,
-              nativeAssetsYamlFile: 'foo.yaml',
-              useImplicitPubspecResolution: true,
-            );
+        fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+          listViews,
+          listViews,
+        ]);
+        globals.fs
+            .file(globals.fs.path.join('lib', 'main.dart'))
+            .createSync(recursive: true);
+        residentRunner = HotRunner(
+          <FlutterDevice>[
+            flutterDevice,
+          ],
+          stayResident: false,
+          debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+            BuildMode.debug,
+            '',
+            treeShakeIcons: false,
+            trackWidgetCreation: true,
+            packageConfigPath: '.dart_tool/package_config.json',
+          )),
+          target: 'main.dart',
+          devtoolsHandler: createNoOpHandler,
+          analytics: globals.analytics,
+          nativeAssetsYamlFile: 'foo.yaml',
+        );
 
-            final int? result = await residentRunner.run();
-            expect(result, 0);
+        final int? result = await residentRunner.run();
+        expect(result, 0);
 
-            expect(residentCompiler.recompileCalled, true);
-            expect(residentCompiler.receivedNativeAssetsYaml,
-                globals.fs.path.toUri('foo.yaml'));
-          }),
+        expect(residentCompiler.recompileCalled, true);
+        expect(residentCompiler.receivedNativeAssetsYaml, globals.fs.path.toUri('foo.yaml'));
+      }),
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () =>
-            TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
+        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true, isMacOSEnabled: true),
       });
 }
 

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -61,6 +61,7 @@ void main() {
         fs: fileSystem,
         fakeFlutterVersion: FakeFlutterVersion(),
       ),
+      useImplicitPubspecResolution: true,
     );
 
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
@@ -91,6 +92,7 @@ void main() {
         fs: fileSystem,
         fakeFlutterVersion: FakeFlutterVersion(),
       ),
+      useImplicitPubspecResolution: true,
     );
 
     expect(() => residentWebRunner.run(), throwsToolExit());
@@ -116,6 +118,7 @@ void main() {
         fs: fileSystem,
         fakeFlutterVersion: FakeFlutterVersion(),
       ),
+      useImplicitPubspecResolution: true,
     );
 
     expect(() async => residentWebRunner.run(), throwsException);
@@ -140,6 +143,7 @@ void main() {
         fs: fileSystem,
         fakeFlutterVersion: FakeFlutterVersion(),
       ),
+      useImplicitPubspecResolution: true,
     );
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
     unawaited(residentWebRunner.run(
@@ -169,6 +173,7 @@ void main() {
         fs: fileSystem,
         fakeFlutterVersion: FakeFlutterVersion(),
       ),
+      useImplicitPubspecResolution: true,
     );
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
     unawaited(residentWebRunner.run(

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -170,6 +170,7 @@ void main() {
       usage: globals.flutterUsage,
       analytics: globals.analytics,
       systemClock: globals.systemClock,
+      useImplicitPubspecResolution: true,
     );
 
     expect(profileResidentWebRunner.debuggingEnabled, false);
@@ -202,6 +203,7 @@ void main() {
       usage: globals.flutterUsage,
       analytics: globals.analytics,
       systemClock: globals.systemClock,
+      useImplicitPubspecResolution: true,
     );
 
     expect(profileResidentWebRunner.uri, webDevFS.baseUri);
@@ -221,6 +223,7 @@ void main() {
       usage: globals.flutterUsage,
       analytics: globals.analytics,
       systemClock: globals.systemClock,
+      useImplicitPubspecResolution: true,
     );
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     flutterDevice.device = chromeDevice;
@@ -234,6 +237,7 @@ void main() {
       usage: globals.flutterUsage,
       analytics: globals.analytics,
       systemClock: globals.systemClock,
+      useImplicitPubspecResolution: true,
     );
 
     expect(profileResidentWebRunner.supportsServiceProtocol, false);
@@ -368,6 +372,7 @@ void main() {
       analytics: globals.analytics,
       systemClock: globals.systemClock,
       devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
     );
 
     expect(await residentWebRunner.run(), 0);
@@ -395,6 +400,7 @@ void main() {
       analytics: globals.analytics,
       systemClock: globals.systemClock,
       devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
     );
 
     expect(await residentWebRunner.run(), 0);
@@ -596,6 +602,7 @@ void main() {
       analytics: globals.analytics,
       systemClock: globals.systemClock,
       devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
     );
     fakeVmServiceHost =
         FakeVmServiceHost(requests: kAttachExpectations.toList());
@@ -1120,6 +1127,7 @@ void main() {
       analytics: globals.analytics,
       systemClock: globals.systemClock,
       devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
     );
 
     final Completer<DebugConnectionInfo> connectionInfoCompleter =
@@ -1169,6 +1177,7 @@ void main() {
       analytics: globals.analytics,
       systemClock: globals.systemClock,
       devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
     );
 
     final Completer<DebugConnectionInfo> connectionInfoCompleter =
@@ -1212,6 +1221,7 @@ void main() {
       analytics: globals.analytics,
       systemClock: globals.systemClock,
       devtoolsHandler: createNoOpHandler,
+      useImplicitPubspecResolution: true,
     );
 
     // Create necessary files.
@@ -1468,6 +1478,7 @@ ResidentRunner setUpResidentRunner(
     fileSystem: globals.fs,
     logger: logger ?? BufferLogger.test(),
     devtoolsHandler: createNoOpHandler,
+    useImplicitPubspecResolution: true,
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -98,6 +98,7 @@ void main() {
         artifacts: Artifacts.test(),
         logger: BufferLogger.test(),
         flutterVersion: FakeFlutterVersion(),
+        useImplicitPubspecResolution: true,
       );
       logLines = <String>[];
       device.getLogReader().logLines.listen(logLines.add);
@@ -217,6 +218,7 @@ FlutterTesterDevices setUpFlutterTesterDevices() {
     processManager: FakeProcessManager.any(),
     fileSystem: MemoryFileSystem.test(),
     flutterVersion: FakeFlutterVersion(),
+    useImplicitPubspecResolution: true,
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/web/compile_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/compile_web_test.dart
@@ -70,6 +70,7 @@ void main() {
       flutterVersion: flutterVersion,
       fileSystem: fileSystem,
       analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
     );
     await webBuilder.buildWeb(
       flutterProject,
@@ -160,6 +161,7 @@ void main() {
       flutterVersion: flutterVersion,
       fileSystem: fileSystem,
       analytics: fakeAnalytics,
+      useImplicitPubspecResolution: true,
     );
     await expectLater(
         () async => webBuilder.buildWeb(

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -183,7 +183,7 @@ void testUsingContext(
       // can provide the AlwaysFalseBotDetector in the overrides, or its own
       // BotDetector implementation in the overrides.
       BotDetector: overrides[BotDetector] ?? () => const FakeBotDetector(true),
-    });
+    }, useImplicitPubspecResolution: true);
   }, testOn: testOn, skip: skip);
   // We don't support "timeout"; see ../../dart_test.yaml which
   // configures all tests to have a 15 minute timeout which should

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -92,7 +92,7 @@ class Testbed {
   ///
   /// `overrides` may be used to provide new context values for the single test
   /// case or override any context values from the setup.
-  Future<T?> run<T>(FutureOr<T> Function() test, {Map<Type, Generator>? overrides}) {
+  Future<T?> run<T>(FutureOr<T> Function() test, {Map<Type, Generator>? overrides, bool useImplicitPubspecResolution = true}) {
     final Map<Type, Generator> testOverrides = <Type, Generator>{
       ..._testbedDefaults,
       // Add the initial setUp overrides
@@ -139,7 +139,7 @@ class Testbed {
             }
             return null;
           });
-      });
+      }, useImplicitPubspecResolution: useImplicitPubspecResolution);
     }, createHttpClient: (SecurityContext? c) => FakeHttpClient.any());
   }
 }

--- a/packages/flutter_tools/test/web.shard/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/web.shard/web_driver_service_test.dart
@@ -21,6 +21,7 @@ void main() {
         processManager: FakeProcessManager.empty(),
       ),
       dartSdkPath: 'dart',
+      useImplicitPubspecResolution: true,
     );
     const String link = 'https://flutter.dev/to/integration-test-on-web';
     try {


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/157819. **No behavior changes as a result of this PR**.

Based on a proof of concept by @jonahwilliams (https://github.com/flutter/flutter/pull/157818).

The existence of this flag (which for the time being, defaults to `true`) implies the following:

1. The (legacy, deprecated) `.flutter-plugins` file is not generated:
    https://docs.flutter.dev/release/breaking-changes/flutter-plugins-configuration
    
2. The (legacy, deprecated) `package:flutter_gen` is not synthetically generated:
    https://github.com/flutter/website/pull/11343
    (awaiting website approvers, but owners approve this change)

This change creates `useImplicitPubspecResolution` and plumbs it through as a required variable, parsing it from a `FlutterCommand.globalResults` where able. In tests, I've defaulted the value to `true` 100% of the time - except for places where the value itself is acted on directly, in which case there are true and false test-cases (e.g. localization and i10n based classes and functions).

I'm not extremely happy this needed to change 50+ files, but is sort of a result of how inter-connected many of the elements of the tools are. I believe keeping this as an explicit (flagged) argument will be our best way to ensure the default behavior changes consistently and that tests are running as expected.