### PR TITLE
Add test for `notification.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -319,5 +319,4 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/scrollbar/raw_scrollbar.0_test.dart',
   'examples/api/test/widgets/interactive_viewer/interactive_viewer.constrained.0_test.dart',
   'examples/api/test/widgets/interactive_viewer/interactive_viewer.transformation_controller.0_test.dart',
-  'examples/api/test/widgets/notification_listener/notification.0_test.dart',
 };

--- a/examples/api/test/widgets/notification_listener/notification.0_test.dart
+++ b/examples/api/test/widgets/notification_listener/notification.0_test.dart
@@ -1,0 +1,128 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/notification_listener/notification.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Shows all elements', (WidgetTester tester) async {
+    final DebugPrintCallback originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {};
+    await tester.pumpWidget(
+      const example.NotificationExampleApp(),
+    );
+
+    expect(find.byType(NestedScrollView), findsOne);
+    expect(find.widgetWithText(SliverAppBar, 'Notification Sample'), findsOne);
+    expect(find.byType(TabBarView), findsOne);
+    expect(find.widgetWithText(Tab, 'Months'), findsOne);
+    expect(find.widgetWithText(Tab, 'Days'), findsOne);
+    expect(find.widgetWithText(ListTile, 'January'), findsOne);
+    expect(find.widgetWithText(ListTile, 'February'), findsOne);
+    expect(find.widgetWithText(ListTile, 'March'), findsOne);
+
+    await tester.tap(find.text('Days'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(ListTile, 'Sunday'), findsOne);
+    expect(find.widgetWithText(ListTile, 'Monday'), findsOne);
+    expect(find.widgetWithText(ListTile, 'Tuesday'), findsOne);
+
+    debugPrint = originalDebugPrint;
+  });
+
+  testWidgets('Scrolling the scroll view triggers the notification', (WidgetTester tester) async {
+    final DebugPrintCallback originalDebugPrint = debugPrint;
+    final List<String> logs = <String>[];
+    debugPrint = (String? message, {int? wrapWidth}) {
+      logs.add(message!);
+    };
+    await tester.pumpWidget(
+      const example.NotificationExampleApp(),
+    );
+
+
+    final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
+    testPointer.hover(tester.getCenter(find.byType(NestedScrollView)));
+    await tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 10)));
+    expect(
+      logs,
+      orderedEquals(const <String>[
+        'Scrolling has started',
+        'Scrolling has started',
+        'Scrolling has ended',
+        'Scrolling has ended',
+      ]),
+    );
+    debugPrint = originalDebugPrint;
+  });
+
+  testWidgets('Changing tabs triggers the notification', (WidgetTester tester) async {
+    final DebugPrintCallback originalDebugPrint = debugPrint;
+    final List<String> logs = <String>[];
+    debugPrint = (String? message, {int? wrapWidth}) {
+      logs.add(message!);
+    };
+    await tester.pumpWidget(
+      const example.NotificationExampleApp(),
+    );
+
+
+    final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
+    testPointer.hover(tester.getCenter(find.byType(NestedScrollView)));
+    await tester.sendEventToBinding(testPointer.scroll(const Offset(500, 0)));
+    expect(
+      logs,
+      orderedEquals(const <String>[
+        'Scrolling has started',
+        'Scrolling has ended',
+        'Scrolling has started',
+      ]),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      logs,
+      orderedEquals(const <String>[
+        'Scrolling has started',
+        'Scrolling has ended',
+        'Scrolling has started',
+        'Scrolling has ended',
+      ]),
+    );
+
+
+    await tester.tap(find.text('Months'));
+    await tester.pump();
+
+    expect(
+      logs,
+      orderedEquals(const <String>[
+        'Scrolling has started',
+        'Scrolling has ended',
+        'Scrolling has started',
+        'Scrolling has ended',
+        'Scrolling has started',
+      ]),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(
+      logs,
+      orderedEquals(const <String>[
+        'Scrolling has started',
+        'Scrolling has ended',
+        'Scrolling has started',
+        'Scrolling has ended',
+        'Scrolling has started',
+        'Scrolling has ended',
+      ]),
+    );
+
+    debugPrint = originalDebugPrint;
+  });
+}

--- a/examples/api/test/widgets/notification_listener/notification.0_test.dart
+++ b/examples/api/test/widgets/notification_listener/notification.0_test.dart
@@ -45,7 +45,6 @@ void main() {
       const example.NotificationExampleApp(),
     );
 
-
     final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
     testPointer.hover(tester.getCenter(find.byType(NestedScrollView)));
     await tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 10)));
@@ -71,7 +70,6 @@ void main() {
       const example.NotificationExampleApp(),
     );
 
-
     final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
     testPointer.hover(tester.getCenter(find.byType(NestedScrollView)));
     await tester.sendEventToBinding(testPointer.scroll(const Offset(500, 0)));
@@ -93,7 +91,6 @@ void main() {
         'Scrolling has ended',
       ]),
     );
-
 
     await tester.tap(find.text('Months'));
     await tester.pump();


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/notification_listener/notification.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
