### PR TITLE
Enable unnecessary_library_name

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -219,7 +219,7 @@ linter:
     # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
     - unnecessary_late
     - unnecessary_library_directive
-    # - unnecessary_library_name # blocked on https://github.com/dart-lang/dartdoc/issues/3882
+    - unnecessary_library_name
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_aware_operator_on_extension_on_nullable

--- a/dev/integration_tests/android_semantics_testing/lib/android_semantics_testing.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/android_semantics_testing.dart
@@ -4,7 +4,7 @@
 
 /// This library provides constants and matchers for testing the Android
 /// accessibility implementation in a flutter driver environment.
-library android_semantics_testing;
+library;
 
 export 'src/common.dart';
 export 'src/constants.dart';

--- a/packages/flutter/lib/animation.dart
+++ b/packages/flutter/lib/animation.dart
@@ -160,7 +160,7 @@
 ///    explicit [Animation] to animate their properties.
 ///
 /// @docImport 'package:flutter/material.dart';
-library animation;
+library;
 
 // AnimationController can throw TickerCanceled
 export 'package:flutter/scheduler.dart' show TickerCanceled;

--- a/packages/flutter/lib/cupertino.dart
+++ b/packages/flutter/lib/cupertino.dart
@@ -20,7 +20,7 @@
 ///  * [flutter.dev/widgets](https://docs.flutter.dev/ui/widgets)
 ///    for a catalog of commonly-used Flutter widgets.
 
-library cupertino;
+library;
 
 export 'src/cupertino/activity_indicator.dart';
 export 'src/cupertino/adaptive_text_selection_toolbar.dart';

--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -7,7 +7,7 @@
 /// The features defined in this library are the lowest-level utility
 /// classes and functions used by all the other layers of the Flutter
 /// framework.
-library foundation;
+library;
 
 export 'package:meta/meta.dart' show
   factory,

--- a/packages/flutter/lib/gestures.dart
+++ b/packages/flutter/lib/gestures.dart
@@ -5,7 +5,7 @@
 /// The Flutter gesture recognizers.
 ///
 /// To use, import `package:flutter/gestures.dart`.
-library gestures;
+library;
 
 export 'src/gestures/arena.dart';
 export 'src/gestures/binding.dart';

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -14,7 +14,7 @@
 ///    for a catalog of commonly-used Material component widgets.
 ///  * [m3.material.io](https://m3.material.io/) for the Material 3 specification
 ///  * [m2.material.io](https://m2.material.io/) for the Material 2 specification
-library material;
+library;
 
 export 'src/material/about.dart';
 export 'src/material/action_buttons.dart';

--- a/packages/flutter/lib/painting.dart
+++ b/packages/flutter/lib/painting.dart
@@ -19,7 +19,7 @@
 /// @docImport 'src/painting/box_decoration.dart';
 /// @docImport 'src/painting/decoration.dart';
 /// @docImport 'src/painting/text_painter.dart';
-library painting;
+library;
 
 export 'dart:ui' show PlaceholderAlignment, Shadow, TextHeightBehavior, TextLeadingDistribution, kTextHeightNone;
 

--- a/packages/flutter/lib/physics.dart
+++ b/packages/flutter/lib/physics.dart
@@ -6,7 +6,7 @@
 /// gravity, for use in user interface animations.
 ///
 /// To use, import `package:flutter/physics.dart`.
-library physics;
+library;
 
 export 'src/physics/clamped_simulation.dart';
 export 'src/physics/friction_simulation.dart';

--- a/packages/flutter/lib/rendering.dart
+++ b/packages/flutter/lib/rendering.dart
@@ -28,7 +28,7 @@
 /// @docImport 'src/rendering/binding.dart';
 /// @docImport 'src/rendering/box.dart';
 /// @docImport 'src/rendering/object.dart';
-library rendering;
+library;
 
 export 'package:flutter/foundation.dart' show
   DiagnosticLevel,

--- a/packages/flutter/lib/scheduler.dart
+++ b/packages/flutter/lib/scheduler.dart
@@ -11,7 +11,7 @@
 ///
 /// The library makes sure that tasks are only run when appropriate.
 /// For example, an idle-task is only executed when no animation is running.
-library scheduler;
+library;
 
 export 'src/scheduler/binding.dart';
 export 'src/scheduler/debug.dart';

--- a/packages/flutter/lib/semantics.dart
+++ b/packages/flutter/lib/semantics.dart
@@ -13,7 +13,7 @@
 /// and is used by the platform-specific accessibility services.
 ///
 /// @docImport 'src/semantics/semantics.dart';
-library semantics;
+library;
 
 export 'dart:ui' show LocaleStringAttribute, SpellOutStringAttribute;
 

