### PR TITLE
Migrate `test/general.shard/build_system` to `explicit-package-dependencies`.

### DIFF
--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
@@ -9,10 +9,14 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/dart_plugin_registrant.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import '../../../src/fake_pub_deps.dart';
+import '../../../src/fakes.dart';
 
 const String _kEmptyPubspecFile = '''
 name: path_provider_example
@@ -86,6 +90,13 @@ environment:
 ''';
 
 void main() {
+  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
+  // See https://github.com/flutter/flutter/issues/160257 for details.
+  FeatureFlags enableExplicitPackageDependencies() {
+    return TestFeatureFlags(
+      isExplicitPackageDependenciesEnabled: true,
+    );
+  }
 
   group('Dart plugin registrant' , () {
     late FileSystem fileSystem;
@@ -182,6 +193,8 @@ void main() {
       expect(generatedMain.existsSync(), isFalse);
     }, overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: enableExplicitPackageDependencies,
+      Pub: FakePubWithPrimedDeps.new,
     });
 
     testUsingContext('regenerates dart_plugin_registrant.dart', () async {
@@ -261,6 +274,8 @@ void main() {
       );
     }, overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: enableExplicitPackageDependencies,
+      Pub: FakePubWithPrimedDeps.new,
     });
 
     testUsingContext('removes dart_plugin_registrant.dart if plugins are removed from pubspec.yaml', () async {
@@ -307,6 +322,8 @@ void main() {
       expect(generatedMain.existsSync(), isFalse);
     }, overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: enableExplicitPackageDependencies,
+      Pub: FakePubWithPrimedDeps.new,
     });
 
     testUsingContext('target file is outside the current project package', () async {
@@ -387,6 +404,8 @@ void main() {
       );
     }, overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: enableExplicitPackageDependencies,
+      Pub: FakePubWithPrimedDeps.new,
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -11,6 +11,8 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/web/compile.dart';
@@ -19,6 +21,8 @@ import 'package:flutter_tools/src/web_template.dart';
 
 import '../../../src/common.dart';
 import '../../../src/fake_process_manager.dart';
+import '../../../src/fake_pub_deps.dart';
+import '../../../src/fakes.dart';
 import '../../../src/testbed.dart';
 
 const List<String> _kDart2jsLinuxArgs = <String>[
@@ -41,6 +45,15 @@ void main() {
   late Testbed testbed;
   late Environment environment;
   late FakeProcessManager processManager;
+
+  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
+  // See https://github.com/flutter/flutter/issues/160257 for details.
+  FeatureFlags enableExplicitPackageDependencies() {
+    return TestFeatureFlags(
+      isExplicitPackageDependenciesEnabled: true,
+    );
+  }
+
   final Platform linux = FakePlatform(
     environment: <String, String>{},
   );
@@ -112,6 +125,8 @@ void main() {
     expect(generated, contains('entrypoint.main as _'));
   }, overrides: <Type, Generator>{
     TemplateRenderer: () => const MustacheTemplateRenderer(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   }));
 
   test('version.json is created after release build', () => testbed.run(() async {
@@ -266,6 +281,8 @@ void main() {
     expect(generated, contains("import 'file:///other/lib/main.dart' as entrypoint;"));
   }, overrides: <Type, Generator>{
     TemplateRenderer: () => const MustacheTemplateRenderer(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   }));
 
   test('WebEntrypointTarget generates a plugin registrant for a file outside of main', () => testbed.run(() async {
@@ -283,6 +300,8 @@ void main() {
     expect(generated, contains("import 'web_plugin_registrant.dart' as pluginRegistrant;"));
   }, overrides: <Type, Generator>{
     TemplateRenderer: () => const MustacheTemplateRenderer(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   }));
 
 
@@ -310,6 +329,8 @@ void main() {
   }, overrides: <Type, Generator>{
     Platform: () => windows,
     TemplateRenderer: () => const MustacheTemplateRenderer(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   }));
 
   test('WebEntrypointTarget generates an entrypoint without plugins and init platform', () => testbed.run(() async {
@@ -334,6 +355,8 @@ void main() {
     expect(generated, contains('entrypoint.main as _'));
   }, overrides: <Type, Generator>{
     TemplateRenderer: () => const MustacheTemplateRenderer(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   }));
 
   test('WebEntrypointTarget generates an entrypoint with a language version', () => testbed.run(() async {
@@ -349,6 +372,8 @@ void main() {
     expect(generated, contains('// @dart=2.8'));
   }, overrides: <Type, Generator>{
     TemplateRenderer: () => const MustacheTemplateRenderer(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   }));
 
   test('WebEntrypointTarget generates an entrypoint with a language version from a package config', () => testbed.run(() async {
@@ -366,6 +391,8 @@ void main() {
     expect(generated, contains('// @dart=2.7'));
   }, overrides: <Type, Generator>{
     TemplateRenderer: () => const MustacheTemplateRenderer(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   }));
 
   test('WebEntrypointTarget generates an entrypoint without plugins and without init platform', () => testbed.run(() async {
@@ -390,6 +417,8 @@ void main() {
     expect(generated, contains('entrypoint.main as _'));
   }, overrides: <Type, Generator>{
     TemplateRenderer: () => const MustacheTemplateRenderer(),
+    FeatureFlags: enableExplicitPackageDependencies,
+    Pub: FakePubWithPrimedDeps.new,
   }));
 
   test('Dart2JSTarget calls dart2js with expected args with csp', () => testbed.run(() async {


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/160257.