### PR TITLE
Android Integration Tests run under an Android Instrumentation

### DIFF
--- a/packages/integration_test/android/build.gradle.kts
+++ b/packages/integration_test/android/build.gradle.kts
@@ -52,9 +52,11 @@ android {
         testImplementation("junit:junit:4.13.2")
         testImplementation("org.mockito:mockito-inline:5.1.0")
 
-        api("androidx.test:runner:1.2+")
+        api("androidx.test:runner:1.5+")
         api("androidx.test:rules:1.2+")
         api("androidx.test.espresso:espresso-core:3.2+")
+        api("androidx.test.uiautomator:uiautomator:2.2+")
+        api("androidx.test:monitor:1.7+")
 
         implementation("com.google.guava:guava:28.1-android")
     }

--- a/packages/integration_test/android/src/main/java/dev/flutter/plugins/integration_test/FlutterActivityIntegrationTest.java
+++ b/packages/integration_test/android/src/main/java/dev/flutter/plugins/integration_test/FlutterActivityIntegrationTest.java
@@ -1,0 +1,8 @@
+// TODO:
+// This file will contain a class that peers a FlutterActivity
+// (and it's Integration Test Plugin) with the MonitoringInstrumentation
+// Will contain the implementations of all IntegrationTestPlugin Java endpoints.
+
+// public class FlutterActivityIntegrationTest {
+//   public FlutterActivityIntegrationTest(Activity activity);
+// }

--- a/packages/integration_test/android/src/main/java/dev/flutter/plugins/integration_test/FlutterTestJUnitRunner.java
+++ b/packages/integration_test/android/src/main/java/dev/flutter/plugins/integration_test/FlutterTestJUnitRunner.java
@@ -1,0 +1,64 @@
+package dev.flutter.plugins.integration_test;
+
+import static org.junit.Assume.*;
+
+import android.app.Instrumentation;
+import android.content.Intent;
+import android.os.Bundle;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnitRunner;
+import com.google.common.util.concurrent.SettableFuture;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+
+public class FlutterTestJUnitRunner extends AndroidJUnitRunner {
+  private final SettableFuture<IntegrationTestPlugin> pluginSettable = SettableFuture.create();
+  public final Future<IntegrationTestPlugin> plugin = pluginSettable;
+
+  @Override
+  protected boolean shouldWaitForActivitiesToComplete() {
+      return false;
+  }
+
+  @Override
+  public void onCreate(Bundle arguments) {
+    super.onCreate(arguments);
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+  }
+
+  public void registerPlugin(IntegrationTestPlugin plugin) {
+    pluginSettable.set(plugin);
+  }
+
+  public IntegrationTestPlugin getPlugin() {
+    try {
+        return this.plugin.get();
+    } catch (ExecutionException | InterruptedException e) {
+        System.out.println("JOHN failed to getPlugin e=" + e);
+    }
+    return null;
+  }
+
+  public String[] getDartTestList() {
+    return getPlugin().getDartTestList();
+  }
+
+  public void startActivity(Class<?> activityClass) {
+    // This code launches the app under test. It's based on ActivityTestRule#launchActivity.
+    // It's simpler because we don't have the need for that much synchronization.
+    // Currently, the only synchronization point we're interested in is when the app under test returns the list of tests.
+    Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+    Intent intent = new Intent(Intent.ACTION_MAIN);
+    intent.setClassName(instrumentation.getTargetContext(), activityClass.getCanonicalName());
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    System.out.println("JOHN SPAWNING Activity=" + activityClass.getCanonicalName());
+    instrumentation.getTargetContext().startActivity(intent);
+  }  
+}

