### PR TITLE
Reland Fix InkWell overlayColor resolution ignores selected state

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1283,12 +1283,16 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     assert(widget.debugCheckContext(context));
     super.build(context); // See AutomaticKeepAliveClientMixin.
 
-    Color getHighlightColorForType(_HighlightType type) {
-      const Set<MaterialState> pressed = <MaterialState>{MaterialState.pressed};
-      const Set<MaterialState> focused = <MaterialState>{MaterialState.focused};
-      const Set<MaterialState> hovered = <MaterialState>{MaterialState.hovered};
+    final ThemeData theme = Theme.of(context);
+    const Set<MaterialState> highlightableStates = <MaterialState>{MaterialState.focused, MaterialState.hovered, MaterialState.pressed};
+    final Set<MaterialState> nonHighlightableStates = statesController.value.difference(highlightableStates);
+    // Each highlightable state will be resolved separately to get the corresponding color.
+    // For this resolution to be correct, the non-highlightable states should be preserved.
+    final Set<MaterialState> pressed = <MaterialState>{...nonHighlightableStates, MaterialState.pressed};
+    final Set<MaterialState> focused = <MaterialState>{...nonHighlightableStates, MaterialState.focused};
+    final Set<MaterialState> hovered = <MaterialState>{...nonHighlightableStates, MaterialState.hovered};
 
-      final ThemeData theme = Theme.of(context);
+    Color getHighlightColorForType(_HighlightType type) {
       return switch (type) {
         // The pressed state triggers a ripple (ink splash), per the current
         // Material Design spec. A separate highlight is no longer used.


### PR DESCRIPTION
Reland https://github.com/flutter/flutter/pull/159072 without change.
The initial PR was flagged for a non-related perf regression, see https://github.com/flutter/flutter/issues/159337#issuecomment-2515486589

Fixes https://github.com/flutter/flutter/issues/159063