### PR TITLE
Increase Java heap limit to 8GB for plugin integration tests using deferred components

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
@@ -242,7 +242,7 @@ class BasicDeferredComponentsConfig extends DeferredComponentsConfig {
 
   @override
   String get androidGradleProperties => '''
-  org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
+  org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
   android.useAndroidX=true
   android.enableJetifier=true
   android.enableR8=true


### PR DESCRIPTION
Should help resolve https://github.com/flutter/flutter/issues/156953