### PR TITLE
Introduce Material 3 `year2023` flag to `SliderThemeData`

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -192,7 +192,7 @@ class Slider extends StatefulWidget {
       'Use SliderTheme to customize the Slider appearance. '
       'This feature was deprecated after v3.27.0-0.1.pre.'
     )
-    this.year2023 = true,
+    this.year2023,
   }) : _sliderType = _SliderType.material,
        assert(min <= max),
        assert(value >= min && value <= max,
@@ -238,7 +238,7 @@ class Slider extends StatefulWidget {
       'Use SliderTheme to customize the Slider appearance. '
       'This feature was deprecated after v3.27.0-0.1.pre.'
     )
-    this.year2023 = true,
+    this.year2023,
   }) : _sliderType = _SliderType.adaptive,
        padding = null,
        assert(min <= max),
@@ -557,17 +557,18 @@ class Slider extends StatefulWidget {
   /// overlay shape, whichever is larger.
   final EdgeInsetsGeometry? padding;
 
-  /// When true, the [Slider] will use the 2023 Material 3 design appearance.
+  /// When true, the [Slider] will use the 2023 Material Design 3 appearance.
+  /// Defaults to true.
   ///
-  /// Defaults to true. If false, the [Slider] will use the latest Material 3
-  /// Design appearance, which was introduced in December 2023.
+  /// If this is set to false, the [Slider] will use the latest Material Design 3
+  /// appearance, which was introduced in December 2023.
   ///
   /// If [ThemeData.useMaterial3] is false, then this property is ignored.
   @Deprecated(
     'Use SliderTheme to customize the Slider appearance. '
     'This feature was deprecated after v3.27.0-0.1.pre.'
   )
-  final bool year2023;
+  final bool? year2023;
 
   final _SliderType _sliderType ;
 
@@ -801,8 +802,9 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   Widget _buildMaterialSlider(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     SliderThemeData sliderTheme = SliderTheme.of(context);
+    final bool year2023 = widget.year2023 ?? sliderTheme.year2023 ?? true;
     final SliderThemeData defaults = switch (theme.useMaterial3) {
-      true => widget.year2023
+      true => year2023
         ? _SliderDefaultsM3Year2023(context)
         : _SliderDefaultsM3(context),
       false => _SliderDefaultsM2(context),

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -299,6 +299,11 @@ class SliderThemeData with Diagnosticable {
     this.padding,
     this.thumbSize,
     this.trackGap,
+    @Deprecated(
+      'Use SliderTheme to customize the Slider appearance. '
+      'This feature was deprecated after v3.27.0-0.2.pre.'
+    )
+    this.year2023,
   });
 
   /// Generates a SliderThemeData from three main colors.
@@ -623,6 +628,21 @@ class SliderThemeData with Diagnosticable {
   /// Defaults to 6.0 pixels of gap between the active and inactive tracks.
   final double? trackGap;
 
+ /// Overrides the default value of [Slider.year2023].
+  ///
+  /// When true, the [Slider] will use the 2023 Material Design 3 appearance.
+  /// Defaults to true.
+  ///
+  /// If this is set to false, the [Slider] will use the latest Material Design 3
+  /// appearance, which was introduced in December 2023.
+  ///
+  /// If [ThemeData.useMaterial3] is false, then this property is ignored.
+  @Deprecated(
+    'Use SliderTheme to customize the Slider appearance. '
+    'This feature was deprecated after v3.27.0-0.2.pre.'
+  )
+  final bool? year2023;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   SliderThemeData copyWith({
@@ -661,6 +681,7 @@ class SliderThemeData with Diagnosticable {
     EdgeInsetsGeometry? padding,
     MaterialStateProperty<Size?>? thumbSize,
     double? trackGap,
+    bool? year2023,
   }) {
     return SliderThemeData(
       trackHeight: trackHeight ?? this.trackHeight,
@@ -698,6 +719,7 @@ class SliderThemeData with Diagnosticable {
       padding: padding ?? this.padding,
       thumbSize: thumbSize ?? this.thumbSize,
       trackGap: trackGap ?? this.trackGap,
+      year2023: year2023 ?? this.year2023,
     );
   }
 
@@ -744,6 +766,7 @@ class SliderThemeData with Diagnosticable {
       padding: EdgeInsetsGeometry.lerp(a.padding, b.padding, t),
       thumbSize: MaterialStateProperty.lerp<Size?>(a.thumbSize, b.thumbSize, t, Size.lerp),
       trackGap: lerpDouble(a.trackGap, b.trackGap, t),
+      year2023: t < 0.5 ? a.year2023 : b.year2023,
     );
   }
 
@@ -784,6 +807,7 @@ class SliderThemeData with Diagnosticable {
       padding,
       thumbSize,
       trackGap,
+      year2023,
     ),
   );
 
@@ -830,7 +854,8 @@ class SliderThemeData with Diagnosticable {
         && other.allowedInteraction == allowedInteraction
         && other.padding == padding
         && other.thumbSize == thumbSize
-        && other.trackGap == trackGap;
+        && other.trackGap == trackGap
+        && other.year2023 == year2023;
   }
 
   @override
@@ -872,6 +897,7 @@ class SliderThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: defaultData.padding));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Size?>>('thumbSize', thumbSize, defaultValue: defaultData.thumbSize));
     properties.add(DoubleProperty('trackGap', trackGap, defaultValue: defaultData.trackGap));
