### PR TITLE
[TextInput] Add TextInputType.webSearch (#15762)

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -194,14 +194,24 @@ class TextInputType {
   /// Prevent the OS from showing the on-screen virtual keyboard.
   static const TextInputType none = TextInputType._(10);
 
+  /// Optimized for web searches.
+  ///
+  /// Requests a keyboard that includes keys useful for web searches as well as URLs.
+  ///
+  /// On iOS, requests a default keyboard with ready access to the "." key. In contrast to
+  /// [url], a space bar is available.
+  ///
+  /// On Android this is remapped to the [url] keyboard type as it always shows a space bar.
+  static const TextInputType webSearch = TextInputType._(11);
+
   /// All possible enum values.
   static const List<TextInputType> values = <TextInputType>[
-    text, multiline, number, phone, datetime, emailAddress, url, visiblePassword, name, streetAddress, none,
+    text, multiline, number, phone, datetime, emailAddress, url, visiblePassword, name, streetAddress, none, webSearch,
   ];
 
   // Corresponding string name for each of the [values].
   static const List<String> _names = <String>[
-    'text', 'multiline', 'number', 'phone', 'datetime', 'emailAddress', 'url', 'visiblePassword', 'name', 'address', 'none',
+    'text', 'multiline', 'number', 'phone', 'datetime', 'emailAddress', 'url', 'visiblePassword', 'name', 'address', 'none', 'webSearch',
   ];
 
   // Enum value name, this is what enum.toString() would normally return.

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -348,6 +348,7 @@ void main() {
       expect(TextInputType.name.toString(), 'TextInputType(name: TextInputType.name, signed: null, decimal: null)');
       expect(TextInputType.streetAddress.toString(), 'TextInputType(name: TextInputType.address, signed: null, decimal: null)');
       expect(TextInputType.none.toString(), 'TextInputType(name: TextInputType.none, signed: null, decimal: null)');
+      expect(TextInputType.webSearch.toString(), 'TextInputType(name: TextInputType.webSearch, signed: null, decimal: null)');
 
       expect(text == number, false);
       expect(number == number2, true);
@@ -376,6 +377,7 @@ void main() {
       expect(TextInputType.name.index, 8);
       expect(TextInputType.streetAddress.index, 9);
       expect(TextInputType.none.index, 10);
+      expect(TextInputType.webSearch.index, 11);
 
       expect(TextEditingValue.empty.toString(),
           'TextEditingValue(text: \u2524\u251C, selection: ${const TextSelection.collapsed(offset: -1)}, composing: ${TextRange.empty})');


### PR DESCRIPTION
This PR  adds `TextInputType.webSearch` that allows to show a keyboard with ready access to a "." key on iOS. On Android this is re-mapped to `url` which shows the same behaviour as `webSearch` on iOS. This fixes issue #157562.

There also is a [corresponding *engine* PR](https://github.com/flutter/engine/pull/56428).

Screenshot from iOS demo app:

![image](https://github.com/user-attachments/assets/94d48752-4cfe-4113-acf9-b3a981952dc7)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
