### PR TITLE
Fix a bug to skip `flutter_gen` when synthetic packages are disabled

### DIFF
--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -49,7 +49,7 @@ Future<void> generateLocalizationsSyntheticPackage({
     // Generate gen_l10n synthetic package only if synthetic-package: true or
     // synthetic-package is null.
     final bool? isSyntheticL10nPackage = value as bool?;
-    if (isSyntheticL10nPackage == false) {
+    if (isSyntheticL10nPackage == false || isSyntheticL10nPackage == null && featureFlags.isExplicitPackageDependenciesEnabled) {
       return;
     }
   } else if (featureFlags.isExplicitPackageDependenciesEnabled) {


### PR DESCRIPTION
Without this bug fix, when flipping the flag a lot of things blow up :)

(https://github.com/flutter/flutter/pull/160289 as an example of needing this)