### PR TITLE
Deprecate `ThemeData.indicatorColor` in favor of `TabBarThemeData.indicatorColor`

### DIFF
--- a/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
@@ -26,6 +26,68 @@
 #     * WidgetState: fix_widget_state.yaml
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/160024
+  - title: "Migrate 'ThemeData.indicatorColor' to 'TabBarThemeData.indicatorColor'"
+    date: 2025-01-03
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'ThemeData'
+    oneOf:
+      - if: "indicatorColor != '' && tabBarTheme != ''"
+        changes:
+          - kind: 'removeParameter'
+            name: 'indicatorColor'
+      - if: "indicatorColor != '' && tabBarTheme == ''"
+        changes:
+          - kind: 'removeParameter'
+            name: 'indicatorColor'
+          - kind: 'addParameter'
+            index: 136
+            name: 'tabBarTheme'
+            style: optional_named
+            argumentValue:
+              expression: 'TabBarThemeData(indicatorColor: {% indicatorColor %})'
+              requiredIf: "indicatorColor != ''"
+    variables:
+      indicatorColor:
+        kind: 'fragment'
+        value: 'arguments[indicatorColor]'
+      tabBarTheme:
+        kind: 'fragment'
+        value: 'arguments[tabBarTheme]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/160024
+  - title: "Migrate 'ThemeData.indicatorColor' to 'TabBarThemeData.indicatorColor'"
+    date: 2025-01-03
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'ThemeData'
+    oneOf:
+      - if: "indicatorColor != '' && tabBarTheme != ''"
+        changes:
+          - kind: 'removeParameter'
+            name: 'indicatorColor'
+      - if: "indicatorColor != '' && tabBarTheme == ''"
+        changes:
+          - kind: 'removeParameter'
+            name: 'indicatorColor'
+          - kind: 'addParameter'
+            index: 136
+            name: 'tabBarTheme'
+            style: optional_named
+            argumentValue:
+              expression: 'TabBarThemeData(indicatorColor: {% indicatorColor %})'
+              requiredIf: "indicatorColor != ''"
+    variables:
+      indicatorColor:
+        kind: 'fragment'
+        value: 'arguments[indicatorColor]'
+      tabBarTheme:
+        kind: 'fragment'
+        value: 'arguments[tabBarTheme]'
+
   # Changes made in https://github.com/flutter/flutter/pull/155072
   - title: "Migrate 'ThemeData.dialogBackgroundColor' to 'DialogThemeData.backgroundColor'"
     date: 2024-09-12

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -2565,14 +2565,16 @@ class _TabPageSelectorState extends State<TabPageSelector> {
 
 // Hand coded defaults based on Material Design 2.
 class _TabsDefaultsM2 extends TabBarThemeData {
-  const _TabsDefaultsM2(this.context, this.isScrollable)
-    : super(indicatorSize: TabBarIndicatorSize.tab);
+  _TabsDefaultsM2(this.context, this.isScrollable) : super(indicatorSize: TabBarIndicatorSize.tab);
 
   final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+  late final bool isDark = Theme.of(context).brightness == Brightness.dark;
+  late final Color primaryColor = isDark ? Colors.grey[900]! : Colors.blue;
   final bool isScrollable;
 
   @override
-  Color? get indicatorColor => Theme.of(context).indicatorColor;
+  Color? get indicatorColor => _colors.secondary == primaryColor ? Colors.white : _colors.secondary;
 
   @override
   Color? get labelColor => Theme.of(context).primaryTextTheme.bodyLarge!.color!;

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -286,7 +286,6 @@ class ThemeData with Diagnosticable {
     Color? highlightColor,
     Color? hintColor,
     Color? hoverColor,
-    Color? indicatorColor,
     Color? primaryColor,
     Color? primaryColorDark,
     Color? primaryColorLight,
@@ -365,6 +364,11 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.27.0-0.1.pre.',
     )
     Color? dialogBackgroundColor,
+    @Deprecated(
+      'Use TabBarThemeData.indicatorColor instead. '
+      'This feature was deprecated after v3.28.0-1.0.pre.',
+    )
+    Color? indicatorColor,
   }) {
     // GENERAL CONFIGURATION
     cupertinoOverrideTheme = cupertinoOverrideTheme?.noDefault();
@@ -459,7 +463,6 @@ class ThemeData with Diagnosticable {
     unselectedWidgetColor ??= isDark ? Colors.white70 : Colors.black54;
     // Spec doesn't specify a dark theme secondaryHeaderColor, this is a guess.
     secondaryHeaderColor ??= isDark ? Colors.grey[700]! : primarySwatch[50]!;
-    indicatorColor ??= colorScheme.secondary == primaryColor ? Colors.white : colorScheme.secondary;
     hintColor ??= isDark ? Colors.white60 : Colors.black.withOpacity(0.6);
     // The default [buttonTheme] is here because it doesn't use the defaults for
     // [disabledColor], [highlightColor], and [splashColor].
@@ -580,6 +583,7 @@ class ThemeData with Diagnosticable {
     // DEPRECATED (newest deprecations at the bottom)
     buttonBarTheme ??= const ButtonBarThemeData();
     dialogBackgroundColor ??= isDark ? Colors.grey[800]! : Colors.white;
+    indicatorColor ??= colorScheme.secondary == primaryColor ? Colors.white : colorScheme.secondary;
     return ThemeData.raw(
       // For the sanity of the reader, make sure these properties are in the same
       // order in every place that they are separated by section comments (e.g.
@@ -609,7 +613,6 @@ class ThemeData with Diagnosticable {
       highlightColor: highlightColor,
       hintColor: hintColor,
       hoverColor: hoverColor,
-      indicatorColor: indicatorColor,
       primaryColor: primaryColor,
       primaryColorDark: primaryColorDark,
       primaryColorLight: primaryColorLight,
@@ -673,6 +676,7 @@ class ThemeData with Diagnosticable {
       // DEPRECATED (newest deprecations at the bottom)
       buttonBarTheme: buttonBarTheme,
       dialogBackgroundColor: dialogBackgroundColor,
+      indicatorColor: indicatorColor,
     );
   }
 
@@ -715,7 +719,6 @@ class ThemeData with Diagnosticable {
     required this.highlightColor,
     required this.hintColor,
     required this.hoverColor,
-    required this.indicatorColor,
     required this.primaryColor,
     required this.primaryColorDark,
     required this.primaryColorLight,
@@ -787,6 +790,11 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.27.0-0.1.pre.',
     )
     required this.dialogBackgroundColor,
+    @Deprecated(
+      'Use TabBarThemeData.indicatorColor instead. '
+      'This feature was deprecated after v3.28.0-1.0.pre.',
+    )
+    required this.indicatorColor,
   }) : // DEPRECATED (newest deprecations at the bottom)
        // should not be `required`, use getter pattern to avoid breakages.
        _buttonBarTheme = buttonBarTheme,
@@ -1204,9 +1212,6 @@ class ThemeData with Diagnosticable {
   /// component.
   final Color hoverColor;
 
-  /// The color of the selected tab indicator in a tab bar.
-  final Color indicatorColor;
-
   /// The background color for major parts of the app (toolbars, tab bars, etc)
   ///
   /// The theme's [colorScheme] property contains [ColorScheme.primary], as
@@ -1451,6 +1456,13 @@ class ThemeData with Diagnosticable {
   )
   final Color dialogBackgroundColor;
 
+  /// The color of the selected tab indicator in a tab bar.
+  @Deprecated(
+    'Use TabBarThemeData.indicatorColor instead. '
+    'This feature was deprecated after v3.28.0-1.0.pre.',
+  )
+  final Color indicatorColor;
+
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ///
   /// The [brightness] value is applied to the [colorScheme].
@@ -1486,7 +1498,6 @@ class ThemeData with Diagnosticable {
     Color? highlightColor,
     Color? hintColor,
     Color? hoverColor,
-    Color? indicatorColor,
     Color? primaryColor,
     Color? primaryColorDark,
     Color? primaryColorLight,
@@ -1568,6 +1579,11 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.27.0-0.1.pre.',
     )
     Color? dialogBackgroundColor,
+    @Deprecated(
+      'Use TabBarThemeData.indicatorColor instead. '
+      'This feature was deprecated after v3.28.0-1.0.pre.',
+    )
+    Color? indicatorColor,
   }) {
     cupertinoOverrideTheme = cupertinoOverrideTheme?.noDefault();
 
@@ -1628,7 +1644,6 @@ class ThemeData with Diagnosticable {
       highlightColor: highlightColor ?? this.highlightColor,
       hintColor: hintColor ?? this.hintColor,
       hoverColor: hoverColor ?? this.hoverColor,
-      indicatorColor: indicatorColor ?? this.indicatorColor,
       primaryColor: primaryColor ?? this.primaryColor,
       primaryColorDark: primaryColorDark ?? this.primaryColorDark,
       primaryColorLight: primaryColorLight ?? this.primaryColorLight,
@@ -1692,6 +1707,7 @@ class ThemeData with Diagnosticable {
       // DEPRECATED (newest deprecations at the bottom)
       buttonBarTheme: buttonBarTheme ?? _buttonBarTheme,
       dialogBackgroundColor: dialogBackgroundColor ?? this.dialogBackgroundColor,
+      indicatorColor: indicatorColor ?? this.indicatorColor,
     );
   }
 
@@ -1835,7 +1851,6 @@ class ThemeData with Diagnosticable {
       highlightColor: Color.lerp(a.highlightColor, b.highlightColor, t)!,
       hintColor: Color.lerp(a.hintColor, b.hintColor, t)!,
       hoverColor: Color.lerp(a.hoverColor, b.hoverColor, t)!,
-      indicatorColor: Color.lerp(a.indicatorColor, b.indicatorColor, t)!,
       primaryColor: Color.lerp(a.primaryColor, b.primaryColor, t)!,
       primaryColorDark: Color.lerp(a.primaryColorDark, b.primaryColorDark, t)!,
       primaryColorLight: Color.lerp(a.primaryColorLight, b.primaryColorLight, t)!,
@@ -1921,6 +1936,7 @@ class ThemeData with Diagnosticable {
       // DEPRECATED (newest deprecations at the bottom)
       buttonBarTheme: ButtonBarThemeData.lerp(a.buttonBarTheme, b.buttonBarTheme, t),
       dialogBackgroundColor: Color.lerp(a.dialogBackgroundColor, b.dialogBackgroundColor, t)!,
+      indicatorColor: Color.lerp(a.indicatorColor, b.indicatorColor, t)!,
     );
   }
 
@@ -1957,7 +1973,6 @@ class ThemeData with Diagnosticable {
         other.highlightColor == highlightColor &&
         other.hintColor == hintColor &&
         other.hoverColor == hoverColor &&
-        other.indicatorColor == indicatorColor &&
         other.primaryColor == primaryColor &&
         other.primaryColorDark == primaryColorDark &&
         other.primaryColorLight == primaryColorLight &&
@@ -2020,7 +2035,8 @@ class ThemeData with Diagnosticable {
         other.tooltipTheme == tooltipTheme &&
         // DEPRECATED (newest deprecations at the bottom)
         other.buttonBarTheme == buttonBarTheme &&
-        other.dialogBackgroundColor == dialogBackgroundColor;
+        other.dialogBackgroundColor == dialogBackgroundColor &&
+        other.indicatorColor == indicatorColor;
   }
 
   @override
@@ -2056,7 +2072,6 @@ class ThemeData with Diagnosticable {
       highlightColor,
       hintColor,
       hoverColor,
-      indicatorColor,
       primaryColor,
       primaryColorDark,
       primaryColorLight,
@@ -2120,6 +2135,7 @@ class ThemeData with Diagnosticable {
       // DEPRECATED (newest deprecations at the bottom)
       buttonBarTheme,
       dialogBackgroundColor,
+      indicatorColor,
     ];
     return Object.hashAll(values);
   }
@@ -2296,14 +2312,6 @@ class ThemeData with Diagnosticable {
         'hoverColor',
         hoverColor,
         defaultValue: defaultData.hoverColor,
-        level: DiagnosticLevel.debug,
-      ),
-    );
-    properties.add(
-      ColorProperty(
-        'indicatorColor',
-        indicatorColor,
-        defaultValue: defaultData.indicatorColor,
         level: DiagnosticLevel.debug,
       ),
     );
@@ -2758,6 +2766,14 @@ class ThemeData with Diagnosticable {
         'dialogBackgroundColor',
         dialogBackgroundColor,
         defaultValue: defaultData.dialogBackgroundColor,
+        level: DiagnosticLevel.debug,
+      ),
+    );
+    properties.add(
+      ColorProperty(
+        'indicatorColor',
+        indicatorColor,
+        defaultValue: defaultData.indicatorColor,
         level: DiagnosticLevel.debug,
       ),
     );

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -1473,13 +1473,11 @@ void main() {
     final TabController controller = TabController(vsync: const TestVSync(), length: tabs.length);
     addTearDown(controller.dispose);
 
-    const Color themeIndicatorColor = Color(0xffff0000);
     const Color tabBarThemeIndicatorColor = Color(0xffffff00);
 
-    Widget buildTabBar({Color? themeIndicatorColor, Color? tabBarThemeIndicatorColor}) {
+    Widget buildTabBar({Color? tabBarThemeIndicatorColor}) {
       return MaterialApp(
         theme: ThemeData(
-          indicatorColor: themeIndicatorColor,
           tabBarTheme: TabBarThemeData(indicatorColor: tabBarThemeIndicatorColor),
           useMaterial3: false,
         ),
@@ -1492,15 +1490,9 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(buildTabBar(themeIndicatorColor: themeIndicatorColor));
-
-    RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
-    expect(tabBarBox, paints..line(color: themeIndicatorColor));
-
     await tester.pumpWidget(buildTabBar(tabBarThemeIndicatorColor: tabBarThemeIndicatorColor));
-    await tester.pumpAndSettle();
 
-    tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
     expect(tabBarBox, paints..line(color: tabBarThemeIndicatorColor));
   });
 

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -893,14 +893,12 @@ void main() {
       canvasColor: Colors.black,
       cardColor: Colors.black,
       colorScheme: const ColorScheme.light(),
-      dialogBackgroundColor: Colors.black,
       disabledColor: Colors.black,
       dividerColor: Colors.black,
       focusColor: Colors.black,
       highlightColor: Colors.black,
       hintColor: Colors.black,
       hoverColor: Colors.black,
-      indicatorColor: Colors.black,
       primaryColor: Colors.black,
       primaryColorDark: Colors.black,
       primaryColorLight: Colors.black,
@@ -925,7 +923,6 @@ void main() {
         type: BottomNavigationBarType.fixed,
       ),
       bottomSheetTheme: const BottomSheetThemeData(backgroundColor: Colors.black),
-      buttonBarTheme: const ButtonBarThemeData(alignment: MainAxisAlignment.start),
       buttonTheme: const ButtonThemeData(colorScheme: ColorScheme.dark()),
       cardTheme: const CardThemeData(color: Colors.black),
       checkboxTheme: const CheckboxThemeData(),
@@ -980,6 +977,10 @@ void main() {
       timePickerTheme: const TimePickerThemeData(backgroundColor: Colors.black),
       toggleButtonsTheme: const ToggleButtonsThemeData(textStyle: TextStyle(color: Colors.black)),
       tooltipTheme: const TooltipThemeData(height: 100),
+      // DEPRECATED (newest deprecations at the bottom)
+      buttonBarTheme: const ButtonBarThemeData(alignment: MainAxisAlignment.start),
+      dialogBackgroundColor: Colors.black,
+      indicatorColor: Colors.black,
     );
 
     final SliderThemeData otherSliderTheme = SliderThemeData.fromPrimaryColors(
@@ -1018,19 +1019,16 @@ void main() {
       splashFactory: InkRipple.splashFactory,
       useMaterial3: true,
       visualDensity: VisualDensity.standard,
-
       // COLOR
       canvasColor: Colors.white,
       cardColor: Colors.white,
       colorScheme: const ColorScheme.light(),
-      dialogBackgroundColor: Colors.white,
       disabledColor: Colors.white,
       dividerColor: Colors.white,
       focusColor: Colors.white,
       highlightColor: Colors.white,
       hintColor: Colors.white,
       hoverColor: Colors.white,
-      indicatorColor: Colors.white,
       primaryColor: Colors.white,
       primaryColorDark: Colors.white,
       primaryColorLight: Colors.white,
@@ -1039,14 +1037,12 @@ void main() {
       shadowColor: Colors.white,
       splashColor: Colors.white,
       unselectedWidgetColor: Colors.white,
-
       // TYPOGRAPHY & ICONOGRAPHY
       iconTheme: ThemeData.light().iconTheme,
       primaryIconTheme: ThemeData.light().iconTheme,
       primaryTextTheme: ThemeData.light().textTheme,
       textTheme: ThemeData.light().textTheme,
       typography: Typography.material2018(platform: TargetPlatform.iOS),
-
       // COMPONENT THEMES
       actionIconTheme: const ActionIconThemeData(),
       appBarTheme: const AppBarTheme(backgroundColor: Colors.white),
@@ -1057,7 +1053,6 @@ void main() {
         type: BottomNavigationBarType.shifting,
       ),
       bottomSheetTheme: const BottomSheetThemeData(backgroundColor: Colors.white),
-      buttonBarTheme: const ButtonBarThemeData(alignment: MainAxisAlignment.end),
       buttonTheme: const ButtonThemeData(colorScheme: ColorScheme.light()),
       cardTheme: const CardThemeData(color: Colors.white),
       checkboxTheme: const CheckboxThemeData(),
@@ -1102,6 +1097,10 @@ void main() {
       timePickerTheme: const TimePickerThemeData(backgroundColor: Colors.white),
       toggleButtonsTheme: const ToggleButtonsThemeData(textStyle: TextStyle(color: Colors.white)),
       tooltipTheme: const TooltipThemeData(height: 100),
+      // DEPRECATED (newest deprecations at the bottom)
+      buttonBarTheme: const ButtonBarThemeData(alignment: MainAxisAlignment.end),
+      dialogBackgroundColor: Colors.white,
+      indicatorColor: Colors.white,
     );
 
     final ThemeData themeDataCopy = theme.copyWith(
@@ -1123,19 +1122,16 @@ void main() {
       splashFactory: otherTheme.splashFactory,
       useMaterial3: otherTheme.useMaterial3,
       visualDensity: otherTheme.visualDensity,
-
       // COLOR
       canvasColor: otherTheme.canvasColor,
       cardColor: otherTheme.cardColor,
       colorScheme: otherTheme.colorScheme,
-      dialogBackgroundColor: otherTheme.dialogBackgroundColor,
       disabledColor: otherTheme.disabledColor,
       dividerColor: otherTheme.dividerColor,
       focusColor: otherTheme.focusColor,
       highlightColor: otherTheme.highlightColor,
       hintColor: otherTheme.hintColor,
       hoverColor: otherTheme.hoverColor,
-      indicatorColor: otherTheme.indicatorColor,
       primaryColor: otherTheme.primaryColor,
       primaryColorDark: otherTheme.primaryColorDark,
       primaryColorLight: otherTheme.primaryColorLight,
@@ -1144,14 +1140,12 @@ void main() {
       shadowColor: otherTheme.shadowColor,
       splashColor: otherTheme.splashColor,
       unselectedWidgetColor: otherTheme.unselectedWidgetColor,
-
       // TYPOGRAPHY & ICONOGRAPHY
       iconTheme: otherTheme.iconTheme,
       primaryIconTheme: otherTheme.primaryIconTheme,
       primaryTextTheme: otherTheme.primaryTextTheme,
       textTheme: otherTheme.textTheme,
       typography: otherTheme.typography,
-
       // COMPONENT THEMES
       actionIconTheme: otherTheme.actionIconTheme,
       appBarTheme: otherTheme.appBarTheme,
@@ -1160,7 +1154,6 @@ void main() {
       bottomAppBarTheme: otherTheme.bottomAppBarTheme,
       bottomNavigationBarTheme: otherTheme.bottomNavigationBarTheme,
       bottomSheetTheme: otherTheme.bottomSheetTheme,
-      buttonBarTheme: otherTheme.buttonBarTheme,
       buttonTheme: otherTheme.buttonTheme,
       cardTheme: otherTheme.cardTheme,
       checkboxTheme: otherTheme.checkboxTheme,
@@ -1197,6 +1190,10 @@ void main() {
       timePickerTheme: otherTheme.timePickerTheme,
       toggleButtonsTheme: otherTheme.toggleButtonsTheme,
       tooltipTheme: otherTheme.tooltipTheme,
+      // DEPRECATED (newest deprecations at the bottom)
+      buttonBarTheme: otherTheme.buttonBarTheme,
+      dialogBackgroundColor: otherTheme.dialogBackgroundColor,
+      indicatorColor: otherTheme.indicatorColor,
     );
 
     // For the sanity of the reader, make sure these properties are in the same
@@ -1217,19 +1214,16 @@ void main() {
     expect(themeDataCopy.splashFactory, equals(otherTheme.splashFactory));
     expect(themeDataCopy.useMaterial3, equals(otherTheme.useMaterial3));
     expect(themeDataCopy.visualDensity, equals(otherTheme.visualDensity));
-
     // COLOR
     expect(themeDataCopy.canvasColor, equals(otherTheme.canvasColor));
     expect(themeDataCopy.cardColor, equals(otherTheme.cardColor));
     expect(themeDataCopy.colorScheme, equals(otherTheme.colorScheme));
-    expect(themeDataCopy.dialogBackgroundColor, equals(otherTheme.dialogBackgroundColor));
     expect(themeDataCopy.disabledColor, equals(otherTheme.disabledColor));
     expect(themeDataCopy.dividerColor, equals(otherTheme.dividerColor));
     expect(themeDataCopy.focusColor, equals(otherTheme.focusColor));
     expect(themeDataCopy.highlightColor, equals(otherTheme.highlightColor));
     expect(themeDataCopy.hintColor, equals(otherTheme.hintColor));
     expect(themeDataCopy.hoverColor, equals(otherTheme.hoverColor));
-    expect(themeDataCopy.indicatorColor, equals(otherTheme.indicatorColor));
     expect(themeDataCopy.primaryColor, equals(otherTheme.primaryColor));
     expect(themeDataCopy.primaryColorDark, equals(otherTheme.primaryColorDark));
     expect(themeDataCopy.primaryColorLight, equals(otherTheme.primaryColorLight));
@@ -1238,14 +1232,12 @@ void main() {
     expect(themeDataCopy.shadowColor, equals(otherTheme.shadowColor));
     expect(themeDataCopy.splashColor, equals(otherTheme.splashColor));
     expect(themeDataCopy.unselectedWidgetColor, equals(otherTheme.unselectedWidgetColor));
-
     // TYPOGRAPHY & ICONOGRAPHY
     expect(themeDataCopy.iconTheme, equals(otherTheme.iconTheme));
     expect(themeDataCopy.primaryIconTheme, equals(otherTheme.primaryIconTheme));
     expect(themeDataCopy.primaryTextTheme, equals(otherTheme.primaryTextTheme));
     expect(themeDataCopy.textTheme, equals(otherTheme.textTheme));
     expect(themeDataCopy.typography, equals(otherTheme.typography));
-
     // COMPONENT THEMES
     expect(themeDataCopy.actionIconTheme, equals(otherTheme.actionIconTheme));
     expect(themeDataCopy.appBarTheme, equals(otherTheme.appBarTheme));
@@ -1254,7 +1246,6 @@ void main() {
     expect(themeDataCopy.bottomAppBarTheme, equals(otherTheme.bottomAppBarTheme));
     expect(themeDataCopy.bottomNavigationBarTheme, equals(otherTheme.bottomNavigationBarTheme));
     expect(themeDataCopy.bottomSheetTheme, equals(otherTheme.bottomSheetTheme));
-    expect(themeDataCopy.buttonBarTheme, equals(otherTheme.buttonBarTheme));
     expect(themeDataCopy.buttonTheme, equals(otherTheme.buttonTheme));
     expect(themeDataCopy.cardTheme, equals(otherTheme.cardTheme));
     expect(themeDataCopy.checkboxTheme, equals(otherTheme.checkboxTheme));
@@ -1302,6 +1293,10 @@ void main() {
     expect(themeDataCopy.timePickerTheme, equals(otherTheme.timePickerTheme));
     expect(themeDataCopy.toggleButtonsTheme, equals(otherTheme.toggleButtonsTheme));
     expect(themeDataCopy.tooltipTheme, equals(otherTheme.tooltipTheme));
+    // DEPRECATED (newest deprecations at the bottom)
+    expect(themeDataCopy.buttonBarTheme, equals(otherTheme.buttonBarTheme));
+    expect(themeDataCopy.dialogBackgroundColor, equals(otherTheme.dialogBackgroundColor));
+    expect(themeDataCopy.indicatorColor, equals(otherTheme.indicatorColor));
   });
 
   testWidgets('ThemeData.toString has less than 200 characters output', (
@@ -1383,8 +1378,6 @@ void main() {
       'unselectedWidgetColor',
       'disabledColor',
       'secondaryHeaderColor',
-      'dialogBackgroundColor',
-      'indicatorColor',
       'hintColor',
       // TYPOGRAPHY & ICONOGRAPHY
       'typography',
@@ -1400,7 +1393,6 @@ void main() {
       'bottomAppBarTheme',
       'bottomNavigationBarTheme',
       'bottomSheetTheme',
-      'buttonBarTheme',
       'buttonTheme',
       'cardTheme',
       'checkboxTheme',
@@ -1439,6 +1431,10 @@ void main() {
       'timePickerTheme',
       'toggleButtonsTheme',
       'tooltipTheme',
+      // DEPRECATED (newest deprecations at the bottom)
+      'buttonBarTheme',
+      'dialogBackgroundColor',
+      'indicatorColor',
     };
 
     final DiagnosticPropertiesBuilder properties = DiagnosticPropertiesBuilder();

--- a/packages/flutter/test_fixes/material/theme_data.dart
+++ b/packages/flutter/test_fixes/material/theme_data.dart
@@ -327,4 +327,18 @@ void main() {
     dialogTheme: DialogThemeData(backgroundColor: Colors.red),
   );
   themeData.dialogBackgroundColor; // Removing field reference not supported.
+
+  // Changes made in https://github.com/flutter/flutter/pull/160024
+  ThemeData themeData = ThemeData();
+  themeData = ThemeData(indicatorColor: Colors.red);
+  themeData = ThemeData(
+    indicatorColor: Colors.red,
+    tabBarTheme: TabBarThemeData(indicatorColor: Colors.green),
+  );
+  themeData = themeData.copyWith(indicatorColor: Colors.red);
+  themeData = themeData.copyWith(
+    indicatorColor: Colors.red,
+    tabBarTheme: TabBarThemeData(indicatorColor: Colors.green),
+  );
+  themeData.indicatorColor; // Removing field reference not supported.
 }

--- a/packages/flutter/test_fixes/material/theme_data.dart.expect
+++ b/packages/flutter/test_fixes/material/theme_data.dart.expect
@@ -405,8 +405,12 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/160024
   ThemeData themeData = ThemeData();
   themeData = ThemeData(tabBarTheme: TabBarThemeData(indicatorColor: Colors.red));
-  themeData = ThemeData(tabBarTheme: TabBarThemeData(indicatorColor: Colors.green));
+  themeData = ThemeData(
+    tabBarTheme: TabBarThemeData(indicatorColor: Colors.green),
+  );
   themeData = themeData.copyWith(tabBarTheme: TabBarThemeData(indicatorColor: Colors.red));
-  themeData = themeData.copyWith(tabBarTheme: TabBarThemeData(indicatorColor: Colors.green));
+  themeData = themeData.copyWith(
+    tabBarTheme: TabBarThemeData(indicatorColor: Colors.green),
+  );
   themeData.indicatorColor; // Removing field reference not supported.
 }

--- a/packages/flutter/test_fixes/material/theme_data.dart.expect
+++ b/packages/flutter/test_fixes/material/theme_data.dart.expect
@@ -401,4 +401,12 @@ void main() {
     dialogTheme: DialogThemeData(backgroundColor: Colors.red),
   );
   themeData.dialogBackgroundColor; // Removing field reference not supported.
+
+  // Changes made in https://github.com/flutter/flutter/pull/160024
+  ThemeData themeData = ThemeData();
+  themeData = ThemeData(tabBarTheme: TabBarThemeData(indicatorColor: Colors.red));
+  themeData = ThemeData(tabBarTheme: TabBarThemeData(indicatorColor: Colors.green));
+  themeData = themeData.copyWith(tabBarTheme: TabBarThemeData(indicatorColor: Colors.red));
+  themeData = themeData.copyWith(tabBarTheme: TabBarThemeData(indicatorColor: Colors.green));
+  themeData.indicatorColor; // Removing field reference not supported.
 }


### PR DESCRIPTION
Related to [☂️ Material Theme System Updates](https://github.com/flutter/flutter/issues/91772)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
