### PR TITLE
Always specify types

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -37,11 +37,11 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_specify_types
+    # - always_specify_types # hurts readability
     # - always_use_package_imports # we do this commonly
     - annotate_overrides
     - annotate_redeclares
-    # - avoid_annotating_with_dynamic # conflicts with always_specify_types
+    # - avoid_annotating_with_dynamic # work-in-progress
     - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses # blocked on https://github.com/dart-lang/linter/issues/3023
     # - avoid_catching_errors # blocked on https://github.com/dart-lang/linter/issues/4998
@@ -74,7 +74,7 @@ linter:
     - avoid_slow_async_io
     - avoid_type_to_string
     - avoid_types_as_parameter_names
-    # - avoid_types_on_closure_parameters # conflicts with always_specify_types
+    # - avoid_types_on_closure_parameters # conflicts with Flutter style
     - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
     - avoid_void_async
@@ -140,7 +140,7 @@ linter:
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter
     - null_closures
-    # - omit_local_variable_types # opposite of always_specify_types
+    # - omit_local_variable_types # contradicts specify_nonobvious_local_variable_types
     # - omit_obvious_local_variable_types # not yet tested
     # - one_member_abstracts # too many false positives
     - only_throw_errors # this does get disabled in a few places where we have legacy code that uses strings et al
@@ -200,11 +200,11 @@ linter:
     - sort_constructors_first
     # - sort_pub_dependencies # prevents separating pinned transitive dependencies
     - sort_unnamed_constructors_first
-    # - specify_nonobvious_local_variable_types # not yet tested
+    - specify_nonobvious_local_variable_types
     - test_types_in_equals
     - throw_in_finally
     - tighten_type_of_initializing_formals
