### PR TITLE
Migrate `generate_synthetic_packages_test.dart` to `explicit-package-dependencies`.

### DIFF
--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -21,6 +21,13 @@ import '../../src/fakes.dart';
 import '../../src/test_build_system.dart';
 
 void main() {
+  // TODO(matanlurey): Remove after support for flutter_gen is removed.
+  // See https://github.com/flutter/flutter/issues/102983 for details.
+  FeatureFlags disableExplicitPackageDependencies() {
+    // ignore: avoid_redundant_argument_values
+    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: false);
+  }
+
   testUsingContext('calls buildSystem.build with blank l10n.yaml file', () async {
     // Project directory setup for gen_l10n logic
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
@@ -68,6 +75,8 @@ void main() {
       ),
     );
     await completer.future;
+  }, overrides: <Type, Generator>{
+    FeatureFlags: disableExplicitPackageDependencies,
   });
 
   testUsingContext('calls buildSystem.build with l10n.yaml synthetic-package: true', () async {
@@ -118,6 +127,8 @@ void main() {
       ),
     );
     await completer.future;
+  }, overrides: <Type, Generator>{
+    FeatureFlags: disableExplicitPackageDependencies,
   });
 
   testUsingContext('calls buildSystem.build with l10n.yaml synthetic-package: null', () async {
@@ -166,6 +177,8 @@ void main() {
       ),
     );
     await completer.future;
+  }, overrides: <Type, Generator>{
+    FeatureFlags: disableExplicitPackageDependencies,
   });
 
   testUsingContext('does not call buildSystem.build when l10n.yaml is not present', () async {
@@ -305,6 +318,8 @@ void main() {
       mockBufferLogger.warningText,
       contains('https://flutter.dev/to/flutter-gen-deprecation'),
     );
+  }, overrides: <Type, Generator>{
+    FeatureFlags: disableExplicitPackageDependencies,
   });
 
   testUsingContext('synthetic-package: true (explicit) logs a deprecation warning', () async {
@@ -340,6 +355,8 @@ void main() {
       mockBufferLogger.warningText,
       contains('https://flutter.dev/to/flutter-gen-deprecation'),
     );
+  }, overrides: <Type, Generator>{
+    FeatureFlags: disableExplicitPackageDependencies,
   });
 
   testUsingContext('synthetic-package: false has no deprecation warning', () async {


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/160257.

Unlike some of the other PRs, this test explicitly _opts-out_ of the flag, as the test itself is testing whether the now deprecated feature works.