### PR TITLE
Adds ListenableBuilder.multiple to make it easier to listen to multiple listenables

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -1104,6 +1104,29 @@ class ListenableBuilder extends AnimatedWidget {
     this.child,
   });
 
+  /// Creates a [ListenableBuilder] that responds to changes in multiple [listenables].
+  ///
+  /// This factory constructor is useful when you need to react to changes from multiple
+  /// [Listenable] objects simultaneously.
+  ///
+  /// [listenables] is a list of [Listenable] objects whose changes will trigger rebuilds.
+  /// [builder] is the callback function that builds the widget based on the latest state.
+  /// [child] is an optional child widget that doesn't depend on the [listenables].
+  ///
+  /// Returns a new [ListenableBuilder] instance configured to listen to all provided
+  /// [listenables].
+  factory ListenableBuilder.multiple({
+    required List<Listenable> listenables,
+    required TransitionBuilder builder,
+    Widget? child,
+  }) {
+    return ListenableBuilder(
+      listenable: Listenable.merge(listenables),
+      builder: builder,
+      child: child,
+    );
+  }
+
   /// The [Listenable] supplied to the constructor.
   ///
   /// {@tool dartpad}

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -1106,15 +1106,15 @@ class ListenableBuilder extends AnimatedWidget {
 
   /// Creates a [ListenableBuilder] that responds to changes in multiple [listenables].
   ///
-  /// This factory constructor is useful when you need to react to changes from multiple
+  /// This constructor is useful when you need to react to changes from multiple
   /// [Listenable] objects simultaneously.
   ///
-  /// [listenables] is a list of [Listenable] objects whose changes will trigger rebuilds.
+  /// [listenables] is an iterable of [Listenable] objects whose changes will trigger rebuilds.
   /// [builder] is the callback function that builds the widget based on the latest state.
   /// [child] is an optional child widget that doesn't depend on the [listenables].
   ///
-  /// Returns a new [ListenableBuilder] instance configured to listen to all provided
-  /// [listenables].
+  /// The returned [ListenableBuilder] instance is configured to listen to all provided
+  /// [listenables] through a merged [Listenable].
   ListenableBuilder.multiple({
     super.key,
     required Iterable<Listenable> listenables,

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -1115,17 +1115,12 @@ class ListenableBuilder extends AnimatedWidget {
   ///
   /// Returns a new [ListenableBuilder] instance configured to listen to all provided
   /// [listenables].
-  factory ListenableBuilder.multiple({
-    required List<Listenable> listenables,
-    required TransitionBuilder builder,
-    Widget? child,
-  }) {
-    return ListenableBuilder(
-      listenable: Listenable.merge(listenables),
-      builder: builder,
-      child: child,
-    );
-  }
+  ListenableBuilder.multiple({
+    super.key,
+    required Iterable<Listenable> listenables,
+    required this.builder,
+    this.child,
+  }) : super(listenable: Listenable.merge(listenables));
 
   /// The [Listenable] supplied to the constructor.
   ///

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -970,7 +970,7 @@ void main() {
     final GlobalKey<RedrawCounterState> redrawKey = GlobalKey<RedrawCounterState>();
     final ChangeNotifier notifier1 = ChangeNotifier();
     final ChangeNotifier notifier2 = ChangeNotifier();
-    
+
     addTearDown(notifier1.dispose);
     addTearDown(notifier2.dispose);
 

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -978,7 +978,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: ListenableBuilder.multiple(
-          listenables: [notifier1, notifier2],
+          listenables: <Listenable>[notifier1, notifier2],
           builder: (BuildContext context, Widget? child) {
             return RedrawCounter(key: redrawKey, child: child);
           },


### PR DESCRIPTION
Adds ListenableBuilder.multiple to make it easier to listen to multiple listenables

Fix #159652

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

