### PR TITLE
Add a warning/additional handlers for parsing`synthetic-package`.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -147,6 +147,8 @@ class GenerateLocalizationsCommand extends FlutterCommand {
             'generated as a synthetic package or at a specified directory in '
             'the Flutter project.\n'
             '\n'
+            'DEPRECATED: https://flutter.dev/to/flutter-gen-deprecation.\n'
+            '\n'
             'This flag is set to true by default.\n'
             '\n'
             'When synthetic-package is set to false, it will generate the '

--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -54,6 +54,14 @@ Future<void> generateLocalizationsSyntheticPackage({
     }
   }
 
+  // Log a warning: synthetic-package: true (or implicit true) is deprecated.
+  environment.logger.printWarning(
+    'Synthetic package output (package:flutter_gen) is deprecated: '
+    'https://flutter.dev/to/flutter-gen-deprecation. In a future release '
+    'this value will default to `false`, and later support removed '
+    'entirely',
+  );
+
   final BuildResult result = await buildSystem.build(
     buildTargets.generateLocalizationsTarget,
     environment,

--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -16,7 +16,9 @@ Future<void> generateLocalizationsSyntheticPackage({
   required BuildTargets buildTargets,
 }) async {
   final FileSystem fileSystem = environment.fileSystem;
-  final File l10nYamlFile = fileSystem.file(fileSystem.path.join(environment.projectDir.path, 'l10n.yaml'));
+  final File l10nYamlFile = fileSystem.file(
+    fileSystem.path.join(environment.projectDir.path, 'l10n.yaml'),
+  );
 
   // If pubspec.yaml has generate:true and if l10n.yaml exists in the
   // root project directory, check to see if a synthetic package should
@@ -27,7 +29,9 @@ Future<void> generateLocalizationsSyntheticPackage({
 
   final YamlNode yamlNode = loadYamlNode(l10nYamlFile.readAsStringSync());
   if (yamlNode.value != null && yamlNode is! YamlMap) {
-    throwToolExit('Expected ${l10nYamlFile.path} to contain a map, instead was $yamlNode');
+    throwToolExit(
+      'Expected ${l10nYamlFile.path} to contain a map, instead was $yamlNode',
+    );
   }
 
   // If an l10n.yaml file exists and is not empty, attempt to parse settings in
@@ -36,8 +40,9 @@ Future<void> generateLocalizationsSyntheticPackage({
     final YamlMap yamlMap = yamlNode as YamlMap;
     final Object? value = yamlMap['synthetic-package'];
     if (value is! bool && value != null) {
-      throwToolExit('Expected "synthetic-package" to have a bool value, '
-          'instead was "$value"');
+      throwToolExit(
+        'Expected "synthetic-package" to have a bool value, instead was "$value"',
+      );
     }
 
     // Generate gen_l10n synthetic package only if synthetic-package: true or
@@ -66,7 +71,7 @@ Future<void> generateLocalizationsSyntheticPackage({
   environment.logger.printWarning(
     'Synthetic package output (package:flutter_gen) is deprecated: '
     'https://flutter.dev/to/flutter-gen-deprecation. In a future release '
-    'this value will default to `false`, and later support removed '
+    'synthetic-package will default to `false`, and later support removed '
     'entirely',
   );
 

--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -70,9 +70,9 @@ Future<void> generateLocalizationsSyntheticPackage({
   // Log a warning: synthetic-package: true (or implicit true) is deprecated.
   environment.logger.printWarning(
     'Synthetic package output (package:flutter_gen) is deprecated: '
-    'https://flutter.dev/to/flutter-gen-deprecation. In a future release '
-    'synthetic-package will default to `false`, and later support removed '
-    'entirely',
+    'https://flutter.dev/to/flutter-gen-deprecation. In a future release, '
+    'synthetic-package will default to `false` and will later be removed '
+    'entirely.',
   );
 
   final BuildResult result = await buildSystem.build(

--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -16,8 +16,7 @@ Future<void> generateLocalizationsSyntheticPackage({
   required BuildTargets buildTargets,
 }) async {
   final FileSystem fileSystem = environment.fileSystem;
-  final File l10nYamlFile = fileSystem
-      .file(fileSystem.path.join(environment.projectDir.path, 'l10n.yaml'));
+  final File l10nYamlFile = fileSystem.file(fileSystem.path.join(environment.projectDir.path, 'l10n.yaml'));
 
   // If pubspec.yaml has generate:true and if l10n.yaml exists in the
   // root project directory, check to see if a synthetic package should
@@ -28,8 +27,7 @@ Future<void> generateLocalizationsSyntheticPackage({
 
   final YamlNode yamlNode = loadYamlNode(l10nYamlFile.readAsStringSync());
   if (yamlNode.value != null && yamlNode is! YamlMap) {
-    throwToolExit(
-        'Expected ${l10nYamlFile.path} to contain a map, instead was $yamlNode');
+    throwToolExit('Expected ${l10nYamlFile.path} to contain a map, instead was $yamlNode');
   }
 
   // If an l10n.yaml file exists and is not empty, attempt to parse settings in

--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -15,10 +15,9 @@ Future<void> generateLocalizationsSyntheticPackage({
   required BuildSystem buildSystem,
   required BuildTargets buildTargets,
 }) async {
-
   final FileSystem fileSystem = environment.fileSystem;
-  final File l10nYamlFile = fileSystem.file(
-    fileSystem.path.join(environment.projectDir.path, 'l10n.yaml'));
+  final File l10nYamlFile = fileSystem
+      .file(fileSystem.path.join(environment.projectDir.path, 'l10n.yaml'));
 
   // If pubspec.yaml has generate:true and if l10n.yaml exists in the
   // root project directory, check to see if a synthetic package should
@@ -30,8 +29,7 @@ Future<void> generateLocalizationsSyntheticPackage({
   final YamlNode yamlNode = loadYamlNode(l10nYamlFile.readAsStringSync());
   if (yamlNode.value != null && yamlNode is! YamlMap) {
     throwToolExit(
-      'Expected ${l10nYamlFile.path} to contain a map, instead was $yamlNode'
-    );
+        'Expected ${l10nYamlFile.path} to contain a map, instead was $yamlNode');
   }
 
   // If an l10n.yaml file exists and is not empty, attempt to parse settings in
@@ -40,10 +38,8 @@ Future<void> generateLocalizationsSyntheticPackage({
     final YamlMap yamlMap = yamlNode as YamlMap;
     final Object? value = yamlMap['synthetic-package'];
     if (value is! bool && value != null) {
-      throwToolExit(
-        'Expected "synthetic-package" to have a bool value, '
-        'instead was "$value"'
-      );
+      throwToolExit('Expected "synthetic-package" to have a bool value, '
+          'instead was "$value"');
     }
 
     // Generate gen_l10n synthetic package only if synthetic-package: true or
@@ -52,6 +48,20 @@ Future<void> generateLocalizationsSyntheticPackage({
     if (isSyntheticL10nPackage == false) {
       return;
     }
+  } else if (!environment.useImplicitPubspecResolution) {
+    // --no-implicit-pubspec-resolution was passed, and synthetic-packages: true was not.
+    return;
+  }
+
+  if (!environment.useImplicitPubspecResolution) {
+    throwToolExit(
+      'Cannot generate a synthetic package when --no-implicit-pubspec-resolution is passed.\n'
+      '\n'
+      'Synthetic package output (package:flutter_gen) is deprecated: '
+      'https://flutter.dev/to/flutter-gen-deprecation. If you are seeing this '
+      'message either you have provided --no-implicit-pubspec-resolution, or '
+      'it is the default value (see flutter --verbose --help).',
+    );
   }
 
   // Log a warning: synthetic-package: true (or implicit true) is deprecated.

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -269,7 +269,7 @@ void main() {
   });
 
   testWithoutContext('synthetic-package: true (implicit) logs a deprecation warning', () async {
-    // Project directory setup for gen_l10n logic
+    // Project directory setup for gen_l10n logic.
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
 
     // Add generate:true to pubspec.yaml.

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -280,7 +280,7 @@ void main() {
     );
     pubspecFile.writeAsStringSync(content);
 
-    // Create a blank l10n.yaml file
+    // Create a blank l10n.yaml file.
     fileSystem.file('l10n.yaml').writeAsStringSync('');
 
     final BufferLogger mockBufferLogger = BufferLogger.test();

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -267,4 +267,111 @@ void main() {
       throwsToolExit(message: 'to have a bool value, instead was "nonBoolValue"'),
     );
   });
+
+  testWithoutContext('synthetic-package: true (implicit) logs a deprecation warning', () async {
+    // Project directory setup for gen_l10n logic
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+
+    // Add generate:true to pubspec.yaml.
+    final File pubspecFile = fileSystem.file('pubspec.yaml')..createSync();
+    final String content = pubspecFile.readAsStringSync().replaceFirst(
+      '\nflutter:\n',
+      '\nflutter:\n  generate: true\n',
+    );
+    pubspecFile.writeAsStringSync(content);
+
+    // Create a blank l10n.yaml file
+    fileSystem.file('l10n.yaml').writeAsStringSync('');
+
+    final BufferLogger mockBufferLogger = BufferLogger.test();
+    final Environment environment = Environment.test(
+      fileSystem.currentDirectory,
+      fileSystem: fileSystem,
+      logger: mockBufferLogger,
+      artifacts: Artifacts.test(),
+      processManager: FakeProcessManager.any(),
+    );
+    final TestBuildSystem buildSystem = TestBuildSystem.all(BuildResult(success: true));
+
+    await generateLocalizationsSyntheticPackage(
+      environment: environment,
+      buildSystem: buildSystem,
+      buildTargets: const BuildTargetsImpl(),
+    );
+
+    expect(
+      mockBufferLogger.warningText,
+      contains('https://flutter.dev/to/flutter-gen-deprecation'),
+    );
+  });
+
+  testWithoutContext('synthetic-package: true (explicit) logs a deprecation warning', () async {
+    // Project directory setup for gen_l10n logic
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+
+    // Add generate:true to pubspec.yaml.
+    final File pubspecFile = fileSystem.file('pubspec.yaml')..createSync();
+    final String content = pubspecFile.readAsStringSync().replaceFirst(
+      '\nflutter:\n',
+      '\nflutter:\n  generate: true\n',
+    );
+    pubspecFile.writeAsStringSync(content);
+    fileSystem.file('l10n.yaml').writeAsStringSync('synthetic-package: true');
+
+    final BufferLogger mockBufferLogger = BufferLogger.test();
+    final Environment environment = Environment.test(
+      fileSystem.currentDirectory,
+      fileSystem: fileSystem,
+      logger: mockBufferLogger,
+      artifacts: Artifacts.test(),
+      processManager: FakeProcessManager.any(),
+    );
+    final TestBuildSystem buildSystem = TestBuildSystem.all(BuildResult(success: true));
+
+    await generateLocalizationsSyntheticPackage(
+      environment: environment,
+      buildSystem: buildSystem,
+      buildTargets: const BuildTargetsImpl(),
+    );
+
+    expect(
+      mockBufferLogger.warningText,
+      contains('https://flutter.dev/to/flutter-gen-deprecation'),
+    );
+  });
+
+  testWithoutContext('synthetic-package: false has no deprecation warning', () async {
+    // Project directory setup for gen_l10n logic
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+
+    // Add generate:true to pubspec.yaml.
+    final File pubspecFile = fileSystem.file('pubspec.yaml')..createSync();
+    final String content = pubspecFile.readAsStringSync().replaceFirst(
+      '\nflutter:\n',
+      '\nflutter:\n  generate: true\n',
+    );
+    pubspecFile.writeAsStringSync(content);
+    fileSystem.file('l10n.yaml').writeAsStringSync('synthetic-package: false');
+
+    final BufferLogger mockBufferLogger = BufferLogger.test();
+    final Environment environment = Environment.test(
+      fileSystem.currentDirectory,
+      fileSystem: fileSystem,
+      logger: mockBufferLogger,
+      artifacts: Artifacts.test(),
+      processManager: FakeProcessManager.any(),
+    );
+    final TestBuildSystem buildSystem = TestBuildSystem.all(BuildResult(success: true));
+
+    await generateLocalizationsSyntheticPackage(
+      environment: environment,
+      buildSystem: buildSystem,
+      buildTargets: const BuildTargetsImpl(),
+    );
+
+    expect(
+      mockBufferLogger.warningText,
+      isNot(contains('https://flutter.dev/to/flutter-gen-deprecation')),
+    );
+  });
 }

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -306,7 +306,7 @@ void main() {
   });
 
   testWithoutContext('synthetic-package: true (explicit) logs a deprecation warning', () async {
-    // Project directory setup for gen_l10n logic
+    // Project directory setup for gen_l10n logic.
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
 
     // Add generate:true to pubspec.yaml.


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/157928.
Closes https://github.com/flutter/flutter/issues/157929.

| Condition | Expectation |
| --------- | ------------ |
| `synthetic-packages: true` && `--implicit-pubpsec-resolution` | Generates `flutter_gen` with warning.
| `<no synthetic-packages key>` && `--implicit-pubspec-resolution` | Generates `flutter_gen` with warning.
| `synthetic-packages: false` && `--implicit-pubpsec-resolution` | Does not generate `flutter_gen`.
| `synthetic-packages: true` && `--no-implicit-pubpsec-resolution` | Error.
| `<no synthetic-packages key>` && `--no-implicit-pubspec-resolution` | Does not generate `flutter_gen`.
| `synthetic-packages: false` && `--no-implicit-pubpsec-resolution` | Generates `flutter_gen` with warning.
