### PR TITLE
Material ButtonStyleButton.icon() constructor param IconAlignment default-safety fix

### DIFF
--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -106,7 +106,7 @@ class ElevatedButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
-    IconAlignment iconAlignment = IconAlignment.start,
+    IconAlignment? iconAlignment,
   }) {
     if (icon == null) {
       return ElevatedButton(
@@ -136,7 +136,7 @@ class ElevatedButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
-      iconAlignment: iconAlignment,
+      iconAlignment: iconAlignment ?? IconAlignment.start,
     );
   }
 

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -107,7 +107,7 @@ class FilledButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
-    IconAlignment iconAlignment = IconAlignment.start,
+    IconAlignment? iconAlignment,
   }) {
      if (icon == null) {
       return FilledButton(
@@ -137,7 +137,7 @@ class FilledButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
-      iconAlignment: iconAlignment,
+      iconAlignment: iconAlignment ?? IconAlignment.start,
     );
   }
 
@@ -180,7 +180,7 @@ class FilledButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
-    IconAlignment iconAlignment = IconAlignment.start,
+    IconAlignment? iconAlignment,
   }) {
     if (icon == null) {
       return FilledButton.tonal(
@@ -210,7 +210,7 @@ class FilledButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
-      iconAlignment: iconAlignment,
+      iconAlignment: iconAlignment ?? IconAlignment.start,
     );
   }
 

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -110,7 +110,7 @@ class OutlinedButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
-    IconAlignment iconAlignment = IconAlignment.start,
+    IconAlignment? iconAlignment,
   }) {
     if (icon == null) {
       return OutlinedButton(
@@ -140,7 +140,7 @@ class OutlinedButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
-      iconAlignment: iconAlignment,
+      iconAlignment: iconAlignment ?? IconAlignment.start,
     );
   }
 

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -119,7 +119,7 @@ class TextButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
-    IconAlignment iconAlignment = IconAlignment.start,
+    IconAlignment? iconAlignment,
   }) {
      if (icon == null) {
       return TextButton(
@@ -148,7 +148,7 @@ class TextButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
-      iconAlignment: iconAlignment,
+      iconAlignment: iconAlignment ?? IconAlignment.start,
     );
   }
 


### PR DESCRIPTION
### Fixes [#159240](https://github.com/flutter/flutter/issues/159240)

### Summary:
Passing a null iconAlignment value to the ButtonStyleButton* icon constructor(s) returns an error.

### Culprit(s)
[ButtonStyleButton] - the base class of: 
- [ElevatedButton]
- [FilledButton] 
- [OutlinedButton] 
- [TextButton]

### Steps to reproduce

```
Widget customButton({
	required String label, 
	Icon? buttonIcon, 
	IconAlignment? iconAlignment, }) {

	return ElevatedButton.icon( 
		label: Text(label), 
		icon: buttonIcon, 
		iconAlignment: iconAlignment ); 
}
```

### Notes
1. The `iconAlignment` named parameter throws an exception when you pass a null/-able value to it, albeit already having logic responsible for a default value.

2. The named parameter `icon` is nullable, as the *Button constructor already implements a fail-safe factory solution returning an iconless button.

3. _All_ other parameters, except for the required `label` are nullable.

3. Two other named parameters - `autofocus` and `clipBehavior`, already implement a default value safety in the initializers of their constructors.

4. No other changes are necessary, as the public constructors are simply passing values to private ones.

### Alternative solutions
You can append `?? IconAlignment.start` to every `ButtonStyleButton*.icon` constructor, or you handle types explicitly and carefully. Either  of those options generates a lot of unnecessary code clutter and/or complications.

### Bottom line
Providing default values in this manner is archaic and stiff, as you have no proper way to NOT pass a named parameter and you have no way to fallback to defaults from function calls alone.

As a default value logic is already implemented, I consider none of this code additional functionality, but rather a fix of the existing one.

The only drawback of this method would be that on a low level, implementing a default value check in the initializer instead of the constructor definition would be considered an Expensive Call.
see stackoverflow#15394313
https://stackoverflow.com/questions/15394313/most-elegant-way-to-initialize-members-with-default-values

However, the improvement in terms of intuitive ease of use as of the current state of the ecosystem outweigh possible code-related doubts.

This issue barely touches on the topic of Dart issue#1512 (and all further referenced ones):
https://github.com/dart-lang/language/issues/1512


### Requests
As it is yet beyond my capabilities, If anyone could assist me with a comparison on the performance side of things -- e.g. default value in constructor vs. in initializer, as that holds potential to be an even larger issue.

Let me know if I am missing any test cases and/or docs.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.