### PR TITLE
Fix DropdownMenu resets text when dropdownMenuEntries is changed

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -584,12 +584,14 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       filteredEntries = widget.dropdownMenuEntries;
       buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
       _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
-      // If the text field content matches one of the new entries do not rematch the initialSelection.
-      final bool isCurrentSelectionValid = filteredEntries.any(
-        (DropdownMenuEntry<T> entry) => entry.label == _localTextEditingController?.text
-      );
-      if (!isCurrentSelectionValid) {
-        _localTextEditingController?.value = _initialTextEditingValue;
+      if (widget.initialSelection != null) {
+        // Rematch initialSelection if the text field content does not match one of the new entries.
+        final bool isCurrentSelectionValid = filteredEntries.any(
+          (DropdownMenuEntry<T> entry) => entry.label == _localTextEditingController?.text
+        );
+        if (!isCurrentSelectionValid) {
+          _localTextEditingController?.value = _initialTextEditingValue;
+        }
       }
     }
     if (oldWidget.leadingIcon != widget.leadingIcon) {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2128,6 +2128,52 @@ void main() {
     },
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/160196.
+  testWidgets(
+    'Updating the menu entries does not reset the text field if no initial selection is given ',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      Widget boilerplate(List<DropdownMenuEntry<TestMenu>> entries) {
+        return MaterialApp(
+          home: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Scaffold(
+                body: DropdownMenu<TestMenu>(
+                  requestFocusOnTap: true,
+                  dropdownMenuEntries: entries,
+                  controller: controller,
+                ),
+              );
+            }
+          ),
+        );
+      }
+
+      await tester.pumpWidget(boilerplate(menuChildren));
+      expect(controller.text, isEmpty);
+
+      // Open the menu.
+      await tester.tap(find.byType(DropdownMenu<TestMenu>));
+      await tester.pump();
+
+      // Enter some text.
+      await tester.enterText(find.byType(TextField).first, 'Flutter');
+      await tester.pump();
+      expect(controller.text, 'Flutter');
+
+      // Update the menu entries with another instance of list containing the
+      // same entries.
+      await tester.pumpWidget(boilerplate(
+        List<DropdownMenuEntry<TestMenu>>.from(menuChildren)
+      ));
+
+      // The text should not be changed.
+      expect(controller.text, 'Flutter');
+    },
+  );
+
   testWidgets('The default text input field should not be focused on mobile platforms '
       'when it is tapped', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();


### PR DESCRIPTION
## Description

This PR fixes `DropdownMenu` to not rematch the `initialSelection` if not provided.
Rematching the `initialSelection` was added in https://github.com/flutter/flutter/pull/155757/ but it was not restricted to the case where `initialSelection` is provided, resulting in the text field being emptied when `initialSelection` is not provided and `dropdownMenuEntries` is changed.

## Related Issue

Fixes [Dropdown Menu Creates Infinite Build Loop](https://github.com/flutter/flutter/issues/160196)

## Tests

Adds 1 test.