### PR TITLE
Fix constrained InputDecorator baseline when content overflows

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -886,11 +886,16 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   static double _minHeight(RenderBox? box, double width) => box?.getMinIntrinsicHeight(width) ?? 0.0;
   static Size _boxSize(RenderBox? box) => box?.size ?? Size.zero;
   static double _getBaseline(RenderBox box, BoxConstraints boxConstraints) {
-    return ChildLayoutHelper.getBaseline(box, boxConstraints, TextBaseline.alphabetic) ?? box.size.height;
+    return math.min(
+      ChildLayoutHelper.getBaseline(box, boxConstraints, TextBaseline.alphabetic) ?? double.infinity,
+      box.size.height,
+    );
   }
   static double _getDryBaseline(RenderBox box, BoxConstraints boxConstraints) {
-    return ChildLayoutHelper.getDryBaseline(box, boxConstraints, TextBaseline.alphabetic)
-        ?? ChildLayoutHelper.dryLayoutChild(box, boxConstraints).height;
+    return math.min(
+      ChildLayoutHelper.getDryBaseline(box, boxConstraints, TextBaseline.alphabetic) ?? double.infinity,
+      ChildLayoutHelper.dryLayoutChild(box, boxConstraints).height,
+    );
   }
 
   static BoxParentData _boxParentData(RenderBox box) => box.parentData! as BoxParentData;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -7652,6 +7652,53 @@ void main() {
     expect(textTop, lessThan(textFieldBottom));
   });
 
+  // Regression test for https://github.com/flutter/flutter/pull/66055.
+  testWidgets('A vertically constrained InputDecorator respects the constraint', (WidgetTester tester) async {
+    final UniqueKey keyWithIcon = UniqueKey();
+    final UniqueKey keyWithoutIcon = UniqueKey();
+    const double constrainedHeight = 48.0;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Center(
+          child: Column(
+            children: <Widget>[
+              InputDecorator(
+                key: keyWithoutIcon,
+                decoration: const InputDecoration(),
+                child: const SizedBox(
+                  height: constrainedHeight,
+                  child: Row(
+                    children: <Widget>[
+                      Text('Flutter', style: TextStyle(fontSize: 60)),
+                    ]
+                  ),
+                ),
+              ),
+              InputDecorator(
+                key: keyWithIcon,
+                decoration: const InputDecoration(),
+                child: const SizedBox(
+                  height: constrainedHeight,
+                  child: Row(
+                    children: <Widget>[
+                      Text('Flutter', style: TextStyle(fontSize: 60)),
+                      Icon(Icons.arrow_drop_down),
+                    ]
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    final double withIconHeight = tester.getSize(find.byKey(keyWithIcon)).height;
+    final double withoutIconHeight = tester.getSize(find.byKey(keyWithoutIcon)).height;
+    expect(withIconHeight, equals(withoutIconHeight));
+  });
+
   testWidgets('Visual density is included in the intrinsic height calculation', (WidgetTester tester) async {
     final UniqueKey key = UniqueKey();
     final UniqueKey intrinsicHeightKey = UniqueKey();


### PR DESCRIPTION
## Description

This PR fixes the height computation for constrained `InputDecorator`s when the content overflows.
Using the code sample from https://github.com/flutter/flutter/issues/159431:

<details><summary>Code sample from 159431 (expected height is 48.0)</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: Scaffold(
        body: Center(
          child: InputDecorator(
            decoration: InputDecoration(
              filled: true
            ),
            child: SizedBox(
              height: 32.0,
              child: Row(
                children: [
                  Text(
                    'Text',
                    style: TextStyle(fontSize: 60.0),
                  ),
                  // Uncomment this line to get the correct height
                  // for the InputDecorator.
                  //Icon(Icons.arrow_drop_down),
                ],
              ),
            ),
          ),
        ),
      ),
    );
  }
}

``` 

</details> 


| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0b082fb0-8992-43b2-922b-c5fc24638a0f) | ![image](https://github.com/user-attachments/assets/96325ad7-e1f0-4f9e-93ee-a7cbe2114e70) | 
| Height = 71.4 | Height = 48.0 |

In that particular case, the text is too big to fit on the constrained size, with the fix the text overflows on the top but the InputDecorator height is correct.

---- 

When using the following code sample (constrained TextField):

<details><summary>Code sample</summary>

```dart

import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Scaffold(
        body: Center(
          child: SizedBox(
            height: 40,
            child: TextField(
              style: const TextStyle(fontSize: 60),
              decoration: const InputDecoration(
                filled: true, // Not required. Make the example more visual.
              ),
              controller: TextEditingController(text: 'efghij'),
            ),
          ),
        ),
      ),
    );
  }
}

```

</details> 

The results seems better with this fix, but because the text is overflowing, it is not clear which result should be expected.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2a04aa62-0e28-4bda-8c64-4b521a5ecd52) | ![image](https://github.com/user-attachments/assets/3af72363-e5c6-47d5-86c2-9c204235420a) | 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/159431
Might be a solution for [Constrained TextFields compensate for prefix/suffix when none exist](https://github.com/flutter/flutter/issues/66050).

## Tests

Adds 1 test.
