### PR TITLE
Manually cherry-pick #158141 (`out_dir_shared`) into `beta`

### DIFF
--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -222,26 +222,6 @@ void main() {
       });
     }
 
-    testWithoutContext('flutter build $buildSubcommand succeeds without libraries', () async {
-      await inTempDir((Directory tempDirectory) async {
-        final Directory projectDirectory = await createTestProjectWithNoCBuild(packageName, tempDirectory);
-
-        final ProcessResult result = processManager.runSync(
-          <String>[
-            flutterBin,
-            'build',
-            buildSubcommand,
-            '--debug',
-            if (buildSubcommand == 'ios') '--no-codesign',
-          ],
-          workingDirectory: projectDirectory.path,
-        );
-        if (result.exitCode != 0) {
-          throw Exception('flutter build failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
-        }
-      });
-    });
-
     // This could be an hermetic unit test if the native_assets_builder
     // could mock process runs and file system.
     // https://github.com/dart-lang/native/issues/90.

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -566,61 +566,6 @@ Future<Directory> createTestProject(String packageName, Directory tempDirectory)
   return packageDirectory;
 }
 
-Future<Directory> createTestProjectWithNoCBuild(String packageName, Directory tempDirectory) async {
-  final ProcessResult result = processManager.runSync(
-    <String>[
-      flutterBin,
-      'create',
-      '--no-pub',
-      packageName,
-    ],
-    workingDirectory: tempDirectory.path,
-  );
-  if (result.exitCode != 0) {
-    throw Exception(
-      'flutter create failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
-    );
-  }
-
-  final Directory packageDirectory = tempDirectory.childDirectory(packageName);
-
-  final ProcessResult result2 = await processManager.run(
-    <String>[
-      flutterBin,
-      'pub',
-      'add',
-      'native_assets_cli',
-    ],
-    workingDirectory: packageDirectory.path,
-  );
-  expect(result2, const ProcessResultMatcher());
-
-  await pinDependencies(packageDirectory.childFile('pubspec.yaml'));
-
-  final ProcessResult result3 = await processManager.run(
-    <String>[
-      flutterBin,
-      'pub',
-      'get',
-    ],
-    workingDirectory: packageDirectory.path,
-  );
-  expect(result3, const ProcessResultMatcher());
-
-  // Add build hook that does nothing to the package.
-  final File buildHook = packageDirectory.childDirectory('hook').childFile('build.dart');
-  buildHook.createSync(recursive: true);
-  buildHook.writeAsStringSync('''
-import 'package:native_assets_cli/native_assets_cli.dart';
-
-void main(List<String> args) async {
-  await build(args, (config, output) async {});
-}
-''');
-
-  return packageDirectory;
-}
-
 Future<void> addLinkHookDependency(Directory packageDirectory) async {
   final Directory flutterDirectory = fileSystem.currentDirectory.parent.parent;
   final Directory linkHookDirectory = flutterDirectory

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -1,0 +1,224 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:file/file.dart';
+import 'package:file_testing/file_testing.dart';
+
+import '../../src/common.dart';
+import '../test_utils.dart' show ProcessResultMatcher, fileSystem;
+import '../transition_test_utils.dart';
+
+Future<Directory> createTestProject(String packageName, Directory tempDirectory) async {
+  final ProcessResult result = processManager.runSync(
+    <String>[
+      flutterBin,
+      'create',
+      '--no-pub',
+      '--template=package_ffi',
+      packageName,
+    ],
+    workingDirectory: tempDirectory.path,
+  );
+  if (result.exitCode != 0) {
+    throw Exception(
+      'flutter create failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
+    );
+  }
+
+  final Directory packageDirectory = tempDirectory.childDirectory(packageName);
+
+  // No platform-specific boilerplate files.
+  expect(packageDirectory.childDirectory('android'), isNot(exists));
+  expect(packageDirectory.childDirectory('ios'), isNot(exists));
+  expect(packageDirectory.childDirectory('linux'), isNot(exists));
+  expect(packageDirectory.childDirectory('macos'), isNot(exists));
+  expect(packageDirectory.childDirectory('windows'), isNot(exists));
+
+  await pinDependencies(packageDirectory.childFile('pubspec.yaml'));
+  await pinDependencies(
+      packageDirectory.childDirectory('example').childFile('pubspec.yaml'));
+
+  await addLinkHookDependency(packageName, packageDirectory);
+  await addDynamicallyLinkedNativeLibrary(packageName, packageDirectory);
+
+  final ProcessResult result2 = await processManager.run(
+    <String>[
+      flutterBin,
+      'pub',
+      'get',
+    ],
+    workingDirectory: packageDirectory.path,
+  );
+  expect(result2, const ProcessResultMatcher());
+
+  return packageDirectory;
+}
+
+Future<void> addLinkHookDependency(String packageName, Directory packageDirectory) async {
+  final Directory flutterDirectory = fileSystem.currentDirectory.parent.parent;
+  final Directory linkHookDirectory = flutterDirectory
+      .childDirectory('dev')
+      .childDirectory('integration_tests')
+      .childDirectory('link_hook');
+  expect(linkHookDirectory, exists);
+
+  final File pubspecFile = packageDirectory.childFile('pubspec.yaml');
+  final String pubspecOld =
+      (await pubspecFile.readAsString()).replaceAll('\r\n', '\n');
+  final String pubspecNew = pubspecOld.replaceFirst('''
+dependencies:
+''', '''
+dependencies:
+  link_hook:
+    path: ${linkHookDirectory.path}
+''');
+  expect(pubspecNew, isNot(pubspecOld));
+  await pubspecFile.writeAsString(pubspecNew);
+
+  final File dartFile =
+      packageDirectory.childDirectory('lib').childFile('$packageName.dart');
+  final String dartFileOld =
+      (await dartFile.readAsString()).replaceAll('\r\n', '\n');
+  // Replace with something that results in the same resulting int, so that the
+  // tests don't have to be updated.
+  final String dartFileNew = dartFileOld.replaceFirst(
+    '''
+import '${packageName}_bindings_generated.dart' as bindings;
+''',
+    '''
+import 'package:link_hook/link_hook.dart' as l;
+
+import '${packageName}_bindings_generated.dart' as bindings;
+''',
+  );
+  expect(dartFileNew, isNot(dartFileOld));
+  final String dartFileNew2 = dartFileNew.replaceFirst(
+    'int sum(int a, int b) => bindings.sum(a, b);',
+    'int sum(int a, int b) => bindings.sum(a, b) + l.difference(2, 1) - 1;',
+  );
+  expect(dartFileNew2, isNot(dartFileNew));
+  await dartFile.writeAsString(dartFileNew2);
+}
+
+/// Adds a native library to be built by the builder and dynamically link it to
+/// the  main library.
+Future<void> addDynamicallyLinkedNativeLibrary(String packageName, Directory packageDirectory) async {
+  // Add linked library source files.
+  final Directory srcDirectory = packageDirectory.childDirectory('src');
+  final File linkedLibraryHeaderFile = srcDirectory.childFile('add.h');
+  await linkedLibraryHeaderFile.writeAsString('''
+#include <stdint.h>
+
+#if _WIN32
+#define FFI_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FFI_PLUGIN_EXPORT
+#endif
+
+FFI_PLUGIN_EXPORT intptr_t add(intptr_t a, intptr_t b);
+'''
+  );
+  final File linkedLibrarySourceFile = srcDirectory.childFile('add.c');
+  await linkedLibrarySourceFile.writeAsString('''
+#include "add.h"
+
+FFI_PLUGIN_EXPORT intptr_t add(intptr_t a, intptr_t b) {
+  return a + b;
+}
+''');
+
+  // Update main library to include call to linked library.
+  final File mainLibrarySourceFile = srcDirectory.childFile('$packageName.c');
+  String mainLibrarySource = await mainLibrarySourceFile.readAsString();
+  mainLibrarySource = mainLibrarySource.replaceFirst(
+    '#include "$packageName.h"',
+'''
+#include "$packageName.h"
+#include "add.h"
+''',
+  );
+  mainLibrarySource = mainLibrarySource.replaceAll('a + b', 'add(a, b)');
+  await mainLibrarySourceFile.writeAsString(mainLibrarySource);
+
+  // Update builder to build the native library and link it into the main library.
+  const String builderSource = r'''
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:logging/logging.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  await build(args, (config, output) async {
+    final packageName = config.packageName;
+
+    final builders = [
+      CBuilder.library(
+        name: 'add',
+        assetName: 'add',
+        sources: ['src/add.c'],
+      ),
+      CBuilder.library(
+        name: packageName,
+        assetName: '${packageName}_bindings_generated.dart',
+        sources: ['src/$packageName.c'],
+        flags: config.dynamicLinkingFlags('add'),
+      ),
+    ];
+
+    final logger = Logger('')
+        ..level = Level.ALL
+        ..onRecord.listen((record) => print(record.message));
+
+    for (final builder in builders) {
+      await builder.run(
+        config: config,
+        output: output,
+        logger: logger,
+      );
+    }
+  });
+}
+
+extension on BuildConfig {
+  List<String> dynamicLinkingFlags(String libraryName) => switch (targetOS) {
+        OS.macOS || OS.iOS => [
+            '-L${outputDirectory.toFilePath()}',
+            '-l$libraryName',
+          ],
+        OS.linux || OS.android => [
+            '-Wl,-rpath=\$ORIGIN/.',
+            '-L${outputDirectory.toFilePath()}',
+            '-l$libraryName',
+          ],
+        OS.windows => [
+            outputDirectory.resolve('$libraryName.lib').toFilePath()
+          ],
+        _ => throw UnimplementedError('Unsupported OS: $targetOS'),
+      };
+}
+''';
+
+  final Directory hookDirectory = packageDirectory.childDirectory('hook');
+  final File builderFile = hookDirectory.childFile('build.dart');
+  await builderFile.writeAsString(builderSource);
+}
+
+Future<void> pinDependencies(File pubspecFile) async {
+  expect(pubspecFile, exists);
+  final String oldPubspec = await pubspecFile.readAsString();
+  final String newPubspec = oldPubspec.replaceAll(RegExp(r':\s*\^'), ': ');
+  expect(newPubspec, isNot(oldPubspec));
+  await pubspecFile.writeAsString(newPubspec);
+}
+
+
+Future<void> inTempDir(Future<void> Function(Directory tempDirectory) fun) async {
+  final Directory tempDirectory = fileSystem.directory(fileSystem.systemTempDirectory.createTempSync().resolveSymbolicLinksSync());
+  try {
+    await fun(tempDirectory);
+  } finally {
+    tryToDelete(tempDirectory);
+  }
+}

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
@@ -1,0 +1,169 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:process/process.dart';
+import 'package:yaml/yaml.dart';
+
+import '../../src/common.dart';
+import '../test_utils.dart';
+import '../transition_test_utils.dart';
+import 'native_assets_test_utils.dart';
+
+/// Regression test as part of https://github.com/flutter/flutter/pull/150742.
+///
+/// Previously, creating a new (blank, i.e. from `flutter create`) Flutter
+/// project, adding `native_assets_cli`, and adding an otherwise valid build hook
+/// (`/hook/build.dart`) would fail to build due to the accompanying shell script
+/// (at least on macOS) assuming the glob would find at least one output.
+///
+/// This test verifies that a blank Flutter project with native_assets_cli can
+/// build, and does so across all of the host platform and target platform
+/// combinations that could trigger this error.
+///
+/// The version of `native_assets_cli` is derived from the template used by
+/// `flutter create --type=pacakges_ffi`. See
+/// [_getPackageFfiTemplatePubspecVersion].
+void main() {
+  if (!platform.isMacOS && !platform.isLinux && !platform.isWindows) {
+    // TODO(dacoharkes): Implement Fuchsia. https://github.com/flutter/flutter/issues/129757
+    return;
+  }
+
+
+  const ProcessManager processManager = LocalProcessManager();
+  final String constraint = _getPackageFfiTemplatePubspecVersion();
+
+  setUpAll(() {
+    processManager.runSync(<String>[
+      flutterBin,
+      'config',
+      '--enable-native-assets',
+    ]);
+  });
+
+  // Test building a host, iOS, and APK (Android) target where possible.
+  for (final String buildCommand in <String>[
+    // Current (Host) OS.
+    platform.operatingSystem,
+
+    // On macOS, also test iOS.
+    if (platform.isMacOS) 'ios',
+
+    // On every host platform, test Android.
+    'apk',
+  ]) {
+    _testBuildCommand(
+      buildCommand: buildCommand,
+      processManager: processManager,
+      nativeAssetsCliVersionConstraint: constraint,
+      codeSign: buildCommand != 'ios',
+    );
+  }
+}
+
+void _testBuildCommand({
+  required String buildCommand,
+  required String nativeAssetsCliVersionConstraint,
+  required ProcessManager processManager,
+  required bool codeSign,
+}) {
+  testWithoutContext(
+    'flutter build "$buildCommand" succeeds without libraries',
+    () async {
+      await inTempDir((Directory tempDirectory) async {
+        const String packageName = 'uses_package_native_assets_cli';
+
+        // Create a new (plain Dart SDK) project.
+        await expectLater(
+          processManager.run(
+            <String>[
+              flutterBin,
+              'create',
+              '--no-pub',
+              packageName,
+            ],
+            workingDirectory: tempDirectory.path,
+          ),
+          completion(const ProcessResultMatcher()),
+        );
+
+        final Directory packageDirectory = tempDirectory.childDirectory(
+          packageName,
+        );
+
+        // Add native_assets_cli and resolve implicitly (pub add does pub get).
+        // See https://dart.dev/tools/pub/cmd/pub-add#version-constraint.
+        await expectLater(
+          processManager.run(
+            <String>[
+              flutterBin,
+              'packages',
+              'add',
+              'native_assets_cli:$nativeAssetsCliVersionConstraint',
+            ],
+            workingDirectory: packageDirectory.path,
+          ),
+          completion(const ProcessResultMatcher()),
+        );
+
+        // Add a build hook that does nothing to the package.
+        packageDirectory.childDirectory('hook').childFile('build.dart')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  await build(args, (config, output) async {});
+}
+''');
+
+        // Try building.
+        await expectLater(
+          processManager.run(
+            <String>[
+              flutterBin,
+              'build',
+              buildCommand,
+              '--debug',
+              if (!codeSign) '--no-codesign',
+            ],
+            workingDirectory: packageDirectory.path,
+          ),
+          completion(const ProcessResultMatcher()),
+        );
+      });
+    },
+  );
+}
+
+/// Reads `templates/package_ffi/pubspec.yaml.tmpl` to use the package version.
+///
+/// For example, if the template would output:
+/// ```yaml
+/// dependencies:
+///   native_assets_cli: ^0.8.0
+/// ```
+///
+/// ... then this function would return `'^0.8.0'`.
+String _getPackageFfiTemplatePubspecVersion() {
+  final String path = Context().join(
+    getFlutterRoot(),
+    'packages',
+    'flutter_tools',
+    'templates',
+    'package_ffi',
+    'pubspec.yaml.tmpl',
+  );
+  final YamlDocument yaml = loadYamlDocument(
+    io.File(path).readAsStringSync(),
+    sourceUrl: Uri.parse(path),
+  );
+  final YamlMap rootNode = yaml.contents as YamlMap;
+  final YamlMap dependencies = rootNode.nodes['dependencies']! as YamlMap;
+  final String version = dependencies['native_assets_cli']! as String;
+  return version;
+}


### PR DESCRIPTION
Cherry-pick https://github.com/flutter/flutter/pull/158141.

Unblocks https://github.com/flutter/flutter/pull/157100#issuecomment-2465138790.

This is a test-only change that works around `native_assets_cli` now being `0.9.0`.