### PR TITLE
[tool] Fix android tests using outdated regexs to modify templates

### DIFF
--- a/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
@@ -45,19 +45,6 @@ void main() {
     final Directory exampleAppDir =
         tempDir.childDirectory(testName).childDirectory('example');
 
-    final File buildGradleFile = exampleAppDir.childDirectory('android').childFile('build.gradle.kts');
-    expect(buildGradleFile, exists);
-
-    final String buildGradle = buildGradleFile.readAsStringSync();
-    final RegExp androidPluginRegExp =
-        RegExp(r'com\.android\.tools\.build:gradle:(\d+\.\d+\.\d+)');
-
-    // Use AGP 7.2.0
-    final String newBuildGradle = buildGradle.replaceAll(
-        androidPluginRegExp, 'com.android.tools.build:gradle:7.2.0');
-    buildGradleFile.writeAsStringSync(newBuildGradle);
-
-    // Run flutter build apk using AGP 7.2.0
     result = processManager.runSync(<String>[
       flutterBin,
       ...getLocalEngineArguments(),

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_agp_version_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_agp_version_test.dart
@@ -16,7 +16,7 @@ const String packageName = 'package_with_native_assets';
 
 /// The AGP versions to run these tests against.
 final List<String> agpVersions = <String>[
-  '8.4'
+  '8.4.0'
 ];
 
 /// The build modes to target for each flutter command that supports passing
@@ -51,50 +51,59 @@ for (final String agpVersion in agpVersions) {
           final Directory packageDirectory = await createTestProject(packageName, tempDirectory);
           final Directory exampleDirectory = packageDirectory.childDirectory('example');
 
-        File buildGradleFile = exampleDirectory.childDirectory('android').childFile('build.gradle');
-        if (!buildGradleFile.existsSync()) {
-          buildGradleFile = exampleDirectory.childDirectory('android').childFile('build.gradle.kts');
-        }
-
         File appBuildGradleFile = exampleDirectory.childDirectory('android').childDirectory('app').childFile('build.gradle');
         if (!appBuildGradleFile.existsSync()) {
           appBuildGradleFile = exampleDirectory.childDirectory('android').childDirectory('app').childFile('build.gradle.kts');
         }
 
-        expect(buildGradleFile, exists);
+        final File settingsGradleFile = exampleDirectory.childDirectory('android').childFile('settings.gradle.kts');
+
         expect(appBuildGradleFile, exists);
+        expect(settingsGradleFile, exists);
 
         // Use expected AGP version.
-        final String buildGradle = buildGradleFile.readAsStringSync();
+        final String settingsGradle = settingsGradleFile.readAsStringSync();
+
         final RegExp androidPluginRegExp =
-            RegExp(r'com\.android\.tools\.build:gradle:(\d+\.\d+\.\d+)');
-        final String newBuildGradle = buildGradle.replaceAll(
-            androidPluginRegExp, 'com.android.tools.build:gradle:$agpVersion');
-        buildGradleFile.writeAsStringSync(newBuildGradle);
+            RegExp(r'id\("com\.android\.application"\)\s+version\s+"([^"]+)"\s+apply\s+false');
+        expect(androidPluginRegExp.firstMatch(settingsGradle), isNotNull);
+
+        final String newSettingsGradle = settingsGradle.replaceAll(
+            androidPluginRegExp, 'id("com.android.application") version "$agpVersion" apply false');
+        settingsGradleFile.writeAsStringSync(newSettingsGradle);
 
         // Use Android app with multiple flavors.
         final String appBuildGradle = appBuildGradleFile.readAsStringSync().replaceAll('\r\n', '\n');
         final RegExp buildTypesBlockRegExp = RegExp(r'buildTypes {\n[ \t]+release {((.|\n)*)\n[ \t]+}\n[ \t]+}');
-        final String buildTypesBlock = buildTypesBlockRegExp.firstMatch(appBuildGradle)!.toString();
+        final String buildTypesBlock = buildTypesBlockRegExp.firstMatch(appBuildGradle)![0]!;
         final String appBuildGradleSegmentDefiningFlavors = '''
     $buildTypesBlock
 
-    flavorDimensions "mode"
+    flavorDimensions += "mode"
 
     productFlavors {
-        flavorOne {}
-        flavorTwo {}
-        flavorThree {}
+        create("flavorOne") {
+            dimension = "mode"
+        }
+        create("flavorTwo") {
+            dimension = "mode"
+        }
+        create("flavorThree") {
+            dimension = "mode"
+        }
     }
 ''';
-        appBuildGradle.replaceFirst(
+        final String newAppBuildGradle = appBuildGradle.replaceFirst(
             buildTypesBlockRegExp, appBuildGradleSegmentDefiningFlavors);
+        appBuildGradleFile.writeAsStringSync(newAppBuildGradle);
 
           final ProcessResult result = processManager.runSync(
             <String>[
               flutterBin,
               'build',
               'apk',
+              '--flavor',
+              'flavorOne',
               '--$buildMode',
             ],
             workingDirectory: exampleDirectory.path,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

**Description**

While exploring some semi-related stuff, found these 2 tests using outdated regex which does not work because AGP version in modern templates is set in `settings.gradle.kts` and in form of `com.android.application` instead of `com.android.tools.build:gradle`.

Apart from that, in `android_plugin_example_app_build_test.dart` deleted all lines regarding version change (instead of comply with new way of declaring plugin) because for a long time it's didn't work anyway: `replaceAll` haven't find any matches and test ran on latest AGP from template. More than that, attempt to adapt this test to modern AGP setup failed because build is not working with AGP < 8 (I lost logs with actual error for this case, but I believe I can reproduce if anyone wants)

in `native_assets_agp_version_test`: 

- Fixed version to comply with AGP versioning format, which is `major.minor.patch`.
- Updated regex and version changing logic to work with `com.android.application` format and `settings.gradle.kts` file. I believe that version updating is desired behavior here, unlike in `android_plugin_example_app_build_test.dart`. 
- Updated `kts` syntax for declaring flavors in `build.gradle.kts` and updated regex-based updating of this file (didn't work previously because there wasn't actual writing to file)

didn't list any issues because there're not any regarding these tests (or maybe I just failed to find). In any case, I think that this doesn't require issue because fix is kinda trivial and motivation is clear.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
