### PR TITLE
[flutter_tools] opt iOS/macOS apps out of Metal API validation via migrator, update templates in repo.

### DIFF
--- a/dev/benchmarks/complex_layout/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/benchmarks/complex_layout/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/benchmarks/complex_layout/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/benchmarks/complex_layout/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/benchmarks/macrobenchmarks/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/benchmarks/macrobenchmarks/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       enableGPUFrameCaptureMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable

--- a/dev/benchmarks/macrobenchmarks/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/benchmarks/macrobenchmarks/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/benchmarks/test_apps/stocks/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/benchmarks/test_apps/stocks/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/channels/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/channels/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/channels/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/channels/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/flutter_gallery/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/flutter_gallery/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -58,6 +58,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/ios_app_with_extensions/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/ios_app_with_extensions/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/non_nullable/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/non_nullable/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/platform_interaction/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/platform_interaction/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/spell_check/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/spell_check/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/ui/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/ui/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/integration_tests/ui/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/ui/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/manual_tests/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/manual_tests/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/dev/manual_tests/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/manual_tests/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/flutter_view/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/flutter_view/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/flutter_view/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/flutter_view/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/hello_world/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/hello_world/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/hello_world/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/hello_world/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/image_list/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/image_list/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -52,6 +52,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/image_list/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/image_list/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/layers/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/layers/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/layers/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/layers/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/platform_channel/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/platform_channel/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/platform_channel/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/platform_channel/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/platform_view/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/platform_view/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/platform_view/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/platform_view/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -36,6 +36,7 @@ import 'application_package.dart';
 import 'code_signing.dart';
 import 'migrations/host_app_info_plist_migration.dart';
 import 'migrations/ios_deployment_target_migration.dart';
+import 'migrations/metal_api_validation_migration.dart';
 import 'migrations/project_base_configuration_migration.dart';
 import 'migrations/project_build_location_migration.dart';
 import 'migrations/remove_bitcode_migration.dart';
@@ -167,6 +168,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     RemoveBitcodeMigration(app.project, globals.logger),
     XcodeThinBinaryBuildPhaseInputPathsMigration(app.project, globals.logger),
     UIApplicationMainDeprecationMigration(app.project, globals.logger),
