### PR TITLE
[DRAFT] Fix `DropdownButtonFormField` icon alignment when label text is provided

### DIFF
--- a/examples/api/test/widgets/autocomplete/raw_autocomplete.2_test.dart
+++ b/examples/api/test/widgets/autocomplete/raw_autocomplete.2_test.dart
@@ -10,8 +10,10 @@ void main() {
   testWidgets('Form is entirely visible and rejects invalid responses', (WidgetTester tester) async {
     await tester.pumpWidget(const example.AutocompleteExampleApp());
     expect(find.text('RawAutocomplete Form'), findsOneWidget);
+    // One of the icon is hidden for an input decoration height workaround
+    // See https://github.com/flutter/flutter/issues/159431.
+    expect(find.byIcon(Icons.arrow_downward), findsNWidgets(2));
     expect(find.byType(TextFormField), findsNWidgets(2));
-    expect(find.byIcon(Icons.arrow_downward), findsOneWidget);
     expect(find.text('This is a regular DropdownButtonFormField'), findsOneWidget);
     expect(find.text('This is a regular TextFormField'), findsOneWidget);
     expect(find.text('This is a RawAutocomplete!'), findsOneWidget);
@@ -37,7 +39,7 @@ void main() {
 
   testWidgets('Form accepts valid inputs', (WidgetTester tester) async {
     await tester.pumpWidget(const example.AutocompleteExampleApp());
-    await tester.tap(find.byIcon(Icons.arrow_downward));
+    await tester.tap(find.byIcon(Icons.arrow_downward).last);
     await tester.pump();
 
     expect(find.text('One'), findsOneWidget);

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1601,8 +1601,8 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     if (widget._inputDecoration != null) {
       result = InputDecorator(
         decoration: widget._inputDecoration!.copyWith(
-          // Override the suffix ucins constraints to allow the
-          // icons alignment to match the regular dropdown button.
+          // Override the suffix icon constraints to allow the
+          // icon alignment to match the regular dropdown button.
           suffixIconConstraints: const BoxConstraints(minWidth: 40.0),
           suffixIcon: effectiveSuffixIcon,
         ),

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1526,6 +1526,15 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
 
     const Icon defaultIcon = Icon(Icons.arrow_drop_down);
+    final Widget effectiveSuffixIcon = IconTheme(
+      data: IconThemeData(
+        color: _iconColor,
+        size: widget.iconSize,
+      ),
+      child: widget.icon
+        ?? widget._inputDecoration?.suffixIcon
+        ?? defaultIcon,
+    );
 
     Widget result = DefaultTextStyle(
       style: _enabled ? _textStyle! : _textStyle!.copyWith(color: Theme.of(context).disabledColor),
@@ -1541,12 +1550,15 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
                 Expanded(child: innerItemsWidget)
               else
                 innerItemsWidget,
-              IconTheme(
-                data: IconThemeData(
-                  color: _iconColor,
-                  size: widget.iconSize,
-                ),
-                child: widget.icon ?? defaultIcon,
+              // TODO(TahaTessser): Remove InputDecorator height workaround.
+              // Wrapped the suffix icon with Visibility widget as a workaround
+              // for https://github.com/flutter/flutter/issues/159431.
+              Visibility(
+                visible: widget._inputDecoration == null,
+                maintainSize: true,
+                maintainState: true,
+                maintainAnimation: true,
+                child: effectiveSuffixIcon,
               ),
             ],
           ),
@@ -1588,7 +1600,12 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
     if (widget._inputDecoration != null) {
       result = InputDecorator(
-        decoration: widget._inputDecoration!,
+        decoration: widget._inputDecoration!.copyWith(
+          // Override the suffix ucins constraints to allow the
+          // icons alignment to match the regular dropdown button.
+          suffixIconConstraints: const BoxConstraints(minWidth: 40.0),
+          suffixIcon: effectiveSuffixIcon,
+        ),
         isEmpty: widget._isEmpty,
         isFocused: widget._isFocused,
         child: result,

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1550,9 +1550,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
                 Expanded(child: innerItemsWidget)
               else
                 innerItemsWidget,
-              // TODO(TahaTessser): Remove InputDecorator height workaround.
-              // Wrapped the suffix icon with Visibility widget as a workaround
+              // TODO(TahaTessser): Remove InputDecorator height workaround
               // for https://github.com/flutter/flutter/issues/159431.
+              // Hiding the icon with maintainSize does not effect the baseline.
               Visibility(
                 visible: widget._inputDecoration == null,
                 maintainSize: true,

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -510,7 +510,7 @@ void main() {
     expect(buttonBox.attached, isTrue);
 
     final RenderBox arrowIcon = tester.renderObject<RenderBox>(
-      find.byIcon(Icons.arrow_drop_down),
+      find.byIcon(Icons.arrow_drop_down).last,
     );
     expect(arrowIcon.attached, isTrue);
 
@@ -813,11 +813,11 @@ void main() {
     ));
 
     // test for size
-    final RenderBox icon = tester.renderObject(find.byKey(iconKey));
-    expect(icon.size, const Size(30.0, 30.0));
+    final RenderBox icon = tester.renderObject(find.byKey(iconKey).last);
+    expect(icon.size, const Size(40.0, 30.0));
 
     // test for enabled color
-    final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
+    final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey).last);
     expect(enabledRichText.text.style!.color, Colors.pink);
 
     // test for disabled color
@@ -829,7 +829,7 @@ void main() {
       items: null,
     ));
 
-    final RichText disabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
+    final RichText disabledRichText = tester.widget<RichText>(_iconRichText(iconKey).last);
     expect(disabledRichText.text.style!.color, Colors.orange);
   });
 
@@ -1306,5 +1306,65 @@ void main() {
     formKey.currentState!.reset();
 
     expect(tester.takeException(), isNull);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/157074.
+  testWidgets('DropdownButtonFormField icon is aligned with label text', (WidgetTester tester) async {
+    const String labelText = 'Label Text';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: DropdownButtonFormField<String>(
+              decoration: const InputDecoration(
+                labelText: labelText,
+              ),
+              items: <String>['One', 'Two']
+                .map<DropdownMenuItem<String>>((String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(value),
+                  );
+              }).toList(),
+              onChanged: (_) { },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getCenter(find.text(labelText)).dy, tester.getCenter(find.byType(Icon).last).dy);
+  });
+
+  // TODO(TahaTessser): Remove this test when the workround is removed.
+  // See https://github.com/flutter/flutter/issues/159431.
+  testWidgets('DropdownButtonFormField workaround hides the suffix icon in the child Row', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: DropdownButtonFormField<String>(
+              items: <String>['One', 'Two']
+                .map<DropdownMenuItem<String>>((String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(value),
+                  );
+              }).toList(),
+              onChanged: (_) { },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Icon), findsNWidgets(2));
+
+    // Test the suffix icon workaround hides the icon.
+    final Visibility visibility = tester.widget<Visibility>(find.ancestor(
+      of: find.byType(Icon).first,
+      matching: find.byType(Visibility),
+    ));
+    expect(visibility.visible, equals(false));
   });
 }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1549,14 +1549,14 @@ void main() {
     // The selected value should be displayed when the button is enabled.
     await tester.pumpWidget(build(onChanged: onChanged, value: 'two'));
     // The dropdown icon and the selected menu item are vertically aligned.
-    expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon)).dy);
+    expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon).last).dy);
     // Selected item has a normal color from [DropdownButtonFormField.style]
     // when the button is enabled.
     expect(textColor('two'), Colors.yellow);
 
     // The selected value should be displayed when the button is disabled.
     await tester.pumpWidget(build(value: 'two'));
