### PR TITLE
Remove some usages of package:usage

### DIFF
--- a/dev/devicelab/bin/tasks/build_android_host_app_with_module_aar.dart
+++ b/dev/devicelab/bin/tasks/build_android_host_app_with_module_aar.dart
@@ -254,9 +254,6 @@ class ModuleTest {
       section(propertyContent);
       await gradleWrapperProperties.writeAsString(propertyContent, flush: true);
 
-      final File analyticsOutputFile =
-          File(path.join(tempDir.path, 'analytics.log'));
-
       section('Build debug host APK');
 
       await inDirectory(hostApp, () async {
@@ -267,7 +264,7 @@ class ModuleTest {
           <String>['app:assembleDebug'],
           environment: <String, String>{
             'JAVA_HOME': javaHome,
-            'FLUTTER_ANALYTICS_LOG_FILE': analyticsOutputFile.path,
+            'FLUTTER_SUPPRESS_ANALYTICS': 'true',
           },
         );
       });
@@ -308,17 +305,6 @@ class ModuleTest {
         return TaskResult.failure("Debug host APK doesn't contain metadata: flutterProjectType = module ");
       }
 
-      final String analyticsOutput = analyticsOutputFile.readAsStringSync();
-      if (!analyticsOutput.contains('cd24: android')
-          || !analyticsOutput.contains('cd25: true')
-          || !analyticsOutput.contains('viewName: assemble')) {
-        return TaskResult.failure(
-          'Building outer app produced the following analytics: "$analyticsOutput" '
-          'but not the expected strings: "cd24: android", "cd25: true" and '
-          '"viewName: assemble"'
-        );
-      }
-
       section('Check file access modes for read-only asset from Flutter module');
 
       final String readonlyDebugAssetFilePath = path.joinAll(<String>[
@@ -350,7 +336,7 @@ class ModuleTest {
           <String>['app:assembleRelease'],
           environment: <String, String>{
             'JAVA_HOME': javaHome,
-            'FLUTTER_ANALYTICS_LOG_FILE': analyticsOutputFile.path,
+            'FLUTTER_SUPPRESS_ANALYTICS': 'true',
           },
         );
       });

--- a/dev/devicelab/bin/tasks/build_android_host_app_with_module_source.dart
+++ b/dev/devicelab/bin/tasks/build_android_host_app_with_module_source.dart
@@ -228,9 +228,6 @@ class ModuleTest {
       section(propertyContent);
       await gradleWrapperProperties.writeAsString(propertyContent, flush: true);
 
-      final File analyticsOutputFile =
-      File(path.join(tempDir.path, 'analytics.log'));
-
       section('Build debug host APK');
 
       await inDirectory(hostApp, () async {
@@ -241,7 +238,7 @@ class ModuleTest {
           <String>['app:assembleDebug'],
           environment: <String, String>{
             'JAVA_HOME': javaHome,
-            'FLUTTER_ANALYTICS_LOG_FILE': analyticsOutputFile.path,
+            'FLUTTER_SUPPRESS_ANALYTICS': 'true',
           },
         );
       });
@@ -282,17 +279,6 @@ class ModuleTest {
         return TaskResult.failure("Debug host APK doesn't contain metadata: flutterProjectType = module ");
       }
 
-      final String analyticsOutput = analyticsOutputFile.readAsStringSync();
-      if (!analyticsOutput.contains('cd24: android')
-          || !analyticsOutput.contains('cd25: true')
-          || !analyticsOutput.contains('viewName: assemble')) {
-        return TaskResult.failure(
-            'Building outer app produced the following analytics: "$analyticsOutput" '
-                'but not the expected strings: "cd24: android", "cd25: true" and '
-                '"viewName: assemble"'
-        );
-      }
-
       section('Check file access modes for read-only asset from Flutter module');
 
       final String readonlyDebugAssetFilePath = path.joinAll(<String>[
@@ -325,7 +311,7 @@ class ModuleTest {
           <String>['app:assembleRelease'],
           environment: <String, String>{
             'JAVA_HOME': javaHome,
-            'FLUTTER_ANALYTICS_LOG_FILE': analyticsOutputFile.path,
+            'FLUTTER_SUPPRESS_ANALYTICS': 'true',
           },
         );
       });

--- a/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
+++ b/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
@@ -192,8 +192,6 @@ Future<void> main() async {
         Directory(path.join(hostApp.path, 'gradle', 'wrapper')),
       );
 
-      final File analyticsOutputFile = File(path.join(tempDir.path, 'analytics.log'));
-
       section('Build debug host APK');
 
       await inDirectory(hostApp, () async {
@@ -204,7 +202,7 @@ Future<void> main() async {
           <String>['SampleApp:assembleDebug'],
           environment: <String, String>{
             'JAVA_HOME': javaHome,
-            'FLUTTER_ANALYTICS_LOG_FILE': analyticsOutputFile.path,
+            'FLUTTER_SUPPRESS_ANALYTICS': 'true',
           },
         );
       });
@@ -243,17 +241,6 @@ Future<void> main() async {
         return TaskResult.failure("Debug host APK doesn't contain metadata: flutterProjectType = module ");
       }
 
-      final String analyticsOutput = analyticsOutputFile.readAsStringSync();
-      if (!analyticsOutput.contains('cd24: android')
-          || !analyticsOutput.contains('cd25: true')
-          || !analyticsOutput.contains('viewName: assemble')) {
-        return TaskResult.failure(
-          'Building outer app produced the following analytics: "$analyticsOutput" '
-          'but not the expected strings: "cd24: android", "cd25: true" and '
-          '"viewName: assemble"'
-        );
-      }
-
       section('Check file access modes for read-only asset from Flutter module');
 
       final String readonlyDebugAssetFilePath = path.joinAll(<String>[
@@ -285,7 +272,7 @@ Future<void> main() async {
           <String>['SampleApp:assembleRelease'],
           environment: <String, String>{
             'JAVA_HOME': javaHome,
-            'FLUTTER_ANALYTICS_LOG_FILE': analyticsOutputFile.path,
+            'FLUTTER_SUPPRESS_ANALYTICS': 'true',
           },
         );
       });

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -271,7 +271,6 @@ dependencies:
         objectiveCHostApp,
       );
 
-      final File objectiveCAnalyticsOutputFile = File(path.join(tempDir.path, 'analytics-objc.log'));
       final Directory objectiveCBuildDirectory = Directory(path.join(tempDir.path, 'build-objc'));
 
       await inDirectory(objectiveCHostApp, () async {
@@ -374,7 +373,7 @@ end
             'COMPILER_INDEX_STORE_ENABLE=NO',
           ],
           environment: <String, String> {
-            'FLUTTER_ANALYTICS_LOG_FILE': objectiveCAnalyticsOutputFile.path,
+            'FLUTTER_SUPPRESS_ANALYTICS': 'true',
           },
         );
       });
