### PR TITLE
No longer pass `--verbose` to implicit `pub` calls when `flutter --verbose` is set.

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -138,7 +138,7 @@ abstract class Pub {
   /// skipped if the package config file has a "generator" other than "pub".
   /// Defaults to true.
   ///
-  /// [outputMode] determines how verbose the output from `pub get` will be.
+  /// [outputMode] determines how detailed the output from `pub get` will be.
   /// If [PubOutputMode.all] is used, `pub get` will print its typical output
   /// which includes information about all changed dependencies. If
   /// [PubOutputMode.summaryOnly] is used, only summary information will be printed.
@@ -353,12 +353,9 @@ class _DefaultPub implements Pub {
     }
 
     final String command = upgrade ? 'upgrade' : 'get';
-    final bool verbose = _logger.isVerbose;
     final List<String> args = <String>[
       if (_logger.supportsColor)
         '--color',
-      if (verbose)
-        '--verbose',
       '--directory',
       _fileSystem.path.relative(directory),
       ...<String>[

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -763,6 +763,49 @@ exit code: 66
     expect(processManager, hasNoRemainingExpectations);
   });
 
+  testWithoutContext('pub get does not inherit logger.verbose', () async {
+    final BufferLogger logger = BufferLogger.test(verbose: true);
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    fileSystem.currentDirectory.childFile('version').createSync();
+
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(command: const <String>[
+        'bin/cache/dart-sdk/bin/dart',
+        // Note: Omitted --verbose.
+        'pub',
+        '--suppress-analytics',
+        '--directory',
+        '.',
+        'get',
+        '--example',
+      ], onRun: (_) {
+        fileSystem.currentDirectory
+            .childDirectory('.dart_tool')
+            .childFile('package_config.json')
+            .createSync(recursive: true);
+      }),
+    ]);
+
+    final Pub pub = Pub.test(
+      platform: FakePlatform(),
+      fileSystem: fileSystem,
+      logger: logger,
+      usage: TestUsage(),
+      botDetector: const FakeBotDetector(false),
+      stdio: FakeStdio(),
+      processManager: processManager,
+    );
+
+    await expectLater(
+      pub.get(
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        context: PubContext.flutterTests,
+        outputMode: PubOutputMode.failuresOnly,
+      ),
+      completes,
+    );
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/116627
   testWithoutContext('pub get suppresses progress output', () async {
     final BufferLogger logger = BufferLogger.test();

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -780,9 +780,9 @@ exit code: 66
         '--example',
       ], onRun: (_) {
         fileSystem.currentDirectory
-            .childDirectory('.dart_tool')
-            .childFile('package_config.json')
-            .createSync(recursive: true);
+          .childDirectory('.dart_tool')
+          .childFile('package_config.json')
+          .createSync(recursive: true);
       }),
     ]);
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/158896.