### PR TITLE
Do a clean shutdown of the flutter_tools processes started by observatory_port_test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/observatory_port_test.dart
+++ b/packages/flutter_tools/test/integration.shard/observatory_port_test.dart
@@ -26,7 +26,7 @@ Future<void> waitForVmServiceMessage(Process process, int port) async {
     .transform(utf8.decoder)
     .listen((String line) {
       printOnFailure(line);
-      if (line.contains('A Dart VM Service on Flutter test device is available at')) {
+      if (line.contains('The Flutter DevTools debugger and profiler on Flutter test device is available at')) {
         if (line.contains('http://127.0.0.1:$port')) {
           completer.complete();
         } else {
@@ -66,7 +66,7 @@ void main() {
       'flutter-tester',
     ], workingDirectory: tempDir.path);
     await waitForVmServiceMessage(process, port);
-    process.kill();
+    process.stdin.writeln('q');
     await process.exitCode;
   });
 
@@ -88,7 +88,7 @@ void main() {
       'flutter-tester',
     ], workingDirectory: tempDir.path);
     await waitForVmServiceMessage(process, ddsPort);
-    process.kill();
+    process.stdin.writeln('q');
     await process.exitCode;
   });
 
@@ -105,7 +105,7 @@ void main() {
       'flutter-tester',
     ], workingDirectory: tempDir.path);
     await waitForVmServiceMessage(process, ddsPort);
-    process.kill();
+    process.stdin.writeln('q');
     await process.exitCode;
   });
 

--- a/packages/flutter_tools/test/integration.shard/observatory_port_test.dart
+++ b/packages/flutter_tools/test/integration.shard/observatory_port_test.dart
@@ -66,6 +66,8 @@ void main() {
       'flutter-tester',
     ], workingDirectory: tempDir.path);
     await waitForVmServiceMessage(process, port);
+    // Send a quit command to flutter_tools to cleanly shut down the tool
+    // and its child processes.
     process.stdin.writeln('q');
     await process.exitCode;
   });


### PR DESCRIPTION
Killing the flutter_tools parent process may leak child processes spawned by the tools.

Also wait for the message indicating that DevTools has started before stopping flutter_tools.  If DevTools has not fully launched, then there may be a race between DevTools startup and flutter_tools shutdown.

Fixes https://github.com/flutter/flutter/issues/159154