-    expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon)).dy);
+    expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon).last).dy);
     // Selected item has a disabled color from [theme.disabledColor]
     // when the button is disable.
     expect(textColor('two'), Colors.pink);


### PR DESCRIPTION
Fix [DropdownButtonFormField arrow icon is misaligned vertically](https://github.com/flutter/flutter/issues/157074)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Scaffold(
        body: Padding(
          padding: const EdgeInsets.all(16),
          child: Center(
            child: DropdownButtonFormField<String>(
              onChanged: (_) {},
              decoration: const InputDecoration(
                labelText: 'Label Text',
                filled: true,
                fillColor: Colors.amber,
              ),
              items: const [
                DropdownMenuItem(
                  value: 'selected',
                  child: Text('Selected item'),
                ),
              ],
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>




### Before

<img width="543" alt="Screenshot 2024-12-03 at 13 51 55" src="https://github.com/user-attachments/assets/fed69c34-fe57-47f6-9850-b9af02f9ee75">

<img width="543" alt="Screenshot 2024-12-03 at 13 51 59" src="https://github.com/user-attachments/assets/1499109e-e08f-471a-a1f2-1ea5ae3d528b">


### After

<img width="543" alt="Screenshot 2024-12-03 at 13 51 40" src="https://github.com/user-attachments/assets/1fb99042-eedc-4a12-a764-4cc34415d0c3">

<img width="543" alt="Screenshot 2024-12-03 at 13 51 44" src="https://github.com/user-attachments/assets/5a23b03c-ccd3-4667-ba9a-79ab5867a157">



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
