### PR TITLE
Use the VM service to proxy `goldenComparator` for integration testing

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -137,6 +137,16 @@ Future<void> run(List<String> args) async {
     }
 
     // TODO(dnfield): This should be injected.
+    final BuildInfo buildInfo = BuildInfo(
+      BuildMode.debug,
+      '',
+      treeShakeIcons: false,
+      packageConfigPath: globals.fs.path.normalize(
+        globals.fs.path.absolute(
+          argResults[_kOptionPackages] as String,
+        ),
+      ),
+    );
     exitCode = await const FlutterTestRunner().runTests(
       const TestWrapper(),
       tests.keys.map(Uri.file).toList(),
@@ -159,6 +169,7 @@ Future<void> run(List<String> args) async {
       icudtlPath: globals.fs.path.absolute(argResults[_kOptionIcudtl] as String),
       coverageDirectory: coverageDirectory,
       nativeAssetsBuilder: const TestCompilerNativeAssetsBuilderImpl(),
+      buildInfo: buildInfo,
     );
 
     if (collector != null) {

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:async/async.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:process/process.dart';
@@ -368,6 +369,7 @@ class FlutterPlatform extends PlatformPlugin {
   final String? integrationTestUserIdentifier;
 
   final FontConfigManager _fontConfigManager = FontConfigManager();
+  final AsyncMemoizer<void> _closeMemo = AsyncMemoizer<void>();
 
   /// The test compiler produces dill files for each test main.
   ///
@@ -776,14 +778,11 @@ class FlutterPlatform extends PlatformPlugin {
   }
 
   @override
-  Future<dynamic> close() async {
-    if (compiler != null) {
-      await compiler!.dispose();
-      compiler = null;
-    }
+  Future<void> close() => _closeMemo.runOnce(() async {
+    await compiler?.dispose();
     await _testGoldenComparator.close();
     await _fontConfigManager.dispose();
-  }
+  });
 }
 
 // The [_shellProcessClosed] future can't have errors thrown on it because it

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -63,7 +63,7 @@ abstract class FlutterTestRunner {
     String? integrationTestUserIdentifier,
     TestTimeRecorder? testTimeRecorder,
     TestCompilerNativeAssetsBuilder? nativeAssetsBuilder,
-    BuildInfo? buildInfo,
+    required BuildInfo buildInfo,
   });
 
   /// Runs tests using the experimental strategy of spawning each test in a
@@ -130,7 +130,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     String? integrationTestUserIdentifier,
     TestTimeRecorder? testTimeRecorder,
     TestCompilerNativeAssetsBuilder? nativeAssetsBuilder,
-    BuildInfo? buildInfo,
+    required BuildInfo buildInfo,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts!.getArtifactPath(Artifact.flutterTester);
@@ -259,6 +259,9 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       testTimeRecorder: testTimeRecorder,
       nativeAssetsBuilder: nativeAssetsBuilder,
       buildInfo: buildInfo,
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      processManager: globals.processManager,
     );
 
     try {

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -45,6 +45,10 @@ void main() {
           hostVmServicePort: 1234,
         ),
         enableVmService: false,
+        buildInfo: BuildInfo.debug,
+        fileSystem: fileSystem,
+        processManager: globals.processManager,
+        logger: globals.logger,
       );
       flutterPlatform.loadChannel('test1.dart', fakeSuitePlatform);
 
@@ -61,6 +65,10 @@ void main() {
         shellPath: '/',
         precompiledDillPath: 'example.dill',
         enableVmService: false,
+        buildInfo: BuildInfo.debug,
+        fileSystem: fileSystem,
+        processManager: globals.processManager,
+        logger: globals.logger,
       );
       flutterPlatform.loadChannel('test1.dart', fakeSuitePlatform);
 
@@ -80,6 +88,10 @@ void main() {
         flutterProject: _FakeFlutterProject(),
         host: InternetAddress.anyIPv4,
         updateGoldens: false,
+        buildInfo: BuildInfo.debug,
+        fileSystem: fileSystem,
+        processManager: globals.processManager,
+        logger: globals.logger,
       );
 
       await expectLater(
@@ -111,6 +123,10 @@ void main() {
         host: InternetAddress.anyIPv4,
         updateGoldens: false,
         shutdownHooks: shutdownHooks,
+        buildInfo: BuildInfo.debug,
+        fileSystem: fileSystem,
+        processManager: globals.processManager,
+        logger: globals.logger,
       );
 
       await expectLater(
@@ -134,6 +150,10 @@ void main() {
           BuildInfo.debug,
           startPaused: true,
         ),
+        buildInfo: BuildInfo.debug,
+        fileSystem: fileSystem,
+        processManager: globals.processManager,
+        logger: globals.logger,
       ), throwsAssertionError);
 
       expect(() => installHook(
@@ -143,6 +163,10 @@ void main() {
           startPaused: true,
           hostVmServicePort: 123,
         ),
+        buildInfo: BuildInfo.debug,
+        fileSystem: fileSystem,
+        processManager: globals.processManager,
+        logger: globals.logger,
       ), throwsAssertionError);
 
       FlutterPlatform? capturedPlatform;
