### PR TITLE
Fix a breakage caused by the test being unskipped.

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -364,6 +364,7 @@ void main() {
       final BuildableIOSApp buildableIOSApp = BuildableIOSApp(flutterProject.ios, 'flutter', 'My Super Awesome App');
 
       processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
+      processManager.addCommand(const FakeCommand(command: kCheckDartPubDeps));
       // The first xcrun call should fail with a
       // concurrent build exception.
       processManager.addCommand(


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/158204 collided with https://github.com/flutter/flutter/pull/157462.

Fortunately the change is 1-line in 1-test.