### PR TITLE
Try with `bringup: true` debugging why `flutter build apk` often times out.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1332,6 +1332,8 @@ targets:
 
   - name: Linux flutter_build_apk_health_tests
     recipe: flutter/flutter_drone
+    # WARNING: Do *NOT* enable. This intended for testing on CI only.
+    # Ask matanlurey@ or @gmackall if you have any questions.
     bringup: true
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1330,6 +1330,27 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Linux flutter_build_apk_health_tests
+    recipe: flutter/flutter_drone
+    bringup: true
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:35v1"},
+          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
+          {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
+          {"dependency": "ninja", "version": "version:1.9.0"},
+          {"dependency": "open_jdk", "version": "version:17"}
+        ]
+      shard: flutter_build_apk_health_tests
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+      test_timeout_secs: "2700"
+
   - name: Linux android_preview_tool_integration_tests
     recipe: flutter/flutter_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -329,6 +329,7 @@
 # coverage @goderbauer @flutter/infra
 # customer_testing @Piinks @flutter/framework
 # docs @Piinks @flutter/framework
+# flutter_build_apk_health_tests @matanlurey @gmackall
 # flutter_driver_android_test @matanlurey @johnmccutchan
 # flutter_packaging @christopherfujino @flutter/infra
 # flutter_plugins @stuartmorgan @flutter/plugin

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -132,6 +132,7 @@ Future<void> main(List<String> args) async {
       'tool_tests': _runToolTests,
       'web_tool_tests': _runWebToolTests,
       'tool_integration_tests': _runIntegrationToolTests,
+      'flutter_build_apk_health_tests': _runFlutterBuildApkHealthTests,
       'android_preview_tool_integration_tests': androidPreviewIntegrationToolTestsRunner,
       'android_java11_tool_integration_tests': androidJava11IntegrationToolTestsRunner,
       'tool_host_cross_arch_tests': _runToolHostCrossArchTests,
@@ -222,6 +223,20 @@ Future<void> _runToolHostCrossArchTests() {
 
 Future<void> _runIntegrationToolTests() async {
   final List<String> allTests = Directory(path.join(_toolsPath, 'test', 'integration.shard'))
+      .listSync(recursive: true).whereType<File>()
+      .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
+      .where((String testPath) => path.basename(testPath).endsWith('_test.dart')).toList();
+
+  await runDartTest(
+    _toolsPath,
+    forceSingleCore: true,
+    testPaths: selectIndexOfTotalSubshard<String>(allTests),
+    collectMetrics: true,
+  );
+}
+
+Future<void> _runFlutterBuildApkHealthTests() async {
+  final List<String> allTests = Directory(path.join(_toolsPath, 'test', 'flutter_build_apk.shard'))
       .listSync(recursive: true).whereType<File>()
       .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
       .where((String testPath) => path.basename(testPath).endsWith('_test.dart')).toList();

--- a/packages/flutter_tools/test/flutter_build_apk.shard/README.md
+++ b/packages/flutter_tools/test/flutter_build_apk.shard/README.md
@@ -1,0 +1,3 @@
+# `flutter_build_apk.shard`
+
+Integration tests that debug why `flutter build apk` sometimes stalls on CI.

--- a/packages/flutter_tools/test/flutter_build_apk.shard/flutter_build_apk_test.dart
+++ b/packages/flutter_tools/test/flutter_build_apk.shard/flutter_build_apk_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+
+import '../integration.shard/test_utils.dart';
+import '../src/common.dart';
+
+void main() {
+  final String flutterRoot = getFlutterRoot();
+  final String flutterBin = fileSystem.path.join(flutterRoot, 'bin', 'flutter');
+
+  late Directory tmpDir;
+
+  setUp(() {
+    tmpDir = fileSystem.systemTempDirectory.createTempSync();
+  });
+
+  tearDown(() {
+    tryToDelete(tmpDir);
+  });
+
+  // Normally these tests should take about a minute, but sometimes for
+  // unknown reasons they can take 30m+ and timeout. The intent behind this loop
+  // is to get more information on what exactly is happening.
+  for (int i = 0; i < 10; i++) {
+    test('flutter build apk | attempt $i of 10', () async {
+      final String package = 'flutter_build_apk_test_$i';
+
+      // Create a new Flutter app.
+      await expectLater(
+        processManager.run(
+          <String>[
+            flutterBin,
+            'create',
+            '--no-pub',
+            package,
+          ],
+          workingDirectory: tmpDir.path,
+        ),
+        completion(const ProcessResultMatcher()),
+        reason: 'Should create a new blank Flutter project',
+      );
+
+      // Build the APK.
+      final List<String> args = <String>[
+        flutterBin,
+        '--verbose',
+        'build',
+        'apk',
+        '--debug',
+      ];
+      io.stderr.writeln('Running $args...');
+
+      final io.Process process = await processManager.start(
+        args,
+        workingDirectory: tmpDir.childDirectory(package).path,
+        mode: io.ProcessStartMode.inheritStdio,
+      );
+      await expectLater(process.exitCode, completion(1));
+    });
+  }
+}

--- a/packages/flutter_tools/test/flutter_build_apk.shard/flutter_build_apk_test.dart
+++ b/packages/flutter_tools/test/flutter_build_apk.shard/flutter_build_apk_test.dart
@@ -26,7 +26,7 @@ void main() {
   // Normally these tests should take about a minute, but sometimes for
   // unknown reasons they can take 30m+ and timeout. The intent behind this loop
   // is to get more information on what exactly is happening.
-  for (int i = 0; i < 10; i++) {
+  for (int i = 1; i <= 10; i++) {
     test('flutter build apk | attempt $i of 10', () async {
       final String package = 'flutter_build_apk_test_$i';
 
@@ -60,7 +60,7 @@ void main() {
         workingDirectory: tmpDir.childDirectory(package).path,
         mode: io.ProcessStartMode.inheritStdio,
       );
-      await expectLater(process.exitCode, completion(1));
+      await expectLater(process.exitCode, completion(0));
     });
   }
 }


### PR DESCRIPTION
It would be nice to have somewhere to iterate and experiment with what we can do to either fix frequent timeout problems we have with `flutter build apk` (across platforms, to be clear, though I've just started with Linux) or get more information on why the crashes/timeouts happen.

Open to other ways to doing this (though preferably _not_ LED).