@@ -166,6 +190,10 @@ void main() {
         platformPluginRegistration: (FlutterPlatform platform) {
           capturedPlatform = platform;
         },
+        buildInfo: BuildInfo.debug,
+        fileSystem: fileSystem,
+        processManager: globals.processManager,
+        logger: globals.logger,
       );
 
       expect(identical(capturedPlatform, flutterPlatform), equals(true));

--- a/packages/integration_test/example/integration_test/matches_golden_test.dart
+++ b/packages/integration_test/example/integration_test/matches_golden_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:integration_test_example/main.dart' as app;
+
+/// To run:
+/// 
+/// ```sh
+/// # Be in this directory
+/// cd dev/packages/integration_test/example
+/// 
+/// flutter test integration_test/matches_golden_test.dart
+/// ```
+/// 
+/// To run on a particular device, see `flutter -d`.
+void main() {
+  // Used in order to skip actually checking the file and just going through the motions.
+  autoUpdateGoldenFiles = true;
+
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  VmServiceProxyGoldenFileComparator.useIfRunningOnDevice();
+
+  testWidgets('can use matchesGoldenFile with integration_test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    app.main();
+    await tester.pumpAndSettle();
+
+    // Take a screenshot.
+    await expectLater(
+      find.byType(MaterialApp),
+      matchesGoldenFile('integration_test_matches_golden_file.png'),
+    );
+  });
+}

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -24,6 +24,8 @@ import 'src/callback.dart' as driver_actions;
 import 'src/channel.dart';
 import 'src/extension.dart';
 
+export 'src/vm_service_golden_client.dart';
+
 const String _success = 'success';
 
 /// Whether results should be reported to the native side over the method

