### PR TITLE
Stop generate both `.kts` and non-`.kts` gradle files for a test project.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/android_plugin_skip_unsupported_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_skip_unsupported_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/cache.dart';
 
 import '../src/common.dart';
+import 'test_data/deferred_components_config.dart';
 import 'test_data/plugin_each_settings_gradle_project.dart';
 import 'test_data/plugin_project.dart';
 import 'test_data/project.dart';
@@ -120,6 +121,28 @@ void main() {
     expect(buildApkResult.stderr.toString(),
         isNot(contains('Please fix your settings.gradle')));
     expect(buildApkResult, const ProcessResultMatcher());
+
+    // Regression check for https://github.com/flutter/flutter/issues/158962.
+    {
+      final Directory androidDir = project.dir.childDirectory('android');
+      expect(
+        androidDir.childFile('settings.gradle.kts'),
+        exists,
+        reason:
+            'Modern flutter create --platforms android template creates this',
+      );
+      expect(
+        androidDir.childFile('settings.gradle'),
+        isNot(exists),
+        reason: ''
+            'flutter create should have created a settings.gradle.kts file '
+            'but not a settings.gradle file. Prior to the change in the PR '
+            'addressing https://github.com/flutter/flutter/issues/158962 '
+            'both files were created, which means that tooling picked one '
+            'and not the other, which causes ambiguity for debugging test '
+            'flakes.',
+      );
+    }
   });
 
   // TODO(54566): Remove test when issue is resolved.
@@ -188,11 +211,23 @@ dependencies:
 
 /// Project that load's a plugin from the specified path.
 class PluginWithPathAndroidProject extends PluginProject {
+  // Intentionally omit; this test case has nothing to do with deferred
+  // components and a DefererdComponentsConfig will cause duplicates of files
+  // such as build.gradle{.kts}, settings.gradle{kts} and related to be
+  // generated, which in turn adds ambiguity to how the tests are built and
+  // executed.
+  //
+  // See https://github.com/flutter/flutter/issues/158962.
+  @override
+  DeferredComponentsConfig? get deferredComponents => null;
+
   @override
   String get pubspec => pubspecWithPluginPath;
 }
 
-// TODO(54566): Remove class when issue is resolved.
+// TODO(matanlurey): Remove class when `.flutter-plugins` is no longer emitted.
+// See https://github.com/flutter/flutter/issues/48918.
+
 /// [PluginEachSettingsGradleProject] that load's a plugin from the specified
 /// path.
 class PluginEachWithPathAndroidProject extends PluginEachSettingsGradleProject {
@@ -200,7 +235,9 @@ class PluginEachWithPathAndroidProject extends PluginEachSettingsGradleProject {
   String get pubspec => pubspecWithPluginPath;
 }
 
-// TODO(54566): Remove class when issue is resolved.
+// TODO(matanlurey): Remove class when `.flutter-plugins` is no longer emitted.
+// See https://github.com/flutter/flutter/issues/48918.
+
 /// [PluginCompromisedEachSettingsGradleProject] that load's a plugin from the
 /// specified path.
 class PluginCompromisedEachWithPathAndroidProject

--- a/packages/flutter_tools/test/integration.shard/android_plugin_skip_unsupported_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_skip_unsupported_test.dart
@@ -115,7 +115,7 @@ void main() {
   test(
       'skip plugin with android folder if it does not support the Android platform',
       () async {
-    final Project project = PluginWithPathAndroidProject();
+    final Project project = PluginWithPathAndroidProjectWithoutDeferred();
     final ProcessResult buildApkResult = await testUnsupportedPlugin(
         project: project, createAndroidPluginFolder: true);
     expect(buildApkResult.stderr.toString(),
@@ -210,7 +210,7 @@ dependencies:
 ''';
 
 /// Project that load's a plugin from the specified path.
-class PluginWithPathAndroidProject extends PluginProject {
+class PluginWithPathAndroidProjectWithoutDeferred extends PluginProject {
   // Intentionally omit; this test case has nothing to do with deferred
   // components and a DefererdComponentsConfig will cause duplicates of files
   // such as build.gradle{.kts}, settings.gradle{kts} and related to be
@@ -221,6 +221,12 @@ class PluginWithPathAndroidProject extends PluginProject {
   @override
   DeferredComponentsConfig? get deferredComponents => null;
 
+  @override
+  String get pubspec => pubspecWithPluginPath;
+}
+
+/// Project that load's a plugin from the specified path.
+class PluginWithPathAndroidProject extends PluginProject {
   @override
   String get pubspec => pubspecWithPluginPath;
 }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/158962.