### PR TITLE
Framework calls setSemanticsTreeEnabled

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -366,6 +366,18 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     }
   }
 
+  @override
+  void scheduleInitialSemantics() {
+    super.scheduleInitialSemantics();
+    _view.setSemanticsTreeEnabled(true);
+  }
+
+  @override
+  void clearSemantics() {
+    _view.setSemanticsTreeEnabled(false);
+    super.clearSemantics();
+  }
+
   /// Sends the provided [ui.SemanticsUpdate] to the [ui.FlutterView] associated with
   /// this [RenderView].
   ///
@@ -374,6 +386,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   void updateSemantics(ui.SemanticsUpdate update) {
     _view.updateSemantics(update);
   }
+
 
   void _updateSystemChrome() {
     // Take overlay style from the place where a system status bar and system

--- a/packages/flutter/test/rendering/view_test.dart
+++ b/packages/flutter/test/rendering/view_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -165,6 +167,22 @@ void main() {
     );
     expect(view2.constraints, constraints);
   });
+
+  test('schedule semantics and clear semantics calls setSemanticsTreeEnabled', () {
+    final FlutterView view = RendererBinding.instance.platformDispatcher.views.single;
+    final TestPlatformDispatcher dispatcher = TestPlatformDispatcher(platformDispatcher: view.platformDispatcher);
+    final TestDisplay display = TestDisplay(dispatcher, view.display);
+    final FlutterViewSpy spy = FlutterViewSpy(view: view, platformDispatcher: dispatcher, display: display);
+    final RenderView renderView = RenderView(
+      view: spy,
+    );
+    expect(spy.enabled, isNull);
+
+    renderView.scheduleInitialSemantics();
+    expect(spy.enabled, isTrue);
+    renderView.clearSemantics();
+    expect(spy.enabled, isFalse);
+  });
 }
 
 const Color orange = Color(0xFFFF9000);
@@ -184,5 +202,18 @@ class TestRenderObject extends RenderBox {
       orangeRect,
       Paint()..color = orange,
     );
+  }
+}
+
+class FlutterViewSpy extends TestFlutterView  {
+  FlutterViewSpy({
+    required super.view,
+    required super.platformDispatcher,
+    required super.display,
+  });
+  bool? enabled;
+  @override
+  void setSemanticsTreeEnabled(bool enabled) {
+    this.enabled = enabled;
   }
 }


### PR DESCRIPTION
engine https://github.com/flutter/engine/pull/56691

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
