### PR TITLE
Cleanup MenuAnchor and Improve DropdownMenu tests readability

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -438,14 +438,12 @@ class _MenuAnchorState extends State<MenuAnchor> {
     // This `Shortcuts` is needed so that shortcuts work when the focus is on
     // MenuAnchor (specifically, the root menu, since submenus have their own
     // `Shortcuts`).
-    return
-    Shortcuts(
+    return Shortcuts(
       shortcuts: _kMenuTraversalShortcuts,
       // Ignore semantics here and since the same information is typically
       // also provided by the children.
       includeSemantics: false,
-      child:
-      _MenuAnchorScope(
+      child: _MenuAnchorScope(
         anchorKey: _anchorKey,
         anchor: this,
         isOpen: _isOpen,
@@ -459,7 +457,7 @@ class _MenuAnchorState extends State<MenuAnchor> {
       actions: <Type, Action<Intent>>{
         DismissIntent: DismissMenuAction(controller: _menuController),
       },
-      child:  Builder(
+      child: Builder(
         key: _anchorKey,
         builder: (BuildContext context) {
           return widget.builder?.call(context, _menuController, widget.child)
@@ -3391,7 +3389,7 @@ class _MenuPanel extends StatefulWidget {
   /// The layout orientation of this panel.
   final Axis orientation;
 
-  /// The list of widgets to use as children of this menu bar.
+  /// The list of widgets to use as children of this menu panel.
   ///
   /// These are the top level [SubmenuButton]s.
   final List<Widget> children;
@@ -3746,7 +3744,6 @@ bool get _isCupertino {
 bool get _usesSymbolicModifiers {
   return _isCupertino;
 }
-
 
 bool get _platformSupportsAccelerators {
   // On iOS and macOS, pressing the Option key (a.k.a. the Alt key) causes a

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -69,11 +69,15 @@ void main() {
     return color == themeData.colorScheme.onSurface.withOpacity(0.12);
   }
 
+  Finder findMenuPanel() {
+    return find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_MenuPanel');
+  }
+
   Finder findMenuMaterial() {
-    return find.ancestor(
-      of: find.widgetWithText(TextButton, TestMenu.mainMenu0.label),
+    return find.descendant(
+      of: findMenuPanel(),
       matching: find.byType(Material),
-    ).at(1);
+    ).first;
   }
 
   testWidgets('DropdownMenu defaults', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_menu_theme_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_theme_test.dart
@@ -22,11 +22,15 @@ void main() {
     ));
   }
 
+  Finder findMenuPanel() {
+    return find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_MenuPanel');
+  }
+
   Material getMenuMaterial(WidgetTester tester) {
-    return tester.widget<Material>(find.ancestor(
-      of: find.widgetWithText(TextButton, 'Item 0'),
+    return tester.widget<Material>(find.descendant(
+      of: findMenuPanel(),
       matching: find.byType(Material),
-    ).at(1));
+    ).first);
   }
 
   test('DropdownMenuThemeData copyWith, ==, hashCode basics', () {


### PR DESCRIPTION
## Description

This PR fixes some typos on `MenuAnchor` and improve the readability of a `DropdownMenu` test utility function.

@justinmc I'm still considering creating a test utils file for DropdownMenu but there are few utilities and I'm worried that helper functions in utils file will cripple completion results (not a big deal because it is just for people working on the framework) but I think this should be used carefully. For instance the function `getButtonMaterial` would have to be renamed to something less generic if exposed more broadly (`getMenuItemButtonMaterial` for instance).
