### PR TITLE
Add support for injecting assets into the widget_preview_scaffold

### DIFF
--- a/packages/flutter_tools/lib/src/base/deferred_component.dart
+++ b/packages/flutter_tools/lib/src/base/deferred_component.dart
@@ -78,6 +78,20 @@ class DeferredComponent {
     };
   }
 
+  /// Returns a descriptor of the component to be used when modifying a
+  /// pubspec.yaml.
+  Map<String, Object?> get descriptor {
+    return <String, Object?>{
+      'name': name,
+      if (libraries.isNotEmpty)
+        'libraries': libraries.toList(),
+      if (assets.isNotEmpty)
+        'assets': assets.map(
+          (AssetsEntry e) => e.descriptor,
+        ).toList(),
+    };
+  }
+
   /// Provides a human readable string representation of the
   /// configuration.
   @override

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -3,12 +3,17 @@
 // found in the LICENSE file.
 
 import 'package:args/args.dart';
+import 'package:meta/meta.dart';
 
 import '../base/common.dart';
+import '../base/deferred_component.dart';
 import '../base/file_system.dart';
 import '../base/platform.dart';
 import '../cache.dart';
+import '../convert.dart';
 import '../dart/pub.dart';
+import '../flutter_manifest.dart';
+
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../runner/flutter_command.dart';
@@ -86,16 +91,17 @@ class WidgetPreviewStartCommand extends FlutterCommand
   @override
   Future<FlutterCommandResult> runCommand() async {
     final FlutterProject rootProject = getRootProject();
+    final Directory widgetPreviewScaffold = rootProject.widgetPreviewScaffold;
 
     // Check to see if a preview scaffold has already been generated. If not,
     // generate one.
-    if (!rootProject.widgetPreviewScaffold.existsSync()) {
+    if (!widgetPreviewScaffold.existsSync()) {
       globals.logger.printStatus(
-        'Creating widget preview scaffolding at: ${rootProject.widgetPreviewScaffold.path}',
+        'Creating widget preview scaffolding at: ${widgetPreviewScaffold.path}',
       );
       await generateApp(
         <String>['widget_preview_scaffold'],
-        rootProject.widgetPreviewScaffold,
+        widgetPreviewScaffold,
         createTemplateContext(
           organization: 'flutter',
           projectName: 'widget_preview_scaffold',
@@ -109,17 +115,183 @@ class WidgetPreviewStartCommand extends FlutterCommand
         overwrite: true,
         generateMetadata: false,
       );
-
-      if (shouldCallPubGet) {
-        await pub.get(
-          context: PubContext.create,
-          project: rootProject.widgetPreviewScaffoldProject,
-          offline: offline,
-          outputMode: PubOutputMode.summaryOnly,
-        );
-      }
+      await _populatePreviewPubspec(rootProject: rootProject);
     }
     return FlutterCommandResult.success();
+  }
+
+  @visibleForTesting
+  static const Map<String, String> flutterGenPackageConfigEntry =
+      <String, String>{
+    'name': 'flutter_gen',
+    'rootUri': '../../flutter_gen',
+    'languageVersion': '2.12',
+  };
+
+  /// Maps asset URIs to relative paths for the widget preview project to
+  /// include.
+  @visibleForTesting
+  static Uri transformAssetUri(Uri uri) {
+    // Assets provided by packages always start with 'packages' and do not
+    // require their URIs to be updated.
+    if (uri.path.startsWith('packages')) {
+      return uri;
+    }
+    // Otherwise, the asset is contained within the root project and needs
+    // to be referenced from the widget preview scaffold project's pubspec.
+    return Uri(path: '../../${uri.path}');
+  }
+
+  @visibleForTesting
+  static AssetsEntry transformAssetsEntry(AssetsEntry asset) {
+    return AssetsEntry(
+      uri: transformAssetUri(asset.uri),
+      flavors: asset.flavors,
+      transformers: asset.transformers,
+    );
+  }
+
+  @visibleForTesting
+  static FontAsset transformFontAsset(FontAsset asset) {
+    return FontAsset(
+      transformAssetUri(asset.assetUri),
+      weight: asset.weight,
+      style: asset.style,
+    );
+  }
+
+  @visibleForTesting
+  static DeferredComponent transformDeferredComponent(
+      DeferredComponent component) {
+    return DeferredComponent(
+      name: component.name,
+      // TODO(bkonyi): verify these library paths are always package: paths from the parent project.
+      libraries: component.libraries,
+      assets: component.assets.map(transformAssetsEntry).toList(),
+    );
+  }
+
+  @visibleForTesting
+  FlutterManifest buildPubspec({
+    required FlutterManifest rootManifest,
+    required FlutterManifest widgetPreviewManifest,
+  }) {
+    final List<AssetsEntry> assets =
+        rootManifest.assets.map(transformAssetsEntry).toList();
+
+    final List<Font> fonts = rootManifest.fonts.map(
+      (Font font) {
+        return Font(
+          font.familyName,
+          font.fontAssets.map(transformFontAsset).toList(),
+        );
+      },
+    ).toList();
+
+    final List<Uri> shaders =
+        rootManifest.shaders.map(transformAssetUri).toList();
+
+    final List<Uri> models =
+        rootManifest.models.map(transformAssetUri).toList();
+
+    final List<DeferredComponent>? deferredComponents = rootManifest
+        .deferredComponents
+        ?.map(transformDeferredComponent)
+        .toList();
+
+    return widgetPreviewManifest.copyWith(
+      logger: globals.logger,
+      assets: assets,
+      fonts: fonts,
+      shaders: shaders,
+      models: models,
+      deferredComponents: deferredComponents,
+    );
+  }
+
+  Future<void> _populatePreviewPubspec({
+    required FlutterProject rootProject,
+  }) async {
+    final FlutterProject widgetPreviewScaffoldProject =
+        rootProject.widgetPreviewScaffoldProject;
+
+    // Overwrite the pubspec for the preview scaffold project to include assets
+    // from the root project.
+    widgetPreviewScaffoldProject.replacePubspec(
+      buildPubspec(
+        rootManifest: rootProject.manifest,
+        widgetPreviewManifest: widgetPreviewScaffoldProject.manifest,
+      ),
+    );
+
+    // Adds a path dependency on the parent project so previews can be
+    // imported directly into the preview scaffold.
+    const String pubAdd = 'add';
+    await pub.interactively(
+      <String>[
+        pubAdd,
+        '--directory',
+        widgetPreviewScaffoldProject.directory.path,
+        '${rootProject.manifest.appName}:{"path":${rootProject.directory.path}}',
+      ],
+      context: PubContext.pubAdd,
+      command: pubAdd,
+      touchesPackageConfig: true,
+    );
+
+    // Generate package_config.json.
+    await pub.get(
+      context: PubContext.create,
+      project: widgetPreviewScaffoldProject,
+      offline: offline,
+      outputMode: PubOutputMode.summaryOnly,
+    );
+
+    if (rootProject.manifest.generateSyntheticPackage) {
+      maybeAddFlutterGenToPackageConfig(
+        rootProject: rootProject,
+      );
+    }
+  }
+
+  /// Manually adds an entry for package:flutter_gen to the preview scaffold's
+  /// package_config.json if the target project makes use of localization.
+  ///
+  /// The Flutter Tool does this when running a Flutter project with
+  /// localization instead of modifying the user's pubspec.yaml to depend on it
+  /// as a path dependency. Unfortunately, the preview scaffold still needs to
+  /// add it directly to its package_config.json as the generated package name
+  /// isn't actually flutter_gen, which pub doesn't really like, and using the
+  /// actual package name will break applications which import
+  /// package:flutter_gen.
+  void maybeAddFlutterGenToPackageConfig({
+    required FlutterProject rootProject,
+  }) {
+    if (!rootProject.manifest.generateSyntheticPackage) {
+      return;
+    }
+    final FlutterProject widgetPreviewScaffoldProject =
+        rootProject.widgetPreviewScaffoldProject;
+    final File packageConfig = widgetPreviewScaffoldProject.packageConfig;
+    final String previewPackageConfigPath = packageConfig.path;
+    if (!packageConfig.existsSync()) {
+      throw StateError(
+        "Could not find preview project's package_config.json at "
+        '$previewPackageConfigPath',
+      );
+    }
+    final Map<String, Object?> packageConfigJson = json.decode(
+      packageConfig.readAsStringSync(),
+    ) as Map<String, Object?>;
+    (packageConfigJson['packages'] as List<dynamic>?)!
+        .cast<Map<String, String>>()
+        .add(flutterGenPackageConfigEntry);
+    packageConfig.writeAsStringSync(
+      json.encode(packageConfigJson),
+    );
+    globals.logger.printStatus(
+      'Added flutter_gen dependency to $previewPackageConfigPath',
+    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -64,6 +64,101 @@ class FlutterManifest {
     return pubspec;
   }
 
+  /// The set of all keys within the pubspec that are referenced by
+  /// [FlutterManifest].
+  static const String kName = 'name';
+  static const String kDependencies = 'dependencies';
+  static const String kVersion = 'version';
+  static const String kFlutter = 'flutter';
+  static const String kAssets = 'assets';
+  static const String kAsset = 'asset';
+  static const String kFonts = 'fonts';
+  static const String kShaders = 'shaders';
+  static const String kModels = 'models';
+  static const String kDeferredComponents = 'deferred-components';
+  static const String kUsesMaterialDesign = 'uses-material-design';
+  static const String kDisableSwiftPackageManager = 'disable-swift-package-manager';
+  static const String kModule = 'module';
+  static const String kAndroid = 'android';
+  static const String kAndroidX = 'androidX';
+  static const String kAndroidPackage = 'androidPackage';
+  static const String kLicenses = 'licenses';
+  static const String kPlugin = 'plugin';
+  static const String kPackage = 'package';
+  static const String kLibraries = 'libraries';
+  static const String kPlatforms = 'platforms';
+  static const String kIosBundleIdentifier = 'iosBundleIdentifier';
+  static const String kWeight = 'weight';
+  static const String kStyle = 'style';
+  static const String kFamily = 'family';
+  static const String kGenerate = 'generate';
+  static const String kDefaultFlavor = 'default-flavor';
+
+  /// Creates a copy of the current manifest with some subset of properties
+  /// modified.
+  FlutterManifest copyWith({
+    required Logger logger,
+    List<AssetsEntry>? assets,
+    List<Font>? fonts,
+    List<Uri>? shaders,
+    List<Uri>? models,
+    List<DeferredComponent>? deferredComponents,
+  }) {
+    final FlutterManifest copy = FlutterManifest._(logger: _logger);
+    copy._descriptor = <String, Object?>{..._descriptor};
+    copy._flutterDescriptor = <String, Object?>{..._flutterDescriptor};
+
+    if (assets != null && assets.isNotEmpty) {
+      copy._flutterDescriptor[kAssets] = YamlList.wrap(
+        <Object?>[
+          for (final AssetsEntry asset in assets)
+            asset.descriptor,
+        ],
+      );
+    }
+
+    if (fonts != null && fonts.isNotEmpty) {
+      copy._flutterDescriptor[kFonts] = YamlList.wrap(
+          <Map<String, Object?>>[
+            for (final Font font in fonts)
+              font.descriptor,
+        ],
+      );
+    }
+
+    if (shaders != null && shaders.isNotEmpty) {
+      copy._flutterDescriptor[kShaders] = YamlList.wrap(
+        shaders.map(
+          (Uri uri) => uri.toString(),
+        ).toList(),
+      );
+    }
+
+    if (models != null && models.isNotEmpty) {
+      copy._flutterDescriptor[kModels] = YamlList.wrap(
+        models.map(
+          (Uri uri) => uri.toString(),
+        ).toList(),
+      );
+    }
+
+    if (deferredComponents != null && deferredComponents.isNotEmpty) {
+      copy._flutterDescriptor[kDeferredComponents] = YamlList.wrap(
+        deferredComponents.map(
+          (DeferredComponent dc) => dc.descriptor,
+        ).toList()
+      );
+    }
+
+    copy._descriptor[kFlutter] = YamlMap.wrap(copy._flutterDescriptor);
+
+    if(!_validate(YamlMap.wrap(copy._descriptor), logger)) {
+      throw StateError('Generated invalid pubspec.yaml.');
+    }
+
+    return copy;
+  }
+
   final Logger _logger;
 
   /// A map representation of the entire `pubspec.yaml` file.
@@ -78,12 +173,12 @@ class FlutterManifest {
   bool get isEmpty => _descriptor.isEmpty;
 
   /// The string value of the top-level `name` property in the `pubspec.yaml` file.
-  String get appName => _descriptor['name'] as String? ?? '';
+  String get appName => _descriptor[kName] as String? ?? '';
 
   /// Contains the name of the dependencies.
   /// These are the keys specified in the `dependency` map.
   Set<String> get dependencies {
-    final YamlMap? dependencies = _descriptor['dependencies'] as YamlMap?;
+    final YamlMap? dependencies = _descriptor[kDependencies] as YamlMap?;
     return dependencies != null ? <String>{...dependencies.keys.cast<String>()} : <String>{};
   }
 
@@ -93,7 +188,7 @@ class FlutterManifest {
   /// The version String from the `pubspec.yaml` file.
   /// Can be null if it isn't set or has a wrong format.
   String? get appVersion {
-    final String? verStr = _descriptor['version']?.toString();
+    final String? verStr = _descriptor[kVersion]?.toString();
     if (verStr == null) {
       return null;
     }
@@ -133,22 +228,22 @@ class FlutterManifest {
   }
 
   bool get usesMaterialDesign {
-    return _flutterDescriptor['uses-material-design'] as bool? ?? false;
+    return _flutterDescriptor[kUsesMaterialDesign] as bool? ?? false;
   }
 
   /// If true, does not use Swift Package Manager as a dependency manager.
   /// CocoaPods will be used instead.
   bool get disabledSwiftPackageManager {
-    return _flutterDescriptor['disable-swift-package-manager'] as bool? ?? false;
+    return _flutterDescriptor[kDisableSwiftPackageManager] as bool? ?? false;
   }
 
   /// True if this Flutter module should use AndroidX dependencies.
   ///
   /// If false the deprecated Android Support library will be used.
   bool get usesAndroidX {
-    final Object? module = _flutterDescriptor['module'];
+    final Object? module = _flutterDescriptor[kModule];
     if (module is YamlMap) {
-      return module['androidX'] == true;
+      return module[kAndroidX] == true;
     }
     return false;
   }
@@ -167,7 +262,7 @@ class FlutterManifest {
   /// ```
   List<String> get additionalLicenses {
     return <String>[
-      if (_flutterDescriptor case {'licenses': final YamlList list})
+      if (_flutterDescriptor case {kLicenses: final YamlList list})
         for (final Object? item in list) '$item',
     ];
   }
@@ -179,7 +274,7 @@ class FlutterManifest {
   /// existing host app, and has managed platform host code.
   ///
   /// Such a project can be created using `flutter create -t module`.
-  bool get isModule => _flutterDescriptor.containsKey('module');
+  bool get isModule => _flutterDescriptor.containsKey(kModule);
 
   /// True if this manifest declares a Flutter plugin project.
   ///
@@ -189,24 +284,24 @@ class FlutterManifest {
   /// projects.
   ///
   /// Such a project can be created using `flutter create -t plugin`.
-  bool get isPlugin => _flutterDescriptor.containsKey('plugin');
+  bool get isPlugin => _flutterDescriptor.containsKey(kPlugin);
 
   /// Returns the Android package declared by this manifest in its
   /// module or plugin descriptor. Returns null, if there is no
   /// such declaration.
   String? get androidPackage {
     if (isModule) {
-      if (_flutterDescriptor case {'module': final YamlMap map}) {
-        return map['androidPackage'] as String?;
+      if (_flutterDescriptor case {kModule: final YamlMap map}) {
+        return map[kAndroidPackage] as String?;
       }
     }
 
-    late final YamlMap? plugin = _flutterDescriptor['plugin'] as YamlMap?;
+    late final YamlMap? plugin = _flutterDescriptor[kPlugin] as YamlMap?;
 
     return switch (supportedPlatforms) {
-      {'android': final YamlMap map} => map['package'] as String?,
+      {kAndroid: final YamlMap map} => map[kPackage] as String?,
       // Pre-multi-platform plugin format
-      null when isPlugin => plugin?['androidPackage'] as String?,
+      null when isPlugin => plugin?[kAndroidPackage] as String?,
       _ => null,
     };
   }
@@ -215,11 +310,11 @@ class FlutterManifest {
   /// null if no deferred components are declared.
   late final List<DeferredComponent>? deferredComponents = computeDeferredComponents();
   List<DeferredComponent>? computeDeferredComponents() {
-    if (!_flutterDescriptor.containsKey('deferred-components')) {
+    if (!_flutterDescriptor.containsKey(kDeferredComponents)) {
       return null;
     }
     final List<DeferredComponent> components = <DeferredComponent>[];
-    final Object? deferredComponents = _flutterDescriptor['deferred-components'];
+    final Object? deferredComponents = _flutterDescriptor[kDeferredComponents];
     if (deferredComponents is! YamlList) {
       return components;
     }
@@ -230,10 +325,10 @@ class FlutterManifest {
       }
       components.add(
         DeferredComponent(
-          name: component['name'] as String,
-          libraries: component['libraries'] == null ?
-              <String>[] : (component['libraries'] as List<dynamic>).cast<String>(),
-          assets: _computeAssets(component['assets']),
+          name: component[kName] as String,
+          libraries: component[kLibraries] == null ?
+              <String>[] : (component[kLibraries] as List<dynamic>).cast<String>(),
+          assets: _computeAssets(component[kAssets]),
         )
       );
     }
@@ -244,8 +339,8 @@ class FlutterManifest {
   /// module descriptor. Returns null if there is no such declaration.
   String? get iosBundleIdentifier {
     if (isModule) {
-      if (_flutterDescriptor case {'module': final YamlMap map}) {
-        return map['iosBundleIdentifier'] as String?;
+      if (_flutterDescriptor case {kModule: final YamlMap map}) {
+        return map[kIosBundleIdentifier] as String?;
       }
     }
     return null;
@@ -256,9 +351,9 @@ class FlutterManifest {
   /// If the plugin uses the legacy pubspec format, this method returns null.
   Map<String, Object?>? get supportedPlatforms {
     if (isPlugin) {
-      final YamlMap? plugin = _flutterDescriptor['plugin'] as YamlMap?;
-      if (plugin?.containsKey('platforms') ?? false) {
-        final YamlMap? platformsMap = plugin!['platforms'] as YamlMap?;
+      final YamlMap? plugin = _flutterDescriptor[kPlugin] as YamlMap?;
+      if (plugin?.containsKey(kPlatforms) ?? false) {
+        final YamlMap? platformsMap = plugin![kPlatforms] as YamlMap?;
         return platformsMap?.value.cast<String, Object?>();
       }
     }
@@ -284,25 +379,25 @@ class FlutterManifest {
   }
 
   List<Map<String, Object?>> get _rawFontsDescriptor {
-    final List<Object?>? fontList = _flutterDescriptor['fonts'] as List<Object?>?;
+    final List<Object?>? fontList = _flutterDescriptor[kFonts] as List<Object?>?;
     return fontList == null
         ? const <Map<String, Object?>>[]
         : fontList.map<Map<String, Object?>?>(castStringKeyedMap).whereType<Map<String, Object?>>().toList();
   }
 
-  late final List<AssetsEntry> assets = _computeAssets(_flutterDescriptor['assets']);
+  late final List<AssetsEntry> assets = _computeAssets(_flutterDescriptor[kAssets]);
 
   late final List<Font> fonts = _extractFonts();
 
   List<Font> _extractFonts() {
-    if (!_flutterDescriptor.containsKey('fonts')) {
+    if (!_flutterDescriptor.containsKey(kFonts)) {
       return <Font>[];
     }
 
     final List<Font> fonts = <Font>[];
     for (final Map<String, Object?> fontFamily in _rawFontsDescriptor) {
-      final YamlList? fontFiles = fontFamily['fonts'] as YamlList?;
-      final String? familyName = fontFamily['family'] as String?;
+      final YamlList? fontFiles = fontFamily[kFonts] as YamlList?;
+      final String? familyName = fontFamily[kFamily] as String?;
       if (familyName == null) {
         _logger.printWarning('Warning: Missing family name for font.', emphasis: true);
         continue;
@@ -314,7 +409,7 @@ class FlutterManifest {
 
       final List<FontAsset> fontAssets = <FontAsset>[];
       for (final Map<Object?, Object?> fontFile in fontFiles.cast<Map<Object?, Object?>>()) {
-        final String? asset = fontFile['asset'] as String?;
+        final String? asset = fontFile[kAssets] as String?;
         if (asset == null) {
           _logger.printWarning('Warning: Missing asset in fonts for $familyName', emphasis: true);
           continue;
@@ -322,8 +417,8 @@ class FlutterManifest {
 
         fontAssets.add(FontAsset(
           Uri.parse(asset),
-          weight: fontFile['weight'] as int?,
-          style: fontFile['style'] as String?,
+          weight: fontFile[kWeight] as int?,
+          style: fontFile[kStyle] as String?,
         ));
       }
       if (fontAssets.isNotEmpty) {
@@ -333,8 +428,8 @@ class FlutterManifest {
     return fonts;
   }
 
-  late final List<Uri> shaders = _extractAssetUris('shaders', 'Shader');
-  late final List<Uri> models = kIs3dSceneSupported ? _extractAssetUris('models', 'Model') : <Uri>[];
+  late final List<Uri> shaders = _extractAssetUris(kShaders, 'Shader');
+  late final List<Uri> models = kIs3dSceneSupported ? _extractAssetUris(kModels, 'Model') : <Uri>[];
 
   List<Uri> _extractAssetUris(String key, String singularName) {
     if (!_flutterDescriptor.containsKey(key)) {
@@ -369,17 +464,21 @@ class FlutterManifest {
   /// alias.
   late final bool generateSyntheticPackage = _computeGenerateSyntheticPackage();
   bool _computeGenerateSyntheticPackage() {
-    if (!_flutterDescriptor.containsKey('generate')) {
+    if (!_flutterDescriptor.containsKey(kGenerate)) {
       return false;
     }
-    final Object? value = _flutterDescriptor['generate'];
+    final Object? value = _flutterDescriptor[kGenerate];
     if (value is! bool) {
       return false;
     }
     return value;
   }
 
-  String? get defaultFlavor => _flutterDescriptor['default-flavor'] as String?;
+  String? get defaultFlavor => _flutterDescriptor[kDefaultFlavor] as String?;
+
+  YamlMap toYaml() {
+    return YamlMap.wrap(_descriptor);
+  }
 }
 
 class Font {
@@ -391,13 +490,15 @@ class Font {
 
   Map<String, Object?> get descriptor {
     return <String, Object?>{
-      'family': familyName,
-      'fonts': fontAssets.map<Map<String, Object?>>((FontAsset a) => a.descriptor).toList(),
+      FlutterManifest.kFamily: familyName,
+      FlutterManifest.kFonts: fontAssets.map<Map<String, Object?>>(
+        (FontAsset a) => a.descriptor,
+      ).toList(),
     };
   }
 
   @override
-  String toString() => '$runtimeType(family: $familyName, assets: $fontAssets)';
+  String toString() => '$runtimeType(${FlutterManifest.kFamily}: $familyName, ${FlutterManifest.kFonts}: $fontAssets)';
 }
 
 class FontAsset {
@@ -410,19 +511,21 @@ class FontAsset {
   Map<String, Object?> get descriptor {
     final Map<String, Object?> descriptor = <String, Object?>{};
     if (weight != null) {
-      descriptor['weight'] = weight;
+      descriptor[FlutterManifest.kWeight] = weight;
     }
 
     if (style != null) {
-      descriptor['style'] = style;
+      descriptor[FlutterManifest.kStyle] = style;
     }
 
-    descriptor['asset'] = assetUri.path;
+    descriptor[FlutterManifest.kAsset] = assetUri.path;
     return descriptor;
   }
 
   @override
-  String toString() => '$runtimeType(asset: ${assetUri.path}, weight; $weight, style: $style)';
+  String toString() => '$runtimeType(${FlutterManifest.kAsset}: '
+                       '${assetUri.path}, ${FlutterManifest.kWeight}; $weight, '
+                       '${FlutterManifest.kStyle}: $style)';
 }
 
 
@@ -437,11 +540,11 @@ bool _validate(Object? manifest, Logger logger) {
         continue;
       }
       switch (kvp.key as String?) {
-        case 'name':
+        case FlutterManifest.kName:
           if (kvp.value is! String) {
             errors.add('Expected "${kvp.key}" to be a string, but got ${kvp.value}.');
           }
-        case 'flutter':
+        case FlutterManifest.kFlutter:
           if (kvp.value == null) {
             continue;
           }
@@ -482,9 +585,9 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         if (yamlValue is! bool) {
           errors.add('Expected "$yamlKey" to be a bool, but got $yamlValue (${yamlValue.runtimeType}).');
         }
-      case 'assets':
+      case FlutterManifest.kAssets:
         errors.addAll(_validateAssets(yamlValue));
-      case 'shaders':
+      case FlutterManifest.kShaders:
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
         } else if (yamlValue.isEmpty) {
@@ -494,7 +597,7 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
             'Expected "$yamlKey" to be a list of strings, but the first element is $yamlValue (${yamlValue.runtimeType}).',
           );
         }
-      case 'models':
+      case FlutterManifest.kModels:
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
         } else if (yamlValue.isEmpty) {
@@ -504,7 +607,7 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
             'Expected "$yamlKey" to be a list of strings, but the first element is $yamlValue (${yamlValue.runtimeType}).',
           );
         }
-      case 'fonts':
+      case FlutterManifest.kFonts:
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
         } else if (yamlValue.isEmpty) {
@@ -516,40 +619,40 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         } else {
           _validateFonts(yamlValue, errors);
         }
-      case 'licenses':
+      case FlutterManifest.kLicenses:
         final (_, List<String> filesErrors) = _parseList<String>(yamlValue, '"$yamlKey"', 'files');
         errors.addAll(filesErrors);
-      case 'module':
+      case FlutterManifest.kModule:
         if (yamlValue is! YamlMap) {
           errors.add('Expected "$yamlKey" to be an object, but got $yamlValue (${yamlValue.runtimeType}).');
           break;
         }
 
-        if (yamlValue['androidX'] != null && yamlValue['androidX'] is! bool) {
-          errors.add('The "androidX" value must be a bool if set.');
+        if (yamlValue[FlutterManifest.kAndroidX] != null && yamlValue[FlutterManifest.kAndroidX] is! bool) {
+          errors.add('The "${FlutterManifest.kAndroidX}" value must be a bool if set.');
         }
-        if (yamlValue['androidPackage'] != null && yamlValue['androidPackage'] is! String) {
-          errors.add('The "androidPackage" value must be a string if set.');
+        if (yamlValue[FlutterManifest.kAndroidPackage] != null && yamlValue[FlutterManifest.kAndroidPackage] is! String) {
+          errors.add('The "${FlutterManifest.kAndroidPackage}" value must be a string if set.');
         }
-        if (yamlValue['iosBundleIdentifier'] != null && yamlValue['iosBundleIdentifier'] is! String) {
-          errors.add('The "iosBundleIdentifier" section must be a string if set.');
+        if (yamlValue[FlutterManifest.kIosBundleIdentifier] != null && yamlValue[FlutterManifest.kIosBundleIdentifier] is! String) {
+          errors.add('The "${FlutterManifest.kIosBundleIdentifier}" section must be a string if set.');
         }
-      case 'plugin':
+      case FlutterManifest.kPlugin:
         if (yamlValue is! YamlMap) {
           errors.add('Expected "$yamlKey" to be an object, but got $yamlValue (${yamlValue.runtimeType}).');
           break;
         }
         final List<String> pluginErrors = Plugin.validatePluginYaml(yamlValue);
         errors.addAll(pluginErrors);
-      case 'generate':
+      case FlutterManifest.kGenerate:
         break;
-      case 'deferred-components':
+      case FlutterManifest.kDeferredComponents:
         _validateDeferredComponents(kvp, errors);
-      case 'disable-swift-package-manager':
+      case FlutterManifest.kDisableSwiftPackageManager:
         if (yamlValue is! bool) {
           errors.add('Expected "$yamlKey" to be a bool, but got $yamlValue (${yamlValue.runtimeType}).');
         }
-      case 'default-flavor':
+      case FlutterManifest.kDefaultFlavor:
         if (yamlValue is! String) {
           errors.add('Expected "$yamlKey" to be a string, but got $yamlValue (${yamlValue.runtimeType}).');
         }
@@ -589,19 +692,19 @@ void _validateDeferredComponents(MapEntry<Object?, Object?> kvp, List<String> er
         errors.add('Expected the $i element in "${kvp.key}" to be a map, but got ${yamlList[i]} (${yamlList[i].runtimeType}).');
         continue;
       }
-      if (!valueMap.containsKey('name') || valueMap['name'] is! String) {
-        errors.add('Expected the $i element in "${kvp.key}" to have required key "name" of type String');
+      if (!valueMap.containsKey(FlutterManifest.kName) || valueMap[FlutterManifest.kName] is! String) {
+        errors.add('Expected the $i element in "${kvp.key}" to have required key "${FlutterManifest.kName}" of type String');
       }
-      if (valueMap.containsKey('libraries')) {
+      if (valueMap.containsKey(FlutterManifest.kLibraries)) {
         final (_, List<String> librariesErrors) = _parseList<String>(
-          valueMap['libraries'],
-          '"libraries" key in the element at index $i of "${kvp.key}"',
+          valueMap[FlutterManifest.kLibraries],
+          '"${FlutterManifest.kLibraries}" key in the element at index $i of "${kvp.key}"',
           'String',
         );
         errors.addAll(librariesErrors);
       }
-      if (valueMap.containsKey('assets')) {
-        errors.addAll(_validateAssets(valueMap['assets']));
+      if (valueMap.containsKey(FlutterManifest.kAssets)) {
+        errors.addAll(_validateAssets(valueMap[FlutterManifest.kAssets]));
       }
     }
   }
@@ -621,7 +724,7 @@ List<String> _validateAssets(Object? yaml) {
     return (const <AssetsEntry>[], const <String>[]);
   }
   if (yaml is! YamlList) {
-    final String error = 'Expected "assets" to be a list, but got $yaml (${yaml.runtimeType}).';
+    final String error = 'Expected "${FlutterManifest.kAssets}" to be a list, but got $yaml (${yaml.runtimeType}).';
     return (const <AssetsEntry>[], <String>[error]);
   }
   final List<AssetsEntry> results = <AssetsEntry>[];
@@ -659,35 +762,35 @@ void _validateFonts(YamlList fonts, List<String> errors) {
     for (final Object? key in fontMap.keys.where((Object? key) => key != 'family' && key != 'fonts')) {
       errors.add('Unexpected child "$key" found under "fonts".');
     }
-    if (fontMap['family'] != null && fontMap['family'] is! String) {
+    if (fontMap[FlutterManifest.kFamily] != null && fontMap[FlutterManifest.kFamily] is! String) {
       errors.add('Font family must either be null or a String.');
     }
-    if (fontMap['fonts'] == null) {
+    if (fontMap[FlutterManifest.kFonts] == null) {
       continue;
-    } else if (fontMap['fonts'] is! YamlList) {
-      errors.add('Expected "fonts" to either be null or a list.');
+    } else if (fontMap[FlutterManifest.kFonts] is! YamlList) {
+      errors.add('Expected "${FlutterManifest.kName}" to either be null or a list.');
       continue;
     }
-    for (final Object? fontMapList in fontMap['fonts'] as List<Object?>) {
+    for (final Object? fontMapList in fontMap[FlutterManifest.kFonts] as List<Object?>) {
       if (fontMapList is! YamlMap) {
-        errors.add('Expected "fonts" to be a list of maps.');
+        errors.add('Expected "${FlutterManifest.kFonts}" to be a list of maps.');
         continue;
       }
       for (final MapEntry<Object?, Object?> kvp in fontMapList.entries) {
         final Object? fontKey = kvp.key;
         if (fontKey is! String) {
-          errors.add('Expected "$fontKey" under "fonts" to be a string.');
+          errors.add('Expected "$fontKey" under "${FlutterManifest.kFonts}" to be a string.');
         }
         switch (fontKey) {
-          case 'asset':
+          case FlutterManifest.kAsset:
             if (kvp.value is! String) {
               errors.add('Expected font asset ${kvp.value} ((${kvp.value.runtimeType})) to be a string.');
             }
-          case 'weight':
+          case FlutterManifest.kWeight:
             if (!fontWeights.contains(kvp.value)) {
               errors.add('Invalid value ${kvp.value} ((${kvp.value.runtimeType})) for font -> weight.');
             }
-          case 'style':
+          case FlutterManifest.kStyle:
             if (kvp.value != 'normal' && kvp.value != 'italic') {
               errors.add('Invalid value ${kvp.value} ((${kvp.value.runtimeType})) for font -> style.');
             }
@@ -711,6 +814,21 @@ class AssetsEntry {
   final Uri uri;
   final Set<String> flavors;
   final List<AssetTransformerEntry> transformers;
+
+  Object? get descriptor {
+    if (transformers.isEmpty && flavors.isEmpty) {
+      return uri.toString();
+    }
+    return <String, Object?> {
+      _pathKey: uri.toString(),
+      if (flavors.isNotEmpty)
+        _flavorKey: flavors.toList(),
+      if (transformers.isNotEmpty)
+        _transformersKey: transformers.map(
+          (AssetTransformerEntry e) => e.descriptor,
+        ).toList(),
+    };
+  }
 
   static const String _pathKey = 'path';
   static const String _flavorKey = 'flavors';
@@ -858,6 +976,17 @@ final class AssetTransformerEntry {
   final String package;
   final List<String>? args;
 
+  Map<String, Object?> get descriptor {
+    return <String, Object?>{
+      _kPackage: package,
+      if (args != null)
+        _kArgs: args,
+    };
+  }
+
+  static const String _kPackage = 'package';
+  static const String _kArgs = 'args';
+
   static (AssetTransformerEntry? entry, List<String> errors) tryParse(Object? yaml) {
     if (yaml == null) {
       return (null, <String>['Transformer entry is null.']);
@@ -866,14 +995,14 @@ final class AssetTransformerEntry {
       return (null, <String>['Expected entry to be a map. Found ${yaml.runtimeType} instead']);
     }
 
-    final Object? package = yaml['package'];
+    final Object? package = yaml[_kPackage];
     if (package is! String || package.isEmpty) {
-      return (null, <String>['Expected "package" to be a String. Found ${package.runtimeType} instead.']);
+      return (null, <String>['Expected "$_kPackage" to be a String. Found ${package.runtimeType} instead.']);
     }
 
-    final (List<String>? args, List<String> argsErrors) = _parseArgsSection(yaml['args']);
+    final (List<String>? args, List<String> argsErrors) = _parseArgsSection(yaml[_kArgs]);
     if (argsErrors.isNotEmpty) {
-      return (null, argsErrors.map((String e) => 'In args section of transformer using package "$package": $e').toList());
+      return (null, argsErrors.map((String e) => 'In $_kArgs section of transformer using package "$package": $e').toList());
     }
 
     return (

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -122,7 +122,7 @@ class FlutterManifest {
 
     copy._descriptor['flutter'] = YamlMap.wrap(copy._flutterDescriptor);
 
-    if(!_validate(YamlMap.wrap(copy._descriptor), logger)) {
+    if (!_validate(YamlMap.wrap(copy._descriptor), logger)) {
       throw StateError('Generated invalid pubspec.yaml.');
     }
 

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -64,36 +64,6 @@ class FlutterManifest {
     return pubspec;
   }
 
-  /// The set of all keys within the pubspec that are referenced by
-  /// [FlutterManifest].
-  static const String kName = 'name';
-  static const String kDependencies = 'dependencies';
-  static const String kVersion = 'version';
-  static const String kFlutter = 'flutter';
-  static const String kAssets = 'assets';
-  static const String kAsset = 'asset';
-  static const String kFonts = 'fonts';
-  static const String kShaders = 'shaders';
-  static const String kModels = 'models';
-  static const String kDeferredComponents = 'deferred-components';
-  static const String kUsesMaterialDesign = 'uses-material-design';
-  static const String kDisableSwiftPackageManager = 'disable-swift-package-manager';
-  static const String kModule = 'module';
-  static const String kAndroid = 'android';
-  static const String kAndroidX = 'androidX';
-  static const String kAndroidPackage = 'androidPackage';
-  static const String kLicenses = 'licenses';
-  static const String kPlugin = 'plugin';
-  static const String kPackage = 'package';
-  static const String kLibraries = 'libraries';
-  static const String kPlatforms = 'platforms';
-  static const String kIosBundleIdentifier = 'iosBundleIdentifier';
-  static const String kWeight = 'weight';
-  static const String kStyle = 'style';
-  static const String kFamily = 'family';
-  static const String kGenerate = 'generate';
-  static const String kDefaultFlavor = 'default-flavor';
-
   /// Creates a copy of the current manifest with some subset of properties
   /// modified.
   FlutterManifest copyWith({
@@ -109,7 +79,7 @@ class FlutterManifest {
     copy._flutterDescriptor = <String, Object?>{..._flutterDescriptor};
 
     if (assets != null && assets.isNotEmpty) {
-      copy._flutterDescriptor[kAssets] = YamlList.wrap(
+      copy._flutterDescriptor['assets'] = YamlList.wrap(
         <Object?>[
           for (final AssetsEntry asset in assets)
             asset.descriptor,
@@ -118,7 +88,7 @@ class FlutterManifest {
     }
 
     if (fonts != null && fonts.isNotEmpty) {
-      copy._flutterDescriptor[kFonts] = YamlList.wrap(
+      copy._flutterDescriptor['fonts'] = YamlList.wrap(
           <Map<String, Object?>>[
             for (final Font font in fonts)
               font.descriptor,
@@ -127,7 +97,7 @@ class FlutterManifest {
     }
 
     if (shaders != null && shaders.isNotEmpty) {
-      copy._flutterDescriptor[kShaders] = YamlList.wrap(
+      copy._flutterDescriptor['shaders'] = YamlList.wrap(
         shaders.map(
           (Uri uri) => uri.toString(),
         ).toList(),
@@ -135,7 +105,7 @@ class FlutterManifest {
     }
 
     if (models != null && models.isNotEmpty) {
-      copy._flutterDescriptor[kModels] = YamlList.wrap(
+      copy._flutterDescriptor['models'] = YamlList.wrap(
         models.map(
           (Uri uri) => uri.toString(),
         ).toList(),
@@ -143,14 +113,14 @@ class FlutterManifest {
     }
 
     if (deferredComponents != null && deferredComponents.isNotEmpty) {
-      copy._flutterDescriptor[kDeferredComponents] = YamlList.wrap(
+      copy._flutterDescriptor['deferred-components'] = YamlList.wrap(
         deferredComponents.map(
           (DeferredComponent dc) => dc.descriptor,
         ).toList()
       );
     }
 
-    copy._descriptor[kFlutter] = YamlMap.wrap(copy._flutterDescriptor);
+    copy._descriptor['flutter'] = YamlMap.wrap(copy._flutterDescriptor);
 
     if(!_validate(YamlMap.wrap(copy._descriptor), logger)) {
       throw StateError('Generated invalid pubspec.yaml.');
@@ -173,12 +143,12 @@ class FlutterManifest {
   bool get isEmpty => _descriptor.isEmpty;
 
   /// The string value of the top-level `name` property in the `pubspec.yaml` file.
-  String get appName => _descriptor[kName] as String? ?? '';
+  String get appName => _descriptor['name'] as String? ?? '';
 
   /// Contains the name of the dependencies.
   /// These are the keys specified in the `dependency` map.
   Set<String> get dependencies {
-    final YamlMap? dependencies = _descriptor[kDependencies] as YamlMap?;
+    final YamlMap? dependencies = _descriptor['dependencies'] as YamlMap?;
     return dependencies != null ? <String>{...dependencies.keys.cast<String>()} : <String>{};
   }
 
@@ -188,7 +158,7 @@ class FlutterManifest {
   /// The version String from the `pubspec.yaml` file.
   /// Can be null if it isn't set or has a wrong format.
   String? get appVersion {
-    final String? verStr = _descriptor[kVersion]?.toString();
+    final String? verStr = _descriptor['version']?.toString();
     if (verStr == null) {
       return null;
     }
@@ -228,22 +198,22 @@ class FlutterManifest {
   }
 
   bool get usesMaterialDesign {
-    return _flutterDescriptor[kUsesMaterialDesign] as bool? ?? false;
+    return _flutterDescriptor['uses-material-design'] as bool? ?? false;
   }
 
   /// If true, does not use Swift Package Manager as a dependency manager.
   /// CocoaPods will be used instead.
   bool get disabledSwiftPackageManager {
-    return _flutterDescriptor[kDisableSwiftPackageManager] as bool? ?? false;
+    return _flutterDescriptor['disable-swift-package-manager'] as bool? ?? false;
   }
 
   /// True if this Flutter module should use AndroidX dependencies.
   ///
   /// If false the deprecated Android Support library will be used.
   bool get usesAndroidX {
-    final Object? module = _flutterDescriptor[kModule];
+    final Object? module = _flutterDescriptor['module'];
     if (module is YamlMap) {
-      return module[kAndroidX] == true;
+      return module['androidX'] == true;
     }
     return false;
   }
@@ -262,7 +232,7 @@ class FlutterManifest {
   /// ```
   List<String> get additionalLicenses {
     return <String>[
-      if (_flutterDescriptor case {kLicenses: final YamlList list})
+      if (_flutterDescriptor case {'licenses': final YamlList list})
         for (final Object? item in list) '$item',
     ];
   }
@@ -274,7 +244,7 @@ class FlutterManifest {
   /// existing host app, and has managed platform host code.
   ///
   /// Such a project can be created using `flutter create -t module`.
-  bool get isModule => _flutterDescriptor.containsKey(kModule);
+  bool get isModule => _flutterDescriptor.containsKey('module');
 
   /// True if this manifest declares a Flutter plugin project.
   ///
@@ -284,24 +254,24 @@ class FlutterManifest {
   /// projects.
   ///
   /// Such a project can be created using `flutter create -t plugin`.
-  bool get isPlugin => _flutterDescriptor.containsKey(kPlugin);
+  bool get isPlugin => _flutterDescriptor.containsKey('plugin');
 
   /// Returns the Android package declared by this manifest in its
   /// module or plugin descriptor. Returns null, if there is no
   /// such declaration.
   String? get androidPackage {
     if (isModule) {
-      if (_flutterDescriptor case {kModule: final YamlMap map}) {
-        return map[kAndroidPackage] as String?;
+      if (_flutterDescriptor case {'module': final YamlMap map}) {
+        return map['androidPackage'] as String?;
       }
     }
 
-    late final YamlMap? plugin = _flutterDescriptor[kPlugin] as YamlMap?;
+    late final YamlMap? plugin = _flutterDescriptor['plugin'] as YamlMap?;
 
     return switch (supportedPlatforms) {
-      {kAndroid: final YamlMap map} => map[kPackage] as String?,
+      {'android': final YamlMap map} => map['package'] as String?,
       // Pre-multi-platform plugin format
-      null when isPlugin => plugin?[kAndroidPackage] as String?,
+      null when isPlugin => plugin?['androidPackage'] as String?,
       _ => null,
     };
   }
@@ -310,11 +280,11 @@ class FlutterManifest {
   /// null if no deferred components are declared.
   late final List<DeferredComponent>? deferredComponents = computeDeferredComponents();
   List<DeferredComponent>? computeDeferredComponents() {
-    if (!_flutterDescriptor.containsKey(kDeferredComponents)) {
+    if (!_flutterDescriptor.containsKey('deferred-components')) {
       return null;
     }
     final List<DeferredComponent> components = <DeferredComponent>[];
-    final Object? deferredComponents = _flutterDescriptor[kDeferredComponents];
+    final Object? deferredComponents = _flutterDescriptor['deferred-components'];
     if (deferredComponents is! YamlList) {
       return components;
     }
@@ -325,10 +295,10 @@ class FlutterManifest {
       }
       components.add(
         DeferredComponent(
-          name: component[kName] as String,
-          libraries: component[kLibraries] == null ?
-              <String>[] : (component[kLibraries] as List<dynamic>).cast<String>(),
-          assets: _computeAssets(component[kAssets]),
+          name: component['name'] as String,
+          libraries: component['libraries'] == null ?
+              <String>[] : (component['libraries'] as List<dynamic>).cast<String>(),
+          assets: _computeAssets(component['assets']),
         )
       );
     }
@@ -339,8 +309,8 @@ class FlutterManifest {
   /// module descriptor. Returns null if there is no such declaration.
   String? get iosBundleIdentifier {
     if (isModule) {
-      if (_flutterDescriptor case {kModule: final YamlMap map}) {
-        return map[kIosBundleIdentifier] as String?;
+      if (_flutterDescriptor case {'module': final YamlMap map}) {
+        return map['iosBundleIdentifier'] as String?;
       }
     }
     return null;
@@ -351,9 +321,9 @@ class FlutterManifest {
   /// If the plugin uses the legacy pubspec format, this method returns null.
   Map<String, Object?>? get supportedPlatforms {
     if (isPlugin) {
-      final YamlMap? plugin = _flutterDescriptor[kPlugin] as YamlMap?;
-      if (plugin?.containsKey(kPlatforms) ?? false) {
-        final YamlMap? platformsMap = plugin![kPlatforms] as YamlMap?;
+      final YamlMap? plugin = _flutterDescriptor['plugin'] as YamlMap?;
+      if (plugin?.containsKey('platforms') ?? false) {
+        final YamlMap? platformsMap = plugin!['platforms'] as YamlMap?;
         return platformsMap?.value.cast<String, Object?>();
       }
     }
@@ -379,25 +349,25 @@ class FlutterManifest {
   }
 
   List<Map<String, Object?>> get _rawFontsDescriptor {
-    final List<Object?>? fontList = _flutterDescriptor[kFonts] as List<Object?>?;
+    final List<Object?>? fontList = _flutterDescriptor['fonts'] as List<Object?>?;
     return fontList == null
         ? const <Map<String, Object?>>[]
         : fontList.map<Map<String, Object?>?>(castStringKeyedMap).whereType<Map<String, Object?>>().toList();
   }
 
-  late final List<AssetsEntry> assets = _computeAssets(_flutterDescriptor[kAssets]);
+  late final List<AssetsEntry> assets = _computeAssets(_flutterDescriptor['assets']);
 
   late final List<Font> fonts = _extractFonts();
 
   List<Font> _extractFonts() {
-    if (!_flutterDescriptor.containsKey(kFonts)) {
+    if (!_flutterDescriptor.containsKey('fonts')) {
       return <Font>[];
     }
 
     final List<Font> fonts = <Font>[];
     for (final Map<String, Object?> fontFamily in _rawFontsDescriptor) {
-      final YamlList? fontFiles = fontFamily[kFonts] as YamlList?;
-      final String? familyName = fontFamily[kFamily] as String?;
+      final YamlList? fontFiles = fontFamily['fonts'] as YamlList?;
+      final String? familyName = fontFamily['family'] as String?;
       if (familyName == null) {
         _logger.printWarning('Warning: Missing family name for font.', emphasis: true);
         continue;
@@ -409,7 +379,7 @@ class FlutterManifest {
 
       final List<FontAsset> fontAssets = <FontAsset>[];
       for (final Map<Object?, Object?> fontFile in fontFiles.cast<Map<Object?, Object?>>()) {
-        final String? asset = fontFile[kAssets] as String?;
+        final String? asset = fontFile['asset'] as String?;
         if (asset == null) {
           _logger.printWarning('Warning: Missing asset in fonts for $familyName', emphasis: true);
           continue;
@@ -417,8 +387,8 @@ class FlutterManifest {
 
         fontAssets.add(FontAsset(
           Uri.parse(asset),
-          weight: fontFile[kWeight] as int?,
-          style: fontFile[kStyle] as String?,
+          weight: fontFile['weight'] as int?,
+          style: fontFile['style'] as String?,
         ));
       }
       if (fontAssets.isNotEmpty) {
@@ -428,8 +398,8 @@ class FlutterManifest {
     return fonts;
   }
 
-  late final List<Uri> shaders = _extractAssetUris(kShaders, 'Shader');
-  late final List<Uri> models = kIs3dSceneSupported ? _extractAssetUris(kModels, 'Model') : <Uri>[];
+  late final List<Uri> shaders = _extractAssetUris('shaders', 'Shader');
+  late final List<Uri> models = kIs3dSceneSupported ? _extractAssetUris('models', 'Model') : <Uri>[];
 
   List<Uri> _extractAssetUris(String key, String singularName) {
     if (!_flutterDescriptor.containsKey(key)) {
@@ -464,17 +434,17 @@ class FlutterManifest {
   /// alias.
   late final bool generateSyntheticPackage = _computeGenerateSyntheticPackage();
   bool _computeGenerateSyntheticPackage() {
-    if (!_flutterDescriptor.containsKey(kGenerate)) {
+    if (!_flutterDescriptor.containsKey('generate')) {
       return false;
     }
-    final Object? value = _flutterDescriptor[kGenerate];
+    final Object? value = _flutterDescriptor['generate'];
     if (value is! bool) {
       return false;
     }
     return value;
   }
 
-  String? get defaultFlavor => _flutterDescriptor[kDefaultFlavor] as String?;
+  String? get defaultFlavor => _flutterDescriptor['default-flavor'] as String?;
 
   YamlMap toYaml() {
     return YamlMap.wrap(_descriptor);
@@ -490,15 +460,13 @@ class Font {
 
   Map<String, Object?> get descriptor {
     return <String, Object?>{
-      FlutterManifest.kFamily: familyName,
-      FlutterManifest.kFonts: fontAssets.map<Map<String, Object?>>(
-        (FontAsset a) => a.descriptor,
-      ).toList(),
+      'family': familyName,
+      'fonts': fontAssets.map<Map<String, Object?>>((FontAsset a) => a.descriptor).toList(),
     };
   }
 
   @override
-  String toString() => '$runtimeType(${FlutterManifest.kFamily}: $familyName, ${FlutterManifest.kFonts}: $fontAssets)';
+  String toString() => '$runtimeType(family: $familyName, assets: $fontAssets)';
 }
 
 class FontAsset {
@@ -511,21 +479,19 @@ class FontAsset {
   Map<String, Object?> get descriptor {
     final Map<String, Object?> descriptor = <String, Object?>{};
     if (weight != null) {
-      descriptor[FlutterManifest.kWeight] = weight;
+      descriptor['weight'] = weight;
     }
 
     if (style != null) {
-      descriptor[FlutterManifest.kStyle] = style;
+      descriptor['style'] = style;
     }
 
-    descriptor[FlutterManifest.kAsset] = assetUri.path;
+    descriptor['asset'] = assetUri.path;
     return descriptor;
   }
 
   @override
-  String toString() => '$runtimeType(${FlutterManifest.kAsset}: '
-                       '${assetUri.path}, ${FlutterManifest.kWeight}; $weight, '
-                       '${FlutterManifest.kStyle}: $style)';
+  String toString() => '$runtimeType(asset: ${assetUri.path}, weight; $weight, style: $style)';
 }
 
 
@@ -540,11 +506,11 @@ bool _validate(Object? manifest, Logger logger) {
         continue;
       }
       switch (kvp.key as String?) {
-        case FlutterManifest.kName:
+        case 'name':
           if (kvp.value is! String) {
             errors.add('Expected "${kvp.key}" to be a string, but got ${kvp.value}.');
           }
-        case FlutterManifest.kFlutter:
+        case 'flutter':
           if (kvp.value == null) {
             continue;
           }
@@ -585,9 +551,9 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         if (yamlValue is! bool) {
           errors.add('Expected "$yamlKey" to be a bool, but got $yamlValue (${yamlValue.runtimeType}).');
         }
-      case FlutterManifest.kAssets:
+      case 'assets':
         errors.addAll(_validateAssets(yamlValue));
-      case FlutterManifest.kShaders:
+      case 'shaders':
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
         } else if (yamlValue.isEmpty) {
@@ -597,7 +563,7 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
             'Expected "$yamlKey" to be a list of strings, but the first element is $yamlValue (${yamlValue.runtimeType}).',
           );
         }
-      case FlutterManifest.kModels:
+      case 'models':
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
         } else if (yamlValue.isEmpty) {
@@ -607,7 +573,7 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
             'Expected "$yamlKey" to be a list of strings, but the first element is $yamlValue (${yamlValue.runtimeType}).',
           );
         }
-      case FlutterManifest.kFonts:
+      case 'fonts':
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
         } else if (yamlValue.isEmpty) {
@@ -619,40 +585,40 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         } else {
           _validateFonts(yamlValue, errors);
         }
-      case FlutterManifest.kLicenses:
+      case 'licenses':
         final (_, List<String> filesErrors) = _parseList<String>(yamlValue, '"$yamlKey"', 'files');
         errors.addAll(filesErrors);
-      case FlutterManifest.kModule:
+      case 'module':
         if (yamlValue is! YamlMap) {
           errors.add('Expected "$yamlKey" to be an object, but got $yamlValue (${yamlValue.runtimeType}).');
           break;
         }
 
-        if (yamlValue[FlutterManifest.kAndroidX] != null && yamlValue[FlutterManifest.kAndroidX] is! bool) {
-          errors.add('The "${FlutterManifest.kAndroidX}" value must be a bool if set.');
+        if (yamlValue['androidX'] != null && yamlValue['androidX'] is! bool) {
+          errors.add('The "androidX" value must be a bool if set.');
         }
-        if (yamlValue[FlutterManifest.kAndroidPackage] != null && yamlValue[FlutterManifest.kAndroidPackage] is! String) {
-          errors.add('The "${FlutterManifest.kAndroidPackage}" value must be a string if set.');
+        if (yamlValue['androidPackage'] != null && yamlValue['androidPackage'] is! String) {
+          errors.add('The "androidPackage" value must be a string if set.');
         }
-        if (yamlValue[FlutterManifest.kIosBundleIdentifier] != null && yamlValue[FlutterManifest.kIosBundleIdentifier] is! String) {
-          errors.add('The "${FlutterManifest.kIosBundleIdentifier}" section must be a string if set.');
+        if (yamlValue['iosBundleIdentifier'] != null && yamlValue['iosBundleIdentifier'] is! String) {
+          errors.add('The "iosBundleIdentifier" section must be a string if set.');
         }
-      case FlutterManifest.kPlugin:
+      case 'plugin':
         if (yamlValue is! YamlMap) {
           errors.add('Expected "$yamlKey" to be an object, but got $yamlValue (${yamlValue.runtimeType}).');
           break;
         }
         final List<String> pluginErrors = Plugin.validatePluginYaml(yamlValue);
         errors.addAll(pluginErrors);
-      case FlutterManifest.kGenerate:
+      case 'generate':
         break;
-      case FlutterManifest.kDeferredComponents:
+      case 'deferred-components':
         _validateDeferredComponents(kvp, errors);
-      case FlutterManifest.kDisableSwiftPackageManager:
+      case 'disable-swift-package-manager':
         if (yamlValue is! bool) {
           errors.add('Expected "$yamlKey" to be a bool, but got $yamlValue (${yamlValue.runtimeType}).');
         }
-      case FlutterManifest.kDefaultFlavor:
+      case 'default-flavor':
         if (yamlValue is! String) {
           errors.add('Expected "$yamlKey" to be a string, but got $yamlValue (${yamlValue.runtimeType}).');
         }
@@ -692,19 +658,19 @@ void _validateDeferredComponents(MapEntry<Object?, Object?> kvp, List<String> er
         errors.add('Expected the $i element in "${kvp.key}" to be a map, but got ${yamlList[i]} (${yamlList[i].runtimeType}).');
         continue;
       }
-      if (!valueMap.containsKey(FlutterManifest.kName) || valueMap[FlutterManifest.kName] is! String) {
-        errors.add('Expected the $i element in "${kvp.key}" to have required key "${FlutterManifest.kName}" of type String');
+      if (!valueMap.containsKey('name') || valueMap['name'] is! String) {
+        errors.add('Expected the $i element in "${kvp.key}" to have required key "name" of type String');
       }
-      if (valueMap.containsKey(FlutterManifest.kLibraries)) {
+      if (valueMap.containsKey('libraries')) {
         final (_, List<String> librariesErrors) = _parseList<String>(
-          valueMap[FlutterManifest.kLibraries],
-          '"${FlutterManifest.kLibraries}" key in the element at index $i of "${kvp.key}"',
+          valueMap['libraries'],
+          '"libraries" key in the element at index $i of "${kvp.key}"',
           'String',
         );
         errors.addAll(librariesErrors);
       }
-      if (valueMap.containsKey(FlutterManifest.kAssets)) {
-        errors.addAll(_validateAssets(valueMap[FlutterManifest.kAssets]));
+      if (valueMap.containsKey('assets')) {
+        errors.addAll(_validateAssets(valueMap['assets']));
       }
     }
   }
@@ -724,7 +690,7 @@ List<String> _validateAssets(Object? yaml) {
     return (const <AssetsEntry>[], const <String>[]);
   }
   if (yaml is! YamlList) {
-    final String error = 'Expected "${FlutterManifest.kAssets}" to be a list, but got $yaml (${yaml.runtimeType}).';
+    final String error = 'Expected "assets" to be a list, but got $yaml (${yaml.runtimeType}).';
     return (const <AssetsEntry>[], <String>[error]);
   }
   final List<AssetsEntry> results = <AssetsEntry>[];
@@ -762,35 +728,35 @@ void _validateFonts(YamlList fonts, List<String> errors) {
     for (final Object? key in fontMap.keys.where((Object? key) => key != 'family' && key != 'fonts')) {
       errors.add('Unexpected child "$key" found under "fonts".');
     }
-    if (fontMap[FlutterManifest.kFamily] != null && fontMap[FlutterManifest.kFamily] is! String) {
+    if (fontMap['family'] != null && fontMap['family'] is! String) {
       errors.add('Font family must either be null or a String.');
     }
-    if (fontMap[FlutterManifest.kFonts] == null) {
+    if (fontMap['fonts'] == null) {
       continue;
-    } else if (fontMap[FlutterManifest.kFonts] is! YamlList) {
-      errors.add('Expected "${FlutterManifest.kName}" to either be null or a list.');
+    } else if (fontMap['fonts'] is! YamlList) {
+      errors.add('Expected "fonts" to either be null or a list.');
       continue;
     }
-    for (final Object? fontMapList in fontMap[FlutterManifest.kFonts] as List<Object?>) {
+    for (final Object? fontMapList in fontMap['fonts'] as List<Object?>) {
       if (fontMapList is! YamlMap) {
-        errors.add('Expected "${FlutterManifest.kFonts}" to be a list of maps.');
+        errors.add('Expected "fonts" to be a list of maps.');
         continue;
       }
       for (final MapEntry<Object?, Object?> kvp in fontMapList.entries) {
         final Object? fontKey = kvp.key;
         if (fontKey is! String) {
-          errors.add('Expected "$fontKey" under "${FlutterManifest.kFonts}" to be a string.');
+          errors.add('Expected "$fontKey" under "fonts" to be a string.');
         }
         switch (fontKey) {
-          case FlutterManifest.kAsset:
+          case 'asset':
             if (kvp.value is! String) {
               errors.add('Expected font asset ${kvp.value} ((${kvp.value.runtimeType})) to be a string.');
             }
-          case FlutterManifest.kWeight:
+          case 'weight':
             if (!fontWeights.contains(kvp.value)) {
               errors.add('Invalid value ${kvp.value} ((${kvp.value.runtimeType})) for font -> weight.');
             }
-          case FlutterManifest.kStyle:
+          case 'style':
             if (kvp.value != 'normal' && kvp.value != 'italic') {
               errors.add('Invalid value ${kvp.value} ((${kvp.value.runtimeType})) for font -> style.');
             }
@@ -995,14 +961,14 @@ final class AssetTransformerEntry {
       return (null, <String>['Expected entry to be a map. Found ${yaml.runtimeType} instead']);
     }
 
-    final Object? package = yaml[_kPackage];
+    final Object? package = yaml['package'];
     if (package is! String || package.isEmpty) {
-      return (null, <String>['Expected "$_kPackage" to be a String. Found ${package.runtimeType} instead.']);
+      return (null, <String>['Expected "package" to be a String. Found ${package.runtimeType} instead.']);
     }
 
-    final (List<String>? args, List<String> argsErrors) = _parseArgsSection(yaml[_kArgs]);
+    final (List<String>? args, List<String> argsErrors) = _parseArgsSection(yaml['args']);
     if (argsErrors.isNotEmpty) {
-      return (null, argsErrors.map((String e) => 'In $_kArgs section of transformer using package "$package": $e').toList());
+      return (null, argsErrors.map((String e) => 'In args section of transformer using package "$package": $e').toList());
     }
 
     return (

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -5,6 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:xml/xml.dart';
 import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 import '../src/convert.dart';
 import 'android/android_builder.dart';
@@ -17,6 +18,7 @@ import 'base/utils.dart';
 import 'base/version.dart';
 import 'bundle.dart' as bundle;
 import 'cmake_project.dart';
+import 'dart/package_map.dart';
 import 'features.dart';
 import 'flutter_manifest.dart';
 import 'flutter_plugins.dart';
@@ -93,7 +95,7 @@ class FlutterProjectFactory {
 /// cached.
 class FlutterProject {
   @visibleForTesting
-  FlutterProject(this.directory, this.manifest, this._exampleManifest);
+  FlutterProject(this.directory, this._manifest, this._exampleManifest);
 
   /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
   /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
@@ -130,7 +132,8 @@ class FlutterProject {
   Directory get buildDirectory => directory.childDirectory('build');
 
   /// The manifest of this project.
-  final FlutterManifest manifest;
+  FlutterManifest get manifest => _manifest;
+  late FlutterManifest _manifest;
 
   /// The manifest of the example sub-project of this project.
   final FlutterManifest _exampleManifest;
@@ -226,6 +229,8 @@ class FlutterProject {
   /// The `.gitignore` file of this project.
   File get gitignoreFile => directory.childFile('.gitignore');
 
+  File get packageConfig => findPackageConfigFileOrDefault(directory);
+
   /// The `.dart-tool` directory of this project.
   Directory get dartTool => directory.childDirectory('.dart_tool');
 
@@ -255,7 +260,7 @@ class FlutterProject {
 
   /// The generated scaffolding project for hosting widget previews from this
   /// project.
-  FlutterProject get widgetPreviewScaffoldProject => FlutterProject.fromDirectory(
+  late final FlutterProject widgetPreviewScaffoldProject = FlutterProject.fromDirectory(
     widgetPreviewScaffold,
   );
 
@@ -318,6 +323,16 @@ class FlutterProject {
       throwToolExit('Please correct the pubspec.yaml file at $path');
     }
     return manifest;
+  }
+
+  /// Replaces the content of [pubspecFile] with the contents of [updated] and
+  /// sets [manifest] to the [updated] manifest.
+  void replacePubspec(FlutterManifest updated) {
+    final YamlMap updatedPubspecContents = updated.toYaml();
+    final YamlEditor editor = YamlEditor('');
+    editor.update(const <String>[], updatedPubspecContents);
+    pubspecFile.writeAsStringSync(editor.toString());
+    _manifest = updated;
   }
 
   /// Reapplies template files and regenerates project files and plugin

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/commands/widget_preview.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:test_api/fake.dart';
 
@@ -207,7 +206,7 @@ flutter:
 
   @override
   late FlutterProject widgetPreviewScaffoldProject = FakeFlutterProject(
-    projectRoot: path.join(
+    projectRoot: fileSystem.path.join(
       projectRoot,
       '.dart_tool',
       'widget_preview_scaffold',
@@ -229,7 +228,7 @@ flutter:
   @override
   late final File packageConfig = () {
     final File file = fileSystem
-        .directory(path.join(projectRoot, '.dart_tool'))
+        .directory(fileSystem.path.join(projectRoot, '.dart_tool'))
         .childFile('package_config.json')
       ..createSync(recursive: true);
     file.writeAsStringSync(basicPackageConfig);

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview_test.dart
@@ -1,0 +1,237 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/commands/widget_preview.dart';
+import 'package:flutter_tools/src/convert.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:test_api/fake.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import 'devices_test.dart';
+
+void main() {
+  group('WidgetPreviewStartCommand', () {
+    late MemoryFileSystem fileSystem;
+    late ProcessManager processManager;
+    late WidgetPreviewStartCommand command;
+    late FlutterProject rootProject;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem.test();
+      processManager = FakeProcessManager.any();
+      command = WidgetPreviewStartCommand();
+      rootProject = FakeFlutterProject(
+        projectRoot: 'some_project',
+        fileSystem: fileSystem,
+        logger: FakeBufferLogger(),
+      );
+    });
+
+    testUsingContext(
+      'can create a pubspec.yaml for the preview scaffold including root project assets',
+      () {
+        final FlutterManifest root = rootProject.manifest;
+        final FlutterManifest updated = command.buildPubspec(
+          rootManifest: rootProject.manifest,
+          widgetPreviewManifest:
+              rootProject.widgetPreviewScaffoldProject.manifest,
+        );
+
+        final List<AssetsEntry> rootAssets = root.assets;
+        final List<AssetsEntry> updatedAssets = updated.assets;
+        expect(updatedAssets.length, rootAssets.length);
+        for (int i = 0; i < rootAssets.length; ++i) {
+          final AssetsEntry rootEntry = rootAssets[i];
+          final AssetsEntry updatedEntry = updatedAssets[i];
+          expect(
+            updatedEntry,
+            WidgetPreviewStartCommand.transformAssetsEntry(rootEntry),
+          );
+        }
+
+        expect(updated.fonts.length, root.fonts.length);
+        for (int i = 0; i < root.fonts.length; ++i) {
+          final Font rootFont = root.fonts[i];
+          final Font updatedFont = updated.fonts[i];
+          expect(updatedFont.familyName, rootFont.familyName);
+          expect(updatedFont.fontAssets.length, rootFont.fontAssets.length);
+          for (int j = 0; j < rootFont.fontAssets.length; ++j) {
+            final FontAsset rootFontAsset = rootFont.fontAssets[j];
+            final FontAsset updatedFontAsset = updatedFont.fontAssets[j];
+            expect(
+              updatedFontAsset,
+              WidgetPreviewStartCommand.transformFontAsset(rootFontAsset),
+            );
+          }
+        }
+
+        expect(
+          updated.shaders,
+          root.shaders.map(WidgetPreviewStartCommand.transformAssetUri),
+        );
+        expect(
+          updated.models,
+          root.models.map(WidgetPreviewStartCommand.transformAssetUri),
+        );
+
+        expect(
+          updated.deferredComponents?.length,
+          root.deferredComponents?.length,
+        );
+        if (root.deferredComponents != null) {
+          for (int i = 0; i < root.deferredComponents!.length; ++i) {
+            expect(
+              updated.deferredComponents![i].toString(),
+              WidgetPreviewStartCommand.transformDeferredComponent(
+                root.deferredComponents![i],
+              ).toString(),
+            );
+          }
+        }
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      'can add flutter_gen to package_config.json if generate is set in the parent project',
+      () async {
+        command.maybeAddFlutterGenToPackageConfig(rootProject: rootProject);
+        final Map<String, Object?> packageConfig = jsonDecode(
+          rootProject.widgetPreviewScaffoldProject.packageConfig
+              .readAsStringSync(),
+        ) as Map<String, Object?>;
+        expect(packageConfig.containsKey('packages'), true);
+        final List<Map<String, Object?>> packages =
+            (packageConfig['packages']! as List<dynamic>)
+                .cast<Map<String, Object?>>();
+        expect(packages.length, 2);
+        expect(
+          packages.last,
+          WidgetPreviewStartCommand.flutterGenPackageConfigEntry,
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+  });
+}
+
+class FakeFlutterProject extends Fake implements FlutterProject {
+  FakeFlutterProject({
+    required this.projectRoot,
+    required this.fileSystem,
+    required this.logger,
+  });
+
+  static const String complexPubspec = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  generate: true
+  assets:
+    - path: foo
+      flavors:
+        - flavor
+      transformers:
+        - package: package:foo
+          args:
+            - arg
+    - path: package/foo
+  fonts:
+    - family: fontFamily
+      fonts:
+        - weight: 100
+          style: normal
+          asset: assetUri
+        - weight: 200
+          style: italic
+          asset: package/assetUri
+  shaders:
+    - shaderUri
+  models:
+    - modelUri
+  deferred-components:
+    - name: deferredComponent
+      libraries:
+        - deferredComponentLibrary
+      assets:
+        - path: deferredComponentUri
+          flavors:
+            - deferredComponentFlavor
+          transformers:
+            - package: package:deferredComponent
+              args:
+                - deferredComponentArg
+        - path: package/deferredComponentUri''';
+
+  static const String basicPackageConfig = '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "test",
+      "rootUri": "fileSystem.currentDirectory.path",
+      "packageUri": "lib/"
+    }
+  ]
+}
+''';
+
+  final String projectRoot;
+  final FileSystem fileSystem;
+  final Logger logger;
+
+  @override
+  late final FlutterManifest manifest = FlutterManifest.createFromPath(
+    pubspecFile.path,
+    fileSystem: fileSystem,
+    logger: logger,
+  )!;
+
+  @override
+  late FlutterProject widgetPreviewScaffoldProject = FakeFlutterProject(
+    projectRoot: path.join(
+      projectRoot,
+      '.dart_tool',
+      'widget_preview_scaffold',
+    ),
+    fileSystem: fileSystem,
+    logger: logger,
+  );
+
+  @override
+  late final File pubspecFile = () {
+    final File file = fileSystem
+        .directory(projectRoot)
+        .childFile('pubspec.yaml')
+      ..createSync(recursive: true);
+    file.writeAsStringSync(complexPubspec);
+    return file;
+  }();
+
+  @override
+  late final File packageConfig = () {
+    final File file = fileSystem
+        .directory(path.join(projectRoot, '.dart_tool'))
+        .childFile('package_config.json')
+      ..createSync(recursive: true);
+    file.writeAsStringSync(basicPackageConfig);
+    return file;
+  }();
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview_test.dart
@@ -67,8 +67,9 @@ void main() {
             final FontAsset rootFontAsset = rootFont.fontAssets[j];
             final FontAsset updatedFontAsset = updatedFont.fontAssets[j];
             expect(
-              updatedFontAsset,
-              WidgetPreviewStartCommand.transformFontAsset(rootFontAsset),
+              updatedFontAsset.descriptor,
+              WidgetPreviewStartCommand.transformFontAsset(rootFontAsset)
+                  .descriptor,
             );
           }
         }

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview_test.dart
@@ -14,7 +14,6 @@ import 'package:test_api/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import 'devices_test.dart';
 
 void main() {
   group('WidgetPreviewStartCommand', () {
@@ -30,7 +29,7 @@ void main() {
       rootProject = FakeFlutterProject(
         projectRoot: 'some_project',
         fileSystem: fileSystem,
-        logger: FakeBufferLogger(),
+        logger: BufferLogger.test(),
       );
     });
 


### PR DESCRIPTION
The generated widget_preview_scaffold project needs to explicitly reference the assets from the parent project's pubspec.yaml. This change updates flutter widget-preview start to read the parent project's pubspec.yaml and add references to the assets listed to the widget_preview_scaffold's pubspec.yaml. If generate: true is set in the parent project, a reference to the autogenerated flutter_gen package is manually added to the widget_preview_scaffold's package_config.json.