### PR TITLE
Adds semantics role and annontates tabs

### DIFF
--- a/engine/src/flutter/lib/ui/fixtures/ui_test.dart
+++ b/engine/src/flutter/lib/ui/fixtures/ui_test.dart
@@ -238,6 +238,74 @@ void sendSemanticsUpdate() {
   _semanticsUpdate(builder.build());
 }
 
+@pragma('vm:entry-point')
+void sendSemanticsUpdateWithRole() {
+  final SemanticsUpdateBuilder builder = SemanticsUpdateBuilder();
+
+  final Float64List transform = Float64List(16);
+  final Int32List childrenInTraversalOrder = Int32List(0);
+  final Int32List childrenInHitTestOrder = Int32List(0);
+  final Int32List additionalActions = Int32List(0);
+  transform[0] = 1;
+  transform[1] = 0;
+  transform[2] = 0;
+  transform[3] = 0;
+
+  transform[4] = 0;
+  transform[5] = 1;
+  transform[6] = 0;
+  transform[7] = 0;
+
+  transform[8] = 0;
+  transform[9] = 0;
+  transform[10] = 1;
+  transform[11] = 0;
+
+  transform[12] = 0;
+  transform[13] = 0;
+  transform[14] = 0;
+  transform[15] = 0;
+  builder.updateNode(
+    id: 0,
+    flags: 0,
+    actions: 0,
+    maxValueLength: 0,
+    currentValueLength: 0,
+    textSelectionBase: -1,
+    textSelectionExtent: -1,
+    platformViewId: -1,
+    scrollChildren: 0,
+    scrollIndex: 0,
+    scrollPosition: 0,
+    scrollExtentMax: 0,
+    scrollExtentMin: 0,
+    rect: Rect.fromLTRB(0, 0, 10, 10),
+    elevation: 0,
+    thickness: 0,
+    identifier: "identifier",
+    label: "label",
+    labelAttributes: const <StringAttribute>[],
+    value: "value",
+    valueAttributes: const <StringAttribute>[],
+    increasedValue: "increasedValue",
+    increasedValueAttributes: const <StringAttribute>[],
+    decreasedValue: "decreasedValue",
+    decreasedValueAttributes: const <StringAttribute>[],
+    hint: "hint",
+    hintAttributes: const <StringAttribute>[],
+    tooltip: "tooltip",
+    textDirection: TextDirection.ltr,
+    transform: transform,
+    childrenInTraversalOrder: childrenInTraversalOrder,
+    childrenInHitTestOrder: childrenInHitTestOrder,
+    additionalActions: additionalActions,
+    headingLevel: 0,
+    linkUrl: '',
+    role: SemanticsRole.tab,
+  );
+  _semanticsUpdate(builder.build());
+}
+
 @pragma('vm:external-name', 'SemanticsUpdate')
 external void _semanticsUpdate(SemanticsUpdate update);
 

--- a/engine/src/flutter/lib/ui/semantics.dart
+++ b/engine/src/flutter/lib/ui/semantics.dart
@@ -339,6 +339,29 @@ class SemanticsAction {
   String toString() => 'SemanticsAction.$name';
 }
 
+/// An enum to describe the role for a semantics node.
+///
+/// The roles are translated into native accessibility roles in each platform.
+enum SemanticsRole {
+  /// Does not represent any role.
+  none,
+
+  /// A tab button.
+  ///
+  /// see also:
+  ///  * [tabBar], which is the role for containers of tab buttons.
+  tab,
+
+  /// Contains tab buttons.
+  ///
+  /// see also:
+  ///  * [tab], which is the role for tab buttons.
+  tabBar,
+
+  /// The main display for a tab.
+  tabPanel,
+}
+
 /// A Boolean value that can be associated with a semantics node.
 //
 // When changes are made to this class, the equivalent APIs in
@@ -1000,6 +1023,7 @@ abstract class SemanticsUpdateBuilder {
     required Int32List additionalActions,
     int headingLevel = 0,
     String linkUrl = '',
+    SemanticsRole role = SemanticsRole.none,
   });
 
   /// Update the custom semantics action associated with the given `id`.
@@ -1075,6 +1099,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
     required Int32List additionalActions,
     int headingLevel = 0,
     String linkUrl = '',
+    SemanticsRole role = SemanticsRole.none,
   }) {
     assert(_matrix4IsValid(transform));
     assert(
@@ -1120,6 +1145,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
       additionalActions,
       headingLevel,
       linkUrl,
+      role.index,
     );
   }
 
@@ -1164,6 +1190,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
       Handle,
       Int32,
       Handle,
