### PR TITLE
Update triage flow chart for SVG packages

### DIFF
--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -85,6 +85,7 @@ In general the flow chart for team assignment is as follows, stopping as soon as
 - If it's about the Flutter tool, add `team-tool`.
 - If it's about a first-party package:
   - If it's about `go_router` or `go_router_builder`, add `team-go_router`.
+  - If it's about `flutter_svg` or `vector_graphics`, add `team-engine`.
   - Otherwise, add `team-ecosystem`.
 - If none of the above apply, add `will need additional triage`.
 


### PR DESCRIPTION
Adds special handling of the newly-imported `flutter_svg` and `vector_graphics` family of packages in the triage flow chart, as they should be directed to the engine team.