### PR TITLE
Remove ancient versions of AGP from integration tests.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
@@ -32,8 +32,7 @@ void main() {
     );
 
     final String testName = '${template}_test';
-
-    final ProcessResult result = processManager.runSync(<String>[
+    ProcessResult result = processManager.runSync(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
       'create',
@@ -41,6 +40,17 @@ void main() {
       '--platforms=android',
       testName,
     ], workingDirectory: tempDir.path);
+    expect(result, const ProcessResultMatcher());
+
+    final Directory exampleAppDir =
+        tempDir.childDirectory(testName).childDirectory('example');
+    result = processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'build',
+      'apk',
+      '--target-platform=android-arm',
+    ], workingDirectory: exampleAppDir.path);
     expect(result, const ProcessResultMatcher());
   }
 

--- a/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 
@@ -10,18 +9,16 @@ import '../src/common.dart';
 import 'test_utils.dart';
 
 void main() {
-  late Directory tempDirPluginMethodChannels;
-  late Directory tempDirPluginFfi;
+  late Directory tempDir;
 
   setUp(() async {
-    tempDirPluginMethodChannels = createResolvedTempDirectorySync('flutter_plugin_test.');
-    tempDirPluginFfi =
-        createResolvedTempDirectorySync('flutter_ffi_plugin_test.');
+    tempDir = createResolvedTempDirectorySync(
+      'android_plugin_example_app_build_test.',
+    );
   });
 
   tearDown(() async {
-    tryToDelete(tempDirPluginMethodChannels);
-    tryToDelete(tempDirPluginFfi);
+    tryToDelete(tempDir);
   });
 
   Future<void> testPlugin({
@@ -36,7 +33,7 @@ void main() {
 
     final String testName = '${template}_test';
 
-    ProcessResult result = processManager.runSync(<String>[
+    final ProcessResult result = processManager.runSync(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
       'create',
@@ -44,106 +41,20 @@ void main() {
       '--platforms=android',
       testName,
     ], workingDirectory: tempDir.path);
-    if (result.exitCode != 0) {
-      throw Exception('flutter create failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
-    }
-
-    final Directory exampleAppDir =
-        tempDir.childDirectory(testName).childDirectory('example');
-
-    final File buildGradleFile = exampleAppDir.childDirectory('android').childFile('build.gradle.kts');
-    expect(buildGradleFile, exists);
-
-    final String buildGradle = buildGradleFile.readAsStringSync();
-    final RegExp androidPluginRegExp =
-        RegExp(r'com\.android\.tools\.build:gradle:(\d+\.\d+\.\d+)');
-
-    // Use AGP 7.2.0
-    final String newBuildGradle = buildGradle.replaceAll(
-        androidPluginRegExp, 'com.android.tools.build:gradle:7.2.0');
-    buildGradleFile.writeAsStringSync(newBuildGradle);
-
-    // Run flutter build apk using AGP 7.2.0
-    result = processManager.runSync(<String>[
-      flutterBin,
-      ...getLocalEngineArguments(),
-      'build',
-      'apk',
-      '--target-platform=android-arm',
-    ], workingDirectory: exampleAppDir.path);
-    if (result.exitCode != 0) {
-      throw Exception('flutter build failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
-    }
-
-    final File exampleApk = fileSystem.file(fileSystem.path.join(
-      exampleAppDir.path,
-      'build',
-      'app',
-      'outputs',
-      'flutter-apk',
-      'app-release.apk',
-    ));
-    expect(exampleApk, exists);
-
-    if (template == 'plugin_ffi') {
-      // Does not support AGP 3.3.0.
-      return;
-    }
-
-    // Clean
-    result = processManager.runSync(<String>[
-      flutterBin,
-      ...getLocalEngineArguments(),
-      'clean',
-    ], workingDirectory: exampleAppDir.path);
-    if (result.exitCode != 0) {
-      throw Exception('flutter clean failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
-    }
-
-    // Remove Gradle wrapper
-    fileSystem
-        .directory(fileSystem.path
-            .join(exampleAppDir.path, 'android', 'gradle', 'wrapper'))
-        .deleteSync(recursive: true);
-
-    // Enable R8 in gradle.properties
-    final File gradleProperties =
-        exampleAppDir.childDirectory('android').childFile('gradle.properties');
-    expect(gradleProperties, exists);
-
-    gradleProperties.writeAsStringSync('''
-org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
-android.useAndroidX=true
-android.enableJetifier=true
-android.enableR8=true''');
-
-    // Run flutter build apk using AGP 3.3.0
-    result = processManager.runSync(<String>[
-      flutterBin,
-      ...getLocalEngineArguments(),
-      'build',
-      'apk',
-      '--target-platform=android-arm',
-    ], workingDirectory: exampleAppDir.path);
-    if (result.exitCode != 0) {
-      throw Exception('flutter build failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
-    }
-    expect(exampleApk, exists);
+    expect(result, const ProcessResultMatcher());
   }
 
-  test('plugin example can be built using current Flutter Gradle plugin',
-      () async {
+  test('plugin example builds using the Flutter Gradle plugin', () async {
     await testPlugin(
       template: 'plugin',
-      tempDir: tempDirPluginMethodChannels,
+      tempDir: tempDir,
     );
   });
 
-  test('FFI plugin example can be built using current Flutter Gradle plugin',
-      () async {
+  test('FFI plugin example builds using the Flutter Gradle plugin', () async {
     await testPlugin(
       template: 'plugin_ffi',
-      tempDir: tempDirPluginFfi,
+      tempDir: tempDir,
     );
   });
 }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/158742.