### PR TITLE
Allow a custom `dart` version in the environment in `computeExclusiveDevDependencies`

### DIFF
--- a/packages/flutter_tools/lib/src/compute_dev_dependencies.dart
+++ b/packages/flutter_tools/lib/src/compute_dev_dependencies.dart
@@ -4,9 +4,11 @@
 
 import 'package:process/process.dart';
 
+import 'artifacts.dart';
 import 'base/io.dart';
 import 'base/logger.dart';
 import 'convert.dart';
+import 'globals.dart' as globals;
 
 /// Returns dependencies of [project] that are _only_ used as `dev_dependency`.
 ///
@@ -19,8 +21,9 @@ Future<Set<String>> computeExclusiveDevDependencies(
   required Logger logger,
   required String projectPath,
 }) async {
+  final String dartBinaryPath = globals.artifacts!.getArtifactPath(Artifact.engineDartBinary);
   final ProcessResult processResult = await processes.run(
-    <String>['dart', 'pub', 'deps', '--json'],
+    <String>[dartBinaryPath, 'pub', 'deps', '--json'],
     workingDirectory: projectPath,
   );
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -75,6 +75,12 @@ void main() {
   late FakeProcessManager processManager;
   late ProcessUtils processUtils;
   late Artifacts artifacts;
+  late final FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
+    artifacts.getArtifactPath(Artifact.engineDartBinary),
+    'pub',
+    'deps',
+    '--json',
+  ]);
 
   setUpAll(() {
     Cache.disableLocking();
@@ -112,13 +118,6 @@ void main() {
 
   const FakeCommand xattrCommand = FakeCommand(command: <String>[
     'xattr', '-r', '-d', 'com.apple.FinderInfo', '/',
-  ]);
-
-  const FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
-    'dart',
-    'pub',
-    'deps',
-    '--json',
   ]);
 
   FakeCommand setUpRsyncCommand({void Function(List<String> command)? onRun}) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -75,12 +75,7 @@ void main() {
   late FakeProcessManager processManager;
   late ProcessUtils processUtils;
   late Artifacts artifacts;
-  late final FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
-    artifacts.getArtifactPath(Artifact.engineDartBinary),
-    'pub',
-    'deps',
-    '--json',
-  ]);
+  late FakeCommand dartPubDepsCommand;
 
   setUpAll(() {
     Cache.disableLocking();
@@ -89,6 +84,12 @@ void main() {
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     artifacts = Artifacts.test(fileSystem: fileSystem);
+    dartPubDepsCommand = FakeCommand(command: <String>[
+      artifacts.getArtifactPath(Artifact.engineDartBinary),
+      'pub',
+      'deps',
+      '--json',
+    ]);
     fakeAnalytics = getInitializedFakeAnalyticsInstance(
       fs: fileSystem,
       fakeFlutterVersion: FakeFlutterVersion(),
@@ -303,6 +304,7 @@ void main() {
     );
     expect(testLogger.statusText, contains(RegExp(r'✓ Built build/ios/iphoneos/Runner\.app \(\d+\.\d+MB\)')));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       xattrCommand,
@@ -342,6 +344,7 @@ void main() {
     );
     expect(testLogger.statusText, contains('build/ios/iphoneos/Runner.app'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
     Platform: () => macosPlatform,
@@ -365,6 +368,7 @@ void main() {
     );
     expect(testLogger.statusText, contains('build/ios/iphoneos/Runner.app'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       xattrCommand,
@@ -398,6 +402,7 @@ void main() {
     );
     expect(testLogger.statusText, contains('build/ios/iphoneos/Runner.app'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       xattrCommand,
@@ -443,6 +448,7 @@ void main() {
     );
     expect(testLogger.statusText, contains('build/ios/iphoneos/Runner.app'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
     Platform: () => macosPlatform,
@@ -474,6 +480,7 @@ void main() {
     );
     expect(testLogger.statusText, contains('build/ios/iphoneos/Runner.app'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
     Platform: () => macosPlatform,
@@ -504,6 +511,7 @@ void main() {
       const <String>['build', 'ios', '--simulator', '--no-pub'],
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
     Platform: () => macosPlatform,
@@ -534,6 +542,7 @@ void main() {
       const <String>['build', 'ios', '--no-pub', '-v'],
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
     Platform: () => macosPlatform,
@@ -586,6 +595,7 @@ void main() {
       Event.codeSizeAnalysis(platform: 'ios')
     ));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => processManager,
@@ -636,6 +646,7 @@ void main() {
         ),
       ));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         xattrCommand,
@@ -691,6 +702,7 @@ void main() {
         ),
       ));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         xattrCommand,
@@ -755,6 +767,7 @@ void main() {
 
       expect(logger.traceText, contains('xcresult parser: Unrecognized top level json format.'));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -795,6 +808,7 @@ void main() {
       expect(logger.statusText, isNot(contains("Xcode's output")));
       expect(logger.statusText, isNot(contains('Lots of spew from Xcode')));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -834,6 +848,7 @@ void main() {
       expect(logger.errorText, isNot(contains('Command PhaseScriptExecution failed with a nonzero exit code')));
       expect(logger.warningText, isNot(contains('but the range of supported deployment target versions is')));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -868,6 +883,7 @@ void main() {
 
       expect(testLogger.traceText, contains('The xcresult bundle are not generated. Displaying xcresult is disabled.'));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
       Platform: () => macosPlatform,
@@ -907,6 +923,7 @@ void main() {
       expect(logger.errorText, contains('open ios/Runner.xcworkspace'));
       expect(logger.errorText, contains("Also try selecting 'Product > Build' to fix the problem."));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -947,6 +964,7 @@ void main() {
       expect(logger.errorText, contains('Runner requires a provisioning profile. Select a provisioning profile in the Signing & Capabilities editor'));
       expect(logger.errorText, contains(noProvisioningProfileInstruction));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -983,6 +1001,7 @@ void main() {
 
       expect(logger.errorText, contains(missingPlatformInstructions('iOS 17.0')));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1031,6 +1050,7 @@ void main() {
 
       expect(logger.statusText, contains('Xcode build done.'));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1073,6 +1093,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
 
       expect(logger.errorText, contains(noProvisioningProfileInstruction));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1112,6 +1133,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
 
       expect(logger.errorText, contains(noDevelopmentTeamInstruction));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1139,6 +1161,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
 
       expect(testLogger.errorText, contains(noProvisioningProfileInstruction));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         xattrCommand,
@@ -1192,6 +1215,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
 
       expect(testLogger.errorText, contains(noDevelopmentTeamInstruction));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
       Platform: () => macosPlatform,
@@ -1231,6 +1255,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
       expect(logger.errorText, contains(noProvisioningProfileInstruction));
       expect(logger.errorText, isNot(contains(noDevelopmentTeamInstruction)));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1271,6 +1296,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
       expect(logger.errorText, contains(noDevelopmentTeamInstruction));
       expect(logger.errorText, isNot(contains('It appears that there was a problem signing your application prior to installation on the device.')));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1313,6 +1339,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
 
       expect(logger.traceText, contains('xcresult parser: Unrecognized top level json format.'));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1354,6 +1381,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
       expect(logger.errorText, contains("Use of undeclared identifier 'asdas'"));
       expect(logger.errorText, contains('/Users/m/Projects/test_create/ios/Runner/AppDelegate.m:7:56'));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1398,6 +1426,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
       expect(logger.errorText, isNot(contains('Command PhaseScriptExecution failed with a nonzero exit code')));
       expect(logger.warningText, isNot(contains('but the range of supported deployment target versions is')));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,
@@ -1435,6 +1464,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
 
       expect(logger.traceText, contains('The xcresult bundle are not generated. Displaying xcresult is disabled.'));
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -84,12 +84,7 @@ void main() {
   late BufferLogger logger;
   late Artifacts artifacts;
   late FakeAnalytics fakeAnalytics;
-  late final FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
-    artifacts.getArtifactPath(Artifact.engineDartBinary),
-    'pub',
-    'deps',
-    '--json',
-  ]);
+  late FakeCommand dartPubDepsCommand;
 
   setUpAll(() {
     Cache.disableLocking();
@@ -98,6 +93,12 @@ void main() {
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     artifacts = Artifacts.test(fileSystem: fileSystem);
+    dartPubDepsCommand = FakeCommand(command: <String>[
+      artifacts.getArtifactPath(Artifact.engineDartBinary),
+      'pub',
+      'deps',
+      '--json',
+    ]);
     fakeProcessManager = FakeProcessManager.empty();
     logger = BufferLogger.test();
     processUtils = ProcessUtils(
@@ -416,6 +417,7 @@ void main() {
     expect(logger.statusText, contains('build/ios/archive/Runner.xcarchive'));
     expect(logger.statusText, contains('Building ad-hoc IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -463,6 +465,7 @@ void main() {
     expect(actualIpaPlistContents, expectedIpaPlistContents);
     expect(logger.statusText, contains('Building debugging IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -510,6 +513,7 @@ void main() {
     expect(actualIpaPlistContents, expectedIpaPlistContents);
     expect(logger.statusText, contains('Building release-testing IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -557,6 +561,7 @@ void main() {
     expect(actualIpaPlistContents, expectedIpaPlistContents);
     expect(logger.statusText, contains('Building App Store IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -586,6 +591,7 @@ void main() {
     );
     expect(logger.statusText, contains('Building enterprise IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -633,6 +639,7 @@ void main() {
     expect(actualIpaPlistContents, expectedIpaPlistContents);
     expect(logger.statusText, contains('Building enterprise IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -662,6 +669,7 @@ void main() {
     );
     expect(logger.statusText, contains('Building App Store IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -701,6 +709,7 @@ void main() {
     expect(logger.statusText, contains('build/ios/archive/Runner.xcarchive'));
     expect(logger.statusText, contains('Building enterprise IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -757,6 +766,7 @@ void main() {
     expect(logger.errorText, contains('open /build/ios/archive/Runner.xcarchive'));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -792,6 +802,7 @@ void main() {
     );
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -845,6 +856,7 @@ void main() {
     expect(logger.statusText, contains('Apple Transporter macOS app'));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -898,6 +910,7 @@ void main() {
     expect(logger.statusText, isNot(contains('To upload')));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -951,6 +964,7 @@ void main() {
     expect(logger.statusText, isNot(contains('To upload')));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -981,6 +995,7 @@ void main() {
     );
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1011,6 +1026,7 @@ void main() {
     );
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
@@ -1063,6 +1079,7 @@ void main() {
     expect(fakeProcessManager, hasNoRemainingExpectations);
     expect(logger.statusText, contains('Codesigning disabled with --no-codesign, skipping IPA'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1091,6 +1108,7 @@ void main() {
       contains('Could not find app to analyze code size'),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
@@ -1145,6 +1163,7 @@ void main() {
       Event.codeSizeAnalysis(platform: 'ios')
     ));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1189,6 +1208,7 @@ void main() {
     expect(logger.statusText, contains(RegExp('Built IPA to $outputPath ' r'\(\d+\.\d+MB\)')));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1224,6 +1244,7 @@ void main() {
     expect(logger.traceText, contains('xcresult parser: Unrecognized top level json format.'));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1260,6 +1281,7 @@ void main() {
     expect(logger.errorText, contains('/Users/m/Projects/test_create/ios/Runner/AppDelegate.m:7:56'));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1298,6 +1320,7 @@ void main() {
     expect(logger.warningText, isNot(contains('but the range of supported deployment target versions')));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1330,6 +1353,7 @@ void main() {
     expect(logger.traceText, contains('The xcresult bundle are not generated. Displaying xcresult is disabled.'));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1370,6 +1394,7 @@ void main() {
     expect(logger.errorText, contains("Also try selecting 'Product > Build' to fix the problem."));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1424,6 +1449,7 @@ void main() {
       contains('To update the settings, please refer to https://flutter.dev/to/ios-deploy')
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1484,6 +1510,7 @@ void main() {
       contains('To update the settings, please refer to https://flutter.dev/to/ios-deploy')
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1543,6 +1570,7 @@ void main() {
       contains('To update the settings, please refer to https://flutter.dev/to/ios-deploy'),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1588,6 +1616,7 @@ void main() {
       contains('    ! Your application still contains the default "com.example" bundle identifier.'),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1631,6 +1660,7 @@ void main() {
       isNot(contains('    ! Your application still contains the default "com.example" bundle identifier.'))
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1716,6 +1746,7 @@ void main() {
       contains('    ! App icon is set to the default placeholder icon. Replace with unique icons.'),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1799,6 +1830,7 @@ void main() {
       isNot(contains('! App icon is set to the default placeholder icon. Replace with unique icons.')),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1862,6 +1894,7 @@ void main() {
       contains('    ! App icon is using the incorrect size (e.g. Icon-App-20x20@2x.png).')
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1926,6 +1959,7 @@ void main() {
       contains('    ! App icon is using the incorrect size (e.g. Icon-App-20x20@2x.png).'),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -1989,6 +2023,7 @@ void main() {
       isNot(contains('    ! App icon is using the incorrect size (e.g. Icon-App-20x20@2x.png).')),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -2055,6 +2090,7 @@ void main() {
       isNot(contains('    ! App icon is using the incorrect size (e.g. Icon-App-20x20@2x.png).')),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -2166,6 +2202,7 @@ void main() {
       );
     }
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -2247,6 +2284,7 @@ void main() {
       contains('    ! Launch image is set to the default placeholder icon. Replace with unique launch image.'),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,
@@ -2329,6 +2367,7 @@ void main() {
       isNot(contains('    ! Launch image is set to the default placeholder icon. Replace with unique launch image.')),
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     Logger: () => logger,
     ProcessManager: () => fakeProcessManager,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -84,6 +84,12 @@ void main() {
   late BufferLogger logger;
   late Artifacts artifacts;
   late FakeAnalytics fakeAnalytics;
+  late final FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
+    artifacts.getArtifactPath(Artifact.engineDartBinary),
+    'pub',
+    'deps',
+    '--json',
+  ]);
 
   setUpAll(() {
     Cache.disableLocking();
@@ -138,13 +144,6 @@ void main() {
 
   const FakeCommand xattrCommand = FakeCommand(command: <String>[
     'xattr', '-r', '-d', 'com.apple.FinderInfo', '/',
-  ]);
-
-  const FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
-    'dart',
-    'pub',
-    'deps',
-    '--json',
   ]);
 
   FakeCommand setUpXCResultCommand({String stdout = '', void Function(List<String> command)? onRun}) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -71,6 +71,12 @@ void main() {
   late XcodeProjectInterpreter xcodeProjectInterpreter;
   late Artifacts artifacts;
   late FakeAnalytics fakeAnalytics;
+  late final FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
+    artifacts.getArtifactPath(Artifact.engineDartBinary),
+    'pub',
+    'deps',
+    '--json',
+  ]);
 
   setUpAll(() {
     Cache.disableLocking();
@@ -104,13 +110,6 @@ void main() {
     fileSystem.directory(fileSystem.path.join('macos', 'Runner.xcworkspace')).createSync(recursive: true);
     createCoreMockProjectFiles();
   }
-
-  const FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
-    'dart',
-    'pub',
-    'deps',
-    '--json',
-  ]);
 
   // Creates a FakeCommand for the xcodebuild call to build the app
   // in the given configuration.

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -71,12 +71,7 @@ void main() {
   late XcodeProjectInterpreter xcodeProjectInterpreter;
   late Artifacts artifacts;
   late FakeAnalytics fakeAnalytics;
-  late final FakeCommand dartPubDepsCommand = FakeCommand(command: <String>[
-    artifacts.getArtifactPath(Artifact.engineDartBinary),
-    'pub',
-    'deps',
-    '--json',
-  ]);
+  late FakeCommand dartPubDepsCommand;
 
   setUpAll(() {
     Cache.disableLocking();
@@ -85,6 +80,12 @@ void main() {
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     artifacts = Artifacts.test(fileSystem: fileSystem);
+    dartPubDepsCommand = FakeCommand(command: <String>[
+      artifacts.getArtifactPath(Artifact.engineDartBinary),
+      'pub',
+      'deps',
+      '--json',
+    ]);
     logger = BufferLogger.test();
     fakeProcessManager = FakeProcessManager.empty();
     processUtils = ProcessUtils(
@@ -304,6 +305,7 @@ STDERR STUFF
     expect(testLogger.errorText, isNot(contains('_NSMainThread:')));
     expect(testLogger.errorText, isNot(contains('Please file a bug at https://feedbackassistant')));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -330,6 +332,7 @@ STDERR STUFF
     );
     expect(testLogger.statusText, contains(RegExp(r'✓ Built build/macos/Build/Products/Release/example.app \(\d+\.\d+MB\)')));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -355,6 +358,7 @@ STDERR STUFF
       const <String>['build', 'macos', '--debug', '--no-pub']
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -380,6 +384,7 @@ STDERR STUFF
       const <String>['build', 'macos', '--debug', '--no-pub', '-v']
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -406,6 +411,7 @@ STDERR STUFF
       const <String>['build', 'macos', '--profile', '--no-pub']
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -432,6 +438,7 @@ STDERR STUFF
       const <String>['build', 'macos', '--release', '--no-pub']
     );
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -503,7 +510,7 @@ STDERR STUFF
     ]),
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
-    Artifacts: () => Artifacts.test(),
+    Artifacts: () => artifacts,
   });
 
   testUsingContext('build settings contains Flutter Xcode environment variables', () async {
@@ -553,6 +560,7 @@ STDERR STUFF
 
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatformCustomEnv,
@@ -589,6 +597,7 @@ STDERR STUFF
     expect(contents, contains('FLUTTER_BUILD_NAME=1.2.3'));
     expect(contents, contains('FLUTTER_BUILD_NUMBER=42'));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -661,6 +670,7 @@ STDERR STUFF
 
     expect(testLogger.statusText, isEmpty);
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -696,6 +706,7 @@ STDERR STUFF
     expect(testLogger.statusText, contains('dart devtools --appSizeBase='));
     expect(fakeAnalytics.sentEvents, contains(Event.codeSizeAnalysis(platform: 'macos')));
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -768,6 +779,7 @@ STDERR STUFF
 
 ''');
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,
@@ -837,6 +849,7 @@ STDERR STUFF
 
 ''');
   }, overrides: <Type, Generator>{
+    Artifacts: () => artifacts,
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       dartPubDepsCommand,

--- a/packages/flutter_tools/test/general.shard/compute_dev_dependencies_test.dart
+++ b/packages/flutter_tools/test/general.shard/compute_dev_dependencies_test.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/compute_dev_dependencies.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../src/common.dart';
-import '../src/fake_process_manager.dart';
+import '../src/context.dart';
 
 // For all of these examples, imagine the following package structure:
 //
@@ -26,7 +28,8 @@ void main() {
     logger = BufferLogger.test();
   });
 
-  test('no dev dependencies at all', () async {
+
+  testUsingContext('no dev dependencies at all', () async {
     // Simulates the following:
     //
     // # /my_app/pubspec.yaml
@@ -86,7 +89,7 @@ void main() {
     );
   });
 
-  test('dev dependency', () async {
+  testUsingContext('dev dependency', () async {
     // Simulates the following:
     //
     // # /my_app/pubspec.yaml
@@ -145,7 +148,7 @@ void main() {
     );
   });
 
-  test('dev used as a non-dev dependency transitively', () async {
+  testUsingContext('dev used as a non-dev dependency transitively', () async {
     // Simulates the following:
     //
     // # /my_app/pubspec.yaml
@@ -210,7 +213,7 @@ void main() {
     );
   });
 
-  test('combination of an included and excluded dev_dependency', () async {
+  testUsingContext('combination of an included and excluded dev_dependency', () async {
     // Simulates the following:
     //
     // # /my_app/pubspec.yaml
@@ -293,7 +296,7 @@ void main() {
     );
   });
 
-  test('throws and logs on non-zero exit code', () async {
+  testUsingContext('throws and logs on non-zero exit code', () async {
     final ProcessManager processes = _dartPubDepsFails(
       'Bad thing',
       exitCode: 1,
@@ -317,7 +320,7 @@ void main() {
     expect(logger.traceText, isEmpty);
   });
 
-  test('throws and logs on unexpected output type', () async {
+  testUsingContext('throws and logs on unexpected output type', () async {
     final ProcessManager processes = _dartPubDepsReturns(
       'Not JSON haha!',
     );
@@ -340,7 +343,7 @@ void main() {
     expect(logger.traceText, contains('Not JSON haha'));
   });
 
-  test('throws and logs on invalid JSON', () async {
+  testUsingContext('throws and logs on invalid JSON', () async {
     final ProcessManager processes = _dartPubDepsReturns('''
     {
       "root": "my_app",
@@ -402,9 +405,10 @@ void main() {
 const String _fakeProjectPath = '/path/to/project';
 
 ProcessManager _dartPubDepsReturns(String dartPubDepsOutput) {
+  final String dartBinaryPath = globals.artifacts!.getArtifactPath(Artifact.engineDartBinary);
   return FakeProcessManager.list(<FakeCommand>[
     FakeCommand(
-      command: const <String>['dart', 'pub', 'deps', '--json'],
+      command: <String>[dartBinaryPath, 'pub', 'deps', '--json'],
       stdout: dartPubDepsOutput,
       workingDirectory: _fakeProjectPath,
     ),
@@ -415,9 +419,10 @@ ProcessManager _dartPubDepsFails(
   String dartPubDepsError, {
   required int exitCode,
 }) {
+  final String dartBinaryPath = globals.artifacts!.getArtifactPath(Artifact.engineDartBinary);
   return FakeProcessManager.list(<FakeCommand>[
     FakeCommand(
-      command: const <String>['dart', 'pub', 'deps', '--json'],
+      command: <String>[dartBinaryPath, 'pub', 'deps', '--json'],
       exitCode: exitCode,
       stderr: dartPubDepsError,
       workingDirectory: _fakeProjectPath,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -87,20 +87,22 @@ final FakeOperatingSystemUtils os = FakeOperatingSystemUtils(
 void main() {
   late Artifacts artifacts;
   late String iosDeployPath;
+
   // TODO(matanlurey): XCode builds call processPodsIfNeeded -> refreshPluginsList
   // ... which in turn requires that `dart pub deps --json` is called in order to
   // label which plugins are dependency plugins.
   //
   // Ideally processPodsIfNeeded should rely on the command (removing this call).
-  late final List<String> kCheckDartPubDeps = <String> [
-    artifacts.getArtifactPath(Artifact.engineDartBinary),
-    'pub',
-    'deps',
-    '--json',
-  ];
+  late List<String> kCheckDartPubDeps;
 
   setUp(() {
     artifacts = Artifacts.test();
+    kCheckDartPubDeps = <String> [
+      artifacts.getArtifactPath(Artifact.engineDartBinary),
+      'pub',
+      'deps',
+      '--json',
+    ];
     iosDeployPath = artifacts.getHostArtifact(HostArtifact.iosDeploy).path;
   });
 
@@ -164,6 +166,7 @@ void main() {
         true,
       );
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       ProcessManager: () => processManager,
       FileSystem: () => fileSystem,
       Logger: () => logger,
@@ -256,6 +259,7 @@ void main() {
       expect(launchResult.started, true);
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       ProcessManager: () => processManager,
       FileSystem: () => fileSystem,
       Logger: () => logger,
@@ -340,6 +344,7 @@ void main() {
       expect(launchResult.started, true);
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       ProcessManager: () => processManager,
       FileSystem: () => fileSystem,
       Logger: () => logger,
@@ -411,6 +416,7 @@ void main() {
         fakeAsync.elapse(const Duration(seconds: 2));
       } while (fakeAsync.pendingTimers.isNotEmpty);
     }, overrides: <Type, Generator>{
+      Artifacts: () => artifacts,
       ProcessManager: () => processManager,
       FileSystem: () => fileSystem,
       Logger: () => logger,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -69,18 +69,6 @@ const List<String> kRunReleaseArgs = <String>[
   'COMPILER_INDEX_STORE_ENABLE=NO',
 ];
 
-// TODO(matanlurey): XCode builds call processPodsIfNeeded -> refreshPluginsList
-// ... which in turn requires that `dart pub deps --json` is called in order to
-// label which plugins are dependency plugins.
-//
-// Ideally processPodsIfNeeded should rely on the command (removing this call).
-const List<String> kCheckDartPubDeps = <String> [
-  'dart',
-  'pub',
-  'deps',
-  '--json',
-];
-
 const String kConcurrentBuildErrorMessage = '''
 "/Developer/Xcode/DerivedData/foo/XCBuildData/build.db":
 database is locked
@@ -99,6 +87,17 @@ final FakeOperatingSystemUtils os = FakeOperatingSystemUtils(
 void main() {
   late Artifacts artifacts;
   late String iosDeployPath;
+  // TODO(matanlurey): XCode builds call processPodsIfNeeded -> refreshPluginsList
+  // ... which in turn requires that `dart pub deps --json` is called in order to
+  // label which plugins are dependency plugins.
+  //
+  // Ideally processPodsIfNeeded should rely on the command (removing this call).
+  late final List<String> kCheckDartPubDeps = <String> [
+    artifacts.getArtifactPath(Artifact.engineDartBinary),
+    'pub',
+    'deps',
+    '--json',
+  ];
 
   setUp(() {
     artifacts = Artifacts.test();
@@ -144,7 +143,7 @@ void main() {
       final BuildableIOSApp buildableIOSApp = BuildableIOSApp(flutterProject.ios, 'flutter', 'My Super Awesome App');
 
       processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
-      processManager.addCommand(const FakeCommand(command: kCheckDartPubDeps));
+      processManager.addCommand(FakeCommand(command: kCheckDartPubDeps));
       processManager.addCommand(const FakeCommand(command: kRunReleaseArgs));
 
       final LaunchResult launchResult = await iosDevice.startApp(
@@ -219,7 +218,7 @@ void main() {
       fileSystem.directory('build/ios/Release-iphoneos/My Super Awesome App.app').createSync(recursive: true);
 
       processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
-      processManager.addCommand(const FakeCommand(command: kCheckDartPubDeps));
+      processManager.addCommand(FakeCommand(command: kCheckDartPubDeps));
       processManager.addCommand(const FakeCommand(command: kRunReleaseArgs));
       processManager.addCommand(const FakeCommand(command: <String>[
         'rsync',
@@ -280,7 +279,7 @@ void main() {
       fileSystem.directory('build/ios/Release-iphoneos/My Super Awesome App.app').createSync(recursive: true);
 
       processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
-      processManager.addCommand(const FakeCommand(command: kCheckDartPubDeps));
+      processManager.addCommand(FakeCommand(command: kCheckDartPubDeps));
       processManager.addCommand(const FakeCommand(command: <String>[
         'xcrun',
         'xcodebuild',
@@ -364,7 +363,7 @@ void main() {
       final BuildableIOSApp buildableIOSApp = BuildableIOSApp(flutterProject.ios, 'flutter', 'My Super Awesome App');
 
       processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
-      processManager.addCommand(const FakeCommand(command: kCheckDartPubDeps));
+      processManager.addCommand(FakeCommand(command: kCheckDartPubDeps));
       // The first xcrun call should fail with a
       // concurrent build exception.
       processManager.addCommand(


### PR DESCRIPTION
`computeExclusiveDevDependencies` does not use `Artifact` when executing the dart command, which can cause exceptions when the dart version in the environment variable is different from the dart version used to execute the flutter command. This directly prevents the `flutter run` command from running in the main channel when the environment variable is not set.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
