### PR TITLE
Make the SwiftPM integration tests more idiomatic

### DIFF
--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
@@ -29,222 +29,90 @@ void main() {
         final Directory workingDirectory = fileSystem.systemTempDirectory
             .createTempSync('swift_package_manager_enabled.');
         final String workingDirectoryPath = workingDirectory.path;
-        try {
-          // Create and build an app using the CocoaPods version of
-          // integration_test.
-          await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
-          final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
-            flutterBin,
-            workingDirectoryPath,
-            iosLanguage: iosLanguage,
-            platform: platformName,
-            usesSwiftPackageManager: true,
-            options: <String>['--platforms=$platformName'],
-          );
-          SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
-          await SwiftPackageManagerUtils.buildApp(
-            flutterBin,
-            appDirectoryPath,
-            options: <String>[platformName, '--debug', '-v'],
-            expectedLines: SwiftPackageManagerUtils.expectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              cocoaPodsPlugin: integrationTestPlugin,
-            ),
-            unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              cocoaPodsPlugin: integrationTestPlugin,
-            ),
-          );
-          expect(
-            fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory(platformName)
-              .childFile('Podfile')
-              .existsSync(),
-            isTrue,
-          );
-          expect(
-            fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory(platformName)
-              .childDirectory('Flutter')
-              .childDirectory('ephemeral')
-              .childDirectory('Packages')
-              .childDirectory('FlutterGeneratedPluginSwiftPackage')
-              .existsSync(),
-            isFalse,
-          );
 
-          final SwiftPackageManagerPlugin createdCocoaPodsPlugin = await SwiftPackageManagerUtils.createPlugin(
-            flutterBin,
-            workingDirectoryPath,
-            platform: platformName,
-            iosLanguage: iosLanguage,
-          );
-
-          // Rebuild app with Swift Package Manager enabled, migrating the app and using the Swift Package Manager version of
-          // integration_test.
-          await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
-          await SwiftPackageManagerUtils.buildApp(
-            flutterBin,
-            appDirectoryPath,
-            options: <String>[platformName, '--debug', '-v'],
-            expectedLines: SwiftPackageManagerUtils.expectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              swiftPackageMangerEnabled: true,
-              swiftPackagePlugin: integrationTestPlugin,
-              migrated: true,
-            ),
-            unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              swiftPackageMangerEnabled: true,
-              swiftPackagePlugin: integrationTestPlugin,
-              migrated: true,
-            ),
-          );
-
-          expect(
-            fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory(platformName)
-              .childFile('Podfile')
-              .existsSync(),
-            isTrue,
-          );
-          expect(
-            fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory(platformName)
-              .childDirectory('Flutter')
-              .childDirectory('ephemeral')
-              .childDirectory('Packages')
-              .childDirectory('FlutterGeneratedPluginSwiftPackage')
-              .existsSync(),
-            isTrue,
-          );
-
-          // Build an app using both a CocoaPods and Swift Package Manager plugin.
-          SwiftPackageManagerUtils.addDependency(
-            appDirectoryPath: appDirectoryPath,
-            plugin: createdCocoaPodsPlugin,
-          );
-          await SwiftPackageManagerUtils.buildApp(
-            flutterBin,
-            appDirectoryPath,
-            options: <String>[platformName, '--debug', '-v'],
-            expectedLines: SwiftPackageManagerUtils.expectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              cocoaPodsPlugin: createdCocoaPodsPlugin,
-              swiftPackageMangerEnabled: true,
-              swiftPackagePlugin: integrationTestPlugin,
-            ),
-            unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              cocoaPodsPlugin: createdCocoaPodsPlugin,
-              swiftPackageMangerEnabled: true,
-              swiftPackagePlugin: integrationTestPlugin,
-            ),
-          );
-
-          expect(
-            fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory(platformName)
-              .childFile('Podfile')
-              .existsSync(),
-            isTrue,
-          );
-          expect(
-            fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory(platformName)
-              .childDirectory('Flutter')
-              .childDirectory('ephemeral')
-              .childDirectory('Packages')
-              .childDirectory('FlutterGeneratedPluginSwiftPackage')
-              .existsSync(),
-            isTrue,
-          );
-
-          // Build app again but with Swift Package Manager disabled by config.
-          // App will now use CocoaPods version of integration_test plugin.
-          await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
-          await SwiftPackageManagerUtils.cleanApp(flutterBin, appDirectoryPath);
-          await SwiftPackageManagerUtils.buildApp(
-            flutterBin,
-            appDirectoryPath,
-            options: <String>[platformName, '--debug', '-v'],
-            expectedLines: SwiftPackageManagerUtils.expectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              cocoaPodsPlugin: integrationTestPlugin,
-            ),
-            unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              cocoaPodsPlugin: integrationTestPlugin,
-            ),
-          );
-
-          // Build app again but with Swift Package Manager disabled by pubspec.
-          // App will still use CocoaPods version of integration_test plugin.
-          await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
-          await SwiftPackageManagerUtils.cleanApp(flutterBin, appDirectoryPath);
-          SwiftPackageManagerUtils.disableSwiftPackageManagerByPubspec(appDirectoryPath: appDirectoryPath);
-          await SwiftPackageManagerUtils.buildApp(
-            flutterBin,
-            appDirectoryPath,
-            options: <String>[platformName, '--debug', '-v'],
-            expectedLines: SwiftPackageManagerUtils.expectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              cocoaPodsPlugin: integrationTestPlugin,
-            ),
-            unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
-              platform: platformName,
-              appDirectoryPath: appDirectoryPath,
-              cocoaPodsPlugin: integrationTestPlugin,
-            ),
-          );
-        } finally {
+        addTearDown(() async {
           await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
           ErrorHandlingFileSystem.deleteIfExists(
             workingDirectory,
             recursive: true,
           );
-        }
-      }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
-    }
+        });
 
-    test('Build $platformName-framework with non-module app uses CocoaPods', () async {
-      final Directory workingDirectory = fileSystem.systemTempDirectory
-          .createTempSync('swift_package_manager_build_framework.');
-      final String workingDirectoryPath = workingDirectory.path;
-      try {
-        // Create and build an app using the Swift Package Manager version of
+        // Create and build an app using the CocoaPods version of
         // integration_test.
-        await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
-
+        await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
         final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
           flutterBin,
           workingDirectoryPath,
-          iosLanguage: 'swift',
+          iosLanguage: iosLanguage,
           platform: platformName,
           usesSwiftPackageManager: true,
           options: <String>['--platforms=$platformName'],
         );
         SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
-
         await SwiftPackageManagerUtils.buildApp(
           flutterBin,
           appDirectoryPath,
-          options: <String>[platformName, '--config-only', '-v'],
+          options: <String>[platformName, '--debug', '-v'],
+          expectedLines: SwiftPackageManagerUtils.expectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            cocoaPodsPlugin: integrationTestPlugin,
+          ),
+          unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            cocoaPodsPlugin: integrationTestPlugin,
+          ),
+        );
+        expect(
+          fileSystem
+            .directory(appDirectoryPath)
+            .childDirectory(platformName)
+            .childFile('Podfile')
+            .existsSync(),
+          isTrue,
+        );
+        expect(
+          fileSystem
+            .directory(appDirectoryPath)
+            .childDirectory(platformName)
+            .childDirectory('Flutter')
+            .childDirectory('ephemeral')
+            .childDirectory('Packages')
+            .childDirectory('FlutterGeneratedPluginSwiftPackage')
+            .existsSync(),
+          isFalse,
+        );
+
+        final SwiftPackageManagerPlugin createdCocoaPodsPlugin = await SwiftPackageManagerUtils.createPlugin(
+          flutterBin,
+          workingDirectoryPath,
+          platform: platformName,
+          iosLanguage: iosLanguage,
+        );
+
+        // Rebuild app with Swift Package Manager enabled, migrating the app and using the Swift Package Manager version of
+        // integration_test.
+        await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
+        await SwiftPackageManagerUtils.buildApp(
+          flutterBin,
+          appDirectoryPath,
+          options: <String>[platformName, '--debug', '-v'],
+          expectedLines: SwiftPackageManagerUtils.expectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            swiftPackageMangerEnabled: true,
+            swiftPackagePlugin: integrationTestPlugin,
+            migrated: true,
+          ),
+          unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            swiftPackageMangerEnabled: true,
+            swiftPackagePlugin: integrationTestPlugin,
+            migrated: true,
+          ),
         );
 
         expect(
@@ -253,7 +121,7 @@ void main() {
             .childDirectory(platformName)
             .childFile('Podfile')
             .existsSync(),
-          isFalse,
+          isTrue,
         );
         expect(
           fileSystem
@@ -267,191 +135,159 @@ void main() {
           isTrue,
         );
 
-        // Create and build framework using the CocoaPods version of
-        // integration_test even though Swift Package Manager is enabled.
+        // Build an app using both a CocoaPods and Swift Package Manager plugin.
+        SwiftPackageManagerUtils.addDependency(
+          appDirectoryPath: appDirectoryPath,
+          plugin: createdCocoaPodsPlugin,
+        );
         await SwiftPackageManagerUtils.buildApp(
           flutterBin,
           appDirectoryPath,
-          options: <String>[
-            '$platformName-framework',
-            '--no-debug',
-            '--no-profile',
-            '-v',
-          ],
-          expectedLines: <String>[
-            'Swift Package Manager does not yet support this command. CocoaPods will be used instead.'
-          ]
+          options: <String>[platformName, '--debug', '-v'],
+          expectedLines: SwiftPackageManagerUtils.expectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            cocoaPodsPlugin: createdCocoaPodsPlugin,
+            swiftPackageMangerEnabled: true,
+            swiftPackagePlugin: integrationTestPlugin,
+          ),
+          unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            cocoaPodsPlugin: createdCocoaPodsPlugin,
+            swiftPackageMangerEnabled: true,
+            swiftPackagePlugin: integrationTestPlugin,
+          ),
         );
 
         expect(
           fileSystem
             .directory(appDirectoryPath)
-            .childDirectory('build')
             .childDirectory(platformName)
-            .childDirectory('framework')
-            .childDirectory('Release')
-            .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
+            .childFile('Podfile')
             .existsSync(),
           isTrue,
         );
