### PR TITLE
[SwiftPM] Rename `SWIFT_PACKAGE_MANAGER` environment variable to `FLUTTER_SWIFT_PACKAGE_MANAGER`

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -185,7 +185,7 @@ const Feature previewDevice = Feature(
 const Feature swiftPackageManager = Feature(
   name: 'support for Swift Package Manager for iOS and macOS',
   configSetting: 'enable-swift-package-manager',
-  environmentOverride: 'SWIFT_PACKAGE_MANAGER',
+  environmentOverride: 'FLUTTER_SWIFT_PACKAGE_MANAGER',
   master: FeatureChannelSetting(
     available: true,
   ),

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -403,13 +403,23 @@ void main() {
       expect(nativeAssets.stable.available, false);
     });
 
-    test('${swiftPackageManager.name} availability and default enabled', () {
-      expect(swiftPackageManager.master.enabledByDefault, false);
-      expect(swiftPackageManager.master.available, true);
-      expect(swiftPackageManager.beta.enabledByDefault, false);
-      expect(swiftPackageManager.beta.available, true);
-      expect(swiftPackageManager.stable.enabledByDefault, false);
-      expect(swiftPackageManager.stable.available, true);
+    group('Swift Package Manager feature', () {
+      test('availability and default enabled', () {
+        expect(swiftPackageManager.master.enabledByDefault, false);
+        expect(swiftPackageManager.master.available, true);
+        expect(swiftPackageManager.beta.enabledByDefault, false);
+        expect(swiftPackageManager.beta.available, true);
+        expect(swiftPackageManager.stable.enabledByDefault, false);
+        expect(swiftPackageManager.stable.available, true);
+      });
+
+      test('can be enabled', () {
+        platform.environment = <String, String>{
+          'FLUTTER_SWIFT_PACKAGE_MANAGER': 'true',
+        };
+
+        expect(featureFlags.isSwiftPackageManagerEnabled, isTrue);
+      });
     });
   });
 }


### PR DESCRIPTION
Previously, the Swift Package Manager feature could be overridden using the `SWIFT_PACKAGE_MANAGER` environment variable.

This environment variable name is a bit generic and might collide with other tooling.

This renames the environment variable to `FLUTTER_SWIFT_PACKAGE_MANAGER`.

**This is a breaking change**, however, [we haven't documented this environment variable](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers#how-to-turn-on-swift-package-manager).

Addresses https://github.com/flutter/flutter/issues/159121

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
