### PR TITLE
Framework sends a11y message when enabling semantics

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -790,9 +790,19 @@ class _BindingPipelineManifold extends ChangeNotifier implements PipelineManifol
       ChangeNotifier.maybeDispatchObjectCreation(this);
     }
     _binding.addSemanticsEnabledListener(notifyListeners);
+    if (_binding.semanticsEnabled) {
+      SystemChannels.accessibility.send(const GeneratingSemanticsTreeSemanticsEvent(true).toMap());
+    }
   }
 
   final RendererBinding _binding;
+
+  @protected
+  @override
+  void notifyListeners() {
+    SystemChannels.accessibility.send(GeneratingSemanticsTreeSemanticsEvent(_binding.semanticsEnabled).toMap());
+    super.notifyListeners();
+  }
 
   @override
   void requestVisualUpdate() {

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -135,6 +135,40 @@ class TooltipSemanticsEvent extends SemanticsEvent {
   }
 }
 
+/// An event to notify native OS that flutter starts or stops the semantics tree
+/// generation
+///
+/// The [generating] indicate whether flutter starts generating the semantics
+/// tree. If true, flutter will start sending semantics update to platform
+/// embedding.
+///
+/// Embeddings must be ready to receive semantics update after they receive this
+/// event with [generating] set to true as framework will start sending
+/// semantics update in the next frame.
+///
+/// If [generating] is false, embeddings need to clean up previous updates as
+/// the framework semantics tree was completely destroyed.
+class GeneratingSemanticsTreeSemanticsEvent extends SemanticsEvent {
+
+  /// Constructs an event that notify platform whether it is generating
+  /// semantics tree.
+  const GeneratingSemanticsTreeSemanticsEvent(this.generating)
+      : super('generatingSemanticsTree');
+
+  /// Whether framework starts generating the semantics tree.
+  ///
+  /// If true, flutter starts sending semantics update to platform
+  /// embedding.
+  final bool generating;
+
+  @override
+  Map<String, dynamic> getDataMap() {
+    return <String, dynamic> {
+      'generating': generating,
+    };
+  }
+}
+
 /// An event which triggers long press semantic feedback.
 ///
 /// Currently only honored on Android. Triggers a long-press specific sound

--- a/packages/flutter/test/rendering/binding_pipeline_manifold_semantics_event_test.dart
+++ b/packages/flutter/test/rendering/binding_pipeline_manifold_semantics_event_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'rendering_tester.dart';
+
+void main() {
+  test('Turning global semantics on/off sends semantics event', () {
+    TestRenderingFlutterBinding.ensureInitialized();
+    final List<dynamic> messages = <dynamic>[];
+    TestRenderingFlutterBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
+      SystemChannels.accessibility,
+      (dynamic message) async {
+        messages.add(message);
+      }
+    );
+    final SemanticsHandle handle = TestRenderingFlutterBinding.instance.ensureSemantics();
+    expect(messages.length, 1);
+    expect(messages[0], <String, dynamic>{
+      'type': 'generatingSemanticsTree',
+      'data': <String, dynamic>{
+        'generating': true,
+      },
+    });
+
+    handle.dispose();
+    expect(messages.length, 2);
+    expect(messages[1], <String, dynamic>{
+      'type': 'generatingSemanticsTree',
+      'data': <String, dynamic>{
+        'generating': false,
+      },
+    });
+    TestRenderingFlutterBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, null);
+  });
+}

--- a/packages/flutter/test/widgets/feedback_test.dart
+++ b/packages/flutter/test/widgets/feedback_test.dart
@@ -38,7 +38,7 @@ void main () {
 
     testWidgets('forTap', (WidgetTester tester) async {
       final SemanticsTester semanticsTester = SemanticsTester(tester);
-
+      semanticEvents.clear();
       await tester.pumpWidget(TestWidget(
         tapHandler: (BuildContext context) {
           return () => Feedback.forTap(context);
@@ -67,7 +67,7 @@ void main () {
 
     testWidgets('forTap Wrapper', (WidgetTester tester) async {
       final SemanticsTester semanticsTester = SemanticsTester(tester);
-
+      semanticEvents.clear();
       int callbackCount = 0;
       void callback() {
         callbackCount++;
@@ -102,7 +102,7 @@ void main () {
 
     testWidgets('forLongPress', (WidgetTester tester) async {
       final SemanticsTester semanticsTester = SemanticsTester(tester);
-
+      semanticEvents.clear();
       await tester.pumpWidget(TestWidget(
         longPressHandler: (BuildContext context) {
           return () => Feedback.forLongPress(context);
@@ -130,6 +130,7 @@ void main () {
 
     testWidgets('forLongPress Wrapper', (WidgetTester tester) async {
       final SemanticsTester semanticsTester = SemanticsTester(tester);
+      semanticEvents.clear();
       int callbackCount = 0;
       void callback() {
         callbackCount++;

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -280,7 +280,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
+    }, semanticsEnabled: false); // Disabling semantics to prevent the unexpected message.
 
     testWidgets(
         'waiting for NoPendingPlatformMessages returns until a single method channel call returns', (WidgetTester tester) async {
@@ -313,7 +313,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
+    }, semanticsEnabled: false); // Disabling semantics to prevent the unexpected message.
 
     testWidgets(
         'waiting for NoPendingPlatformMessages returns until both method channel calls return', (WidgetTester tester) async {
@@ -362,7 +362,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
+    }, semanticsEnabled: false); // Disabling semantics to prevent the unexpected message.
 
     testWidgets(
         'waiting for NoPendingPlatformMessages returns until new method channel call returns', (WidgetTester tester) async {
@@ -413,7 +413,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
+    }, semanticsEnabled: false); // Disabling semantics to prevent the unexpected message.
 
     testWidgets(
         'waiting for NoPendingPlatformMessages returns until both old and new method channel calls return', (WidgetTester tester) async {
@@ -463,7 +463,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
+    }, semanticsEnabled: false); // Disabling semantics to prevent the unexpected message.
   });
 
   group('getSemanticsId', () {

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -280,7 +280,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    });
+    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
 
     testWidgets(
         'waiting for NoPendingPlatformMessages returns until a single method channel call returns', (WidgetTester tester) async {
@@ -313,7 +313,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    });
+    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
 
     testWidgets(
         'waiting for NoPendingPlatformMessages returns until both method channel calls return', (WidgetTester tester) async {
@@ -362,7 +362,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    });
+    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
 
     testWidgets(
         'waiting for NoPendingPlatformMessages returns until new method channel call returns', (WidgetTester tester) async {
@@ -413,7 +413,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    });
+    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
 
     testWidgets(
         'waiting for NoPendingPlatformMessages returns until both old and new method channel calls return', (WidgetTester tester) async {
@@ -463,7 +463,7 @@ void main() {
           'response': <String, dynamic>{},
         },
       );
-    });
+    }, semanticsEnabled: false); // Disabling semantics to prevent unexpected message.
   });
 
   group('getSemanticsId', () {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/158399

engine ios https://github.com/flutter/engine/pull/56691

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