+      Int32,
     )
   >(symbol: 'SemanticsUpdateBuilder::updateNode')
   external void _updateNode(
@@ -1205,6 +1232,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
     Int32List additionalActions,
     int headingLevel,
     String linkUrl,
+    int role,
   );
 
   @override

--- a/engine/src/flutter/lib/ui/semantics/semantics_node.h
+++ b/engine/src/flutter/lib/ui/semantics/semantics_node.h
@@ -57,6 +57,19 @@ const int kHorizontalScrollSemanticsActions =
 const int kScrollableSemanticsActions =
     kVerticalScrollSemanticsActions | kHorizontalScrollSemanticsActions;
 
+/// C/C++ representation of `SemanticsRole` defined in
+/// `lib/ui/semantics.dart`.
+///\warning This must match the `SemanticsRole` enum in
+///         `lib/ui/semantics.dart`.
+/// See also:
+///   - file://./../../../lib/ui/semantics.dart
+enum class SemanticsRole : int32_t {
+  kNone = 0,
+  kTab = 1,
+  kTabBar = 2,
+  kTabPanel = 3,
+};
+
 /// C/C++ representation of `SemanticsFlags` defined in
 /// `lib/ui/semantics.dart`.
 ///\warning This must match the `SemanticsFlags` enum in
