### PR TITLE
Enable `explicit-package-dependencies` (`resident_web_runner_cold_test.dart`)

### DIFF
--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -36,7 +36,7 @@ void main() {
 
   // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
   // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDepdendencies() {
+  FeatureFlags enableExplicitPackageDependencies() {
     return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
   }
 
@@ -83,7 +83,7 @@ void main() {
     BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
-    FeatureFlags: enableExplicitPackageDepdendencies,
+    FeatureFlags: enableExplicitPackageDependencies,
     Pub: FakePubWithPrimedDeps.new,
   });
 
@@ -110,7 +110,7 @@ void main() {
     BuildSystem: () => TestBuildSystem.all(BuildResult(success: false)),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
-    FeatureFlags: enableExplicitPackageDepdendencies,
+    FeatureFlags: enableExplicitPackageDependencies,
     Pub: FakePubWithPrimedDeps.new,
   });
 
@@ -137,7 +137,7 @@ void main() {
     BuildSystem: () => TestBuildSystem.error(Exception('foo')),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
-    FeatureFlags: enableExplicitPackageDepdendencies,
+    FeatureFlags: enableExplicitPackageDependencies,
     Pub: FakePubWithPrimedDeps.new,
   });
 
@@ -168,7 +168,7 @@ void main() {
     BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
-    FeatureFlags: enableExplicitPackageDepdendencies,
+    FeatureFlags: enableExplicitPackageDependencies,
     Pub: FakePubWithPrimedDeps.new,
   });
 
@@ -203,7 +203,7 @@ void main() {
     ]),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
-    FeatureFlags: enableExplicitPackageDepdendencies,
+    FeatureFlags: enableExplicitPackageDependencies,
     Pub: FakePubWithPrimedDeps.new,
   });
 }

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -11,8 +11,10 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/isolated/devfs_web.dart';
 import 'package:flutter_tools/src/isolated/resident_web_runner.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -23,6 +25,7 @@ import 'package:test/fake.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_pub_deps.dart';
 import '../src/fakes.dart';
 import '../src/test_build_system.dart';
 
@@ -30,6 +33,12 @@ void main() {
   late FakeFlutterDevice mockFlutterDevice;
   late FakeWebDevFS mockWebDevFS;
   late MemoryFileSystem fileSystem;
+
+  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
+  // See https://github.com/flutter/flutter/issues/160257 for details.
+  FeatureFlags enableExplicitPackageDepdendencies() {
+    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
+  }
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -74,6 +83,8 @@ void main() {
     BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
+    FeatureFlags: enableExplicitPackageDepdendencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
@@ -99,6 +110,8 @@ void main() {
     BuildSystem: () => TestBuildSystem.all(BuildResult(success: false)),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
+    FeatureFlags: enableExplicitPackageDepdendencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
@@ -124,6 +137,8 @@ void main() {
     BuildSystem: () => TestBuildSystem.error(Exception('foo')),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
+    FeatureFlags: enableExplicitPackageDepdendencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
   testUsingContext('Can full restart after attaching', () async {
@@ -153,6 +168,8 @@ void main() {
     BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
+    FeatureFlags: enableExplicitPackageDepdendencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
   testUsingContext('Fails on compilation errors in hot restart', () async {
@@ -186,6 +203,8 @@ void main() {
     ]),
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
+    FeatureFlags: enableExplicitPackageDepdendencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 }
 


### PR DESCRIPTION
Example of option (2) for https://github.com/flutter/flutter/issues/160257.