### PR TITLE
Remove `BuildInfo.buildNativeAssets` and align usage of file system abstraction

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -47,7 +47,6 @@ class BuildInfo {
     this.packageConfig = PackageConfig.empty,
     this.initializeFromDill,
     this.assumeInitializeFromDillUpToDate = false,
-    this.buildNativeAssets = true,
     this.useLocalCanvasKit = false,
   }) : extraFrontEndOptions = extraFrontEndOptions ?? const <String>[],
        extraGenSnapshotOptions = extraGenSnapshotOptions ?? const <String>[],
@@ -179,9 +178,6 @@ class BuildInfo {
   /// If set, assumes that the file passed in [initializeFromDill] is up to date
   /// and skips the check and potential invalidation of files.
   final bool assumeInitializeFromDillUpToDate;
-
-  /// If set, builds native assets with `build.dart` from all packages.
-  final bool buildNativeAssets;
 
   /// If set, web builds will use the locally built CanvasKit instead of using the CDN
   final bool useLocalCanvasKit;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -30,8 +30,6 @@ import 'macos/native_assets.dart';
 import 'macos/native_assets_host.dart';
 import 'windows/native_assets.dart';
 
-export 'package:native_assets_cli/code_assets_builder.dart' show OS;
-
 /// The assets produced by a Dart build and the dependencies of those assets.
 ///
 /// If any of the dependencies change, then the Dart build should be performed

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -4,6 +4,8 @@
 
 // Logic for native assets shared between all host OSes.
 
+import 'dart:io' as io; // flutter_ignore: dart_io_import
+
 import 'package:logging/logging.dart' as logging;
 import 'package:native_assets_builder/native_assets_builder.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
@@ -27,6 +29,8 @@ import 'linux/native_assets.dart';
 import 'macos/native_assets.dart';
 import 'macos/native_assets_host.dart';
 import 'windows/native_assets.dart';
+
+export 'package:native_assets_cli/code_assets_builder.dart' show OS;
 
 /// The assets produced by a Dart build and the dependencies of those assets.
 ///
@@ -219,8 +223,13 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
   );
 
   @override
-  Future<bool> hasPackageConfig() {
-    return fileSystem.file(packageConfigPath).exists();
+  Future<bool> hasPackageConfig() async {
+    // WARNING: We do not use [fileSystem] here because the code in
+    // [packagesWithNativeAssets] below uses `PackageLayout.fromPackageConfig`
+    // (from package:native_assets_builder`) which asserts that the file
+    // actually exists on disc using `dart:io` (instead of using a file system
+    // mock).
+    return io.File.fromUri(Uri.file(packageConfigPath)).existsSync();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -27,9 +27,6 @@ class TestCompilerNativeAssetsBuilderImpl
 }
 
 Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
-  if (!buildInfo.buildNativeAssets) {
-    return null;
-  }
   final Uri projectUri = FlutterProject.current().directory.uri;
   final FlutterNativeAssetsBuildRunner buildRunner = FlutterNativeAssetsBuildRunnerImpl(
     projectUri,


### PR DESCRIPTION
We remove an unnecessary `BuildInfo.buildNativeAssets` boolean
=> It was suspiciously defaulting to `true` (even though native assets should be off by-default and only on if experiment is enabled)
=> It's not really needed as `runFlutterSpecificDartBuild` will be a NOP if experiment isn't enabled.

We also fix an inconsistency when native asset implementation deals with package config
=> It was using `fileSystem` abstraction when checking for existence of package config file
=> It was using `dart:io` when using the package config
=> These two have to be in sync and the ladder is in another package, so we use `dart:io`.