### PR TITLE
Make native asset tests more robust against flutter upgrading its pinned dependencies

### DIFF
--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -71,7 +71,8 @@ Future<void> addLinkHookDependency(String packageName, Directory packageDirector
   final File thisPubspecFile = packageDirectory.childFile('pubspec.yaml');
 
   final Map<String, Object?> linkHookPubspec = _pubspecAsMutableJson(linkHookPubspecFile.readAsStringSync());
-  final Map<String, Object?> allLinkHookDeps = linkHookPubspec['dependencies']! as Map<String, Object?>;
+  final Map<String, Object?> linkHooksDependencies = linkHookPubspec['dependencies']! as Map<String, Object?>;
+  final Map<String, Object?> linkHooksDevDependencies = linkHookPubspec['dev_dependencies']! as Map<String, Object?>;
 
   final Map<String, Object?> thisPubspec = _pubspecAsMutableJson(thisPubspecFile.readAsStringSync());
 
@@ -86,8 +87,20 @@ Future<void> addLinkHookDependency(String packageName, Directory packageDirector
   //
   // We ensure that the test package we generate here will have versions
   // compatible with the one from flutter CIs pinned dependencies.
-  _updateDependencies(thisDependencies, allLinkHookDeps);
-  _updateDependencies(thisDevDependencies, allLinkHookDeps);
+  _updateDependencies(thisDependencies, linkHooksDependencies);
+  _updateDependencies(thisDevDependencies, linkHooksDependencies);
+  // Resolving dependencies for this package wouldn't normally use
+  // the dev dependencies of the `link_hook` package. But there may be some
+  // non-dev `link_hook` dependencies that affect resolution of dev
+  // dependencies. So by making this compatible to `link_hook`s dev dependencies
+  // we implicitly also make it compatible to `link_hook`s non-dev dependencies.
+  //
+  // Example: `link_hook` has `test_core` as dependency and `test` as dev
+  // dependency. By using the same version of `test` in this package as
+  // `link_hook` we implicitly are guaranteed to also get a version of
+  // `test_core` that is compatible (and `test_core` is pinned in `link_hook`)
+  _updateDependencies(thisDependencies, linkHooksDevDependencies);
+  _updateDependencies(thisDevDependencies, linkHooksDevDependencies);
   thisDependencies['link_hook'] = <String, Object?>{ 'path' : linkHookDirectory.path };
 
   await thisPubspecFile.writeAsString(json.encode(thisPubspec));


### PR DESCRIPTION
Native asset tests use `flutter create --no-pub --template=package_ffi`. The template used for this is checked in. It then adds extra dependencies to checked-in packages in flutter/flutter (which have pinned deps) in those generated templates.

It then pins all dependencies in the modified template project. This can lead to constraint violations when flutter updates pinned dependencies, because the template uses old constraints (which are turned from `^x` to `=x`) and the additional dependency on flutter/flutter checked in package brings in different pinned dependencies.

In a previous PR we already made this more robust by using flutter's pinned versions over the the versions from the template (that are changed from `^x` to `=x`).

Though a new upgrade of flutters pinned packages reveals that this isn't quite sufficient: The template uses `test` at `^X`. The additional dependency to `link_hook` doesn't depend on `test`. It therefore turns it into `=X`. BUT `link_hooks` has a non-dev dependency on `test_core` which is incompatible with `=X`.

=> So we relax this even more by prefering to choose (pinned) versions of the flutter/flutter `link_hook` dependencies and (new) dev dependencies over the template dependencies.
=> This will make use use the pinned `test` version from `link_hooks` instead of from the template.