### PR TITLE
🚀 Implements `globalPosition` and `localPosition` for `TapDragEndDetails`

### DIFF
--- a/packages/flutter/lib/src/gestures/tap_and_drag.dart
+++ b/packages/flutter/lib/src/gestures/tap_and_drag.dart
@@ -1169,10 +1169,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
     }
 
     if (dragStartBehavior == DragStartBehavior.start) {
-      _initialPosition += OffsetPair(
-        global: event.delta,
-        local: event.localDelta,
-      );
+      _initialPosition += OffsetPair(global: event.delta, local: event.localDelta);
       _currentPosition = _initialPosition;
     }
     _checkDragStart(event);
@@ -1187,10 +1184,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
         untransformedDelta: localDelta,
         untransformedEndPosition: correctedLocalPosition,
       );
-      final OffsetPair updateDelta = OffsetPair(
-        local: localDelta,
-        global: globalUpdateDelta,
-      );
+      final OffsetPair updateDelta = OffsetPair(local: localDelta, global: globalUpdateDelta);
       // Only adds delta for down behaviour
       _checkDragUpdate(event, corrected: _initialPosition + updateDelta);
     }

--- a/packages/flutter/test/gestures/tap_and_drag_test.dart
+++ b/packages/flutter/test/gestures/tap_and_drag_test.dart
@@ -1030,13 +1030,14 @@ void main() {
 
   testGesture('Contains correct positions in the drag end details', (GestureTester tester) {
     late TapDragEndDetails tapDragEndDetails;
-    tapAndDrag = TapAndHorizontalDragGestureRecognizer()
-      ..dragStartBehavior = DragStartBehavior.down
-      ..eagerVictoryOnDrag = true
-      ..maxConsecutiveTap = 3
-      ..onDragEnd = (TapDragEndDetails details) {
-        tapDragEndDetails = details;
-      };
+    tapAndDrag =
+        TapAndHorizontalDragGestureRecognizer()
+          ..dragStartBehavior = DragStartBehavior.down
+          ..eagerVictoryOnDrag = true
+          ..maxConsecutiveTap = 3
+          ..onDragEnd = (TapDragEndDetails details) {
+            tapDragEndDetails = details;
+          };
     addTearDown(tapAndDrag.dispose);
 
     final TestPointer pointer = TestPointer(5);

--- a/packages/flutter/test/gestures/tap_and_drag_test.dart
+++ b/packages/flutter/test/gestures/tap_and_drag_test.dart
@@ -1027,4 +1027,29 @@ void main() {
     GestureBinding.instance.gestureArena.sweep(1);
     expect(events, <String>['down#1']);
   });
+
+  testGesture('Contains correct positions in the drag end details', (GestureTester tester) {
+    late TapDragEndDetails tapDragEndDetails;
+    tapAndDrag = TapAndHorizontalDragGestureRecognizer()
+      ..dragStartBehavior = DragStartBehavior.down
+      ..eagerVictoryOnDrag = true
+      ..maxConsecutiveTap = 3
+      ..onDragEnd = (TapDragEndDetails details) {
+        tapDragEndDetails = details;
+      };
+    addTearDown(tapAndDrag.dispose);
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent pointerDown = pointer.down(const Offset(10.0, 10.0));
+
+    tapAndDrag.addPointer(pointerDown);
+    tester.closeArena(pointer.pointer);
+    tester.route(pointerDown);
+    tester.route(pointer.move(const Offset(50.0, 20.0)));
+    tester.route(pointer.move(const Offset(90.0, 30.0)));
+    tester.route(pointer.move(const Offset(120.0, 45.0)));
+    tester.route(pointer.up());
+
+    expect(tapDragEndDetails.globalPosition, const Offset(120.0, 45.0));
+  });
 }


### PR DESCRIPTION
Resolves #159961

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