-    # - type_annotate_public_apis # subset of always_specify_types
+    - type_annotate_public_apis
     - type_init_formals
     - type_literal_in_constant_pattern
     # - unawaited_futures # too many false positives, especially with the way AnimationController works

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
@@ -1056,7 +1056,7 @@ class Profile {
       final dynamic value = extraData[key];
       if (value is List) {
         buffer.writeln('$key:');
-        for (final dynamic item in value) {
+        for (final Object? item in value) {
           buffer.writeln(' - $item');
         }
       } else {

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -360,7 +360,7 @@ class _MemoryIOSink implements IOSink {
   @override
   void writeAll(Iterable<dynamic> objects, [String separator = '']) {
     bool addSeparator = false;
-    for (final dynamic object in objects) {
+    for (final Object? object in objects) {
       if (addSeparator) {
         write(separator);
       }

--- a/dev/integration_tests/channels/lib/src/test_step.dart
+++ b/dev/integration_tests/channels/lib/src/test_step.dart
@@ -181,7 +181,7 @@ bool _deepEqualsMap(Map<dynamic, dynamic> a, Map<dynamic, dynamic> b) {
   if (a.length != b.length) {
     return false;
   }
-  for (final dynamic key in a.keys) {
+  for (final Object? key in a.keys) {
     if (!b.containsKey(key) || !_deepEquals(a[key], b[key])) {
       return false;
     }

--- a/dev/tools/localization/bin/gen_date_localizations.dart
+++ b/dev/tools/localization/bin/gen_date_localizations.dart
@@ -172,7 +172,7 @@ String _jsonToObject(dynamic json) {
     case Iterable<Object?>():
       final Type type = json.first.runtimeType;
       final StringBuffer buffer = StringBuffer('const <$type>[');
-      for (final dynamic value in json) {
+      for (final Object? value in json) {
         buffer.writeln('${_jsonToMap(value)},');
       }
       buffer.write(']');
@@ -197,7 +197,7 @@ String _jsonToMap(dynamic json) {
       return generateEncodedString(currentLocale, json);
     case Iterable<dynamic>():
       final StringBuffer buffer = StringBuffer('<String>[');
-      for (final dynamic value in json) {
+      for (final Object? value in json) {
         buffer.writeln('${_jsonToMap(value)},');
       }
       buffer.write(']');

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -297,7 +297,7 @@ void main() {
 
     // `Future` is disallowed in this file due to the import of
     // scheduler_tester.dart so annotations cannot be specified.
-    // ignore: always_specify_types
+    // ignore: specify_nonobvious_local_variable_types
     final result = scheduler.scheduleTask(
       () async {
         // Yield, so if awaiting `result` did not wait for completion of this

--- a/packages/flutter/test/services/message_codecs_testing.dart
+++ b/packages/flutter/test/services/message_codecs_testing.dart
@@ -81,7 +81,7 @@ bool deepEqualsMap(Map<dynamic, dynamic> valueA, Map<dynamic, dynamic> valueB) {
   if (valueA.length != valueB.length) {
     return false;
   }
-  for (final dynamic key in valueA.keys) {
+  for (final Object? key in valueA.keys) {
     if (!valueB.containsKey(key) || !deepEquals(valueA[key], valueB[key])) {
       return false;
     }

--- a/packages/flutter/test_private/test/animated_icons_private_test.dart.tmpl
+++ b/packages/flutter/test_private/test/animated_icons_private_test.dart.tmpl
@@ -396,7 +396,7 @@ class Mock {
               '${expected[count].memberName} instead.');
       if (call.positionalArguments != null && !expected[count].acceptAny) {
         int countArg = 0;
-        for (final dynamic arg in call.positionalArguments!) {
+        for (final Object? arg in call.positionalArguments!) {
           expect(arg, equals(expected[count].positionalArguments![countArg]),
               reason: 'Failed at call $count. Positional argument $countArg to ${call.memberName} '
                   'not as expected. Expected ${expected[count].positionalArguments![countArg]} '

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -1687,7 +1687,7 @@ class _IsMethodCall extends Matcher {
     if (a.length != b.length) {
       return false;
     }
-    for (final dynamic key in a.keys) {
+    for (final Object? key in a.keys) {
       if (!b.containsKey(key) || !_deepEquals(a[key], b[key])) {
         return false;
       }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -159,7 +159,7 @@ void testWidgets(
   assert(variant.values.isNotEmpty, 'There must be at least one value to test in the testing variant.');
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
   final WidgetTester tester = WidgetTester._(binding);
-  for (final dynamic value in variant.values) {
+  for (final Object? value in variant.values) {
     final String variationDescription = variant.describeValue(value);
     // IDEs may make assumptions about the format of this suffix in order to
     // support running tests directly from the editor (where they may have

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -206,7 +206,7 @@ class _MemoryIOSink implements IOSink {
   @override
   void writeAll(Iterable<dynamic> objects, [ String separator = '' ]) {
     bool addSeparator = false;
-    for (final dynamic object in objects) {
+    for (final Object? object in objects) {
       if (addSeparator) {
         write(separator);
       }

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -166,13 +166,14 @@ class _BufferedStreamController<T> {
   late final StreamController<T> _streamController = () {
     final StreamController<T> streamControllerInstance = StreamController<T>.broadcast();
       streamControllerInstance.onListen = () {
-      for (final dynamic event in _events) {
+      for (final Object? event in _events) {
         if (event is T) {
           streamControllerInstance.add(event);
         } else {
+          final iterable = event! as Iterable<Object?>;
           streamControllerInstance.addError(
-            (event as Iterable<dynamic>).first as Object,
-            event.last as StackTrace,
+            iterable.first!,
+            iterable.last! as StackTrace,
           );
         }
       }

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -563,7 +563,7 @@ bool _mapsEqual(Map<dynamic, dynamic>? a, Map<dynamic, dynamic>? b) {
     return false;
   }
 
-  for (final dynamic k in a.keys) {
+  for (final Object? k in a.keys) {
     final dynamic bValue = b[k];
     if (bValue == null && !b.containsKey(k)) {
       return false;

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -153,7 +153,7 @@ class MemoryIOSink implements IOSink {
   @override
   void writeAll(Iterable<dynamic> objects, [ String separator = '' ]) {
     bool addSeparator = false;
-    for (final dynamic object in objects) {
+    for (final Object? object in objects) {
       if (addSeparator) {
         write(separator);
       }


### PR DESCRIPTION
<details> <summary><b>always_specify_types</b> has some false positives.</summary>

<br>

Specifically, [**always_specify_types**](https://dart.dev/lints/always_specify_types) is not satisfied by a constructor or type cast, leading to the same type annotation showing up twice in the same line.

https://github.com/flutter/flutter/blob/4b818b56c2607ed0f952db48613e0704b77a238f/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart#L31

https://github.com/flutter/flutter/blob/4b818b56c2607ed0f952db48613e0704b77a238f/packages/flutter_tools/lib/src/commands/validate_project.dart#L37

https://github.com/flutter/flutter/blob/4b818b56c2607ed0f952db48613e0704b77a238f/packages/flutter_tools/lib/src/commands/daemon.dart#L653

https://github.com/flutter/flutter/blob/4b818b56c2607ed0f952db48613e0704b77a238f/packages/flutter_tools/test/general.shard/project_test.dart#L1780

https://github.com/flutter/flutter/blob/4b818b56c2607ed0f952db48613e0704b77a238f/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart#L265

</details>

<br>

The [**ideal replacement**](https://dart.dev/lints/specify_nonobvious_local_variable_types) is currently lying dormant in our config file, marked as "not yet tested".

https://github.com/flutter/flutter/blob/4b818b56c2607ed0f952db48613e0704b77a238f/analysis_options.yaml#L203

So let's test it out!

<hr>

**Edit:** based on https://github.com/flutter/flutter/issues/158954#issuecomment-2484106030, it sounds like this will likely be a post-monorepo change.