### PR TITLE
Add adaptive vertical positioning to RenderFollowerLayer

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2368,6 +2368,12 @@ class LayerLink {
   /// layout.
   Size? leaderSize;
 
+  /// The position of the content of the connected [LeaderLayer]
+  /// in global coordinates.
+  ///
+  /// This is required when adaptive positioning is desired.
+  Offset? leaderGlobalOffset;
+
   @override
   String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
     return '${describeIdentity(this)}(${ _leader != null ? "<linked>" : "<dangling>" })';

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1781,6 +1781,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
     this.offset = Offset.zero,
     this.targetAnchor = Alignment.topLeft,
     this.followerAnchor = Alignment.topLeft,
+    this.allowedRect,
     super.child,
   });
 
@@ -1828,6 +1829,10 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// position.
   final Offset offset;
 
+  /// An optional rect that defines bounds into which the follower child
+  /// should be painted if possible.
+  final Rect? allowedRect;
+
   @override
   RenderFollowerLayer createRenderObject(BuildContext context) {
     return RenderFollowerLayer(
@@ -1836,6 +1841,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
       offset: offset,
       leaderAnchor: targetAnchor,
       followerAnchor: followerAnchor,
+      allowedRect: allowedRect,
     );
   }
 
@@ -1846,7 +1852,8 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
       ..showWhenUnlinked = showWhenUnlinked
       ..offset = offset
       ..leaderAnchor = targetAnchor
-      ..followerAnchor = followerAnchor;
+      ..followerAnchor = followerAnchor
+      ..allowedRect = allowedRect;
   }
 }
 

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3868,57 +3868,107 @@ void main() {
       );
     });
 
-    testWidgets('Menu follows content position when a LayerLink is provided', (WidgetTester tester) async {
-      final MenuController controller = MenuController();
-      final UniqueKey contentKey = UniqueKey();
+    group('When a LayerLink is provided', () {
+      testWidgets('menu follows content position', (WidgetTester tester) async {
+        final MenuController controller = MenuController();
+        final UniqueKey contentKey = UniqueKey();
 
-      Widget boilerplate(double bottomInsets) {
-        return MaterialApp(
-          home: MediaQuery(
-            data: MediaQueryData(
-              viewInsets: EdgeInsets.only(bottom: bottomInsets),
-            ),
-            child: Scaffold(
-              body: Center(
-                child: MenuAnchor(
-                  controller: controller,
-                  layerLink: LayerLink(),
-                  menuChildren: <Widget>[
-                    MenuItemButton(
-                      onPressed: () {},
-                      child: const Text('Button 1'),
-                    ),
-                  ],
-                  builder: (BuildContext context, MenuController controller, Widget? child) {
-                    return SizedBox(key: contentKey, width: 100, height: 100);
-                  },
+        Widget boilerplate(double bottomInsets) {
+          return MaterialApp(
+            home: MediaQuery(
+              data: MediaQueryData(
+                viewInsets: EdgeInsets.only(bottom: bottomInsets),
+              ),
+              child: Scaffold(
+                body: Center(
+                  child: MenuAnchor(
+                    controller: controller,
+                    layerLink: LayerLink(),
+                    menuChildren: <Widget>[
+                      MenuItemButton(
+                        onPressed: () {},
+                        child: const Text('Button 1'),
+                      ),
+                    ],
+                    builder: (BuildContext context, MenuController controller, Widget? child) {
+                      return SizedBox(key: contentKey, width: 100, height: 100);
+                    },
+                  ),
                 ),
               ),
             ),
+          );
+        }
+
+        // Build once without bottom insets and open the menu.
+        await tester.pumpWidget(boilerplate(0.0));
+        controller.open();
+        await tester.pump();
+
+        // Menu vertical position is just under the content.
+        expect(
+          tester.getRect(findMenuPanels()).top,
+          tester.getRect(find.byKey(contentKey)).bottom,
+        );
+
+        // Simulate the keyboard opening resizing the view.
+        await tester.pumpWidget(boilerplate(100.0));
+        await tester.pump();
+
+        // Menu vertical position is just under the content.
+        expect(
+          tester.getRect(findMenuPanels()).top,
+          tester.getRect(find.byKey(contentKey)).bottom,
+        );
+      });
+
+      testWidgets('vertically constrained menus are positioned above the anchor', (WidgetTester tester) async {
+        await changeSurfaceSize(tester, const Size(800, 600));
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (BuildContext context) {
+                return Directionality(
+                  textDirection: TextDirection.ltr,
+                  child: Align(
+                    alignment: Alignment.bottomLeft,
+                    child: MenuAnchor(
+                      layerLink: LayerLink(),
+                      menuChildren: const <Widget>[
+                        MenuItemButton(
+                          child: Text('Button1'),
+                        ),
+                      ],
+                      builder: (BuildContext context, MenuController controller, Widget? child) {
+                        return FilledButton(
+                          onPressed: () {
+                            if (controller.isOpen) {
+                              controller.close();
+                            } else {
+                              controller.open();
+                            }
+                          },
+                          child: const Text('Tap me'),
+                        );
+                      },
+                    ),
+                  ),
+                );
+              },
+            ),
           ),
         );
-      }
 
-      // Build once without bottom insets and open the menu.
-      await tester.pumpWidget(boilerplate(0.0));
-      controller.open();
-      await tester.pump();
+        await tester.pump();
+        await tester.tap(find.text('Tap me'));
+        await tester.pump();
 
-      // Menu vertical position is just under the content.
-      expect(
-        tester.getRect(findMenuPanels()).top,
-        tester.getRect(find.byKey(contentKey)).bottom,
-      );
-
-      // Simulate the keyboard opening resizing the view.
-      await tester.pumpWidget(boilerplate(100.0));
-      await tester.pump();
-
-      // Menu vertical position is just under the content.
-      expect(
-        tester.getRect(findMenuPanels()).top,
-        tester.getRect(find.byKey(contentKey)).bottom,
-      );
+        expect(find.byType(MenuItemButton), findsNWidgets(1));
+        expect(
+          collectSubmenuRects().first,
+          rectMoreOrLessEquals(const Rect.fromLTRB(0.0, 488.0, 122.7, 552.0), epsilon: 0.001),
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Description

This PR adds adaptive positioning to Leader/Follower.
Doing so a follower position can be automatically modified if not enough space is available.

For the moment, only bottom overflow is implemented as it corresponds to DropdownMenu use case.

## Context

Since https://github.com/flutter/flutter/pull/154667, `DropdownMenu` relies on Leader/Follower approach in order to position the menu below the text field.
While this change was needed to fix several positioning issues where the menu did not move while the text field did, it also introduced a regression as the menu is always positioned below the text field and might not be visible or be partially visible.

This PR aims to fix this issues by adding an adaptive positioning logic at the Leader/Follower level. Doing so this logic would be reusable for other widgets (for instance Autocomplete which faces the same problem).


## Related Issue

Fixes [DropdownMenu menu always appears below the TextField](https://github.com/flutter/flutter/issues/157916)

## Tests

Adds 6 tests.