### PR TITLE
Fix InkWell overlayColor resolution ignores selected state

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1286,8 +1286,8 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     final ThemeData theme = Theme.of(context);
     const Set<MaterialState> highlightableStates = <MaterialState>{MaterialState.focused, MaterialState.hovered, MaterialState.pressed};
     final Set<MaterialState> nonHighlightableStates = statesController.value.difference(highlightableStates);
-    // Each highlightable states will be resolved separatly to get the corresponding color.
-    // For this resolution to be correct, The non-highlightable states should be preserved.
+    // Each highlightable state will be resolved separately to get the corresponding color.
+    // For this resolution to be correct, the non-highlightable states should be preserved.
     final Set<MaterialState> pressed = <MaterialState>{...nonHighlightableStates, MaterialState.pressed};
     final Set<MaterialState> focused = <MaterialState>{...nonHighlightableStates, MaterialState.focused};
     final Set<MaterialState> hovered = <MaterialState>{...nonHighlightableStates, MaterialState.hovered};

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1283,12 +1283,16 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     assert(widget.debugCheckContext(context));
     super.build(context); // See AutomaticKeepAliveClientMixin.
 
-    Color getHighlightColorForType(_HighlightType type) {
-      const Set<MaterialState> pressed = <MaterialState>{MaterialState.pressed};
-      const Set<MaterialState> focused = <MaterialState>{MaterialState.focused};
-      const Set<MaterialState> hovered = <MaterialState>{MaterialState.hovered};
+    final ThemeData theme = Theme.of(context);
+    const Set<MaterialState> highlightableStates = <MaterialState>{MaterialState.focused, MaterialState.hovered, MaterialState.pressed};
+    final Set<MaterialState> nonHighlightableStates = statesController.value.difference(highlightableStates);
+    // Each highlightable states will be resolved separatly to get the corresponding color.
+    // For this resolution to be correct, The non-highlightable states should be preserved.
+    final Set<MaterialState> pressed = <MaterialState>{...nonHighlightableStates, MaterialState.pressed};
+    final Set<MaterialState> focused = <MaterialState>{...nonHighlightableStates, MaterialState.focused};
+    final Set<MaterialState> hovered = <MaterialState>{...nonHighlightableStates, MaterialState.hovered};
 
-      final ThemeData theme = Theme.of(context);
+    Color getHighlightColorForType(_HighlightType type) {
       return switch (type) {
         // The pressed state triggers a ripple (ink splash), per the current
         // Material Design spec. A separate highlight is no longer used.


### PR DESCRIPTION
## Description

This PR fixes `InkWell` overlay colors resolution.
The `InkWell` overlay color is resolved when the `InkWell` is either focused, hovered , and/or pressed.
This resolution happens at two places:
- first when the highlight is created.
- then on each build, using the inner function named `getHighlightColorForType`.
This second resolution should be aware of other current states (such as selected) as it might impact the color resolution.

For instance, several Material styles have colors resolution define similarly to:
https://github.com/flutter/flutter/blob/dc44547d0d90dfff4fd4c3bdcd525f9d7a70744e/packages/flutter/lib/src/material/date_picker_theme.dart#L982-L1006

## Related Issue

Fixes [InkWell overlay colors aren't applied on MaterialState.selected state](https://github.com/flutter/flutter/issues/159063)
First step for [Date picker overlay colors aren't applied on MaterialState.selected state](https://github.com/flutter/flutter/issues/130586).

## Tests

Adds 3 tests.