### PR TITLE
Pin pkg:intl to 0.19.0

### DIFF
--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -23,6 +23,7 @@ const Map<String, String> kManuallyPinnedDependencies = <String, String>{
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
   'flutter_template_images': '4.2.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912
+  'intl': '0.19.0', // 0.20.0 introsuces new transitive dependencies that are not (yet) cleared in allow list.
   'native_assets_builder': '0.9.0', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'native_assets_cli': '0.9.0', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'material_color_utilities': '0.11.1', // Keep pinned to latest until 1.0.0.

--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -23,7 +23,7 @@ const Map<String, String> kManuallyPinnedDependencies = <String, String>{
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
   'flutter_template_images': '4.2.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912
-  'intl': '0.19.0', // 0.20.0 introsuces new transitive dependencies that are not (yet) cleared in allow list.
+  'intl': '0.19.0', // 0.20.0 introduces new transitive dependencies that are not (yet) cleared in Flutter's allow list.
   'native_assets_builder': '0.9.0', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'native_assets_cli': '0.9.0', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'material_color_utilities': '0.11.1', // Keep pinned to latest until 1.0.0.


### PR DESCRIPTION
Version 0.20.0 introduces new transitive dependencies that are not cleared (yet) in our allow list [1]. Work is underway in https://github.com/flutter/flutter/pull/158555 to change that.

[1] https://github.com/flutter/flutter/blob/eabed2381b3f4d155d3f58386e26e1401d4a413f/dev/bots/allowlist.dart
