### PR TITLE
[SwiftPM] Move where the migration checks feature flags

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -18,6 +18,7 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../device.dart';
+import '../features.dart';
 import '../flutter_manifest.dart';
 import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
@@ -166,17 +167,17 @@ Future<XcodeBuildResult> buildXcodeProject({
     RemoveBitcodeMigration(app.project, globals.logger),
     XcodeThinBinaryBuildPhaseInputPathsMigration(app.project, globals.logger),
     UIApplicationMainDeprecationMigration(app.project, globals.logger),
-    if (app.project.usesSwiftPackageManager && app.project.flutterPluginSwiftPackageManifest.existsSync())
-      SwiftPackageManagerIntegrationMigration(
-        app.project,
-        SupportedPlatform.ios,
-        buildInfo,
-        xcodeProjectInterpreter: globals.xcodeProjectInterpreter!,
-        logger: globals.logger,
-        fileSystem: globals.fs,
-        plistParser: globals.plistParser,
-      ),
-      SwiftPackageManagerGitignoreMigration(project, globals.logger),
+    SwiftPackageManagerIntegrationMigration(
+      app.project,
+      SupportedPlatform.ios,
+      buildInfo,
+      xcodeProjectInterpreter: globals.xcodeProjectInterpreter!,
+      logger: globals.logger,
+      fileSystem: globals.fs,
+      plistParser: globals.plistParser,
+      features: featureFlags,
+    ),
+    SwiftPackageManagerGitignoreMigration(project, globals.logger),
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -13,6 +13,7 @@ import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../convert.dart';
+import '../features.dart';
 import '../globals.dart' as globals;
 import '../ios/xcode_build_settings.dart';
 import '../ios/xcodeproj.dart';
@@ -91,17 +92,17 @@ Future<void> buildMacOS({
     FlutterApplicationMigration(flutterProject.macos, globals.logger),
     NSApplicationMainDeprecationMigration(flutterProject.macos, globals.logger),
     SecureRestorableStateMigration(flutterProject.macos, globals.logger),
-    if (flutterProject.macos.usesSwiftPackageManager && flutterProject.macos.flutterPluginSwiftPackageManifest.existsSync())
-      SwiftPackageManagerIntegrationMigration(
-        flutterProject.macos,
-        SupportedPlatform.macos,
-        buildInfo,
-        xcodeProjectInterpreter: globals.xcodeProjectInterpreter!,
-        logger: globals.logger,
-        fileSystem: globals.fs,
-        plistParser: globals.plistParser,
-      ),
-      SwiftPackageManagerGitignoreMigration(flutterProject, globals.logger),
+    SwiftPackageManagerIntegrationMigration(
+      flutterProject.macos,
+      SupportedPlatform.macos,
+      buildInfo,
+      xcodeProjectInterpreter: globals.xcodeProjectInterpreter!,
+      logger: globals.logger,
+      fileSystem: globals.fs,
+      plistParser: globals.plistParser,
+      features: featureFlags,
+    ),
+    SwiftPackageManagerGitignoreMigration(flutterProject, globals.logger),
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);

--- a/packages/flutter_tools/test/general.shard/migrations/swift_package_manager_integration_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/swift_package_manager_integration_migration_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
+import '../../src/fakes.dart';
 
 const List<SupportedPlatform> supportedPlatforms = <SupportedPlatform>[
   SupportedPlatform.ios,
@@ -22,8 +23,12 @@ const List<SupportedPlatform> supportedPlatforms = <SupportedPlatform>[
 ];
 
 void main() {
+  final TestFeatureFlags swiftPackageManagerFullyEnabledFlags = TestFeatureFlags(
+    isSwiftPackageManagerEnabled: true,
+  );
+
   group('Flutter Package Migration', () {
-    testWithoutContext('fails if Xcode project not found', () async {
+    testWithoutContext('skips if swift package manager is off', () async {
       final MemoryFileSystem memoryFileSystem = MemoryFileSystem();
       final BufferLogger testLogger = BufferLogger.test();
 
@@ -39,6 +44,66 @@ void main() {
         logger: testLogger,
         fileSystem: memoryFileSystem,
         plistParser: FakePlistParser(),
+        features: TestFeatureFlags(),
+      );
+      await projectMigration.migrate();
+      expect(
+        testLogger.traceText,
+        contains('Skipping the migration that adds Swift Package Manager integration...'),
+      );
+      expect(testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext("skips if there's no generated swift package", () async {
+      final MemoryFileSystem memoryFileSystem = MemoryFileSystem();
+      final BufferLogger testLogger = BufferLogger.test();
+
+      final SwiftPackageManagerIntegrationMigration projectMigration = SwiftPackageManagerIntegrationMigration(
+        FakeXcodeProject(
+          platform: SupportedPlatform.ios.name,
+          fileSystem: memoryFileSystem,
+          logger: testLogger,
+        ),
+        SupportedPlatform.ios,
+        BuildInfo.debug,
+        xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+        logger: testLogger,
+        fileSystem: memoryFileSystem,
+        plistParser: FakePlistParser(),
+        features: swiftPackageManagerFullyEnabledFlags,
+      );
+      await projectMigration.migrate();
+      expect(
+        testLogger.traceText,
+        contains('Skipping the migration that adds Swift Package Manager integration...'),
+      );
+      expect(
+        testLogger.traceText,
+        contains('The tool did not generate a Swift package.'),
+      );
+      expect(testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('fails if Xcode project not found', () async {
+      final MemoryFileSystem memoryFileSystem = MemoryFileSystem();
+      final BufferLogger testLogger = BufferLogger.test();
+      final FakeXcodeProject project = FakeXcodeProject(
+        platform: SupportedPlatform.ios.name,
+        fileSystem: memoryFileSystem,
+        logger: testLogger,
+      );
+
+      project.flutterPluginSwiftPackageManifest.createSync(recursive: true);
+
+      final SwiftPackageManagerIntegrationMigration projectMigration = SwiftPackageManagerIntegrationMigration(
+        project,
+        SupportedPlatform.ios,
+        BuildInfo.debug,
+        xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+        logger: testLogger,
+        fileSystem: memoryFileSystem,
+        plistParser: FakePlistParser(),
+        features: swiftPackageManagerFullyEnabledFlags,
       );
       await expectLater(
         () => projectMigration.migrate(),
@@ -68,6 +133,7 @@ void main() {
           logger: testLogger,
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(),
+          features: swiftPackageManagerFullyEnabledFlags,
         );
         await expectLater(
           () => projectMigration.migrate(),
@@ -96,6 +162,7 @@ void main() {
           logger: testLogger,
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(),
+          features: swiftPackageManagerFullyEnabledFlags,
         );
         await expectLater(
           () => projectMigration.migrate(),
@@ -129,6 +196,7 @@ void main() {
           logger: testLogger,
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(),
+          features: swiftPackageManagerFullyEnabledFlags,
         );
         await expectLater(
           () => projectMigration.migrate(),
@@ -160,6 +228,7 @@ void main() {
           logger: testLogger,
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(),
+          features: swiftPackageManagerFullyEnabledFlags,
         );
         await expectLater(
           () => projectMigration.migrate(),
@@ -194,6 +263,7 @@ void main() {
         logger: testLogger,
         fileSystem: memoryFileSystem,
         plistParser: FakePlistParser(),
+        features: swiftPackageManagerFullyEnabledFlags,
       );
       await projectMigration.migrate();
       expect(testLogger.traceText, isEmpty);
@@ -233,6 +303,7 @@ void main() {
           plistParser: FakePlistParser(
             json: _plutilOutput(settingsAsJsonBeforeMigration),
           ),
+          features: swiftPackageManagerFullyEnabledFlags,
         );
         await expectLater(() => projectMigration.migrate(), throwsToolExit());
         expect(
@@ -262,6 +333,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: FakePlistParser(),
+              features: swiftPackageManagerFullyEnabledFlags,
             );
             await expectLater(
               () => projectMigration.migrate(),
@@ -296,6 +368,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: FakePlistParser(),
+              features: swiftPackageManagerFullyEnabledFlags,
             );
 
             await expectLater(
@@ -331,6 +404,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: FakePlistParser(),
+              features: swiftPackageManagerFullyEnabledFlags,
             );
 
             await expectLater(
@@ -366,6 +440,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: FakePlistParser(),
+              features: swiftPackageManagerFullyEnabledFlags,
             );
 
             await expectLater(
@@ -395,6 +470,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: FakePlistParser(),
+              features: swiftPackageManagerFullyEnabledFlags,
             );
 
             await expectLater(
@@ -423,6 +499,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: FakePlistParser(),
+              features: swiftPackageManagerFullyEnabledFlags,
             );
 
             await expectLater(
@@ -455,6 +532,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: plistParser,
+              features: swiftPackageManagerFullyEnabledFlags,
             );
 
             await projectMigration.migrate();
@@ -489,6 +567,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: plistParser,
+              features: swiftPackageManagerFullyEnabledFlags,
             );
 
             await projectMigration.migrate();
@@ -531,6 +610,7 @@ void main() {
           plistParser: FakePlistParser(
             json: _plutilOutput(settingsAsJsonBeforeMigration),
           ),
+          features: swiftPackageManagerFullyEnabledFlags,
         );
         await projectMigration.migrate();
         expect(
@@ -558,6 +638,7 @@ void main() {
             logger: testLogger,
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
+            features: swiftPackageManagerFullyEnabledFlags,
           );
           await expectLater(
             () => projectMigration.migrate(),
@@ -583,6 +664,7 @@ void main() {
             logger: testLogger,
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(json: '[]'),
+            features: swiftPackageManagerFullyEnabledFlags,
           );
           await expectLater(
             () => projectMigration.migrate(),
@@ -608,6 +690,7 @@ void main() {
             logger: testLogger,
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(json: 'this is not json'),
+            features: swiftPackageManagerFullyEnabledFlags,
           );
           await expectLater(
             () => projectMigration.migrate(),
@@ -636,6 +719,7 @@ void main() {
             logger: testLogger,
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
+            features: swiftPackageManagerFullyEnabledFlags,
           );
           expect(
             () => projectMigration.migrate(),
@@ -662,6 +746,7 @@ void main() {
             logger: testLogger,
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
+            features: swiftPackageManagerFullyEnabledFlags,
           );
           expect(
             () => projectMigration.migrate(),
@@ -688,6 +773,7 @@ void main() {
             logger: testLogger,
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
+            features: swiftPackageManagerFullyEnabledFlags,
           );
           expect(
             () => projectMigration.migrate(),
@@ -719,6 +805,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(<String>[]),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -760,6 +847,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(<String>[]),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -802,6 +890,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(<String>[]),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -844,6 +933,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -893,6 +983,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -935,6 +1026,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -981,6 +1073,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1020,6 +1113,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1075,6 +1169,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1122,6 +1217,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1184,6 +1280,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1232,6 +1329,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1271,6 +1369,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1312,6 +1411,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1357,6 +1457,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1412,6 +1513,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1460,6 +1562,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1518,6 +1621,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1566,6 +1670,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1609,6 +1714,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1656,6 +1762,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1695,6 +1802,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1752,6 +1860,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1800,6 +1909,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1858,6 +1968,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1899,6 +2010,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1945,6 +2057,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1993,6 +2106,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2049,6 +2163,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2090,6 +2205,7 @@ void main() {
                 plistParser: FakePlistParser(
                   json: _plutilOutput(settingsAsJsonBeforeMigration),
                 ),
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -2131,6 +2247,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2179,6 +2296,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2235,6 +2353,7 @@ void main() {
                 logger: testLogger,
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
+                features: swiftPackageManagerFullyEnabledFlags,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2276,6 +2395,7 @@ void main() {
               logger: testLogger,
               fileSystem: memoryFileSystem,
               plistParser: plistParser,
+              features: swiftPackageManagerFullyEnabledFlags,
             );
             await expectLater(
               () => projectMigration.migrate(),
@@ -2340,6 +2460,7 @@ void main() {
           logger: testLogger,
           fileSystem: memoryFileSystem,
           plistParser: plistParser,
+          features: swiftPackageManagerFullyEnabledFlags,
         );
         await expectLater(
           () => projectMigration.migrate(),
@@ -2379,6 +2500,7 @@ void main() {
           logger: testLogger,
           fileSystem: memoryFileSystem,
           plistParser: plistParser,
+          features: swiftPackageManagerFullyEnabledFlags,
           validateBackup: true,
         );
         await expectLater(
@@ -2411,6 +2533,7 @@ void _createProjectFiles(
   project.parent.directory.createSync(recursive: true);
   project.hostAppRoot.createSync(recursive: true);
   project.xcodeProjectInfoFile.createSync(recursive: true);
+  project.flutterPluginSwiftPackageManifest.createSync(recursive: true);
   if (createSchemeFile) {
     project.xcodeProjectSchemeFile(scheme: scheme).createSync(recursive: true);
     project.xcodeProjectSchemeFile().writeAsStringSync(
@@ -3229,6 +3352,7 @@ class FakeSwiftPackageManagerIntegrationMigration extends SwiftPackageManagerInt
     required super.logger,
     required super.fileSystem,
     required super.plistParser,
+    required super.features,
     this.validateBackup = false,
   }) : _xcodeProject = project;
 


### PR DESCRIPTION
Previously, the Swift Package Manager app migration would only be registered if the feature was on. 

Now, the Swift Package Manager app migration is always registered but only runs if the SwiftPM feature is on. This change will make it easier to introduce a separate feature flag for just the SwiftPM app migration.

This is a refactoring with no semantic change.

Part of https://github.com/flutter/flutter/issues/151567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
