### PR TITLE
`AlignTransition` / `DecoratedBoxTransition` without rebuilds

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -158,6 +158,35 @@ typedef DelegatedTransitionBuilder =
       Widget? child,
     );
 
+mixin _RenderTransition<L extends Listenable> on RenderObject {
+  void _listener();
+
+  L get listenable => _listenable;
+  abstract L _listenable;
+  set listenable(L value) {
+    if (value == _listenable) {
+      return;
+    }
+    _listenable.removeListener(_listener);
+    _listenable = value;
+    if (attached) {
+      value.addListener(_listener..call());
+    }
+  }
+
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+    listenable.addListener(_listener);
+  }
+
+  @override
+  void detach() {
+    listenable.removeListener(_listener);
+    super.detach();
+  }
+}
+
 /// Animates the position of a widget relative to its normal position.
 ///
 /// The translation is expressed as an [Offset] scaled to the child's size. For
@@ -979,35 +1008,22 @@ class AlignTransition extends SingleChildRenderObjectWidget {
   }
 }
 
-class _RenderAnimatedAlign extends RenderPositionedBox {
+class _RenderAnimatedAlign extends RenderPositionedBox
+    with _RenderTransition<ValueListenable<AlignmentGeometry>> {
   _RenderAnimatedAlign({
     required ValueListenable<AlignmentGeometry> listenable,
     super.widthFactor,
     super.heightFactor,
     super.textDirection,
   }) : _listenable = listenable,
-       super(alignment: listenable.value) {
-    _listenable.addListener(_listener);
-  }
-
-  ValueListenable<AlignmentGeometry> get listenable => _listenable;
-  ValueListenable<AlignmentGeometry> _listenable;
-  set listenable(ValueListenable<AlignmentGeometry> newValue) {
-    if (newValue == _listenable) {
-      return;
-    }
-    _listenable.removeListener(_listener);
-    _listenable = newValue..addListener(_listener);
-  }
-
-  void _listener() {
-    alignment = _listenable.value;
-  }
+       super(alignment: listenable.value);
 
   @override
-  void dispose() {
-    _listenable.removeListener(_listener);
-    super.dispose();
+  ValueListenable<AlignmentGeometry> _listenable;
+
+  @override
+  void _listener() {
+    alignment = _listenable.value;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -8,6 +8,7 @@ library;
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
@@ -934,7 +935,7 @@ class DecoratedBoxTransition extends AnimatedWidget {
 ///    aligns its child.
 ///  * [SlideTransition], a widget that animates the position of a widget
 ///    relative to its normal position.
-class AlignTransition extends AnimatedWidget {
+class AlignTransition extends SingleChildRenderObjectWidget {
   /// Creates an animated [Align] whose [AlignmentGeometry] animation updates
   /// the widget.
   ///
@@ -943,14 +944,14 @@ class AlignTransition extends AnimatedWidget {
   ///  * [Align.new].
   const AlignTransition({
     super.key,
-    required Animation<AlignmentGeometry> alignment,
-    required this.child,
+    required this.alignment,
     this.widthFactor,
     this.heightFactor,
-  }) : super(listenable: alignment);
+    required Widget super.child,
+  });
 
   /// The animation that controls the child's alignment.
-  Animation<AlignmentGeometry> get alignment => listenable as Animation<AlignmentGeometry>;
+  final ValueListenable<AlignmentGeometry> alignment;
 
   /// If non-null, the child's width factor, see [Align.widthFactor].
   final double? widthFactor;
@@ -958,19 +959,55 @@ class AlignTransition extends AnimatedWidget {
   /// If non-null, the child's height factor, see [Align.heightFactor].
   final double? heightFactor;
 
-  /// The widget below this widget in the tree.
-  ///
-  /// {@macro flutter.widgets.ProxyWidget.child}
-  final Widget child;
-
   @override
-  Widget build(BuildContext context) {
-    return Align(
-      alignment: alignment.value,
+  RenderPositionedBox createRenderObject(BuildContext context) {
+    return _RenderAnimatedAlign(
+      listenable: alignment,
       widthFactor: widthFactor,
       heightFactor: heightFactor,
-      child: child,
+      textDirection: Directionality.maybeOf(context),
     );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderPositionedBox renderObject) {
+    (renderObject as _RenderAnimatedAlign)
+      ..listenable = alignment
+      ..widthFactor = widthFactor
+      ..heightFactor = heightFactor
+      ..textDirection = Directionality.maybeOf(context);
+  }
+}
+
+class _RenderAnimatedAlign extends RenderPositionedBox {
+  _RenderAnimatedAlign({
+    required ValueListenable<AlignmentGeometry> listenable,
+    super.widthFactor,
+    super.heightFactor,
+    super.textDirection,
+  }) : _listenable = listenable,
+       super(alignment: listenable.value) {
+    _listenable.addListener(_listener);
+  }
+
+  ValueListenable<AlignmentGeometry> get listenable => _listenable;
+  ValueListenable<AlignmentGeometry> _listenable;
+  set listenable(ValueListenable<AlignmentGeometry> newValue) {
+    if (newValue == _listenable) {
+      return;
+    }
+    _listenable.removeListener(_listener);
+    _listenable = newValue..addListener(_listener);
+  }
+
+  void _listener() {
+    alignment = _listenable.value;
+  }
+
+  @override
+  void dispose() {
+    _listenable.removeListener(_listener);
+    super.dispose();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -170,7 +170,8 @@ mixin _RenderTransition<L extends Listenable> on RenderObject {
     _listenable.removeListener(_listener);
     _listenable = value;
     if (attached) {
-      value.addListener(_listener..call());
+      value.addListener(_listener);
+      _listener();
     }
   }
 
@@ -178,6 +179,7 @@ mixin _RenderTransition<L extends Listenable> on RenderObject {
   void attach(PipelineOwner owner) {
     super.attach(owner);
     listenable.addListener(_listener);
+    _listener();
   }
 
   @override
@@ -1023,6 +1025,8 @@ class _RenderAnimatedAlign extends RenderPositionedBox
 
   @override
   void _listener() {
+    // Sets the alignment to match the listenable's current value,
+    // and triggers a layout update.
     alignment = _listenable.value;
   }
 }

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -403,8 +403,7 @@ void main() {
   testWidgets('Decorated with white background by default', (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoApp(home: CupertinoPageScaffold(child: Center())));
 
-    final DecoratedBox decoratedBox =
-        tester.widgetList(find.byType(DecoratedBox)).elementAt(1) as DecoratedBox;
+    final DecoratedBox decoratedBox = tester.widget(find.byType(DecoratedBox));
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -418,8 +417,7 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox =
-        tester.widgetList(find.byType(DecoratedBox)).elementAt(1) as DecoratedBox;
+    final DecoratedBox decoratedBox = tester.widget(find.byType(DecoratedBox));
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -46,7 +46,7 @@ void main() {
       );
 
       await tester.pumpWidget(transitionUnderTest);
-      RenderDecoratedBox actualBox = tester.renderObject(find.byType(DecoratedBox));
+      RenderDecoratedBox actualBox = tester.renderObject(find.byType(DecoratedBoxTransition));
       BoxDecoration actualDecoration = actualBox.decoration as BoxDecoration;
 
       expect(actualDecoration.color, isSameColorAs(const Color(0xFFFFFFFF)));
@@ -57,7 +57,7 @@ void main() {
       controller.value = 0.5;
 
       await tester.pump();
-      actualBox = tester.renderObject(find.byType(DecoratedBox));
+      actualBox = tester.renderObject(find.byType(DecoratedBoxTransition));
       actualDecoration = actualBox.decoration as BoxDecoration;
 
       expect(actualDecoration.color, isSameColorAs(const Color(0xFF7F7F7F)));
@@ -76,7 +76,7 @@ void main() {
       controller.value = 1.0;
 
       await tester.pump();
-      actualBox = tester.renderObject(find.byType(DecoratedBox));
+      actualBox = tester.renderObject(find.byType(DecoratedBoxTransition));
       actualDecoration = actualBox.decoration as BoxDecoration;
 
       expect(actualDecoration.color, const Color(0xFF000000));
@@ -101,7 +101,7 @@ void main() {
 
       await tester.pumpWidget(transitionUnderTest);
 
-      RenderDecoratedBox actualBox = tester.renderObject(find.byType(DecoratedBox));
+      RenderDecoratedBox actualBox = tester.renderObject(find.byType(DecoratedBoxTransition));
       BoxDecoration actualDecoration = actualBox.decoration as BoxDecoration;
 
       expect(actualDecoration.color, isSameColorAs(const Color(0xFFFFFFFF)));
@@ -112,7 +112,7 @@ void main() {
       controller.value = 0.5;
 
       await tester.pump();
-      actualBox = tester.renderObject(find.byType(DecoratedBox));
+      actualBox = tester.renderObject(find.byType(DecoratedBoxTransition));
       actualDecoration = actualBox.decoration as BoxDecoration;
 
       // Same as the test above but the values should be much closer to the

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -149,7 +149,9 @@ void main() {
 
     await tester.pumpWidget(widget);
 
-    final RenderPositionedBox actualPositionedBox = tester.renderObject(find.byType(Align));
+    final RenderPositionedBox actualPositionedBox = tester.renderObject(
+      find.byType(AlignTransition),
+    );
 
     Alignment actualAlignment = actualPositionedBox.alignment as Alignment;
     expect(actualAlignment, Alignment.centerLeft);
@@ -158,6 +160,25 @@ void main() {
     await tester.pump();
     actualAlignment = actualPositionedBox.alignment as Alignment;
     expect(actualAlignment, const Alignment(0.0, 0.5));
+  });
+
+  testWidgets('AlignTransition with ValueNotifier', (WidgetTester tester) async {
+    final ValueNotifier<Alignment> alignment = ValueNotifier<Alignment>(Alignment.centerLeft);
+    addTearDown(alignment.dispose);
+
+    await tester.pumpWidget(
+      AlignTransition(
+        alignment: alignment,
+        child: const Text('Ready', textDirection: TextDirection.ltr),
+      ),
+    );
+
+    final RenderPositionedBox renderBox = tester.renderObject(find.byType(AlignTransition));
+    expect(renderBox.alignment, Alignment.centerLeft);
+
+    alignment.value = const Alignment(0.0, 0.5);
+    await tester.pump();
+    expect(renderBox.alignment, const Alignment(0.0, 0.5));
   });
 
   testWidgets('RelativePositionedTransition animates', (WidgetTester tester) async {
@@ -223,7 +244,7 @@ void main() {
 
     await tester.pumpWidget(widget);
 
-    final Align actualAlign = tester.widget(find.byType(Align));
+    final RenderPositionedBox actualAlign = tester.renderObject(find.byType(AlignTransition));
 
     expect(actualAlign.widthFactor, 0.3);
     expect(actualAlign.heightFactor, 0.4);


### PR DESCRIPTION
This PR reworks the [**AlignTransition**](https://main-api.flutter.dev/flutter/widgets/AlignTransition-class.html) widget to enable skipping the "build" stage of the pipeline entirely.

Additionally, the alignment parameter's type has been changed from `Animation` to `ValueListenable`, to allow using a ValueNotifier if desired.

<hr>

<br>

I ran a benchmark with some colored boxes to see the performance difference between rebuilding each frame vs. updating the render object directly.

|                      | debug (raster) | debug (UI) | profile (raster) | profile (UI) |
|---------------------:|---------------:|-----------:|-----------------:|-------------:|
|   listenable builder |         3.5 ms |    24.0 ms |           3.4 ms |       4.6 ms |
| custom render object |         3.4 ms |     6.5 ms |           3.4 ms |       3.4 ms |
|          improvement |             3% |       269% |               0% |          35% |

Avoiding rebuilds gives a decent boost in profile mode and a significant improvement in debug mode.

<br>

I remember there being some concerns about adding a bunch of new RenderObject subclasses, but this one is short enough that I can copy-paste here:

```dart
_RenderAnimatedAlign extends RenderPositionedBox
    with _RenderTransition<ValueListenable<AlignmentGeometry>> {
  _RenderAnimatedAlign({
    required ValueListenable<AlignmentGeometry> listenable,
    super.widthFactor,
    super.heightFactor,
    super.textDirection,
  }) : _listenable = listenable,
       super(alignment: listenable.value);

  @override
  ValueListenable<AlignmentGeometry> _listenable;

  @override
  void _listener() {
    alignment = _listenable.value;
  }
```

Obviously, a real-world app is going to have a bit more going on than a few "transition" widgets, but still—30 lines of code for a 30% performance boost is a pretty sweet deal!