### PR TITLE
Refactor native asset integration into flutter tools

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -289,7 +289,7 @@ class KernelSnapshotNativeAssets extends Target {
 
   @override
   List<Source> get inputs => <Source>[
-    const Source.pattern('{BUILD_DIR}/native_assets.yaml'),
+    const Source.pattern('{BUILD_DIR}/${InstallCodeAssets.nativeAssetsFilename}'),
     ...const KernelSnapshotProgram().inputs,
   ];
 
@@ -302,15 +302,15 @@ class KernelSnapshotNativeAssets extends Target {
   List<String> get depfiles => const <String>[];
 
   @override
-  List<Target> get dependencies => <Target>[
-    const NativeAssets(),
+  List<Target> get dependencies => const <Target>[
+    InstallCodeAssets(),
   ];
 
   static const String dillName = 'native_assets.dill';
 
   @override
   Future<void> build(Environment environment) async {
-    final File nativeAssetsFile = environment.buildDir.childFile('native_assets.yaml');
+    final File nativeAssetsFile = environment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename);
     final File dillFile = environment.buildDir.childFile(dillName);
 
     final YamlNode nativeAssetContents = loadYamlNode(await nativeAssetsFile.readAsString());

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config_types.dart';
 
 import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../build_info.dart';
+import '../../convert.dart';
 import '../../dart/package_map.dart';
 import '../../isolated/native_assets/native_assets.dart';
 import '../build_system.dart';

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:meta/meta.dart';
-import 'package:native_assets_builder/native_assets_builder.dart';
 import 'package:package_config/package_config_types.dart';
 
 import '../../base/common.dart';
@@ -16,25 +17,8 @@ import '../depfile.dart';
 import '../exceptions.dart';
 import 'common.dart';
 
-/// Builds the right native assets for a Flutter app.
-///
-/// The build mode and target architecture can be changed from the
-/// native build project (Xcode etc.), so only `flutter assemble` has the
-/// information about build-mode and target architecture.
-/// Invocations of flutter_tools other than `flutter assemble` are dry runs.
-///
-/// This step needs to be consistent with the dry run invocations in `flutter
-/// run`s so that the kernel mapping of asset id to dylib lines up after hot
-/// restart.
-///
-/// [KernelSnapshot] depends on this target. We produce a native_assets.yaml
-/// here, and embed that mapping inside the kernel snapshot.
-///
-/// The build always produces a valid native_assets.yaml and a native_assets.d
-/// even if there are no native assets. This way the caching logic won't try to
-/// rebuild.
-class NativeAssets extends Target {
-  const NativeAssets({
+abstract class DartBuild extends Target {
+  const DartBuild({
     @visibleForTesting FlutterNativeAssetsBuildRunner? buildRunner,
   }) : _buildRunner = buildRunner;
 
@@ -42,26 +26,20 @@ class NativeAssets extends Target {
 
   @override
   Future<void> build(Environment environment) async {
-    final String? nativeAssetsEnvironment = environment.defines[kNativeAssets];
     final FileSystem fileSystem = environment.fileSystem;
-    final Uri nativeAssetsFileUri = environment.buildDir.childFile('native_assets.yaml').uri;
+    final String? nativeAssetsEnvironment = environment.defines[kNativeAssets];
 
     final DartBuildResult result;
     if (nativeAssetsEnvironment == 'false') {
       result = const DartBuildResult.empty();
-      await writeNativeAssetsYaml(KernelAssets(), nativeAssetsFileUri, fileSystem);
     } else {
-      final String? targetPlatformEnvironment = environment.defines[kTargetPlatform];
-      if (targetPlatformEnvironment == null) {
-        throw MissingDefineException(kTargetPlatform, name);
-      }
-      final TargetPlatform targetPlatform = getTargetPlatformForName(targetPlatformEnvironment);
-      final Uri projectUri = environment.projectDir.uri;
+      final TargetPlatform targetPlatform = _getTargetPlatformFromEnvironment(environment, name);
 
       final PackageConfig packageConfig = await loadPackageConfigWithLogging(
         fileSystem.file(environment.packageConfigPath),
         logger: environment.logger,
       );
+      final Uri projectUri = environment.projectDir.uri;
       final FlutterNativeAssetsBuildRunner buildRunner = _buildRunner ??
           FlutterNativeAssetsBuildRunnerImpl(
             projectUri,
@@ -70,48 +48,41 @@ class NativeAssets extends Target {
             fileSystem,
             environment.logger,
           );
-
-      (result, _) = await runFlutterSpecificDartBuild(
+      result = await runFlutterSpecificDartBuild(
         environmentDefines: environment.defines,
         buildRunner: buildRunner,
         targetPlatform: targetPlatform,
         projectUri: projectUri,
-        nativeAssetsYamlUri : nativeAssetsFileUri,
         fileSystem: fileSystem,
       );
     }
+
+    final File dartBuildResultJsonFile = environment.buildDir.childFile(dartBuildResultFilename);
+    if (!dartBuildResultJsonFile.parent.existsSync()) {
+      dartBuildResultJsonFile.parent.createSync(recursive: true);
+    }
+    dartBuildResultJsonFile.writeAsStringSync(json.encode(result.toJson()));
 
     final Depfile depfile = Depfile(
       <File>[
         for (final Uri dependency in result.dependencies) fileSystem.file(dependency),
       ],
       <File>[
-        fileSystem.file(nativeAssetsFileUri),
+        fileSystem.file(dartBuildResultJsonFile),
       ],
     );
-    final File outputDepfile = environment.buildDir.childFile('native_assets.d');
+    final File outputDepfile = environment.buildDir.childFile(depFilename);
     if (!outputDepfile.parent.existsSync()) {
       outputDepfile.parent.createSync(recursive: true);
     }
     environment.depFileService.writeToFile(depfile, outputDepfile);
-    if (!await fileSystem.file(nativeAssetsFileUri).exists()) {
-      throwToolExit("${nativeAssetsFileUri.path} doesn't exist.");
-    }
     if (!await outputDepfile.exists()) {
       throwToolExit("${outputDepfile.path} doesn't exist.");
     }
   }
 
   @override
-  List<String> get depfiles => <String>[
-    'native_assets.d',
-  ];
-
-  @override
-  List<Target> get dependencies => const <Target>[
-    // In AOT, depends on tree-shaking information (resources.json) from compiling dart.
-    KernelSnapshotProgram(),
-  ];
+  List<String> get depfiles => const <String>[depFilename];
 
   @override
   List<Source> get inputs => const <Source>[
@@ -122,10 +93,109 @@ class NativeAssets extends Target {
   ];
 
   @override
-  String get name => 'native_assets';
+  String get name => 'dart_build';
 
   @override
   List<Source> get outputs => const <Source>[
-    Source.pattern('{BUILD_DIR}/native_assets.yaml'),
+    Source.pattern('{BUILD_DIR}/$dartBuildResultFilename'),
   ];
+
+  /// Dependent build [Target]s can use this to consume the result of the
+  /// [DartBuild] target.
+  static Future<DartBuildResult> loadBuildResult(Environment environment) async {
+    final File dartBuildResultJsonFile = environment.buildDir.childFile(DartBuild.dartBuildResultFilename);
+    return DartBuildResult.fromJson(json.decode(dartBuildResultJsonFile.readAsStringSync()) as Map<String, Object?>);
+  }
+
+  static const String dartBuildResultFilename = 'dart_build_result.json';
+  static const String depFilename = 'dart_build.d';
+}
+
+class DartBuildForNative extends DartBuild {
+  const DartBuildForNative({@visibleForTesting super.buildRunner});
+
+  @override
+  List<Target> get dependencies => const <Target>[
+    KernelSnapshotProgram(),
+  ];
+}
+
+/// Installs the code assets from a [DartBuild] Flutter app.
+///
+/// The build mode and target architecture can be changed from the
+/// native build project (Xcode etc.), so only `flutter assemble` has the
+/// information about build-mode and target architecture.
+/// Invocations of flutter_tools other than `flutter assemble` are dry runs.
+///
+/// This step needs to be consistent with the dry run invocations in `flutter
+/// run`s so that the kernel mapping of asset id to dylib lines up after hot
+/// restart.
+class InstallCodeAssets extends Target {
+  const InstallCodeAssets();
+
+  @override
+  Future<void> build(Environment environment) async {
+    final Uri projectUri = environment.projectDir.uri;
+    final FileSystem fileSystem = environment.fileSystem;
+    final TargetPlatform targetPlatform = _getTargetPlatformFromEnvironment(environment, name);
+
+    // We fetch the result from the [DartBuild].
+    final DartBuildResult dartBuildResult = await DartBuild.loadBuildResult(environment);
+
+    // And install/copy the code assets to the right place and create a
+    // native_asset.yaml that can be used by the final AOT compilation.
+    final Uri nativeAssetsFileUri = environment.buildDir.childFile(nativeAssetsFilename).uri;
+    await installCodeAssets(dartBuildResult: dartBuildResult, environmentDefines: environment.defines,
+      targetPlatform: targetPlatform, projectUri: projectUri, fileSystem: fileSystem,
+      nativeAssetsFileUri: nativeAssetsFileUri);
+    assert(await fileSystem.file(nativeAssetsFileUri).exists());
+
+    final Depfile depfile = Depfile(
+      <File>[
+        for (final Uri file in dartBuildResult.filesToBeBundled) fileSystem.file(file),
+      ],
+      <File>[
+        fileSystem.file(nativeAssetsFileUri),
+      ],
+    );
+    final File outputDepfile = environment.buildDir.childFile(depFilename);
+    environment.depFileService.writeToFile(depfile, outputDepfile);
+    if (!await outputDepfile.exists()) {
+      throwToolExit("${outputDepfile.path} doesn't exist.");
+    }
+  }
+
+  @override
+  List<String> get depfiles => <String>[depFilename];
+
+  @override
+  List<Target> get dependencies => const <Target>[
+    DartBuildForNative(),
+  ];
+
+  @override
+  List<Source> get inputs => const <Source>[
+    Source.pattern('{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart'),
+    // If different packages are resolved, different native assets might need to be built.
+    Source.pattern('{WORKSPACE_DIR}/.dart_tool/package_config_subset'),
+  ];
+
+  @override
+  String get name => 'install_code_assets';
+
+  @override
+  List<Source> get outputs => const <Source>[
+    Source.pattern('{BUILD_DIR}/$nativeAssetsFilename'),
+  ];
+
+  static const String nativeAssetsFilename = 'native_assets.yaml';
+  static const String depFilename = 'install_code_assets.d';
+}
+
+TargetPlatform _getTargetPlatformFromEnvironment(Environment environment, String name) {
+  final String? targetPlatformEnvironment = environment.defines[kTargetPlatform];
+  if (targetPlatformEnvironment == null) {
+    throw MissingDefineException(kTargetPlatform, name);
+  }
+  return getTargetPlatformForName(targetPlatformEnvironment);
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -17,6 +17,7 @@ import '../depfile.dart';
 import '../exceptions.dart';
 import 'common.dart';
 
+/// Runs the dart build of the app.
 abstract class DartBuild extends Target {
   const DartBuild({
     @visibleForTesting FlutterNativeAssetsBuildRunner? buildRunner,

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -35,9 +35,11 @@ import 'windows/native_assets.dart';
 /// again.
 final class DartBuildResult {
   const DartBuildResult(this.codeAssets, this.dependencies);
+
   const DartBuildResult.empty()
       : codeAssets = const <CodeAsset>[],
         dependencies = const <Uri>[];
+
   factory DartBuildResult.fromJson(Map<String, Object?> json) {
     final List<Uri> dependencies = <Uri>[
       for (final Object? encodedUri in json['dependencies']! as List<Object?>)

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -38,36 +38,51 @@ final class DartBuildResult {
   const DartBuildResult.empty()
       : codeAssets = const <CodeAsset>[],
         dependencies = const <Uri>[];
+  factory DartBuildResult.fromJson(Map<String, Object?> json) {
+    final List<Uri> dependencies = <Uri>[
+      for (final Object? encodedUri in json['dependencies']! as List<Object?>)
+        Uri.parse(encodedUri! as String),
+    ];
+    final List<CodeAsset> codeAssets = <CodeAsset>[
+      for (final Object? json in json['code_assets']! as List<Object?>)
+        CodeAsset.fromEncoded(EncodedAsset.fromJson(json! as Map<String, Object?>)),
+    ];
+    return DartBuildResult(codeAssets, dependencies);
+  }
 
   final List<CodeAsset> codeAssets;
   final List<Uri> dependencies;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'dependencies': <Object?>[
+      for (final Uri dep in dependencies) dep.toString(),
+    ],
+    'code_assets': <Object?>[
+      for (final CodeAsset code in codeAssets) code.encode().toJson(),
+    ],
+  };
+
+  /// The files that eventually should be bundled with the app.
+  List<Uri> get filesToBeBundled => <Uri>[
+    for (final CodeAsset code in codeAssets)
+      if (code.linkMode is DynamicLoadingBundled) code.file!,
+  ];
 }
 
 /// Invokes the build of all transitive Dart packages and prepares code assets
 /// to be included in the native build.
-Future<(DartBuildResult, Uri)> runFlutterSpecificDartBuild({
+Future<DartBuildResult> runFlutterSpecificDartBuild({
   required Map<String, String> environmentDefines,
   required FlutterNativeAssetsBuildRunner buildRunner,
   required build_info.TargetPlatform targetPlatform,
   required Uri projectUri,
-  Uri? nativeAssetsYamlUri,
   required FileSystem fileSystem,
 }) async {
-  final OS targetOS = _getNativeOSFromTargetPlatfrorm(targetPlatform);
+  final OS targetOS = getNativeOSFromTargetPlatfrorm(targetPlatform);
   final Uri buildUri = nativeAssetsBuildUri(projectUri, targetOS);
   final Directory buildDir = fileSystem.directory(buildUri);
 
   final bool flutterTester = targetPlatform == build_info.TargetPlatform.tester;
-
-  if (nativeAssetsYamlUri == null) {
-    // Only `flutter test` uses the
-    // `build/native_assets/<os>/native_assets.yaml` file which uses absolute
-    // paths to the shared libraries.
-    //
-    // testCompilerBuildNativeAssets() passes `null`
-    assert(flutterTester);
-    nativeAssetsYamlUri ??= buildUri.resolve('native_assets.yaml');
-  }
 
   if (!await buildDir.exists()) {
     // Ensure the folder exists so the native build system can copy it even
@@ -76,22 +91,10 @@ Future<(DartBuildResult, Uri)> runFlutterSpecificDartBuild({
   }
 
   if (!await _nativeBuildRequired(buildRunner)) {
-    await writeNativeAssetsYaml(
-        KernelAssets(), nativeAssetsYamlUri, fileSystem);
-    return (const DartBuildResult.empty(), nativeAssetsYamlUri);
+    return const DartBuildResult.empty();
   }
 
-  final build_info.BuildMode buildMode;
-  if (flutterTester) {
-    buildMode = build_info.BuildMode.debug;
-  } else {
-    final String? environmentBuildMode =
-        environmentDefines[build_info.kBuildMode];
-    if (environmentBuildMode == null) {
-      throw MissingDefineException(build_info.kBuildMode, 'native_assets');
-    }
-    buildMode = build_info.BuildMode.fromCliName(environmentBuildMode);
-  }
+  final build_info.BuildMode buildMode = _getBuildMode(targetPlatform, environmentDefines, flutterTester);
   final List<Target> targets = flutterTester
       ? <Target>[Target.current]
       : _targetsForOS(targetPlatform, targetOS, environmentDefines);
@@ -105,19 +108,27 @@ Future<(DartBuildResult, Uri)> runFlutterSpecificDartBuild({
           buildMode: _nativeAssetsBuildMode(buildMode),
           fileSystem: fileSystem,
           targetOS: targetOS);
+  return result;
+}
 
-  final String? codesignIdentity =
-      environmentDefines[build_info.kCodesignIdentity];
+Future<void> installCodeAssets({
+  required DartBuildResult dartBuildResult,
+  required Map<String, String> environmentDefines,
+  required build_info.TargetPlatform targetPlatform,
+  required Uri projectUri,
+  required FileSystem fileSystem,
+  required Uri nativeAssetsFileUri,
+}) async {
+  final OS targetOS = getNativeOSFromTargetPlatfrorm(targetPlatform);
+  final Uri buildUri = nativeAssetsBuildUri(projectUri, targetOS);
+  final bool flutterTester = targetPlatform == build_info.TargetPlatform.tester;
+  final build_info.BuildMode buildMode = _getBuildMode(targetPlatform, environmentDefines, flutterTester);
 
-  final Map<CodeAsset, KernelAsset> assetTargetLocations =
-      _assetTargetLocationsForOS(
-          targetOS, result.codeAssets, flutterTester, buildUri);
-  await _copyNativeCodeAssetsForOS(targetOS, buildUri, buildMode, fileSystem,
-      assetTargetLocations, codesignIdentity, flutterTester);
-  final KernelAssets vmAssetMapping =
-      KernelAssets(assetTargetLocations.values.toList());
-  await writeNativeAssetsYaml(vmAssetMapping, nativeAssetsYamlUri, fileSystem);
-  return (result, nativeAssetsYamlUri);
+  final String? codesignIdentity = environmentDefines[build_info.kCodesignIdentity];
+  final Map<CodeAsset, KernelAsset> assetTargetLocations = assetTargetLocationsForOS(targetOS, dartBuildResult.codeAssets, flutterTester, buildUri);
+  await _copyNativeCodeAssetsForOS(targetOS, buildUri, buildMode, fileSystem, assetTargetLocations, codesignIdentity, flutterTester);
+  final KernelAssets kernelAssets = KernelAssets(assetTargetLocations.values.toList());
+  await _writeNativeAssetsYaml(kernelAssets, nativeAssetsFileUri, fileSystem);
 }
 
 Future<Uri?> runFlutterSpecificDartDryRunOnPlatforms({
@@ -142,7 +153,7 @@ Future<Uri?> runFlutterSpecificDartDryRunOnPlatforms({
     final bool flutterTester =
         targetPlatform == build_info.TargetPlatform.tester;
 
-    final OS targetOS = _getNativeOSFromTargetPlatfrorm(targetPlatform);
+    final OS targetOS = getNativeOSFromTargetPlatfrorm(targetPlatform);
     if (targetOS != OS.macOS &&
         targetOS != OS.windows &&
         targetOS != OS.linux &&
@@ -162,16 +173,16 @@ Future<Uri?> runFlutterSpecificDartDryRunOnPlatforms({
         projectUri: projectUri,
         fileSystem: fileSystem,
         targetOS: targetOS);
-    assetTargetLocations.addAll(_assetTargetLocationsForOS(
+    assetTargetLocations.addAll(assetTargetLocationsForOS(
         targetOS, result.codeAssets, flutterTester, buildUri));
   }
 
   final Uri buildUri = targetPlatforms.length == 1
       ? nativeAssetsBuildUri(
-          projectUri, _getNativeOSFromTargetPlatfrorm(targetPlatforms.single))
+          projectUri, getNativeOSFromTargetPlatfrorm(targetPlatforms.single))
       : _buildUriMultiple(projectUri);
   final Uri nativeAssetsYamlUri = buildUri.resolve('native_assets.yaml');
-  await writeNativeAssetsYaml(
+  await _writeNativeAssetsYaml(
     KernelAssets(assetTargetLocations.values.toList()),
     nativeAssetsYamlUri,
     fileSystem,
@@ -405,7 +416,7 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
   }();
 }
 
-Future<Uri> writeNativeAssetsYaml(
+Future<Uri> _writeNativeAssetsYaml(
   KernelAssets assets,
   Uri nativeAssetsYamlUri,
   FileSystem fileSystem,
@@ -602,7 +613,7 @@ KernelAsset _targetLocationSingleArchitecture(
   );
 }
 
-Map<CodeAsset, KernelAsset> _assetTargetLocationsForOS(
+Map<CodeAsset, KernelAsset> assetTargetLocationsForOS(
     OS targetOS, List<CodeAsset> codeAssets, bool flutterTester, Uri buildUri) {
   switch (targetOS) {
     case OS.windows:
@@ -957,7 +968,7 @@ Never _throwNativeAssetsLinkFailed() {
   );
 }
 
-OS _getNativeOSFromTargetPlatfrorm(build_info.TargetPlatform platform) {
+OS getNativeOSFromTargetPlatfrorm(build_info.TargetPlatform platform) {
   switch (platform) {
     case build_info.TargetPlatform.ios:
       return OS.iOS;
@@ -1083,3 +1094,14 @@ const Map<OS, Set<Architecture>> _osTargets = <OS, Set<Architecture>>{
     Architecture.x64,
   },
 };
+
+build_info.BuildMode _getBuildMode(build_info.TargetPlatform targetPlatform, Map<String, String> environmentDefines, bool isFlutterTester) {
+  if (isFlutterTester) {
+    return build_info.BuildMode.debug;
+  }
+  final String? environmentBuildMode = environmentDefines[build_info.kBuildMode];
+  if (environmentBuildMode == null) {
+    throw MissingDefineException(build_info.kBuildMode, 'native_assets');
+  }
+  return build_info.BuildMode.fromCliName(environmentBuildMode);
+}

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -74,7 +74,7 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
   await installCodeAssets(dartBuildResult: dartBuildResult, environmentDefines: environmentDefines,
     targetPlatform: TargetPlatform.tester, projectUri: projectUri, fileSystem: globals.fs,
     nativeAssetsFileUri: nativeAssetsFileUri);
-  assert(!await globals.fs.file(nativeAssetsFileUri).exists());
+  assert(await globals.fs.file(nativeAssetsFileUri).exists());
 
   return nativeAssetsFileUri;
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/ios.dart';
+import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/compile.dart';
 
 import '../../../src/common.dart';
@@ -437,7 +438,7 @@ native-assets:
         fileSystem.file('.dart_tool/package_config.json')
           ..createSync(recursive: true)
           ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
-        androidEnvironment.buildDir.childFile('native_assets.yaml')
+        androidEnvironment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename)
           ..createSync(recursive: true)
           ..writeAsStringSync(empty ? emptyNativeAssets : nonEmptyNativeAssets);
         final String build = androidEnvironment.buildDir.path;
@@ -463,7 +464,7 @@ native-assets:
               '--output-dill',
               '$build/native_assets.dill',
               '--native-assets',
-              '$build/native_assets.yaml',
+              '$build/${InstallCodeAssets.nativeAssetsFilename}',
               '--verbosity=error',
               '--native-assets-only',
             ], stdout: 'result $kBoundaryKey\n$kBoundaryKey\n$kBoundaryKey $build/app.dill 0\n'),

--- a/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
@@ -60,8 +60,7 @@ void main() {
           FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
           ProcessManager: () => FakeProcessManager.empty(),
         }, () async {
-      final File packageConfig =
-          environment.projectDir.childFile('.dart_tool/package_config.json');
+      final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
       final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename).uri;
       await packageConfig.parent.create();
       await packageConfig.create();
@@ -91,9 +90,9 @@ void main() {
         ),
       );
       final Map<String, String> environmentDefines = <String, String>{
-          kBuildMode: buildMode.cliName,
-          kMinSdkVersion: minSdkVersion,
-        };
+        kBuildMode: buildMode.cliName,
+        kMinSdkVersion: minSdkVersion,
+      };
       final DartBuildResult result = await runFlutterSpecificDartBuild(
         environmentDefines: environmentDefines,
         targetPlatform: TargetPlatform.android_arm64,
@@ -117,7 +116,7 @@ void main() {
         ]),
       );
 
-      expect(nonFlutterTesterAssetUri , exists);
+      expect(environment.buildDir.childFile('native_assets.yaml'), exists);
       expect(buildRunner.buildInvocations, 1);
       expect(
         buildRunner.linkInvocations,

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -215,18 +215,31 @@ void main() {
       await DartBuildForNative(buildRunner: buildRunner).build(iosEnvironment);
       await const InstallCodeAssets().build(iosEnvironment);
 
-      final File nativeAssetsYaml = iosEnvironment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename);
-      final File depsFile = iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename);
-      expect(depsFile, exists);
-      // We don't care about the specific format, but it should contain the
-      // yaml as the file depending on the source files that went in to the
-      // build.
+      // We don't care about the specific format, but
+      //  * dart build output should depend on C source
+      //  * installation output should depend on shared library from dart build
+
+      final File dartBuildResult = iosEnvironment.buildDir.childFile(DartBuild.dartBuildResultFilename);
+      final File buildDepsFile = iosEnvironment.buildDir.childFile(DartBuild.depFilename);
+      expect(buildDepsFile, exists);
       expect(
-        depsFile.readAsStringSync(),
+        buildDepsFile.readAsStringSync(),
+        stringContainsInOrder(<String>[
+          dartBuildResult.path,
+          ':',
+          'src/foo.c',
+        ]),
+      );
+
+      final File nativeAssetsYaml = iosEnvironment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename);
+      final File installDepsFile = iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename);
+      expect(installDepsFile, exists);
+      expect(
+        installDepsFile.readAsStringSync(),
         stringContainsInOrder(<String>[
           nativeAssetsYaml.path,
           ':',
-          'src/foo.c',
+          'foo.framework/foo',
         ]),
       );
       expect(nativeAssetsYaml, exists);

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -68,7 +68,7 @@ void main() {
 
   testWithoutContext('NativeAssets throws error if missing target platform', () async {
     iosEnvironment.defines.remove(kTargetPlatform);
-    expect(const NativeAssets().build(iosEnvironment), throwsA(isA<MissingDefineException>()));
+    expect(const DartBuild(dependency: null).build(iosEnvironment), throwsA(isA<MissingDefineException>()));
   });
 
   testUsingContext('NativeAssets defaults to ios archs if missing', () async {
@@ -77,14 +77,12 @@ void main() {
     iosEnvironment.defines.remove(kIosArchs);
 
     final FlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner();
-    await NativeAssets(buildRunner: buildRunner).build(iosEnvironment);
+    await DartBuild(dependency: null, buildRunner: buildRunner).build(iosEnvironment);
+    await const InstallCodeAssets(dependency: null).build(iosEnvironment);
 
-    final File nativeAssetsYaml =
-        iosEnvironment.buildDir.childFile('native_assets.yaml');
-
-    final File depsFile = iosEnvironment.buildDir.childFile('native_assets.d');
-    expect(depsFile, exists);
-    expect(nativeAssetsYaml, exists);
+    expect(iosEnvironment.buildDir.childFile(DartBuild.depFilename), exists);
+    expect(iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename), exists);
+    expect(iosEnvironment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename), exists);
   });
 
   testUsingContext('NativeAssets throws error if missing sdk root', overrides: <Type, Generator>{
@@ -98,7 +96,7 @@ void main() {
       ]);
 
     iosEnvironment.defines.remove(kSdkRoot);
-    expect(NativeAssets(buildRunner: buildRunner).build(iosEnvironment), throwsA(isA<MissingDefineException>()));
+    expect(DartBuild(dependency: null, buildRunner: buildRunner).build(iosEnvironment), throwsA(isA<MissingDefineException>()));
   });
 
   // The NativeAssets Target should _always_ be creating a yaml an d file.
@@ -118,10 +116,12 @@ void main() {
         await createPackageConfig(iosEnvironment);
 
         final FlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner();
-        await NativeAssets(buildRunner: buildRunner).build(iosEnvironment);
+        await DartBuild(dependency: null, buildRunner: buildRunner).build(iosEnvironment);
+        await const InstallCodeAssets(dependency: null).build(iosEnvironment);
 
-        expect(iosEnvironment.buildDir.childFile('native_assets.d'), exists);
-        expect(iosEnvironment.buildDir.childFile('native_assets.yaml'), exists);
+        expect(iosEnvironment.buildDir.childFile(DartBuild.depFilename), exists);
+        expect(iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename), exists);
+        expect(iosEnvironment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename), exists);
       },
     );
   }
@@ -212,10 +212,11 @@ void main() {
           codeAssets: codeAssets,
         ),
       );
-      await NativeAssets(buildRunner: buildRunner).build(iosEnvironment);
+      await DartBuild(dependency: null, buildRunner: buildRunner).build(iosEnvironment);
+      await const InstallCodeAssets(dependency: null).build(iosEnvironment);
 
-      final File nativeAssetsYaml = iosEnvironment.buildDir.childFile('native_assets.yaml');
-      final File depsFile = iosEnvironment.buildDir.childFile('native_assets.d');
+      final File nativeAssetsYaml = iosEnvironment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename);
+      final File depsFile = iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename);
       expect(depsFile, exists);
       // We don't care about the specific format, but it should contain the
       // yaml as the file depending on the source files that went in to the
@@ -281,7 +282,7 @@ void main() {
             codeAssets: codeAssets,
           ),
         );
-        await NativeAssets(buildRunner: buildRunner).build(androidEnvironment);
+        await DartBuild(dependency: null, buildRunner: buildRunner).build(androidEnvironment);
         expect(
           buildRunner.lastBuildMode,
           native_assets_cli.BuildMode.release,

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -68,7 +68,7 @@ void main() {
 
   testWithoutContext('NativeAssets throws error if missing target platform', () async {
     iosEnvironment.defines.remove(kTargetPlatform);
-    expect(const DartBuild(dependency: null).build(iosEnvironment), throwsA(isA<MissingDefineException>()));
+    expect(const DartBuildForNative().build(iosEnvironment), throwsA(isA<MissingDefineException>()));
   });
 
   testUsingContext('NativeAssets defaults to ios archs if missing', () async {
@@ -77,8 +77,8 @@ void main() {
     iosEnvironment.defines.remove(kIosArchs);
 
     final FlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner();
-    await DartBuild(dependency: null, buildRunner: buildRunner).build(iosEnvironment);
-    await const InstallCodeAssets(dependency: null).build(iosEnvironment);
+    await DartBuildForNative(buildRunner: buildRunner).build(iosEnvironment);
+    await const InstallCodeAssets().build(iosEnvironment);
 
     expect(iosEnvironment.buildDir.childFile(DartBuild.depFilename), exists);
     expect(iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename), exists);
@@ -96,7 +96,7 @@ void main() {
       ]);
 
     iosEnvironment.defines.remove(kSdkRoot);
-    expect(DartBuild(dependency: null, buildRunner: buildRunner).build(iosEnvironment), throwsA(isA<MissingDefineException>()));
+    expect(DartBuildForNative(buildRunner: buildRunner).build(iosEnvironment), throwsA(isA<MissingDefineException>()));
   });
 
   // The NativeAssets Target should _always_ be creating a yaml an d file.
@@ -116,8 +116,8 @@ void main() {
         await createPackageConfig(iosEnvironment);
 
         final FlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner();
-        await DartBuild(dependency: null, buildRunner: buildRunner).build(iosEnvironment);
-        await const InstallCodeAssets(dependency: null).build(iosEnvironment);
+        await DartBuildForNative(buildRunner: buildRunner).build(iosEnvironment);
+        await const InstallCodeAssets().build(iosEnvironment);
 
         expect(iosEnvironment.buildDir.childFile(DartBuild.depFilename), exists);
         expect(iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename), exists);
@@ -212,8 +212,8 @@ void main() {
           codeAssets: codeAssets,
         ),
       );
-      await DartBuild(dependency: null, buildRunner: buildRunner).build(iosEnvironment);
-      await const InstallCodeAssets(dependency: null).build(iosEnvironment);
+      await DartBuildForNative(buildRunner: buildRunner).build(iosEnvironment);
+      await const InstallCodeAssets().build(iosEnvironment);
 
       final File nativeAssetsYaml = iosEnvironment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename);
       final File depsFile = iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename);
@@ -282,7 +282,7 @@ void main() {
             codeAssets: codeAssets,
           ),
         );
-        await DartBuild(dependency: null, buildRunner: buildRunner).build(androidEnvironment);
+        await DartBuildForNative(buildRunner: buildRunner).build(androidEnvironment);
         expect(
           buildRunner.lastBuildMode,
           native_assets_cli.BuildMode.release,

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -208,7 +208,7 @@ void main() {
       await installCodeAssets(
         dartBuildResult: dartBuildResult,
         environmentDefines: environmentDefines,
-        targetPlatform: TargetPlatform.android_arm64,
+        targetPlatform: TargetPlatform.ios,
         projectUri: projectUri,
         fileSystem: fileSystem,
         nativeAssetsFileUri: nonFlutterTesterAssetUri,

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
@@ -159,7 +160,7 @@ void main() {
       }
       final File packageConfig =
           environment.projectDir.childFile('.dart_tool/package_config.json');
-      final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile('native_assets.yaml').uri;
+      final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename).uri;
       await packageConfig.parent.create();
       await packageConfig.create();
 
@@ -192,17 +193,25 @@ void main() {
             ? null
             : FakeFlutterNativeAssetsBuilderResult.fromAssets(codeAssets: codeAssets(config.targetOS, config.codeConfig)),
       );
-      await runFlutterSpecificDartBuild(
-        environmentDefines: <String, String>{
-          kBuildMode: buildMode.cliName,
-          kSdkRoot: '.../iPhone Simulator',
-          kIosArchs: 'arm64 x86_64',
-        },
+      final Map<String, String> environmentDefines = <String, String>{
+        kBuildMode: buildMode.cliName,
+        kSdkRoot: '.../iPhone Simulator',
+        kIosArchs: 'arm64 x86_64',
+      };
+      final DartBuildResult dartBuildResult = await runFlutterSpecificDartBuild(
+        environmentDefines: environmentDefines,
         targetPlatform: TargetPlatform.ios,
         projectUri: projectUri,
-        nativeAssetsYamlUri: nonFlutterTesterAssetUri,
         fileSystem: fileSystem,
         buildRunner: buildRunner,
+      );
+      await installCodeAssets(
+        dartBuildResult: dartBuildResult,
+        environmentDefines: environmentDefines,
+        targetPlatform: TargetPlatform.android_arm64,
+        projectUri: projectUri,
+        fileSystem: fileSystem,
+        nativeAssetsFileUri: nonFlutterTesterAssetUri,
       );
       expect(
         (globals.logger as BufferLogger).traceText,
@@ -211,10 +220,7 @@ void main() {
           'Building native assets for [ios_arm64, ios_x64] $buildMode done.',
         ]),
       );
-      expect(
-        environment.buildDir.childFile('native_assets.yaml'),
-        exists,
-      );
+      expect(environment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename), exists);
       // Two archs.
       expect(buildRunner.buildInvocations, 2);
       expect(

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -53,7 +53,6 @@ void main() {
     ProcessManager: () => FakeProcessManager.empty(),
   }, () async {
     final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
-    final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile('native_assets.yaml').uri;
     await packageConfig.create(recursive: true);
 
     await runFlutterSpecificDartBuild(
@@ -62,7 +61,6 @@ void main() {
       },
       targetPlatform: TargetPlatform.linux_x64,
       projectUri: projectUri,
-      nativeAssetsYamlUri: nonFlutterTesterAssetUri,
       fileSystem: fileSystem,
       buildRunner: _BuildRunnerWithoutClang(),
     );

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
@@ -69,14 +70,12 @@ void main() {
   testUsingContext('build with no package config', overrides: <Type, Generator>{
     ProcessManager: () => FakeProcessManager.empty(),
   }, () async {
-    final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile('native_assets.yaml').uri;
     await runFlutterSpecificDartBuild(
       environmentDefines: <String, String>{
         kBuildMode: BuildMode.debug.cliName,
       },
       targetPlatform: TargetPlatform.windows_x64,
       projectUri: projectUri,
-      nativeAssetsYamlUri: nonFlutterTesterAssetUri,
       fileSystem: fileSystem,
       buildRunner: FakeFlutterNativeAssetsBuildRunner(
         hasPackageConfigResult: false,
@@ -171,7 +170,7 @@ void main() {
     );
     expect(
       nativeAssetsYaml,
-      projectUri.resolve('build/native_assets/windows/native_assets.yaml'),
+      projectUri.resolve('build/native_assets/windows/${InstallCodeAssets.nativeAssetsFilename}'),
     );
     expect(
       await fileSystem.file(nativeAssetsYaml).readAsString(),
@@ -232,7 +231,6 @@ void main() {
     ProcessManager: () => FakeProcessManager.empty(),
   }, () async {
     final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
-    final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile('native_assets.yaml').uri;
     await packageConfig.parent.create();
     await packageConfig.create();
     expect(
@@ -242,7 +240,6 @@ void main() {
         },
         targetPlatform: TargetPlatform.windows_x64,
         projectUri: projectUri,
-        nativeAssetsYamlUri: nonFlutterTesterAssetUri,
         fileSystem: fileSystem,
         buildRunner: FakeFlutterNativeAssetsBuildRunner(
           packagesWithNativeAssetsResult: <Package>[
@@ -262,16 +259,17 @@ void main() {
     ProcessManager: () => FakeProcessManager.empty(),
   }, () async {
     final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
-    final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile('native_assets.yaml').uri;
+    final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename).uri;
     await packageConfig.parent.create();
     await packageConfig.create();
-    final (_, Uri nativeAssetsYaml) = await runFlutterSpecificDartBuild(
-      environmentDefines: <String, String>{
-        kBuildMode: BuildMode.debug.cliName,
-      },
+
+    final Map<String, String> environmentDefines = <String, String>{
+      kBuildMode: BuildMode.debug.cliName,
+    };
+    final DartBuildResult dartBuildResult = await runFlutterSpecificDartBuild(
+      environmentDefines: environmentDefines,
       targetPlatform: TargetPlatform.windows_x64,
       projectUri: projectUri,
-      nativeAssetsYamlUri: nonFlutterTesterAssetUri,
       fileSystem: fileSystem,
       buildRunner: FakeFlutterNativeAssetsBuildRunner(
         packagesWithNativeAssetsResult: <Package>[
@@ -279,9 +277,16 @@ void main() {
         ],
       ),
     );
-    expect(nativeAssetsYaml, nonFlutterTesterAssetUri);
+    await installCodeAssets(
+      dartBuildResult: dartBuildResult,
+      environmentDefines: environmentDefines,
+      targetPlatform: TargetPlatform.windows_x64,
+      projectUri: projectUri,
+      fileSystem: fileSystem,
+      nativeAssetsFileUri: nonFlutterTesterAssetUri,
+    );
     expect(
-      await fileSystem.file(nativeAssetsYaml).readAsString(),
+      await fileSystem.file(nonFlutterTesterAssetUri).readAsString(),
       isNot(contains('package:bar/bar.dart')),
     );
     expect(
@@ -323,7 +328,6 @@ void main() {
   }, () async {
     final File packageConfig =
         environment.projectDir.childFile('.dart_tool/package_config.json');
-    final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile('native_assets.yaml').uri;
     await packageConfig.parent.create();
     await packageConfig.create();
     expect(
@@ -333,7 +337,6 @@ void main() {
         },
         targetPlatform: TargetPlatform.linux_x64,
         projectUri: projectUri,
-        nativeAssetsYamlUri: nonFlutterTesterAssetUri,
         fileSystem: fileSystem,
         buildRunner: FakeFlutterNativeAssetsBuildRunner(
           packagesWithNativeAssetsResult: <Package>[

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -71,7 +72,7 @@ void main() {
         ProcessManager: () => FakeProcessManager.empty(),
       }, () async {
         final File packageConfig = environment.projectDir.childDirectory('.dart_tool').childFile('package_config.json');
-        final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile('native_assets.yaml').uri;
+        final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename).uri;
         await packageConfig.parent.create();
         await packageConfig.create();
         final File dylibAfterCompiling = fileSystem.file('bar.dll');
@@ -98,17 +99,31 @@ void main() {
               : FakeFlutterNativeAssetsBuilderResult.fromAssets(codeAssets: codeAssets,
           ),
         );
-        final (_, Uri nativeAssetsYaml) = await runFlutterSpecificDartBuild(
-          environmentDefines: <String, String>{
-            kBuildMode: buildMode.cliName,
-          },
+        final Map<String, String> environmentDefines = <String, String>{
+              kBuildMode: buildMode.cliName,
+        };
+        final DartBuildResult dartBuildResult = await runFlutterSpecificDartBuild(
+          environmentDefines: environmentDefines,
           targetPlatform: flutterTester
               ? TargetPlatform.tester
               : TargetPlatform.windows_x64,
           projectUri: projectUri,
-          nativeAssetsYamlUri: flutterTester ? null : nonFlutterTesterAssetUri,
           fileSystem: fileSystem,
           buildRunner: buildRunner,
+        );
+        final String expectedDirectory = flutterTester
+            ? native_assets_cli.OS.current.toString()
+            : 'windows';
+        final Uri nativeAssetsFileUri = flutterTester
+            ? projectUri.resolve('build/native_assets/$expectedDirectory/${InstallCodeAssets.nativeAssetsFilename}')
+            : nonFlutterTesterAssetUri;
+        await installCodeAssets(
+          dartBuildResult: dartBuildResult,
+          environmentDefines: environmentDefines,
+          targetPlatform: TargetPlatform.android_arm64,
+          projectUri: projectUri,
+          fileSystem: fileSystem,
+          nativeAssetsFileUri: nonFlutterTesterAssetUri,
         );
         final String expectedOS = flutterTester
             ? native_assets_cli.Target.current.toString()
@@ -120,16 +135,8 @@ void main() {
             'Building native assets for $expectedOS $buildMode done.',
           ]),
         );
-        final String expectedDirectory = flutterTester
-            ? native_assets_cli.OS.current.toString()
-            : 'windows';
-        expect(nativeAssetsYaml,
-               flutterTester
-                   ? projectUri.resolve('build/native_assets/$expectedDirectory/native_assets.yaml')
-                   : nonFlutterTesterAssetUri
-        );
         expect(
-          await fileSystem.file(nativeAssetsYaml).readAsString(),
+          await fileSystem.file(nativeAssetsFileUri ).readAsString(),
           stringContainsInOrder(<String>[
             'package:bar/bar.dart',
             if (flutterTester)

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -100,13 +100,14 @@ void main() {
           ),
         );
         final Map<String, String> environmentDefines = <String, String>{
-              kBuildMode: buildMode.cliName,
+          kBuildMode: buildMode.cliName,
         };
+        final TargetPlatform targetPlatform = flutterTester
+            ? TargetPlatform.tester
+            : TargetPlatform.windows_x64;
         final DartBuildResult dartBuildResult = await runFlutterSpecificDartBuild(
           environmentDefines: environmentDefines,
-          targetPlatform: flutterTester
-              ? TargetPlatform.tester
-              : TargetPlatform.windows_x64,
+          targetPlatform: targetPlatform,
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: buildRunner,
@@ -120,7 +121,7 @@ void main() {
         await installCodeAssets(
           dartBuildResult: dartBuildResult,
           environmentDefines: environmentDefines,
-          targetPlatform: TargetPlatform.android_arm64,
+          targetPlatform: targetPlatform,
           projectUri: projectUri,
           fileSystem: fileSystem,
           nativeAssetsFileUri: nonFlutterTesterAssetUri,
@@ -136,7 +137,7 @@ void main() {
           ]),
         );
         expect(
-          await fileSystem.file(nativeAssetsFileUri ).readAsString(),
+          await fileSystem.file(nativeAssetsFileUri).readAsString(),
           stringContainsInOrder(<String>[
             'package:bar/bar.dart',
             if (flutterTester)

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -124,7 +124,7 @@ void main() {
           targetPlatform: targetPlatform,
           projectUri: projectUri,
           fileSystem: fileSystem,
-          nativeAssetsFileUri: nonFlutterTesterAssetUri,
+          nativeAssetsFileUri: nativeAssetsFileUri,
         );
         final String expectedOS = flutterTester
             ? native_assets_cli.Target.current.toString()


### PR DESCRIPTION
Currently the `NativeAsset` target in flutter tools is responsible for two things:

  * performing the dart build (in the app as well as all transitive pub dependencies)
  * taking output (shared libraries) from this build and copying them around

This intermingling of responsibilities leads to more complex code and potentially unnecessary work: If the source code changed (e.g. `.c` files change) we have to run the dart build again. But doing so may result in the same shared libraries (e.g. adding comments to the `.c` code). Currently we're going to copy the shared libraries despite them having not changed, which then may cause upstream things to be dirtied (if it's based on timestamp of files) and re-built.

Instead this PR splits this `NativeAsset` into the two orthogonal pieces

* `DartBuild` target that is responsible for the dart build
* `InstallCodeAssets` that is responsible for copying shared libraries to the right place and producing a `native_assets.yaml`.

This decopuling is also prepration for a future where a dart build can produce other kinds of assets (e.g. data assets) and is used in the web build as well. (The web build would use `DartBuild` but not `InstalCodeAssets`).