-      } finally {
-        await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
-        ErrorHandlingFileSystem.deleteIfExists(
-          workingDirectory,
-          recursive: true,
+        expect(
+          fileSystem
+            .directory(appDirectoryPath)
+            .childDirectory(platformName)
+            .childDirectory('Flutter')
+            .childDirectory('ephemeral')
+            .childDirectory('Packages')
+            .childDirectory('FlutterGeneratedPluginSwiftPackage')
+            .existsSync(),
+          isTrue,
         );
-      }
-    }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 
-    test('Caches build targets between builds with Swift Package Manager on $platformName', () async {
-      final Directory workingDirectory = fileSystem.systemTempDirectory
-        .createTempSync('swift_package_manager_caching.');
-      final String workingDirectoryPath = workingDirectory.path;
-      try {
-        // Create and build an app using the Swift Package Manager version of
-        // integration_test.
+        // Build app again but with Swift Package Manager disabled by config.
+        // App will now use CocoaPods version of integration_test plugin.
+        await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
+        await SwiftPackageManagerUtils.cleanApp(flutterBin, appDirectoryPath);
+        await SwiftPackageManagerUtils.buildApp(
+          flutterBin,
+          appDirectoryPath,
+          options: <String>[platformName, '--debug', '-v'],
+          expectedLines: SwiftPackageManagerUtils.expectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            cocoaPodsPlugin: integrationTestPlugin,
+          ),
+          unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            cocoaPodsPlugin: integrationTestPlugin,
+          ),
+        );
+
+        // Build app again but with Swift Package Manager disabled by pubspec.
+        // App will still use CocoaPods version of integration_test plugin.
         await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
-
-        final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
-          flutterBin,
-          workingDirectoryPath,
-          iosLanguage: 'swift',
-          platform: platformName,
-          usesSwiftPackageManager: true,
-          options: <String>['--platforms=$platformName'],
-        );
-        SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
-
-        final String unpackTarget = 'debug_unpack_$platformName';
-        final String bundleFlutterAssetsTarget = 'debug_${platformName}_bundle_flutter_assets';
-        final bool noCodesign = platformName == 'ios';
+        await SwiftPackageManagerUtils.cleanApp(flutterBin, appDirectoryPath);
+        SwiftPackageManagerUtils.disableSwiftPackageManagerByPubspec(appDirectoryPath: appDirectoryPath);
         await SwiftPackageManagerUtils.buildApp(
           flutterBin,
           appDirectoryPath,
-          options: <String>[
-            platformName,
-            '--debug',
-            '-v',
-            if (noCodesign)
-              '--no-codesign',
-          ],
-          expectedLines: <Pattern>[
-            r'SchemeAction Run\ Prepare\ Flutter\ Framework\ Script',
-            '$unpackTarget: Starting due to',
-            '-dPreBuildAction=PrepareFramework $unpackTarget',
-          ],
-          unexpectedLines: <String>[],
+          options: <String>[platformName, '--debug', '-v'],
+          expectedLines: SwiftPackageManagerUtils.expectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            cocoaPodsPlugin: integrationTestPlugin,
+          ),
+          unexpectedLines: SwiftPackageManagerUtils.unexpectedLines(
+            platform: platformName,
+            appDirectoryPath: appDirectoryPath,
+            cocoaPodsPlugin: integrationTestPlugin,
+          ),
         );
+      }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
+    }
 
-        await SwiftPackageManagerUtils.buildApp(
-          flutterBin,
-          appDirectoryPath,
-          options: <String>[
-            platformName,
-            '--debug',
-            '-v',
-            if (noCodesign)
-              '--no-codesign',
-          ],
-          expectedLines: <Pattern>[
-            r'SchemeAction Run\ Prepare\ Flutter\ Framework\ Script',
-            'Skipping target: $unpackTarget',
-            'Skipping target: $bundleFlutterAssetsTarget',
-          ],
-          unexpectedLines: <String>[
-            'Starting due to',
-          ],
-        );
+    test('Build $platformName-framework with non-module app uses CocoaPods', () async {
+      final Directory workingDirectory = fileSystem.systemTempDirectory
+          .createTempSync('swift_package_manager_build_framework.');
+      final String workingDirectoryPath = workingDirectory.path;
 
-      } finally {
+      addTearDown(() async {
         await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
         ErrorHandlingFileSystem.deleteIfExists(
           workingDirectory,
           recursive: true,
         );
-      }
-    }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
-  }
+      });
 
