### PR TITLE
Disable failing native assets test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -223,6 +223,26 @@ void main() {
       });
     }
 
+    testWithoutContext('flutter build $buildSubcommand succeeds without libraries', () async {
+      await inTempDir((Directory tempDirectory) async {
+        final Directory projectDirectory = await createTestProjectWithNoCBuild(packageName, tempDirectory);
+
+        final ProcessResult result = processManager.runSync(
+          <String>[
+            flutterBin,
+            'build',
+            buildSubcommand,
+            '--debug',
+            if (buildSubcommand == 'ios') '--no-codesign',
+          ],
+          workingDirectory: projectDirectory.path,
+        );
+        if (result.exitCode != 0) {
+          throw Exception('flutter build failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
+        }
+      });
+    }, skip: true);
+
     // This could be an hermetic unit test if the native_assets_builder
     // could mock process runs and file system.
     // https://github.com/dart-lang/native/issues/90.

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -223,26 +223,6 @@ void main() {
       });
     }
 
-    testWithoutContext('flutter build $buildSubcommand succeeds without libraries', () async {
-      await inTempDir((Directory tempDirectory) async {
-        final Directory projectDirectory = await createTestProjectWithNoCBuild(packageName, tempDirectory);
-
-        final ProcessResult result = processManager.runSync(
-          <String>[
-            flutterBin,
-            'build',
-            buildSubcommand,
-            '--debug',
-            if (buildSubcommand == 'ios') '--no-codesign',
-          ],
-          workingDirectory: projectDirectory.path,
-        );
-        if (result.exitCode != 0) {
-          throw Exception('flutter build failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
-        }
-      });
-    });
-
     // This could be an hermetic unit test if the native_assets_builder
     // could mock process runs and file system.
     // https://github.com/dart-lang/native/issues/90.

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -241,7 +241,7 @@ void main() {
           throw Exception('flutter build failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
         }
       });
-    }, skip: true);
+    }, skip: true); // https://github.com/flutter/flutter/issues/158120
 
     // This could be an hermetic unit test if the native_assets_builder
     // could mock process runs and file system.


### PR DESCRIPTION
## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
