### PR TITLE
Fix Menu is detached when MenuAnchor is given tight constraints

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -157,6 +157,7 @@ class MenuAnchor extends StatefulWidget {
     this.crossAxisUnconstrained = true,
     required this.menuChildren,
     this.builder,
+    this.builderAlignment,
     this.child,
   });
 
@@ -274,6 +275,18 @@ class MenuAnchor extends StatefulWidget {
   ///
   /// {@macro flutter.material.MenuBar.shortcuts_note}
   final List<Widget> menuChildren;
+
+  /// The optional alignment for the widget that this [MenuAnchor] surrounds.
+  ///
+  /// If provided, [builder] is placed inside an [Align] using this alignment.
+  /// This can be used when the [MenuAnchor] parent sets tight constraints
+  /// which will result in the menu appearing below these tight constraints
+  /// instead of below the widget returned by the [builder].
+  ///
+  /// The recommanded value is [AlignmentDirectional.topStart].
+  ///
+  /// Defaults to null which means no [Align] is added by default.
+  final AlignmentGeometry? builderAlignment;
 
   /// The widget that this [MenuAnchor] surrounds.
   ///
@@ -453,17 +466,30 @@ class _MenuAnchorState extends State<MenuAnchor> {
   }
 
   Widget _buildContents(BuildContext context) {
+    Widget builder = Builder(
+      key: _anchorKey,
+      builder: (BuildContext context) {
+        return widget.builder?.call(context, _menuController, widget.child)
+            ?? widget.child ?? const SizedBox();
+      },
+    );
+
+    if (widget.builderAlignment != null) {
+      // Using this Align, the menu will appear attached to the widget
+      // returned by the builder.
+      builder = Align(
+        alignment: widget.builderAlignment!,
+        heightFactor: 1.0,
+        widthFactor: 1.0,
+        child: builder,
+      );
+    }
+
     return Actions(
       actions: <Type, Action<Intent>>{
         DismissIntent: DismissMenuAction(controller: _menuController),
       },
-      child: Builder(
-        key: _anchorKey,
-        builder: (BuildContext context) {
-          return widget.builder?.call(context, _menuController, widget.child)
-              ?? widget.child ?? const SizedBox();
-        },
-      ),
+      child: builder,
     );
   }
 

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -278,14 +278,14 @@ class MenuAnchor extends StatefulWidget {
 
   /// The optional alignment for the widget that this [MenuAnchor] surrounds.
   ///
-  /// If provided, [builder] is placed inside an [Align] using this alignment.
-  /// This can be used when the [MenuAnchor] parent sets tight constraints
-  /// which will result in the menu appearing below these tight constraints
-  /// instead of below the widget returned by the [builder].
+  /// If [builderAlignment] is provided, [builder] is placed inside an [Align]
+  /// using this alignment. This can be used when the [MenuAnchor] parent sets
+  /// tight constraints which will result in the menu appearing below these
+  /// constraints instead of below the widget returned by the [builder].
   ///
   /// The recommanded value is [AlignmentDirectional.topStart].
   ///
-  /// Defaults to null which means no [Align] is added by default.
+  /// Defaults to null, which means no [Align] is added by default.
   final AlignmentGeometry? builderAlignment;
 
   /// The widget that this [MenuAnchor] surrounds.

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3961,14 +3961,10 @@ void main() {
       );
     });
 
