### PR TITLE
Define and use `flutterBin` consistently across `integration.shard`.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -20,7 +20,6 @@ const String runDevToolsMessage = 'dart devtools ';
 void main() {
   testWithoutContext('--analyze-size flag produces expected output on hello_world for Android', () async {
     final String workingDirectory = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'build',
@@ -53,7 +52,6 @@ void main() {
 
   testWithoutContext('--analyze-size flag produces expected output on hello_world for iOS', () async {
     final String workingDirectory = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final Directory tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_size_test.');
     final Directory codeSizeDir = tempDir.childDirectory('code size dir')..createSync();
     final ProcessResult result = await processManager.run(<String>[
@@ -91,7 +89,6 @@ void main() {
 
   testWithoutContext('--analyze-size flag produces expected output on hello_world for macOS', () async {
     final String workingDirectory = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final Directory tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_size_test.');
     final Directory codeSizeDir = tempDir.childDirectory('code size dir')..createSync();
 
@@ -143,7 +140,6 @@ void main() {
   }, skip: !platform.isMacOS); // [intended] this is a macos only test.
 
   testWithoutContext('--analyze-size is only supported in release mode', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'build',
@@ -163,7 +159,6 @@ void main() {
   });
 
   testWithoutContext('--analyze-size is not supported in combination with --split-debug-info', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final List<String> command = <String>[
       flutterBin,
       'build',
@@ -188,7 +183,6 @@ void main() {
   });
 
   testWithoutContext('--analyze-size allows overriding the directory for code size files', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final Directory tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_size_test.');
 
     final List<String> command = <String>[

--- a/packages/flutter_tools/test/integration.shard/android_e2e_api_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_e2e_api_test.dart
@@ -20,7 +20,6 @@ void main() {
   });
 
   testWithoutContext('build succeeds with api 33 features', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'create',

--- a/packages/flutter_tools/test/integration.shard/android_gradle_daemon_cache_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_daemon_cache_test.dart
@@ -22,8 +22,6 @@ void main() {
   testWithoutContext(
       'gradle task succeeds when adding plugins with gradle daemon enabled',
       () async {
-    final String flutterBin =
-        fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final Directory appDir = tempDir.childDirectory('testapp');
     final Directory androidDir = appDir.childDirectory('android');
 

--- a/packages/flutter_tools/test/integration.shard/android_gradle_deprecated_plugin_apply_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_deprecated_plugin_apply_test.dart
@@ -24,8 +24,6 @@ void main() {
   testWithoutContext(
       'gradle prints warning when Flutter\'s Gradle plugins are applied using deprecated "apply plugin" way', () async {
     // Create a new flutter project.
-    final String flutterBin =
-    fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'create',

--- a/packages/flutter_tools/test/integration.shard/android_gradle_flutter_source_path_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_flutter_source_path_test.dart
@@ -29,11 +29,6 @@ void main() {
     final Project project = DeferredComponentsProject(
       MissingFlutterSourcePathDeferredComponentsConfig(),
     );
-    final String flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
 
     final Directory exampleAppDir = tempDir.childDirectory('example');
     await project.setUpIn(exampleAppDir);

--- a/packages/flutter_tools/test/integration.shard/android_gradle_java_version_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_java_version_test.dart
@@ -24,8 +24,6 @@ void main() {
   testWithoutContext(
       'gradle task exists named javaVersion that prints jdk version', () async {
     // Create a new flutter project.
-    final String flutterBin =
-        fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'create',

--- a/packages/flutter_tools/test/integration.shard/android_gradle_legacy_flutter_plugins_strings_in_comments_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_legacy_flutter_plugins_strings_in_comments_test.dart
@@ -24,12 +24,6 @@ void main() {
   });
 
   test('should build Android app with commented-out ".flutter-plugins" in settings.gradle', () async {
-    final String flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
-
     // Create Android app project instead of plugin
     processManager.runSync(<String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
@@ -278,8 +278,6 @@ void main() {
   testWithoutContext(
       'gradle task outputs<mode>AppLinkSettings works when a project has app links', () async {
     // Create a new flutter project.
-    final String flutterBin =
-    fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'create',
@@ -345,8 +343,6 @@ void main() {
   testWithoutContext(
       'gradle task outputs<mode>AppLinkSettings works when a project does not have app link and the flutter_deeplinking_enabled flag', () async {
     // Create a new flutter project.
-    final String flutterBin =
-    fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'create',

--- a/packages/flutter_tools/test/integration.shard/android_gradle_print_build_variants_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_print_build_variants_test.dart
@@ -27,8 +27,6 @@ void main() {
   testWithoutContext(
       'gradle task exists named printBuildVariants that prints build variants', () async {
     // Create a new flutter project.
-    final String flutterBin =
-    fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'create',

--- a/packages/flutter_tools/test/integration.shard/android_plugin_compilesdkversion_mismatch_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_compilesdkversion_mismatch_test.dart
@@ -24,12 +24,6 @@ void main() {
   });
 
   test('error logged when plugin Android compileSdk version higher than project', () async {
-    final String flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
-
     // Create dummy plugin
     processManager.runSync(<String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
@@ -28,12 +28,6 @@ void main() {
     required String template,
     required Directory tempDir,
   }) async {
-    final String flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
-
     final String testName = '${template}_test';
 
     ProcessResult result = processManager.runSync(<String>[

--- a/packages/flutter_tools/test/integration.shard/android_plugin_ndkversion_mismatch_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_ndkversion_mismatch_test.dart
@@ -23,12 +23,6 @@ void main() {
   });
 
   test('error logged when plugin Android ndkVersion higher than project', () async {
-    final String flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
-
     // Create dummy plugin
     processManager.runSync(<String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
@@ -26,11 +26,6 @@ void main() {
   });
 
   test('plugins use individualized build directories based on their name.', () async {
-    final String flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
     // create flutter module project
     ProcessResult result = processManager.runSync(<String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/android_plugin_skip_unsupported_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_skip_unsupported_test.dart
@@ -37,12 +37,6 @@ void main() {
     required Project project,
     required bool createAndroidPluginFolder,
   }) async {
-    final String flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
-
     // Create dummy plugin that supports iOS and optionally Android.
     processManager.runSync(<String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/asset_transformation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/asset_transformation_test.dart
@@ -67,11 +67,6 @@ Future<void> main() async {
         ..createSync(recursive: true)
         ..writeAsStringSync('abc');
 
-      final String flutterBin = fileSystem.path.join(
-        getFlutterRoot(),
-        'bin',
-        'flutter',
-      );
       final ProcessResult result = await processManager.run(
         <String>[
           flutterBin,

--- a/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
@@ -17,7 +17,6 @@ void main() {
       'integration_tests',
       'flutter_gallery',
     );
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
 
     await processManager.run(<String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/build_macos_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_macos_config_only_test.dart
@@ -17,7 +17,6 @@ void main() {
       'integration_tests',
       'flutter_gallery',
     );
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
 
     await processManager.run(<String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/build_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_preview_test.dart
@@ -18,7 +18,6 @@ void main() {
 
   late Directory tempDir;
   final FileSystem fs = LocalFileSystemBlockingSetCurrentDirectory();
-  final String flutterBin = fs.path.join(getFlutterRoot(), 'bin', 'flutter');
   final File previewBin = fs
           .directory(getFlutterRoot())
           .childDirectory('bin')

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -16,7 +16,6 @@ import 'test_utils.dart';
 
 void main() {
   testWithoutContext('All development tools and deprecated commands are hidden and help text is not verbose', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       '-h',
@@ -34,7 +33,6 @@ void main() {
   });
 
   testWithoutContext('Flutter help is shown with -? command line argument', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       '-?',
@@ -48,7 +46,6 @@ void main() {
   });
 
   testWithoutContext('flutter doctor is not verbose', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'doctor',
@@ -60,7 +57,6 @@ void main() {
   });
 
   testWithoutContext('flutter doctor -vv super verbose', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'doctor',
@@ -72,7 +68,6 @@ void main() {
   });
 
   testWithoutContext('flutter config --list contains all features', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'config',
@@ -99,7 +94,6 @@ void main() {
         .childDirectory('lib')
         .childFile('main.dart')
         .createSync(recursive: true);
-      final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
       final ProcessResult result = await processManager.run(<String>[
         flutterBin,
         'run',
@@ -115,7 +109,6 @@ void main() {
   });
 
   testWithoutContext('flutter attach --machine uses AppRunLogger', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'attach',
@@ -127,7 +120,6 @@ void main() {
   });
 
   testWithoutContext('flutter --version --machine outputs JSON with flutterRoot', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       '--version',
@@ -145,7 +137,6 @@ void main() {
 
   testWithoutContext('A tool exit is thrown for an invalid debug-url in flutter attach', () async {
     // This test is almost exactly like the next one; update them together please.
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final String helloWorld = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
@@ -164,7 +155,6 @@ void main() {
 
   testWithoutContext('--debug-uri is an alias for --debug-url', () async {
     // This text is exactly the same as the previous one but with a "l" turned to an "i".
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final String helloWorld = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
@@ -186,8 +176,6 @@ void main() {
   });
 
   testWithoutContext('will load bootstrap script before starting', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
-
     final File bootstrap = fileSystem.file(fileSystem.path.join(
       getFlutterRoot(),
       'bin',
@@ -208,7 +196,6 @@ void main() {
   });
 
   testWithoutContext('Providing sksl bundle with missing file with tool exit', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final String helloWorld = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
@@ -224,7 +211,6 @@ void main() {
   });
 
   testWithoutContext('flutter attach does not support --release', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final String helloWorld = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
@@ -238,7 +224,6 @@ void main() {
   });
 
   testWithoutContext('flutter can report crashes', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'update-packages',
@@ -255,7 +240,6 @@ void main() {
   });
 
   testWithoutContext('flutter supports trailing args', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final String helloWorld = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,

--- a/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
@@ -31,8 +31,6 @@ void main() {
     final BasicProject project = BasicProject();
     await project.setUpIn(tempDir);
 
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
-
     const ProcessManager processManager = LocalProcessManager();
     daemonProcess = await processManager.start(
       <String>[flutterBin, ...getLocalEngineArguments(), '--show-test-device', 'daemon'],

--- a/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
@@ -30,7 +30,6 @@ void main() {
   testWithoutContext('simple build appbundle android-arm64 target succeeds', () async {
     final DeferredComponentsProject project = DeferredComponentsProject(BasicDeferredComponentsConfig());
     await project.setUpIn(tempDir);
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
@@ -64,7 +63,6 @@ void main() {
   testWithoutContext('simple build appbundle all targets succeeds', () async {
     final DeferredComponentsProject project = DeferredComponentsProject(BasicDeferredComponentsConfig());
     await project.setUpIn(tempDir);
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
@@ -109,7 +107,6 @@ void main() {
   testWithoutContext('simple build appbundle no-deferred-components succeeds', () async {
     final DeferredComponentsProject project = DeferredComponentsProject(BasicDeferredComponentsConfig());
     await project.setUpIn(tempDir);
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
@@ -153,7 +150,6 @@ void main() {
   testWithoutContext('simple build appbundle mismatched golden no-validate-deferred-components succeeds', () async {
     final DeferredComponentsProject project = DeferredComponentsProject(MismatchedGoldenDeferredComponentsConfig());
     await project.setUpIn(tempDir);
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
@@ -199,7 +195,6 @@ void main() {
   testWithoutContext('simple build appbundle missing android dynamic feature module fails', () async {
     final DeferredComponentsProject project = DeferredComponentsProject(NoAndroidDynamicFeatureModuleDeferredComponentsConfig());
     await project.setUpIn(tempDir);
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
@@ -221,7 +216,6 @@ void main() {
   testWithoutContext('simple build appbundle missing golden fails', () async {
     final DeferredComponentsProject project = DeferredComponentsProject(NoGoldenDeferredComponentsConfig());
     await project.setUpIn(tempDir);
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
@@ -243,7 +237,6 @@ void main() {
   testWithoutContext('simple build appbundle mismatched golden fails', () async {
     final DeferredComponentsProject project = DeferredComponentsProject(MismatchedGoldenDeferredComponentsConfig());
     await project.setUpIn(tempDir);
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       ...getLocalEngineArguments(),

--- a/packages/flutter_tools/test/integration.shard/deprecated_gradle_settings_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deprecated_gradle_settings_test.dart
@@ -15,7 +15,6 @@ import 'test_utils.dart';
 void main() {
   test('android project using deprecated settings.gradle will still build', () async {
     final String workingDirectory = fileSystem.path.join(getFlutterRoot(), 'dev', 'integration_tests', 'gradle_deprecated_settings');
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
 
     final File settingsDotGradleFile = fileSystem.file(
         fileSystem.path.join(workingDirectory, 'android', 'settings.gradle'));

--- a/packages/flutter_tools/test/integration.shard/devtools_uri_test.dart
+++ b/packages/flutter_tools/test/integration.shard/devtools_uri_test.dart
@@ -30,7 +30,6 @@ void main() {
     final Completer<void> completer = Completer<void>();
     const String matcher = 'The Flutter DevTools debugger and profiler on';
 
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final Process process = await processManager.start(<String>[
       flutterBin,
       'run',

--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -23,7 +23,6 @@ final BufferLogger logger = BufferLogger.test(
   outputPreferences: OutputPreferences.test(wrapText: true),
 );
 final ProcessUtils processUtils = ProcessUtils(processManager: processManager, logger: logger);
-final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', platform.isWindows ? 'flutter.bat' : 'flutter');
 
 /// A test for flutter upgrade & downgrade that checks out a parallel flutter repo.
 void main() {

--- a/packages/flutter_tools/test/integration.shard/flutter_build_android_app_project_builddir_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_android_app_project_builddir_test.dart
@@ -16,16 +16,10 @@ import 'test_utils.dart';
 // project in the test.
 void main() {
   late Directory tempDir;
-  late String flutterBin;
   late Directory exampleAppDir;
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('flutter_plugin_test.');
-    flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
     exampleAppDir = tempDir.childDirectory('aaa').childDirectory('example');
 
     processManager.runSync(<String>[

--- a/packages/flutter_tools/test/integration.shard/flutter_build_apk_verbose_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_apk_verbose_test.dart
@@ -11,16 +11,10 @@ import 'test_utils.dart';
 // Test that verbosity it propagated to Gradle tasks correctly.
 void main() {
   late Directory tempDir;
-  late String flutterBin;
   late Directory exampleAppDir;
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('flutter_build_test.');
-    flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
     exampleAppDir = tempDir.childDirectory('aaa').childDirectory('example');
 
     processManager.runSync(<String>[

--- a/packages/flutter_tools/test/integration.shard/flutter_build_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_config_only_test.dart
@@ -12,16 +12,10 @@ import 'test_utils.dart';
 // Test that configOnly creates the gradlew file and does not assemble and app.
 void main() {
   late Directory tempDir;
-  late String flutterBin;
   late Directory exampleAppDir;
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('flutter_build_test.');
-    flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
     exampleAppDir = tempDir.childDirectory('bbb').childDirectory('example');
 
     processManager.runSync(

--- a/packages/flutter_tools/test/integration.shard/flutter_build_wasm_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_wasm_test.dart
@@ -12,16 +12,10 @@ import 'test_utils.dart';
 
 void main() {
   late Directory tempDir;
-  late String flutterBin;
   late Directory exampleAppDir;
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('flutter_web_wasm_test.');
-    flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
     exampleAppDir = tempDir.childDirectory('test_app');
 
     processManager.runSync(<String>[

--- a/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
@@ -15,18 +15,12 @@ import 'test_utils.dart';
 void main() {
   late Directory tempDir;
   late Directory projectRoot;
-  late String flutterBin;
   late Directory releaseDir;
   late File exeFile;
 
   group('flutter build windows command', () {
     setUpAll(() {
       tempDir = createResolvedTempDirectorySync('build_windows_test.');
-      flutterBin = fileSystem.path.join(
-        getFlutterRoot(),
-        'bin',
-        'flutter',
-      );
       ProcessResult result = processManager.runSync(<String>[flutterBin, 'config',
         '--enable-windows-desktop',
       ]);

--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -11,7 +11,6 @@ import 'test_utils.dart';
 void main() {
   late Directory tempDir;
   late Directory projectRoot;
-  late String flutterBin;
   final List<String> targetPlatforms = <String>[
     'apk',
     'web',
@@ -23,11 +22,6 @@ void main() {
 
   setUpAll(() {
     tempDir = createResolvedTempDirectorySync('build_compilation_error_test.');
-    flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
     processManager.runSync(<String>[flutterBin, 'config',
       '--enable-macos-desktop',
       '--enable-windows-desktop',

--- a/packages/flutter_tools/test/integration.shard/flutter_plugins_dependencies_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_plugins_dependencies_test.dart
@@ -30,9 +30,6 @@ void main() {
       '.flutter-plugins-dependencies correctly denotes project dev dependencies on all default platforms',
       () async {
     // Create Flutter project.
-    final String flutterBin =
-        fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
-
     await processManager.run(<String>[
       flutterBin,
       'create',

--- a/packages/flutter_tools/test/integration.shard/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_run_test.dart
@@ -32,7 +32,6 @@ void main() {
     // like https://github.com/flutter/flutter/issues/21418 which were skipped
     // over because other integration tests run using flutter-tester which short-cuts
     // some of the checks for devices.
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
 
     const ProcessManager processManager = LocalProcessManager();
     final ProcessResult proc = await processManager.run(

--- a/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
@@ -31,12 +31,6 @@ void main() {
   });
 
   testWithoutContext('flutter run in non-machine mode reports an early error in an application', () async {
-    final String flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
-
     final StringBuffer stdout = StringBuffer();
 
     final Process process = await processManager.start(<String>[

--- a/packages/flutter_tools/test/integration.shard/gradle_non_android_plugin_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gradle_non_android_plugin_test.dart
@@ -21,12 +21,6 @@ void main() {
   });
 
   testWithoutContext('Flutter app that depends on a non-Android plugin can still build for Android', () {
-    final String flutterRoot = getFlutterRoot();
-    final String flutterBin = fileSystem.path.join(
-      flutterRoot,
-      'bin',
-      'flutter',
-    );
     processManager.runSync(<String>[
       flutterBin,
       ...getLocalEngineArguments(),

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_agp_version_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_agp_version_test.dart
@@ -11,7 +11,7 @@ import 'package:file/file.dart';
 import 'package:file_testing/file_testing.dart';
 
 import '../../src/common.dart';
-import '../test_utils.dart' show platform;
+import '../test_utils.dart' show flutterBin, platform;
 import '../transition_test_utils.dart';
 import 'native_assets_test_utils.dart';
 

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -22,7 +22,7 @@ import 'package:flutter_tools/src/base/os.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
 
 import '../../src/common.dart';
-import '../test_utils.dart' show fileSystem, platform;
+import '../test_utils.dart' show fileSystem, flutterBin, platform;
 import '../transition_test_utils.dart';
 import 'native_assets_test_utils.dart';
 

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -10,7 +10,7 @@ import 'package:file_testing/file_testing.dart';
 import 'package:yaml/yaml.dart';
 
 import '../../src/common.dart';
-import '../test_utils.dart' show ProcessResultMatcher, fileSystem;
+import '../test_utils.dart' show ProcessResultMatcher, fileSystem, flutterBin;
 import '../transition_test_utils.dart';
 
 Future<Directory> createTestProject(String packageName, Directory tempDirectory) async {

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
@@ -11,7 +11,6 @@ import 'package:yaml/yaml.dart';
 
 import '../../src/common.dart';
 import '../test_utils.dart';
-import '../transition_test_utils.dart';
 import 'native_assets_test_utils.dart';
 
 /// Regression test as part of https://github.com/flutter/flutter/pull/150742.

--- a/packages/flutter_tools/test/integration.shard/observatory_port_test.dart
+++ b/packages/flutter_tools/test/integration.shard/observatory_port_test.dart
@@ -54,7 +54,6 @@ void main() {
   });
 
   testWithoutContext('flutter run --vm-service-port', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final int port = await getFreePort();
     // If only --vm-service-port is provided, --vm-service-port will be used by DDS
     // and the VM service will bind to a random port.
@@ -72,7 +71,6 @@ void main() {
   });
 
   testWithoutContext('flutter run --dds-port --vm-service-port', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final int vmServicePort = await getFreePort();
     int ddsPort = await getFreePort();
     while (ddsPort == vmServicePort) {
@@ -95,7 +93,6 @@ void main() {
   });
 
   testWithoutContext('flutter run --dds-port', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final int ddsPort = await getFreePort();
     // If only --dds-port is provided, --dds-port will be used by DDS and the VM service
     // will bind to a random port.

--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_create_app_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_create_app_test.dart
@@ -10,12 +10,6 @@ import 'swift_package_manager_utils.dart';
 import 'test_utils.dart';
 
 void main() {
-  final String flutterBin = fileSystem.path.join(
-    getFlutterRoot(),
-    'bin',
-    'flutter',
-  );
-
   final List<String> platforms = <String>['ios', 'macos'];
   for (final String platformName in platforms) {
     final List<String> iosLanguages = <String>[

--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_create_plugin_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_create_plugin_test.dart
@@ -10,12 +10,6 @@ import 'swift_package_manager_utils.dart';
 import 'test_utils.dart';
 
 void main() {
-  final String flutterBin = fileSystem.path.join(
-    getFlutterRoot(),
-    'bin',
-    'flutter',
-  );
-
   final List<String> platforms = <String>['ios', 'macos'];
   for (final String platformName in platforms) {
     final List<String> iosLanguages = <String>[

--- a/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/integration.shard/swift_package_manager_test.dart
@@ -13,12 +13,6 @@ import 'swift_package_manager_utils.dart';
 import 'test_utils.dart';
 
 void main() {
-  final String flutterBin = fileSystem.path.join(
-    getFlutterRoot(),
-    'bin',
-    'flutter',
-  );
-
   final List<String> platforms = <String>['ios', 'macos'];
   for (final String platformName in platforms) {
     final List<String> iosLanguages = <String>[

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -92,7 +92,6 @@ abstract class FlutterTestDriver {
     bool withDebugger = false,
     bool verbose = false,
   }) async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     if (withDebugger) {
       arguments.add('--start-paused');
     }

--- a/packages/flutter_tools/test/integration.shard/test_test.dart
+++ b/packages/flutter_tools/test/integration.shard/test_test.dart
@@ -17,7 +17,6 @@ final String automatedTestsDirectory = fileSystem.path.join('..', '..', 'dev', '
 final String missingDependencyDirectory = fileSystem.path.join('..', '..', 'dev', 'missing_dependency_tests');
 final String flutterTestDirectory = fileSystem.path.join(automatedTestsDirectory, 'flutter_test');
 final String integrationTestDirectory = fileSystem.path.join(automatedTestsDirectory, 'integration_test');
-final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', platform.isWindows ? 'flutter.bat' : 'flutter');
 
 // Running Integration Tests in the Flutter Tester will still exercise the same
 // flows specific to Integration Tests.

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -15,6 +15,13 @@ import 'test_driver.dart';
 /// The [FileSystem] for the integration test environment.
 const FileSystem fileSystem = LocalFileSystem();
 
+/// The (real) `flutter` binary (i.e. `{ROOT}/bin/flutter`) to execute in tests.
+final String flutterBin = fileSystem.path.join(
+  getFlutterRoot(),
+  'bin',
+  platform.isWindows ? 'flutter.bat' : 'flutter',
+);
+
 /// The [Platform] for the integration test environment.
 const Platform platform = LocalPlatform();
 

--- a/packages/flutter_tools/test/integration.shard/transition_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/transition_test_utils.dart
@@ -11,11 +11,10 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import '../src/common.dart';
-import 'test_utils.dart' show fileSystem;
+import 'test_utils.dart' show flutterBin;
 
 const ProcessManager processManager = LocalProcessManager();
 final String flutterRoot = getFlutterRoot();
-final String flutterBin = fileSystem.path.join(flutterRoot, 'bin', 'flutter');
 
 void debugPrint(String message) {
   // This is called to intentionally print debugging output when a test is


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/158875.

This should be a NOP, and just reduce the amount of copy-pasted code across tests.