--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -8,7 +8,7 @@
 ///
 /// This library depends only on core Dart libraries and the `foundation`
 /// library.
-library services;
+library;
 
 export 'src/services/asset_bundle.dart';
 export 'src/services/asset_manifest.dart';

--- a/packages/flutter/lib/src/material/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons.dart
@@ -7,7 +7,7 @@
 ///
 /// @docImport 'icons.dart';
 /// @docImport 'theme.dart';
-library material_animated_icons;
+library material_animated_icons; // ignore: unnecessary_library_name
 
 import 'dart:math' as math show pi;
 import 'dart:ui' as ui show Canvas, Paint, Path, lerpDouble;

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -10,7 +10,7 @@
 ///
 ///  * [flutter.dev/widgets](https://flutter.dev/widgets/)
 ///    for a catalog of commonly-used Flutter widgets.
-library widgets;
+library;
 
 export 'package:characters/characters.dart';
 export 'package:vector_math/vector_math_64.dart' show Matrix4;

--- a/packages/flutter/test_private/test/animated_icons_private_test.dart.tmpl
+++ b/packages/flutter/test_private/test/animated_icons_private_test.dart.tmpl
@@ -9,7 +9,7 @@
 // material material_animated_icons library, but instead, this test file is an
 // implementation of that library, using some of the parts of the real
 // material_animated_icons, this give the test access to the private APIs.
-library material_animated_icons;
+library material_animated_icons; // ignore: unnecessary_library_name
 
 import 'dart:math' as math show pi;
 import 'dart:ui' as ui show Canvas, Paint, Path, lerpDouble;

--- a/packages/flutter_driver/lib/driver_extension.dart
+++ b/packages/flutter_driver/lib/driver_extension.dart
@@ -24,7 +24,7 @@
 ///     }
 ///
 /// @docImport 'src/extension/extension.dart';
-library flutter_driver_extension;
+library;
 
 export 'src/common/deserialization_factory.dart';
 export 'src/common/handler_factory.dart';

--- a/packages/flutter_driver/lib/flutter_driver.dart
+++ b/packages/flutter_driver/lib/flutter_driver.dart
@@ -9,7 +9,7 @@
 ///
 /// This is Flutter's version of Selenium WebDriver (generic web),
 /// Protractor (Angular), Espresso (Android) or Earl Gray (iOS).
-library flutter_driver;
+library;
 
 export 'src/common/deserialization_factory.dart';
 export 'src/common/diagnostics_tree.dart';

--- a/packages/flutter_localizations/lib/flutter_localizations.dart
+++ b/packages/flutter_localizations/lib/flutter_localizations.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 /// Localizations for the Flutter library.
-library flutter_localizations;
+library;
 
 export 'src/cupertino_localizations.dart';
 export 'src/l10n/generated_cupertino_localizations.dart';

--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -57,7 +57,7 @@
 /// @docImport 'src/controller.dart';
 /// @docImport 'src/test_compat.dart';
 /// @docImport 'src/widget_tester.dart';
-library flutter_test;
+library;
 
 export 'dart:async' show Future;
 

--- a/packages/flutter_tools/lib/src/reporting/reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/reporting.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library reporting;
+library;
 
 import 'dart:async';
 

--- a/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
+++ b/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
@@ -15,7 +15,7 @@
 ///    describing how the `url_launcher` package was created using `flutter_web_plugins`.
 ///
 /// @docImport 'src/plugin_registry.dart';
-library flutter_web_plugins;
+library;
 
 export 'src/navigation/url_strategy.dart';
 export 'src/navigation/utils.dart';

--- a/packages/fuchsia_remote_debug_protocol/lib/fuchsia_remote_debug_protocol.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/fuchsia_remote_debug_protocol.dart
@@ -14,7 +14,7 @@
 /// subscribe to creation and destruction of Dart VM instances, Isolates, and
 /// Flutter Views. Not all of these features are yet implemented, as this
 /// library is a work in progress.
-library fuchsia_remote_debug_protocol;
+library;
 
 export 'src/common/network.dart';
 export 'src/dart/dart_vm.dart';

--- a/packages/fuchsia_remote_debug_protocol/lib/logging.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/logging.dart
@@ -7,6 +7,6 @@
 /// Useful for determining connection issues and the like. This is included as a
 /// separate library so that it can be imported under a separate namespace in
 /// the event that you are using a logging package with similar class names.
-library logging;
+library;
 
 export 'src/common/logging.dart';


### PR DESCRIPTION
Supersedes https://github.com/flutter/flutter/pull/145714 now that https://github.com/dart-lang/dartdoc/issues/3882 is fixed.