-    group('The menu is attached to the bottom of the MenuAnchor content', () {
+    group('The menu is attached to the MenuAnchor content', () {
       const double contentHeight = 100.0;
       final MenuController menuController = MenuController();
       final UniqueKey contentKey = UniqueKey();
-
-      Finder findMenuPanel() {
-        return find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_MenuPanel');
-      }
 
       MenuAnchor buildMenuAnchor() {
         return MenuAnchor(
@@ -3983,39 +3979,42 @@ void main() {
           builder: (BuildContext context, MenuController controller, Widget? child) {
             return SizedBox(key: contentKey, width: 100.0, height: contentHeight);
           },
-          child: Container(width: 200, height: 60, color: Colors.purple),
         );
       }
 
-      testWidgets('when given loose constraints', (WidgetTester tester) async {
-        await tester.pumpWidget(MaterialApp(
-          home: Scaffold(
-            body: buildMenuAnchor(),
+      testWidgets('when given loose constraints and placed below', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: buildMenuAnchor(),
+            ),
           ),
-        ));
+        );
 
         menuController.open();
         await tester.pump();
 
-        final double menuTop = tester.getRect(findMenuPanel()).top;
+        final double menuTop = tester.getRect(findMenuPanels()).top;
         expect(menuTop, contentHeight);
       });
 
-      testWidgets('when given tight constraints', (WidgetTester tester) async {
-        await tester.pumpWidget(MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              width: 200,
-              height: 300,
-              child: buildMenuAnchor(),
+      testWidgets('when given tight constraints and placed below', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 200,
+                height: 300,
+                child: buildMenuAnchor(),
+              ),
             ),
           ),
-        ));
+        );
 
         menuController.open();
         await tester.pump();
 
-        final double menuTop = tester.getRect(findMenuPanel()).top;
+        final double menuTop = tester.getRect(findMenuPanels()).top;
         expect(menuTop, contentHeight);
       });
     });

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3960,6 +3960,65 @@ void main() {
         tester.getRect(find.byKey(contentKey)).left + horizontalOffset,
       );
     });
+
+    group('The menu is attached to the bottom of the MenuAnchor content', () {
+      const double contentHeight = 100.0;
+      final MenuController menuController = MenuController();
+      final UniqueKey contentKey = UniqueKey();
+
+      Finder findMenuPanel() {
+        return find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_MenuPanel');
+      }
+
+      MenuAnchor buildMenuAnchor() {
+        return MenuAnchor(
+          controller: menuController,
+          builderAlignment: AlignmentDirectional.topStart,
+          menuChildren: <Widget>[
+            MenuItemButton(
+              onPressed: () {},
+              child: const Text('Item 1'),
+            ),
+          ],
+          builder: (BuildContext context, MenuController controller, Widget? child) {
+            return SizedBox(key: contentKey, width: 100.0, height: contentHeight);
+          },
+          child: Container(width: 200, height: 60, color: Colors.purple),
+        );
+      }
+
+      testWidgets('when given loose constraints', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            body: buildMenuAnchor(),
+          ),
+        ));
+
+        menuController.open();
+        await tester.pump();
+
+        final double menuTop = tester.getRect(findMenuPanel()).top;
+        expect(menuTop, contentHeight);
+      });
+
+      testWidgets('when given tight constraints', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 200,
+              height: 300,
+              child: buildMenuAnchor(),
+            ),
+          ),
+        ));
+
+        menuController.open();
+        await tester.pump();
+
+        final double menuTop = tester.getRect(findMenuPanel()).top;
+        expect(menuTop, contentHeight);
+      });
+    });
   });
 
   group('LocalizedShortcutLabeler', () {


### PR DESCRIPTION
## Description

This PR fixes `MenuAnchor`  menu vertical position when tight constraints are given to the `MenuAnchor`.


Before:

![image](https://github.com/user-attachments/assets/4c06d9ef-6fd9-4390-97ca-1477f5eead3a)

After:

![image](https://github.com/user-attachments/assets/80ead9ec-a39a-4f6b-8533-f4a9cfd74e00)

## Context

The solution is based on https://github.com/flutter/flutter/issues/158264#issuecomment-2462981982. The new parameter is optional and defaults to null to lower breaking risks.

I will apply the fix for `DropdownMenu` on a separate PR to make things easier to track and provide a solution for https://github.com/flutter/flutter/issues/147076.

## Related Issue

Fixes [Menu is detached from content when MenuAnchor is given tight constraints](https://github.com/flutter/flutter/issues/158264). 

## Tests

Adds 2 tests.
