### PR TITLE
force Linux plugin_test to run on Ubuntu 20.04

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1040,6 +1040,8 @@ targets:
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:17"}
         ]
+      drone_dimensions: >
+        ["os=Linux", "os=Ubuntu-20"]
       tags: >
         ["devicelab", "hostonly", "linux"]
       task_name: plugin_test

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1040,6 +1040,8 @@ targets:
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:17"}
         ]
+      # TODO(fujino): delete once propagation from
+      # https://github.com/flutter/flutter/issues/158521 completes.
       drone_dimensions: >
         ["os=Linux", "os=Ubuntu-20"]
       tags: >


### PR DESCRIPTION
Work around propagation from https://github.com/flutter/flutter/issues/158521

