### PR TITLE
`WidgetStateDouble`

### DIFF
--- a/packages/flutter/test/widgets/widget_state_property_test.dart
+++ b/packages/flutter/test/widgets/widget_state_property_test.dart
@@ -260,6 +260,32 @@ void main() {
     expect(style1 == style2, isTrue);
     expect(style1 == style3, isFalse);
   });
+
+  test('WidgetStateDouble works!', () {
+    final WidgetStateDouble widgetStateDouble = WidgetStateDouble.fromMap(
+      <WidgetStatesConstraint, double>{
+        WidgetState.focused: 5,
+        WidgetState.error: -1,
+        WidgetState.any: 0,
+      },
+    );
+    const Set<WidgetState> focused = <WidgetState>{WidgetState.focused};
+    const Set<WidgetState> error = <WidgetState>{WidgetState.error};
+
+    expect(WidgetStateProperty.resolveAs<double>(widgetStateDouble, focused), 5);
+    expect(WidgetStateProperty.resolveAs<double>(widgetStateDouble, error),  -1);
+    expect(WidgetStateProperty.resolveAs<double>(widgetStateDouble, enabled), 0);
+
+
+    const double normalDouble = 0.5;
+
+    expect(WidgetStateProperty.resolveAs<double>(normalDouble, focused), 0.5);
+    expect(WidgetStateProperty.resolveAs<double>(normalDouble, error),   0.5);
+    expect(WidgetStateProperty.resolveAs<double>(normalDouble, enabled), 0.5);
+
+    // Of course this is what we'd expect!
+    expect(normalDouble, isA<WidgetStateDouble>());
+  });
 }
 
 const Set<WidgetState> enabled = <WidgetState>{};


### PR DESCRIPTION
`double` is a `final class`, so it can't be extended or implemented, except with an extension type.

<br>

```dart
final doubleMap1 = WidgetStateDouble.fromMap({
  WidgetState.error: 0.0,
  WidgetState.any:   2.0,
});
final doubleMap2 = WidgetStateDouble.fromMap({
  WidgetState.pressed: 0.0,
  WidgetState.hovered: 4.0,
  WidgetState.any:     1.0,
});
final doubleMap3 = WidgetStateDouble.fromMap({
  WidgetState.any: 0.0,
});
```

<br>

Each time `WidgetStateDouble.fromMap()` is called, it links the map to a `double` value:

|    Mapper    |   Value   |
|:------------:|:---------:|
| `doubleMap1` | -999999.0 |
| `doubleMap2` | -999998.0 |
| `doubleMap3` | -999997.0 |

Then `WidgetStateProperty.resolveAs<double>()` will first check the table of registered `WidgetStateDouble` values, and if there's a match it returns the resolved value.

<br>

`WidgetStateDouble` is somewhat memory-intensive, doesn't have a `const` constructor, and technically could result in `double` values being misinterpreted as `WidgetStateProperty` objects. This is truly a wonderful API!