### PR TITLE
Do not rely on Leader/Follower to position DropdownMenu menu

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -902,7 +902,6 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       controller: _controller,
       menuChildren: menu,
       crossAxisUnconstrained: false,
-      layerLink: LayerLink(),
       builder: (BuildContext context, MenuController controller, Widget? child) {
         assert(_initialMenu != null);
         final Widget trailingButton = Padding(

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3366,47 +3366,6 @@ void main() {
     expect(controller.offset, 0.0);
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/149037.
-  testWidgets('Dropdown menu follows the text field when keyboard opens', (WidgetTester tester) async {
-    Widget boilerplate(double bottomInsets) {
-      return MaterialApp(
-        home: MediaQuery(
-          data: MediaQueryData(viewInsets: EdgeInsets.only(bottom: bottomInsets)),
-          child: Scaffold(
-            body: Center(
-              child: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren),
-            ),
-          ),
-        ),
-      );
-    }
-
-    // Build once without bottom insets and open the menu.
-    await tester.pumpWidget(boilerplate(0.0));
-    await tester.tap(find.byType(TextField).first);
-    await tester.pump();
-
-    Finder findMenuPanels() {
-      return find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_MenuPanel');
-    }
-
-    // Menu vertical position is just under the text field.
-    expect(
-      tester.getRect(findMenuPanels()).top,
-      tester.getRect(find.byType(TextField).first).bottom,
-    );
-
-    // Simulate the keyboard opening resizing the view.
-    await tester.pumpWidget(boilerplate(100.0));
-    await tester.pump();
-
-    // Menu vertical position is just under the text field.
-    expect(
-      tester.getRect(findMenuPanels()).top,
-      tester.getRect(find.byType(TextField).first).bottom,
-    );
-  });
-
   testWidgets('DropdownMenu with expandedInsets can be aligned', (WidgetTester tester) async {
     Widget buildMenuAnchor({ AlignmentGeometry alignment = Alignment.topCenter }) {
       return MaterialApp(


### PR DESCRIPTION
## Description

This PR removes `DropdownMenu` usage of Leader/Follower.

Leader/Follower positioning was introduced in https://github.com/flutter/flutter/pull/154667 which uses Leader/Follower approach to fix some weird positioning issues (such as https://github.com/flutter/flutter/issues/149037).

Unfortunately, it also introduces some regressions, see:
- https://github.com/flutter/flutter/issues/157916
- https://github.com/flutter/flutter/issues/158924

Because https://github.com/flutter/flutter/pull/154667 is already included in the beta channel, cherry-picking this PR should be considered.

## Context

This PR is not a full revert and keeps Leader/Follower usage in `MenuAnchor` because this usage is optional and doesn't cause any regression.
There are some ongoing work which might fix or mitigate this problem:
- https://github.com/flutter/flutter/pull/157921
- https://github.com/flutter/flutter/pull/158255

## Related Issue

Fixes https://github.com/flutter/flutter/issues/157916
Fixes https://github.com/flutter/flutter/issues/158924

Reopens https://github.com/flutter/flutter/issues/123395
Reopens https://github.com/flutter/flutter/issues/149037
Reopens https://github.com/flutter/flutter/issues/151856 
