### PR TITLE
remove `bringup` status for recently re-subsharded targets

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1202,7 +1202,6 @@ targets:
       - .ci.yaml
 
   - name: Linux tool_integration_tests_1_6
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1229,7 +1228,6 @@ targets:
       - .ci.yaml
 
   - name: Linux tool_integration_tests_2_6
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1256,7 +1254,6 @@ targets:
       - .ci.yaml
 
   - name: Linux tool_integration_tests_3_6
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1283,7 +1280,6 @@ targets:
       - .ci.yaml
 
   - name: Linux tool_integration_tests_4_6
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1310,7 +1306,6 @@ targets:
       - .ci.yaml
 
   - name: Linux tool_integration_tests_5_6
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1337,7 +1332,6 @@ targets:
       - .ci.yaml
 
   - name: Linux tool_integration_tests_6_6
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5448,7 +5442,6 @@ targets:
       task_name: run_release_test_macos
 
   - name: Windows build_tests_1_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5467,7 +5460,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_2_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5486,7 +5478,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_3_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5505,7 +5496,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_4_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5524,7 +5514,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_5_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5543,7 +5532,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_6_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5562,7 +5550,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_7_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5581,7 +5568,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_8_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -5600,7 +5586,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_9_9
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Cleans up https://github.com/flutter/flutter/pull/158196 and https://github.com/flutter/flutter/pull/158146


<details>

<summary> Pre-launch checklist </summary> 


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

</details>


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
