### PR TITLE
Add support for experimental dart data assets (under experimental flag) - part 1

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/android.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/android.dart
@@ -64,9 +64,11 @@ abstract class AndroidAssetBundle extends Target {
       environment.fileSystem.file(isolateSnapshotData)
           .copySync(outputDirectory.childFile('isolate_snapshot_data').path);
     }
+    final DartBuildResult dartBuildResult = await DartBuild.loadBuildResult(environment);
     final Depfile assetDepfile = await copyAssets(
       environment,
       outputDirectory,
+      dartBuildResult: dartBuildResult,
       targetPlatform: TargetPlatform.android,
       buildMode: buildMode,
       flavor: environment.defines[kFlavor],
@@ -83,6 +85,7 @@ abstract class AndroidAssetBundle extends Target {
 
   @override
   List<Target> get dependencies => const <Target>[
+    DartBuildForNative(),
     KernelSnapshot(),
     InstallCodeAssets(),
   ];

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -74,9 +74,11 @@ class CopyFlutterBundle extends Target {
       environment.fileSystem.file(isolateSnapshotData)
           .copySync(environment.outputDir.childFile('isolate_snapshot_data').path);
     }
+    final DartBuildResult dartBuildResult = await DartBuild.loadBuildResult(environment);
     final Depfile assetDepfile = await copyAssets(
       environment,
       environment.outputDir,
+      dartBuildResult: dartBuildResult,
       targetPlatform: TargetPlatform.android,
       buildMode: buildMode,
       flavor: flavor,
@@ -93,6 +95,7 @@ class CopyFlutterBundle extends Target {
 
   @override
   List<Target> get dependencies => const <Target>[
+    DartBuildForNative(),
     KernelSnapshot(),
     InstallCodeAssets(),
   ];

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -465,6 +465,7 @@ abstract class IosAssetBundle extends Target {
 
   @override
   List<Target> get dependencies => const <Target>[
+    DartBuildForNative(),
     KernelSnapshot(),
     InstallCodeAssets(),
   ];
@@ -545,9 +546,11 @@ abstract class IosAssetBundle extends Target {
     final FlutterProject flutterProject = FlutterProject.fromDirectory(environment.projectDir);
 
     // Copy the assets.
+    final DartBuildResult dartBuildResult = await DartBuild.loadBuildResult(environment);
     final Depfile assetDepfile = await copyAssets(
       environment,
       assetDirectory,
+      dartBuildResult: dartBuildResult,
       targetPlatform: TargetPlatform.ios,
       buildMode: buildMode,
       additionalInputs: <File>[

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -99,6 +99,7 @@ abstract class BundleLinuxAssets extends Target {
 
   @override
   List<Target> get dependencies => <Target>[
+    const DartBuildForNative(),
     const KernelSnapshot(),
     const InstallCodeAssets(),
     UnpackLinux(targetPlatform),
@@ -135,9 +136,11 @@ abstract class BundleLinuxAssets extends Target {
         .copySync(outputDirectory.childFile('kernel_blob.bin').path);
     }
     final String versionInfo = getVersionInfo(environment.defines);
+    final DartBuildResult dartBuildResult = await DartBuild.loadBuildResult(environment);
     final Depfile depfile = await copyAssets(
       environment,
       outputDirectory,
+      dartBuildResult: dartBuildResult,
       targetPlatform: targetPlatform,
       buildMode: buildMode,
       additionalContent: <String, DevFSContent>{

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -421,6 +421,11 @@ abstract class MacOSBundleFlutterAssets extends Target {
   const MacOSBundleFlutterAssets();
 
   @override
+  List<Target> get dependencies => const <Target>[
+    DartBuildForNative(),
+  ];
+
+  @override
   List<Source> get inputs => const <Source>[
     Source.pattern('{BUILD_DIR}/App.framework/App'),
     ...IconTreeShaker.inputs,
@@ -485,9 +490,11 @@ abstract class MacOSBundleFlutterAssets extends Target {
       .childDirectory('flutter_assets');
     assetDirectory.createSync(recursive: true);
 
+    final DartBuildResult dartBuildResult = await DartBuild.loadBuildResult(environment);
     final Depfile assetDepfile = await copyAssets(
       environment,
       assetDirectory,
+      dartBuildResult: dartBuildResult,
       targetPlatform: TargetPlatform.darwin,
       buildMode: buildMode,
       flavor: environment.defines[kFlavor],
@@ -593,11 +600,12 @@ class DebugMacOSBundleFlutterAssets extends MacOSBundleFlutterAssets {
   String get name => 'debug_macos_bundle_flutter_assets';
 
   @override
-  List<Target> get dependencies => const <Target>[
-    KernelSnapshot(),
-    DebugMacOSFramework(),
-    DebugUnpackMacOS(),
-    InstallCodeAssets(),
+  List<Target> get dependencies => <Target>[
+    ...super.dependencies,
+    const KernelSnapshot(),
+    const DebugMacOSFramework(),
+    const DebugUnpackMacOS(),
+    const InstallCodeAssets(),
   ];
 
   @override
@@ -625,10 +633,11 @@ class ProfileMacOSBundleFlutterAssets extends MacOSBundleFlutterAssets {
   String get name => 'profile_macos_bundle_flutter_assets';
 
   @override
-  List<Target> get dependencies => const <Target>[
-    CompileMacOSFramework(),
-    InstallCodeAssets(),
-    ProfileUnpackMacOS(),
+  List<Target> get dependencies => <Target>[
+    ...super.dependencies,
+    const CompileMacOSFramework(),
+    const ProfileUnpackMacOS(),
+    const InstallCodeAssets(),
   ];
 
   @override

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -28,6 +28,7 @@ import '../depfile.dart';
 import '../exceptions.dart';
 import 'assets.dart';
 import 'localizations.dart';
+import 'native_assets.dart';
 
 /// Generates an entry point for a web target.
 // Keep this in sync with build_runner/resident_web_runner.dart
@@ -422,6 +423,7 @@ class WebReleaseBundle extends Target {
   List<Target> get dependencies => <Target>[
     ...compileTargets,
     templatedFilesTarget,
+    DartBuildForWeb(compileTargets),
   ];
 
   Iterable<String> get buildPatternStems => compileTargets.expand(
@@ -466,9 +468,11 @@ class WebReleaseBundle extends Target {
     final Directory outputDirectory = environment.outputDir.childDirectory('assets');
     outputDirectory.createSync(recursive: true);
 
+    final DartBuildResult dartBuildResult = await DartBuild.loadBuildResult(environment);
     final Depfile depfile = await copyAssets(
       environment,
       environment.outputDir.childDirectory('assets'),
+      dartBuildResult: dartBuildResult,
       targetPlatform: TargetPlatform.web_javascript,
       buildMode: buildMode,
     );

--- a/packages/flutter_tools/lib/src/build_system/targets/windows.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/windows.dart
@@ -106,6 +106,7 @@ abstract class BundleWindowsAssets extends Target {
 
   @override
   List<Target> get dependencies => <Target>[
+    const DartBuildForNative(),
     const KernelSnapshot(),
     const InstallCodeAssets(),
     UnpackWindows(targetPlatform),
@@ -141,9 +142,11 @@ abstract class BundleWindowsAssets extends Target {
       environment.buildDir.childFile('app.dill')
         .copySync(outputDirectory.childFile('kernel_blob.bin').path);
     }
+    final DartBuildResult dartBuildResult = await DartBuild.loadBuildResult(environment);
     final Depfile depfile = await copyAssets(
       environment,
       outputDirectory,
+      dartBuildResult: dartBuildResult,
       targetPlatform: targetPlatform,
       buildMode: buildMode,
       additionalContent: <String, DevFSContent>{

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -419,7 +419,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       webUseWasm: useWasm,
     );
 
-    final Uri? nativeAssetsJson = await nativeAssetsBuilder?.build(buildInfo);
+    final Uri? nativeAssetsJson = await nativeAssetsBuilder?.build(buildInfo, isWeb);
     String? testAssetPath;
     if (buildTestAssets) {
       await _buildTestAsset(

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -48,6 +48,9 @@ abstract class FeatureFlags {
   /// Whether native assets compilation and bundling is enabled.
   bool get isNativeAssetsEnabled => false;
 
+  /// Whether dart data assets building and bundling is enabled.
+  bool get isDartDataAssetsEnabled => false;
+
   /// Whether native assets compilation and bundling is enabled.
   bool get isPreviewDeviceEnabled => true;
 
@@ -75,6 +78,7 @@ const List<Feature> allFeatures = <Feature>[
   flutterCustomDevicesFeature,
   cliAnimation,
   nativeAssets,
+  dartDataAssets,
   previewDevice,
   swiftPackageManager,
   explicitPackageDependencies,
@@ -163,6 +167,16 @@ const Feature nativeAssets = Feature(
   name: 'native assets compilation and bundling',
   configSetting: 'enable-native-assets',
   environmentOverride: 'FLUTTER_NATIVE_ASSETS',
+  master: FeatureChannelSetting(
+    available: true,
+  ),
+);
+
+/// Enable dart data assets building and bundling.
+const Feature dartDataAssets = Feature(
+  name: 'dart data assets building and bundling',
+  configSetting: 'enable-dart-data-assets',
+  environmentOverride: 'FLUTTER_DART_DATA_ASSETS',
   master: FeatureChannelSetting(
     available: true,
   ),

--- a/packages/flutter_tools/lib/src/flutter_features.dart
+++ b/packages/flutter_tools/lib/src/flutter_features.dart
@@ -56,6 +56,9 @@ class FlutterFeatureFlags implements FeatureFlags {
   bool get isNativeAssetsEnabled => isEnabled(nativeAssets);
 
   @override
+  bool get isDartDataAssetsEnabled => isEnabled(dartDataAssets);
+
+  @override
   bool get isPreviewDeviceEnabled => isEnabled(previewDevice);
 
   @override

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -13,6 +13,8 @@ import '../../../native_assets.dart';
 import '../../../project.dart';
 import '../native_assets.dart';
 
+const bool _isWeb = false;
+
 class TestCompilerNativeAssetsBuilderImpl
     implements TestCompilerNativeAssetsBuilder {
   const TestCompilerNativeAssetsBuilderImpl();
@@ -23,7 +25,7 @@ class TestCompilerNativeAssetsBuilderImpl
 
   @override
   String windowsBuildDirectory(FlutterProject project) =>
-      nativeAssetsBuildUri(project.directory.uri, OS.windows).toFilePath();
+      nativeAssetsBuildUri(project.directory.uri, _isWeb, OS.windows).toFilePath();
 }
 
 Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
@@ -55,7 +57,7 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
   // `build/native_assets/<os>/native_assets.json` file which uses absolute
   // paths to the shared libraries.
   final OS targetOS = getNativeOSFromTargetPlatfrorm(TargetPlatform.tester);
-  final Uri buildUri = nativeAssetsBuildUri(projectUri, targetOS);
+  final Uri buildUri = nativeAssetsBuildUri(projectUri, _isWeb, targetOS);
   final Uri nativeAssetsFileUri = buildUri.resolve('native_assets.json');
 
   final Map<String, String> environmentDefines = <String, String>{

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -566,6 +566,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
     if (rebuildBundle) {
       _logger.printTrace('Updating assets');
       final int result = await assetBundle.build(
+        dartBuildResult: await runDartBuild(),
         packageConfigPath: debuggingOptions.buildInfo.packageConfigPath,
         targetPlatform: TargetPlatform.web_javascript,
       );

--- a/packages/flutter_tools/lib/src/native_assets.dart
+++ b/packages/flutter_tools/lib/src/native_assets.dart
@@ -8,7 +8,7 @@ import 'project.dart';
 /// An interface to enable overriding native assets build logic in other
 /// build systems.
 abstract class TestCompilerNativeAssetsBuilder {
-  Future<Uri?> build(BuildInfo buildInfo);
+  Future<Uri?> build(BuildInfo buildInfo, bool isWeb);
 
   /// Returns the Windows native assets build directory.
   ///

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -489,6 +489,7 @@ class HotRunner extends ResidentRunner {
     if (rebuildBundle) {
       globals.printTrace('Updating assets');
       final int result = await assetBundle.build(
+        dartBuildResult: await runDartBuild(),
         packageConfigPath: debuggingOptions.buildInfo.packageConfigPath,
         flavor: debuggingOptions.buildInfo.flavor,
       );

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -24,6 +24,7 @@ import 'package:flutter_tools/src/build_system/tools/shader_compiler.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
@@ -946,6 +947,7 @@ class FakeBundle extends AssetBundle {
 
   @override
   Future<int> build({
+    DartBuildResult? dartBuildResult,
     String manifestPath = defaultManifestPath,
     String? assetDirPath,
     String? packageConfigPath,

--- a/packages/flutter_tools/test/integration.shard/isolated/dart_data_asset_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/dart_data_asset_test.dart
@@ -1,0 +1,367 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This test exercises the embedding of the native assets mapping in dill files.
+// An initial dill file is created by `flutter assemble` and used for running
+// the application. This dill must contain the mapping.
+// When doing hot reload, this mapping must stay in place.
+// When doing a hot restart, a new dill file is pushed. This dill file must also
+// contain the native assets mapping.
+// When doing a hot reload, this mapping must stay in place.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file/file.dart';
+
+import '../../src/common.dart';
+import '../test_utils.dart' show ProcessResultMatcher, fileSystem, flutterBin, platform;
+import '../transition_test_utils.dart';
+import 'native_assets_test_utils.dart';
+
+final String hostOs = platform.operatingSystem;
+const String packageName = 'data_asset_example';
+
+void main() {
+  if (!platform.isMacOS && !platform.isLinux && !platform.isWindows) {
+    return;
+  }
+
+  // Create project structure once as we can re-use this for executing the
+  // various test modes.
+  late final Directory tempDirectory;
+  late final Directory root;
+  setUpAll(() async {
+    processManager.runSync(<String>[
+      flutterBin,
+      'config',
+      '--enable-native-assets',
+    ]);
+    tempDirectory = fileSystem.directory(fileSystem.systemTempDirectory.createTempSync().resolveSymbolicLinksSync());
+    root = await createDataAssetApp(packageName, tempDirectory);
+  });
+  tearDownAll(() {
+    tryToDelete(tempDirectory);
+  });
+
+  group('dart data assets', () {
+    // NOTE: flutter-tester doesn't support profile/release mode.
+    // NOTE: flutter web doesn't allow cpaturing print()s in profile/release
+    // nOTE: flutter web doens't allow adding assets on hot-restart
+    final List<String> devices = <String>[hostOs, 'chrome', 'flutter-tester'];
+    final List<String> modes  = <String>['debug', 'release'];
+
+    for (final String mode in modes) {
+      for (final String device in devices) {
+        final bool isFlutterTester = device == 'flutter-tester';
+        final bool isWeb = device == 'chrome';
+        final bool isDebug = mode == 'debug';
+
+        // This test relies on running the flutter app and capturing `print()`s
+        // the app prints to determine if the test succeeded.
+        // `flutter run --profile/release` on the web doesn't support capturing
+        // prints
+        // -> See https://github.com/flutter/flutter/issues/159668
+        if (isWeb && !isDebug) {
+          continue;
+        }
+
+        // Flutter tester only supports debug mode.
+        if (isFlutterTester && !isDebug) {
+          continue;
+        }
+
+        testWithoutContext('flutter run on $device --$mode', () async {
+          final bool performRestart = isDebug;
+          final bool performReload = isDebug && !isWeb;
+
+          final Map<String, String> assets = <String, String>{
+            'id1' : 'content1',
+            'id2' : 'content2'
+          };
+          writeHookLibrary(root, assets, available: <String>['id1']);
+          writeHelperLibrary(root, 'version1', assets.keys.toList());
+
+          final ProcessTestResult result = await runFlutter(
+            <String>['run', '-v', '-d', device, '--$mode'],
+            root.path,
+            <Transition>[
+              Barrier.contains('Launching lib/main.dart on'),
+              Multiple.contains(<Pattern>[
+                  // The flutter tool will print it's ready to accept keys (e.g.
+                  // q=quit, ...)
+                  // (This can be racy with app already running and printing)
+                  if (isWeb) 'To hot restart changes while running'
+                  else 'Flutter run key command',
+
+                  // Once the app runs it will print whether it found assets.
+                  'VERSION: version1',
+                  'FOUND "packages/data_asset_example/id1": "content1".',
+                  'NOT-FOUND "packages/data_asset_example/id2".',
+                ],
+                handler: (_) {
+                  if (!performRestart) {
+                    return 'q';
+                  }
+                  // Now we trigger a hot-restart with new assets & new
+                  // application code, we make the build hook now emit also the
+                  // `id2` data asset.
+                  writeHookLibrary(root, assets, available: <String>['id1', 'id2']);
+                  writeHelperLibrary(root, 'version2', assets.keys.toList());
+                  return 'R';
+                },
+              ),
+              if (performRestart)
+                Multiple.contains(<Pattern>[
+                  // Once the app runs it will print whether it found assets.
+                  // We expect it to having found the new `id2` now.
+                  'VERSION: version2',
+                  'FOUND "packages/data_asset_example/id1": "content1".',
+
+                  // Flutter web doesn't support new assets on hot-restart atm
+                  // -> See https://github.com/flutter/flutter/issues/159666
+                  if (isWeb) 'NOT-FOUND "packages/data_asset_example/id2".'
+                  else 'FOUND "packages/data_asset_example/id2": "content2".',
+                ],
+                handler: (_) {
+                  if (!performReload) {
+                    return 'q';
+                  }
+                  // Now we trigger a hot-reload with new assets & new
+                  // application code, we make the build hook now emit also the
+                  // `id3` data asset (but not `id4`).
+                  assets['id3'] = 'content3';
+                  assets['id4'] = 'content4';
+                  writeHookLibrary(root, assets, available: <String>['id1', 'id2', 'id3']);
+                  writeHelperLibrary(root, 'version3', assets.keys.toList());
+                  return 'r';
+                }),
+              if (performReload)
+                Multiple.contains(<Pattern>[
+                  // Once the app runs it will print whether it found assets.
+                  'VERSION: version3',
+                  'FOUND "packages/data_asset_example/id1": "content1".',
+                  'FOUND "packages/data_asset_example/id2": "content2".',
+                  'FOUND "packages/data_asset_example/id3": "content3".',
+                  'NOT-FOUND "packages/data_asset_example/id4".',
+                ],
+                handler: (_) {
+                  return 'q'; // quit
+                }),
+              Barrier.contains('Application finished.'),
+            ],
+            debug: true,
+          );
+          if (result.exitCode != 0) {
+            throw Exception(
+                'flutter run failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
+          }
+        });
+      }
+    }
+
+    for (final String target in <String>[hostOs, 'web']) {
+      testWithoutContext('flutter build $target', () async {
+        final Map<String, String> assets = <String, String>{
+          'id1' : 'content1',
+          'id2' : 'content2'
+        };
+        final List<String> available = <String>['id1'];
+        writeHookLibrary(root, assets, available: available);
+        writeHelperLibrary(root, 'version1', assets.keys.toList());
+
+        final ProcessTestResult result = await runFlutter(
+          <String>['build', '-v', target ],
+          root.path,
+          <Transition>[
+            Barrier.contains('Built build/$target'),
+          ],
+          debug: true,
+        );
+        if (result.exitCode != 0) {
+          throw Exception(
+              'flutter build failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
+        }
+        final Directory buildTargetDir = root.childDirectory('build').childDirectory(target);
+
+        final List<File> manifestFiles  = buildTargetDir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((File file) => file.path.endsWith('AssetManifest.json'))
+            .toList();
+
+        if (manifestFiles.isEmpty) {
+          throw Exception('Expected a `AssetManifest.json` to be avilable in the $buildTargetDir.');
+        }
+        for (final File manifestFile in manifestFiles) {
+          final Map<String, Object?> manifest = json.decode(manifestFile.readAsStringSync()) as Map<String, Object?>;
+          for (final String id in available) {
+            final String key = 'packages/$packageName/$id';
+            final List<Object?> entry = manifest[key]! as List<Object?>;
+            expect(entry, equals(<String>[key]));
+
+            final File file = manifestFile.parent.childFile(key);
+            expect(file.readAsStringSync(), assets[id]);
+          }
+        }
+      });
+    }
+  });
+}
+
+
+Future<Directory> createDataAssetApp(String packageName, Directory tempDirectory) async {
+  final ProcessResult result = processManager.runSync(
+    <String>[flutterBin, 'create', '--no-pub', packageName],
+    workingDirectory: tempDirectory.path,
+  );
+  expect(result, const ProcessResultMatcher());
+
+  final Directory root = tempDirectory.childDirectory(packageName);
+  final File pubspecFile = root.childFile('pubspec.yaml');
+  await replaceFileSection(
+    pubspecFile,
+    'dependencies:\n',
+    'dependencies:\n  native_assets_cli: ^0.9.0\n',
+  );
+  await pinDependencies(pubspecFile);
+
+  final File mainFile = root.childDirectory('lib').childFile('main.dart');
+  writeFile(
+    mainFile,
+    '''
+        import 'dart:async';
+
+        import 'package:flutter/material.dart';
+
+        import 'helper.dart';
+
+        void main() {
+          runApp(const MyApp());
+        }
+
+        class MyApp extends StatelessWidget {
+          const MyApp({super.key});
+
+          @override
+          Widget build(BuildContext context) {
+            bool first = true;
+            Timer.periodic(const Duration(seconds: 1), (_) async {
+              // Delay to give the `flutter run` command time to connect and
+              // setup `print()` capturing logic (especially on web it won't be
+              // able to intercept prints until it has connected to DevTools).
+              if (first) {
+                await Future.delayed(const Duration(seconds: 5));
+              }
+              dumpAssets();
+            });
+
+            return MaterialApp(
+              title: 'Flutter Demo',
+              home: Scaffold(
+                body: Text('Hello world'),
+              ),
+            );
+          }
+        }
+    ''');
+
+  final ProcessResult result2 = await processManager.run(
+    <String>[flutterBin, 'pub', 'get'],
+    workingDirectory: root.path,
+  );
+  expect(result2, const ProcessResultMatcher());
+
+  return root;
+}
+
+void writeHookLibrary(
+    Directory root,
+    Map<String, String> dataAssets,
+    {required List<String> available}) {
+
+  final Directory assetDir = root.childDirectory('asset');
+
+  dataAssets.forEach((String id, String content) {
+    writeFile(assetDir.childFile('$id.txt'), content);
+  });
+
+  final File hookFile = root.childDirectory('hook').childFile('build.dart');
+  available = <String>[
+    for (final String id in available) '"$id"',
+  ];
+  writeFile(hookFile, '''
+      import 'package:native_assets_cli/data_assets.dart';
+
+      void main(List<String> args) async {
+        await build(args, (BuildConfig config, BuildOutputBuilder output) async {
+          for (final id in $available) {
+            output.dataAssets.add(
+              DataAsset(
+                package: '$packageName',
+                name: '\$id',
+                file: config.packageRoot.resolve('asset/\$id.txt'),
+              ),
+            );
+          }
+
+          // This is a workaround for an issue in the
+          // `package:native_assets_builder` package:
+          // -> See https://github.com/dart-lang/native/issues/1770
+          output.addDependency(config.packageRoot.resolve('hook/build.dart'));
+        });
+      }
+  ''');
+}
+
+void writeHelperLibrary(
+    Directory root,
+    String version,
+    List<String> assetIds) {
+  assetIds = <String>[
+    for (final String id in assetIds) '"packages/$packageName/$id"',
+  ];
+  final File helperFile = root.childDirectory('lib').childFile('helper.dart');
+  writeFile(
+    helperFile,
+  '''
+      import 'package:flutter/services.dart' show rootBundle;
+
+      // Only run the code once, but after hot-restart & hot-reload we want to
+      // run it again.
+      bool $version = false;
+      void dumpAssets() async {
+        if ($version) return;
+        $version = true;
+
+        final found = <String, String>{};
+        final notFound = <String>[];
+        for (final String assetId in $assetIds) {
+          try {
+            found[assetId] = await rootBundle.loadString(assetId);
+          } catch (e, s) {
+            print('EXCEPTION \$e');
+            notFound.add(assetId);
+          }
+        }
+        print('VERSION: $version');
+        for (final MapEntry(:key, :value) in found.entries) {
+          print('FOUND "\$key": "\$value".');
+        }
+        for (final id in notFound) {
+          print('NOT-FOUND "\$id".');
+        }
+      }
+      ''');
+}
+
+void writeFile(File file, String content) {
+  file.parent.createSync(recursive: true);
+  file.writeAsStringSync(content);
+}
+
+Future<void> replaceFileSection(File file, Pattern pattern, String replacement) async {
+  final String content = await file.readAsString();
+  await file.writeAsString(content.replaceFirst(pattern, replacement));
+}

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -133,7 +133,7 @@ void main() {
                   return 'q';
                 }),
               ],
-              const Barrier('Application finished.'),
+              Barrier('Application finished.'),
             ],
             logging: false,
           );

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -48,7 +48,7 @@ void main() {
             existsDuringTest = fileSystem.file(pidFile).existsSync();
             return 'q';
           }),
-          const Barrier('Application finished.'),
+          Barrier('Application finished.'),
         ],
       );
       expect(existsDuringTest, isNot(isNull));
@@ -102,7 +102,7 @@ void main() {
           Multiple(<Pattern>[RegExp(r'^Restarted application in .+m?s.$'), 'called main', 'called paint'], handler: (String line) {
             return 'q';
           }),
-          const Barrier('Application finished.'),
+          Barrier('Application finished.'),
         ],
         logging: false, // we ignore leading log lines to avoid making this test sensitive to e.g. the help message text
       );
@@ -173,7 +173,7 @@ void main() {
           Multiple(<Pattern>['ready', 'called paint'], handler: (String line) {
             return 'q';
           }),
-          const Barrier('Application finished.'),
+          Barrier('Application finished.'),
         ],
         logging: false, // we ignore leading log lines to avoid making this test sensitive to e.g. the help message text
       );
@@ -307,7 +307,7 @@ void main() {
         Barrier(finalLine, handler: (String line) {
           return 'q';
         }),
-        const Barrier('Application finished.'),
+        Barrier('Application finished.'),
       ],
     );
     expect(result.exitCode, 0);

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -480,6 +480,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.areCustomDevicesEnabled = false,
     this.isCliAnimationEnabled = true,
     this.isNativeAssetsEnabled = false,
+    this.isDartDataAssetsEnabled = false,
     this.isPreviewDeviceEnabled = false,
     this.isSwiftPackageManagerEnabled = false,
     this.isExplicitPackageDependenciesEnabled = false,
@@ -514,6 +515,9 @@ class TestFeatureFlags implements FeatureFlags {
 
   @override
   final bool isNativeAssetsEnabled;
+
+  @override
+  final bool isDartDataAssetsEnabled;
 
   @override
   final bool isPreviewDeviceEnabled;


### PR DESCRIPTION
This PR adds bundling support for the experimental dart data asset feature: Dart packages with hooks can now emit data assets which the flutter tool will bundle.

It relies on flutter's existing asset bundling mechanism (e.g. entries in `AssetManifest.json`, DevFS syncing in reload/restart, ...).

The support is added under an experimental flag (similar to the existing native assets experimental flag).