### PR TITLE
Remove `RepaintBoundary` that is no longer needed.

### DIFF
--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -30,6 +30,11 @@ void main() {
       final Matrix4 matrix = TestViewConfiguration(size: Size.zero).toMatrix();
       expect(matrix.storage.every((double x) => x.isFinite), isTrue);
     });
+
+    test('sets the DPR to match the window', () {
+      final TestViewConfiguration configuration = TestViewConfiguration(size: const Size(1280.0, 800.0));
+      expect(configuration.devicePixelRatio, binding.window.devicePixelRatio);
+    });
   });
 
   group(AutomatedTestWidgetsFlutterBinding, () {

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -447,14 +447,6 @@ https://docs.flutter.dev/testing/integration-tests
   Timeout defaultTestTimeout = Timeout.none;
 
   @override
-  Widget wrapWithDefaultView(Widget rootWidget) {
-    // This is a workaround where screenshots of root widgets have incorrect
-    // bounds.
-    // TODO(jiahaog): Remove when https://github.com/flutter/flutter/issues/66006 is fixed.
-    return super.wrapWithDefaultView(RepaintBoundary(child: rootWidget));
-  }
-
-  @override
   void reportExceptionNoticed(FlutterErrorDetails exception) {
     // This method is called to log errors as they happen, and they will also
     // be eventually logged again at the end of the tests. The superclass

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -124,11 +124,11 @@ Future<void> main() async {
       });
     });
 
-    // TODO(jiahaog): Remove when https://github.com/flutter/flutter/issues/66006 is fixed.
-    testWidgets('root widgets are wrapped with a RepaintBoundary', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/66006.
+    testWidgets('root view reports correct dimensions', (WidgetTester tester) async {
       await tester.pumpWidget(const Placeholder());
 
-      expect(find.byType(RepaintBoundary), findsOneWidget);
+      expect(tester.binding.renderView.paintBounds, const Rect.fromLTWH(0, 0, 2400, 1800));
     });
 
     testWidgets('integration test has no label', (WidgetTester tester) async {


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/66006.

From what I can tell in the multi-view effort a variation of https://github.com/flutter/flutter/pull/88609 already landed, meaning that the current device-pixel-ratio is being used (as the tests in #88609 are now passing), and I believe that means we can remove the override/hack.

Will rely on "Google Testing" to run a TGP internally, or do so myself if necessary.
