### PR TITLE
Adds a new Widget Inspector API: `getSelectedLocalWidget`

### DIFF
--- a/packages/flutter/lib/src/widgets/service_extensions.dart
+++ b/packages/flutter/lib/src/widgets/service_extensions.dart
@@ -446,6 +446,19 @@ enum WidgetInspectorServiceExtensions {
   getSelectedWidget,
 
   /// Name of service extension that, when called, will return the
+  /// [DiagnosticsNode] data for the currently selected [Element] or the first
+  /// ancestor of that widget which was created in the local project.
+  ///
+  /// See also:
+  ///
+  /// * [WidgetInspectorServiceExtensions.getSelectedWidget], which returns the
+  ///    currently selected widget, regardless of whether or not it was created
+  ///    in the local project.
+  /// * [WidgetInspectorService.initServiceExtensions], where the service
+  ///   extension is registered.
+  getSelectedLocalWidget,
+
+  /// Name of service extension that, when called, will return the
   /// [DiagnosticsNode] data for the currently selected [Element] in the summary
   /// tree, which only includes [Element]s created in user code.
   ///

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2124,6 +2124,13 @@ mixin WidgetInspectorService {
     return _safeJsonEncode(_getSelectedWidget(null, groupName));
   }
 
+  /// Returns a [DiagnosticsNode] representing the currently selected [Element]
+  /// if it was created by the local project, or its nearest ancestor that was.
+  @protected
+  String getSelectedLocalWidget(String groupName) {
+    return _safeJsonEncode(_getSelectedLocalWidget(null, groupName));
+  }
+
   /// Captures an image of the current state of an [object] that is a
   /// [RenderObject] or [Element].
   ///


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8626

When DevTools is notified that a selection change has occurred (i.e., a user has selected a widget using the on-device widget inspector), it then sends a request to Flutter to get the selected widget (`getSelectedWidget`). 

This PR adds a new API that DevTools can call (`getSelectedLocalWidget`) when implementation widgets are hidden in the tree. `getSelectedLocalWidget` will return the currently selected widget if it was created in the user's project, or will return the nearest ancestor of the currently selected widget if its an implementation widget.

After this has landed, we can follow up with the necessary DevTools change (Draft PR here: https://github.com/flutter/devtools/pull/8625)