### PR TITLE
Fix DropdownButtonFormField overlay colors management

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -23,7 +23,6 @@ import 'constants.dart';
 import 'debug.dart';
 import 'icons.dart';
 import 'ink_well.dart';
-import 'input_border.dart';
 import 'input_decorator.dart';
 import 'material.dart';
 import 'material_localizations.dart';
@@ -1010,8 +1009,7 @@ class DropdownButton<T> extends StatefulWidget {
               ),
        assert(itemHeight == null || itemHeight >=  kMinInteractiveDimension),
        _inputDecoration = null,
-       _isEmpty = false,
-       _isFocused = false;
+       _isEmpty = false;
 
   DropdownButton._formField({
     super.key,
@@ -1044,7 +1042,6 @@ class DropdownButton<T> extends StatefulWidget {
     this.padding,
     required InputDecoration inputDecoration,
     required bool isEmpty,
-    required bool isFocused,
   }) : assert(items == null || items.isEmpty || value == null ||
               items.where((DropdownMenuItem<T> item) {
                 return item.value == value;
@@ -1056,8 +1053,7 @@ class DropdownButton<T> extends StatefulWidget {
               ),
        assert(itemHeight == null || itemHeight >=  kMinInteractiveDimension),
        _inputDecoration = inputDecoration,
-       _isEmpty = isEmpty,
-       _isFocused = isFocused;
+       _isEmpty = isEmpty;
 
   /// The list of items the user can select.
   ///
@@ -1287,8 +1283,6 @@ class DropdownButton<T> extends StatefulWidget {
 
   final bool _isEmpty;
 
-  final bool _isFocused;
-
   @override
   State<DropdownButton<T>> createState() => _DropdownButtonState<T>();
 }
@@ -1300,6 +1294,8 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   FocusNode? _internalNode;
   FocusNode? get focusNode => widget.focusNode ?? _internalNode;
   late Map<Type, Action<Intent>> _actionMap;
+  bool _isHovering = false;
+  bool _hasPrimaryFocus = false;
 
   // Only used if needed to create _internalNode.
   FocusNode _createFocusNode() {
@@ -1321,14 +1317,24 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         onInvoke: (ButtonActivateIntent intent) => _handleTap(),
       ),
     };
+    focusNode?.addListener(_handleFocusChanged);
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _removeDropdownRoute();
+    focusNode?.removeListener(_handleFocusChanged);
     _internalNode?.dispose();
     super.dispose();
+  }
+
+  void _handleFocusChanged() {
+    if (_hasPrimaryFocus != focusNode!.hasPrimaryFocus) {
+      setState(() {
+        _hasPrimaryFocus = focusNode!.hasPrimaryFocus;
+      });
+    }
   }
 
   void _removeDropdownRoute() {
@@ -1586,30 +1592,75 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       },
     );
 
+    // When an InputDecoration is provided, use it instead of using an InkWell
+    // that overflows in some cases (such as showing an errorText) and requires
+    // additional logic to manage clipping properly.
+    // A filled InputDecoration is able to fill the InputDecorator container
+    // without overflowing. It also supports blending the hovered color.
+    // According to the Material specification, the overlay colors should be
+    // visible only for filled dropdown button, see:
+    // https://m2.material.io/components/menus#dropdown-menu
     if (widget._inputDecoration != null) {
-      result = InputDecorator(
-        decoration: widget._inputDecoration!,
-        isEmpty: widget._isEmpty,
-        isFocused: widget._isFocused,
-        child: result,
+      InputDecoration effectiveDecoration = widget._inputDecoration!;
+      if (_hasPrimaryFocus) {
+        final Color effectiveFocusColor = widget.focusColor
+          ?? effectiveDecoration.focusColor
+          ?? Theme.of(context).focusColor;
+        effectiveDecoration = effectiveDecoration.copyWith(fillColor: effectiveFocusColor);
+      }
+      result = Focus(
+        canRequestFocus: _enabled,
+        focusNode: focusNode,
+        autofocus: widget.autofocus,
+        child: MouseRegion(
+          onHover: (PointerHoverEvent event) {
+            if (!_isHovering) {
+              setState(() {
+                _isHovering = true;
+              });
+            }
+          },
+          onExit: (PointerExitEvent event) {
+            if (_isHovering) {
+              setState(() {
+                _isHovering = false;
+              });
+            }
+          },
+          cursor: effectiveMouseCursor,
+          child: GestureDetector(
+            onTap: _enabled ? _handleTap : null,
+            behavior: HitTestBehavior.opaque,
+            child: InputDecorator(
+              decoration: effectiveDecoration,
+              isEmpty: widget._isEmpty,
+              isFocused: _hasPrimaryFocus,
+              isHovering: _isHovering,
+              child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
+            ),
+          ),
+        ),
+      );
+    } else {
+      result = InkWell(
+        mouseCursor: effectiveMouseCursor,
+        onTap: _enabled ? _handleTap : null,
+        canRequestFocus: _enabled,
+        borderRadius: widget.borderRadius,
+        focusNode: focusNode,
+        autofocus: widget.autofocus,
+        focusColor: widget.focusColor ?? Theme.of(context).focusColor,
+        enableFeedback: false,
+        child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
       );
     }
+
     final bool childHasButtonSemantic = hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
     return Semantics(
       button: !childHasButtonSemantic,
       child: Actions(
         actions: _actionMap,
-        child: InkWell(
-          mouseCursor: effectiveMouseCursor,
-          onTap: _enabled ? _handleTap : null,
-          canRequestFocus: _enabled,
-          borderRadius: widget.borderRadius,
-          focusNode: focusNode,
-          autofocus: widget.autofocus,
-          focusColor: widget.focusColor ?? Theme.of(context).focusColor,
-          enableFeedback: false,
-          child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
-        ),
+        child: result,
       ),
     );
   }
@@ -1679,13 +1730,13 @@ class DropdownButtonFormField<T> extends FormField<T> {
           'with the same value',
         ),
         assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
-        decoration = decoration ?? InputDecoration(focusColor: focusColor),
+        decoration = decoration ?? const InputDecoration(),
         super(
           initialValue: value,
           autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
           builder: (FormFieldState<T> field) {
             final _DropdownButtonFormFieldState<T> state = field as _DropdownButtonFormFieldState<T>;
-            final InputDecoration decorationArg =  decoration ?? InputDecoration(focusColor: focusColor);
+            final InputDecoration decorationArg =  decoration ?? const InputDecoration();
             final InputDecoration effectiveDecoration = decorationArg.applyDefaults(
               Theme.of(field.context).inputDecorationTheme,
             );
@@ -1707,19 +1758,6 @@ class DropdownButtonFormField<T> extends FormField<T> {
               canRequestFocus: false,
               skipTraversal: true,
               child: Builder(builder: (BuildContext context) {
-                final bool isFocused = Focus.of(context).hasFocus;
-                late final InputBorder? resolvedBorder = switch ((
-                  enabled: effectiveDecoration.enabled,
-                  focused: isFocused,
-                  error: effectiveDecoration.errorText != null,
-                )) {
-                  (enabled: _, focused: true, error: true) => effectiveDecoration.focusedErrorBorder,
-                  (enabled: _, focused: _,    error: true) => effectiveDecoration.errorBorder,
-                  (enabled: _, focused: true,  error: _)   => effectiveDecoration.focusedBorder,
-                  (enabled: true,  focused: _, error: _)   => effectiveDecoration.enabledBorder,
-                  (enabled: false, focused: _, error: _)   => effectiveDecoration.border,
-                };
-
                 return DropdownButtonHideUnderline(
                   child: DropdownButton<T>._formField(
                     items: items,
@@ -1745,18 +1783,13 @@ class DropdownButtonFormField<T> extends FormField<T> {
                     menuMaxHeight: menuMaxHeight,
                     enableFeedback: enableFeedback,
                     alignment: alignment,
-                    borderRadius: borderRadius ?? switch (resolvedBorder) {
-                      final OutlineInputBorder border   => border.borderRadius,
-                      final UnderlineInputBorder border => border.borderRadius,
-                      _ => null,
-                    },
+                    borderRadius: borderRadius,
                     // Clear the decoration hintText because DropdownButton has its own hint logic.
                     inputDecoration: effectiveDecoration.copyWith(
                       errorText: field.errorText,
                       hintText: effectiveDecoration.hintText != null ? '' : null,
                     ),
                     isEmpty: isEmpty,
-                    isFocused: isFocused,
                     padding: padding,
                   ),
                 );

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1603,17 +1603,18 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     if (widget._inputDecoration != null) {
       InputDecoration effectiveDecoration = widget._inputDecoration!;
       if (_hasPrimaryFocus) {
-        final Color effectiveFocusColor = widget.focusColor
-          ?? effectiveDecoration.focusColor
-          ?? Theme.of(context).focusColor;
-        effectiveDecoration = effectiveDecoration.copyWith(fillColor: effectiveFocusColor);
+        final Color? focusColor = widget.focusColor ?? effectiveDecoration.focusColor;
+        // For compatibility, override the fill color when focusColor is set.
+        if (focusColor != null) {
+          effectiveDecoration = effectiveDecoration.copyWith(fillColor: focusColor);
+        }
       }
       result = Focus(
         canRequestFocus: _enabled,
         focusNode: focusNode,
         autofocus: widget.autofocus,
         child: MouseRegion(
-          onHover: (PointerHoverEvent event) {
+          onEnter: (PointerEnterEvent event) {
             if (!_isHovering) {
               setState(() {
                 _isHovering = true;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2079,7 +2079,6 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     if (_hasError) MaterialState.error,
   };
 
-
   InputBorder _getDefaultBorder(ThemeData themeData, InputDecorationTheme defaults) {
     final InputBorder border =  MaterialStateProperty.resolveAs(decoration.border, materialState)
       ?? const UnderlineInputBorder();

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2470,11 +2470,12 @@ void main() {
     await tester.pump(); // Pump a frame for autofocus to take effect.
     expect(focusNode.hasPrimaryFocus, isTrue);
 
-    // Default focus Color from ThemeData.focusColor.
+    // Default focus Color from InputDecorator defaults.
+    final ThemeData theme = Theme.of(tester.element(find.byType(InputDecorator)));
     expect(findInputDecoratorBorderPainter(), paints
       ..path(
         style: PaintingStyle.fill,
-        color: const Color(0x1f000000),
+        color: theme.colorScheme.surfaceContainerHighest,
       ),
     );
 

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2429,6 +2429,13 @@ void main() {
     expect(tester.getTopLeft(find.text('-item0-')).dx, 8);
   });
 
+  Finder findInputDecoratorBorderPainter() {
+    return find.descendant(
+      of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_BorderContainer'),
+      matching: find.byWidgetPredicate((Widget w) => w is CustomPaint),
+    );
+  }
+
   testWidgets('DropdownButton can be focused, and has focusColor', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     final UniqueKey buttonKey = UniqueKey();
@@ -2451,14 +2458,135 @@ void main() {
     final FocusNode focusNode = FocusNode(debugLabel: 'DropdownButtonFormField');
     addTearDown(focusNode.dispose);
 
-    await tester.pumpWidget(buildFrame(isFormField: true, buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, autofocus: true));
-    await tester.pumpAndSettle(); // Pump a frame for autofocus to take effect.
-    expect(focusNode.hasPrimaryFocus, isTrue);
-    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 268.0, 800.0, 332.0), color: const Color(0x1f000000)));
+    await tester.pumpWidget(buildFrame(
+      isFormField: true,
+      buttonKey: buttonKey,
+      onChanged: onChanged,
+      focusNode: focusNode,
+      autofocus: true,
+      decoration: const InputDecoration(filled: true),
+    ));
 
-    await tester.pumpWidget(buildFrame(isFormField: true, buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, focusColor: const Color(0xff00ff00)));
-    await tester.pumpAndSettle(); // Pump a frame for autofocus to take effect.
-    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 268.0, 800.0, 332.0), color: const Color(0x1f00ff00)));
+    await tester.pump(); // Pump a frame for autofocus to take effect.
+    expect(focusNode.hasPrimaryFocus, isTrue);
+
+    // Default focus Color from ThemeData.focusColor.
+    expect(findInputDecoratorBorderPainter(), paints
+      ..path(
+        style: PaintingStyle.fill,
+        color: const Color(0x1f000000),
+      ),
+    );
+
+    // Focus color from Decoration.
+    await tester.pumpWidget(buildFrame(
+      isFormField: true,
+      buttonKey: buttonKey,
+      onChanged: onChanged,
+      focusNode: focusNode,
+      decoration: const InputDecoration(
+        filled: true,
+        focusColor: Color(0xff00ffff),
+      ),
+    ));
+
+    expect(findInputDecoratorBorderPainter(), paints
+      ..path(
+        style: PaintingStyle.fill,
+        color: const Color(0xff00ffff),
+      ),
+    );
+
+    // Focus color from focusColor property.
+    await tester.pumpWidget(buildFrame(
+      isFormField: true,
+      buttonKey: buttonKey,
+      onChanged: onChanged,
+      focusNode: focusNode,
+      decoration: const InputDecoration(
+        filled: true,
+        focusColor: Color(0xff00ffff),
+      ),
+      focusColor: const Color(0xff00ff00),
+    ));
+
+    expect(findInputDecoratorBorderPainter(), paints
+      ..path(
+        style: PaintingStyle.fill,
+        color: const Color(0xff00ff00),
+      ),
+    );
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/147069.
+  testWidgets('DropdownButtonFormField can be hovered', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    final UniqueKey buttonKey = UniqueKey();
+
+    await tester.pumpWidget(buildFrame(
+      isFormField: true,
+      buttonKey: buttonKey,
+      onChanged: onChanged,
+    ));
+    await tester.pump();
+
+    // Check inputDecorator.isHovering value because DropdownButtonFormField
+    // delegates to the InputDecorator which manages hover overlay.
+    InputDecorator inputDecorator = tester.widget(find.byType(InputDecorator));
+    expect(inputDecorator.isHovering, false);
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(tester.getCenter(find.byKey(buttonKey)));
+    await tester.pump();
+
+    inputDecorator = tester.widget(find.byType(InputDecorator));
+    expect(inputDecorator.isHovering, true);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/151460.
+  testWidgets('DropdownButtonFormField has hover color', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    final UniqueKey buttonKey = UniqueKey();
+
+    await tester.pumpWidget(buildFrame(
+      isFormField: true,
+      buttonKey: buttonKey,
+      onChanged: onChanged,
+      // Setting InputDecoration.filled to true is required to get overlay showing.
+      decoration: const InputDecoration(filled: true),
+    ));
+    await tester.pump();
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(tester.getCenter(find.byKey(buttonKey)));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 15)); // Hover animation.
+
+    // Default hover color.
+    final ThemeData theme = Theme.of(tester.element(find.byType(InputDecorator)));
+    expect(findInputDecoratorBorderPainter(), paints
+      ..path(
+        style: PaintingStyle.fill,
+        color: Color.alphaBlend(theme.hoverColor, theme.colorScheme.surfaceContainerHighest),
+      ),
+    );
+
+    // Custom hover color.
+    const Color hoverColor = Color(0xaa00ff00);
+    await tester.pumpWidget(buildFrame(
+      isFormField: true,
+      buttonKey: buttonKey,
+      onChanged: onChanged,
+      decoration: const InputDecoration(
+        filled: true,
+        hoverColor: hoverColor),
+    ));
+    expect(findInputDecoratorBorderPainter(), paints
+      ..path(
+        style: PaintingStyle.fill,
+        color: Color.alphaBlend(hoverColor, theme.colorScheme.surfaceContainerHighest),
+      ),
+    );
   });
 
   testWidgets("DropdownButton won't be focused if not enabled", (WidgetTester tester) async {
@@ -4023,7 +4151,7 @@ void main() {
     });
   });
 
-  testWidgets('BorderRadius property clips dropdown button and dropdown menu', (WidgetTester tester) async {
+  testWidgets('BorderRadius property clips dropdown menu', (WidgetTester tester) async {
     const double radius = 20.0;
 
     await tester.pumpWidget(
@@ -4046,14 +4174,6 @@ void main() {
         ),
       ),
     );
-
-    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer();
-    await gesture.moveTo(tester.getCenter(find.byType(DropdownButtonFormField<String>)));
-    await tester.pumpAndSettle();
-
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
-    expect(inkFeatures, paints..rrect(rrect: RRect.fromLTRBR(0.0, 276.0, 800.0, 324.0, const Radius.circular(radius))));
 
     await tester.tap(find.text('One'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Description

This PR fixes some `DropdownButtonFormField` issues where the overlay color overflows.

Before this PR, `DropdownButtonFormField` was relying on an `InkWell` to display overlay colors. This resulted in several issues related to the `InkWell` overflowing because it is not aware of the inner container inside `InputDecorator`, for instance see https://github.com/flutter/flutter/issues/106659.

With this PR, `DropdownButtonFormField` does not use an `InkWell` but rely on `InputDecorator` to paint overlay colors. `InputDecorator` paints overlay colors only on its internal container, this fixes the color overflowing when using `InkWell`. With this change users can opt-in for overlay colors to be painted by setting InputDecorator.filled to true (similarly to TextField and accordingly to [the Material specification](https://m2.material.io/components/menus#dropdown-menu)).

Code sample from https://github.com/flutter/flutter/issues/106659 with InputDecoration.filled set to true:

<details><summary>Code sample with InputDecoration.filled set to true</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  MyApp({Key? key}) : super(key: key);

  static const String _title = 'Flutter Code Sample';
  final _formKey = GlobalKey<FormState>();

  @override
  Widget build(BuildContext context) {
    var items = [
      'Ayo',
      'This',
      'Don',
      'Look',
      'Right',
    ].map((String val) {
      return DropdownMenuItem(
        value: val,
        child: Text(
          val,
        ),
      );
    }).toList();

    return MaterialApp(
      title: _title,
      theme: ThemeData(
        inputDecorationTheme: const InputDecorationTheme(
          border: OutlineInputBorder(
            borderRadius: BorderRadius.all(Radius.circular(32)),
            borderSide: BorderSide(color: Colors.blue, width: 2),
          ),
        ),
      ),
      home: Scaffold(
        body: Center(
          child: SizedBox(
            width: 500,
            child: Column(
              mainAxisAlignment: MainAxisAlignment.center,
              children: [
                Form(
                  key: _formKey,
                  child: DropdownButtonFormField(
                    onTap: () {
                      _formKey.currentState!.validate();
                    },
                    validator: (String? v) => 'Required',
                    onChanged: (String? value) {},
                    items: items,
                    // Set InputDecoration.filled to true if overlays should be visible.
                    // See Material specification for filled vs outlined dropdown button:
                    // https://m2.material.io/components/menus#dropdown-menu.
                    decoration: const InputDecoration(filled: true),
                  ),
                ),
              ],
            ),
          ),
        ),
      ),
    );
  }
}


``` 
</details> 

Before:

![image](https://github.com/user-attachments/assets/3c22975f-9b8c-4184-8ffe-67f2191bf563)

After:

![image](https://github.com/user-attachments/assets/47ac35c3-b516-454f-bd47-2d35d85f172f)

After (when filled is not set to true):

![image](https://github.com/user-attachments/assets/faf46e40-5817-4d64-9158-7a57d94a9776)


## Related Issue

Fixes [DropdownButtonFormField InkWell spreads to error message](https://github.com/flutter/flutter/issues/106659).
Fixes [DropdownButtonFormField input decorator focus/hover is not clipped and appears behind fill color.](https://github.com/flutter/flutter/issues/147069)
First step for [DropDownButtonFormField hoverColor has no effect in web and desktop platforms](https://github.com/flutter/flutter/issues/151460) 

## Tests

Adds 4 tests.
Updates 2 tests (remove checks specific to InkWell usage and use filled: true when checking for hover/focus colors).
Removes 1 test (test specific to InkWell usage, because this PR removes the InkWell the test is obsolete).
