### PR TITLE
Remove references to the HTML renderer in public docs.

### DIFF
--- a/docs/contributing/testing/Flutter-Test-Fonts.md
+++ b/docs/contributing/testing/Flutter-Test-Fonts.md
@@ -17,7 +17,7 @@ Thanks to that, the `FlutterTest` font generally provides more precise and font-
 
 **Example**
 
-You can expect this test to pass on all platforms (currently with the exception of the web HTML renderer):
+You can expect this test to pass on all platforms:
 
 ```dart
 final painter = TextPainter(

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -1413,9 +1413,7 @@ class ResizeImage extends ImageProvider<ResizeImageKey> {
 ///
 /// When a network image is used on the Web platform, the `getTargetSize`
 /// parameter of the [ImageDecoderCallback] is only supported when the
-/// application is running with the CanvasKit renderer. When the application is
-/// using the HTML renderer, the web engine delegates image decoding of network
-/// images to the Web, which does not support custom decode sizes.
+/// application is running with the CanvasKit renderer.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -508,9 +508,7 @@ class BackdropGroup extends InheritedWidget {
 /// [BlendMode.srcOver] which works well for most scenes. But that value may
 /// produce surprising results when a parent of the [BackdropFilter] uses a
 /// temporary buffer, or save layer, as does an [Opacity] widget. In that
-/// situation, a value of [BlendMode.src] can produce more pleasing results,
-/// but at the cost of incompatibility with some platforms, most notably the
-/// html renderer for web applications.
+/// situation, a value of [BlendMode.src] can produce more pleasing results.
 /// {@endtemplate}
 ///
 /// Multiple backdrop filters can be combined into a single rendering operation

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -310,9 +310,7 @@ typedef ImageErrorWidgetBuilder = Widget Function(
 ///
 /// In the case where a network image is used on the Web platform, the
 /// `cacheWidth` and `cacheHeight` parameters are only supported when the
-/// application is running with the CanvasKit renderer. When the application is
-/// using the HTML renderer, the web engine delegates image decoding of network
-/// images to the Web, which does not support custom decode sizes.
+/// application is running with the CanvasKit renderer.
 ///
 /// ## Custom image providers
 ///


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/157547.