### PR TITLE
Make GlobalKey a `mixin class`

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -156,7 +156,7 @@ class ObjectKey extends LocalKey {
 ///  * The discussion at [Widget.key] for more information about how widgets use
 ///    keys.
 @optionalTypeArgs
-abstract class GlobalKey<T extends State<StatefulWidget>> extends Key {
+abstract mixin class GlobalKey<T extends State<StatefulWidget>> implements Key {
   /// Creates a [LabeledGlobalKey], which is a [GlobalKey] with a label used for
   /// debugging.
   ///
@@ -168,7 +168,7 @@ abstract class GlobalKey<T extends State<StatefulWidget>> extends Key {
   ///
   /// Used by subclasses because the factory constructor shadows the implicit
   /// constructor.
-  const GlobalKey.constructor() : super.empty();
+  const GlobalKey.constructor();
 
   Element? get _currentElement => WidgetsBinding.instance.buildOwner!._globalKeyRegistry[this];
 

--- a/packages/flutter/test/widgets/key_test.dart
+++ b/packages/flutter/test/widgets/key_test.dart
@@ -18,6 +18,8 @@ class NotEquals {
   int get hashCode => 0;
 }
 
+enum GlobalKeys with GlobalKey { a, b, c, d }
+
 void main() {
   testWidgets('Keys', (WidgetTester tester) async {
     expect(ValueKey<int>(nonconst(3)) == ValueKey<int>(nonconst(3)), isTrue);
@@ -56,5 +58,23 @@ void main() {
     expect(GlobalKey(), hasOneLineDescription);
     expect(GlobalKey(debugLabel: 'hello'), hasOneLineDescription);
     expect(const GlobalObjectKey(true), hasOneLineDescription);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/158876
+  testWidgets('Enum values as global keys', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Column(
+        children: <Widget>[
+          SizedBox(key: GlobalKeys.a),
+          SizedBox(key: GlobalKeys.b),
+          SizedBox(key: GlobalKeys.c),
+        ],
+      ),
+    );
+
+    expect(GlobalKeys.a.currentContext, isA<BuildContext>());
+    expect(GlobalKeys.b.currentContext, isA<BuildContext>());
+    expect(GlobalKeys.c.currentContext, isA<BuildContext>());
+    expect(GlobalKeys.d.currentContext, isNull);
   });
 }


### PR DESCRIPTION
Since `GlobalKey` has a private instance field accessed elsewhere, subtypes cannot safely implement the interface.

But thanks to its empty constructor, this class can be declared as a mixin!

<br>

resolves https://github.com/flutter/flutter/issues/158876