### PR TITLE
Migrate `test_compiler_test.dart` to `explicit-package-dependencies`.

### DIFF
--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/compile.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/test/test_compiler.dart';
 import 'package:flutter_tools/src/test/test_time_recorder.dart';
@@ -17,6 +19,8 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_pub_deps.dart';
+import '../../src/fakes.dart';
 import '../../src/logging_logger.dart';
 
 final Platform linuxPlatform = FakePlatform(
@@ -37,6 +41,12 @@ void main() {
   late FakeResidentCompiler residentCompiler;
   late FileSystem fileSystem;
   late LoggingLogger logger;
+
+  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
+  // See https://github.com/flutter/flutter/issues/160257 for details.
+  FeatureFlags enableExplicitPackageDependencies() {
+    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
+  }
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -64,6 +74,8 @@ void main() {
     Platform: () => linuxPlatform,
     ProcessManager: () => FakeProcessManager.any(),
     Logger: () => BufferLogger.test(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
   testUsingContext('TestCompiler does not try to cache the dill file when precompiled dill is passed', () async {
@@ -81,6 +93,8 @@ void main() {
     Platform: () => linuxPlatform,
     ProcessManager: () => FakeProcessManager.any(),
     Logger: () => BufferLogger.test(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
   testUsingContext('TestCompiler reports null when a compile fails', () async {
@@ -98,6 +112,8 @@ void main() {
     Platform: () => linuxPlatform,
     ProcessManager: () => FakeProcessManager.any(),
     Logger: () => BufferLogger.test(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
 
@@ -126,6 +142,8 @@ void main() {
     Platform: () => linuxPlatform,
     ProcessManager: () => FakeProcessManager.any(),
     Logger: () => logger,
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
   testUsingContext('TestCompiler disposing test compiler shuts down backing compiler', () async {
@@ -147,6 +165,8 @@ void main() {
     Platform: () => linuxPlatform,
     ProcessManager: () => FakeProcessManager.any(),
     Logger: () => BufferLogger.test(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 
   testUsingContext('TestCompiler updates dart_plugin_registrant.dart', () async {
@@ -212,6 +232,8 @@ environment:
     Platform: () => linuxPlatform,
     ProcessManager: () => FakeProcessManager.any(),
     Logger: () => BufferLogger.test(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   });
 }
 


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/160257.