### PR TITLE
re-enable linux packages-autoroller

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -392,7 +392,6 @@ targets:
 
   - name: Linux packages_autoroller
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/160055
     recipe: pub_autoroller/pub_autoroller
     # This takes a while because we need to fetch network dependencies and run
     # Gradle for every android app in the repo


### PR DESCRIPTION
I fixed the autoroller in https://github.com/flutter/flutter/pull/160059 but forgot to mark the shard non-bring-up. Note, it's currently failing in post-submit, but only because bringUp shards run in the staging pool, which does not have access to the GitHub access token necessary for the roller to operate.