### PR TITLE
`TappableLabel` extension type

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -949,6 +949,40 @@ class _TappableLabel {
   final VoidCallback onTap;
 }
 
+/// Exposes fields from the [TimePickerDialog]'s painter for testing purposes.
+///
+/// Values are accessed via [TappableLabel.labels].
+@visibleForTesting
+extension type TappableLabel._(_TappableLabel _label) implements Object {
+  /// If the painter is a `_DialPainter`, returns information about its
+  /// labels for testing purposes.
+  ///
+  /// Otherwise, returns a [Record] of empty lists.
+  static ({List<TappableLabel> primary, List<TappableLabel> selected}) labels(
+    CustomPaint dialPaint,
+  ) {
+    if (dialPaint.painter case _DialPainter(
+      :final List<TappableLabel> primaryLabels,
+      :final List<TappableLabel> selectedLabels,
+    )) {
+      return (primary: primaryLabels, selected: selectedLabels);
+    }
+
+    const List<TappableLabel> notFound = <TappableLabel>[];
+    return (primary: notFound, selected: notFound);
+  }
+
+  /// Whether the label is part of the "inner" ring of values on the dial,
+  /// used for 24 hour input.
+  bool get inner => _label.inner;
+
+  /// The [TextSpan] associated with this label.
+  TextSpan? get textSpan {
+    final InlineSpan? span = _label.painter.text;
+    return span is TextSpan ? span : null;
+  }
+}
+
 class _DialPainter extends CustomPainter {
   _DialPainter({
     required this.primaryLabels,

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -107,20 +107,10 @@ void main() {
     final List<String> labels00To22 = List<String>.generate(12, (int index) {
       return (index * 2).toString().padLeft(2, '0');
     });
-    final CustomPaint dialPaint = tester.widget(findDialPaint);
-    final dynamic dialPainter = dialPaint.painter;
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
-    // ignore: avoid_dynamic_calls
-    expect(primaryLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels00To22);
-
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
-    expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String),
-      labels00To22,
-    );
+    final List<TappableLabel> primary, selected;
+    (:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));
+    expect(primary.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels00To22);
+    expect(selected.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels00To22);
   });
 
   testWidgets('Material3 - Dialog size - dial mode', (WidgetTester tester) async {
@@ -201,24 +191,14 @@ void main() {
     });
     final List<bool> inner0To23 = List<bool>.generate(24, (int index) => index >= 12);
 
-    final CustomPaint dialPaint = tester.widget(findDialPaint);
-    final dynamic dialPainter = dialPaint.painter;
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
-    // ignore: avoid_dynamic_calls
-    expect(primaryLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels00To23);
-    // ignore: avoid_dynamic_calls
-    expect(primaryLabels.map<bool>((dynamic tp) => tp.inner as bool), inner0To23);
+    final List<TappableLabel> primary, selected;
+    (:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));
 
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
-    expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String),
-      labels00To23,
-    );
-    // ignore: avoid_dynamic_calls
-    expect(selectedLabels.map<bool>((dynamic tp) => tp.inner as bool), inner0To23);
+    expect(primary.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels00To23);
+    expect(primary.map<bool>((TappableLabel tp) => tp.inner), inner0To23);
+
+    expect(selected.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels00To23);
+    expect(selected.map<bool>((TappableLabel tp) => tp.inner), inner0To23);
   });
 
   testWidgets('Material3 - Dial background uses correct default color', (
@@ -612,23 +592,11 @@ void main() {
           '11',
         ];
 
-        final CustomPaint dialPaint = tester.widget(findDialPaint);
-        final dynamic dialPainter = dialPaint.painter;
-        // ignore: avoid_dynamic_calls
-        final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
-        expect(
-          // ignore: avoid_dynamic_calls
-          primaryLabels.map<String>((dynamic tp) => tp.painter.text.text as String),
-          labels12To11,
-        );
+        final List<TappableLabel> primary, selected;
+        (:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));
 
-        // ignore: avoid_dynamic_calls
-        final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
-        expect(
-          // ignore: avoid_dynamic_calls
-          selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String),
-          labels12To11,
-        );
+        expect(primary.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels12To11);
+        expect(selected.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels12To11);
       });
 
       testWidgets('when change orientation, should reflect in render objects', (

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -109,6 +109,7 @@ void main() {
     });
     final List<TappableLabel> primary, selected;
     (:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));
+
     expect(primary.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels00To22);
     expect(selected.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels00To22);
   });

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -196,22 +196,16 @@ void main() {
       ),
     );
 