+    MetalAPIValidationMigrator(app.project, globals.logger),
     SwiftPackageManagerIntegrationMigration(
       app.project,
       SupportedPlatform.ios,

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -168,7 +168,6 @@ Future<XcodeBuildResult> buildXcodeProject({
     RemoveBitcodeMigration(app.project, globals.logger),
     XcodeThinBinaryBuildPhaseInputPathsMigration(app.project, globals.logger),
     UIApplicationMainDeprecationMigration(app.project, globals.logger),
-    MetalAPIValidationMigrator(app.project, globals.logger),
     SwiftPackageManagerIntegrationMigration(
       app.project,
       SupportedPlatform.ios,
@@ -180,6 +179,7 @@ Future<XcodeBuildResult> buildXcodeProject({
       features: featureFlags,
     ),
     SwiftPackageManagerGitignoreMigration(project, globals.logger),
+    MetalAPIValidationMigrator.ios(app.project, globals.logger),
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);

--- a/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
@@ -8,8 +8,13 @@ import '../../xcode_project.dart';
 
 /// Remove Metal API validation setting that slows down applications.
 class MetalAPIValidationMigrator extends ProjectMigrator {
-  MetalAPIValidationMigrator(
+  MetalAPIValidationMigrator.ios(
     IosProject project,
+    super.logger,
+  )   : _xcodeProjectScheme = project.xcodeProjectSchemeFile();
+
+  MetalAPIValidationMigrator.macos(
+    MacOSProject project,
     super.logger,
   )   : _xcodeProjectScheme = project.xcodeProjectSchemeFile();
 

--- a/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
@@ -39,9 +39,13 @@ class MetalAPIValidationMigrator extends ProjectMigrator {
     }
     // Look for a setting that is included in LaunchAction by default and
     // insert the opt out after it.
-    const String kDebugServiceExtension = 'debugServiceExtension = "internal"';
-    const String kReplacement = '''debugServiceExtension = "internal"\n    enableGPUValidationMode = "1"''';
-    return fileContents.replaceFirst(kDebugServiceExtension, kReplacement);
+    final RegExp kDebugServiceExtension = RegExp('(\\s)*debugServiceExtension = "internal"\n');
+    const String kValidationString = 'enableGPUValidationMode = "1"';
+    return fileContents.replaceFirstMapped(kDebugServiceExtension, (Match match) {
+      final String group = match.group(0)!;
+      final int leadingCount = group.split('debugServiceExtension')[0].codeUnits.where((int codeUnit) => codeUnit == 32).length;
+      return '$group${' ' * leadingCount}$kValidationString\n';
+    });
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
@@ -1,0 +1,42 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../../base/file_system.dart';
+import '../../base/project_migrator.dart';
+import '../../xcode_project.dart';
+
+/// Remove Metal API validation setting that slows down applications.
+class MetalAPIValidationMigrator extends ProjectMigrator {
+  MetalAPIValidationMigrator(
+    IosProject project,
+    super.logger,
+  )   : _xcodeProjectScheme = project.xcodeProjectSchemeFile();
+
+  final File _xcodeProjectScheme;
+
+
+  @override
+  Future<void> migrate() async {
+    if (_xcodeProjectScheme.existsSync()) {
+      processFileLines(_xcodeProjectScheme);
+    } else {
+      logger.printTrace('default xcscheme file not found. Skipping Metal API validation migration.');
+    }
+  }
+
+  @override
+  String migrateFileContents(String fileContents) {
+    // Look for a setting that is included in LaunchAction by default and
+    // insert the opt out after it.
+    const String kDebugServiceExtension = 'debugServiceExtension = "internal"';
+    const String kReplacement = '''debugServiceExtension = "internal"\n    enableGPUValidationMode = "1"''';
+
+    return fileContents.replaceFirst(kDebugServiceExtension, kReplacement);
+  }
+
+  @override
+  String? migrateLine(String line) {
+    return line;
+  }
+}

--- a/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
@@ -27,11 +27,15 @@ class MetalAPIValidationMigrator extends ProjectMigrator {
 
   @override
   String migrateFileContents(String fileContents) {
+    // If this string is anywhere in the file, assume that either we already
+    // migrated it or the developer made an intentional choice to opt in or out.
+    if (fileContents.contains('enableGPUValidationMode')) {
+      return fileContents;
+    }
     // Look for a setting that is included in LaunchAction by default and
     // insert the opt out after it.
     const String kDebugServiceExtension = 'debugServiceExtension = "internal"';
     const String kReplacement = '''debugServiceExtension = "internal"\n    enableGPUValidationMode = "1"''';
-
     return fileContents.replaceFirst(kDebugServiceExtension, kReplacement);
   }
 

--- a/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/metal_api_validation_migration.dart
@@ -47,9 +47,4 @@ class MetalAPIValidationMigrator extends ProjectMigrator {
       return '$group${' ' * leadingCount}$kValidationString\n';
     });
   }
-
-  @override
-  String? migrateLine(String line) {
-    return line;
-  }
 }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:unified_analytics/unified_analytics.dart';
+import 'package:vm_snapshot_analysis/v8_profile.dart';
 
 import '../base/analyze_size.dart';
 import '../base/common.dart';
@@ -15,6 +16,7 @@ import '../build_info.dart';
 import '../convert.dart';
 import '../features.dart';
 import '../globals.dart' as globals;
+import '../ios/migrations/metal_api_validation_migration.dart';
 import '../ios/xcode_build_settings.dart';
 import '../ios/xcodeproj.dart';
 import '../migrations/swift_package_manager_gitignore_migration.dart';
@@ -103,6 +105,7 @@ Future<void> buildMacOS({
       features: featureFlags,
     ),
     SwiftPackageManagerGitignoreMigration(flutterProject, globals.logger),
+    MetalAPIValidationMigrator.macos(flutterProject.macos, globals.logger),
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:unified_analytics/unified_analytics.dart';
-import 'package:vm_snapshot_analysis/v8_profile.dart';
 
 import '../base/analyze_size.dart';
 import '../base/common.dart';

--- a/packages/flutter_tools/templates/app_shared/ios-objc.tmpl/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme.tmpl
+++ b/packages/flutter_tools/templates/app_shared/ios-objc.tmpl/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme.tmpl
@@ -79,6 +79,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/packages/flutter_tools/templates/app_shared/ios-swift.tmpl/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme.tmpl
+++ b/packages/flutter_tools/templates/app_shared/ios-swift.tmpl/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme.tmpl
@@ -79,6 +79,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme.tmpl
+++ b/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme.tmpl
@@ -79,6 +79,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/packages/flutter_tools/templates/xcode/ios/custom_application_bundle/Runner.xcodeproj.tmpl/xcshareddata/xcschemes/Runner.xcscheme.tmpl
+++ b/packages/flutter_tools/templates/xcode/ios/custom_application_bundle/Runner.xcodeproj.tmpl/xcshareddata/xcschemes/Runner.xcscheme.tmpl
@@ -37,6 +37,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <PathRunnable
          runnableDebuggingMode = "0"

--- a/packages/flutter_tools/test/general.shard/ios/metal_api_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/metal_api_validator_test.dart
@@ -1,4 +1,3 @@
-
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -12,7 +11,6 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
-
 
 void main() {
   testWithoutContext('Adds Metal API setting to matching file', () {
@@ -34,7 +32,7 @@ void main() {
     allowLocationSimulation = "YES">
 ''');
     final FakeIosProject project = FakeIosProject(file);
-    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator(project, BufferLogger.test());
+    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator.ios(project, BufferLogger.test());
 
     expect(() async => validator.migrate(), returnsNormally);
 
@@ -63,7 +61,7 @@ void main() {
     allowLocationSimulation = "YES">
 ''');
     final FakeIosProject project = FakeIosProject(file);
-    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator(project, BufferLogger.test());
+    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator.ios(project, BufferLogger.test());
 
     final String initialContents = file.readAsStringSync();
 
@@ -78,7 +76,7 @@ void main() {
       ..createSync()
       ..writeAsStringSync('NO_OP');
     final FakeIosProject project = FakeIosProject(file);
-    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator(project, BufferLogger.test());
+    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator.ios(project, BufferLogger.test());
 
     expect(() async => validator.migrate(), returnsNormally);
 
@@ -88,7 +86,7 @@ void main() {
   testWithoutContext('No-op on missing file', () async {
     final FileSystem fs = MemoryFileSystem.test();
     final FakeIosProject project = FakeIosProject(fs.file('does_not_exist'));
-    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator(project, BufferLogger.test());
+    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator.ios(project, BufferLogger.test());
 
     expect(() async => validator.migrate(), returnsNormally);
   });

--- a/packages/flutter_tools/test/general.shard/ios/metal_api_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/metal_api_validator_test.dart
@@ -41,6 +41,34 @@ void main() {
     '\n    enableGPUValidationMode = "1"'));
   });
 
+  testWithoutContext('Adds Metal API setting to matching file and crazy indentation', () {
+    final FileSystem fs = MemoryFileSystem.test();
+
+    final File file = fs.file('test_file')
+      ..createSync()
+      ..writeAsStringSync('''
+<?xml version="1.0" encoding="UTF-8"?>
+      <LaunchAction
+        buildConfiguration = "Debug"
+        selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+        selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+        launchStyle = "0"
+        useCustomWorkingDirectory = "NO"
+        ignoresPersistentStateOnLaunch = "NO"
+        debugDocumentVersioning = "YES"
+        debugServiceExtension = "internal"
+        allowLocationSimulation = "YES">
+''');
+    final FakeIosProject project = FakeIosProject(file);
+    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator.ios(project, BufferLogger.test());
+
+    expect(() async => validator.migrate(), returnsNormally);
+
+    expect(file.readAsStringSync(), contains(
+      'debugServiceExtension = "internal"'
+    '\n        enableGPUValidationMode = "1"'));
+  });
+
   testWithoutContext('Skips modifying file that already references Metal API setting', () {
     final FileSystem fs = MemoryFileSystem.test();
 

--- a/packages/flutter_tools/test/general.shard/ios/metal_api_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/metal_api_validator_test.dart
@@ -1,0 +1,78 @@
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/ios/migrations/metal_api_validation_migration.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:test/fake.dart';
+
+import '../../src/common.dart';
+
+
+void main() {
+  testWithoutContext('Adds Metal API setting to matching file', () {
+    final FileSystem fs = MemoryFileSystem.test();
+
+    final File file = fs.file('does_not_exist')
+      ..createSync()
+      ..writeAsStringSync('''
+<?xml version="1.0" encoding="UTF-8"?>
+  <LaunchAction
+    buildConfiguration = "Debug"
+    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+    launchStyle = "0"
+    useCustomWorkingDirectory = "NO"
+    ignoresPersistentStateOnLaunch = "NO"
+    debugDocumentVersioning = "YES"
+    debugServiceExtension = "internal"
+    allowLocationSimulation = "YES">
+''');
+    final FakeIosProject project = FakeIosProject(file);
+    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator(project, BufferLogger.test());
+
+    expect(() async => validator.migrate(), returnsNormally);
+
+    expect(file.readAsStringSync(), contains(
+      'debugServiceExtension = "internal"'
+    '\n    enableGPUValidationMode = "1"'));
+  });
+
+  testWithoutContext('No-op on file with no match', () {
+    final FileSystem fs = MemoryFileSystem.test();
+
+    final File file = fs.file('does_not_exist')
+      ..createSync()
+      ..writeAsStringSync('NO_OP');
+    final FakeIosProject project = FakeIosProject(file);
+    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator(project, BufferLogger.test());
+
+    expect(() async => validator.migrate(), returnsNormally);
+
+    expect(file.readAsStringSync(), 'NO_OP');
+  });
+
+  testWithoutContext('No-op on missing file', () async {
+    final FileSystem fs = MemoryFileSystem.test();
+    final FakeIosProject project = FakeIosProject(fs.file('does_not_exist'));
+    final MetalAPIValidationMigrator validator = MetalAPIValidationMigrator(project, BufferLogger.test());
+
+    expect(() async => validator.migrate(), returnsNormally);
+  });
+}
+
+class FakeIosProject extends Fake implements IosProject {
+  FakeIosProject(this._file);
+
+  final File _file;
+
+  @override
+  File xcodeProjectSchemeFile({String? scheme}) {
+    return _file;
+  }
+}


### PR DESCRIPTION
Setting "enableGPUValidationMode = "1"" disables Metal API validation. I know, I know.

Fixes https://github.com/flutter/flutter/issues/159227
