### PR TITLE
Deprecate unused `ButtonStyleButton.iconAlignment` property

### DIFF
--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -165,7 +165,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
   @Deprecated(
     'Remove this parameter as it is now ignored. '
-      'Use ButtonStyle.iconAlignment instead. '
+    'Use ButtonStyle.iconAlignment instead. '
     'This feature was deprecated after v3.28.0-0.1.pre.'
   )
   final IconAlignment? iconAlignment;

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -88,7 +88,8 @@ abstract class ButtonStyleButton extends StatefulWidget {
     this.isSemanticButton = true,
     @Deprecated(
       'Remove this parameter as it is now ignored. '
-      'This feature was deprecated after v3.27.0-0.2.pre.'
+      'Use ButtonStyle.iconAlignment instead. '
+      'This feature was deprecated after v3.28.0-0.1.pre.'
     )
     this.iconAlignment,
     this.tooltip,
@@ -164,7 +165,8 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
   @Deprecated(
     'Remove this parameter as it is now ignored. '
-    'This feature was deprecated after v3.27.0-0.2.pre.'
+      'Use ButtonStyle.iconAlignment instead. '
+    'This feature was deprecated after v3.28.0-0.1.pre.'
   )
   final IconAlignment? iconAlignment;
 

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -86,6 +86,10 @@ abstract class ButtonStyleButton extends StatefulWidget {
     required this.clipBehavior,
     this.statesController,
     this.isSemanticButton = true,
+    @Deprecated(
+      'Remove this parameter as it is now ignored. '
+      'This feature was deprecated after v3.27.0-0.2.pre.'
+    )
     this.iconAlignment,
     this.tooltip,
     required this.child,
@@ -158,6 +162,10 @@ abstract class ButtonStyleButton extends StatefulWidget {
   final bool? isSemanticButton;
 
   /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
+  @Deprecated(
+    'Remove this parameter as it is now ignored. '
+    'This feature was deprecated after v3.27.0-0.2.pre.'
+  )
   final IconAlignment? iconAlignment;
 
   /// Text that describes the action that will occur when the button is pressed or

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -89,7 +89,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
     @Deprecated(
       'Remove this parameter as it is now ignored. '
       'Use ButtonStyle.iconAlignment instead. '
-      'This feature was deprecated after v3.28.0-0.1.pre.'
+      'This feature was deprecated after v3.28.0-1.0.pre.'
     )
     this.iconAlignment,
     this.tooltip,
@@ -166,7 +166,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   @Deprecated(
     'Remove this parameter as it is now ignored. '
     'Use ButtonStyle.iconAlignment instead. '
-    'This feature was deprecated after v3.28.0-0.1.pre.'
+    'This feature was deprecated after v3.28.0-1.0.pre.'
   )
   final IconAlignment? iconAlignment;
 

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -89,7 +89,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
     @Deprecated(
       'Remove this parameter as it is now ignored. '
       'Use ButtonStyle.iconAlignment instead. '
-      'This feature was deprecated after v3.28.0-1.0.pre.'
+      'This feature was deprecated after v3.28.0-1.0.pre.',
     )
     this.iconAlignment,
     this.tooltip,
@@ -166,7 +166,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   @Deprecated(
     'Remove this parameter as it is now ignored. '
     'Use ButtonStyle.iconAlignment instead. '
-    'This feature was deprecated after v3.28.0-1.0.pre.'
+    'This feature was deprecated after v3.28.0-1.0.pre.',
   )
   final IconAlignment? iconAlignment;
 


### PR DESCRIPTION
Fixes [Deprecate unused `ButtonStyleButton.iconAlignment` property](https://github.com/flutter/flutter/issues/159782)

Refactor done in https://github.com/flutter/flutter/pull/158503 makes `ButtonStyleButton.iconAlignment` redundant. In this PR I'm marking it as deprecated without migration guide. However, it may possible to remove it altogether. 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