--- a/packages/integration_test/android/src/main/java/dev/flutter/plugins/integration_test/IntegrationTestPlugin.java
+++ b/packages/integration_test/android/src/main/java/dev/flutter/plugins/integration_test/IntegrationTestPlugin.java
@@ -17,23 +17,52 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import java.io.IOException;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnitRunner;
 
 /** IntegrationTestPlugin */
 public class IntegrationTestPlugin implements MethodCallHandler, FlutterPlugin, ActivityAware {
   private static final String CHANNEL = "plugins.flutter.io/integration_test";
   private static final SettableFuture<Map<String, String>> testResultsSettable =
       SettableFuture.create();
+  public static final Future<Map<String, String>> testResults = testResultsSettable;
+  private final SettableFuture<String[]> testListSettable = SettableFuture.create();
+  private final Future<String[]> testListFuture = testListSettable;
 
   private MethodChannel methodChannel;
   private Activity flutterActivity;
-  public static final Future<Map<String, String>> testResults = testResultsSettable;
+  private FlutterTestJUnitRunner instrumentation;
+
+  public IntegrationTestPlugin() {
+    System.out.println("JOHN IntegrationTestPlugin");
+    instrumentation = (FlutterTestJUnitRunner)InstrumentationRegistry.getInstrumentation();
+    if (instrumentation == null) {
+      return;
+    }
+    System.out.println("JOHN Registering plugin with instrumentation");
+    instrumentation.registerPlugin(this);
+  }
+
+  String[] getDartTestList() {
+    try {
+      return this.testListFuture.get();
+    }  catch (ExecutionException | InterruptedException e) {
+      System.out.println("JOHN failed to get rest getDartTestList execpteion=" + e);
+    }
+    return new String[0];
+  }
 
   /** Plugin registration. */
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
+    UiDevice device = UiDevice.getInstance(instrumentation);
+
   }
 
   private void onAttachedToEngine(Context unusedApplicationContext, BinaryMessenger messenger) {
@@ -69,6 +98,7 @@ public class IntegrationTestPlugin implements MethodCallHandler, FlutterPlugin, 
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {
+    System.out.println("JOHN IntegrestionTestPlugin onMethodCall " + call.method);
     switch (call.method) {
       case "allTestsFinished":
         final Map<String, String> results = call.argument("results");
@@ -108,6 +138,16 @@ public class IntegrationTestPlugin implements MethodCallHandler, FlutterPlugin, 
           return;
         }
         FlutterDeviceScreenshot.captureView(flutterActivity, methodChannel, result);
+        return;
+      case "populateTestList":
+          final ArrayList<String> testList = call.argument("testList");
+          final String[] tests = new String[testList.size()];
+          for (int i = 0; i < testList.size(); i++) {
+            tests[i] = testList.get(i);
+          }
+          System.out.println("JOHN populateTEstList JAVA SIDE: " + tests);
+          testListSettable.set(tests);
+          result.success(null);
         return;
       default:
         result.notImplemented();


### PR DESCRIPTION
WIP

- Adds our own MonitoringInstrumentation class with Flutter specific bits
- Allows us to make calls to ui-automator methods
- TODO: Generate the activityTest in a new project
- TODO: flutter test integration_test/... does the right thing

To build and run:

```$ flutter create hello```

Add `integration_test/test_entry.dart`:

```
import 'dart:async';

import 'package:flutter_test/flutter_test.dart';

import 'counter_test.dart' as counter_test;
import 'dart:io';

Future<void> main() async {
  counter_test.main();
}
```

Here is my `build.gradle` file which contains some tweaks:

```
plugins {
    id "com.android.application"
    id "kotlin-android"
    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
    id "dev.flutter.flutter-gradle-plugin"
}

android {
    namespace = "com.example.hello"
    compileSdk = flutter.compileSdkVersion
    ndkVersion = flutter.ndkVersion

    compileOptions {
        sourceCompatibility = JavaVersion.VERSION_1_8
        targetCompatibility = JavaVersion.VERSION_1_8
    }

    kotlinOptions {
        jvmTarget = JavaVersion.VERSION_1_8
    }

    defaultConfig {
        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
        applicationId = "com.example.hello"
        // You can update the following values to match your application needs.
        // For more information, see: https://flutter.dev/to/review-gradle-config.
        minSdk = 23
        targetSdk = 34
        versionCode = flutter.versionCode
        versionName = flutter.versionName
        testInstrumentationRunner "dev.flutter.plugins.integration_test.FlutterTestJUnitRunner"
    }

    testOptions {
        execution "ANDROIDX_TEST_ORCHESTRATOR"
    }

    buildTypes {
        release {
            // TODO: Add your own signing config for the release build.
            // Signing with the debug keys for now, so `flutter run --release` works.
            signingConfig = signingConfigs.debug
        }
    }
}

flutter {
    source = "../.."
}

dependencies {
    androidTestUtil 'androidx.test:orchestrator:1.4.2'
}
```

Add `MainActivityTest.java` to `hello/android/app/src/androidTest/java/com/example/hello/MainActivityTest.java`:

```
package com.example.hello;

import androidx.test.platform.app.InstrumentationRegistry;

import java.util.concurrent.ExecutionException;

import android.os.Looper;

import org.junit.Test;
import org.junit.runner.RunWith;
import org.junit.runners.Parameterized;
import org.junit.runners.Parameterized.Parameters;
import dev.flutter.plugins.integration_test.FlutterTestJUnitRunner;
import dev.flutter.plugins.integration_test.IntegrationTestPlugin;

@RunWith(Parameterized.class)
public class MainActivityTest {
    @Parameters(name = "{0}")
    public static Object[] testCases() {
        FlutterTestJUnitRunner instrumentation = (FlutterTestJUnitRunner) InstrumentationRegistry.getInstrumentation();
        // Start the activity here. This results in the Dart code being run.
        instrumentation.startActivity(MainActivity.class);
        // System.out.println("JOHN getPlugin()");
        // IntegrationTestPlugin plugin = instrumentation.getPlugin();
        // System.out.println("JOHN getPlugin()=" + plugin);
        // //instrumentation.getDartTests();
        return instrumentation.getDartTestList();
        // TODO(johnmccutchan): Enumerate the Dart tests.
        // return new String[] { "runDartTests"};
    }

    public MainActivityTest(String dartTestName) {
        this.dartTestName = dartTestName;
        System.out.println("JOHN MAT: activity=" + dartTestName);
    }

    private final String dartTestName;

    @Test
    public void runDartTests() {
        FlutterTestJUnitRunner instrumentation = (FlutterTestJUnitRunner) InstrumentationRegistry.getInstrumentation();
        //instrumentation.startActivity(MainActivity.class);
        System.out.println("JOHN main thread=" + (Looper.getMainLooper() == Looper.myLooper()));
        System.out.println("JOHN runDartTests waiting...");
        try {
            instrumentation.getPlugin().testResults.get();
        } catch (ExecutionException | InterruptedException e) {
            System.out.println("JOHN failed to get rest results execpteion=" + e);
        }
        System.out.println("JOHN runDartTests DONEDONEONDONE");
    }
}
```

To do the initial build of the flutter app in debug mode to generate the gradlew executable

```$ flutter build apk```

To iterate:

```
$ cd android
```

```
$ ./gradlew :app:assembleDebugAndroidTest -Ptarget=integration_test/test_entry.dart && ./gradlew :app:connectedDebugAndroidTest --info -Ptarget=integration_test/test_entry.dart
```

The gradlew command installs the apk and launches the apk under our instrumentation code