-  test('Build ios-framework with module app uses CocoaPods', () async {
-    final Directory workingDirectory = fileSystem.systemTempDirectory
-        .createTempSync('swift_package_manager_build_framework_module.');
-    final String workingDirectoryPath = workingDirectory.path;
-    try {
-      // Create and build module and framework using the CocoaPods version of
-      // integration_test even though Swift Package Manager is enabled.
+      // Create and build an app using the Swift Package Manager version of
+      // integration_test.
       await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
 
       final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
         flutterBin,
         workingDirectoryPath,
         iosLanguage: 'swift',
-        platform: 'ios',
+        platform: platformName,
         usesSwiftPackageManager: true,
-        options: <String>['--template=module'],
+        options: <String>['--platforms=$platformName'],
       );
-      final SwiftPackageManagerPlugin integrationTestPlugin = SwiftPackageManagerUtils.integrationTestPlugin('ios');
       SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
 
       await SwiftPackageManagerUtils.buildApp(
         flutterBin,
         appDirectoryPath,
-        options: <String>['ios', '--config-only', '-v'],
+        options: <String>[platformName, '--config-only', '-v'],
       );
 
       expect(
         fileSystem
-            .directory(appDirectoryPath)
-            .childDirectory('.ios')
-            .childFile('Podfile')
-            .existsSync(),
-        isTrue,
+          .directory(appDirectoryPath)
+          .childDirectory(platformName)
+          .childFile('Podfile')
+          .existsSync(),
+        isFalse,
       );
       expect(
         fileSystem
           .directory(appDirectoryPath)
-          .childDirectory('.ios')
+          .childDirectory(platformName)
           .childDirectory('Flutter')
           .childDirectory('ephemeral')
           .childDirectory('Packages')
           .childDirectory('FlutterGeneratedPluginSwiftPackage')
           .existsSync(),
-        isFalse,
-      );
-      final File pbxprojFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('.ios')
-        .childDirectory('Runner.xcodeproj')
-        .childFile('project.pbxproj');
-      expect(pbxprojFile.existsSync(), isTrue);
-      expect(
-        pbxprojFile.readAsStringSync(),
-        isNot(contains('FlutterGeneratedPluginSwiftPackage')),
-      );
-      final File xcschemeFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('.ios')
-        .childDirectory('Runner.xcodeproj')
-        .childDirectory('xcshareddata')
-        .childDirectory('xcschemes')
-        .childFile('Runner.xcscheme');
-      expect(xcschemeFile.existsSync(), isTrue);
-      expect(
-        xcschemeFile.readAsStringSync(),
-        isNot(contains('Run Prepare Flutter Framework Script')),
+        isTrue,
       );
 
+      // Create and build framework using the CocoaPods version of
+      // integration_test even though Swift Package Manager is enabled.
       await SwiftPackageManagerUtils.buildApp(
         flutterBin,
         appDirectoryPath,
         options: <String>[
-          'ios-framework',
+          '$platformName-framework',
           '--no-debug',
           '--no-profile',
           '-v',
         ],
-        unexpectedLines: <String>[
-          'Adding Swift Package Manager integration...',
+        expectedLines: <String>[
           'Swift Package Manager does not yet support this command. CocoaPods will be used instead.'
         ]
       );
@@ -460,442 +296,614 @@ void main() {
         fileSystem
           .directory(appDirectoryPath)
           .childDirectory('build')
-          .childDirectory('ios')
+          .childDirectory(platformName)
           .childDirectory('framework')
           .childDirectory('Release')
           .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
           .existsSync(),
         isTrue,
       );
-    } finally {
+    }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
+
+    test('Caches build targets between builds with Swift Package Manager on $platformName', () async {
+      final Directory workingDirectory = fileSystem.systemTempDirectory
+        .createTempSync('swift_package_manager_caching.');
+      final String workingDirectoryPath = workingDirectory.path;
+
+      addTearDown(() async {
+        await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
+        ErrorHandlingFileSystem.deleteIfExists(
+          workingDirectory,
+          recursive: true,
+        );
+      });
+
+      // Create and build an app using the Swift Package Manager version of
+      // integration_test.
+      await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
+
+      final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+        flutterBin,
+        workingDirectoryPath,
+        iosLanguage: 'swift',
+        platform: platformName,
+        usesSwiftPackageManager: true,
+        options: <String>['--platforms=$platformName'],
+      );
+      SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
+
+      final String unpackTarget = 'debug_unpack_$platformName';
+      final String bundleFlutterAssetsTarget = 'debug_${platformName}_bundle_flutter_assets';
+      final bool noCodesign = platformName == 'ios';
+      await SwiftPackageManagerUtils.buildApp(
+        flutterBin,
+        appDirectoryPath,
+        options: <String>[
+          platformName,
+          '--debug',
+          '-v',
+          if (noCodesign)
+            '--no-codesign',
+        ],
+        expectedLines: <Pattern>[
+          r'SchemeAction Run\ Prepare\ Flutter\ Framework\ Script',
+          '$unpackTarget: Starting due to',
+          '-dPreBuildAction=PrepareFramework $unpackTarget',
+        ],
+        unexpectedLines: <String>[],
+      );
+
+      await SwiftPackageManagerUtils.buildApp(
+        flutterBin,
+        appDirectoryPath,
+        options: <String>[
+          platformName,
+          '--debug',
+          '-v',
+          if (noCodesign)
+            '--no-codesign',
+        ],
+        expectedLines: <Pattern>[
+          r'SchemeAction Run\ Prepare\ Flutter\ Framework\ Script',
+          'Skipping target: $unpackTarget',
+          'Skipping target: $bundleFlutterAssetsTarget',
+        ],
+        unexpectedLines: <String>[
+          'Starting due to',
+        ],
+      );
+    }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
+  }
+
+  test('Build ios-framework with module app uses CocoaPods', () async {
+    final Directory workingDirectory = fileSystem.systemTempDirectory
+        .createTempSync('swift_package_manager_build_framework_module.');
+    final String workingDirectoryPath = workingDirectory.path;
+
+    addTearDown(() async {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(
         workingDirectory,
         recursive: true,
       );
-    }
+    });
+
+    // Create and build module and framework using the CocoaPods version of
+    // integration_test even though Swift Package Manager is enabled.
+    await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
+
+    final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+      flutterBin,
+      workingDirectoryPath,
+      iosLanguage: 'swift',
+      platform: 'ios',
+      usesSwiftPackageManager: true,
+      options: <String>['--template=module'],
+    );
+    final SwiftPackageManagerPlugin integrationTestPlugin = SwiftPackageManagerUtils.integrationTestPlugin('ios');
+    SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
+
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>['ios', '--config-only', '-v'],
+    );
+
+    expect(
+      fileSystem
+        .directory(appDirectoryPath)
+        .childDirectory('.ios')
+        .childFile('Podfile')
+        .existsSync(),
+      isTrue,
+    );
+    expect(
+      fileSystem
+        .directory(appDirectoryPath)
+        .childDirectory('.ios')
+        .childDirectory('Flutter')
+        .childDirectory('ephemeral')
+        .childDirectory('Packages')
+        .childDirectory('FlutterGeneratedPluginSwiftPackage')
+        .existsSync(),
+      isFalse,
+    );
+    final File pbxprojFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('.ios')
+      .childDirectory('Runner.xcodeproj')
+      .childFile('project.pbxproj');
+    expect(pbxprojFile.existsSync(), isTrue);
+    expect(
+      pbxprojFile.readAsStringSync(),
+      isNot(contains('FlutterGeneratedPluginSwiftPackage')),
+    );
+    final File xcschemeFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('.ios')
+      .childDirectory('Runner.xcodeproj')
+      .childDirectory('xcshareddata')
+      .childDirectory('xcschemes')
+      .childFile('Runner.xcscheme');
+    expect(xcschemeFile.existsSync(), isTrue);
+    expect(
+      xcschemeFile.readAsStringSync(),
+      isNot(contains('Run Prepare Flutter Framework Script')),
+    );
+
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>[
+        'ios-framework',
+        '--no-debug',
+        '--no-profile',
+        '-v',
+      ],
+      unexpectedLines: <String>[
+        'Adding Swift Package Manager integration...',
+        'Swift Package Manager does not yet support this command. CocoaPods will be used instead.'
+      ]
+    );
+
+    expect(
+      fileSystem
+        .directory(appDirectoryPath)
+        .childDirectory('build')
+        .childDirectory('ios')
+        .childDirectory('framework')
+        .childDirectory('Release')
+        .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
+        .existsSync(),
+      isTrue,
+    );
   }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 
   test('Build ios-framework with non module app uses CocoaPods', () async {
     final Directory workingDirectory = fileSystem.systemTempDirectory
       .createTempSync('swift_package_manager_build_framework_non_module.');
     final String workingDirectoryPath = workingDirectory.path;
-    try {
-      // Create and build a regular app and framework using the CocoaPods version of
-      // integration_test even though Swift Package Manager is enabled.
-      await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
 
-      final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
-        flutterBin,
-        workingDirectoryPath,
-        iosLanguage: 'swift',
-        platform: 'ios',
-        usesSwiftPackageManager: true,
-        options: <String>[],
-      );
-      final SwiftPackageManagerPlugin integrationTestPlugin = SwiftPackageManagerUtils.integrationTestPlugin('ios');
-      SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
-
-      await SwiftPackageManagerUtils.cleanApp(flutterBin, appDirectoryPath);
-
-      await SwiftPackageManagerUtils.buildApp(
-        flutterBin,
-        appDirectoryPath,
-        options: <String>[
-          'ios-framework',
-          '--xcframework',
-          '--no-debug',
-          '--no-profile',
-          '-v',
-        ],
-        expectedLines: <String>[
-          'Swift Package Manager does not yet support this command. CocoaPods will be used instead.',
-        ],
-        unexpectedLines: <String>[
-          'Adding Swift Package Manager integration...',
-        ]
-      );
-
-      expect(
-        fileSystem
-          .directory(appDirectoryPath)
-          .childDirectory('.ios')
-          .existsSync(),
-        isFalse,
-      );
-
-      // TODO(loic-sharma): A Swift package manifest should not be generated.
-      // https://github.com/flutter/flutter/issues/146957
-      // expect(
-      //   fileSystem
-      //     .directory(appDirectoryPath)
-      //     .childDirectory('ios')
-      //     .childDirectory('Flutter')
-      //     .childDirectory('ephemeral')
-      //     .childDirectory('Packages')
-      //     .childDirectory('FlutterGeneratedPluginSwiftPackage')
-      //     .childFile('Package.swift'),
-      //   isFalse,
-      // );
-
-      expect(
-        fileSystem
-          .directory(appDirectoryPath)
-          .childDirectory('build')
-          .childDirectory('ios')
-          .childDirectory('framework')
-          .childDirectory('Release')
-          .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
-          .existsSync(),
-        isTrue,
-      );
-
-      final File flutterPluginsDependenciesFile = fileSystem
-        .directory(appDirectoryPath)
-        .childFile('.flutter-plugins-dependencies');
-
-      expect(flutterPluginsDependenciesFile.existsSync(), isTrue);
-      expect(
-        flutterPluginsDependenciesFile.readAsStringSync(),
-        isNot(contains('"swift_package_manager_enabled":true')),
-      );
-      expect(
-        flutterPluginsDependenciesFile.readAsStringSync(),
-        contains('"swift_package_manager_enabled":false'),
-      );
-    } finally {
+    addTearDown(() async {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(
         workingDirectory,
         recursive: true,
       );
-    }
+    });
+
+    // Create and build a regular app and framework using the CocoaPods version of
+    // integration_test even though Swift Package Manager is enabled.
+    await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
+
+    final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+      flutterBin,
+      workingDirectoryPath,
+      iosLanguage: 'swift',
+      platform: 'ios',
+      usesSwiftPackageManager: true,
+      options: <String>[],
+    );
+    final SwiftPackageManagerPlugin integrationTestPlugin = SwiftPackageManagerUtils.integrationTestPlugin('ios');
+    SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
+
+    await SwiftPackageManagerUtils.cleanApp(flutterBin, appDirectoryPath);
+
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>[
+        'ios-framework',
+        '--xcframework',
+        '--no-debug',
+        '--no-profile',
+        '-v',
+      ],
+      expectedLines: <String>[
+        'Swift Package Manager does not yet support this command. CocoaPods will be used instead.',
+      ],
+      unexpectedLines: <String>[
+        'Adding Swift Package Manager integration...',
+      ]
+    );
+
+    expect(
+      fileSystem
+        .directory(appDirectoryPath)
+        .childDirectory('.ios')
+        .existsSync(),
+      isFalse,
+    );
+
+    // TODO(loic-sharma): A Swift package manifest should not be generated.
+    // https://github.com/flutter/flutter/issues/146957
+    // expect(
+    //   fileSystem
+    //     .directory(appDirectoryPath)
+    //     .childDirectory('ios')
+    //     .childDirectory('Flutter')
+    //     .childDirectory('ephemeral')
+    //     .childDirectory('Packages')
+    //     .childDirectory('FlutterGeneratedPluginSwiftPackage')
+    //     .childFile('Package.swift'),
+    //   isFalse,
+    // );
+
+    expect(
+      fileSystem
+        .directory(appDirectoryPath)
+        .childDirectory('build')
+        .childDirectory('ios')
+        .childDirectory('framework')
+        .childDirectory('Release')
+        .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
+        .existsSync(),
+      isTrue,
+    );
+
+    final File flutterPluginsDependenciesFile = fileSystem
+      .directory(appDirectoryPath)
+      .childFile('.flutter-plugins-dependencies');
+
+    expect(flutterPluginsDependenciesFile.existsSync(), isTrue);
+    expect(
+      flutterPluginsDependenciesFile.readAsStringSync(),
+      isNot(contains('"swift_package_manager_enabled":true')),
+    );
+    expect(
+      flutterPluginsDependenciesFile.readAsStringSync(),
+      contains('"swift_package_manager_enabled":false'),
+    );
   }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 
   test("Generated Swift package uses iOS's project minimum deployment", () async {
     final Directory workingDirectory = fileSystem.systemTempDirectory
       .createTempSync('swift_package_manager_minimum_deployment_ios.');
     final String workingDirectoryPath = workingDirectory.path;
-    try {
-      await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
-      final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
-        flutterBin,
-        workingDirectoryPath,
-        iosLanguage: 'swift',
-        platform: 'ios',
-        usesSwiftPackageManager: true,
-        options: <String>['--platforms=ios'],
-      );
 
-      // Modify the project to raise the deployment version.
-      final File projectFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('ios')
-        .childDirectory('Runner.xcodeproj')
-        .childFile('project.pbxproj');
-
-      final String oldProject = projectFile.readAsStringSync();
-      final String newProject = oldProject.replaceAll(
-        RegExp(r'IPHONEOS_DEPLOYMENT_TARGET = \d+\.\d+;'),
-        'IPHONEOS_DEPLOYMENT_TARGET = 15.1;',
-      );
-
-      projectFile.writeAsStringSync(newProject);
-
-      // Build the app. This generates Flutter's Swift package.
-      await SwiftPackageManagerUtils.buildApp(
-        flutterBin,
-        appDirectoryPath,
-        options: <String>['ios', '--debug', '-v'],
-      );
-
-      // Verify the generated Swift package uses the project's minimum deployment.
-      final File generatedManifestFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('ios')
-        .childDirectory('Flutter')
-        .childDirectory('ephemeral')
-        .childDirectory('Packages')
-        .childDirectory('FlutterGeneratedPluginSwiftPackage')
-        .childFile('Package.swift');
-
-      expect(generatedManifestFile.existsSync(), isTrue);
-
-      final String generatedManifest = generatedManifestFile.readAsStringSync();
-      const String expected = '''
-    platforms: [
-        .iOS("15.1")
-    ],
-''';
-
-      expect(generatedManifest.contains(expected), isTrue);
-    } finally {
+    addTearDown(() async {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(
         workingDirectory,
         recursive: true,
       );
-    }
+    });
+
+    await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
+    final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+      flutterBin,
+      workingDirectoryPath,
+      iosLanguage: 'swift',
+      platform: 'ios',
+      usesSwiftPackageManager: true,
+      options: <String>['--platforms=ios'],
+    );
+
+    // Modify the project to raise the deployment version.
+    final File projectFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('ios')
+      .childDirectory('Runner.xcodeproj')
+      .childFile('project.pbxproj');
+
+    final String oldProject = projectFile.readAsStringSync();
+    final String newProject = oldProject.replaceAll(
+      RegExp(r'IPHONEOS_DEPLOYMENT_TARGET = \d+\.\d+;'),
+      'IPHONEOS_DEPLOYMENT_TARGET = 15.1;',
+    );
+
+    projectFile.writeAsStringSync(newProject);
+
+    // Build the app. This generates Flutter's Swift package.
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>['ios', '--debug', '-v'],
+    );
+
+    // Verify the generated Swift package uses the project's minimum deployment.
+    final File generatedManifestFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('ios')
+      .childDirectory('Flutter')
+      .childDirectory('ephemeral')
+      .childDirectory('Packages')
+      .childDirectory('FlutterGeneratedPluginSwiftPackage')
+      .childFile('Package.swift');
+
+    expect(generatedManifestFile.existsSync(), isTrue);
+
+    final String generatedManifest = generatedManifestFile.readAsStringSync();
+    const String expected = '''
+    platforms: [
+        .iOS("15.1")
+    ],
+''';
+
+    expect(generatedManifest.contains(expected), isTrue);
   }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 
   test("Generated Swift package uses macOS's project minimum deployment", () async {
     final Directory workingDirectory = fileSystem.systemTempDirectory
       .createTempSync('swift_package_manager_minimum_deployment_macos.');
     final String workingDirectoryPath = workingDirectory.path;
-    try {
-      await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
-      final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
-        flutterBin,
-        workingDirectoryPath,
-        iosLanguage: 'swift',
-        platform: 'macos',
-        usesSwiftPackageManager: true,
-        options: <String>['--platforms=macos'],
-      );
 
-      // Modify the project to raise the deployment version.
-      final File projectFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('macos')
-        .childDirectory('Runner.xcodeproj')
-        .childFile('project.pbxproj');
-
-      final String oldProject = projectFile.readAsStringSync();
-      final String newProject = oldProject.replaceAll(
-        RegExp(r'MACOSX_DEPLOYMENT_TARGET = \d+\.\d+;'),
-        'MACOSX_DEPLOYMENT_TARGET = 15.1;',
-      );
-
-      projectFile.writeAsStringSync(newProject);
-
-      // Build the app. This generates Flutter's Swift package.
-      await SwiftPackageManagerUtils.buildApp(
-        flutterBin,
-        appDirectoryPath,
-        options: <String>['macos', '--debug', '-v'],
-      );
-
-      // Verify the generated Swift package uses the project's minimum deployment.
-      final File generatedManifestFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('macos')
-        .childDirectory('Flutter')
-        .childDirectory('ephemeral')
-        .childDirectory('Packages')
-        .childDirectory('FlutterGeneratedPluginSwiftPackage')
-        .childFile('Package.swift');
-
-      expect(generatedManifestFile.existsSync(), isTrue);
-
-      final String generatedManifest = generatedManifestFile.readAsStringSync();
-      const String expected = '''
-    platforms: [
-        .macOS("15.1")
-    ],
-''';
-
-      expect(generatedManifest, contains(expected));
-    } finally {
+    addTearDown(() async {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(
         workingDirectory,
         recursive: true,
       );
-    }
+    });
+
+    await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
+    final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+      flutterBin,
+      workingDirectoryPath,
+      iosLanguage: 'swift',
+      platform: 'macos',
+      usesSwiftPackageManager: true,
+      options: <String>['--platforms=macos'],
+    );
+
+    // Modify the project to raise the deployment version.
+    final File projectFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('macos')
+      .childDirectory('Runner.xcodeproj')
+      .childFile('project.pbxproj');
+
+    final String oldProject = projectFile.readAsStringSync();
+    final String newProject = oldProject.replaceAll(
+      RegExp(r'MACOSX_DEPLOYMENT_TARGET = \d+\.\d+;'),
+      'MACOSX_DEPLOYMENT_TARGET = 15.1;',
+    );
+
+    projectFile.writeAsStringSync(newProject);
+
+    // Build the app. This generates Flutter's Swift package.
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>['macos', '--debug', '-v'],
+    );
+
+    // Verify the generated Swift package uses the project's minimum deployment.
+    final File generatedManifestFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('macos')
+      .childDirectory('Flutter')
+      .childDirectory('ephemeral')
+      .childDirectory('Packages')
+      .childDirectory('FlutterGeneratedPluginSwiftPackage')
+      .childFile('Package.swift');
+
+    expect(generatedManifestFile.existsSync(), isTrue);
+
+    final String generatedManifest = generatedManifestFile.readAsStringSync();
+    const String expected = '''
+    platforms: [
+        .macOS("15.1")
+    ],
+''';
+
+    expect(generatedManifest, contains(expected));
   }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 
   test('Removing the last plugin updates the generated Swift package', () async {
     final Directory workingDirectory = fileSystem.systemTempDirectory
       .createTempSync('swift_package_manager_remove_last_plugin.');
     final String workingDirectoryPath = workingDirectory.path;
-    try {
-      await SwiftPackageManagerUtils.enableSwiftPackageManager(
-        flutterBin,
-        workingDirectoryPath,
-      );
 
-      // Create an app with a plugin.
-      final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
-        flutterBin,
-        workingDirectoryPath,
-        iosLanguage: 'swift',
-        platform: 'ios',
-        usesSwiftPackageManager: true,
-        options: <String>['--platforms=ios'],
-      );
-
-      final SwiftPackageManagerPlugin integrationTestPlugin =
-        SwiftPackageManagerUtils.integrationTestPlugin('ios');
-
-      SwiftPackageManagerUtils.addDependency(
-        appDirectoryPath: appDirectoryPath,
-        plugin: integrationTestPlugin,
-      );
-
-      // Build the app to generate the Swift package.
-      await SwiftPackageManagerUtils.buildApp(
-        flutterBin,
-        appDirectoryPath,
-        options: <String>['ios', '--config-only', '-v'],
-      );
-
-      // Verify the generated Swift package depends on the plugin.
-      final File generatedManifestFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('ios')
-        .childDirectory('Flutter')
-        .childDirectory('ephemeral')
-        .childDirectory('Packages')
-        .childDirectory('FlutterGeneratedPluginSwiftPackage')
-        .childFile('Package.swift');
-
-      expect(generatedManifestFile.existsSync(), isTrue);
-
-      String generatedManifest = generatedManifestFile.readAsStringSync();
-      final String generatedSwiftDependency = '''
-    dependencies: [
-        .package(name: "integration_test", path: "${integrationTestPlugin.swiftPackagePlatformPath}")
-    ],
-''';
-
-      expect(generatedManifest.contains(generatedSwiftDependency), isTrue);
-
-      // Remove the plugin and rebuild the app to re-generate the Swift package.
-      SwiftPackageManagerUtils.removeDependency(
-        appDirectoryPath: appDirectoryPath,
-        plugin: integrationTestPlugin,
-      );
-
-      await SwiftPackageManagerUtils.buildApp(
-        flutterBin,
-        appDirectoryPath,
-        options: <String>['ios', '--config-only', '-v'],
-      );
-
-      // Verify the generated Swift package does not depend on the plugin.
-      expect(generatedManifestFile.existsSync(), isTrue);
-
-      generatedManifest = generatedManifestFile.readAsStringSync();
-      const String emptyDependencies = 'dependencies: [\n        \n    ],\n';
-
-      expect(generatedManifest, isNot(contains(generatedSwiftDependency)));
-      expect(generatedManifest, contains(emptyDependencies));
-    } finally {
+    addTearDown(() async {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(
         workingDirectory,
         recursive: true,
       );
-    }
+    });
+
+    await SwiftPackageManagerUtils.enableSwiftPackageManager(
+      flutterBin,
+      workingDirectoryPath,
+    );
+
+    // Create an app with a plugin.
+    final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+      flutterBin,
+      workingDirectoryPath,
+      iosLanguage: 'swift',
+      platform: 'ios',
+      usesSwiftPackageManager: true,
+      options: <String>['--platforms=ios'],
+    );
+
+    final SwiftPackageManagerPlugin integrationTestPlugin =
+      SwiftPackageManagerUtils.integrationTestPlugin('ios');
+
+    SwiftPackageManagerUtils.addDependency(
+      appDirectoryPath: appDirectoryPath,
+      plugin: integrationTestPlugin,
+    );
+
+    // Build the app to generate the Swift package.
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>['ios', '--config-only', '-v'],
+    );
+
+    // Verify the generated Swift package depends on the plugin.
+    final File generatedManifestFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('ios')
+      .childDirectory('Flutter')
+      .childDirectory('ephemeral')
+      .childDirectory('Packages')
+      .childDirectory('FlutterGeneratedPluginSwiftPackage')
+      .childFile('Package.swift');
+
+    expect(generatedManifestFile.existsSync(), isTrue);
+
+    String generatedManifest = generatedManifestFile.readAsStringSync();
+    final String generatedSwiftDependency = '''
+    dependencies: [
+        .package(name: "integration_test", path: "${integrationTestPlugin.swiftPackagePlatformPath}")
+    ],
+''';
+
+    expect(generatedManifest.contains(generatedSwiftDependency), isTrue);
+
+    // Remove the plugin and rebuild the app to re-generate the Swift package.
+    SwiftPackageManagerUtils.removeDependency(
+      appDirectoryPath: appDirectoryPath,
+      plugin: integrationTestPlugin,
+    );
+
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>['ios', '--config-only', '-v'],
+    );
+
+    // Verify the generated Swift package does not depend on the plugin.
+    expect(generatedManifestFile.existsSync(), isTrue);
+
+    generatedManifest = generatedManifestFile.readAsStringSync();
+    const String emptyDependencies = 'dependencies: [\n        \n    ],\n';
+
+    expect(generatedManifest, isNot(contains(generatedSwiftDependency)));
+    expect(generatedManifest, contains(emptyDependencies));
   }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 
   test('Migrated app builds after Swift Package Manager is turned off', () async {
     final Directory workingDirectory = fileSystem.systemTempDirectory
       .createTempSync('swift_package_manager_turned_off.');
     final String workingDirectoryPath = workingDirectory.path;
-    try {
-      await SwiftPackageManagerUtils.enableSwiftPackageManager(
-        flutterBin,
-        workingDirectoryPath,
-      );
 
-      // Create an app with a plugin and Swift Package Manager integration.
-      final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
-        flutterBin,
-        workingDirectoryPath,
-        iosLanguage: 'swift',
-        platform: 'ios',
-        usesSwiftPackageManager: true,
-        options: <String>['--platforms=ios'],
-      );
-
-      final SwiftPackageManagerPlugin integrationTestPlugin =
-        SwiftPackageManagerUtils.integrationTestPlugin('ios');
-
-      SwiftPackageManagerUtils.addDependency(
-        appDirectoryPath: appDirectoryPath,
-        plugin: integrationTestPlugin,
-      );
-
-      // Build the app.
-      await SwiftPackageManagerUtils.buildApp(
-        flutterBin,
-        appDirectoryPath,
-        options: <String>['ios', '--config-only', '-v'],
-      );
-
-      // The app should have SwiftPM integration.
-      final File xcodeProjectFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('ios')
-        .childDirectory('Runner.xcodeproj')
-        .childFile('project.pbxproj');
-      final File generatedManifestFile = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('ios')
-        .childDirectory('Flutter')
-        .childDirectory('ephemeral')
-        .childDirectory('Packages')
-        .childDirectory('FlutterGeneratedPluginSwiftPackage')
-        .childFile('Package.swift');
-      final Directory cocoaPodsPluginFramework = fileSystem
-        .directory(appDirectoryPath)
-        .childDirectory('build')
-        .childDirectory('ios')
-        .childDirectory('iphoneos')
-        .childDirectory('Runner.app')
-        .childDirectory('Frameworks')
-        .childDirectory('${integrationTestPlugin.pluginName}.framework');
-
-      expect(xcodeProjectFile.existsSync(), isTrue);
-      expect(generatedManifestFile.existsSync(), isTrue);
-      expect(cocoaPodsPluginFramework.existsSync(), isFalse);
-
-      String xcodeProject = xcodeProjectFile.readAsStringSync();
-      String generatedManifest = generatedManifestFile.readAsStringSync();
-      final String generatedSwiftDependency = '''
-    dependencies: [
-        .package(name: "integration_test", path: "${integrationTestPlugin.swiftPackagePlatformPath}")
-    ],
-''';
-
-      expect(xcodeProject, contains('FlutterGeneratedPluginSwiftPackage'));
-      expect(generatedManifest, contains(generatedSwiftDependency));
-
-      // Disable Swift Package Manager and do a clean re-build of the app.
-      // The build should succeed.
-      await SwiftPackageManagerUtils.disableSwiftPackageManager(
-        flutterBin,
-        workingDirectoryPath,
-      );
-
-      await SwiftPackageManagerUtils.cleanApp(flutterBin, appDirectoryPath);
-
-      await SwiftPackageManagerUtils.buildApp(
-        flutterBin,
-        appDirectoryPath,
-        options: <String>['ios', '-v'],
-      );
-
-      // The app should still have SwiftPM integration,
-      // but the plugin should be added using CocoaPods.
-      expect(xcodeProjectFile.existsSync(), isTrue);
-      expect(generatedManifestFile.existsSync(), isTrue);
-
-      xcodeProject = xcodeProjectFile.readAsStringSync();
-      generatedManifest = generatedManifestFile.readAsStringSync();
-      const String emptyDependencies = 'dependencies: [\n        \n    ],\n';
-
-      expect(xcodeProject, contains('FlutterGeneratedPluginSwiftPackage'));
-      expect(generatedManifest, isNot(contains('integration_test')));
-      expect(generatedManifest, contains(emptyDependencies));
-      expect(cocoaPodsPluginFramework.existsSync(), isTrue);
-    } finally {
+    addTearDown(() async {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(
         workingDirectory,
         recursive: true,
       );
-    }
+    });
+
+    await SwiftPackageManagerUtils.enableSwiftPackageManager(
+      flutterBin,
+      workingDirectoryPath,
+    );
+
+    // Create an app with a plugin and Swift Package Manager integration.
+    final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+      flutterBin,
+      workingDirectoryPath,
+      iosLanguage: 'swift',
+      platform: 'ios',
+      usesSwiftPackageManager: true,
+      options: <String>['--platforms=ios'],
+    );
+
+    final SwiftPackageManagerPlugin integrationTestPlugin =
+      SwiftPackageManagerUtils.integrationTestPlugin('ios');
+
+    SwiftPackageManagerUtils.addDependency(
+      appDirectoryPath: appDirectoryPath,
+      plugin: integrationTestPlugin,
+    );
+
+    // Build the app.
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>['ios', '--config-only', '-v'],
+    );
+
+    // The app should have SwiftPM integration.
+    final File xcodeProjectFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('ios')
+      .childDirectory('Runner.xcodeproj')
+      .childFile('project.pbxproj');
+    final File generatedManifestFile = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('ios')
+      .childDirectory('Flutter')
+      .childDirectory('ephemeral')
+      .childDirectory('Packages')
+      .childDirectory('FlutterGeneratedPluginSwiftPackage')
+      .childFile('Package.swift');
+    final Directory cocoaPodsPluginFramework = fileSystem
+      .directory(appDirectoryPath)
+      .childDirectory('build')
+      .childDirectory('ios')
+      .childDirectory('iphoneos')
+      .childDirectory('Runner.app')
+      .childDirectory('Frameworks')
+      .childDirectory('${integrationTestPlugin.pluginName}.framework');
+
+    expect(xcodeProjectFile.existsSync(), isTrue);
+    expect(generatedManifestFile.existsSync(), isTrue);
+    expect(cocoaPodsPluginFramework.existsSync(), isFalse);
+
+    String xcodeProject = xcodeProjectFile.readAsStringSync();
+    String generatedManifest = generatedManifestFile.readAsStringSync();
+    final String generatedSwiftDependency = '''
+    dependencies: [
+        .package(name: "integration_test", path: "${integrationTestPlugin.swiftPackagePlatformPath}")
+    ],
+''';
+
+    expect(xcodeProject, contains('FlutterGeneratedPluginSwiftPackage'));
+    expect(generatedManifest, contains(generatedSwiftDependency));
+
+    // Disable Swift Package Manager and do a clean re-build of the app.
+    // The build should succeed.
+    await SwiftPackageManagerUtils.disableSwiftPackageManager(
+      flutterBin,
+      workingDirectoryPath,
+    );
+
+    await SwiftPackageManagerUtils.cleanApp(flutterBin, appDirectoryPath);
+
+    await SwiftPackageManagerUtils.buildApp(
+      flutterBin,
+      appDirectoryPath,
+      options: <String>['ios', '-v'],
+    );
+
+    // The app should still have SwiftPM integration,
+    // but the plugin should be added using CocoaPods.
+    expect(xcodeProjectFile.existsSync(), isTrue);
+    expect(generatedManifestFile.existsSync(), isTrue);
+
+    xcodeProject = xcodeProjectFile.readAsStringSync();
+    generatedManifest = generatedManifestFile.readAsStringSync();
+    const String emptyDependencies = 'dependencies: [\n        \n    ],\n';
+
+    expect(xcodeProject, contains('FlutterGeneratedPluginSwiftPackage'));
+    expect(generatedManifest, isNot(contains('integration_test')));
+    expect(generatedManifest, contains(emptyDependencies));
+    expect(cocoaPodsPluginFramework.existsSync(), isTrue);
   }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 }

