### PR TITLE
Try running historically flaky tests first to make `flutter build apk` health tests time out more often?

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -247,6 +247,7 @@ Future<void> _runFlutterBuildApkHealthTests() async {
     forceSingleCore: true,
     testPaths: selectIndexOfTotalSubshard<String>(toolIntegrationTests, subshardKey: '6_6'),
     collectMetrics: true,
+    runSkipped: true,
   );
 
   // Then run the health tests after.

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -236,7 +236,8 @@ Future<void> _runIntegrationToolTests() async {
 }
 
 Future<void> _runFlutterBuildApkHealthTests() async {
-  final List<String> allTests = Directory(path.join(_toolsPath, 'test', 'flutter_build_apk.shard'))
+  // Try "priming" the test environment by running historically problematic tests first.
+  final List<String> toolIntegrationTests = Directory(path.join(_toolsPath, 'test', 'integration.shard'))
       .listSync(recursive: true).whereType<File>()
       .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
       .where((String testPath) => path.basename(testPath).endsWith('_test.dart')).toList();
@@ -244,7 +245,20 @@ Future<void> _runFlutterBuildApkHealthTests() async {
   await runDartTest(
     _toolsPath,
     forceSingleCore: true,
-    testPaths: selectIndexOfTotalSubshard<String>(allTests),
+    testPaths: selectIndexOfTotalSubshard<String>(toolIntegrationTests, subshardKey: '6_6'),
+    collectMetrics: true,
+  );
+
+  // Then run the health tests after.
+  final List<String> flutterBuildApkTests = Directory(path.join(_toolsPath, 'test', 'flutter_build_apk.shard'))
+      .listSync(recursive: true).whereType<File>()
+      .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
+      .where((String testPath) => path.basename(testPath).endsWith('_test.dart')).toList();
+
+  await runDartTest(
+    _toolsPath,
+    forceSingleCore: true,
+    testPaths: selectIndexOfTotalSubshard<String>(flutterBuildApkTests),
     collectMetrics: true,
   );
 }

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -342,6 +342,7 @@ Future<void> runDartTest(String workingDirectory, {
   bool ensurePrecompiledTool = true,
   bool shuffleTests = true,
   bool collectMetrics = false,
+  bool runSkipped = false,
 }) async {
   int? cpus;
   final String? cpuVariable = Platform.environment['CPU']; // CPU is set in cirrus.yml
@@ -379,6 +380,8 @@ Future<void> runDartTest(String workingDirectory, {
       '--coverage=$coverage',
     if (perTestTimeout != null)
       '--timeout=${perTestTimeout.inMilliseconds}ms',
+    if (runSkipped)
+      '--run-skipped',
     if (testPaths != null)
       for (final String testPath in testPaths)
         testPath,


### PR DESCRIPTION
I have no idea if this will work, but `6_6` is currently the suite that seems to have the most problems.

Towards https://github.com/flutter/flutter/issues/158560.