### PR TITLE
Fix code signing regex not resilient to whitespace

### DIFF
--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -85,7 +85,7 @@ const String fixWithDevelopmentTeamInstruction = '''
 final RegExp _securityFindIdentityDeveloperIdentityExtractionPattern =
     RegExp(r'^\s*\d+\).+"(.+Develop(ment|er).+)"$');
 final RegExp _securityFindIdentityCertificateCnExtractionPattern = RegExp(r'.*\(([a-zA-Z0-9]+)\)');
-final RegExp _certificateOrganizationalUnitExtractionPattern = RegExp(r'OU=([a-zA-Z0-9]+)');
+final RegExp _certificateOrganizationalUnitExtractionPattern = RegExp(r'OU[\s]*=[\s]*([a-zA-Z0-9]+)');
 
 /// Given a [BuildableIOSApp], this will try to find valid development code
 /// signing identities in the user's keychain prompting a choice if multiple


### PR DESCRIPTION
Fixes #159642

The flutter tools for creating a new flutter project will attempt to detect the iOS Team Identifier, and populate the Runner project with that code-signing team-id.
A regex for parsing output from OpenSSL is not resilient to whitespace, causing it to fail to obtain team id, when one is legitimately available.
This issue may not manifest on all systems, given the nature of how the input is being obtained (i.e, the specific certificate, version of openssl, etc).
This fix simple adds appropriate whitespace handling.

## Pre-launch Checklist

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x] I signed the [CLA].
- [ x] I listed at least one issue that this PR fixes in the description above.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ x] All existing and new tests are passing.