### PR TITLE
Remove dependency on [Target] and instead operate on [Architecture]

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
@@ -34,7 +34,7 @@ Future<void> copyNativeCodeAssetsAndroid(
     final Uri source = assetMapping.key.file!;
     final Uri target = (assetMapping.value.path as KernelAssetAbsolutePath).uri;
     final AndroidArch androidArch =
-        _getAndroidArch(assetMapping.value.target);
+        _getAndroidArch(assetMapping.value.target.architecture);
     final String jniArchDir = androidArch.archName;
     final Uri archUri = buildUri.resolve('jniLibs/lib/$jniArchDir/');
     final Uri targetUri = archUri.resolveUri(target);
@@ -43,25 +43,25 @@ Future<void> copyNativeCodeAssetsAndroid(
   }
 }
 
-/// Get the [Target] for [androidArch].
-Target getNativeAndroidTarget(AndroidArch androidArch) {
+/// Get the [Architecture] for [androidArch].
+Architecture getNativeAndroidArchitecture(AndroidArch androidArch) {
   return switch (androidArch) {
-    AndroidArch.armeabi_v7a => Target.androidArm,
-    AndroidArch.arm64_v8a   => Target.androidArm64,
-    AndroidArch.x86         => Target.androidIA32,
-    AndroidArch.x86_64      => Target.androidX64,
+    AndroidArch.armeabi_v7a => Architecture.arm,
+    AndroidArch.arm64_v8a   => Architecture.arm64,
+    AndroidArch.x86         => Architecture.ia32,
+    AndroidArch.x86_64      => Architecture.x64,
   };
 }
 
-/// Get the [AndroidArch] for [target].
-AndroidArch _getAndroidArch(Target target) {
-  return switch (target) {
-    Target.androidArm   => AndroidArch.armeabi_v7a,
-    Target.androidArm64 => AndroidArch.arm64_v8a,
-    Target.androidIA32  => AndroidArch.x86,
-    Target.androidX64   => AndroidArch.x86_64,
-    Target.androidRiscv64 => throwToolExit('Android RISC-V not yet supported.'),
-    _ => throwToolExit('Invalid target: $target.'),
+/// Get the [AndroidArch] for [architecture].
+AndroidArch _getAndroidArch(Architecture architecture) {
+  return switch (architecture) {
+    Architecture.arm     => AndroidArch.armeabi_v7a,
+    Architecture.arm64   => AndroidArch.arm64_v8a,
+    Architecture.ia32    => AndroidArch.x86,
+    Architecture.x64     => AndroidArch.x86_64,
+    Architecture.riscv64 => throwToolExit('Android RISC-V not yet supported.'),
+    _ => throwToolExit('Invalid architecture: $architecture.'),
   };
 }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -20,12 +20,12 @@ IOSSdk getIOSSdk(EnvironmentType environmentType) {
   };
 }
 
-/// Extract the [Target] from a [DarwinArch].
-Target getNativeIOSTarget(DarwinArch darwinArch) {
+/// Extract the [Architecture] from a [DarwinArch].
+Architecture getNativeIOSArchitecture(DarwinArch darwinArch) {
   return switch (darwinArch) {
-    DarwinArch.armv7  => Target.iOSArm,
-    DarwinArch.arm64  => Target.iOSArm64,
-    DarwinArch.x86_64 => Target.iOSX64,
+    DarwinArch.armv7  => Architecture.arm,
+    DarwinArch.arm64  => Architecture.arm64,
+    DarwinArch.x86_64 => Architecture.x64,
   };
 }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -13,11 +13,11 @@ import 'native_assets_host.dart';
 // TODO(dcharkes): Fetch minimum MacOS version from somewhere. https://github.com/flutter/flutter/issues/145104
 const int targetMacOSVersion = 13;
 
-/// Extract the [Target] from a [DarwinArch].
-Target getNativeMacOSTarget(DarwinArch darwinArch) {
+/// Extract the [Architecture] from a [DarwinArch].
+Architecture getNativeMacOSArchitecture(DarwinArch darwinArch) {
   return switch (darwinArch) {
-    DarwinArch.arm64  => Target.macOSArm64,
-    DarwinArch.x86_64 => Target.macOSX64,
+    DarwinArch.arm64  => Architecture.arm64,
+    DarwinArch.x86_64 => Architecture.x64,
     DarwinArch.armv7  => throw Exception('Unknown DarwinArch: $darwinArch.'),
   };
 }

--- a/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
@@ -111,8 +111,8 @@ void main() {
       expect(
         (globals.logger as BufferLogger).traceText,
         stringContainsInOrder(<String>[
-          'Building native assets for android_arm64 $buildMode.',
-          'Building native assets for android_arm64 $buildMode done.',
+          'Building native assets for android arm64 $buildMode.',
+          'Building native assets for android arm64 $buildMode done.',
         ]),
       );
 

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -216,8 +216,8 @@ void main() {
       expect(
         (globals.logger as BufferLogger).traceText,
         stringContainsInOrder(<String>[
-          'Building native assets for [ios_arm64, ios_x64] $buildMode.',
-          'Building native assets for [ios_arm64, ios_x64] $buildMode done.',
+          'Building native assets for ios [arm64, x64] $buildMode.',
+          'Building native assets for ios [arm64, x64] $buildMode done.',
         ]),
       );
       expect(environment.buildDir.childFile(InstallCodeAssets.nativeAssetsFilename), exists);

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -323,13 +323,13 @@ void main() {
           nativeAssetsFileUri: nativeAssetsFileUri ,
         );
         final String expectedArchsBeingBuilt = flutterTester
-            ? (isArm64 ? 'macos_arm64' : 'macos_x64')
-            : '[macos_arm64, macos_x64]';
+            ? (isArm64 ? 'arm64' : 'x64')
+            : '[arm64, x64]';
         expect(
           (globals.logger as BufferLogger).traceText,
           stringContainsInOrder(<String>[
-            'Building native assets for $expectedArchsBeingBuilt $buildMode.',
-            'Building native assets for $expectedArchsBeingBuilt $buildMode done.',
+            'Building native assets for macos $expectedArchsBeingBuilt $buildMode.',
+            'Building native assets for macos $expectedArchsBeingBuilt $buildMode done.',
           ]),
         );
         final String nativeAssetsFileContent = await fileSystem.file(nativeAssetsFileUri).readAsString();

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -127,13 +127,16 @@ void main() {
           nativeAssetsFileUri: nativeAssetsFileUri,
         );
         final String expectedOS = flutterTester
-            ? native_assets_cli.Target.current.toString()
-            : 'windows_x64';
+            ? OS.current.toString()
+            : 'windows';
+        final String expectedArch = flutterTester
+            ? Architecture.current.toString()
+            : 'x64';
         expect(
           (globals.logger as BufferLogger).traceText,
           stringContainsInOrder(<String>[
-            'Building native assets for $expectedOS $buildMode.',
-            'Building native assets for $expectedOS $buildMode done.',
+            'Building native assets for $expectedOS $expectedArch $buildMode.',
+            'Building native assets for $expectedOS $expectedArch $buildMode done.',
           ]),
         );
         expect(


### PR DESCRIPTION
The dart-lang/native repository contains a `Target` class that is almost not needed anymore. The remaining uses are mainly due to kernel asset mapping (which we may be able to remove in the future).

This PR removes usages of that `Target` (in favor of `Architecture`) class in most places in flutter tools.
This makes the code also cleaner because we no longer have an implicit assumption that
a `List<Target>` all belong to the same operating system.