### PR TITLE
Update `image_filter_test` and `color_filter_test.dart` for Material 3

### DIFF
--- a/packages/flutter/test/widgets/color_filter_test.dart
+++ b/packages/flutter/test/widgets/color_filter_test.dart
@@ -30,8 +30,7 @@ void main() {
     );
   });
 
-  testWidgets('Color filter - sepia', (WidgetTester tester) async {
-
+  testWidgets('Material2 - Color filter - sepia', (WidgetTester tester) async {
     const ColorFilter sepia = ColorFilter.matrix(<double>[
       0.39,  0.769, 0.189, 0, 0, //
       0.349, 0.686, 0.168, 0, 0, //
@@ -65,7 +64,45 @@ void main() {
     );
     await expectLater(
       find.byType(ColorFiltered),
-      matchesGoldenFile('color_filter_sepia.png'),
+      matchesGoldenFile('color_filter_sepia_m2.png'),
+    );
+  }, skip: impellerEnabled); // https://github.com/flutter/flutter/issues/143616
+
+  testWidgets('Color filter - sepia', (WidgetTester tester) async {
+    const ColorFilter sepia = ColorFilter.matrix(<double>[
+      0.39,  0.769, 0.189, 0, 0, //
+      0.349, 0.686, 0.168, 0, 0, //
+      0.272, 0.534, 0.131, 0, 0, //
+      0,     0,     0,     1, 0, //
+    ]);
+    await tester.pumpWidget(
+      RepaintBoundary(
+        child: ColorFiltered(
+          colorFilter: sepia,
+          child: MaterialApp(
+            debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
+            title: 'Flutter Demo',
+            theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue)),
+            home: Scaffold(
+              appBar: AppBar(
+                title: const Text('Sepia ColorFilter Test'),
+              ),
+              body: const Center(
+                child:Text('Hooray!'),
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () { },
+                tooltip: 'Increment',
+                child: const Icon(Icons.add),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await expectLater(
+      find.byType(ColorFiltered),
+      matchesGoldenFile('color_filter_sepia_m3.png'),
     );
   }, skip: impellerEnabled); // https://github.com/flutter/flutter/issues/143616
 

--- a/packages/flutter/test/widgets/image_filter_test.dart
+++ b/packages/flutter/test/widgets/image_filter_test.dart
@@ -84,10 +84,10 @@ void main() {
 
   testWidgets('Material2 - Image filter - matrix', (WidgetTester tester) async {
     final ImageFilter matrix = ImageFilter.matrix(Float64List.fromList(<double>[
-      0.5, 0.0, 0.0, 0.0, //
-      0.0, 0.5, 0.0, 0.0, //
-      0.0, 0.0, 1.0, 0.0, //
-      0.0, 0.0, 0.0, 1.0, //
+      0.5, 0.0, 0.0, 0.0,
+      0.0, 0.5, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      0.0, 0.0, 0.0, 1.0,
     ]));
     await tester.pumpWidget(
       RepaintBoundary(
@@ -122,10 +122,10 @@ void main() {
 
   testWidgets('Image filter - matrix', (WidgetTester tester) async {
     final ImageFilter matrix = ImageFilter.matrix(Float64List.fromList(<double>[
-      0.5, 0.0, 0.0, 0.0, //
-      0.0, 0.5, 0.0, 0.0, //
-      0.0, 0.0, 1.0, 0.0, //
-      0.0, 0.0, 0.0, 1.0, //
+      0.5, 0.0, 0.0, 0.0,
+      0.0, 0.5, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      0.0, 0.0, 0.0, 1.0,
     ]));
     await tester.pumpWidget(
       RepaintBoundary(

--- a/packages/flutter/test/widgets/image_filter_test.dart
+++ b/packages/flutter/test/widgets/image_filter_test.dart
@@ -82,7 +82,7 @@ void main() {
     );
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/101874
 
-  testWidgets('Image filter - matrix', (WidgetTester tester) async {
+  testWidgets('Material2 - Image filter - matrix', (WidgetTester tester) async {
     final ImageFilter matrix = ImageFilter.matrix(Float64List.fromList(<double>[
       0.5, 0.0, 0.0, 0.0, //
       0.0, 0.5, 0.0, 0.0, //
@@ -116,11 +116,49 @@ void main() {
     );
     await expectLater(
       find.byType(ImageFiltered),
-      matchesGoldenFile('image_filter_matrix.png'),
+      matchesGoldenFile('image_filter_matrix_m2.png'),
     );
   });
 
-  testWidgets('Image filter - matrix with offset', (WidgetTester tester) async {
+  testWidgets('Image filter - matrix', (WidgetTester tester) async {
+    final ImageFilter matrix = ImageFilter.matrix(Float64List.fromList(<double>[
+      0.5, 0.0, 0.0, 0.0, //
+      0.0, 0.5, 0.0, 0.0, //
+      0.0, 0.0, 1.0, 0.0, //
+      0.0, 0.0, 0.0, 1.0, //
+    ]));
+    await tester.pumpWidget(
+      RepaintBoundary(
+        child: ImageFiltered(
+          imageFilter: matrix,
+          child: MaterialApp(
+            title: 'Flutter Demo',
+            theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue)),
+            debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
+            home: Scaffold(
+              appBar: AppBar(
+                title: const Text('Matrix ImageFilter Test'),
+              ),
+              body: const Center(
+                child:Text('Hooray!'),
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () { },
+                tooltip: 'Increment',
+                child: const Icon(Icons.add),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await expectLater(
+      find.byType(ImageFiltered),
+      matchesGoldenFile('image_filter_matrix_m3.png'),
+    );
+  });
+
+  testWidgets('Material2 - Image filter - matrix with offset', (WidgetTester tester) async {
     final Matrix4 matrix = Matrix4.rotationZ(pi / 18);
     final ImageFilter matrixFilter = ImageFilter.matrix(matrix.storage);
     final Key key = GlobalKey();
@@ -155,7 +193,46 @@ void main() {
     );
     await expectLater(
       find.byKey(key),
-      matchesGoldenFile('image_filter_matrix_offset.png'),
+      matchesGoldenFile('image_filter_matrix_offset_m2.png'),
+    );
+  });
+
+  testWidgets('Image filter - matrix with offset', (WidgetTester tester) async {
+    final Matrix4 matrix = Matrix4.rotationZ(pi / 18);
+    final ImageFilter matrixFilter = ImageFilter.matrix(matrix.storage);
+    final Key key = GlobalKey();
+    await tester.pumpWidget(
+      RepaintBoundary(
+        key: key,
+        child: Transform.translate(
+          offset: const Offset(50, 50),
+          child: ImageFiltered(
+            imageFilter: matrixFilter,
+            child: MaterialApp(
+              title: 'Flutter Demo',
+              theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue)),
+              debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
+              home: Scaffold(
+                appBar: AppBar(
+                  title: const Text('Matrix ImageFilter Test'),
+                ),
+                body: const Center(
+                  child:Text('Hooray!'),
+                ),
+                floatingActionButton: FloatingActionButton(
+                  onPressed: () { },
+                  tooltip: 'Increment',
+                  child: const Icon(Icons.add),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('image_filter_matrix_offset_m3.png'),
     );
   });
 


### PR DESCRIPTION
Updated unit tests for `ColorFiltered` and `ImageFiltered` to have M2 and M3 versions.

More info in #139076

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