--- a/packages/integration_test/lib/src/vm_service_golden_client.dart
+++ b/packages/integration_test/lib/src/vm_service_golden_client.dart
@@ -1,0 +1,174 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer' as dev;
+import 'dart:io' as io;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
+
+/// Compares image pixels against a golden image file on the host system.
+///
+/// This comparator will send a request, using the VM service protocol, to a
+/// host script (i.e. the _driver_ script, running in a Dart VM on the host
+/// desktop OS), which will then forward the comparison to a concrete
+/// [GoldenFileComparator].
+///
+/// To use, run [useIfRunningOnDevice] in the `main()` of a test file or similar:
+///
+/// ```dart
+/// import 'package:integration_test/integration_test.dart';
+///
+/// void main() {
+///   VmServiceProxyGoldenFileComparator.useIfRunningOnDevice();
+///
+///   // Actual tests and such below.
+/// }
+/// ```
+///
+/// When either [compare] or [update] is called, the following event is sent
+/// with [dev.postEvent]:
+///
+/// ```dart
+/// postEvent('compare' /* or 'update' */, {
+///   'id':    1001,                 // a valid unique integer, often incrementing;
+///   'path':  'path/to/image.png',  // golden key created by matchesGoldenFile;
+///   'bytes': '...base64encoded',   // base64 encoded bytes representing the current image.
+/// }, stream: 'integration_test.VmServiceProxyGoldenFileComparator');
+/// ```
+///
+/// The comparator expects a response at the service extension
+/// `ext.integration_test.VmServiceProxyGoldenFileComparator` that is either
+/// of the following formats:
+///
+/// ```dart
+/// {
+///   'error': 'Description of why the operation failed'
+/// }
+/// ```
+///
+/// or:
+///
+/// ```dart
+/// {
+///   'result': true /* or possibly false, in the case of 'compare' calls */
+/// }
+/// ```
+///
+/// See also:
+///
+///   * [matchesGoldenFile], the function that invokes the comparator.
+@experimental
+final class VmServiceProxyGoldenFileComparator extends GoldenFileComparator {
+  VmServiceProxyGoldenFileComparator._() {
+    dev.registerExtension(_kServiceName, _postEventResponseHandler);
+  }
+
+  static bool get _isRunningOnHost {
+    if (kIsWeb) {
+      return false;
+    }
+    return !io.Platform.isAndroid && !io.Platform.isIOS;
+  }
+
+  static void _assertNotRunningOnFuchsia() {
+    if (!kIsWeb && io.Platform.isFuchsia) {
+      throw UnsupportedError('Fuchsia is not supported');
+    }
+  }
+
+  /// Conditionally sets [goldenFileComparator] to [VmServiceProxyGoldenFileComparator].
+  ///
+  /// If running on a non-mobile non-web platform (i.e. desktop), this method has no effect.
+  static void useIfRunningOnDevice() {
+    if (_isRunningOnHost) {
+      return;
+    }
+    _assertNotRunningOnFuchsia();
+    goldenFileComparator = _kInstance;
+  }
+
+  static final GoldenFileComparator _kInstance = VmServiceProxyGoldenFileComparator._();
+  static const String _kServiceName = 'ext.$_kEventName';
+  static const String _kEventName = 'integration_test.VmServiceProxyGoldenFileComparator';
+
+  Future<dev.ServiceExtensionResponse> _postEventResponseHandler(
+    String method,
+    Map<String, String> parameters,
+  ) async {
+    // Treat the method as the ID number of the pending request.
+    final int? methodId = int.tryParse(method);
+    if (methodId == null) {
+      return dev.ServiceExtensionResponse.error(
+        dev.ServiceExtensionResponse.extensionError,
+        'Not a valid (integer) method (id): "$method".',
+      );
+    }
+    final Completer<bool>? completer = _pendingRequests[methodId];
+    if (completer == null) {
+      return dev.ServiceExtensionResponse.error(
+        dev.ServiceExtensionResponse.extensionError,
+        'No pending request with method ID "$method".',
+      );
+    }
+    if (completer.isCompleted) {
+      return dev.ServiceExtensionResponse.error(
+        dev.ServiceExtensionResponse.extensionError,
+        'Result already received for method ID "$method".',
+      );
+    }
+    final String? error = parameters['error'];
+    if (error != null) {
+      completer.completeError(error);
+      return dev.ServiceExtensionResponse.result('{}');
+    }
+    final String? result = parameters['result'];
+    if (result == null) {
+      return dev.ServiceExtensionResponse.error(
+        dev.ServiceExtensionResponse.invalidParams,
+        'Required parameter "result" not present in response.',
+      );
+    }
+    if (bool.tryParse(result) case final bool result) {
+      completer.complete(result);
+      return dev.ServiceExtensionResponse.result('{}');
+    } else {
+      return dev.ServiceExtensionResponse.error(
+        dev.ServiceExtensionResponse.invalidParams,
+        'Required parameter "result" not a valid boolean: "$result".',
+      );
+    }
+  }
+
+  int _nextId = 0;
+  final Map<int, Completer<bool>> _pendingRequests = <int, Completer<bool>>{};
+
+  Future<bool> _postAndWait(Uint8List imageBytes, Uri golden, {required String operation}) async {
+    final int nextId = ++_nextId;
+    assert(!_pendingRequests.containsKey(nextId));
+
+    final Completer<bool> completer = Completer<bool>();
+    dev.postEvent(operation, <String, Object?>{
+      'id': nextId,
+      'path': '$golden',
+      'bytes': base64.encode(imageBytes),
+    }, stream: _kEventName);
+
+    _pendingRequests[nextId] = completer;
+    return completer.future;
+  }
+
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+    return _postAndWait(imageBytes, golden, operation: 'compare');
+  }
+
+  @override
+  Future<void> update(Uri golden, Uint8List imageBytes) async {
+    await _postAndWait(imageBytes, golden, operation: 'update');
+  }
+}

--- a/packages/integration_test/lib/src/vm_service_golden_client.dart
+++ b/packages/integration_test/lib/src/vm_service_golden_client.dart
@@ -152,6 +152,7 @@ final class VmServiceProxyGoldenFileComparator extends GoldenFileComparator {
     assert(!_pendingRequests.containsKey(nextId));
 
     final Completer<bool> completer = Completer<bool>();
+    print('>>> Posting $nextId|$golden|${imageBytes.length} bytes');
     dev.postEvent(operation, <String, Object?>{
       'id': nextId,
       'path': '$golden',


### PR DESCRIPTION
Prospective implementation, as a proof of concept, for https://github.com/flutter/flutter/issues/160043.

This re-uses `TestGoldenComparator`, which was written for Flutter Web (which, similar to Android and iOS, can't do golden-file comparisons on "device"), but this time would apply them to Android and iOS builds as well (though in this PR, no conditional logic is applied).

What works:

- The client (device) sends events to the VM service
- The host (`flutter_tools` CLI) listens on the VM service 

What doesn't:

- The host (`flutter_tools` CLI) doesn't get the event the client sent

The console output at the current commit looks like this:

```txt
✓ Built build/app/outputs/flutter-apk/app-debug.apk
Installing build/app/outputs/flutter-apk/app-debug.apk...          661ms
_handleStartedDevice(http://127.0.0.1:49570/_CTw0sDgEv4=/, 0)
Connecting
Listening
00:13 +0: can use matchesGoldenFile with integration_test                                                                                                                                                                                             
>>> Posting 1|integration_test_matches_golden_file.png|37911 bytes

(nothing else ever happens until timeout)
```

I'm perhaps doing something wrong, so I'll get some help tomorrow.