### PR TITLE
Support EdgeInsetsGeometry shorthands

### DIFF
--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -26,6 +26,12 @@ abstract class AlignmentGeometry {
   /// const constructors so that they can be used in const expressions.
   const AlignmentGeometry();
 
+  /// Creates an [Alignment].
+  factory AlignmentGeometry.xy(double x, double y) => Alignment(x, y);
+
+  /// Creates a directional alignment, or [AlignmentDirectional].
+  factory AlignmentGeometry.directional(double start, double y) => AlignmentDirectional(start, y);
+
   double get _x;
 
   double get _start;

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -26,6 +26,94 @@ abstract class BorderRadiusGeometry {
   /// const constructors so that they can be used in const expressions.
   const BorderRadiusGeometry();
 
+  /// Creates a [BorderRadius] where all radii are `radius`.
+  // The radius applies equally on all sides, so BorderRadiusDirectional is
+  // irrelevant in this case.
+  factory BorderRadiusGeometry.all(Radius radius) => BorderRadius.all(radius);
+
+  /// Creates a [BorderRadius] where all radii are [Radius.circular(radius)].
+  // The radius applies equally on all sides, so BorderRadiusDirectional is
+  // irrelevant in this case.
+  factory BorderRadiusGeometry.circular(double radius) => BorderRadius.circular(radius);
+
+  /// Creates a horizontally symmetrical border radius.
+  ///
+  /// Utilizing the `left` and `right` properties will return a [BorderRadius],
+  /// while `start` and `end` will yield a [BorderRadiusDirectional]. These
+  /// properties cannot be used interchangeably.
+  factory BorderRadiusGeometry.horizontal({
+    Radius? left,  // BorderRadius
+    Radius? right, // BorderRadius
+    Radius? start, // BorderRadiusDirectional
+    Radius? end,   // BorderRadiusDirectional
+  }) {
+    assert(
+      (left == null && right == null) || (start == null && end == null),
+      'The left and right values cannot be used in conjunction with start and end.',
+    );
+
+    if (start != null || end != null) {
+      return BorderRadiusDirectional.horizontal(
+        start: start ?? Radius.zero,
+        end: end ?? Radius.zero,
+      );
+    }
+    return BorderRadius.horizontal(
+      left: left ?? Radius.zero,
+      right: right ?? Radius.zero,
+    );
+  }
+
+  /// Creates a border radius with only the given non-zero values. The other
+  /// corners will be right angles.
+  ///
+  /// Utilizing the `topLeft`, `topRight`, `bottomLeft`, and `bottomRight`
+  /// properties will return a [BorderRadius], while `topStart`, `topEnd`,
+  /// `bottomStart`, and `bottomEnd` will yield a [BorderRadiusDirectional].
+  /// These properties cannot be used interchangeably.
+  factory BorderRadiusGeometry.only({
+    Radius? topLeft,     // BorderRadius
+    Radius? topRight,    // BorderRadius
+    Radius? bottomLeft,  // BorderRadius
+    Radius? bottomRight, // BorderRadius
+    Radius? topStart,    // BorderRadiusDirectional
+    Radius? topEnd,      // BorderRadiusDirectional
+    Radius? bottomStart, // BorderRadiusDirectional
+    Radius? bottomEnd ,  // BorderRadiusDirectional
+  }) {
+    assert(
+      (topLeft == null && topRight == null && bottomLeft == null && bottomRight == null)
+        || (topStart == null && topEnd == null && bottomStart == null && bottomEnd == null),
+      'Directional properties ending with start and end cannot be used interchangeably with properties ending in left and right.'
+    );
+
+    if (topStart != null || topEnd != null || bottomStart != null || bottomEnd != null) {
+      return BorderRadiusDirectional.only(
+        topStart: topStart ?? Radius.zero,
+        topEnd: topEnd ?? Radius.zero,
+        bottomStart: bottomStart ?? Radius.zero,
+        bottomEnd: bottomEnd ?? Radius.zero,
+      );
+    }
+    return BorderRadius.only(
+      topLeft: topLeft ?? Radius.zero,
+      topRight: topRight ?? Radius.zero,
+      bottomLeft: bottomLeft ?? Radius.zero,
+      bottomRight: bottomRight ?? Radius.zero,
+    );
+  }
+
+  /// Creates a vertically symmetric [BorderRadius] where the top and bottom
+  /// sides of the rectangle have the same radii.
+  factory BorderRadiusGeometry.vertical({
+    Radius top = Radius.zero,
+    Radius bottom = Radius.zero,
+  }) {
+    // Directionality does not apply vertically, and so BorderRadiusDirectional
+    // is not needed.
+    return BorderRadius.vertical(top: top, bottom: bottom);
+  }
+
   Radius get _topLeft;
   Radius get _topRight;
   Radius get _bottomLeft;

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -114,6 +114,9 @@ abstract class BorderRadiusGeometry {
     return BorderRadius.vertical(top: top, bottom: bottom);
   }
 
+  /// A [BorderRadius] with all zero radii.
+  static const BorderRadiusGeometry zero = BorderRadius.zero;
+
   Radius get _topLeft;
   Radius get _topRight;
   Radius get _bottomLeft;

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -67,6 +67,54 @@ abstract class BoxBorder extends ShapeBorder {
   /// const constructors so that they can be used in const expressions.
   const BoxBorder();
 
+  /// Creates a [Border].
+  ///
+  /// All the sides of the border default to [BorderSide.none].
+  factory BoxBorder.fromLTRB({
+    BorderSide top = BorderSide.none,
+    BorderSide right = BorderSide.none,
+    BorderSide bottom = BorderSide.none,
+    BorderSide left = BorderSide.none,
+  }) => Border(top: top, right: right, bottom: bottom, left: left);
+
+  /// A uniform [Border] with all sides the same color and width.
+  ///
+  /// The sides default to black solid borders, one logical pixel wide.
+  factory BoxBorder.all({
+    Color color = const Color(0xFF000000),
+    double width = 1.0,
+    BorderStyle style = BorderStyle.solid,
+    double strokeAlign = BorderSide.strokeAlignInside,
+  }) => Border.all(color: color, width: width, style: style, strokeAlign: strokeAlign);
+
+  /// Creates a [Border] whose sides are all the same.
+  factory BoxBorder.fromBorderSide(BorderSide side) => Border.fromBorderSide(side);
+
+  /// Creates a [Border] with symmetrical vertical and horizontal sides.
+  ///
+  /// The `vertical` argument applies to the [left] and [right] sides, and the
+  /// `horizontal` argument applies to the [top] and [bottom] sides.
+  ///
+  /// All arguments default to [BorderSide.none].
+  factory BoxBorder.symmetric({
+    BorderSide vertical = BorderSide.none,
+    BorderSide horizontal = BorderSide.none,
+  }) => Border.symmetric(vertical: vertical, horizontal: horizontal);
+
+  /// Creates a [BorderDirectional].
+  ///
+  /// The [start] and [end] sides represent the horizontal sides; the start side
+  /// is on the leading edge given the reading direction, and the end side is on
+  /// the trailing edge. They are resolved during [paint].
+  ///
+  /// All the sides of the border default to [BorderSide.none].
+  factory BoxBorder.fromSTEB({
+    BorderSide top = BorderSide.none,
+    BorderSide start = BorderSide.none,
+    BorderSide end = BorderSide.none,
+    BorderSide bottom = BorderSide.none,
+  }) => BorderDirectional(top: top, start: start, end: end, bottom: bottom);
+
   /// The top side of this border.
   ///
   /// This getter is available on both [Border] and [BorderDirectional]. If

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -32,6 +32,95 @@ abstract class EdgeInsetsGeometry {
   /// const constructors so that they can be used in const expressions.
   const EdgeInsetsGeometry();
 
+  /// Creates insets where all the offsets are `value`.
+  factory EdgeInsetsGeometry.all(double value) {
+    // Direction does not matter here, the same inset is applied to all sides.
+    // Therefore, EdgeInsetsDirectional is not included.
+    return EdgeInsets.all(value);
+  }
+
+  /// Creates insets with only the given values non-zero.
+  ///
+  /// The `left` and `right` properties will yield [EdgeInsets], while `start`
+  /// and `end` will return [EdgeInsetsDirectional]. They cannot be used
+  /// together.
+  factory EdgeInsetsGeometry.only({
+    double? left,  // EdgeInsets
+    double? right, // EdgeInsets
+    double? top,
+    double? bottom,
+    double? start, // EdgeInsetsDirectional
+    double? end,   // EdgeInsetsDirectional
+  }) {
+    assert(
+      (left == null && right == null) || (start == null && end == null),
+      'The left and right values cannot be used in conjunction with start and end.',
+    );
+
+    if (start != null || end != null) {
+      return EdgeInsetsDirectional.only(
+        start: start ?? 0.0,
+        top: top ?? 0.0,
+        end: end ?? 0.0,
+        bottom: bottom ?? 0.0,
+      );
+    }
+    return EdgeInsets.only(
+      left: left ?? 0.0,
+      top: top ?? 0.0,
+      right: right ?? 0.0,
+      bottom: bottom ?? 0.0,
+    );
+  }
+
+  /// Creates insets with symmetrical vertical and horizontal offsets.
+  ///
+  /// If `horizontal` insets are provided, `directional` must also be provided
+  /// in order to determine if [EdgeInsets] or [EdgeInsetsDirectional] should be
+  /// returned.
+  factory EdgeInsetsGeometry.symmetric({
+    double? vertical,
+    double? horizontal,
+    bool? directional,
+  }) {
+    assert(
+      horizontal == null || directional != null,
+      'For horizontal insets, directional must be provided.',
+    );
+
+    return switch (directional) {
+      true => EdgeInsetsDirectional.symmetric(
+        horizontal: horizontal ?? 0.0,
+        vertical: vertical ?? 0.0,
+      ),
+      _ => EdgeInsets.symmetric(
+        horizontal: horizontal ?? 0.0,
+        vertical: vertical ?? 0.0,
+      ),
+    };
+  }
+
+  /// Creates [EdgeInsets] from offsets from the left, top, right, and bottom.
+  factory EdgeInsetsGeometry.fromLTRB(double left, double top, double right, double bottom) {
+    return EdgeInsets.fromLTRB(left, top, right, bottom);
+  }
+
+  /// Creates [EdgeInsets] that match the given view padding.
+  ///
+  /// If you need the current system padding or view insets in the context of a
+  /// widget, consider using [MediaQuery.paddingOf] to obtain these values
+  /// rather than using the value from a [FlutterView] directly, so that you get
+  /// notified of changes.
+  factory EdgeInsetsGeometry.fromViewPadding(ui.ViewPadding padding, double devicePixelRatio) {
+    return EdgeInsets.fromViewPadding(padding, devicePixelRatio);
+  }
+
+  /// Creates [EdgeInsetsDirectional] from offsets from the start, top, end, and
+  /// bottom.
+  factory EdgeInsetsGeometry.fromSTEB(double start, double top, double end, double bottom) {
+    return EdgeInsetsDirectional.fromSTEB(start, top, end, bottom);
+  }
+
   double get _bottom;
   double get _end;
   double get _left;

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -121,6 +121,9 @@ abstract class EdgeInsetsGeometry {
     return EdgeInsetsDirectional.fromSTEB(start, top, end, bottom);
   }
 
+  /// An [EdgeInsets] with zero offsets in each direction.
+  static const EdgeInsetsGeometry zero = EdgeInsets.zero;
+
   double get _bottom;
   double get _end;
   double get _left;


### PR DESCRIPTION
Working on a proof of concept.

EdgeInsets and EdgeInsetsDirectional are subtypes of EdgeInsetsGeometry.
The both have only, all, and symmetric constructors, which creates collisions in a world where Dart supported a short hand such as:

```dart
Padding(
  padding: .only(bottom: 10.0),
),
```

By adding factory constructors to the super class, EdgeInsetsGeometry, we could resolve these conflicts -- I think. 😉 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
