### PR TITLE
Add one MenuAnchor alignment test

### DIFF
--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3920,6 +3920,46 @@ void main() {
         tester.getRect(find.byKey(contentKey)).bottom,
       );
     });
+
+    testWidgets('Menu is correctly offsetted when a LayerLink is provided and alignmentOffset is set', (WidgetTester tester) async {
+      final MenuController controller = MenuController();
+      final UniqueKey contentKey = UniqueKey();
+      const double horizontalOffset = 16.0;
+      const double verticalOffset = 20.0;
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: MenuAnchor(
+              controller: controller,
+              layerLink: LayerLink(),
+              alignmentOffset: const Offset(horizontalOffset, verticalOffset),
+              menuChildren: <Widget>[
+                MenuItemButton(
+                  onPressed: () {},
+                  child: const Text('Button 1'),
+                ),
+              ],
+              builder: (BuildContext context, MenuController controller, Widget? child) {
+                return SizedBox(key: contentKey, width: 100, height: 100);
+              },
+            ),
+          ),
+        ),
+      ));
+
+      controller.open();
+      await tester.pump();
+
+      expect(
+        tester.getRect(findMenuPanels()).top,
+        tester.getRect(find.byKey(contentKey)).bottom + verticalOffset,
+      );
+      expect(
+        tester.getRect(findMenuPanels()).left,
+        tester.getRect(find.byKey(contentKey)).left + horizontalOffset,
+      );
+    });
   });
 
   group('LocalizedShortcutLabeler', () {


### PR DESCRIPTION
This PR adds a `MenuAnchor` test to check that `MenuAnchor.alignmentOffset` is correctly applied when `MenuAnchor.layerlink` is provided.
While reviewing https://github.com/flutter/flutter/pull/158255, I found that this new test would be useful.