### PR TITLE
[Widget Inspector] Fix stack overflow error for Flutter web when requesting a large widget tree

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1670,7 +1670,7 @@ abstract class DiagnosticsNode {
   /// This is only used when [WidgetInspectorServiceExtensions.getRootWidgetTree]
   /// is called with fullDetails=false. To get the full widget details, including
   /// any details provided by subclasses, [toJsonMap] should be used instead.
-  /// 
+  ///
   /// See https://github.com/flutter/devtools/issues/8553 for details about this
   /// iterative approach.
   Map<String, Object?> toJsonMapIterative(
@@ -1884,9 +1884,10 @@ abstract class DiagnosticsNode {
     return <String, Object?>{
       'description': description,
       'shouldIndent': shouldIndent,
-      // TODO(https://github.com/flutter/devtools/issues/8556): This can be
-      // removed to reduce the JSON response even further once DevTools computes
-      // the widget runtime type from the description instead.
+      // TODO(elliette): This can be removed to reduce the JSON response even
+      // further once DevTools computes the widget runtime type from the
+      // description instead, see:
+      // https://github.com/flutter/devtools/issues/8556
       'widgetRuntimeType': widgetRuntimeType,
       'truncated': truncated,
       ...delegate.additionalNodeProperties(this, fullDetails: false),

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1605,29 +1605,12 @@ abstract class DiagnosticsNode {
   ///    by this method and interactive tree views in the Flutter IntelliJ
   ///    plugin.
   @mustCallSuper
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
     Map<String, Object?> result = <String, Object?>{};
     assert(() {
       final bool hasChildren = getChildren().isNotEmpty;
-      final Map<String, Object?> essentialDetails = <String, Object?>{
+      result = <String, Object?>{
         'description': toDescription(),
-        'shouldIndent': style != DiagnosticsTreeStyle.flat &&
-            style != DiagnosticsTreeStyle.error,
-        ...delegate.additionalNodeProperties(this, fullDetails: fullDetails),
-        if (delegate.subtreeDepth > 0)
-          'children': toJsonList(
-            delegate.filterChildren(getChildren(), this),
-            this,
-            delegate,
-            fullDetails: fullDetails,
-          ),
-      };
-
-      result = !fullDetails ? essentialDetails : <String, Object?>{
-        ...essentialDetails,
         'type': runtimeType.toString(),
         if (name != null)
           'name': name,
@@ -1651,12 +1634,18 @@ abstract class DiagnosticsNode {
           'allowWrap': allowWrap,
         if (allowNameWrap)
           'allowNameWrap': allowNameWrap,
+        ...delegate.additionalNodeProperties(this, fullDetails: true),
         if (delegate.includeProperties)
           'properties': toJsonList(
             delegate.filterProperties(getProperties(), this),
             this,
             delegate,
-            fullDetails: fullDetails,
+          ),
+        if (delegate.subtreeDepth > 0)
+          'children': toJsonList(
+            delegate.filterChildren(getChildren(), this),
+            this,
+            delegate,
           ),
       };
       return true;
@@ -1672,9 +1661,8 @@ abstract class DiagnosticsNode {
   static List<Map<String, Object?>> toJsonList(
     List<DiagnosticsNode>? nodes,
     DiagnosticsNode? parent,
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
+    DiagnosticsSerializationDelegate delegate,
+  ) {
     bool truncated = false;
     if (nodes == null) {
       return const <Map<String, Object?>>[];
@@ -1686,10 +1674,7 @@ abstract class DiagnosticsNode {
       truncated = true;
     }
     final List<Map<String, Object?>> json = nodes.map<Map<String, Object?>>((DiagnosticsNode node) {
-      return node.toJsonMap(
-        delegate.delegateForNode(node),
-        fullDetails: fullDetails,
-      );
+      return node.toJsonMap(delegate.delegateForNode(node));
     }).toList();
     if (truncated) {
       json.last['truncated'] = true;
@@ -1872,17 +1857,8 @@ class StringProperty extends DiagnosticsProperty<String> {
   final bool quoted;
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     json['quoted'] = quoted;
     return json;
   }
@@ -1937,18 +1913,8 @@ abstract class _NumProperty<T extends num> extends DiagnosticsProperty<T> {
   }) : super.lazy();
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
-
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     if (unit != null) {
       json['unit'] = unit;
     }
@@ -2131,17 +2097,8 @@ class FlagProperty extends DiagnosticsProperty<bool> {
        );
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     if (ifTrue != null) {
       json['ifTrue'] = ifTrue;
     }
@@ -2262,17 +2219,8 @@ class IterableProperty<T> extends DiagnosticsProperty<Iterable<T>> {
   }
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     if (value != null) {
       json['values'] = value!.map<String>((T value) => value.toString()).toList();
     }
@@ -2409,17 +2357,8 @@ class ObjectFlagProperty<T> extends DiagnosticsProperty<T> {
   }
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     if (ifPresent != null) {
       json['ifPresent'] = ifPresent;
     }
@@ -2496,17 +2435,8 @@ class FlagsSummary<T> extends DiagnosticsProperty<Map<String, T?>> {
   }
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     if (value.isNotEmpty) {
       json['values'] = _formattedValues().toList();
     }
@@ -2625,10 +2555,7 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
   final bool allowNameWrap;
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
     final T? v = value;
     List<Map<String, Object?>>? properties;
     if (delegate.expandPropertyValues && delegate.includeProperties && v is Diagnosticable && getProperties().isEmpty) {
@@ -2638,16 +2565,9 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
         delegate.filterProperties(v.toDiagnosticsNode().getProperties(), this),
         this,
         delegate,
-        fullDetails: fullDetails,
       );
     }
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     if (properties != null) {
       json['properties'] = properties;
     }

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1851,11 +1851,12 @@ abstract class DiagnosticsNode {
   }) {
     final List<_JsonDiagnosticsNode> childrenJsonList =
         <_JsonDiagnosticsNode>[];
-    final bool hasChildren = getChildren().isNotEmpty;
+    final bool includeChildren =
+        getChildren().isNotEmpty && delegate.subtreeDepth > 0;
 
     // Collect the children nodes to convert to JSON later:
     bool truncated = false;
-    if (hasChildren && delegate.subtreeDepth > 0) {
+    if (includeChildren) {
       List<DiagnosticsNode> childrenNodes =
           delegate.filterChildren(getChildren(), this);
       final int originalNodeCount = childrenNodes.length;
@@ -1889,7 +1890,7 @@ abstract class DiagnosticsNode {
       'widgetRuntimeType': widgetRuntimeType,
       'truncated': truncated,
       ...delegate.additionalNodeProperties(this, fullDetails: false),
-      if (hasChildren) 'children': childrenJsonList,
+      if (includeChildren) 'children': childrenJsonList,
     };
   }
 }

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -495,17 +495,8 @@ class ColorProperty extends DiagnosticsProperty<Color> {
   });
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     if (value != null) {
       json['valueProperties'] = <String, Object>{
         'red': value!.red,

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5382,18 +5382,13 @@ class _ElementDiagnosticableTreeNode extends DiagnosticableTreeNode {
   final bool stateful;
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(delegate, fullDetails: fullDetails,);
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     final Element element = value as Element;
     if (!element.debugIsDefunct) {
       json['widgetRuntimeType'] = element.widget.runtimeType.toString();
     }
-    if (fullDetails) {
-      json['stateful'] = stateful;
-    }
+    json['stateful'] = stateful;
     return json;
   }
 }

--- a/packages/flutter/lib/src/widgets/icon_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_data.dart
@@ -121,17 +121,8 @@ class IconDataProperty extends DiagnosticsProperty<IconData> {
   });
 
   @override
-  Map<String, Object?> toJsonMap(
-    DiagnosticsSerializationDelegate delegate, {
-    bool fullDetails = true,
-  }) {
-    final Map<String, Object?> json = super.toJsonMap(
-      delegate,
-      fullDetails: fullDetails,
-    );
-    if (!fullDetails) {
-      return json;
-    }
+  Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
+    final Map<String, Object?> json = super.toJsonMap(delegate);
     if (value != null) {
       json['valueProperties'] = <String, Object>{
         'codePoint': value!.codePoint,

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1754,8 +1754,14 @@ mixin WidgetInspectorService {
     bool fullDetails = true,
   }
   ) {
-    // TODO: switch here.
-    return node?.toJsonMap(delegate);
+    if (fullDetails) {
+      return node?.toJsonMap(delegate);
+    } else {
+      // If we don't need the full details fetched from all the subclasses, we
+      // can iteratively build the JSON map. This prevents a stack overflow
+      // exception for particularly large widget trees.
+      return node?.toJsonMapIterative(delegate);
+    }
   }
 
   bool _isValueCreatedByLocalProject(Object? value) {

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1759,7 +1759,8 @@ mixin WidgetInspectorService {
     } else {
       // If we don't need the full details fetched from all the subclasses, we
       // can iteratively build the JSON map. This prevents a stack overflow
-      // exception for particularly large widget trees.
+      // exception for particularly large widget trees. For details, see:
+      // https://github.com/flutter/devtools/issues/8553
       return node?.toJsonMapIterative(delegate);
     }
   }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1754,7 +1754,8 @@ mixin WidgetInspectorService {
     bool fullDetails = true,
   }
   ) {
-    return node?.toJsonMap(delegate, fullDetails: fullDetails);
+    // TODO: switch here.
+    return node?.toJsonMap(delegate);
   }
 
   bool _isValueCreatedByLocalProject(Object? value) {
@@ -1824,14 +1825,8 @@ mixin WidgetInspectorService {
     List<DiagnosticsNode> nodes,
     InspectorSerializationDelegate delegate, {
     required DiagnosticsNode? parent,
-    bool fullDetails = true,
   }) {
-    return DiagnosticsNode.toJsonList(
-      nodes,
-      parent,
-      delegate,
-      fullDetails: fullDetails,
-    );
+    return DiagnosticsNode.toJsonList(nodes, parent, delegate);
   }
 
   /// Returns a JSON representation of the properties of the [DiagnosticsNode]

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -102,7 +102,7 @@ void main() {
       }
     });
 
-    test('iterative implemenation (without full details)', () {
+    test('iterative implementation (without full details)', () {
       final Map<String, Object?> result = testTree
         .toDiagnosticsNode()
           .toJsonMapIterative(const DiagnosticsSerializationDelegate()

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -84,7 +84,6 @@ void main() {
     test('default', () {
       final Map<String, Object?> result = testTree.toDiagnosticsNode().toJsonMap(const DiagnosticsSerializationDelegate());
       expect(result.containsKey('properties'), isFalse);
-      print(result['children']);
       expect(result.containsKey('children'), isFalse);
 
       for (final String keyName in defaultDiagnosticKeys) {

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -24,10 +24,15 @@ void main() {
   });
 
   group('Serialization', () {
-    const List<String> essentialDiagnosticKeys = <String>[
+    // These are always included.
+    const List<String> defaultDiagnosticKeys = <String>[
       'description',
+    ];
+    // These are only included when fullDetails = false.
+    const List<String> essentialDiagnosticKeys = <String>[
       'shouldIndent',
     ];
+    // These are only included with fullDetails = true.
     const List<String> detailedDiagnosticKeys = <String>[
       'type',
       'hasChildren',
@@ -79,9 +84,10 @@ void main() {
     test('default', () {
       final Map<String, Object?> result = testTree.toDiagnosticsNode().toJsonMap(const DiagnosticsSerializationDelegate());
       expect(result.containsKey('properties'), isFalse);
+      print(result['children']);
       expect(result.containsKey('children'), isFalse);
 
-      for (final String keyName in essentialDiagnosticKeys) {
+      for (final String keyName in defaultDiagnosticKeys) {
         expect(
           result.containsKey(keyName),
           isTrue,
@@ -97,15 +103,20 @@ void main() {
       }
     });
 
-    test('without full details', () {
+    test('iterative implemenation (without full details)', () {
       final Map<String, Object?> result = testTree
         .toDiagnosticsNode()
-        .toJsonMap(
-          const DiagnosticsSerializationDelegate(), fullDetails: false
+          .toJsonMapIterative(const DiagnosticsSerializationDelegate()
         );
       expect(result.containsKey('properties'), isFalse);
       expect(result.containsKey('children'), isFalse);
-
+      for (final String keyName in defaultDiagnosticKeys) {
+        expect(
+          result.containsKey(keyName),
+          isTrue,
+          reason: '$keyName is included.',
+        );
+      }
       for (final String keyName in essentialDiagnosticKeys) {
         expect(
           result.containsKey(keyName),

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2516,40 +2516,39 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
               ),
               isTrue,
             );
-
-            // expect(
-            //   allChildrenSatisfyCondition(rootJson,
-            //     condition: wasCreatedByLocalProject,
-            //   ),
-            //   isFalse,
-            // );
-            // expect(
-            //   oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
-            //     return hasDescription(child, description: 'Text') &&
-            //         wasCreatedByLocalProject(child) &&
-            //         !hasTextPreview(child, preview: 'a');
-            //     },
-            //   ),
-            //   isTrue,
-            // );
-            // expect(
-            //   oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
-            //     return hasDescription(child, description: 'Text') &&
-            //         wasCreatedByLocalProject(child) &&
-            //         !hasTextPreview(child, preview: 'b');
-            //     },
-            //   ),
-            //   isTrue,
-            // );
-            // expect(
-            //   oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
-            //     return hasDescription(child, description: 'Text') &&
-            //         wasCreatedByLocalProject(child) &&
-            //         !hasTextPreview(child, preview: 'c');
-            //     },
-            //   ),
-            //   isTrue,
-            // );
+            expect(
+              allChildrenSatisfyCondition(rootJson,
+                condition: wasCreatedByLocalProject,
+              ),
+              isFalse,
+            );
+            expect(
+              oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
+                return hasDescription(child, description: 'Text') &&
+                    wasCreatedByLocalProject(child) &&
+                    !hasTextPreview(child, preview: 'a');
+                },
+              ),
+              isTrue,
+            );
+            expect(
+              oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
+                return hasDescription(child, description: 'Text') &&
+                    wasCreatedByLocalProject(child) &&
+                    !hasTextPreview(child, preview: 'b');
+                },
+              ),
+              isTrue,
+            );
+            expect(
+              oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
+                return hasDescription(child, description: 'Text') &&
+                    wasCreatedByLocalProject(child) &&
+                    !hasTextPreview(child, preview: 'c');
+                },
+              ),
+              isTrue,
+            );
           });
 
           testWidgets(

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2122,7 +2122,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
           /// Gets the children nodes from the JSON response.
           List<Object?> childrenFromJsonResponse(Map<String, Object?> json) {
-            return json['children']! as List<Object?>;
+            return (json['children'] as List<Object?>?) ?? <Object?>[];
           }
 
           /// Gets the children nodes using a call to
@@ -2517,39 +2517,39 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
               isTrue,
             );
 
-            expect(
-              allChildrenSatisfyCondition(rootJson,
-                condition: wasCreatedByLocalProject,
-              ),
-              isFalse,
-            );
-            expect(
-              oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
-                return hasDescription(child, description: 'Text') &&
-                    wasCreatedByLocalProject(child) &&
-                    !hasTextPreview(child, preview: 'a');
-                },
-              ),
-              isTrue,
-            );
-            expect(
-              oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
-                return hasDescription(child, description: 'Text') &&
-                    wasCreatedByLocalProject(child) &&
-                    !hasTextPreview(child, preview: 'b');
-                },
-              ),
-              isTrue,
-            );
-            expect(
-              oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
-                return hasDescription(child, description: 'Text') &&
-                    wasCreatedByLocalProject(child) &&
-                    !hasTextPreview(child, preview: 'c');
-                },
-              ),
-              isTrue,
-            );
+            // expect(
+            //   allChildrenSatisfyCondition(rootJson,
+            //     condition: wasCreatedByLocalProject,
+            //   ),
+            //   isFalse,
+            // );
+            // expect(
+            //   oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
+            //     return hasDescription(child, description: 'Text') &&
+            //         wasCreatedByLocalProject(child) &&
+            //         !hasTextPreview(child, preview: 'a');
+            //     },
+            //   ),
+            //   isTrue,
+            // );
+            // expect(
+            //   oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
+            //     return hasDescription(child, description: 'Text') &&
+            //         wasCreatedByLocalProject(child) &&
+            //         !hasTextPreview(child, preview: 'b');
+            //     },
+            //   ),
+            //   isTrue,
+            // );
+            // expect(
+            //   oneChildSatisfiesCondition(rootJson, condition: (Map<String, Object?> child) {
+            //     return hasDescription(child, description: 'Text') &&
+            //         wasCreatedByLocalProject(child) &&
+            //         !hasTextPreview(child, preview: 'c');
+            //     },
+            //   ),
+            //   isTrue,
+            // );
           });
 
           testWidgets(
@@ -5703,7 +5703,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         node.toJsonMap(const DiagnosticsSerializationDelegate()),
         equals(<String, dynamic>{
           'description': 'description of the deep link',
-          'shouldIndent': true,
           'type': 'DevToolsDeepLinkProperty',
           'name': '',
           'style': 'singleLine',


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8553

Context: 

A Flutter web customer with a large widget tree was getting a stack overflow error when they toggled on "show implementation widgets" in the Flutter DevTools Inspector. This is because building the JSON tree recursively was hitting Chrome's stack limit. 

This PR creates the JSON tree **iteratively** if the `getRootWidgetTree` service extension is called with `fullDetails = false` (which is what DevTools uses to fetch the widget tree).

For all other instances of creating a widget JSON map (for example, when fetching widget properties) the recursive implementation is used. This allows properties provided by subclasses implementing `toJsonMap` to be included in the response.

Note: Because with this change `toJsonMap` is only called when `fullDetails = true` and `toJsonMapIterative` is only called when `fullDetails = false`, this PR partially reverts the changes in https://github.com/flutter/flutter/pull/157309.
