### PR TITLE
Improve consistency of code snippets in basic.dart

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -302,7 +302,6 @@ class Directionality extends _UbiquitousInheritedWidget {
 ///   colorBlendMode: BlendMode.modulate
 /// )
 /// ```
-///
 /// {@end-tool}
 ///
 /// Directly drawing an [Image] or [Color] with opacity is faster than using
@@ -559,6 +558,7 @@ class BackdropGroup extends InheritedWidget {
 /// {@youtube 560 315 https://www.youtube.com/watch?v=dYRs7Q1vfYI}
 ///
 /// {@tool snippet}
+///
 /// If the [BackdropFilter] needs to be applied to an area that exactly matches
 /// its child, wraps the [BackdropFilter] with a clip widget that clips exactly
 /// to that child.
@@ -622,6 +622,7 @@ class BackdropGroup extends InheritedWidget {
 /// ```
 /// {@end-tool}
 /// {@tool snippet}
+///
 /// Instead consider the following approach which directly applies a blur
 /// to the child widget.
 ///
@@ -633,7 +634,6 @@ class BackdropGroup extends InheritedWidget {
 ///    );
 ///  }
 /// ```
-///
 /// {@end-tool}
 ///
 /// See also:
@@ -2132,6 +2132,7 @@ class Padding extends SingleChildRenderObjectWidget {
 /// the width of this widget will always be twice its child's width.
 ///
 /// {@tool snippet}
+///
 /// The [Align] widget in this example uses one of the defined constants from
 /// [Alignment], [Alignment.topRight]. This places the [FlutterLogo] in the top
 /// right corner of the parent blue [Container].
@@ -2163,6 +2164,7 @@ class Padding extends SingleChildRenderObjectWidget {
 /// each other.
 ///
 /// {@tool snippet}
+///
 /// The [Alignment] used in the following example defines two points:
 ///
 ///   * (0.2 * width of [FlutterLogo]/2 + width of [FlutterLogo]/2, 0.6 * height
@@ -2199,6 +2201,7 @@ class Padding extends SingleChildRenderObjectWidget {
 /// {@end-tool}
 ///
 /// {@tool snippet}
+///
 /// The [FractionalOffset] used in the following example defines two points:
 ///
 ///   * (0.2 * width of [FlutterLogo], 0.6 * height of [FlutterLogo]) = (12.0, 36.0)
@@ -2691,6 +2694,7 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
 /// vertically:
 ///
 /// {@tool snippet}
+///
 /// In the following snippet, the [Card] is guaranteed to be at least as tall as
 /// its "natural" height. Unlike [UnconstrainedBox], it will become taller if
 /// its "natural" height is smaller than 40 px. If the [Container] isn't high
@@ -7540,6 +7544,7 @@ class Semantics extends SingleChildRenderObjectWidget {
 /// the user would not be able to be sure that they were related.
 ///
 /// {@tool snippet}
+///
 /// This snippet shows how to use [MergeSemantics] to merge the semantics of
 /// a [Checkbox] and [Text] widget.
 ///


### PR DESCRIPTION
Updates `basic.dart` to use consistent doc snippets that follows the style from the [documentation on snippets](https://github.com/flutter/flutter/tree/master/dev/snippets#snippet-tool).

Follow-up to: https://github.com/flutter/flutter/pull/157227#discussion_r1807499353

