### PR TITLE
[SwiftPM] Update .flutter-plugin-dependencies format

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -210,7 +210,7 @@ public class DummyPluginAClass {
       final String flutterPluginsDependenciesFileContent = flutterPluginsDependenciesFile.readAsStringSync();
 
       final Map<String, dynamic> jsonContent = json.decode(flutterPluginsDependenciesFileContent) as Map<String, dynamic>;
-      final bool swiftPackageManagerEnabled = jsonContent['swift_package_manager_enabled'] as bool? ?? false;
+      final Map<String, dynamic>? swiftPackageManagerJson = jsonContent['swift_package_manager_enabled'] as Map<String, dynamic>?;
 
       // Verify the dependencyGraph object is valid. The rest of the contents of this file are not relevant to the
       // dependency graph and are tested by unit tests.
@@ -302,6 +302,18 @@ public class DummyPluginAClass {
 
         if (!exists(appBundle)) {
           return TaskResult.failure('Failed to build plugin A example iOS app');
+        }
+
+        final bool? swiftPackageManagerEnabled = swiftPackageManagerJson?['ios'] as bool?;
+        if (swiftPackageManagerEnabled == null) {
+          return TaskResult.failure(
+            '${flutterPluginsDependenciesFile.path} is missing the '
+            '"swift_package_manager_enabled" > "ios" property.\n'
+            '\n'
+            '.flutter_plugin_dependencies content:\n'
+            '\n'
+            '$flutterPluginsDependenciesFileContent',
+          );
         }
 
         if (swiftPackageManagerEnabled) {

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -304,7 +304,7 @@ def flutter_install_plugin_pods(application_path = nil, relative_symlink_dir, pl
   plugins_file = File.join(application_path, '..', '.flutter-plugins-dependencies')
   dependencies_hash = flutter_parse_plugins_file(plugins_file)
   plugin_pods = flutter_get_plugins_list(dependencies_hash, platform)
-  swift_package_manager_enabled = flutter_get_swift_package_manager_enabled(dependencies_hash)
+  swift_package_manager_enabled = flutter_get_swift_package_manager_enabled(dependencies_hash, platform)
 
   plugin_pods.each do |plugin_hash|
     plugin_name = plugin_hash['name']
@@ -353,10 +353,12 @@ def flutter_get_plugins_list(dependencies_hash, platform)
   dependencies_hash['plugins'][platform] || []
 end
 
-def flutter_get_swift_package_manager_enabled(dependencies_hash)
+def flutter_get_swift_package_manager_enabled(dependencies_hash, platform)
   return false unless dependencies_hash.any?
   return false unless dependencies_hash.has_key?('swift_package_manager_enabled')
-  dependencies_hash['swift_package_manager_enabled'] == true
+  return false unless dependencies_hash['swift_package_manager_enabled'].has_key?(platform)
+
+  dependencies_hash['swift_package_manager_enabled'][platform] == true
 end
 
 def flutter_relative_path_from_podfile(path)

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -168,7 +168,8 @@ const String _kFlutterPluginsSharedDarwinSource = 'shared_darwin_source';
 bool _writeFlutterPluginsList(
   FlutterProject project,
   List<Plugin> plugins, {
-  bool forceCocoaPodsOnly = false,
+  required bool swiftPackageManagerEnabledIos,
+  required bool swiftPackageManagerEnabledMacos,
 }) {
   final File pluginsFile = project.flutterPluginsDependenciesFile;
   if (plugins.isEmpty) {
@@ -204,7 +205,11 @@ bool _writeFlutterPluginsList(
   result['dependencyGraph'] = _createPluginLegacyDependencyGraph(plugins);
   result['date_created'] = globals.systemClock.now().toString();
   result['version'] = globals.flutterVersion.frameworkVersion;
-  result['swift_package_manager_enabled'] = !forceCocoaPodsOnly && project.usesSwiftPackageManager;
+
+  result['swift_package_manager_enabled'] = <String, bool>{
+    'ios': swiftPackageManagerEnabledIos,
+    'macos': swiftPackageManagerEnabledMacos,
+  };
 
   // Only notify if the plugins list has changed. [date_created] will always be different,
   // [version] is not relevant for this check.
@@ -1019,10 +1024,12 @@ Future<void> refreshPluginsList(
   // Write the legacy plugin files to avoid breaking existing apps.
   final bool legacyChanged = writeLegacyPluginsList && _writeFlutterPluginsListLegacy(project, plugins);
 
+  final bool swiftPackageManagerEnabled = !forceCocoaPodsOnly && project.usesSwiftPackageManager;
   final bool changed = _writeFlutterPluginsList(
     project,
     plugins,
-    forceCocoaPodsOnly: forceCocoaPodsOnly,
+    swiftPackageManagerEnabledIos: swiftPackageManagerEnabled,
+    swiftPackageManagerEnabledMacos: swiftPackageManagerEnabled,
   );
   if (changed || legacyChanged || forceCocoaPodsOnly) {
     createPluginSymlinks(project, force: true);

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -545,7 +545,15 @@ dependencies:
         expect(jsonContent['dependencyGraph'], expectedDependencyGraph);
         expect(jsonContent['date_created'], dateCreated.toString());
         expect(jsonContent['version'], '1.0.0');
-        expect(jsonContent['swift_package_manager_enabled'], false);
+
+        final Map<String, dynamic> expectedSwiftPackageManagerEnabled = <String, bool>{
+          'ios': false,
+          'macos': false,
+        };
+        expect(
+          jsonContent['swift_package_manager_enabled'],
+          expectedSwiftPackageManagerEnabled,
+        );
 
         // Make sure tests are updated if a new object is added/removed.
         final List<String> expectedKeys = <String>[
@@ -662,7 +670,14 @@ dependencies:
             .readAsStringSync();
         final Map<String, dynamic> jsonContent = json.decode(pluginsString) as Map<String, dynamic>;
 
-        expect(jsonContent['swift_package_manager_enabled'], true);
+        final Map<String, dynamic> expectedSwiftPackageManagerEnabled = <String, dynamic>{
+          'ios': true,
+          'macos': true,
+        };
+        expect(
+          jsonContent['swift_package_manager_enabled'],
+          expectedSwiftPackageManagerEnabled,
+        );
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -699,7 +714,14 @@ dependencies:
             .readAsStringSync();
         final Map<String, dynamic> jsonContent = json.decode(pluginsString) as Map<String, dynamic>;
 
-        expect(jsonContent['swift_package_manager_enabled'], false);
+        final Map<String, dynamic> expectedSwiftPackageManagerEnabled = <String, dynamic>{
+          'ios': false,
+          'macos': false,
+        };
+        expect(
+          jsonContent['swift_package_manager_enabled'],
+          expectedSwiftPackageManagerEnabled,
+        );
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -553,14 +555,14 @@ void main() {
       .childFile('.flutter-plugins-dependencies');
 
     expect(flutterPluginsDependenciesFile, exists);
-    expect(
-      flutterPluginsDependenciesFile.readAsStringSync(),
-      isNot(contains('"swift_package_manager_enabled":true')),
-    );
-    expect(
-      flutterPluginsDependenciesFile.readAsStringSync(),
-      contains('"swift_package_manager_enabled":false'),
-    );
+
+    final String dependenciesString = flutterPluginsDependenciesFile.readAsStringSync();
+    final Map<String, dynamic>? dependenciesJson = json.decode(dependenciesString) as Map<String, dynamic>?;
+    final Map<String, dynamic>? swiftPackageManagerEnabled =
+      dependenciesJson?['swift_package_manager_enabled'] as Map<String, dynamic>?;
+    final bool? swiftPackageManagerEnabledIos = swiftPackageManagerEnabled?['ios'] as bool?;
+
+    expect(swiftPackageManagerEnabledIos, isFalse);
   }, skip: !platform.isMacOS); // [intended] Swift Package Manager only works on macos.
 
   test("Generated Swift package uses iOS's project minimum deployment", () async {


### PR DESCRIPTION
In the future, it will be possible for Swift Package Manager to be enabled on one but not all platforms (see https://github.com/flutter/flutter/issues/151567#issuecomment-2455941279).

This updates the `.flutter-plugin-dependencies` file format to separate iOS's and macOS's SwiftPM enablement. For now, these platforms will always have the same value.

This `.flutter-plugin-dependencies` file is read by our CocoaPods scripts to determine whether we should use CocoaPods or not to inject plugins.

Part of https://github.com/flutter/flutter/issues/151567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
