### PR TITLE
Fix `status` update when manually setting `AnimationController` value

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -387,6 +387,9 @@ class AnimationController extends Animation<double>
   ///    which start the animation controller.
   set value(double newValue) {
     stop();
+    if (newValue != _value) {
+      _direction = newValue > _value ? _AnimationDirection.forward : _AnimationDirection.reverse;
+    }
     _internalSetValue(newValue);
     notifyListeners();
     _checkStatusChanged();

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -67,6 +67,34 @@ void main() {
     controller.dispose();
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/158233.
+  test('Setting value updates AnimationStatus accordingly', () {
+    final AnimationController controller = AnimationController(
+      vsync: const TestVSync(),
+    );
+
+    controller.value = 0.0;
+    expect(controller.status, AnimationStatus.dismissed);
+
+    controller.value = 0.5;
+    expect(controller.status, AnimationStatus.forward);
+
+    controller.value = 0.4;
+    expect(controller.status, AnimationStatus.reverse);
+
+    controller.value = 0.75;
+    expect(controller.status, AnimationStatus.forward);
+
+    controller.value = 1.0;
+    expect(controller.status, AnimationStatus.completed);
+
+    controller.value = 0.9;
+    expect(controller.status, AnimationStatus.reverse);
+
+    controller.value = 0.0;
+    expect(controller.status, AnimationStatus.dismissed);
+  });
+
   test('Receives status callbacks for forward and reverse', () {
     final AnimationController controller = AnimationController(
       duration: const Duration(milliseconds: 100),


### PR DESCRIPTION
The [**AnimationController.value**](https://main-api.flutter.dev/flutter/animation/AnimationController/value.html) setter now updates the animation's direction accordingly.

Fixes https://github.com/flutter/flutter/issues/158233