### PR TITLE
Adds splashColor to ChipThemeData & Chip Widget

### DIFF
--- a/packages/flutter/lib/src/material/action_chip.dart
+++ b/packages/flutter/lib/src/material/action_chip.dart
@@ -121,6 +121,7 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
     this.avatarBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor,
   }) : assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
        _chipVariant = _ChipVariant.flat;
@@ -158,6 +159,7 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
     this.avatarBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor,
   }) : assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
        _chipVariant = _ChipVariant.elevated;
@@ -212,6 +214,8 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
   final ChipAnimationStyle? chipAnimationStyle;
   @override
   final MouseCursor? mouseCursor;
+  @override
+  final Color? splashColor;
 
   @override
   bool get isEnabled => onPressed != null;
@@ -252,6 +256,7 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
       avatarBoxConstraints: avatarBoxConstraints,
       chipAnimationStyle: chipAnimationStyle,
       mouseCursor: mouseCursor,
+      splashColor: splashColor,
     );
   }
 }

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -614,6 +614,9 @@ abstract interface class TappableChipAttributes {
   /// Tooltip string to be used for the body area (where the label and avatar
   /// are) of the chip.
   String? get tooltip;
+
+  /// the color of the splash shown when the chip is pressed.
+  Color? get splashColor;
 }
 
 /// A helper class that overrides the default chip animation parameters.
@@ -895,6 +898,7 @@ class RawChip extends StatefulWidget
     this.deleteIconBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor
   }) : assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
        deleteIcon = deleteIcon ?? _kDefaultDeleteIcon;
@@ -938,6 +942,8 @@ class RawChip extends StatefulWidget
   final Color? selectedColor;
   @override
   final String? tooltip;
+  @override
+  final Color? splashColor;
   @override
   final BorderSide? side;
   @override
@@ -1424,6 +1430,7 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
         autofocus: widget.autofocus,
         canRequestFocus: widget.isEnabled,
         onTap: canTap ? _handleTap : null,
+        splashColor: widget.splashColor ?? chipTheme.splashColor,
         onTapDown: canTap ? _handleTapDown : null,
         onTapCancel: canTap ? _handleTapCancel : null,
         onHover: canTap ? updateMaterialState(MaterialState.hovered) : null,

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -291,6 +291,9 @@ abstract interface class ChipAttributes {
   ///
   /// If this property is null, [WidgetStateMouseCursor.clickable] will be used.
   MouseCursor? get mouseCursor;
+
+  /// the color of the splash shown when the chip is pressed.
+  Color? get splashColor;
 }
 
 /// An interface for Material Design chips that can be deleted.
@@ -614,9 +617,6 @@ abstract interface class TappableChipAttributes {
   /// Tooltip string to be used for the body area (where the label and avatar
   /// are) of the chip.
   String? get tooltip;
-
-  /// the color of the splash shown when the chip is pressed.
-  Color? get splashColor;
 }
 
 /// A helper class that overrides the default chip animation parameters.
@@ -721,6 +721,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
     this.deleteIconBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor,
   }) : assert(elevation == null || elevation >= 0.0);
 
   @override
@@ -775,6 +776,8 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
   final ChipAnimationStyle? chipAnimationStyle;
   @override
   final MouseCursor? mouseCursor;
