### PR TITLE
`WidgetStateMap` observer

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -10,7 +10,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 // Examples can assume:
 // late BuildContext context;
@@ -992,8 +991,8 @@ class WidgetStateMapper<T> with Diagnosticable implements WidgetStateProperty<T>
 
   final WidgetStateMap<T> _map;
 
-  /// Returns a copy of this [WidgetStateMapper] that invokes the provided
-  /// [onResolve] callback during its [resolve] method.
+  /// In debug mode, returns a copy of this [WidgetStateMapper] that invokes
+  /// the provided [onResolve] callback during its [resolve] method.
   ///
   /// {@tool snippet}
   ///
@@ -1020,11 +1019,15 @@ class WidgetStateMapper<T> with Diagnosticable implements WidgetStateProperty<T>
   /// );
   /// ```
   /// {@end-tool}
-  @doNotSubmit
-  WidgetStateMapper<T> withObserver(
+  WidgetStateMapper<T> debugObserveWith(
     void Function(MapEntry<WidgetStatesConstraint?, T> entry) onResolve,
   ) {
-    return _WidgetStateMapObserver<T>(_map, onResolve);
+    WidgetStateMapper<T>? result;
+    assert(() {
+      result = _WidgetStateMapObserver<T>(_map, onResolve);
+      return true;
+    }());
+    return result ?? this;
   }
 
   @override
@@ -1090,7 +1093,6 @@ class WidgetStateMapper<T> with Diagnosticable implements WidgetStateProperty<T>
 }
 
 class _WidgetStateMapObserver<T> extends WidgetStateMapper<T> {
-  @doNotSubmit
   const _WidgetStateMapObserver(super.map, this.onResolve);
 
   final void Function(MapEntry<WidgetStatesConstraint?, T> entry) onResolve;

--- a/packages/flutter/test/widgets/widget_state_property_test.dart
+++ b/packages/flutter/test/widgets/widget_state_property_test.dart
@@ -280,7 +280,7 @@ void main() {
         WidgetState.disabled:               Colors.blueGrey,
         ~WidgetState.disabled:              Colors.black,
       },
-    ).withObserver(observer); // ignore: invalid_use_of_do_not_submit_member
+    ).debugObserveWith(observer);
 
     // Adding the observer should not call its closure.
     expect(selectedConstraint ?? resolvedColor, isNull);


### PR DESCRIPTION
This pull request adds a utility method to `WidgetStateMapper` that calls a closure each time the property is resolved.

```dart
final mapper = const WidgetStateMapper({
  WidgetState.hovered: 5.0,
  WidgetState.pressed: 0.0,
  WidgetState.any:     2.0,
}).withObserver(print),

mapper.resolve({WidgetState.pressed}); // prints "MapEntry(WidgetState.pressed: 0)"
```

<br>

related: https://github.com/flutter/flutter/pull/152535#issuecomment-2491982596