+    properties.add(DiagnosticsProperty<bool>('year2023', year2023, defaultValue: defaultData.year2023));
   }
 }
 

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -63,6 +63,10 @@ void main() {
       valueIndicatorTextStyle: TextStyle(color: Colors.black),
       mouseCursor: MaterialStateMouseCursor.clickable,
       allowedInteraction: SliderInteraction.tapOnly,
+      padding: EdgeInsets.all(1.0),
+      thumbSize: WidgetStatePropertyAll<Size>(Size(20, 20)),
+      trackGap: 10.0,
+      year2023: false,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -100,7 +104,11 @@ void main() {
       'showValueIndicator: always',
       'valueIndicatorTextStyle: TextStyle(inherit: true, color: ${const Color(0xff000000)})',
       'mouseCursor: WidgetStateMouseCursor(clickable)',
-      'allowedInteraction: tapOnly'
+      'allowedInteraction: tapOnly',
+      'padding: EdgeInsets.all(1.0)',
+      'thumbSize: WidgetStatePropertyAll(Size(20.0, 20.0))',
+      'trackGap: 10.0',
+      'year2023: false',
     ]);
   });
 
@@ -2641,172 +2649,263 @@ void main() {
   });
 
   testWidgets('Can customize track gap when year2023 is false', (WidgetTester tester) async {
-    debugDisableShadows = false;
-    try {
-      Widget buildSlider({ double? trackGap }) {
-        return MaterialApp(
-          theme: ThemeData(
-            sliderTheme: SliderThemeData(
-              trackGap: trackGap,
+    Widget buildSlider({ double? trackGap }) {
+      return MaterialApp(
+        theme: ThemeData(
+          sliderTheme: SliderThemeData(
+            trackGap: trackGap,
+          ),
+        ),
+        home: Material(
+          child: Center(
+            child: Slider(
+              year2023: false,
+              value: 0.5,
+              onChanged: (double value) { },
             ),
           ),
-          home: Directionality(
-            textDirection: TextDirection.ltr,
-            child: Material(
-              child: Center(
-                child: Slider(
-                  year2023: false,
-                  value: 0.5,
-                  onChanged: (double value) { },
-                ),
-              ),
-            ),
-          ),
-        );
-      }
-
-      await tester.pumpWidget(buildSlider(trackGap: 0));
-
-      final MaterialInkController material = Material.of(tester.element(find.byType(Slider)));
-
-      // Test default track shape.
-      const Radius trackOuterCornerRadius = Radius.circular(8.0);
-      const Radius trackInnerCornerRadius = Radius.circular(2.0);
-      expect(
-        material,
-        paints
-          // Active track.
-          ..rrect(
-            rrect: RRect.fromLTRBAndCorners(
-              24.0, 292.0, 400.0, 308.0,
-              topLeft: trackOuterCornerRadius,
-              topRight: trackInnerCornerRadius,
-              bottomRight: trackInnerCornerRadius,
-              bottomLeft: trackOuterCornerRadius,
-            ),
-          )
-          // Inactive track.
-          ..rrect(
-            rrect: RRect.fromLTRBAndCorners(
-              400.0, 292.0, 776.0, 308.0,
-              topLeft: trackInnerCornerRadius,
-              topRight: trackOuterCornerRadius,
-              bottomRight: trackOuterCornerRadius,
-              bottomLeft: trackInnerCornerRadius,
-            ),
-          )
+        ),
       );
-
-      await tester.pumpWidget(buildSlider(trackGap: 10));
-      await tester.pumpAndSettle();
-      expect(
-        material,
-        paints
-          // Active track.
-          ..rrect(
-            rrect: RRect.fromLTRBAndCorners(
-              24.0, 292.0, 390.0, 308.0,
-              topLeft: trackOuterCornerRadius,
-              topRight: trackInnerCornerRadius,
-              bottomRight: trackInnerCornerRadius,
-              bottomLeft: trackOuterCornerRadius,
-            ),
-          )
-          // Inactive track.
-          ..rrect(
-            rrect: RRect.fromLTRBAndCorners(
-              410.0, 292.0, 776.0, 308.0,
-              topLeft: trackInnerCornerRadius,
-              topRight: trackOuterCornerRadius,
-              bottomRight: trackOuterCornerRadius,
-              bottomLeft: trackInnerCornerRadius,
-            ),
-          )
-      );
-    } finally {
-      debugDisableShadows = true;
     }
+
+    await tester.pumpWidget(buildSlider(trackGap: 0));
+
+    final MaterialInkController material = Material.of(tester.element(find.byType(Slider)));
+
+    // Test default track shape.
+    const Radius trackOuterCornerRadius = Radius.circular(8.0);
+    const Radius trackInnerCornerRadius = Radius.circular(2.0);
+    expect(
+      material,
+      paints
+        // Active track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            24.0, 292.0, 400.0, 308.0,
+            topLeft: trackOuterCornerRadius,
+            topRight: trackInnerCornerRadius,
+            bottomRight: trackInnerCornerRadius,
+            bottomLeft: trackOuterCornerRadius,
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            400.0, 292.0, 776.0, 308.0,
+            topLeft: trackInnerCornerRadius,
+            topRight: trackOuterCornerRadius,
+            bottomRight: trackOuterCornerRadius,
+            bottomLeft: trackInnerCornerRadius,
+          ),
+        )
+    );
+
+    await tester.pumpWidget(buildSlider(trackGap: 10));
+    await tester.pumpAndSettle();
+    expect(
+      material,
+      paints
+        // Active track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            24.0, 292.0, 390.0, 308.0,
+            topLeft: trackOuterCornerRadius,
+            topRight: trackInnerCornerRadius,
+            bottomRight: trackInnerCornerRadius,
+            bottomLeft: trackOuterCornerRadius,
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            410.0, 292.0, 776.0, 308.0,
+            topLeft: trackInnerCornerRadius,
+            topRight: trackOuterCornerRadius,
+            bottomRight: trackOuterCornerRadius,
+            bottomLeft: trackInnerCornerRadius,
+          ),
+        )
+    );
   });
 
   testWidgets('Can customize thumb size when year2023 is false', (WidgetTester tester) async {
-    debugDisableShadows = false;
-    try {
-      Widget buildSlider({ WidgetStateProperty<Size?>? thumbSize }) {
-        return MaterialApp(
-          theme: ThemeData(
-            sliderTheme: SliderThemeData(
-              thumbSize: thumbSize,
+    Widget buildSlider({ WidgetStateProperty<Size?>? thumbSize }) {
+      return MaterialApp(
+        theme: ThemeData(
+          sliderTheme: SliderThemeData(
+            thumbSize: thumbSize,
+          ),
+        ),
+        home: Material(
+          child: Center(
+            child: Slider(
+              year2023: false,
+              value: 0.5,
+              onChanged: (double value) { },
             ),
           ),
-          home: Directionality(
-            textDirection: TextDirection.ltr,
-            child: Material(
-              child: Center(
-                child: Slider(
-                  year2023: false,
-                  value: 0.5,
-                  onChanged: (double value) { },
-                ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildSlider(thumbSize: const WidgetStatePropertyAll<Size>(Size(20, 20))));
+
+    final MaterialInkController material = Material.of(tester.element(find.byType(Slider)));
+    expect(
+      material,
+      paints
+        ..circle()
+        ..rrect(
+          rrect: RRect.fromLTRBR(
+          390.0, 290.0, 410.0, 310.0,
+          const Radius.circular(10.0),
+        ),
+    ));
+
+    await tester.pumpWidget(buildSlider(thumbSize: const WidgetStateProperty<Size?>.fromMap(
+      <WidgetStatesConstraint, Size>{
+        WidgetState.pressed: Size(20, 20),
+        WidgetState.any:  Size(10, 10),
+      },
+    )));
+    await tester.pumpAndSettle();
+
+    expect(
+      material,
+      paints
+        ..circle()
+        ..rrect(
+          rrect: RRect.fromLTRBR(
+          395.0, 295.0, 405.0, 305.0,
+          const Radius.circular(5.0),
+        ),
+    ));
+
+
+    final Offset center = tester.getCenter(find.byType(Slider));
+    final TestGesture gesture = await tester.startGesture(center);
+    await tester.pumpAndSettle();
+
+    expect(
+      material,
+      paints
+        ..circle()
+        ..rrect(
+          rrect: RRect.fromLTRBR(
+          390.0, 295.0, 410.0, 305.0,
+          const Radius.circular(5.0),
+        ),
+    ));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('Opt into 2024 Slider appearance with SliderThemeData.year2023', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(
+      sliderTheme: const SliderThemeData(year2023: false),
+    );
+    final ColorScheme colorScheme = theme.colorScheme;
+    final Color activeTrackColor = colorScheme.primary;
+    final Color inactiveTrackColor = colorScheme.secondaryContainer;
+    const double value = 0.45;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: Slider(
+              value: value,
+              onChanged: (double value) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final MaterialInkController material = Material.of(tester.element(find.byType(Slider)));
+
+    // Test default track shape.
+    const Radius trackOuterCornerRadius = Radius.circular(8.0);
+    const Radius trackInnerCornderRadius = Radius.circular(2.0);
+    expect(
+      material,
+      paints
+        // Active track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            24.0, 292.0, 356.4, 308.0,
+            topLeft: trackOuterCornerRadius,
+            topRight: trackInnerCornderRadius,
+            bottomRight: trackInnerCornderRadius,
+            bottomLeft: trackOuterCornerRadius,
+          ),
+          color: activeTrackColor,
+        )
+        // Inctive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            368.4, 292.0, 776.0, 308.0,
+            topLeft: trackInnerCornderRadius,
+            topRight: trackOuterCornerRadius,
+            bottomRight: trackOuterCornerRadius,
+            bottomLeft: trackInnerCornderRadius,
+          ),
+          color: inactiveTrackColor,
+        ),
+    );
+  });
+
+  testWidgets('Slider.year2023 overrides SliderThemeData.year2023', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(
+      sliderTheme: const SliderThemeData(year2023: false),
+    );
+    final ColorScheme colorScheme = theme.colorScheme;
+    final Color activeTrackColor = colorScheme.primary;
+    final Color inactiveTrackColor = colorScheme.surfaceContainerHighest;
+    const double value = 0.45;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: Theme(
+              data: theme,
+              child: Slider(
+                year2023: true,
+                value: value,
+                onChanged: (double value) { },
               ),
             ),
           ),
-        );
-      }
+        ),
+      ),
+    );
 
-      await tester.pumpWidget(buildSlider(thumbSize: const WidgetStatePropertyAll<Size>(Size(20, 20))));
+    final MaterialInkController material = Material.of(tester.element(find.byType(Slider)));
 
-      final MaterialInkController material = Material.of(tester.element(find.byType(Slider)));
-      expect(
-        material,
-        paints
-          ..circle()
-          ..rrect(
-            rrect: RRect.fromLTRBR(
-            390.0, 290.0, 410.0, 310.0,
-            const Radius.circular(10.0),
+    // Test default track shape.
+    const Radius activeTrackCornerRadius = Radius.circular(3.0);
+    const Radius inactiveTrackCornerRadius = Radius.circular(2.0);
+    expect(
+      material,
+      paints
+        // Active track.
+        ..rrect(
+          rrect: RRect.fromLTRBR(
+            360.4, 298.0, 776.0, 302.0,
+            inactiveTrackCornerRadius,
           ),
-      ));
-
-      await tester.pumpWidget(buildSlider(thumbSize: const WidgetStateProperty<Size?>.fromMap(
-        <WidgetStatesConstraint, Size>{
-          WidgetState.pressed: Size(20, 20),
-          WidgetState.any:  Size(10, 10),
-        },
-      )));
-      await tester.pumpAndSettle();
-
-      expect(
-        material,
-        paints
-          ..circle()
-          ..rrect(
-            rrect: RRect.fromLTRBR(
-            395.0, 295.0, 405.0, 305.0,
-            const Radius.circular(5.0),
+          color: inactiveTrackColor,
+        )
+        // Inctive track.
+        ..rrect(
+          rrect: RRect.fromLTRBR(
+            24.0, 297.0, 364.4, 303.0,
+            activeTrackCornerRadius,
           ),
-      ));
-
-
-      final Offset center = tester.getCenter(find.byType(Slider));
-      final TestGesture gesture = await tester.startGesture(center);
-      await tester.pumpAndSettle();
-
-      expect(
-        material,
-        paints
-          ..circle()
-          ..rrect(
-            rrect: RRect.fromLTRBR(
-            390.0, 295.0, 410.0, 305.0,
-            const Radius.circular(5.0),
-          ),
-      ));
-
-      await gesture.up();
-      await tester.pumpAndSettle();
-    } finally {
-      debugDisableShadows = true;
-    }
+          color: activeTrackColor,
+        ),
+    );
   });
 
   group('Material 2', () {
@@ -2847,17 +2946,14 @@ void main() {
               };
           return MaterialApp(
             theme: theme,
-            home: Directionality(
-              textDirection: TextDirection.ltr,
-              child: Material(
-                child: Center(
-                  child: Slider(
-                    value: value,
-                    secondaryTrackValue: 0.75,
-                    label: '$value',
-                    divisions: divisions,
-                    onChanged: onChanged,
-                  ),
+            home: Material(
+              child: Center(
+                child: Slider(
+                  value: value,
+                  secondaryTrackValue: 0.75,
+                  label: '$value',
+                  divisions: divisions,
+                  onChanged: onChanged,
                 ),
               ),
             ),
@@ -2979,23 +3075,20 @@ void main() {
         Widget buildApp(String value, { double sliderValue = 0.5, TextScaler textScaler = TextScaler.noScaling }) {
           return MaterialApp(
             theme: theme,
-            home: Directionality(
-              textDirection: TextDirection.ltr,
-              child: MediaQuery(
-                data: MediaQueryData(textScaler: textScaler),
-                child: Material(
-                  child: Row(
-                    children: <Widget>[
-                      Expanded(
-                        child: Slider(
-                          value: sliderValue,
-                          label: value,
-                          divisions: 3,
-                          onChanged: (double d) { },
-                        ),
+            home: MediaQuery(
+              data: MediaQueryData(textScaler: textScaler),
+              child: Material(
+                child: Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: Slider(
+                        value: sliderValue,
+                        label: value,
+                        divisions: 3,
+                        onChanged: (double d) { },
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
             ),


### PR DESCRIPTION
Related to [Introduce Material 3 `year2023` flag to the updated widget themes](https://github.com/flutter/flutter/issues/159484)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