+  @override
+  final Color? splashColor;
 
   @override
   Widget build(BuildContext context) {
@@ -807,6 +810,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
       deleteIconBoxConstraints: deleteIconBoxConstraints,
       chipAnimationStyle: chipAnimationStyle,
       mouseCursor: mouseCursor,
+      splashColor: splashColor,
     );
   }
 }

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -197,6 +197,7 @@ class ChipThemeData with Diagnosticable {
     this.selectedShadowColor,
     this.showCheckmark,
     this.checkmarkColor,
+    this.splashColor,
     this.labelPadding,
     this.padding,
     this.side,
@@ -355,6 +356,11 @@ class ChipThemeData with Diagnosticable {
   /// This property applies to [FilterChip], [InputChip], [RawChip].
   final Color? checkmarkColor;
 
+  /// Overrides the default for [ChipAttributes.splashColor],
+  /// the color of the splash shown when the chip is pressed.
+  ///
+  final Color? splashColor;
+
   /// Overrides the default for [ChipAttributes.labelPadding],
   /// the padding around the chip's label widget.
   ///
@@ -475,6 +481,7 @@ class ChipThemeData with Diagnosticable {
     Color? selectedShadowColor,
     bool? showCheckmark,
     Color? checkmarkColor,
+    Color? splashColor,
     EdgeInsetsGeometry? labelPadding,
     EdgeInsetsGeometry? padding,
     BorderSide? side,
@@ -500,6 +507,7 @@ class ChipThemeData with Diagnosticable {
       selectedShadowColor: selectedShadowColor ?? this.selectedShadowColor,
       showCheckmark: showCheckmark ?? this.showCheckmark,
       checkmarkColor: checkmarkColor ?? this.checkmarkColor,
+      splashColor: splashColor ?? this.splashColor,
       labelPadding: labelPadding ?? this.labelPadding,
       padding: padding ?? this.padding,
       side: side ?? this.side,
@@ -534,6 +542,7 @@ class ChipThemeData with Diagnosticable {
       selectedShadowColor: Color.lerp(a?.selectedShadowColor, b?.selectedShadowColor, t),
       showCheckmark: t < 0.5 ? a?.showCheckmark ?? true : b?.showCheckmark ?? true,
       checkmarkColor: Color.lerp(a?.checkmarkColor, b?.checkmarkColor, t),
+      splashColor: Color.lerp(a?.splashColor, b?.splashColor, t),
       labelPadding: EdgeInsetsGeometry.lerp(a?.labelPadding, b?.labelPadding, t),
       padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
       side: _lerpSides(a?.side, b?.side, t),
@@ -592,6 +601,7 @@ class ChipThemeData with Diagnosticable {
     selectedShadowColor,
     showCheckmark,
     checkmarkColor,
+    splashColor,
     labelPadding,
     padding,
     side,
@@ -626,6 +636,7 @@ class ChipThemeData with Diagnosticable {
         && other.selectedShadowColor == selectedShadowColor
         && other.showCheckmark == showCheckmark
         && other.checkmarkColor == checkmarkColor
+        && other.splashColor == splashColor
         && other.labelPadding == labelPadding
         && other.padding == padding
         && other.side == side
@@ -654,6 +665,7 @@ class ChipThemeData with Diagnosticable {
     properties.add(ColorProperty('selectedShadowColor', selectedShadowColor, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('showCheckmark', showCheckmark, defaultValue: null));
     properties.add(ColorProperty('checkMarkColor', checkmarkColor, defaultValue: null));
+    properties.add(ColorProperty('splashColor', splashColor, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('labelPadding', labelPadding, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
     properties.add(DiagnosticsProperty<BorderSide>('side', side, defaultValue: null));

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -359,6 +359,7 @@ class ChipThemeData with Diagnosticable {
   /// Overrides the default for [TappableChipAttributes.splashColor],
   /// the color of the splash shown when the chip is pressed.
   ///
+  /// This property applies to all chip types.
   final Color? splashColor;
 
   /// Overrides the default for [ChipAttributes.labelPadding],

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -359,7 +359,8 @@ class ChipThemeData with Diagnosticable {
   /// Overrides the default for [TappableChipAttributes.splashColor],
   /// the color of the splash shown when the chip is pressed.
   ///
-  /// This property applies to all chip types.
+  /// This property applies to [ActionChip], [Chip], [ChoiceChip],
+  /// [FilterChip], [InputChip], [RawChip].
   final Color? splashColor;
 
   /// Overrides the default for [ChipAttributes.labelPadding],

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -356,7 +356,7 @@ class ChipThemeData with Diagnosticable {
   /// This property applies to [FilterChip], [InputChip], [RawChip].
   final Color? checkmarkColor;
 
-  /// Overrides the default for [ChipAttributes.splashColor],
+  /// Overrides the default for [TappableChipAttributes.splashColor],
   /// the color of the splash shown when the chip is pressed.
   ///
   final Color? splashColor;

--- a/packages/flutter/lib/src/material/choice_chip.dart
+++ b/packages/flutter/lib/src/material/choice_chip.dart
@@ -102,6 +102,7 @@ class ChoiceChip extends StatelessWidget
     this.avatarBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor,
   }) : assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
        _chipVariant = _ChipVariant.flat;
@@ -145,6 +146,7 @@ class ChoiceChip extends StatelessWidget
     this.avatarBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor,
   }) : assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
        _chipVariant = _ChipVariant.elevated;
@@ -211,6 +213,8 @@ class ChoiceChip extends StatelessWidget
   final ChipAnimationStyle? chipAnimationStyle;
   @override
   final MouseCursor? mouseCursor;
+  @override
+  final Color? splashColor;
 
   @override
   bool get isEnabled => onSelected != null;

--- a/packages/flutter/lib/src/material/filter_chip.dart
+++ b/packages/flutter/lib/src/material/filter_chip.dart
@@ -114,6 +114,7 @@ class FilterChip extends StatelessWidget
     this.deleteIconBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor,
   }) : assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
        _chipVariant = _ChipVariant.flat;
@@ -162,6 +163,7 @@ class FilterChip extends StatelessWidget
     this.deleteIconBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor,
   }) : assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
        _chipVariant = _ChipVariant.elevated;
@@ -238,6 +240,8 @@ class FilterChip extends StatelessWidget
   final ChipAnimationStyle? chipAnimationStyle;
   @override
   final MouseCursor? mouseCursor;
+  @override
+  final Color? splashColor;
 
   @override
   bool get isEnabled => onSelected != null;

--- a/packages/flutter/lib/src/material/input_chip.dart
+++ b/packages/flutter/lib/src/material/input_chip.dart
@@ -133,6 +133,7 @@ class InputChip extends StatelessWidget
     this.deleteIconBoxConstraints,
     this.chipAnimationStyle,
     this.mouseCursor,
+    this.splashColor,
   }) : assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0);
 
@@ -212,6 +213,8 @@ class InputChip extends StatelessWidget
   final ChipAnimationStyle? chipAnimationStyle;
   @override
   final MouseCursor? mouseCursor;
+  @override
+  final Color? splashColor;
 
   @override
   Widget build(BuildContext context) {
@@ -261,6 +264,7 @@ class InputChip extends StatelessWidget
       deleteIconBoxConstraints: deleteIconBoxConstraints,
       chipAnimationStyle: chipAnimationStyle,
       mouseCursor: mouseCursor,
+      splashColor: splashColor,
     );
   }
 }


### PR DESCRIPTION
Adds splashColor to ChipThemeData

Fix #152098 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