--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
@@ -59,21 +59,21 @@ void main() {
           );
           expect(
             fileSystem
-                .directory(appDirectoryPath)
-                .childDirectory(platformName)
-                .childFile('Podfile')
-                .existsSync(),
+              .directory(appDirectoryPath)
+              .childDirectory(platformName)
+              .childFile('Podfile')
+              .existsSync(),
             isTrue,
           );
           expect(
             fileSystem
-                .directory(appDirectoryPath)
-                .childDirectory(platformName)
-                .childDirectory('Flutter')
-                .childDirectory('ephemeral')
-                .childDirectory('Packages')
-                .childDirectory('FlutterGeneratedPluginSwiftPackage')
-                .existsSync(),
+              .directory(appDirectoryPath)
+              .childDirectory(platformName)
+              .childDirectory('Flutter')
+              .childDirectory('ephemeral')
+              .childDirectory('Packages')
+              .childDirectory('FlutterGeneratedPluginSwiftPackage')
+              .existsSync(),
             isFalse,
           );
 
@@ -109,21 +109,21 @@ void main() {
 
           expect(
             fileSystem
-                .directory(appDirectoryPath)
-                .childDirectory(platformName)
-                .childFile('Podfile')
-                .existsSync(),
+              .directory(appDirectoryPath)
+              .childDirectory(platformName)
+              .childFile('Podfile')
+              .existsSync(),
             isTrue,
           );
           expect(
             fileSystem
-                .directory(appDirectoryPath)
-                .childDirectory(platformName)
-                .childDirectory('Flutter')
-                .childDirectory('ephemeral')
-                .childDirectory('Packages')
-                .childDirectory('FlutterGeneratedPluginSwiftPackage')
-                .existsSync(),
+              .directory(appDirectoryPath)
+              .childDirectory(platformName)
+              .childDirectory('Flutter')
+              .childDirectory('ephemeral')
+              .childDirectory('Packages')
+              .childDirectory('FlutterGeneratedPluginSwiftPackage')
+              .existsSync(),
             isTrue,
           );
 
@@ -154,21 +154,21 @@ void main() {
 
           expect(
             fileSystem
-                .directory(appDirectoryPath)
-                .childDirectory(platformName)
-                .childFile('Podfile')
-                .existsSync(),
+              .directory(appDirectoryPath)
+              .childDirectory(platformName)
+              .childFile('Podfile')
+              .existsSync(),
             isTrue,
           );
           expect(
             fileSystem
-                .directory(appDirectoryPath)
-                .childDirectory(platformName)
-                .childDirectory('Flutter')
-                .childDirectory('ephemeral')
-                .childDirectory('Packages')
-                .childDirectory('FlutterGeneratedPluginSwiftPackage')
-                .existsSync(),
+              .directory(appDirectoryPath)
+              .childDirectory(platformName)
+              .childDirectory('Flutter')
+              .childDirectory('ephemeral')
+              .childDirectory('Packages')
+              .childDirectory('FlutterGeneratedPluginSwiftPackage')
+              .existsSync(),
             isTrue,
           );
 
@@ -249,21 +249,21 @@ void main() {
 
         expect(
           fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory(platformName)
-              .childFile('Podfile')
-              .existsSync(),
+            .directory(appDirectoryPath)
+            .childDirectory(platformName)
+            .childFile('Podfile')
+            .existsSync(),
           isFalse,
         );
         expect(
           fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory(platformName)
-              .childDirectory('Flutter')
-              .childDirectory('ephemeral')
-              .childDirectory('Packages')
-              .childDirectory('FlutterGeneratedPluginSwiftPackage')
-              .existsSync(),
+            .directory(appDirectoryPath)
+            .childDirectory(platformName)
+            .childDirectory('Flutter')
+            .childDirectory('ephemeral')
+            .childDirectory('Packages')
+            .childDirectory('FlutterGeneratedPluginSwiftPackage')
+            .existsSync(),
           isTrue,
         );
 
@@ -285,13 +285,13 @@ void main() {
 
         expect(
           fileSystem
-              .directory(appDirectoryPath)
-              .childDirectory('build')
-              .childDirectory(platformName)
-              .childDirectory('framework')
-              .childDirectory('Release')
-              .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
-              .existsSync(),
+            .directory(appDirectoryPath)
+            .childDirectory('build')
+            .childDirectory(platformName)
+            .childDirectory('framework')
+            .childDirectory('Release')
+            .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
+            .existsSync(),
           isTrue,
         );
       } finally {
@@ -305,71 +305,71 @@ void main() {
 
     test('Caches build targets between builds with Swift Package Manager on $platformName', () async {
       final Directory workingDirectory = fileSystem.systemTempDirectory
-            .createTempSync('swift_package_manager_caching.');
-        final String workingDirectoryPath = workingDirectory.path;
-        try {
-          // Create and build an app using the Swift Package Manager version of
-          // integration_test.
-          await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
+        .createTempSync('swift_package_manager_caching.');
+      final String workingDirectoryPath = workingDirectory.path;
+      try {
+        // Create and build an app using the Swift Package Manager version of
+        // integration_test.
+        await SwiftPackageManagerUtils.enableSwiftPackageManager(flutterBin, workingDirectoryPath);
 
-          final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
-            flutterBin,
-            workingDirectoryPath,
-            iosLanguage: 'swift',
-            platform: platformName,
-            usesSwiftPackageManager: true,
-            options: <String>['--platforms=$platformName'],
-          );
-          SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
+        final String appDirectoryPath = await SwiftPackageManagerUtils.createApp(
+          flutterBin,
+          workingDirectoryPath,
+          iosLanguage: 'swift',
+          platform: platformName,
+          usesSwiftPackageManager: true,
+          options: <String>['--platforms=$platformName'],
+        );
+        SwiftPackageManagerUtils.addDependency(appDirectoryPath: appDirectoryPath, plugin: integrationTestPlugin);
 
-          final String unpackTarget = 'debug_unpack_$platformName';
-          final String bundleFlutterAssetsTarget = 'debug_${platformName}_bundle_flutter_assets';
-          final bool noCodesign = platformName == 'ios';
-          await SwiftPackageManagerUtils.buildApp(
-            flutterBin,
-            appDirectoryPath,
-            options: <String>[
-              platformName,
-              '--debug',
-              '-v',
-              if (noCodesign)
-                '--no-codesign',
-            ],
-            expectedLines: <Pattern>[
-              r'SchemeAction Run\ Prepare\ Flutter\ Framework\ Script',
-              '$unpackTarget: Starting due to',
-              '-dPreBuildAction=PrepareFramework $unpackTarget',
-            ],
-            unexpectedLines: <String>[],
-          );
+        final String unpackTarget = 'debug_unpack_$platformName';
+        final String bundleFlutterAssetsTarget = 'debug_${platformName}_bundle_flutter_assets';
+        final bool noCodesign = platformName == 'ios';
+        await SwiftPackageManagerUtils.buildApp(
+          flutterBin,
+          appDirectoryPath,
+          options: <String>[
+            platformName,
+            '--debug',
+            '-v',
+            if (noCodesign)
+              '--no-codesign',
+          ],
+          expectedLines: <Pattern>[
+            r'SchemeAction Run\ Prepare\ Flutter\ Framework\ Script',
+            '$unpackTarget: Starting due to',
+            '-dPreBuildAction=PrepareFramework $unpackTarget',
+          ],
+          unexpectedLines: <String>[],
+        );
 
-          await SwiftPackageManagerUtils.buildApp(
-            flutterBin,
-            appDirectoryPath,
-            options: <String>[
-              platformName,
-              '--debug',
-              '-v',
-              if (noCodesign)
-                '--no-codesign',
-            ],
-            expectedLines: <Pattern>[
-              r'SchemeAction Run\ Prepare\ Flutter\ Framework\ Script',
-              'Skipping target: $unpackTarget',
-              'Skipping target: $bundleFlutterAssetsTarget',
-            ],
-            unexpectedLines: <String>[
-              'Starting due to',
-            ],
-          );
+        await SwiftPackageManagerUtils.buildApp(
+          flutterBin,
+          appDirectoryPath,
+          options: <String>[
+            platformName,
+            '--debug',
+            '-v',
+            if (noCodesign)
+              '--no-codesign',
+          ],
+          expectedLines: <Pattern>[
+            r'SchemeAction Run\ Prepare\ Flutter\ Framework\ Script',
+            'Skipping target: $unpackTarget',
+            'Skipping target: $bundleFlutterAssetsTarget',
+          ],
+          unexpectedLines: <String>[
+            'Starting due to',
+          ],
+        );
 
-        } finally {
-          await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
-          ErrorHandlingFileSystem.deleteIfExists(
-            workingDirectory,
-            recursive: true,
-          );
-        }
+      } finally {
+        await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
+        ErrorHandlingFileSystem.deleteIfExists(
+          workingDirectory,
+          recursive: true,
+        );
+      }
     }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
   }
 
@@ -409,36 +409,36 @@ void main() {
       );
       expect(
         fileSystem
-            .directory(appDirectoryPath)
-            .childDirectory('.ios')
-            .childDirectory('Flutter')
-            .childDirectory('ephemeral')
-            .childDirectory('Packages')
-            .childDirectory('FlutterGeneratedPluginSwiftPackage')
-            .existsSync(),
+          .directory(appDirectoryPath)
+          .childDirectory('.ios')
+          .childDirectory('Flutter')
+          .childDirectory('ephemeral')
+          .childDirectory('Packages')
+          .childDirectory('FlutterGeneratedPluginSwiftPackage')
+          .existsSync(),
         isFalse,
       );
       final File pbxprojFile = fileSystem
-          .directory(appDirectoryPath)
-          .childDirectory('.ios')
-          .childDirectory('Runner.xcodeproj')
-          .childFile('project.pbxproj');
+        .directory(appDirectoryPath)
+        .childDirectory('.ios')
+        .childDirectory('Runner.xcodeproj')
+        .childFile('project.pbxproj');
       expect(pbxprojFile.existsSync(), isTrue);
       expect(
-        pbxprojFile.readAsStringSync().contains('FlutterGeneratedPluginSwiftPackage'),
-        isFalse,
+        pbxprojFile.readAsStringSync(),
+        isNot(contains('FlutterGeneratedPluginSwiftPackage')),
       );
       final File xcschemeFile = fileSystem
-          .directory(appDirectoryPath)
-          .childDirectory('.ios')
-          .childDirectory('Runner.xcodeproj')
-          .childDirectory('xcshareddata')
-          .childDirectory('xcschemes')
-          .childFile('Runner.xcscheme');
+        .directory(appDirectoryPath)
+        .childDirectory('.ios')
+        .childDirectory('Runner.xcodeproj')
+        .childDirectory('xcshareddata')
+        .childDirectory('xcschemes')
+        .childFile('Runner.xcscheme');
       expect(xcschemeFile.existsSync(), isTrue);
       expect(
-        xcschemeFile.readAsStringSync().contains('Run Prepare Flutter Framework Script'),
-        isFalse,
+        xcschemeFile.readAsStringSync(),
+        isNot(contains('Run Prepare Flutter Framework Script')),
       );
 
       await SwiftPackageManagerUtils.buildApp(
@@ -458,13 +458,13 @@ void main() {
 
       expect(
         fileSystem
-            .directory(appDirectoryPath)
-            .childDirectory('build')
-            .childDirectory('ios')
-            .childDirectory('framework')
-            .childDirectory('Release')
-            .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
-            .existsSync(),
+          .directory(appDirectoryPath)
+          .childDirectory('build')
+          .childDirectory('ios')
+          .childDirectory('framework')
+          .childDirectory('Release')
+          .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
+          .existsSync(),
         isTrue,
       );
     } finally {
@@ -478,7 +478,7 @@ void main() {
 
   test('Build ios-framework with non module app uses CocoaPods', () async {
     final Directory workingDirectory = fileSystem.systemTempDirectory
-        .createTempSync('swift_package_manager_build_framework_non_module.');
+      .createTempSync('swift_package_manager_build_framework_non_module.');
     final String workingDirectoryPath = workingDirectory.path;
     try {
       // Create and build a regular app and framework using the CocoaPods version of
@@ -540,13 +540,13 @@ void main() {
 
       expect(
         fileSystem
-            .directory(appDirectoryPath)
-            .childDirectory('build')
-            .childDirectory('ios')
-            .childDirectory('framework')
-            .childDirectory('Release')
-            .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
-            .existsSync(),
+          .directory(appDirectoryPath)
+          .childDirectory('build')
+          .childDirectory('ios')
+          .childDirectory('framework')
+          .childDirectory('Release')
+          .childDirectory('${integrationTestPlugin.pluginName}.xcframework')
+          .existsSync(),
         isTrue,
       );
 
@@ -694,7 +694,7 @@ void main() {
     ],
 ''';
 
-      expect(generatedManifest.contains(expected), isTrue);
+      expect(generatedManifest, contains(expected));
     } finally {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(
@@ -778,8 +778,8 @@ void main() {
       generatedManifest = generatedManifestFile.readAsStringSync();
       const String emptyDependencies = 'dependencies: [\n        \n    ],\n';
 
-      expect(generatedManifest.contains(generatedSwiftDependency), isFalse);
-      expect(generatedManifest.contains(emptyDependencies), isTrue);
+      expect(generatedManifest, isNot(contains(generatedSwiftDependency)));
+      expect(generatedManifest, contains(emptyDependencies));
     } finally {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);
       ErrorHandlingFileSystem.deleteIfExists(
@@ -859,8 +859,8 @@ void main() {
     ],
 ''';
 
-      expect(xcodeProject.contains('FlutterGeneratedPluginSwiftPackage'), isTrue);
-      expect(generatedManifest.contains(generatedSwiftDependency), isTrue);
+      expect(xcodeProject, contains('FlutterGeneratedPluginSwiftPackage'));
+      expect(generatedManifest, contains(generatedSwiftDependency));
 
       // Disable Swift Package Manager and do a clean re-build of the app.
       // The build should succeed.
@@ -886,9 +886,9 @@ void main() {
       generatedManifest = generatedManifestFile.readAsStringSync();
       const String emptyDependencies = 'dependencies: [\n        \n    ],\n';
 
-      expect(xcodeProject.contains('FlutterGeneratedPluginSwiftPackage'), isTrue);
-      expect(generatedManifest.contains('integration_test'), isFalse);
-      expect(generatedManifest.contains(emptyDependencies), isTrue);
+      expect(xcodeProject, contains('FlutterGeneratedPluginSwiftPackage'));
+      expect(generatedManifest, isNot(contains('integration_test')));
+      expect(generatedManifest, contains(emptyDependencies));
       expect(cocoaPodsPluginFramework.existsSync(), isTrue);
     } finally {
       await SwiftPackageManagerUtils.disableSwiftPackageManager(flutterBin, workingDirectoryPath);


### PR DESCRIPTION
I recommend reviewing with [whitespace changes disabled](https://github.com/flutter/flutter/pull/157971/files?diff=split&w=1).

Changes:

1. Replaces `expect(string.contains('foo'), isTrue)` with `expect(string, contains('foo'))`
2. Replaces `try/finally` with `addTearDown`

Follow-up to: https://github.com/flutter/flutter/pull/157482#discussion_r1813939657