### PR TITLE
Fix menu is detached when a MenuAnchor is given tight constraints

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -435,6 +435,20 @@ class _MenuAnchorState extends State<MenuAnchor> {
       );
     }
 
+    // If this menu anchor is not a menu bar, wrap the content into a Column
+    // to allow the child to use its preferred size.
+    // This is required when the menu anchor receives tight constraints.
+    // Otherwise the menu will be positioned below those constraints height
+    // and might appear detached from the menu anchor content when the content
+    // has an intrinsic height which is lower than the tight constraints height.
+    if (_orientation == Axis.vertical) {
+      child = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[child],
+      );
+    }
+
     // This `Shortcuts` is needed so that shortcuts work when the focus is on
     // MenuAnchor (specifically, the root menu, since submenus have their own
     // `Shortcuts`).

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3529,6 +3529,93 @@ void main() {
     // None of the menus should be closed.
     expect(dropdownMenuAnchor.controller!.isOpen, true);
   });
+
+  group('The menu is attached to the bottom of the TextField', () {
+    const double textFieldBottom = 56.0;
+
+    testWidgets('when given loose constraints and expandedInsets is set', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: DropdownMenu<TestMenu>(
+            expandedInsets: EdgeInsets.zero,
+            initialSelection: TestMenu.mainMenu3,
+            dropdownMenuEntries: menuChildrenWithIcons,
+          ),
+        ),
+      ));
+
+      // Open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final double menuTop = tester.getRect(findMenuMaterial()).top;
+      expect(menuTop, textFieldBottom);
+    });
+
+    testWidgets('when given tight constraints and expandedInsets is set', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 200,
+            height: 300,
+            child: DropdownMenu<TestMenu>(
+              expandedInsets: EdgeInsets.zero,
+              initialSelection: TestMenu.mainMenu3,
+              dropdownMenuEntries: menuChildrenWithIcons,
+            ),
+          ),
+        ),
+      ));
+
+      // Open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final double menuTop = tester.getRect(findMenuMaterial()).top;
+      expect(menuTop, textFieldBottom);
+    });
+
+    testWidgets('when given loose constraints and expandedInsets is not set', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: DropdownMenu<TestMenu>(
+            initialSelection: TestMenu.mainMenu3,
+            dropdownMenuEntries: menuChildrenWithIcons,
+          ),
+        ),
+      ));
+
+      // Open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final double menuTop = tester.getRect(findMenuMaterial()).top;
+      expect(menuTop, textFieldBottom);
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/147076.
+    testWidgets('when given tight constraints and expandedInsets is not set', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 300,
+            child: DropdownMenu<TestMenu>(
+              initialSelection: TestMenu.mainMenu3,
+              dropdownMenuEntries: menuChildrenWithIcons,
+            ),
+          ),
+        ),
+      ));
+
+      // Open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final double menuTop = tester.getRect(findMenuMaterial()).top;
+      expect(menuTop, textFieldBottom);
+    });
+  });
 }
 
 enum TestMenu {

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3920,6 +3920,64 @@ void main() {
         tester.getRect(find.byKey(contentKey)).bottom,
       );
     });
+
+    group('The menu is attached to the bottom of the MenuAnchor content', () {
+      const double contentHeight = 100.0;
+      final MenuController menuController = MenuController();
+      final UniqueKey contentKey = UniqueKey();
+
+      Finder findMenuPanel() {
+        return find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_MenuPanel');
+      }
+
+      MenuAnchor buildMenuAnchor() {
+        return MenuAnchor(
+          controller: menuController,
+          layerLink: LayerLink(),
+          menuChildren: <Widget>[
+            MenuItemButton(
+              onPressed: () {},
+              child: const Text('Item 1'),
+            ),
+          ],
+          builder: (BuildContext context, MenuController controller, Widget? child) {
+            return SizedBox(key: contentKey, width: 100.0, height: contentHeight);
+          },
+        );
+      }
+
+      testWidgets('when given loose constraints', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            body: buildMenuAnchor(),
+          ),
+        ));
+
+        menuController.open();
+        await tester.pump();
+
+        final double menuTop = tester.getRect(findMenuPanel()).top;
+        expect(menuTop, contentHeight);
+      });
+
+      testWidgets('when given tight constraints', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 200,
+              height: 300,
+              child: buildMenuAnchor(),
+            ),
+          ),
+        ));
+
+        menuController.open();
+        await tester.pump();
+
+        final double menuTop = tester.getRect(findMenuPanel()).top;
+        expect(menuTop, contentHeight);
+      });
+    });
   });
 
   group('LocalizedShortcutLabeler', () {


### PR DESCRIPTION
## Description

This PR fixes `MenuAnchor`  menu vertical position when tight constraints are given to the `MenuAnchor`.

Before:

![image](https://github.com/user-attachments/assets/4c06d9ef-6fd9-4390-97ca-1477f5eead3a)

After:

![image](https://github.com/user-attachments/assets/80ead9ec-a39a-4f6b-8533-f4a9cfd74e00)


Il also fixes the same issue for `DropdownMenu`.

Before:

![image](https://github.com/user-attachments/assets/d8d9b857-07ed-4d3c-afe2-44518d979e66)

After:

![image](https://github.com/user-attachments/assets/a71ea3c8-a408-43a1-8c99-c2612ad4b24b)



## Related Issue

Fixes [Menu is detached from content when MenuAnchor is given tight constraints](https://github.com/flutter/flutter/issues/158264). 
Fixes the minHeight part of [DropdownMenu does not correctly handle incoming maxWidth and minHeight constraints](https://github.com/flutter/flutter/issues/147076).
(The maxWidth part was already fixed in https://github.com/flutter/flutter/pull/147233).

## Tests

Adds 6 tests.
