### PR TITLE
Further remove web-only considerations that are no longer necessary

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -1411,10 +1411,6 @@ class ResizeImage extends ImageProvider<ResizeImageKey> {
 ///
 /// The image will be cached regardless of cache headers from the server.
 ///
-/// When a network image is used on the Web platform, the `getTargetSize`
-/// parameter of the [ImageDecoderCallback] is only supported when the
-/// application is running with the CanvasKit renderer.
-///
 /// See also:
 ///
 ///  * [Image.network] for a shorthand of an [Image] widget backed by [NetworkImage].

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -306,12 +306,6 @@ typedef ImageErrorWidgetBuilder = Widget Function(
 /// using the `cacheWidth` and `cacheHeight` parameters, a 100-fold reduction in
 /// memory usage.
 ///
-/// ### Web considerations
-///
-/// In the case where a network image is used on the Web platform, the
-/// `cacheWidth` and `cacheHeight` parameters are only supported when the
-/// application is running with the CanvasKit renderer.
-///
 /// ## Custom image providers
 ///
 /// {@tool dartpad}


### PR DESCRIPTION
... to mention because without HTML they work the same as the native renderer! Yay!

Post-submit follow-up cleanups to https://github.com/flutter/flutter/pull/158035#pullrequestreview-2414359559 (https://github.com/flutter/flutter/issues/157547).