### PR TITLE
Add test for `raw_scrollbar.shape.0.dart`

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -314,5 +314,4 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/image/image.loading_builder.0_test.dart',
   'examples/api/test/widgets/scrollbar/raw_scrollbar.2_test.dart',
   'examples/api/test/widgets/scrollbar/raw_scrollbar.desktop.0_test.dart',
-  'examples/api/test/widgets/scrollbar/raw_scrollbar.shape.0_test.dart',
 };

--- a/examples/api/test/widgets/scrollbar/raw_scrollbar.shape.0_test.dart
+++ b/examples/api/test/widgets/scrollbar/raw_scrollbar.shape.0_test.dart
@@ -1,0 +1,34 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/scrollbar/raw_scrollbar.shape.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The thumb of the scrollbar is drawn by the stadium border', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ShapeExampleApp(),
+    );
+
+    expect(find.byType(RawScrollbar), findsOne);
+    expect(find.byType(ListView), findsOne);
+
+    expect(find.text('0'), findsOne);
+    expect(find.text('1'), findsOne);
+    expect(find.text('4'), findsOne);
+
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..path(color: Colors.blue)
+        ..rrect(
+          rrect: RRect.fromLTRBR(786.5, 1.5, 798.5, 178.5, const Radius.circular(6)),
+          color: Colors.brown,
+        ),
+    );
+  });
+}

--- a/examples/api/test/widgets/scrollbar/raw_scrollbar.shape.0_test.dart
+++ b/examples/api/test/widgets/scrollbar/raw_scrollbar.shape.0_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_api_samples/widgets/scrollbar/raw_scrollbar.shape.0.dart
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('The thumb of the scrollbar is drawn by the stadium border', (WidgetTester tester) async {
+  testWidgets('The thumb shape is a stadium border', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.ShapeExampleApp(),
     );


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/scrollbar/raw_scrollbar.shape.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
