### PR TITLE
Replace custom `RPCErrorCodes` with `RPCErrorKind` from `package:vm_service`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -31,7 +31,6 @@ import '../run_cold.dart';
 import '../run_hot.dart';
 import '../runner/flutter_command.dart';
 import '../runner/flutter_command_runner.dart';
-import '../vmservice.dart';
 
 /// A Flutter-command that attaches to applications that have been launched
 /// without `flutter run`.
@@ -415,7 +414,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
         _logger.printStatus('Waiting for a new connection from Flutter on ${device.name}...');
       }
     } on RPCError catch (err) {
-      if (err.code == RPCErrorCodes.kServiceDisappeared ||
+      if (err.code == RPCErrorKind.kServiceDisappeared.code ||
           err.message.contains('Service connection disposed')) {
         throwToolExit('Lost connection to device.');
       }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -28,7 +28,6 @@ import '../run_hot.dart';
 import '../runner/flutter_command.dart';
 import '../runner/flutter_command_runner.dart';
 import '../tracing.dart';
-import '../vmservice.dart';
 import '../web/compile.dart';
 import '../web/web_constants.dart';
 import '../web/web_runner.dart';
@@ -866,7 +865,7 @@ class RunCommand extends RunCommandBase {
         throwToolExit(null, exitCode: result);
       }
     } on RPCError catch (error) {
-      if (error.code == RPCErrorCodes.kServiceDisappeared ||
+      if (error.code == RPCErrorKind.kServiceDisappeared.code ||
           error.message.contains('Service connection disposed')) {
         throwToolExit('Lost connection to device.');
       }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -516,7 +516,7 @@ class DevFS {
       final vm_service.Response response = await _vmService.createDevFS(fsName);
       _baseUri = Uri.parse(response.json!['uri'] as String);
     } on vm_service.RPCError catch (rpcException) {
-      if (rpcException.code == RPCErrorCodes.kServiceDisappeared ||
+      if (rpcException.code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
           rpcException.message.contains('Service connection disposed')) {
         // This can happen if the device has been disconnected, so translate to
         // a DevFSException, which the caller will handle.

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -176,7 +176,7 @@ class HotRunner extends ResidentRunner {
     if (!result.isOk) {
       throw vm_service.RPCError(
         'Unable to reload sources',
-        RPCErrorCodes.kInternalError,
+        vm_service.RPCErrorKind.kInternalError.code,
         '',
       );
     }
@@ -188,7 +188,7 @@ class HotRunner extends ResidentRunner {
     if (!result.isOk) {
       throw vm_service.RPCError(
         'Unable to restart',
-        RPCErrorCodes.kInternalError,
+        vm_service.RPCErrorKind.kInternalError.code,
         '',
       );
     }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -58,29 +58,6 @@ set openChannelForTesting(WebSocketConnector? connector) {
   _openChannel = connector ?? _defaultOpenChannel;
 }
 
-/// The error codes for the JSON-RPC standard, including VM service specific
-/// error codes.
-///
-/// See also: https://www.jsonrpc.org/specification#error_object
-abstract class RPCErrorCodes {
-  /// The method does not exist or is not available.
-  static const int kMethodNotFound = -32601;
-
-  /// Invalid method parameter(s), such as a mismatched type.
-  static const int kInvalidParams = -32602;
-
-  /// Internal JSON-RPC error.
-  static const int kInternalError = -32603;
-
-  /// Application specific error codes.
-  static const int kServerError = -32000;
-
-  /// Non-standard JSON-RPC error codes:
-
-  /// The VM service or extension service has disappeared.
-  static const int kServiceDisappeared = 112;
-}
-
 /// A function that reacts to the invocation of the 'reloadSources' service.
 ///
 /// The VM Service Protocol allows clients to register custom services that
@@ -424,7 +401,7 @@ String _validateRpcStringParam(String methodName, Map<String, Object?> params, S
   if (value is! String || value.isEmpty) {
     throw vm_service.RPCError(
       methodName,
-      RPCErrorCodes.kInvalidParams,
+      vm_service.RPCErrorKind.kInvalidParams.code,
       "Invalid '$paramName': $value",
     );
   }
@@ -436,7 +413,7 @@ bool _validateRpcBoolParam(String methodName, Map<String, Object?> params, Strin
   if (value != null && value is! bool) {
     throw vm_service.RPCError(
       methodName,
-      RPCErrorCodes.kInvalidParams,
+      vm_service.RPCErrorKind.kInvalidParams.code,
       "Invalid '$paramName': $value",
     );
   }
@@ -498,7 +475,7 @@ class FlutterVmService {
     try {
       return await service.getVM();
     } on vm_service.RPCError catch (err) {
-      if (err.code == RPCErrorCodes.kServiceDisappeared ||
+      if (err.code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
           err.message.contains('Service connection disposed')) {
         globals.printTrace('VmService.getVm call failed: $err');
         return null;
@@ -519,7 +496,7 @@ class FlutterVmService {
       // and should begin to shutdown due to the service connection closing.
       // Swallow the exception here and let the shutdown logic elsewhere deal
       // with cleaning up.
-      if (e.code == RPCErrorCodes.kServiceDisappeared ||
+      if (e.code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
           e.message.contains('Service connection disposed')) {
         return null;
       }
@@ -589,8 +566,7 @@ class FlutterVmService {
       await service.streamListen(vm_service.EventStreams.kIsolate);
     } on vm_service.RPCError catch (e) {
       // Do nothing if the tool is already subscribed.
-      const int streamAlreadySubscribed = 103;
-      if (e.code != streamAlreadySubscribed) {
+      if (e.code != vm_service.RPCErrorKind.kStreamAlreadySubscribed.code) {
         rethrow;
       }
     }
@@ -890,8 +866,8 @@ class FlutterVmService {
     } on vm_service.RPCError catch (err) {
       // If an application is not using the framework or the VM service
       // disappears while handling a request, return null.
-      if ((err.code == RPCErrorCodes.kMethodNotFound) ||
-          (err.code == RPCErrorCodes.kServiceDisappeared) ||
+      if ((err.code == vm_service.RPCErrorKind.kMethodNotFound.code) ||
+          (err.code == vm_service.RPCErrorKind.kServiceDisappeared.code) ||
           (err.message.contains('Service connection disposed'))) {
         return null;
       }
@@ -1029,7 +1005,7 @@ class FlutterVmService {
         onError: (Object? error, StackTrace stackTrace) {
           if (error is vm_service.SentinelException ||
             error == null ||
-            (error is vm_service.RPCError && error.code == RPCErrorCodes.kServiceDisappeared)) {
+            (error is vm_service.RPCError && error.code == vm_service.RPCErrorKind.kServiceDisappeared.code)) {
             return null;
           }
           return Future<vm_service.Isolate?>.error(error, stackTrace);
@@ -1045,7 +1021,7 @@ class FlutterVmService {
         onError: (Object? error, StackTrace stackTrace) {
           if (error is vm_service.SentinelException ||
             error == null ||
-            (error is vm_service.RPCError && error.code == RPCErrorCodes.kServiceDisappeared)) {
+            (error is vm_service.RPCError && error.code == vm_service.RPCErrorKind.kServiceDisappeared.code)) {
             return null;
           }
           return Future<vm_service.Event?>.error(error, stackTrace);

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -30,7 +30,6 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
-import 'package:flutter_tools/src/vmservice.dart';
 import 'package:multicast_dns/multicast_dns.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -1100,7 +1099,7 @@ void main() {
         bool enableDevTools,
       ) async {
         await null;
-        throw vm_service.RPCError('flutter._listViews', RPCErrorCodes.kServiceDisappeared, '');
+        throw vm_service.RPCError('flutter._listViews', vm_service.RPCErrorKind.kServiceDisappeared.code, '');
       };
 
       testDeviceManager.devices = <Device>[device];
@@ -1139,7 +1138,7 @@ void main() {
         bool enableDevTools,
       ) async {
         await null;
-        throw vm_service.RPCError('flutter._listViews', RPCErrorCodes.kServerError, 'Service connection disposed');
+        throw vm_service.RPCError('flutter._listViews', vm_service.RPCErrorKind.kServerError.code, 'Service connection disposed');
       };
 
       testDeviceManager.devices = <Device>[device];
@@ -1179,7 +1178,7 @@ void main() {
         bool enableDevTools,
       ) async {
         await null;
-        throw vm_service.RPCError('flutter._listViews', RPCErrorCodes.kInvalidParams, '');
+        throw vm_service.RPCError('flutter._listViews', vm_service.RPCErrorKind.kInvalidParams.code, '');
       };
 
       testDeviceManager.devices = <Device>[device];

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -29,7 +29,6 @@ import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
-import 'package:flutter_tools/src/vmservice.dart';
 import 'package:flutter_tools/src/web/compile.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart' as analytics;
@@ -1129,7 +1128,7 @@ void main() {
     final FakeResidentRunner residentRunner = FakeResidentRunner();
     residentRunner.rpcError = RPCError(
       'flutter._listViews',
-      RPCErrorCodes.kServiceDisappeared,
+      RPCErrorKind.kServiceDisappeared.code,
       '',
     );
     final TestRunCommandWithFakeResidentRunner command = TestRunCommandWithFakeResidentRunner();
@@ -1142,7 +1141,7 @@ void main() {
 
     residentRunner.rpcError = RPCError(
       'flutter._listViews',
-      RPCErrorCodes.kServerError,
+      RPCErrorKind.kServerError.code,
       'Service connection disposed.',
     );
 
@@ -1158,7 +1157,7 @@ void main() {
 
   testUsingContext('Flutter run does not catch other RPC errors', () async {
     final FakeResidentRunner residentRunner = FakeResidentRunner();
-    residentRunner.rpcError = RPCError('flutter._listViews', RPCErrorCodes.kInvalidParams, '');
+    residentRunner.rpcError = RPCError('flutter._listViews', RPCErrorKind.kInvalidParams.code, '');
     final TestRunCommandWithFakeResidentRunner command = TestRunCommandWithFakeResidentRunner();
     command.fakeResidentRunner = residentRunner;
 

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -24,9 +24,9 @@ import 'package:flutter_tools/src/build_system/tools/shader_compiler.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
-import 'package:flutter_tools/src/vmservice.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -46,18 +46,18 @@ final FakeVmServiceRequest createDevFSRequest = FakeVmServiceRequest(
   }
 );
 
-const FakeVmServiceRequest failingCreateDevFSRequest = FakeVmServiceRequest(
+FakeVmServiceRequest failingCreateDevFSRequest = FakeVmServiceRequest(
   method: '_createDevFS',
   args: <String, Object>{
     'fsName': 'test',
   },
-  error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+  error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
 );
 
-const FakeVmServiceRequest failingDeleteDevFSRequest = FakeVmServiceRequest(
+FakeVmServiceRequest failingDeleteDevFSRequest = FakeVmServiceRequest(
   method: '_deleteDevFS',
   args: <String, dynamic>{'fsName': 'test'},
-  error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+  error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
 );
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
+import 'package:vm_service/vm_service.dart';
 
 import '../src/common.dart';
 import '../src/fake_process_manager.dart';
@@ -254,9 +255,9 @@ void main() {
           'streamId': 'Isolate',
         },
       ),
-      const FakeVmServiceRequest(
+      FakeVmServiceRequest(
         method: kListViewsMethod,
-        error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+        error: FakeRPCError(code: RPCErrorKind.kServiceDisappeared.code),
       ),
     ], httpAddress: Uri.parse('http://localhost:1234'));
 
@@ -317,9 +318,9 @@ void main() {
           'streamId': 'Isolate',
         },
       ),
-      const FakeVmServiceRequest(
+      FakeVmServiceRequest(
         method: kListViewsMethod,
-        error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+        error: FakeRPCError(code: RPCErrorKind.kServiceDisappeared.code),
       ),
     ], httpAddress: Uri.parse('http://localhost:5678'));
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1958,10 +1958,10 @@ flutter:
   testUsingContext('FlutterDevice does not throw when unable to initiate log reader due to VM service disconnection', () async {
     fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'getVM',
           error: FakeRPCError(
-            code: RPCErrorCodes.kServerError,
+            code: vm_service.RPCErrorKind.kServerError.code,
             error: 'Service connection disposed',
           ),
         ),

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -979,10 +979,10 @@ void main() {
     final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
-      const FakeVmServiceRequest(
+      FakeVmServiceRequest(
         method: kHotRestartServiceName,
         // Failed response,
-        error: FakeRPCError(code: RPCErrorCodes.kInternalError),
+        error: FakeRPCError(code: vm_service.RPCErrorKind.kInternalError.code),
       ),
     ]);
     setupMocks();
@@ -995,7 +995,7 @@ void main() {
     final OperationResult result = await residentWebRunner.restart();
 
     expect(result.code, 1);
-    expect(result.message, contains(RPCErrorCodes.kInternalError.toString()));
+    expect(result.message, contains(vm_service.RPCErrorKind.kInternalError.toString()));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -995,7 +995,10 @@ void main() {
     final OperationResult result = await residentWebRunner.restart();
 
     expect(result.code, 1);
-    expect(result.message, contains(vm_service.RPCErrorKind.kInternalError.toString()));
+    expect(
+      result.message,
+      contains(vm_service.RPCErrorKind.kInternalError.code.toString()),
+    );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -1118,10 +1118,10 @@ void main() {
             'enabled': 'false',
           },
         ),
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'ext.dwds.screenshot',
           // Failed response,
-          error: FakeRPCError(code: RPCErrorCodes.kInternalError),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kInternalError.code),
         ),
         FakeVmServiceRequest(
           method: 'ext.flutter.debugAllowBanner',
@@ -1161,7 +1161,7 @@ void main() {
             'enabled': 'true',
           },
           // Failed response,
-          error: const FakeRPCError(code: RPCErrorCodes.kInternalError),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kInternalError.code),
         ),
       ],
       logger: logger,

--- a/packages/flutter_tools/test/general.shard/tracing_test.dart
+++ b/packages/flutter_tools/test/general.shard/tracing_test.dart
@@ -138,9 +138,9 @@ void main() {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
       ...vmServiceSetup,
-      const FakeVmServiceRequest(
+      FakeVmServiceRequest(
         method: 'getVMTimeline',
-        error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+        error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
       ),
       const FakeVmServiceRequest(
         method: 'setVMTimelineFlags',

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -263,12 +263,12 @@ void main() {
   testWithoutContext('flutterDebugDumpSemanticsTreeInTraversalOrder handles missing method', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'ext.flutter.debugDumpSemanticsTreeInTraversalOrder',
           args: <String, Object>{
             'isolateId': '1',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kMethodNotFound),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kMethodNotFound.code),
         ),
       ]
     );
@@ -282,12 +282,12 @@ void main() {
   testWithoutContext('flutterDebugDumpSemanticsTreeInInverseHitTestOrder handles missing method', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'ext.flutter.debugDumpSemanticsTreeInInverseHitTestOrder',
           args: <String, Object>{
             'isolateId': '1',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kMethodNotFound),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kMethodNotFound.code),
         ),
       ]
     );
@@ -301,12 +301,12 @@ void main() {
   testWithoutContext('flutterDebugDumpLayerTree handles missing method', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'ext.flutter.debugDumpLayerTree',
           args: <String, Object>{
             'isolateId': '1',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kMethodNotFound),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kMethodNotFound.code),
         ),
       ]
     );
@@ -320,12 +320,12 @@ void main() {
   testWithoutContext('flutterDebugDumpRenderTree handles missing method', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'ext.flutter.debugDumpRenderTree',
           args: <String, Object>{
             'isolateId': '1',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kMethodNotFound),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kMethodNotFound.code),
         ),
       ]
     );
@@ -339,12 +339,12 @@ void main() {
   testWithoutContext('flutterDebugDumpApp handles missing method', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'ext.flutter.debugDumpApp',
           args: <String, Object>{
             'isolateId': '1',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kMethodNotFound),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kMethodNotFound.code),
         ),
       ]
     );
@@ -358,12 +358,12 @@ void main() {
   testWithoutContext('flutterDebugDumpFocusTree handles missing method', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'ext.flutter.debugDumpFocusTree',
           args: <String, Object>{
             'isolateId': '1',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kMethodNotFound),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kMethodNotFound.code),
         ),
       ]
     );
@@ -398,31 +398,31 @@ void main() {
   testWithoutContext('Framework service extension invocations return null if service disappears ', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: kGetSkSLsMethod,
           args: <String, Object>{
             'viewId': '1234',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
         ),
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: kListViewsMethod,
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
         ),
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: kScreenshotSkpMethod,
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
         ),
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'setVMTimelineFlags',
           args: <String, dynamic>{
             'recordedStreams': <String>['test'],
           },
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
         ),
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'getVMTimeline',
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
         ),
       ]
     );
@@ -450,12 +450,12 @@ void main() {
   testWithoutContext('getIsolateOrNull returns null if service disappears ', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'getIsolate',
           args: <String, Object>{
             'isolateId': 'isolate/123',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
         ),
       ]
     );
@@ -615,12 +615,12 @@ void main() {
             ],
           },
         ),
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: 'getIsolate',
           args: <String, Object>{
             'isolateId': '1',
           },
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
         ),
         // Assume a different isolate returns.
         FakeVmServiceStreamResponse(
@@ -700,9 +700,9 @@ void main() {
             'streamId': 'Isolate',
           },
         ),
-        const FakeVmServiceRequest(
+        FakeVmServiceRequest(
           method: kListViewsMethod,
-          error: FakeRPCError(code: RPCErrorCodes.kServiceDisappeared),
+          error: FakeRPCError(code: vm_service.RPCErrorKind.kServiceDisappeared.code),
         ),
       ]);
 


### PR DESCRIPTION
Removes duplicated constants and ensures consistency by using package:vm_service as a source of truth for RPC error codes for requests made with package:vm_service.