### PR TITLE
EditableTextState._schedulePeriodicPostFrameCallbacks null error

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4497,7 +4497,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _schedulePeriodicPostFrameCallbacks([Duration? duration]) {
-    if (!_hasInputConnection) {
+    if (!_hasInputConnection || !mounted) {
       return;
     }
     _updateSelectionRects();


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

`EditableTextState._schedulePeriodicPostFrameCallbacks` doesn't check if context is mounted (there is only assert), this PR ensures that we don't execute `_schedulePeriodicPostFrameCallbacks` needlessly.

I wasn't able to create an issue for this PR as I would need a minimal code to repro and I wasn't able to repro. This error exists however as we have sentry reports (apparently happens whenever our app goes into background).

```
TypeError: Null check operator used on a null value
  App                 0x10d35bc60  RenderObject.getTransformTo (object.dart:3386)
  App                 0x10d35b460  RenderBox.localToGlobal (box.dart:2887)
  App                 0x10d35b22c  RenderEditable._snapToPhysicalPixel (editable.dart:2276)
  App                 0x10d35b1d0  RenderEditable.getLocalRectForCaret (editable.dart:1822)
  App                 0x10d42f3c8  EditableTextState._updateComposingRectIfNeeded (editable_text.dart:4498)
  App                 0x10d42ecd8  EditableTextState._schedulePeriodicPostFrameCallbacks (editable_text.dart:4405)
  App                 0x10d4307b4  EditableTextState._schedulePeriodicPostFrameCallbacks (editable_text.dart:4400)
  App                 0x10da15280  SchedulerBinding._invokeFrameCallback (binding.dart:1397)
  App                 0x10da15174  SchedulerBinding.handleDrawFrame (binding.dart:1331)
  App                 0x10d34875c  SchedulerBinding._handleDrawFrame (binding.dart:1176)
  App                 0x10d348634  SchedulerBinding._handleDrawFrame (binding.dart:1158)
  App                 0x10d330a58  _invoke (hooks.dart:312)
  App                 0x10d332784  PlatformDispatcher._drawFrame (platform_dispatcher.dart:419)
  App                 0x10d332748  _drawFrame (hooks.dart:283)
  App                 0x10d3327b4  _drawFrame (hooks.dart:281)
```

Sadly I can't provide any more detail than this at the moment.

If you look at `EditableTextState._updateComposingRectIfNeeded` you can see there's `assert(mounted)` present. `_updateComposingRectIfNeeded` method is only called from `_schedulePeriodicPostFrameCallbacks` which checks for `hasInputConnection` but doesn't check for context being `mounted`. I believe doing this might fix the issue (but I will only know if I am able to repro or these reports disappear from sentry). Maybe someone knowledgeable on this code area can verify if what I'm saying makes sense.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