-    final CustomPaint dialPaint = tester.widget(findDialPaint);
-    final dynamic dialPainter = dialPaint.painter;
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
+    final List<TappableLabel> primary, selected;
+    (:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));
     expect(
-      // ignore: avoid_dynamic_calls
-      primaryLabels.first.painter.text.style,
+      primary.first.textSpan?.style,
       Typography.material2014().englishLike.bodyLarge!
           .merge(Typography.material2014().black.bodyLarge)
           .copyWith(color: defaultTheme.colorScheme.onSurface),
     );
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.first.painter.text.style,
+      selected.first.textSpan?.style,
       Typography.material2014().englishLike.bodyLarge!
           .merge(Typography.material2014().white.bodyLarge)
           .copyWith(color: defaultTheme.colorScheme.onPrimary),
@@ -350,13 +344,10 @@ void main() {
           ),
     );
 
-    final CustomPaint dialPaint = tester.widget(findDialPaint);
-    final dynamic dialPainter = dialPaint.painter;
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
+    final List<TappableLabel> primary, selected;
+    (:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));
     expect(
-      // ignore: avoid_dynamic_calls
-      primaryLabels.first.painter.text.style,
+      primary.first.textSpan?.style,
       Typography.material2021().englishLike.bodyLarge!
           .merge(Typography.material2021().black.bodyLarge)
           .copyWith(
@@ -364,11 +355,8 @@ void main() {
             decorationColor: defaultTheme.colorScheme.onSurface,
           ),
     );
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.first.painter.text.style,
+      selected.first.textSpan?.style,
       Typography.material2021().englishLike.bodyLarge!
           .merge(Typography.material2021().black.bodyLarge)
           .copyWith(
@@ -630,22 +618,16 @@ void main() {
           .merge(timePickerTheme.helpTextStyle),
     );
 
-    final CustomPaint dialPaint = tester.widget(findDialPaint);
-    final dynamic dialPainter = dialPaint.painter;
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
+    final List<TappableLabel> primary, selected;
+    (:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));
     expect(
-      // ignore: avoid_dynamic_calls
-      primaryLabels.first.painter.text.style,
+      primary.first.textSpan?.style,
       Typography.material2014().englishLike.bodyLarge!
           .merge(Typography.material2014().black.bodyLarge)
           .copyWith(color: _unselectedColor),
     );
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.first.painter.text.style,
+      selected.first.textSpan?.style,
       Typography.material2014().englishLike.bodyLarge!
           .merge(Typography.material2014().white.bodyLarge)
           .copyWith(color: _selectedColor),
@@ -762,22 +744,16 @@ void main() {
           ),
     );
 
-    final CustomPaint dialPaint = tester.widget(findDialPaint);
-    final dynamic dialPainter = dialPaint.painter;
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
+    final List<TappableLabel> primary, selected;
+    (:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));
     expect(
-      // ignore: avoid_dynamic_calls
-      primaryLabels.first.painter.text.style,
+      primary.first.textSpan?.style,
       Typography.material2021().englishLike.bodyLarge!
           .merge(Typography.material2021().black.bodyLarge)
           .copyWith(color: _unselectedColor, decorationColor: theme.colorScheme.onSurface),
     );
-    // ignore: avoid_dynamic_calls
-    final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.first.painter.text.style,
+      selected.first.textSpan?.style,
       Typography.material2021().englishLike.bodyLarge!
           .merge(Typography.material2021().black.bodyLarge)
           .copyWith(color: _selectedColor, decorationColor: theme.colorScheme.onSurface),


### PR DESCRIPTION
This pull request adds a type interface and removes `// ignore` comments from tests.

<br>

```dart
@visibleForTesting
extension type TappableLabel(_TappableLabel _label) {}
```

<br><br>

### Before
```dart
final CustomPaint dialPaint = tester.widget(findDialPaint);
final dynamic dialPainter = dialPaint.painter;
// ignore: avoid_dynamic_calls
final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
// ignore: avoid_dynamic_calls
expect(primaryLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels12To11);

// ignore: avoid_dynamic_calls
final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
// ignore: avoid_dynamic_calls
expect(selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels12To11);
```

### After
```dart
final List<TappableLabel> primary, selected;
(:primary, :selected) = TappableLabel.labels(tester.widget(findDialPaint));

expect(primary.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels12To11);
expect(selected.map<String?>((TappableLabel tp) => tp.textSpan?.text), labels12To11);
```