### PR TITLE
[SwiftPM] Simplify logic that determines if CocoaPods is used

### DIFF
--- a/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
+++ b/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
@@ -90,11 +90,7 @@ class DarwinDependencyManagement {
 
     final bool useCocoapods;
     if (_project.usesSwiftPackageManager) {
-      useCocoapods = _usingCocoaPodsPlugin(
-        pluginCount: totalCount,
-        swiftPackageCount: swiftPackageCount,
-        cocoapodCount: podCount,
-      );
+      useCocoapods = swiftPackageCount < totalCount;
     } else {
       // When Swift Package Manager is not enabled, set up Podfile if plugins
       // is not empty, regardless of if plugins are CocoaPod compatible. This
@@ -110,19 +106,6 @@ class DarwinDependencyManagement {
     else if (xcodeProject.podfile.existsSync() && xcodeProject.podfileLock.existsSync()) {
       _cocoapods.addPodsDependencyToFlutterXcconfig(xcodeProject);
     }
-  }
-
-  bool _usingCocoaPodsPlugin({
-    required int pluginCount,
-    required int swiftPackageCount,
-    required int cocoapodCount,
-  }) {
-    if (_project.usesSwiftPackageManager) {
-      if (pluginCount == swiftPackageCount) {
-        return false;
-      }
-    }
-    return cocoapodCount > 0;
   }
 
   /// Returns count of total number of plugins, number of Swift Package Manager


### PR DESCRIPTION
This is a refactoring with no semantic changes. I will get a text exemption.

Part of https://github.com/flutter/flutter/issues/151567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
