### PR TITLE
Allow `devDependencies` to be omitted and not cause a tool crash.

### DIFF
--- a/packages/flutter_tools/lib/src/compute_dev_dependencies.dart
+++ b/packages/flutter_tools/lib/src/compute_dev_dependencies.dart
@@ -64,6 +64,10 @@ Future<Set<String>> computeExclusiveDevDependencies(
   }
 
   List<T> asListOrFail<T>(Object? value, String name) {
+    // Allow omitting a list as empty to default to an empty list
+    if (value == null) {
+      return <T>[];
+    }
     if (value is! List<Object?>) {
       fail('Expected field "$name" to be a list, got "$value"');
     }
@@ -115,7 +119,7 @@ Future<Set<String>> computeExclusiveDevDependencies(
 
   // Start initially with every `devDependency` listed.
   final Set<String> devDependencies = asListOrFail<String>(
-    rootPackage['devDependencies'],
+    rootPackage['devDependencies'] ?? <String>[],
     'devDependencies',
   ).toSet();
 

--- a/packages/flutter_tools/test/general.shard/compute_dev_dependencies_test.dart
+++ b/packages/flutter_tools/test/general.shard/compute_dev_dependencies_test.dart
@@ -293,6 +293,52 @@ void main() {
     );
   });
 
+  test('omitted devDependencies in app package', () async {
+    // Simulates the following:
+    //
+    // # /my_app/pubspec.yaml
+    // name: my_app
+    // dependencies:
+    //   package_a:
+    //
+    // # /package_a/pubspec.yaml
+    // name: package_a
+    final ProcessManager processes = _dartPubDepsReturns('''
+    {
+      "root": "my_app",
+      "packages": [
+        {
+          "name": "my_app",
+          "kind": "root",
+          "dependencies": [
+            "package_a"
+          ],
+          "directDependencies": [
+            "package_a"
+          ]
+        },
+        {
+          "name": "package_a",
+          "kind": "direct",
+          "dependencies": [],
+          "directDependencies": []
+        }
+      ]
+    }''');
+
+    final Set<String> dependencies = await computeExclusiveDevDependencies(
+      processes,
+      projectPath: _fakeProjectPath,
+      logger: logger,
+    );
+
+    expect(
+      dependencies,
+      isEmpty,
+      reason: 'package_b is excluded but package_c should not',
+    );
+  });
+
   test('throws and logs on non-zero exit code', () async {
     final ProcessManager processes = _dartPubDepsFails(
       'Bad thing',

--- a/packages/flutter_tools/test/general.shard/compute_dev_dependencies_test.dart
+++ b/packages/flutter_tools/test/general.shard/compute_dev_dependencies_test.dart
@@ -335,7 +335,7 @@ void main() {
     expect(
       dependencies,
       isEmpty,
-      reason: 'package_b is excluded but package_c should not',
+      reason: 'No devDependencies: [] specified but still parsed successfully',
     );
   });
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/158441.