### PR TITLE
Formatter pre-work: Fix syntax in test_fixes

### DIFF
--- a/packages/flutter/test_fixes/material/app_bar.dart
+++ b/packages/flutter/test_fixes/material/app_bar.dart
@@ -19,6 +19,6 @@ void main() {
 
   AppBar appBar = AppBar();
   appBar = AppBar(backwardsCompatibility: true);
-  appBar = AppBar(backwardsCompatibility: false));
+  appBar = AppBar(backwardsCompatibility: false);
   appBar.backwardsCompatibility; // Removing field reference not supported.
 }

--- a/packages/flutter/test_fixes/material/app_bar.dart.expect
+++ b/packages/flutter/test_fixes/material/app_bar.dart.expect
@@ -20,6 +20,6 @@ void main() {
 
   AppBar appBar = AppBar();
   appBar = AppBar();
-  appBar = AppBar());
+  appBar = AppBar();
   appBar.backwardsCompatibility; // Removing field reference not supported.
 }

--- a/packages/flutter/test_fixes/material/widget_state.dart
+++ b/packages/flutter/test_fixes/material/widget_state.dart
@@ -32,42 +32,6 @@ void main() {
 
   final MaterialStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(getColor);
 
-  class _MouseCursor extends MaterialStateMouseCursor {
-    const _MouseCursor(this.resolveCallback);
-
-    final MaterialPropertyResolver<MouseCursor?> resolveCallback;
-
-    @override
-    MouseCursor resolve(Set<MaterialState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
-  }
-
-  MaterialStateBorderSide? get side {
-    return MaterialStateBorderSide.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
-        if (states.contains(MaterialState.selected)) {
-          return const BorderSide(width: 2.0);
-        }
-        return BorderSide(width: 1.0);
-      }
-      if (states.contains(MaterialState.selected)) {
-        return const BorderSide(width: 1.5);
-      }
-      return BorderSide(width: 0.5);
-    });
-  }
-
-  class SelectedBorder extends RoundedRectangleBorder implements MaterialStateOutlinedBorder {
-    const SelectedBorder();
-
-    @override
-    OutlinedBorder? resolve(Set<MaterialState> states) {
-      if (states.contains(MaterialState.selected)) {
-        return const RoundedRectangleBorder();
-      }
-      return null;
-    }
-  }
-
   TextStyle floatingLabelStyle = MaterialStateTextStyle.resolveWith(
     (Set<MaterialState> states) {
       final Color color =
@@ -90,26 +54,61 @@ void main() {
 
   final MaterialStatesController statesController =
     MaterialStatesController(<MaterialState>{if (widget.selected) MaterialState.selected});
+}
 
-  class _MyWidget extends StatefulWidget {
-    const _MyWidget({
-      required this.controller,
-      required this.evaluator,
-      required this.materialState,
+class _MouseCursor extends MaterialStateMouseCursor {
+  const _MouseCursor(this.resolveCallback);
+
+  final MaterialPropertyResolver<MouseCursor?> resolveCallback;
+
+  @override
+  MouseCursor resolve(Set<MaterialState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
+}
+
+class SelectedBorder extends RoundedRectangleBorder implements MaterialStateOutlinedBorder {
+  const SelectedBorder();
+
+  @override
+  OutlinedBorder? resolve(Set<MaterialState> states) {
+    if (states.contains(MaterialState.selected)) {
+      return const RoundedRectangleBorder();
+    }
+    return null;
+  }
+}
+
+class _MyWidget extends StatefulWidget {
+  const _MyWidget({
+    required this.controller,
+    required this.evaluator,
+    required this.materialState,
+  });
+
+  final bool Function(_MyWidgetState state) evaluator;
+
+  /// Stream passed down to the child [_InnerWidget] to begin the process.
+  /// This plays the role of an actual user interaction in the wild, but allows
+  /// us to engage the system without mocking pointers/hovers etc.
+  final StreamController<bool> controller;
+
+  /// The value we're watching in the given test.
+  final MaterialState materialState;
+
+  MaterialStateBorderSide? get side {
+    return MaterialStateBorderSide.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        if (states.contains(MaterialState.selected)) {
+          return const BorderSide(width: 2.0);
+        }
+        return BorderSide(width: 1.0);
+      }
+      if (states.contains(MaterialState.selected)) {
+        return const BorderSide(width: 1.5);
+      }
+      return BorderSide(width: 0.5);
     });
-
-    final bool Function(_MyWidgetState state) evaluator;
-
-    /// Stream passed down to the child [_InnerWidget] to begin the process.
-    /// This plays the role of an actual user interaction in the wild, but allows
-    /// us to engage the system without mocking pointers/hovers etc.
-    final StreamController<bool> controller;
-
-    /// The value we're watching in the given test.
-    final MaterialState materialState;
-
-    @override
-    State createState() => _MyWidgetState();
   }
 
+  @override
+  State createState() => _MyWidgetState();
 }

--- a/packages/flutter/test_fixes/material/widget_state.dart.expect
+++ b/packages/flutter/test_fixes/material/widget_state.dart.expect
@@ -32,42 +32,6 @@ void main() {
 
   final WidgetStateProperty<Color> backgroundColor = WidgetStateColor.resolveWith(getColor);
 
-  class _MouseCursor extends WidgetStateMouseCursor {
-    const _MouseCursor(this.resolveCallback);
-
-    final WidgetPropertyResolver<MouseCursor?> resolveCallback;
-
-    @override
-    MouseCursor resolve(Set<WidgetState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
-  }
-
-  WidgetStateBorderSide? get side {
-    return WidgetStateBorderSide.resolveWith((Set<WidgetState> states) {
-      if (states.contains(WidgetState.disabled)) {
-        if (states.contains(WidgetState.selected)) {
-          return const BorderSide(width: 2.0);
-        }
-        return BorderSide(width: 1.0);
-      }
-      if (states.contains(WidgetState.selected)) {
-        return const BorderSide(width: 1.5);
-      }
-      return BorderSide(width: 0.5);
-    });
-  }
-
-  class SelectedBorder extends RoundedRectangleBorder implements WidgetStateOutlinedBorder {
-    const SelectedBorder();
-
-    @override
-    OutlinedBorder? resolve(Set<WidgetState> states) {
-      if (states.contains(WidgetState.selected)) {
-        return const RoundedRectangleBorder();
-      }
-      return null;
-    }
-  }
-
   TextStyle floatingLabelStyle = WidgetStateTextStyle.resolveWith(
     (Set<WidgetState> states) {
       final Color color =
@@ -90,26 +54,61 @@ void main() {
 
   final WidgetStatesController statesController =
     WidgetStatesController(<WidgetState>{if (widget.selected) WidgetState.selected});
+}
 
-  class _MyWidget extends StatefulWidget {
-    const _MyWidget({
-      required this.controller,
-      required this.evaluator,
-      required this.materialState,
+class _MouseCursor extends WidgetStateMouseCursor {
+  const _MouseCursor(this.resolveCallback);
+
+  final WidgetPropertyResolver<MouseCursor?> resolveCallback;
+
+  @override
+  MouseCursor resolve(Set<WidgetState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
+}
+
+class SelectedBorder extends RoundedRectangleBorder implements WidgetStateOutlinedBorder {
+  const SelectedBorder();
+
+  @override
+  OutlinedBorder? resolve(Set<WidgetState> states) {
+    if (states.contains(WidgetState.selected)) {
+      return const RoundedRectangleBorder();
+    }
+    return null;
+  }
+}
+
+class _MyWidget extends StatefulWidget {
+  const _MyWidget({
+    required this.controller,
+    required this.evaluator,
+    required this.materialState,
+  });
+
+  final bool Function(_MyWidgetState state) evaluator;
+
+  /// Stream passed down to the child [_InnerWidget] to begin the process.
+  /// This plays the role of an actual user interaction in the wild, but allows
+  /// us to engage the system without mocking pointers/hovers etc.
+  final StreamController<bool> controller;
+
+  /// The value we're watching in the given test.
+  final WidgetState materialState;
+
+  WidgetStateBorderSide? get side {
+    return WidgetStateBorderSide.resolveWith((Set<WidgetState> states) {
+      if (states.contains(WidgetState.disabled)) {
+        if (states.contains(WidgetState.selected)) {
+          return const BorderSide(width: 2.0);
+        }
+        return BorderSide(width: 1.0);
+      }
+      if (states.contains(WidgetState.selected)) {
+        return const BorderSide(width: 1.5);
+      }
+      return BorderSide(width: 0.5);
     });
-
-    final bool Function(_MyWidgetState state) evaluator;
-
-    /// Stream passed down to the child [_InnerWidget] to begin the process.
-    /// This plays the role of an actual user interaction in the wild, but allows
-    /// us to engage the system without mocking pointers/hovers etc.
-    final StreamController<bool> controller;
-
-    /// The value we're watching in the given test.
-    final WidgetState materialState;
-
-    @override
-    State createState() => _MyWidgetState();
   }
 
+  @override
+  State createState() => _MyWidgetState();
 }


### PR DESCRIPTION
* removes an extra `)` in `app_bar.dart`
* Moves class definitions and getter definition out of the `main` method in `widget_state.dart` (defining classes/getters inside of methods is not allowed in Dart)

The formatter was stumbling over these syntax errors.