@@ -435,18 +434,6 @@ end
         }
       });
 
-      section('Check that the host build sends the correct analytics');
-
-      final String objectiveCAnalyticsOutput = objectiveCAnalyticsOutputFile.readAsStringSync();
-      if (!objectiveCAnalyticsOutput.contains('cd24: ios')
-          || !objectiveCAnalyticsOutput.contains('cd25: true')
-          || !objectiveCAnalyticsOutput.contains('viewName: assemble')) {
-        return TaskResult.failure(
-          'Building outer Objective-C app produced the following analytics: "$objectiveCAnalyticsOutput" '
-          'but not the expected strings: "cd24: ios", "cd25: true", "viewName: assemble"'
-        );
-      }
-
       section('Archive iOS Objective-C host app');
 
       await inDirectory(objectiveCHostApp, () async {
@@ -470,7 +457,7 @@ end
             'archive',
           ],
           environment: <String, String> {
-            'FLUTTER_ANALYTICS_LOG_FILE': objectiveCAnalyticsOutputFile.path,
+            'FLUTTER_SUPPRESS_ANALYTICS': 'true',
           },
         );
 

--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:flutter_tools/src/reporting/reporting.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 const String _kOptionPackages = 'packages';
 const String _kOptionAsset = 'asset-dir';
@@ -33,7 +33,7 @@ const List<String> _kRequiredOptions = <String>[
 
 Future<void> main(List<String> args) {
   return runInContext<void>(() => run(args), overrides: <Type, Generator>{
-    Usage: () => DisabledUsage(),
+    Analytics: () => const NoOpAnalytics(),
   });
 }
 

--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -18,10 +18,10 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/test/native_assets.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/test/coverage_collector.dart';
 import 'package:flutter_tools/src/test/runner.dart';
 import 'package:flutter_tools/src/test/test_wrapper.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 const String _kOptionPackages = 'packages';
 const String _kOptionShell = 'shell';
@@ -42,7 +42,7 @@ const String _kOptionCoveragePath = 'coverage-path';
 
 void main(List<String> args) {
   runInContext<void>(() => run(args), overrides: <Type, Generator>{
-    Usage: () => DisabledUsage(),
+    Analytics: () => const NoOpAnalytics(),
   });
 }
 

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -70,9 +70,8 @@ void main() {
     final String projectPath = await createProject(tempDir,
         arguments: <String>['--no-pub', '--template=module']);
 
-    final BuildBundleCommand command = await runCommandIn(projectPath);
+    await runCommandIn(projectPath);
 
-    expect((await command.usageValues).commandBuildBundleIsModule, true);
     expect(
       fakeAnalytics.sentEvents,
       contains(


### PR DESCRIPTION
Split-off from https://github.com/flutter/flutter/pull/151518. Helps https://github.com/flutter/flutter/issues/150575


<details>

<summary> Pre-launch checklist </summary> 


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

</details>


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
