### PR TITLE
Fix overlay overlapps the popup menu created by PopupMenuButton

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1116,27 +1116,30 @@ Future<T?> showMenu<T>({
 
   final List<GlobalKey> menuItemKeys = List<GlobalKey>.generate(items.length, (int index) => GlobalKey());
   final NavigatorState navigator = Navigator.of(context, rootNavigator: useRootNavigator);
-  return navigator.push(_PopupMenuRoute<T>(
-    position: position,
-    positionBuilder: positionBuilder,
-    items: items,
-    itemKeys: menuItemKeys,
-    initialValue: initialValue,
-    elevation: elevation,
-    shadowColor: shadowColor,
-    surfaceTintColor: surfaceTintColor,
-    semanticLabel: semanticLabel,
-    barrierLabel: MaterialLocalizations.of(context).menuDismissLabel,
-    shape: shape,
-    menuPadding: menuPadding,
-    color: color,
-    capturedThemes: InheritedTheme.capture(from: context, to: navigator.context),
-    constraints: constraints,
-    clipBehavior: clipBehavior,
-    settings: routeSettings,
-    popUpAnimationStyle: popUpAnimationStyle,
-    requestFocus: requestFocus,
-  ));
+  return navigator.push(
+    _PopupMenuRoute<T>(
+      position: position,
+      positionBuilder: positionBuilder,
+      items: items,
+      itemKeys: menuItemKeys,
+      initialValue: initialValue,
+      elevation: elevation,
+      shadowColor: shadowColor,
+      surfaceTintColor: surfaceTintColor,
+      semanticLabel: semanticLabel,
+      barrierLabel: MaterialLocalizations.of(context).menuDismissLabel,
+      shape: shape,
+      menuPadding: menuPadding,
+      color: color,
+      capturedThemes: InheritedTheme.capture(from: context, to: navigator.context),
+      constraints: constraints,
+      clipBehavior: clipBehavior,
+      settings: routeSettings,
+      popUpAnimationStyle: popUpAnimationStyle,
+      requestFocus: requestFocus,
+    ),
+    overlaysOnTop: true,
+  );
 }
 
 /// Signature for the callback invoked when a menu item is selected. The


### PR DESCRIPTION
## Description

This PR proposes a solution to get the popup menu alway showing on top of other overlay entries.

PopupMenuButton shows the popup menu by adding a route the closest navigator. The navigator manages the corresponding overlay entries.
This is fine until the app also inserts a custom OverlayEntry to the same Overlay used by the navigator.
When doing so, the custom OverlayEntry will always appear on top of OverlayEntry created by routes.

This PR fixes the issue by adding a new parameter to NavigatorState.push in order to force the route overlay entries to appear on top of other existing overlay entries.

## Related Issue

Fixes [Overlay overlapps the popup menu created by PopupMenuButton](https://github.com/flutter/flutter/issues/116504)

## Tests

TBD