### PR TITLE
[ Tool ] Fix "Error: Unable to find git in your PATH" when Command Processor `AutoRun` registry key is defined

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -66,7 +66,7 @@ GOTO :after_subroutine
     REM
     REM See https://github.com/flutter/flutter/issues/159018
     FOR /f %%r IN ('PUSHD %FLUTTER_ROOT% ^& $git rev-parse HEAD') DO (
-      SET compilekey="%%r:%FLUTTER_TOOL_ARGS%"
+      SET compilekey="%%r%:%FLUTTER_TOOL_ARGS%"
     )
   )
 

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -66,9 +66,10 @@ GOTO :after_subroutine
     REM
     REM See https://github.com/flutter/flutter/issues/159018
     FOR /f %%r IN ('PUSHD %FLUTTER_ROOT% ^& $git rev-parse HEAD') DO (
-      SET compilekey="%%r%:%FLUTTER_TOOL_ARGS%"
+      SET revision=%%r
     )
   )
+  SET compilekey="%revision%:%FLUTTER_TOOL_ARGS%"
 
   REM Invalidate cache if:
   REM  * SNAPSHOT_PATH is not a file, or

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -59,10 +59,11 @@ GOTO :after_subroutine
     ECHO Error: Unable to find git in your PATH. && EXIT 1
   )
   2>NUL (
-    REM 'FOR /f' spawns a new terminal instance to run the command, so we need
-    REM to 'PUSHD %FLUTTER_ROOT%' before getting the git revision. If an
-    REM 'AutoRun' command is defined in the user's registry, we might not be in
-    REM the directory we expect to be in.
+    REM 'FOR /f' spawns a new terminal instance to run the command. If an
+    REM 'AutoRun' command is defined in the user's registry, that command could
+    REM change the working directory, and then we wouldn't be in the directory
+    REM we expect to be in. To prevent this, we need to 'PUSHD %FLUTTER_ROOT%'
+    REM before getting the git revision.
     REM
     REM See https://github.com/flutter/flutter/issues/159018
     FOR /f %%r IN ('PUSHD %FLUTTER_ROOT% ^& $git rev-parse HEAD') DO (


### PR DESCRIPTION
cmd.exe will read from the AutoRun registry key at launch and execute the commands listed in the key. Since `FOR /F IN (command) ...` causes a new terminal instance to start, the AutoRun commands will be run again, possibly changing the current working directory. In this case, the `git rev-parse HEAD` check run in `shared.bat` could fail, which we were assuming meant `git` was not on the user's PATH.

This change ensures that `git rev-parse HEAD` will always run in %FLUTTER_ROOT% and explicitly adds a separate check for `git` using `WHERE git` to more accurately determine if `git` is on the PATH.

Fixes https://github.com/flutter/flutter/issues/159018