### PR TITLE
Un-skip tests that use `flutter build apk`.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -223,9 +223,6 @@ void main() {
           expectCCompilerIsConfigured(exampleDirectory);
         });
       },
-      // TODO(matanlurey): Debug why flutter build apk often timesout.
-      // See https://github.com/flutter/flutter/issues/158560 for details.
-      skip: buildSubcommand == 'apk' ? 'flutter build apk times out' : false, // Temporary workaround for https://github.com/flutter/flutter/issues/158560.
       tags: <String>['flutter-build-apk'],
       );
     }

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
@@ -143,9 +143,6 @@ void main(List<String> args) async {
         expect(await process.exitCode, 0);
       },);
     },
-    // TODO(matanlurey): Debug why flutter build apk often timesout.
-    // See https://github.com/flutter/flutter/issues/158560 for details.
-    skip: buildCommand == 'apk' ? 'flutter build apk times out' : false, // Temporary workaround for https://github.com/flutter/flutter/issues/158560.
     tags: <String>['flutter-build-apk'],
   );
 }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/158560.

I believe but am not sure as of https://github.com/flutter/flutter/pull/159170 merging, many process flakes that were consuming memory and in turn, making Gradle particularly sensitive to timing out or being killing by the OS for low-memory, have been rectified.

It is possible there are additional problems, but they aren't visible at the moment.

I'd like to re-enable these and keep tracking their stability.