### PR TITLE
Don't throw `StateError` when listing core devices during tool shutdown

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -47,7 +47,6 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
       _platform = platform,
       super(delegate);
 
-  @visibleForTesting
   FileSystem get fileSystem => delegate;
 
   final Platform _platform;

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -7,7 +7,6 @@ import 'dart:io' as io show Directory, File, Link, Process, ProcessException, Pr
 import 'dart:typed_data';
 
 import 'package:file/file.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p; // flutter_ignore: package_path_import
 import 'package:process/process.dart';
 

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -9,18 +9,16 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/ios/core_devices.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
 
-class LocalFileSystemFake extends LocalFileSystem {
-  LocalFileSystemFake.test({required super.signals}) : super.test();
-
+class LocalFileSystemFake extends Fake implements LocalFileSystem {
   MemoryFileSystem memoryFileSystem = MemoryFileSystem.test();
 
   @override
@@ -31,6 +29,19 @@ class LocalFileSystemFake extends LocalFileSystem {
 
   @override
   File file(dynamic path) => memoryFileSystem.file(path);
+
+  @override
+  Context get path => memoryFileSystem.path;
+
+  @override
+  Future<void> dispose() async {
+    _disposed = true;
+  }
+
+  @override
+  bool get disposed => _disposed;
+
+  bool _disposed = false;
 }
 
 void main() {
@@ -1419,7 +1430,7 @@ invalid JSON
       });
 
       testWithoutContext('Handles file system disposal', () async {
-        final LocalFileSystem localFs = LocalFileSystemFake.test(signals: Signals.test());
+        final LocalFileSystem localFs = LocalFileSystemFake();
         final ErrorHandlingFileSystem fs = ErrorHandlingFileSystem(delegate: localFs, platform: FakePlatform());
         deviceControl = IOSCoreDeviceControl(
           logger: logger,

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -25,6 +25,12 @@ class LocalFileSystemFake extends LocalFileSystem {
 
   @override
   Directory get systemTempDirectory => memoryFileSystem.systemTempDirectory;
+
+  @override
+  Directory directory(dynamic path) => memoryFileSystem.directory(path);
+
+  @override
+  File file(dynamic path) => memoryFileSystem.file(path);
 }
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -4,9 +4,11 @@
 
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/ios/core_devices.dart';
@@ -1412,11 +1414,12 @@ invalid JSON
 
       testWithoutContext('Handles file system disposal', () async {
         final LocalFileSystem localFs = LocalFileSystemFake.test(signals: Signals.test());
+        final ErrorHandlingFileSystem fs = ErrorHandlingFileSystem(delegate: localFs, platform: FakePlatform());
         deviceControl = IOSCoreDeviceControl(
           logger: logger,
           processManager: fakeProcessManager,
           xcode: xcode,
-          fileSystem: localFs,
+          fileSystem: fs,
         );
         final Directory tempDir = localFs.systemTempDirectory
             .childDirectory('core_devices.rand0');


### PR DESCRIPTION
The previous attempt at this fix was assuming that the tool's file system was a `LocalFileSystem`, but in reality it's a `LocalFileSystem` wrapped in an `ErrorHandlingFileSystem`. This change takes this into account.

Fixes https://github.com/flutter/flutter/issues/160082 
Fixes https://github.com/flutter/flutter/issues/156962