### PR TITLE
Forward fix `CupertinoDynamicColor` by adding `toARGB32()`.

### DIFF
--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -1149,6 +1149,11 @@ class CupertinoDynamicColor with Diagnosticable implements Color {
   @override
   int get value => _effectiveColor.value;
 
+  // TODO(matanl): Remove once https://github.com/flutter/engine/pull/56329 lands in the framework.
+  // ignore: unnecessary_override
+  @override
+  int toARGB32() => value;
+
   @override
   int get alpha => _effectiveColor.alpha;
 

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -1149,9 +1149,9 @@ class CupertinoDynamicColor with Diagnosticable implements Color {
   @override
   int get value => _effectiveColor.value;
 
-  // TODO(matanl): Remove once https://github.com/flutter/engine/pull/56329 lands in the framework.
-  // ignore: unnecessary_override
   @override
+  // TODO(matanl): Remove once https://github.com/flutter/engine/pull/56329 lands in the framework.
+  // ignore: override_on_non_overriding_member, public_member_api_docs
   int toARGB32() => value;
 
   @override

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -413,6 +413,26 @@ void main() {
     expect(find.byType(DependentWidget), paints..rect(color: color7));
   });
 
+  testWidgets('CupertinoDynamicColor toARGB32() is the same as value', (WidgetTester tester) async {
+    late CupertinoDynamicColor color;
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(
+          brightness: Brightness.dark,
+          primaryColor: dynamicColor,
+        ),
+        home: Builder(
+          builder: (BuildContext context) {
+            color = CupertinoTheme.of(context).primaryColor as CupertinoDynamicColor;
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+
+    expect(color.value, color.toARB32());
+  });
+
   testWidgets('CupertinoDynamicColor used in a CupertinoTheme', (WidgetTester tester) async {
     late CupertinoDynamicColor color;
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -430,7 +430,7 @@ void main() {
       ),
     );
 
-    expect(color.value, color.toARB32());
+    expect(color.value, color.toARGB32());
   });
 
   testWidgets('CupertinoDynamicColor used in a CupertinoTheme', (WidgetTester tester) async {


### PR DESCRIPTION
Unblocks landing https://github.com/flutter/engine/pull/56329.

@jtmcdole monorepo can't come soon enough...