### PR TITLE
use root directory as the default for rootOverride in Cache.test constructor

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -148,7 +148,7 @@ class Cache {
     platform ??= FakePlatform(environment: <String, String>{});
     logger ??= BufferLogger.test();
     return Cache(
-      rootOverride: rootOverride ?? fileSystem.directory('cache'),
+      rootOverride: rootOverride ?? fileSystem.currentDirectory,
       artifacts: artifacts ?? <ArtifactSet>[],
       logger: logger,
       fileSystem: fileSystem,

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -144,6 +144,15 @@ class Cache {
     Platform? platform,
     required ProcessManager processManager,
   }) {
+    if (rootOverride?.fileSystem != null &&
+        fileSystem != null &&
+        rootOverride!.fileSystem != fileSystem) {
+      throw ArgumentError(
+        'If rootOverride and fileSystem are both non-null, '
+        'rootOverride.fileSystem must be the same as fileSystem.',
+        'fileSystem'
+      );
+    }
     fileSystem ??= rootOverride?.fileSystem ?? MemoryFileSystem.test();
     platform ??= FakePlatform(environment: <String, String>{});
     logger ??= BufferLogger.test();

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -24,7 +24,7 @@ void main() {
     setUp(() {
       fileSystem = MemoryFileSystem.test();
       gradleWrapperDirectory =
-          fileSystem.directory('cache/bin/cache/artifacts/gradle_wrapper');
+          fileSystem.directory('bin/cache/artifacts/gradle_wrapper');
       gradleWrapperDirectory.createSync(recursive: true);
       gradleWrapperDirectory
           .childFile('gradlew')

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -338,7 +338,6 @@ void main() {
     testWithoutContext('a non-empty realm is included in the storage url', () async {
       final MemoryFileSystem fileSystem = MemoryFileSystem.test();
       final Directory internalDir = fileSystem.currentDirectory
-        .childDirectory('cache')
         .childDirectory('bin')
         .childDirectory('internal');
       final File engineVersionFile = internalDir.childFile('engine.version');
@@ -803,7 +802,6 @@ void main() {
   testWithoutContext('FlutterWebSdk fetches web artifacts and deletes previous directory contents', () async {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Directory internalDir = fileSystem.currentDirectory
-      .childDirectory('cache')
       .childDirectory('bin')
       .childDirectory('internal');
     final File canvasKitVersionFile = internalDir.childFile('canvaskit.version');
@@ -842,7 +840,7 @@ void main() {
     ]);
 
     expect(locations, <String>[
-      'cache/bin/cache/flutter_web_sdk',
+      '/bin/cache/flutter_web_sdk',
     ]);
 
     expect(webCacheDirectory.childFile('foo'), exists);
@@ -852,7 +850,6 @@ void main() {
   testWithoutContext('FlutterWebSdk CanvasKit URL can be overridden via FLUTTER_STORAGE_BASE_URL', () async {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Directory internalDir = fileSystem.currentDirectory
-      .childDirectory('cache')
       .childDirectory('bin')
       .childDirectory('internal');
     final File canvasKitVersionFile = internalDir.childFile('canvaskit.version');
@@ -909,7 +906,7 @@ void main() {
     handler.addError(webCacheDirectory, FileSystemOp.delete, const FileSystemException('', '', OSError('', 2)));
 
     await expectLater(() => webSdk.updateInner(artifactUpdater, fileSystem, FakeOperatingSystemUtils()), throwsToolExit(
-      message: RegExp('Unable to delete file or directory at "cache/bin/cache/flutter_web_sdk"'),
+      message: RegExp('Unable to delete file or directory at "/bin/cache/flutter_web_sdk"'),
     ));
   });
 
@@ -1108,11 +1105,11 @@ void main() {
       Platform: () => FakePlatform(),
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          '/cache/bin/cache/flutter_gradle_wrapper.rand0/gradlew',
+          '/bin/cache/flutter_gradle_wrapper.rand0/gradlew',
           '-b',
           'packages/flutter_tools/gradle/resolve_dependencies.gradle',
           '--project-cache-dir',
-          'cache/bin/cache/flutter_gradle_wrapper.rand0',
+          '/bin/cache/flutter_gradle_wrapper.rand0',
           'resolveDependencies',
         ]),
       ]),


### PR DESCRIPTION
While doing some hacking on `Cache` in https://github.com/flutter/flutter/pull/158081, I noticed that [`Cache.test`](https://github.com/flutter/flutter/blob/de9318275391a6d2f10ae33c576f4113b25fd156/packages/flutter_tools/lib/src/cache.dart#L139) allows the caller to tell Cache to use some given directory as the flutter root (instead of depending on the static global [`Cache.flutterRoot`](https://github.com/flutter/flutter/blob/4f3976a4f2b722d26c3353158dcd26590859dde0/packages/flutter_tools/lib/src/cache.dart#L206)). This has a default value, `/cache`. However, `/cache` is an unintuitive name for the root directory of a Flutter installation.

This led to confusion when updating some tests. I wanted to create `/bin/cache/engine-dart-sdk.stamp` for tests, but in reality I needed to create `/cache/bin/cache/engine-dart-sdk.stamp`.

This PR changes this default to the current directory of the file system (which I'm guessing is `/` for all intents and purposes). 

<details>

<summary> Pre-launch checklist </summary> 


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

</details>


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
