### PR TITLE
Added additional logging to `_listCoreDevices`

### DIFF
--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -94,6 +94,10 @@ class IOSCoreDeviceControl {
         _logger.printError('The process exited with code ${result.exitCode} and');
         _logger.printError('Stdout:\n\n${result.stdout.trim()}\n');
         _logger.printError('Stderr:\n\n${result.stderr.trim()}');
+        _logger.printError('Using file system type: ${_fileSystem.runtimeType}');
+        if (_fileSystem is LocalFileSystem) {
+          _logger.printError('LocalFileSystem disposed: ${_fileSystem.disposed}');
+        }
         throw StateError('Expected the file ${output.path} to exist but it did not');
       } else if (isToolPossiblyShutdown) {
         return <Object?>[];


### PR DESCRIPTION
Attempting to collect additional context into the failure outlined in https://github.com/flutter/flutter/issues/141892