### PR TITLE
Further skip `native_assets_test`(s) that runs `flutter build apk`.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -220,7 +220,11 @@ void main() {
           }
           expectCCompilerIsConfigured(exampleDirectory);
         });
-      });
+      },
+      // TODO(matanlurey): Debug why flutter build apk often timesout.
+      // See https://github.com/flutter/flutter/issues/158560 for details.
+      skip: buildSubcommand == 'apk' ? 'flutter build apk times out' : false, // Temporary workaround for https://github.com/flutter/flutter/issues/158560.
+      );
     }
   }
 


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/158560.

Still occurred twice in the last 24h:

https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20tool_integration_tests_6_6/42/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20tool_integration_tests_6_6/44/overview

Let's continue to debug why these are so troublesome, but not block the tree doing so.