### PR TITLE
🐛 [tool] Do not handle directory arguments implicitly for `pub` commands

### DIFF
--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -234,7 +234,7 @@ class PackagesGetCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    List<String> rest = argResults!.rest;
+    final List<String> rest = argResults!.rest;
     bool isHelp = false;
     bool example = true;
     bool exampleWasParsed = false;
@@ -254,30 +254,12 @@ class PackagesGetCommand extends FlutterCommand {
     FlutterProject? rootProject;
 
     if (!isHelp) {
-      if (name == 'get' &&
-          directoryOption == null &&
-          rest.length == 1 &&
-          // Anything that looks like an argument should not be interpreted as
-          // a directory.
-          !rest.single.startsWith('-')) {
-        globals.printWarning('''
-  Using a naked argument for directory is deprecated and will stop working in a future Flutter release.
-  (${rest.single})
-
-  Use --directory instead.''');
-        target = findProjectRoot(globals.fs, rest.single);
-        if (target == null) {
-          throwToolExit('Expected to find project root in ${rest.single}.');
-        }
-        rest = <String>[];
-      } else {
-        target = findProjectRoot(globals.fs, directoryOption);
-        if (target == null) {
-          if (directoryOption == null) {
-            throwToolExit('Expected to find project root in current working directory.');
-          } else {
-            throwToolExit('Expected to find project root in $directoryOption.');
-          }
+      target = findProjectRoot(globals.fs, directoryOption);
+      if (target == null) {
+        if (directoryOption == null) {
+          throwToolExit('Expected to find project root in current working directory.');
+        } else {
+          throwToolExit('Expected to find project root in $directoryOption.');
         }
       }
 

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -260,12 +260,12 @@ class PackagesGetCommand extends FlutterCommand {
           // Anything that looks like an argument should not be interpreted as
           // a directory.
           !rest.single.startsWith('-')) {
-        target = findProjectRoot(globals.fs, rest.single);
-
         globals.printWarning('''
   Using a naked argument for directory is deprecated and will stop working in a future Flutter release.
+  (${rest.single})
 
   Use --directory instead.''');
+        target = findProjectRoot(globals.fs, rest.single);
         if (target == null) {
           throwToolExit('Expected to find project root in ${rest.single}.');
         }

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -238,7 +238,7 @@ class PackagesGetCommand extends FlutterCommand {
     //  * foo:{"hosted":"my-pub.dev"}
     //  * foo:{"sdk":"flutter"}
     //  * foo:{"git":"https://github.com/foo/foo"}
-    if (RegExp(r':\{.*}').hasMatch(arg)) {
+    if (name == 'add' && RegExp(r':\{.*}').hasMatch(arg)) {
       return false;
     }
     // For historical reasons, if there is one argument to the command and it

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -232,21 +232,6 @@ class PackagesGetCommand extends FlutterCommand {
     return argParser;
   }
 
-  bool _validDirectoryArg(String arg) {
-    // Handles `pub add`: it accepts below formats of the argument:
-    //  * foo:{"path":"../foo"}
-    //  * foo:{"hosted":"my-pub.dev"}
-    //  * foo:{"sdk":"flutter"}
-    //  * foo:{"git":"https://github.com/foo/foo"}
-    if (name == 'add' && RegExp(r':\{.*}').hasMatch(arg)) {
-      return false;
-    }
-    // For historical reasons, if there is one argument to the command and it
-    // contains a multiple-component path (i.e. contains a slash) then we use
-    // that to determine to which project we're applying the command.
-    return arg.contains('/') || arg.contains(r'\');
-  }
-
   @override
   Future<FlutterCommandResult> runCommand() async {
     List<String> rest = argResults!.rest;
@@ -269,12 +254,12 @@ class PackagesGetCommand extends FlutterCommand {
     FlutterProject? rootProject;
 
     if (!isHelp) {
-      if (directoryOption == null &&
+      if (name == 'get' &&
+          directoryOption == null &&
           rest.length == 1 &&
           // Anything that looks like an argument should not be interpreted as
           // a directory.
-          !rest.single.startsWith('-') &&
-          (_validDirectoryArg(rest.single) || name == 'get')) {
+          !rest.single.startsWith('-')) {
         target = findProjectRoot(globals.fs, rest.single);
 
         globals.printWarning('''

--- a/packages/flutter_tools/test/commands.shard/hermetic/pub_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/pub_test.dart
@@ -114,7 +114,7 @@ void main() {
     final PackagesGetCommand command = PackagesGetCommand('get', '', PubContext.pubGet);
     final CommandRunner<void> commandRunner = createTestCommandRunner(command);
 
-    await commandRunner.run(<String>['get', targetDirectory.path]);
+    await commandRunner.run(<String>['get', '--directory=${targetDirectory.path}']);
     final FlutterProject rootProject = FlutterProject.fromDirectory(targetDirectory);
     final File packageConfigFile = rootProject.dartTool.childFile('package_config.json');
     expect(packageConfigFile.existsSync(), true);
@@ -207,7 +207,7 @@ void main() {
     final CommandRunner<void> commandRunner = createTestCommandRunner(command);
 
     try {
-      await commandRunner.run(<String>['get', 'missing_dir']);
+      await commandRunner.run(<String>['get', '--directory=missing_dir']);
       fail('expected an exception');
     } on Exception catch (e) {
       expect(e.toString(), contains('Expected to find project root in missing_dir'));


### PR DESCRIPTION
- Resolves https://github.com/flutter/flutter/issues/144898
- Resolves https://github.com/flutter/flutter/issues/160145

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
