### PR TITLE
Add File > Close to macOS menu template

### DIFF
--- a/dev/integration_tests/flutter_gallery/macos/Runner/Base.lproj/MainMenu.xib
+++ b/dev/integration_tests/flutter_gallery/macos/Runner/Base.lproj/MainMenu.xib
@@ -66,6 +66,18 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem title="File" id="hiu-hw-ojH">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="File" id="anW-Pk-PLB">
+                        <items>
+                            <menuItem title="Close" keyEquivalent="w" id="Fnw-My-UjB">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="Aol-0B-rGG"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
                 <menuItem title="Edit" id="5QF-Oa-p0T">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Edit" id="W48-6f-4Dl">

--- a/dev/integration_tests/flutter_gallery/macos/RunnerTests/RunnerTests.m
+++ b/dev/integration_tests/flutter_gallery/macos/RunnerTests/RunnerTests.m
@@ -20,6 +20,7 @@
 
   // The number of submenu items changes depending on what the OS decides to inject.
   // Just check there's at least one per menu item.
+  XCTAssertGreaterThanOrEqual([mainMenu itemWithTitle:@"File"].submenu.numberOfItems, 1);
   XCTAssertGreaterThanOrEqual([mainMenu itemWithTitle:@"Edit"].submenu.numberOfItems, 1);
   XCTAssertGreaterThanOrEqual([mainMenu itemWithTitle:@"View"].submenu.numberOfItems, 1);
   XCTAssertGreaterThanOrEqual([mainMenu itemWithTitle:@"Window"].submenu.numberOfItems, 1);

--- a/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner/Base.lproj/MainMenu.xib
+++ b/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner/Base.lproj/MainMenu.xib
@@ -66,6 +66,18 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem title="File" id="hiu-hw-ojH">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="File" id="anW-Pk-PLB">
+                        <items>
+                            <menuItem title="Close" keyEquivalent="w" id="Fnw-My-UjB">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="Aol-0B-rGG"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
                 <menuItem title="Edit" id="5QF-Oa-p0T">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Edit" id="W48-6f-4Dl">


### PR DESCRIPTION
This PR updates the macOS template to accept a `command + w` keystroke in order to close the window.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

#102439

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
