### PR TITLE
Make native asset integration test more robust, thereby allowing smooth auto-update of packages via `flutter update-packages`

### DIFF
--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -70,7 +70,7 @@ Future<void> addLinkHookDependency(String packageName, Directory packageDirector
   final File linkHookPubspecFile = linkHookDirectory.childFile('pubspec.yaml');
   final File thisPubspecFile = packageDirectory.childFile('pubspec.yaml');
 
-  final Map<String, Object?> linkHookPubspec = _pubspecAsMutableJson(linkHookPubspecFile .readAsStringSync());
+  final Map<String, Object?> linkHookPubspec = _pubspecAsMutableJson(linkHookPubspecFile.readAsStringSync());
   final Map<String, Object?> allLinkHookDeps = linkHookPubspec['dependencies']! as Map<String, Object?>;
 
   final Map<String, Object?> thisPubspec = _pubspecAsMutableJson(thisPubspecFile.readAsStringSync());
@@ -121,15 +121,10 @@ Map<String, Object?> _pubspecAsMutableJson(String pubspecContent) {
   return json.decode(json.encode(loadYaml(pubspecContent))) as Map<String, Object?>;
 }
 
-void _updateDependencies(Map<String, Object?>? to, Map<String, Object?> from) {
-  if (to == null) {
-    return;
+void _updateDependencies(Map<String, Object?> to, Map<String, Object?> from) {
+  for (final String packageName in to.keys) {
+    to[packageName] = from[packageName] ?? to[packageName];
   }
-  from.forEach((String packageName, Object? value) {
-    if (to.containsKey(packageName)) {
-      to[packageName] = value;
-    }
-  });
 }
 
 /// Adds a native library to be built by the builder and dynamically link it to

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:yaml/yaml.dart';
 
 import '../../src/common.dart';
 import '../test_utils.dart' show ProcessResultMatcher, fileSystem;
@@ -65,18 +67,30 @@ Future<void> addLinkHookDependency(String packageName, Directory packageDirector
       .childDirectory('link_hook');
   expect(linkHookDirectory, exists);
 
-  final File pubspecFile = packageDirectory.childFile('pubspec.yaml');
-  final String pubspecOld =
-      (await pubspecFile.readAsString()).replaceAll('\r\n', '\n');
-  final String pubspecNew = pubspecOld.replaceFirst('''
-dependencies:
-''', '''
-dependencies:
-  link_hook:
-    path: ${linkHookDirectory.path}
-''');
-  expect(pubspecNew, isNot(pubspecOld));
-  await pubspecFile.writeAsString(pubspecNew);
+  final File linkHookPubspecFile = linkHookDirectory.childFile('pubspec.yaml');
+  final File thisPubspecFile = packageDirectory.childFile('pubspec.yaml');
+
+  final Map<String, Object?> linkHookPubspec = _pubspecAsMutableJson(linkHookPubspecFile .readAsStringSync());
+  final Map<String, Object?> allLinkHookDeps = linkHookPubspec['dependencies']! as Map<String, Object?>;
+
+  final Map<String, Object?> thisPubspec = _pubspecAsMutableJson(thisPubspecFile.readAsStringSync());
+
+  final Map<String, Object?> thisDependencies = thisPubspec['dependencies']! as Map<String, Object?>;
+  final Map<String, Object?> thisDevDependencies = thisPubspec['dev_dependencies']! as Map<String, Object?>;
+
+  // Flutter CI uses pinned dependencies for all packages (including
+  // dev/integration_tests/link_hook) for deterministic testing on CI.
+  //
+  // The ffi template that was generated with `flutter create` does not use
+  // pinned dependencies.
+  //
+  // We ensure that the test package we generate here will have versions
+  // compatible with the one from flutter CIs pinned dependencies.
+  _updateDependencies(thisDependencies, allLinkHookDeps);
+  _updateDependencies(thisDevDependencies, allLinkHookDeps);
+  thisDependencies['link_hook'] = <String, Object?>{ 'path' : linkHookDirectory.path };
+
+  await thisPubspecFile.writeAsString(json.encode(thisPubspec));
 
   final File dartFile =
       packageDirectory.childDirectory('lib').childFile('$packageName.dart');
@@ -101,6 +115,21 @@ import '${packageName}_bindings_generated.dart' as bindings;
   );
   expect(dartFileNew2, isNot(dartFileNew));
   await dartFile.writeAsString(dartFileNew2);
+}
+
+Map<String, Object?> _pubspecAsMutableJson(String pubspecContent) {
+  return json.decode(json.encode(loadYaml(pubspecContent))) as Map<String, Object?>;
+}
+
+void _updateDependencies(Map<String, Object?>? to, Map<String, Object?> from) {
+  if (to == null) {
+    return;
+  }
+  from.forEach((String packageName, Object? value) {
+    if (to.containsKey(packageName)) {
+      to[packageName] = value;
+    }
+  });
 }
 
 /// Adds a native library to be built by the builder and dynamically link it to


### PR DESCRIPTION
Currently the bot that runs `flutter update-packages` makes PRs that fail due to native asset integration tests failing.

The root cause is due to incompatible versions on `package:logging`. The bot tries to upgrade `package:logging` from `1.2.0` to `1.3.0`.

Here's what seems to happen:

  * `flutter update-packages` will update `dev/integration_tests/link_hook/pubspec.yaml` with `package:logging` to `1.3.0` (as it does with all other `pubspec.yaml` files in the flutter repository)

  * `flutter create  --template=package_ffi` will generate a template with `package:logging` `^1.2.0`

  * The test in question
    * creates ffi template (which will use `^1.2.0`)
    * make it depend on `dev/integration_tests/link_hook` (which uses `=1.3.0`)
    * changes logging dependency from the template from `^1.2.0` to `=1.2.0`

IMHO

  * `flutter update-packages` is doing what it's supposed to

  * `flutter create --template=package_ffi` can generate templates with versions it determines (maybe there are use cases where we want to generate templates with older versions)

  * The problematic part is the test:

     * it makes the generated template depend on `link_hook` and
     * changes template generated pubspec to use pinned dependencies

This PR makes the test package (created via template) use the pinned package versions from `dev/integration_tests/link_hook` (for dependencies that are common among the two).
All other dependencies that the template has on top of `dev/integration_tests/link_hook` it can pin as it does currently.

This will give us deterministic CI behavior (as we use flutter pined packages and remaining deps being pinned via template) It avoids changing the `flutter update-packages` and `flutter create --template=package_ffi` (as their behavior seems reasonable)

Should fix https://github.com/flutter/flutter/issues/158135