### PR TITLE
[Widget Inspector] Only include `truncated` field in JSON response if `true`

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1892,7 +1892,8 @@ abstract class DiagnosticsNode {
       // description instead, see:
       // https://github.com/flutter/devtools/issues/8556
       'widgetRuntimeType': widgetRuntimeType,
-      'truncated': truncated,
+      if (truncated)
+        'truncated': truncated,
       ...delegate.additionalNodeProperties(this, fullDetails: false),
       if (includeChildren) 'children': childrenJsonList,
     };

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -130,6 +130,12 @@ void main() {
           reason: '$keyName is  not included.',
         );
       }
+
+      // The truncated value should not be included if it is false.
+      expect(
+        result['truncated'] == null || result['truncated'] == true,
+        isTrue,
+      );
     });
 
     test('subtreeDepth 1', () {


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8582

Follow up to https://github.com/flutter/flutter/pull/159454

Only include the `truncated` field if it is `true`. We accidentally were including it even when `false` which is what caused the regression in the DevTools tests.
