### PR TITLE
Fix scrollUntilVisible in WidgetTester

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -2312,7 +2312,7 @@ abstract class WidgetController {
   /// If `scrollable` is `null`, a [Finder] that looks for a [Scrollable] is
   /// used instead.
   ///
-  /// If [continuous] is `true`, the gesture will be reused to simulate the effect
+  /// If `continuous` is `true`, the gesture will be reused to simulate the effect
   /// of actual finger scrolling, which is useful when used alongside listeners
   /// like [GestureDetector.onTap]. The default is `false`.
   ///

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -624,10 +624,12 @@ void main() {
           body: ListView.builder(
             key: ValueKey<bool>(hasOnTap), // Trigger a rebuild.
             itemCount: itemCount,
-            itemBuilder: (BuildContext context, int index) => ListTile(
-              onTap: hasOnTap ? () {} : null,
-              title: Text('$index'),
-            ),
+            itemBuilder: (BuildContext context, int index) {
+              return ListTile(
+                onTap: hasOnTap ? () {} : null,
+                title: Text('$index'),
+              );
+            },
           ),
         ),
       );

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -612,6 +612,43 @@ void main() {
     });
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/143921.
+  testWidgets('WidgetTester.scrollUntilVisible should work together with onTap', (WidgetTester tester) async {
+    const int itemCount = 20;
+
+    Widget buildFrame(bool hasOnTap) {
+      return MaterialApp(
+        home: Scaffold(
+          body: ListView.builder(
+            key: ValueKey<bool>(hasOnTap), // Trigger a rebuild.
+            itemCount: itemCount,
+            itemBuilder: (BuildContext context, int index) => ListTile(
+              onTap: hasOnTap ? () {} : null,
+              title: Text('$index'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final Finder target = find.text('${itemCount - 1}');
+    final Finder scrollable = find.byType(Scrollable);
+
+    // Scroll without onTap.
+    await tester.pumpWidget(buildFrame(false));
+    await tester.pumpAndSettle();
+    expect(target, findsNothing);
+    await tester.scrollUntilVisible(target, 20, scrollable: scrollable);
+    expect(target, findsOneWidget);
+
+    // Scroll with onTap.
+    await tester.pumpWidget(buildFrame(true));
+    await tester.pumpAndSettle();
+    expect(target, findsNothing);
+    await tester.scrollUntilVisible(target, 20, scrollable: scrollable);
+    expect(target, findsOneWidget);
+  });
+
   testWidgets('platformDispatcher exposes the platformDispatcher from binding', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -613,7 +613,9 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/143921.
-  testWidgets('WidgetTester.scrollUntilVisible should work together with onTap', (WidgetTester tester) async {
+  testWidgets('WidgetTester.scrollUntilVisible should work together with onTap', (
+    WidgetTester tester,
+  ) async {
     const int itemCount = 20;
 
     Widget buildFrame(bool hasOnTap) {
@@ -638,14 +640,14 @@ void main() {
     await tester.pumpWidget(buildFrame(false));
     await tester.pumpAndSettle();
     expect(target, findsNothing);
-    await tester.scrollUntilVisible(target, 20, scrollable: scrollable);
+    await tester.scrollUntilVisible(target, 20, scrollable: scrollable, continuous: true);
     expect(target, findsOneWidget);
 
     // Scroll with onTap.
     await tester.pumpWidget(buildFrame(true));
     await tester.pumpAndSettle();
     expect(target, findsNothing);
-    await tester.scrollUntilVisible(target, 20, scrollable: scrollable);
+    await tester.scrollUntilVisible(target, 20, scrollable: scrollable, continuous: true);
     expect(target, findsOneWidget);
   });
 

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -625,10 +625,7 @@ void main() {
             key: ValueKey<bool>(hasOnTap), // Trigger a rebuild.
             itemCount: itemCount,
             itemBuilder: (BuildContext context, int index) {
-              return ListTile(
-                onTap: hasOnTap ? () {} : null,
-                title: Text('$index'),
-              );
+              return ListTile(onTap: hasOnTap ? () {} : null, title: Text('$index'));
             },
           ),
         ),


### PR DESCRIPTION
Fixes #143921.

The single `moveBy` event may be consumed when `onTap` is present.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