@@ -148,6 +161,7 @@ struct SemanticsNode {
   int32_t headingLevel = 0;
 
   std::string linkUrl;
+  SemanticsRole role;
 };
 
 // Contains semantic nodes that need to be updated.

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
@@ -68,7 +68,8 @@ void SemanticsUpdateBuilder::updateNode(
     const tonic::Int32List& childrenInHitTestOrder,
     const tonic::Int32List& localContextActions,
     int headingLevel,
-    std::string linkUrl) {
+    std::string linkUrl,
+    int role) {
   FML_CHECK(scrollChildren == 0 ||
             (scrollChildren > 0 && childrenInHitTestOrder.data()))
       << "Semantics update contained scrollChildren but did not have "
@@ -123,6 +124,7 @@ void SemanticsUpdateBuilder::updateNode(
 
   node.headingLevel = headingLevel;
   node.linkUrl = std::move(linkUrl);
+  node.role = (SemanticsRole)role;
 }
 
 void SemanticsUpdateBuilder::updateCustomAction(int id,

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
@@ -67,7 +67,8 @@ class SemanticsUpdateBuilder
       const tonic::Int32List& childrenInHitTestOrder,
       const tonic::Int32List& customAccessibilityActions,
       int headingLevel,
-      std::string linkUrl);
+      std::string linkUrl,
+      int role);
 
   void updateCustomAction(int id,
                           std::string label,

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder_unittests.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder_unittests.cc
@@ -89,46 +89,46 @@ TEST_F(SemanticsUpdateBuilderTest, CanHandleAttributedStrings) {
 }
 
 TEST_F(SemanticsUpdateBuilderTest, CanHandleSemanticsRole) {
-    auto message_latch = std::make_shared<fml::AutoResetWaitableEvent>();
+  auto message_latch = std::make_shared<fml::AutoResetWaitableEvent>();
 
-    auto nativeSemanticsUpdate = [message_latch](Dart_NativeArguments args) {
-        auto handle = Dart_GetNativeArgument(args, 0);
-        intptr_t peer = 0;
-        Dart_Handle result = Dart_GetNativeInstanceField(
-                handle, tonic::DartWrappable::kPeerIndex, &peer);
-        ASSERT_FALSE(Dart_IsError(result));
-        SemanticsUpdate* update = reinterpret_cast<SemanticsUpdate*>(peer);
-        SemanticsNodeUpdates nodes = update->takeNodes();
-        ASSERT_EQ(nodes.size(), (size_t)1);
-        auto node = nodes.find(0)->second;
-        // Should match the updateNode in ui_test.dart.
-        ASSERT_EQ(node.role, SemanticsRole::kTab);
-        message_latch->Signal();
-    };
+  auto nativeSemanticsUpdate = [message_latch](Dart_NativeArguments args) {
+    auto handle = Dart_GetNativeArgument(args, 0);
+    intptr_t peer = 0;
+    Dart_Handle result = Dart_GetNativeInstanceField(
+        handle, tonic::DartWrappable::kPeerIndex, &peer);
+    ASSERT_FALSE(Dart_IsError(result));
+    SemanticsUpdate* update = reinterpret_cast<SemanticsUpdate*>(peer);
+    SemanticsNodeUpdates nodes = update->takeNodes();
+    ASSERT_EQ(nodes.size(), (size_t)1);
+    auto node = nodes.find(0)->second;
+    // Should match the updateNode in ui_test.dart.
+    ASSERT_EQ(node.role, SemanticsRole::kTab);
+    message_latch->Signal();
+  };
 
-    Settings settings = CreateSettingsForFixture();
-    TaskRunners task_runners("test",                  // label
-                             GetCurrentTaskRunner(),  // platform
-                             CreateNewThread(),       // raster
-                             CreateNewThread(),       // ui
-                             CreateNewThread()        // io
-    );
+  Settings settings = CreateSettingsForFixture();
+  TaskRunners task_runners("test",                  // label
+                           GetCurrentTaskRunner(),  // platform
+                           CreateNewThread(),       // raster
+                           CreateNewThread(),       // ui
+                           CreateNewThread()        // io
+  );
 
-    AddNativeCallback("SemanticsUpdate",
-    CREATE_NATIVE_ENTRY(nativeSemanticsUpdate));
+  AddNativeCallback("SemanticsUpdate",
+                    CREATE_NATIVE_ENTRY(nativeSemanticsUpdate));
 
-    std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
+  std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
 
-    ASSERT_TRUE(shell->IsSetup());
-    auto configuration = RunConfiguration::InferFromSettings(settings);
-    configuration.SetEntrypoint("sendSemanticsUpdateWithRole");
+  ASSERT_TRUE(shell->IsSetup());
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("sendSemanticsUpdateWithRole");
 
-    shell->RunEngine(std::move(configuration), [](auto result) {
+  shell->RunEngine(std::move(configuration), [](auto result) {
     ASSERT_EQ(result, Engine::RunStatus::Success);
-    });
+  });
 
-    message_latch->Wait();
-    DestroyShell(std::move(shell), task_runners);
+  message_latch->Wait();
+  DestroyShell(std::move(shell), task_runners);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder_unittests.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder_unittests.cc
@@ -95,7 +95,7 @@ TEST_F(SemanticsUpdateBuilderTest, CanHandleSemanticsRole) {
     auto handle = Dart_GetNativeArgument(args, 0);
     intptr_t peer = 0;
     Dart_Handle result = Dart_GetNativeInstanceField(
-            handle, tonic::DartWrappable::kPeerIndex, &peer);
+        handle, tonic::DartWrappable::kPeerIndex, &peer);
     ASSERT_FALSE(Dart_IsError(result));
     SemanticsUpdate* update = reinterpret_cast<SemanticsUpdate*>(peer);
     SemanticsNodeUpdates nodes = update->takeNodes();
@@ -120,7 +120,7 @@ TEST_F(SemanticsUpdateBuilderTest, CanHandleSemanticsRole) {
     ASSERT_EQ(node.hintAttributes[0]->end, 1);
     ASSERT_EQ(node.hintAttributes[0]->type, StringAttributeType::kLocale);
     auto local_attribute =
-            std::static_pointer_cast<LocaleStringAttribute>(node.hintAttributes[0]);
+        std::static_pointer_cast<LocaleStringAttribute>(node.hintAttributes[0]);
     ASSERT_EQ(local_attribute->locale, "en-MX");
 
     ASSERT_EQ(node.increasedValue, "increasedValue");
@@ -157,7 +157,7 @@ TEST_F(SemanticsUpdateBuilderTest, CanHandleSemanticsRole) {
   configuration.SetEntrypoint("sendSemanticsUpdate");
 
   shell->RunEngine(std::move(configuration), [](auto result) {
-      ASSERT_EQ(result, Engine::RunStatus::Success);
+    ASSERT_EQ(result, Engine::RunStatus::Success);
   });
 
   message_latch->Wait();

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder_unittests.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder_unittests.cc
@@ -95,14 +95,47 @@ TEST_F(SemanticsUpdateBuilderTest, CanHandleSemanticsRole) {
     auto handle = Dart_GetNativeArgument(args, 0);
     intptr_t peer = 0;
     Dart_Handle result = Dart_GetNativeInstanceField(
-        handle, tonic::DartWrappable::kPeerIndex, &peer);
+            handle, tonic::DartWrappable::kPeerIndex, &peer);
     ASSERT_FALSE(Dart_IsError(result));
     SemanticsUpdate* update = reinterpret_cast<SemanticsUpdate*>(peer);
     SemanticsNodeUpdates nodes = update->takeNodes();
     ASSERT_EQ(nodes.size(), (size_t)1);
     auto node = nodes.find(0)->second;
     // Should match the updateNode in ui_test.dart.
-    ASSERT_EQ(node.role, SemanticsRole::kTab);
+    ASSERT_EQ(node.label, "label");
+    ASSERT_EQ(node.labelAttributes.size(), (size_t)1);
+    ASSERT_EQ(node.labelAttributes[0]->start, 1);
+    ASSERT_EQ(node.labelAttributes[0]->end, 2);
+    ASSERT_EQ(node.labelAttributes[0]->type, StringAttributeType::kSpellOut);
+
+    ASSERT_EQ(node.value, "value");
+    ASSERT_EQ(node.valueAttributes.size(), (size_t)1);
+    ASSERT_EQ(node.valueAttributes[0]->start, 2);
+    ASSERT_EQ(node.valueAttributes[0]->end, 3);
+    ASSERT_EQ(node.valueAttributes[0]->type, StringAttributeType::kSpellOut);
+
+    ASSERT_EQ(node.hint, "hint");
+    ASSERT_EQ(node.hintAttributes.size(), (size_t)1);
+    ASSERT_EQ(node.hintAttributes[0]->start, 0);
+    ASSERT_EQ(node.hintAttributes[0]->end, 1);
+    ASSERT_EQ(node.hintAttributes[0]->type, StringAttributeType::kLocale);
+    auto local_attribute =
+            std::static_pointer_cast<LocaleStringAttribute>(node.hintAttributes[0]);
+    ASSERT_EQ(local_attribute->locale, "en-MX");
+
+    ASSERT_EQ(node.increasedValue, "increasedValue");
+    ASSERT_EQ(node.increasedValueAttributes.size(), (size_t)1);
+    ASSERT_EQ(node.increasedValueAttributes[0]->start, 4);
+    ASSERT_EQ(node.increasedValueAttributes[0]->end, 5);
+    ASSERT_EQ(node.increasedValueAttributes[0]->type,
+              StringAttributeType::kSpellOut);
+
+    ASSERT_EQ(node.decreasedValue, "decreasedValue");
+    ASSERT_EQ(node.decreasedValueAttributes.size(), (size_t)1);
+    ASSERT_EQ(node.decreasedValueAttributes[0]->start, 5);
+    ASSERT_EQ(node.decreasedValueAttributes[0]->end, 6);
+    ASSERT_EQ(node.decreasedValueAttributes[0]->type,
+              StringAttributeType::kSpellOut);
     message_latch->Signal();
   };
 
@@ -121,10 +154,10 @@ TEST_F(SemanticsUpdateBuilderTest, CanHandleSemanticsRole) {
 
   ASSERT_TRUE(shell->IsSetup());
   auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("sendSemanticsUpdateWithRole");
+  configuration.SetEntrypoint("sendSemanticsUpdate");
 
   shell->RunEngine(std::move(configuration), [](auto result) {
-    ASSERT_EQ(result, Engine::RunStatus::Success);
+      ASSERT_EQ(result, Engine::RunStatus::Success);
   });
 
   message_latch->Wait();

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder_unittests.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder_unittests.cc
@@ -88,5 +88,48 @@ TEST_F(SemanticsUpdateBuilderTest, CanHandleAttributedStrings) {
   DestroyShell(std::move(shell), task_runners);
 }
 
+TEST_F(SemanticsUpdateBuilderTest, CanHandleSemanticsRole) {
+    auto message_latch = std::make_shared<fml::AutoResetWaitableEvent>();
+
+    auto nativeSemanticsUpdate = [message_latch](Dart_NativeArguments args) {
+        auto handle = Dart_GetNativeArgument(args, 0);
+        intptr_t peer = 0;
+        Dart_Handle result = Dart_GetNativeInstanceField(
+                handle, tonic::DartWrappable::kPeerIndex, &peer);
+        ASSERT_FALSE(Dart_IsError(result));
+        SemanticsUpdate* update = reinterpret_cast<SemanticsUpdate*>(peer);
+        SemanticsNodeUpdates nodes = update->takeNodes();
+        ASSERT_EQ(nodes.size(), (size_t)1);
+        auto node = nodes.find(0)->second;
+        // Should match the updateNode in ui_test.dart.
+        ASSERT_EQ(node.role, SemanticsRole::kTab);
+        message_latch->Signal();
+    };
+
+    Settings settings = CreateSettingsForFixture();
+    TaskRunners task_runners("test",                  // label
+                             GetCurrentTaskRunner(),  // platform
+                             CreateNewThread(),       // raster
+                             CreateNewThread(),       // ui
+                             CreateNewThread()        // io
+    );
+
+    AddNativeCallback("SemanticsUpdate",
+    CREATE_NATIVE_ENTRY(nativeSemanticsUpdate));
+
+    std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
+
+    ASSERT_TRUE(shell->IsSetup());
+    auto configuration = RunConfiguration::InferFromSettings(settings);
+    configuration.SetEntrypoint("sendSemanticsUpdateWithRole");
+
+    shell->RunEngine(std::move(configuration), [](auto result) {
+    ASSERT_EQ(result, Engine::RunStatus::Success);
+    });
+
+    message_latch->Wait();
+    DestroyShell(std::move(shell), task_runners);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/lib/web_ui/lib/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/semantics.dart
@@ -255,6 +255,9 @@ class SemanticsFlag {
   String toString() => 'SemanticsFlag.$name';
 }
 
+// Mirrors engine/src/flutter/lib/ui/semantics.dart
+enum SemanticsRole { none, tab, tabBar, tabPanel }
+
 // When adding a new StringAttributeType, the classes in these file must be
 // updated as well.
 //  * engine/src/flutter/lib/ui/semantics.dart
@@ -341,6 +344,7 @@ class SemanticsUpdateBuilder {
     required Int32List additionalActions,
     int headingLevel = 0,
     String? linkUrl,
+    SemanticsRole role = SemanticsRole.none,
   }) {
     if (transform.length != 16) {
       throw ArgumentError('transform argument must have 16 entries.');
@@ -382,6 +386,7 @@ class SemanticsUpdateBuilder {
         platformViewId: platformViewId,
         headingLevel: headingLevel,
         linkUrl: linkUrl,
+        role: role,
       ),
     );
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine.dart
@@ -159,6 +159,7 @@ export 'engine/semantics/route.dart';
 export 'engine/semantics/scrollable.dart';
 export 'engine/semantics/semantics.dart';
 export 'engine/semantics/semantics_helper.dart';
+export 'engine/semantics/tabs.dart';
 export 'engine/semantics/tappable.dart';
 export 'engine/semantics/text_field.dart';
 export 'engine/services/buffers.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics.dart
@@ -16,5 +16,6 @@ export 'semantics/platform_view.dart';
 export 'semantics/scrollable.dart';
 export 'semantics/semantics.dart';
 export 'semantics/semantics_helper.dart';
+export 'semantics/tabs.dart';
 export 'semantics/tappable.dart';
 export 'semantics/text_field.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/tabs.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/tabs.dart
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'label_and_value.dart';
+import 'semantics.dart';
+
+/// Indicates an interactive element inside a tablist that, when activated,
+/// displays its associated tabpanel.
+///
+/// Uses aria tab role to convey this semantic information to the element.
+///
+/// Screen-readers takes advantage of "aria-label" to describe the visual.
+class SemanticTab extends SemanticRole {
+  SemanticTab(SemanticsObject semanticsObject)
+    : super.withBasics(
+        SemanticRoleKind.tab,
+        semanticsObject,
+        preferredLabelRepresentation: LabelRepresentation.ariaLabel,
+      );
+  @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
+
+  @override
+  void update() {
+    super.update();
+    setAriaRole('tab');
+  }
+}
+
+/// Indicates the main display for a tab when activated.
+///
+/// Uses aria tabpanel role to convey this semantic information to the element.
+///
+/// Screen-readers takes advantage of "aria-label" to describe the visual.
+class SemanticTabPanel extends SemanticRole {
+  SemanticTabPanel(SemanticsObject semanticsObject)
+    : super.withBasics(
+        SemanticRoleKind.tabPanel,
+        semanticsObject,
+        preferredLabelRepresentation: LabelRepresentation.ariaLabel,
+      );
+  @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
+
+  @override
+  void update() {
+    super.update();
+    setAriaRole('tabpanel');
+  }
+}
+
+/// Indicates a container that contains multiple tabs.
+///
+/// Uses aria tablist role to convey this semantic information to the element.
+///
+/// Screen-readers takes advantage of "aria-label" to describe the visual.
+class SemanticTabList extends SemanticRole {
+  SemanticTabList(SemanticsObject semanticsObject)
+    : super.withBasics(
+        SemanticRoleKind.tabList,
+        semanticsObject,
+        preferredLabelRepresentation: LabelRepresentation.ariaLabel,
+      );
+  @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
+
+  @override
+  void update() {
+    super.update();
+    setAriaRole('tablist');
+  }
+}

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -122,6 +122,9 @@ void runSemanticsTests() {
   group('link', () {
     _testLink();
   });
+  group('tabs', () {
+    _testTabs();
+  });
 }
 
 void _testSemanticRole() {
@@ -3578,6 +3581,71 @@ void _testLink() {
     final SemanticsObject object = pumpSemantics();
     expect(object.element.tagName.toLowerCase(), 'a');
     expect(object.element.getAttribute('href'), 'https://flutter.dev');
+  });
+}
+
+void _testTabs() {
+  test('nodes with tab role', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    SemanticsObject pumpSemantics() {
+      final SemanticsTester tester = SemanticsTester(owner());
+      tester.updateNode(
+        id: 0,
+        role: ui.SemanticsRole.tab,
+        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      );
+      tester.apply();
+      return tester.getSemanticsObject(0);
+    }
+
+    final SemanticsObject object = pumpSemantics();
+    expect(object.semanticRole?.kind, SemanticRoleKind.tab);
+    expect(object.element.getAttribute('role'), 'tab');
+  });
+
+  test('nodes with tab panel role', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    SemanticsObject pumpSemantics() {
+      final SemanticsTester tester = SemanticsTester(owner());
+      tester.updateNode(
+        id: 0,
+        role: ui.SemanticsRole.tabPanel,
+        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      );
+      tester.apply();
+      return tester.getSemanticsObject(0);
+    }
+
+    final SemanticsObject object = pumpSemantics();
+    expect(object.semanticRole?.kind, SemanticRoleKind.tabPanel);
+    expect(object.element.getAttribute('role'), 'tabpanel');
+  });
+
+  test('nodes with tab panel role', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    SemanticsObject pumpSemantics() {
+      final SemanticsTester tester = SemanticsTester(owner());
+      tester.updateNode(
+        id: 0,
+        role: ui.SemanticsRole.tabBar,
+        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      );
+      tester.apply();
+      return tester.getSemanticsObject(0);
+    }
+
+    final SemanticsObject object = pumpSemantics();
+    expect(object.semanticRole?.kind, SemanticRoleKind.tabList);
+    expect(object.element.getAttribute('role'), 'tablist');
   });
 }
 

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -115,6 +115,7 @@ class SemanticsTester {
     List<SemanticsNodeUpdate>? children,
     int? headingLevel,
     String? linkUrl,
+    ui.SemanticsRole? role,
   }) {
     // Flags
     if (hasCheckedState ?? false) {
@@ -323,6 +324,7 @@ class SemanticsTester {
       additionalActions: additionalActions ?? Int32List(0),
       headingLevel: headingLevel ?? 0,
       linkUrl: linkUrl,
+      role: role ?? ui.SemanticsRole.none,
     );
     _nodeUpdates.add(update);
     return update;

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -6,7 +6,7 @@
 library;
 
 import 'dart:math' as math;
-import 'dart:ui' show lerpDouble;
+import 'dart:ui' show SemanticsRole, lerpDouble;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show DragStartBehavior;
@@ -209,9 +209,12 @@ class Tab extends StatelessWidget implements PreferredSizeWidget {
       );
     }
 
-    return SizedBox(
-      height: height ?? calculatedHeight,
-      child: Center(widthFactor: 1.0, child: label),
+    return Semantics(
+      role: SemanticsRole.tab,
+      child: SizedBox(
+        height: height ?? calculatedHeight,
+        child: Center(widthFactor: 1.0, child: label),
+      ),
     );
   }
 
@@ -1865,7 +1868,8 @@ class _TabBarState extends State<TabBar> {
               wrappedTabs[index],
               Semantics(
                 selected: index == _currentIndex,
-                label: localizations.tabLabel(tabIndex: index + 1, tabCount: tabCount),
+                label:
+                    kIsWeb ? null : localizations.tabLabel(tabIndex: index + 1, tabCount: tabCount),
               ),
             ],
           ),
