### PR TITLE
Lay the groundwork for removing the `Key` class

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -310,7 +310,32 @@ class GlobalObjectKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
 @immutable
 abstract class Widget extends DiagnosticableTree {
   /// Initializes [key] for subclasses.
-  const Widget({ this.key });
+  const Widget({Key? key}) : objectKey = key;
+
+  /// Returns the key passed to this widget's constructor.
+  ///
+  /// This getter will be deprecated in a future release, to allow any [Object]
+  /// to be used as a key. Consider using the [objectKey] field to access
+  /// this value.
+  Key? get key {
+    final Object? key = objectKey;
+    assert(() {
+      if (key is Key?) {
+        return true;
+      }
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+        ErrorSummary('$runtimeType\'s key is not a "Key".'),
+        ErrorDescription(
+          'This widget has its key set to "$key", which is a ${key.runtimeType}.',
+        ),
+        ErrorHint(
+          "Consider accessing the widget's `.objectKey` getter instead.",
+        )
+      ]);
+    }());
+
+    return key is Key ? key : null;
+  }
 
   /// Controls how one widget replaces another widget in the tree.
   ///
@@ -333,8 +358,9 @@ abstract class Widget extends DiagnosticableTree {
   ///
   /// See also:
   ///
-  ///  * The discussions at [Key] and [GlobalKey].
-  final Key? key;
+  ///  * [key], which returns this value if a [Key] object was passed.
+  ///  * The discussion at [GlobalKey].
+  final Object? objectKey;
 
   /// Inflates this configuration to a concrete instance.
   ///
@@ -351,7 +377,7 @@ abstract class Widget extends DiagnosticableTree {
   @override
   String toStringShort() {
     final String type = objectRuntimeType(this, 'Widget');
-    return key == null ? type : '$type-$key';
+    return objectKey == null ? type : '$type-$objectKey';
   }
 
   @override
@@ -380,7 +406,7 @@ abstract class Widget extends DiagnosticableTree {
   /// different.
   static bool canUpdate(Widget oldWidget, Widget newWidget) {
     return oldWidget.runtimeType == newWidget.runtimeType
-        && oldWidget.key == newWidget.key;
+        && oldWidget.objectKey == newWidget.objectKey;
   }
 
   // Return a numeric encoding of the specific `Widget` concrete subtype.

--- a/packages/flutter/test/widgets/key_test.dart
+++ b/packages/flutter/test/widgets/key_test.dart
@@ -57,4 +57,13 @@ void main() {
     expect(GlobalKey(debugLabel: 'hello'), hasOneLineDescription);
     expect(const GlobalObjectKey(true), hasOneLineDescription);
   });
+
+  test('Widget.objectKey control test', () {
+    Widget widget = Container(key: UniqueKey());
+    expect(identical(widget.key, widget.objectKey), isTrue);
+
+    widget = const SizedBox.shrink();
+    expect(widget.key, isNull);
+    expect(widget.objectKey, isNull);
+  });
 }


### PR DESCRIPTION
- https://github.com/flutter/flutter/issues/159224

- 📜 **design doc: [flutter.dev/go/unwrapping-widget-keys](https://docs.google.com/document/d/1Fc9ZYTTxlJUAfGeQzf83wXuV-wSiRZFHhMgwoUNukhI)**


<hr>

<br>

```dart
// before
class Widget {
  final Key? key;
}


// after
class Widget {
  final Object? key;
}
```

<br><br>

In order to mitigate breakages, this is being broken up into stages:

#### Current Structure
```dart
class Widget {
  const Widget({this.key});

  final Key? key;
}
```

#### After this PR
```dart
class Widget {
  const Widget({Key? key}) : objectKey = key;

  Key? get key => objectKey is Key ? objectKey : null;
  final Object? objectKey;
}
```

#### Once the framework migrates to the `objectKey` field
```dart
class Widget {
  const Widget({Object? key}) : objectKey = key;

  @Deprecated('2-stage deprecation, part 1')
  Key? get key => objectKey is Key ? objectKey : null;
  final Object? objectKey;
}
```

#### After the first deprecation is done
```dart
class Widget {
  const Widget({this.key});

  final Object? key;

  @Deprecated('2-stage deprecation, part 2')
  Object? get objectKey => key;
}
```

#### Final result
```dart
class Widget {
  const Widget({this.key});

  final Object? key;
}
```

<br>

Introducing a field with plans to deprecate & remove it isn't ideal, but fortunately, this only applies to _accessing_ the field. The vast majority of the time, a key is created to be assigned to a widget, and then the framework takes care of the rest.