### PR TITLE
Fix `SafeArea` DartPad sample

### DIFF
--- a/examples/api/lib/widgets/safe_area/safe_area.0.dart
+++ b/examples/api/lib/widgets/safe_area/safe_area.0.dart
@@ -26,7 +26,7 @@ class SafeAreaExampleApp extends StatelessWidget {
     scaffoldBackgroundColor: const Color(0xFFD0FFE8),
     listTileTheme: const ListTileThemeData(
       tileColor: Colors.white70,
-      contentPadding: EdgeInsets.all(6.0),
+      visualDensity: VisualDensity(horizontal: -4, vertical: -4),
     ),
     appBarTheme: AppBarTheme(
       backgroundColor: colors.secondary,
@@ -65,7 +65,7 @@ class SafeAreaExample extends StatelessWidget {
 
   static final Widget controls = Column(
     children: <Widget>[
-      const SizedBox(height: 14),
+      const SizedBox(height: 6),
       Builder(
         builder: (BuildContext context) => Text(
           Toggle.safeArea.of(context) ? 'safe area!' : 'no safe area',
@@ -122,6 +122,7 @@ enum Inset implements Value {
     Text(label),
     Builder(
       builder: (BuildContext context) => Slider(
+        key: ValueKey<Inset>(this),
         max: 50,
         value: of(context),
         onChanged: (double newValue) {

--- a/examples/api/lib/widgets/safe_area/safe_area.0.dart
+++ b/examples/api/lib/widgets/safe_area/safe_area.0.dart
@@ -122,7 +122,6 @@ enum Inset implements Value {
     Text(label),
     Builder(
       builder: (BuildContext context) => Slider(
-        key: ValueKey<Inset>(this),
         max: 50,
         value: of(context),
         onChanged: (double newValue) {

--- a/examples/api/test/widgets/safe_area/safe_area.0_test.dart
+++ b/examples/api/test/widgets/safe_area/safe_area.0_test.dart
@@ -100,13 +100,9 @@ void main() {
     expect(appScreenHeight(), 480);
     expect(insetsState.insets, const EdgeInsets.fromLTRB(8.0, 25.0, 8.0, 12.0));
 
-    const List<Key> keys = <Key>[
-      ValueKey<example.Inset>(example.Inset.top),
-      ValueKey<example.Inset>(example.Inset.sides),
-      ValueKey<example.Inset>(example.Inset.bottom),
-    ];
-    for (final Key key in keys) {
-      await tester.drag(find.byKey(key), const Offset(500.0, 0.0));
+    // Drag each slider to its maximum value.
+    for (int index = 0; index < 3; index++) {
+      await tester.drag(find.byType(Slider).at(index), const Offset(500.0, 0.0));
       await tester.pumpAndSettle();
       expect(tester.takeException(), isNull);
     }

--- a/examples/api/test/widgets/safe_area/safe_area.0_test.dart
+++ b/examples/api/test/widgets/safe_area/safe_area.0_test.dart
@@ -81,4 +81,37 @@ void main() {
     context = tester.element(find.text('safe area!'));
     expect(MediaQuery.paddingOf(context), EdgeInsets.zero);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/159340.
+  testWidgets('App displays without layout issues', (WidgetTester tester) async {
+    // Set the app's size to to match the default DartPad demo screen.
+    await tester.pumpWidget(
+      const Center(
+        child: SizedBox(
+          width: 500.0,
+          height: 480.0,
+          child: example.Insets(),
+        ),
+      ),
+    );
+
+    double appScreenHeight() => tester.getRect(find.byType(example.Insets)).height;
+
+    expect(appScreenHeight(), 480);
+    expect(insetsState.insets, const EdgeInsets.fromLTRB(8.0, 25.0, 8.0, 12.0));
+
+    const List<Key> keys = <Key>[
+      ValueKey<example.Inset>(example.Inset.top),
+      ValueKey<example.Inset>(example.Inset.sides),
+      ValueKey<example.Inset>(example.Inset.bottom),
+    ];
+    for (final Key key in keys) {
+      await tester.drag(find.byKey(key), const Offset(500.0, 0.0));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+    }
+
+    expect(appScreenHeight(), 480);
+    expect(insetsState.insets, const EdgeInsets.all(50));
+  });
 }


### PR DESCRIPTION
This pull request fixes a bug I introduced in https://github.com/flutter/flutter/pull/158019.

<br>

<h3 align="center">Before</h3>
<p align="center">
  <img 
    src="https://github.com/user-attachments/assets/fcb68fac-9c63-445d-8d2b-afc28c685053"
    alt="RenderFlex overflowed"
    width="523px"
  />
</p>

<h3 align="center">After</h3>
<p align="center">
  <img 
    src="https://github.com/user-attachments/assets/82091c6a-b3c5-4994-978e-5e76cbb7edfd"
    alt="RenderFlex overflowed"
    width="523px"
  />
</p>

<br><br>

- fixes https://github.com/flutter/flutter/issues/159340