### PR TITLE
Update PopInvokedCallback Deprecated message

### DIFF
--- a/packages/flutter/lib/src/widgets/pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/pop_scope.dart
@@ -20,7 +20,7 @@ import 'routes.dart';
 /// Accepts a didPop boolean indicating whether or not back navigation
 /// succeeded.
 @Deprecated(
-  'Use PopWithResultInvokedCallback instead. '
+  'Use PopInvokedWithResultCallback instead. '
   'This feature was deprecated after v3.22.0-12.0.pre.',
 )
 typedef PopInvokedCallback = void Function(bool didPop);


### PR DESCRIPTION
I might be mistaken, but it seems like there's an error in the `pop_scope.dart` file. Instead of `PopWithResultInvokedCallback`, it has `PopInvokedWithResultCallback`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.