@@ -1876,22 +1880,25 @@ class _TabBarState extends State<TabBar> {
       }
     }
 
-    Widget tabBar = CustomPaint(
-      painter: _indicatorPainter,
-      child: _TabStyle(
-        animation: kAlwaysDismissedAnimation,
-        isSelected: false,
-        isPrimary: widget._isPrimary,
-        labelColor: widget.labelColor,
-        unselectedLabelColor: widget.unselectedLabelColor,
-        labelStyle: widget.labelStyle,
-        unselectedLabelStyle: widget.unselectedLabelStyle,
-        defaults: _defaults,
-        child: _TabLabelBar(
-          onPerformLayout: _saveTabOffsets,
-          mainAxisSize:
-              effectiveTabAlignment == TabAlignment.fill ? MainAxisSize.max : MainAxisSize.min,
-          children: wrappedTabs,
+    Widget tabBar = Semantics(
+      role: SemanticsRole.tabBar,
+      child: CustomPaint(
+        painter: _indicatorPainter,
+        child: _TabStyle(
+          animation: kAlwaysDismissedAnimation,
+          isSelected: false,
+          isPrimary: widget._isPrimary,
+          labelColor: widget.labelColor,
+          unselectedLabelColor: widget.unselectedLabelColor,
+          labelStyle: widget.labelStyle,
+          unselectedLabelStyle: widget.unselectedLabelStyle,
+          defaults: _defaults,
+          child: _TabLabelBar(
+            onPerformLayout: _saveTabOffsets,
+            mainAxisSize:
+                effectiveTabAlignment == TabAlignment.fill ? MainAxisSize.max : MainAxisSize.min,
+            children: wrappedTabs,
+          ),
         ),
       ),
     );
@@ -2131,7 +2138,11 @@ class _TabBarViewState extends State<TabBarView> {
   }
 
   void _updateChildren() {
-    _childrenWithKey = KeyedSubtree.ensureUniqueKeysForList(widget.children);
+    _childrenWithKey = KeyedSubtree.ensureUniqueKeysForList(
+      widget.children.map<Widget>((Widget child) {
+        return Semantics(role: SemanticsRole.tabPanel, child: child);
+      }).toList(),
+    );
   }
 
   void _handleTabControllerAnimationTick() {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4430,6 +4430,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     if (_properties.tagForChildren != null) {
       config.addTagForChildren(_properties.tagForChildren!);
     }
+    config.role = _properties.role;
     // Registering _perform* as action handlers instead of the user provided
     // ones to ensure that changing a user provided handler from a non-null to
     // another non-null value doesn't require a semantics update.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -16,6 +16,7 @@ import 'dart:ui'
         Rect,
         SemanticsAction,
         SemanticsFlag,
+        SemanticsRole,
         SemanticsUpdate,
         SemanticsUpdateBuilder,
         StringAttribute,
@@ -481,6 +482,7 @@ class SemanticsData with Diagnosticable {
     required this.currentValueLength,
     required this.headingLevel,
     required this.linkUrl,
+    required this.role,
     this.tags,
     this.transform,
     this.customSemanticsActionIds,
@@ -738,6 +740,9 @@ class SemanticsData with Diagnosticable {
   ///  * [CustomSemanticsAction], for an explanation of custom actions.
   final List<int>? customSemanticsActionIds;
 
+  /// {@macro flutter.semantics.SemanticsNode.identifier}
+  final SemanticsRole role;
+
   /// Whether [flags] contains the given flag.
   bool hasFlag(SemanticsFlag flag) => (flags & flag.index) != 0;
 
@@ -826,6 +831,7 @@ class SemanticsData with Diagnosticable {
         other.thickness == thickness &&
         other.headingLevel == headingLevel &&
         other.linkUrl == linkUrl &&
+        other.role == role &&
         _sortedListsEqual(other.customSemanticsActionIds, customSemanticsActionIds);
   }
 
@@ -859,6 +865,7 @@ class SemanticsData with Diagnosticable {
       headingLevel,
       linkUrl,
       customSemanticsActionIds == null ? null : Object.hashAll(customSemanticsActionIds!),
+      role,
     ),
   );
 
@@ -1026,6 +1033,7 @@ class SemanticsProperties extends DiagnosticableTree {
     this.onFocus,
     this.onDismiss,
     this.customSemanticsActions,
+    this.role = SemanticsRole.none,
   }) : assert(
          label == null || attributedLabel == null,
          'Only one of label or attributedLabel should be provided',
@@ -1799,6 +1807,11 @@ class SemanticsProperties extends DiagnosticableTree {
   ///  * [CustomSemanticsAction], for an explanation of custom actions.
   final Map<CustomSemanticsAction, VoidCallback>? customSemanticsActions;
 
+  /// {@template flutter.semantics.SemanticsProperties.role}
+  /// A enum to describe what role the subtree represents.
+  /// {@endtemplate}
+  final SemanticsRole role;
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
@@ -1835,6 +1848,7 @@ class SemanticsProperties extends DiagnosticableTree {
     properties.add(AttributedStringProperty('attributedHint', attributedHint, defaultValue: null));
     properties.add(StringProperty('tooltip', tooltip, defaultValue: null));
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
+    properties.add(EnumProperty<SemanticsRole>('role', role, defaultValue: null));
     properties.add(DiagnosticsProperty<SemanticsSortKey>('sortKey', sortKey, defaultValue: null));
     properties.add(
       DiagnosticsProperty<SemanticsHintOverrides>(
@@ -2392,6 +2406,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
         _mergeAllDescendantsIntoThisNode != config.isMergingSemanticsOfDescendants ||
         _areUserActionsBlocked != config.isBlockingUserActions ||
         _headingLevel != config._headingLevel ||
+        _linkUrl != config._linkUrl ||
         _linkUrl != config._linkUrl;
   }
 
@@ -2708,6 +2723,12 @@ class SemanticsNode with DiagnosticableTreeMixin {
   Uri? get linkUrl => _linkUrl;
   Uri? _linkUrl = _kEmptyConfig._linkUrl;
 
+  /// {@template flutter.semantics.SemanticsNode.role}
+  /// The role this node represents
+  /// {@endtemplate}
+  SemanticsRole get role => _role;
+  SemanticsRole _role = _kEmptyConfig.role;
+
   bool _canPerformAction(SemanticsAction action) => _actions.containsKey(action);
 
   static final SemanticsConfiguration _kEmptyConfig = SemanticsConfiguration();
@@ -2773,6 +2794,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     _areUserActionsBlocked = config.isBlockingUserActions;
     _headingLevel = config._headingLevel;
     _linkUrl = config._linkUrl;
+    _role = config._role;
     _replaceChildren(childrenInInversePaintOrder ?? const <SemanticsNode>[]);
 
     if (mergeAllDescendantsIntoThisNodeValueChanged) {
@@ -2821,6 +2843,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     final double elevation = _elevation;
     double thickness = _thickness;
     Uri? linkUrl = _linkUrl;
+    SemanticsRole role = _role;
     final Set<int> customSemanticsActionIds = <int>{};
     for (final CustomSemanticsAction action in _customSemanticsActions.keys) {
       customSemanticsActionIds.add(CustomSemanticsAction.getIdentifier(action));
@@ -2875,6 +2898,9 @@ class SemanticsNode with DiagnosticableTreeMixin {
         }
         if (attributedDecreasedValue.string == '') {
           attributedDecreasedValue = node._attributedDecreasedValue;
+        }
+        if (role == SemanticsRole.none) {
+          role = node._role;
         }
         if (tooltip == '') {
           tooltip = node._tooltip;
@@ -2949,6 +2975,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       customSemanticsActionIds: customSemanticsActionIds.toList()..sort(),
       headingLevel: headingLevel,
       linkUrl: linkUrl,
+      role: role,
     );
   }
 
@@ -3026,6 +3053,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       additionalActions: customSemanticsActionIds ?? _kEmptyCustomSemanticsActionsList,
       headingLevel: data.headingLevel,
       linkUrl: data.linkUrl?.toString() ?? '',
+      role: data.role,
     );
     _dirty = false;
   }
@@ -3202,6 +3230,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     properties.add(
       EnumProperty<TextDirection>('textDirection', _textDirection, defaultValue: null),
     );
+    properties.add(EnumProperty<SemanticsRole>('role', _role, defaultValue: null));
     properties.add(DiagnosticsProperty<SemanticsSortKey>('sortKey', sortKey, defaultValue: null));
     if (_textSelection?.isValid ?? false) {
       properties.add(
@@ -4560,6 +4589,14 @@ class SemanticsConfiguration {
     _hasBeenAnnotated = true;
   }
 
+  /// {@macro flutter.semantics.SemanticsProperties.role}
+  SemanticsRole get role => _role;
+  SemanticsRole _role = SemanticsRole.none;
+  set role(SemanticsRole value) {
+    _role = value;
+    _hasBeenAnnotated = true;
+  }
+
   /// A textual description of the owning [RenderObject].
   ///
   /// Setting this attribute will override the [attributedLabel].
@@ -5313,6 +5350,9 @@ class SemanticsConfiguration {
     if (_attributedDecreasedValue.string == '') {
       _attributedDecreasedValue = child._attributedDecreasedValue;
     }
+    if (_role == SemanticsRole.none) {
+      _role = child._role;
+    }
     _attributedHint = _concatAttributedString(
       thisAttributedString: _attributedHint,
       thisTextDirection: textDirection,
@@ -5365,7 +5405,8 @@ class SemanticsConfiguration {
       .._customSemanticsActions.addAll(_customSemanticsActions)
       ..isBlockingUserActions = isBlockingUserActions
       .._headingLevel = _headingLevel
-      .._linkUrl = _linkUrl;
+      .._linkUrl = _linkUrl
+      .._role = _role;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -9,7 +9,7 @@
 library;
 
 import 'dart:math' as math;
-import 'dart:ui' as ui show Image, ImageFilter, TextHeightBehavior;
+import 'dart:ui' as ui show Image, ImageFilter, SemanticsRole, TextHeightBehavior;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
@@ -7288,6 +7288,7 @@ class Semantics extends SingleChildRenderObjectWidget {
     VoidCallback? onDidLoseAccessibilityFocus,
     VoidCallback? onFocus,
     Map<CustomSemanticsAction, VoidCallback>? customSemanticsActions,
+    ui.SemanticsRole role = ui.SemanticsRole.none,
   }) : this.fromProperties(
          key: key,
          child: child,
@@ -7362,6 +7363,7 @@ class Semantics extends SingleChildRenderObjectWidget {
                onTapHint != null || onLongPressHint != null
                    ? SemanticsHintOverrides(onTapHint: onTapHint, onLongPressHint: onLongPressHint)
                    : null,
+           role: role,
          ),
        );
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/157824

engine: https://github.com/flutter/engine/pull/56318

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
