### PR TITLE
Adjusts the Hindi TimeOfDayFormat to display in a LTR orientation in localizations.

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -18612,7 +18612,7 @@ class MaterialLocalizationHi extends GlobalMaterialLocalizations {
   String get tabLabelRaw => r'$tabCount का टैब $tabIndex';
 
   @override
-  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.a_space_h_colon_mm;
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.h_colon_mm_space_a;
 
   @override
   String get timePickerDialHelpText => 'समय चुनें';

--- a/packages/flutter_localizations/lib/src/l10n/material_hi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_hi.arb
@@ -1,6 +1,6 @@
 {
   "scriptCategory": "dense",
-  "timeOfDayFormat": "ah:mm",
+  "timeOfDayFormat": "h:mm a",
   "openAppDrawerTooltip": "नेविगेशन मेन्यू खोलें",
   "backButtonTooltip": "वापस जाएं",
   "closeButtonTooltip": "बंद करें",

--- a/packages/flutter_localizations/test/material/time_picker_test.dart
+++ b/packages/flutter_localizations/test/material/time_picker_test.dart
@@ -603,6 +603,38 @@ void main() {
       labels00To22TwoDigit,
     );
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/156565
+  testWidgets('AM/PM buttons should be aligned to LTR in Hindi language - Portrait', (WidgetTester tester) async {
+    const Locale locale = Locale('hi', 'HI');
+
+    final Offset centerPortrait = await startPicker(tester, (TimeOfDay? time) {}, locale: locale, useMaterial3: false, orientation: Orientation.portrait);
+
+    final Finder amButtonPortrait = find.text('AM');
+    final Finder pmButtonPortrait = find.text('PM') ;
+
+    final Offset amButtonPositionPortrait = tester.getCenter(amButtonPortrait);
+    final Offset pmButtonPositionPortrait = tester.getCenter(pmButtonPortrait);
+
+    expect(amButtonPositionPortrait.dx, greaterThan(centerPortrait.dx));
+    expect(pmButtonPositionPortrait.dx, greaterThan(centerPortrait.dx));
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/156565
+  testWidgets('AM/PM buttons should be aligned to LTR in Hindi language - Landscape', (WidgetTester tester) async {
+    const Locale locale = Locale('hi', 'HI');
+
+    final Offset centerLandscape = await startPicker(tester, (TimeOfDay? time) {}, locale: locale, useMaterial3: false, orientation: Orientation.landscape);
+
+    final Finder amButtonLandscape = find.text('AM');
+    final Finder pmButtonLandscape = find.text('PM');
+
+    final Offset amButtonPositionLandscape = tester.getCenter(amButtonLandscape);
+    final Offset pmButtonPositionLandscape = tester.getCenter(pmButtonLandscape);
+
+    expect(amButtonPositionLandscape.dy, greaterThan(centerLandscape.dy));
+    expect(pmButtonPositionLandscape.dy, greaterThan(centerLandscape.dy));
+  });
 }
 
 class _TimePickerLauncher extends StatelessWidget {
@@ -611,12 +643,14 @@ class _TimePickerLauncher extends StatelessWidget {
     required this.locale,
     this.entryMode = TimePickerEntryMode.dial,
     this.useMaterial3,
+    this.orientation,
   });
 
   final ValueChanged<TimeOfDay?>? onChanged;
   final Locale locale;
   final TimePickerEntryMode entryMode;
   final bool? useMaterial3;
+  final Orientation? orientation;
 
   @override
   Widget build(BuildContext context) {
@@ -635,6 +669,7 @@ class _TimePickerLauncher extends StatelessWidget {
                   onChanged?.call(await showTimePicker(
                     context: context,
                     initialEntryMode: entryMode,
+                    orientation: orientation,
                     initialTime: const TimeOfDay(hour: 7, minute: 0),
                   ));
                 },
@@ -652,12 +687,14 @@ Future<Offset> startPicker(
   ValueChanged<TimeOfDay?> onChanged, {
     Locale locale = const Locale('en', 'US'),
     bool? useMaterial3,
+    Orientation? orientation,
 }) async {
   await tester.pumpWidget(
     _TimePickerLauncher(
       onChanged: onChanged,
       locale: locale,
       useMaterial3: useMaterial3,
+      orientation: orientation,
     ),
   );
   await tester.tap(find.text('X'));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156565
This update corrects the `TimeOfDayFormat` mapping for the Hindi language. Previously, the format was incorrectly set to `a_space_h_colon_mm` - (a h:mm), but it should be `h_colon_mm_space_a` - (h:mm a) since Hindi is a LTR language.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
