### PR TITLE
Adjust ignores for 'dart format'

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -181,45 +181,68 @@ TaskFunction createHotModeTest({
     });
 
     return TaskResult.success(
-      <String, dynamic> {
-        // ignore: avoid_dynamic_calls
-        'hotReloadInitialDevFSSyncMilliseconds': smallReloadData['hotReloadInitialDevFSSyncMilliseconds'][0],
+      <String, dynamic>{
+        'hotReloadInitialDevFSSyncMilliseconds':
+            // ignore: avoid_dynamic_calls
+            smallReloadData['hotReloadInitialDevFSSyncMilliseconds'][0],
         // ignore: avoid_dynamic_calls
         'hotRestartMillisecondsToFrame': smallReloadData['hotRestartMillisecondsToFrame'][0],
         // ignore: avoid_dynamic_calls
-        'hotReloadMillisecondsToFrame' : smallReloadData['hotReloadMillisecondsToFrame'][0],
+        'hotReloadMillisecondsToFrame': smallReloadData['hotReloadMillisecondsToFrame'][0],
         // ignore: avoid_dynamic_calls
         'hotReloadDevFSSyncMilliseconds': smallReloadData['hotReloadDevFSSyncMilliseconds'][0],
-        // ignore: avoid_dynamic_calls
-        'hotReloadFlutterReassembleMilliseconds': smallReloadData['hotReloadFlutterReassembleMilliseconds'][0],
+        'hotReloadFlutterReassembleMilliseconds':
+            // ignore: avoid_dynamic_calls
+            smallReloadData['hotReloadFlutterReassembleMilliseconds'][0],
         // ignore: avoid_dynamic_calls
         'hotReloadVMReloadMilliseconds': smallReloadData['hotReloadVMReloadMilliseconds'][0],
-        // ignore: avoid_dynamic_calls
-        'hotReloadMillisecondsToFrameAfterChange' : smallReloadData['hotReloadMillisecondsToFrame'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadDevFSSyncMillisecondsAfterChange': smallReloadData['hotReloadDevFSSyncMilliseconds'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadFlutterReassembleMillisecondsAfterChange': smallReloadData['hotReloadFlutterReassembleMilliseconds'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadVMReloadMillisecondsAfterChange': smallReloadData['hotReloadVMReloadMilliseconds'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadInitialDevFSSyncAfterRelaunchMilliseconds' : freshRestartReloadsData['hotReloadInitialDevFSSyncMilliseconds'][0],
-        // ignore: avoid_dynamic_calls
-        'hotReloadMillisecondsToFrameAfterMediumChange' : mediumReloadData['hotReloadMillisecondsToFrame'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadDevFSSyncMillisecondsAfterMediumChange': mediumReloadData['hotReloadDevFSSyncMilliseconds'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadFlutterReassembleMillisecondsAfterMediumChange': mediumReloadData['hotReloadFlutterReassembleMilliseconds'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadVMReloadMillisecondsAfterMediumChange': mediumReloadData['hotReloadVMReloadMilliseconds'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadMillisecondsToFrameAfterLargeChange' : largeReloadData['hotReloadMillisecondsToFrame'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadDevFSSyncMillisecondsAfterLargeChange': largeReloadData['hotReloadDevFSSyncMilliseconds'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadFlutterReassembleMillisecondsAfterLargeChange': largeReloadData['hotReloadFlutterReassembleMilliseconds'][1],
-        // ignore: avoid_dynamic_calls
-        'hotReloadVMReloadMillisecondsAfterLargeChange': largeReloadData['hotReloadVMReloadMilliseconds'][1],
+        'hotReloadMillisecondsToFrameAfterChange':
+            // ignore: avoid_dynamic_calls
+            smallReloadData['hotReloadMillisecondsToFrame'][1],
+        'hotReloadDevFSSyncMillisecondsAfterChange':
+            // ignore: avoid_dynamic_calls
+            smallReloadData['hotReloadDevFSSyncMilliseconds'][1],
+        'hotReloadFlutterReassembleMillisecondsAfterChange':
+            // ignore: avoid_dynamic_calls
+            smallReloadData['hotReloadFlutterReassembleMilliseconds'][1],
+        'hotReloadVMReloadMillisecondsAfterChange':
+            // ignore: avoid_dynamic_calls
+            smallReloadData['hotReloadVMReloadMilliseconds'][1],
+        'hotReloadInitialDevFSSyncAfterRelaunchMilliseconds':
+            // ignore: avoid_dynamic_calls
+            freshRestartReloadsData['hotReloadInitialDevFSSyncMilliseconds'][0],
+
+        'hotReloadMillisecondsToFrameAfterMediumChange':
+            // ignore: avoid_dynamic_calls
+            mediumReloadData['hotReloadMillisecondsToFrame'][1],
+
+        'hotReloadDevFSSyncMillisecondsAfterMediumChange':
+            // ignore: avoid_dynamic_calls
+            mediumReloadData['hotReloadDevFSSyncMilliseconds'][1],
+
+        'hotReloadFlutterReassembleMillisecondsAfterMediumChange':
+            // ignore: avoid_dynamic_calls
+            mediumReloadData['hotReloadFlutterReassembleMilliseconds'][1],
+
+        'hotReloadVMReloadMillisecondsAfterMediumChange':
+            // ignore: avoid_dynamic_calls
+            mediumReloadData['hotReloadVMReloadMilliseconds'][1],
+
+        'hotReloadMillisecondsToFrameAfterLargeChange':
+            // ignore: avoid_dynamic_calls
+            largeReloadData['hotReloadMillisecondsToFrame'][1],
+
+        'hotReloadDevFSSyncMillisecondsAfterLargeChange':
+            // ignore: avoid_dynamic_calls
+            largeReloadData['hotReloadDevFSSyncMilliseconds'][1],
+
+        'hotReloadFlutterReassembleMillisecondsAfterLargeChange':
+            // ignore: avoid_dynamic_calls
+            largeReloadData['hotReloadFlutterReassembleMilliseconds'][1],
+
+        'hotReloadVMReloadMillisecondsAfterLargeChange':
+            // ignore: avoid_dynamic_calls
+            largeReloadData['hotReloadVMReloadMilliseconds'][1],
       },
       benchmarkScoreKeys: <String>[
         'hotReloadInitialDevFSSyncMilliseconds',

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -883,7 +883,8 @@ class _ReusableRenderView extends RenderView {
   }
 
   @override
-  void dispose() { // ignore: must_call_super
+  // ignore: must_call_super
+  void dispose() {
     child = null;
   }
 }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2461,7 +2461,8 @@ class RenderTransform extends RenderProxyBox {
   /// There is no getter for [transform], because [Matrix4] is mutable, and
   /// mutations outside of the control of the render object could not reliably
   /// be reflected in the rendering.
-  set transform(Matrix4 value) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set transform(Matrix4 value) {
     if (_transform == value) {
       return;
     }

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -393,7 +393,8 @@ class StandardMessageCodec implements MessageCodec<Object?> {
                                    // decoding because we use tags to detect the type of value.
       buffer.putUint8(_valueFloat64);
       buffer.putFloat64(value);
-    } else if (value is int) { // ignore: avoid_double_and_int_checks, JS code always goes through the `double` path above
+      // ignore: avoid_double_and_int_checks, JS code always goes through the `double` path above
+    } else if (value is int) {
       if (-0x7fffffff - 1 <= value && value <= 0x7fffffff) {
         buffer.putUint8(_valueInt32);
         buffer.putInt32(value);

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -204,8 +204,10 @@ class BasicMessageChannel<T> {
     final BinaryMessenger result = _binaryMessenger ?? _findBinaryMessenger();
     return shouldProfilePlatformChannels
         ? _profiledBinaryMessengers[this] ??= _ProfiledBinaryMessenger(
-            // ignore: no_runtimetype_tostring
-            result, runtimeType.toString(), codec.runtimeType.toString())
+          result,
+          runtimeType.toString(), // ignore: no_runtimetype_tostring
+          codec.runtimeType.toString(),
+        )
         : result;
   }
   final BinaryMessenger? _binaryMessenger;
@@ -293,8 +295,10 @@ class MethodChannel {
     final BinaryMessenger result = _binaryMessenger ?? _findBinaryMessenger();
     return shouldProfilePlatformChannels
         ? _profiledBinaryMessengers[this] ??= _ProfiledBinaryMessenger(
-            // ignore: no_runtimetype_tostring
-            result, runtimeType.toString(), codec.runtimeType.toString())
+          result,
+          runtimeType.toString(), // ignore: no_runtimetype_tostring
+          codec.runtimeType.toString(),
+        )
         : result;
   }
   final BinaryMessenger? _binaryMessenger;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6634,7 +6634,8 @@ abstract class RenderObjectElement extends Element {
   }
 
   @override
-  void performRebuild() { // ignore: must_call_super, _performRebuild calls super.
+  // ignore: must_call_super, _performRebuild calls super.
+  void performRebuild() {
     _performRebuild(); // calls widget.updateRenderObject()
   }
 

--- a/packages/flutter/test/foundation/synchronous_future_test.dart
+++ b/packages/flutter/test/foundation/synchronous_future_test.dart
@@ -27,7 +27,8 @@ void main() {
     expect(await stream.single, equals(42));
 
     bool ranAction = false;
-    final Future<int> completeResult = future.whenComplete(() { // ignore: void_checks, https://github.com/dart-lang/linter/issues/1675
+    // ignore: void_checks, https://github.com/dart-lang/linter/issues/1675
+    final Future<int> completeResult = future.whenComplete(() {
       ranAction = true;
       // verify that whenComplete does NOT propagate its return value:
       return Future<int>.value(31);

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -433,7 +433,10 @@ void main() {
   test('PointerEventConverter processes view IDs', () {
     const int startID = 987654;
     const List<ui.PointerData> data = <ui.PointerData>[
-      ui.PointerData(viewId: startID + 0, change: ui.PointerChange.cancel), // ignore: avoid_redundant_argument_values
+      ui.PointerData(
+        viewId: startID + 0,
+        change: ui.PointerChange.cancel, // ignore: avoid_redundant_argument_values
+      ),
       ui.PointerData(viewId: startID + 1, change: ui.PointerChange.add),
       ui.PointerData(viewId: startID + 2, change: ui.PointerChange.remove),
       ui.PointerData(viewId: startID + 3, change: ui.PointerChange.hover),

--- a/packages/flutter/test/gestures/multidrag_test.dart
+++ b/packages/flutter/test/gestures/multidrag_test.dart
@@ -96,8 +96,9 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/pull/122227
 
     final ImmediateMultiDragGestureRecognizer recognizer1 = ImmediateMultiDragGestureRecognizer();
-    // ignore: avoid_redundant_argument_values
-    final ImmediateMultiDragGestureRecognizer recognizer2 = ImmediateMultiDragGestureRecognizer(allowedButtonsFilter: null);
+    final ImmediateMultiDragGestureRecognizer recognizer2 = ImmediateMultiDragGestureRecognizer(
+      allowedButtonsFilter: null, // ignore: avoid_redundant_argument_values
+    );
 
     // We want to test _allowedButtonsFilter, which is called in this method.
     const PointerDownEvent allowedPointer = PointerDownEvent(timeStamp: Duration(days: 10));

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -73,12 +73,20 @@ dynamic getRenderChip(WidgetTester tester) {
   return element.renderObject;
 }
 
-// ignore: avoid_dynamic_calls
-double getSelectProgress(WidgetTester tester) => getRenderChip(tester)?.checkmarkAnimation?.value as double;
-// ignore: avoid_dynamic_calls
-double getAvatarDrawerProgress(WidgetTester tester) => getRenderChip(tester)?.avatarDrawerAnimation?.value as double;
-// ignore: avoid_dynamic_calls
-double getDeleteDrawerProgress(WidgetTester tester) => getRenderChip(tester)?.deleteDrawerAnimation?.value as double;
+double getSelectProgress(WidgetTester tester) {
+  // ignore: avoid_dynamic_calls
+  return getRenderChip(tester)?.checkmarkAnimation?.value as double;
+}
+
+double getAvatarDrawerProgress(WidgetTester tester) {
+  // ignore: avoid_dynamic_calls
+  return getRenderChip(tester)?.avatarDrawerAnimation?.value as double;
+}
+
+double getDeleteDrawerProgress(WidgetTester tester) {
+  // ignore: avoid_dynamic_calls
+  return getRenderChip(tester)?.deleteDrawerAnimation?.value as double;
+}
 
 /// Adds the basic requirements for a Chip.
 Widget wrapForChip({

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -124,8 +124,11 @@ void main() {
 
     // ignore: avoid_dynamic_calls
     final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
-    // ignore: avoid_dynamic_calls
-    expect(selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels00To22);
+    expect(
+      // ignore: avoid_dynamic_calls
+      selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String),
+      labels00To22,
+    );
   });
 
   testWidgets('Material3 - Dialog size - dial mode', (WidgetTester tester) async {
@@ -227,8 +230,11 @@ void main() {
 
     // ignore: avoid_dynamic_calls
     final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
-    // ignore: avoid_dynamic_calls
-    expect(selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels00To23);
+    expect(
+      // ignore: avoid_dynamic_calls
+      selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String),
+      labels00To23,
+    );
     // ignore: avoid_dynamic_calls
     expect(selectedLabels.map<bool>((dynamic tp) => tp.inner as bool), inner0To23);
   });
@@ -580,13 +586,19 @@ void main() {
         final dynamic dialPainter = dialPaint.painter;
         // ignore: avoid_dynamic_calls
         final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
-        // ignore: avoid_dynamic_calls
-        expect(primaryLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels12To11);
+        expect(
+          // ignore: avoid_dynamic_calls
+          primaryLabels.map<String>((dynamic tp) => tp.painter.text.text as String),
+          labels12To11,
+        );
 
         // ignore: avoid_dynamic_calls
         final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
-        // ignore: avoid_dynamic_calls
-        expect(selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels12To11);
+        expect(
+          // ignore: avoid_dynamic_calls
+          selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String),
+          labels12To11,
+        );
       });
 
       testWidgets('when change orientation, should reflect in render objects', (WidgetTester tester) async {

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -132,20 +132,11 @@ void main() {
     expect(const EdgeInsetsDirectional.only(top: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(0.0, 963.25, 0.0, 0.0));
     expect(const EdgeInsetsDirectional.only(end: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(963.25, 0.0, 0.0, 0.0));
     expect(const EdgeInsetsDirectional.only(bottom: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 963.25));
-    expect(EdgeInsetsDirectional.only(), EdgeInsetsDirectional.only()); // ignore: prefer_const_constructors
+    expect(
+      EdgeInsetsDirectional.only(), // ignore: prefer_const_constructors
+      EdgeInsetsDirectional.only(), // ignore: prefer_const_constructors
+    );
     expect(const EdgeInsetsDirectional.only(top: 1.0), isNot(const EdgeInsetsDirectional.only(bottom: 1.0)));
-    expect(
-      const EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
-      const EdgeInsetsDirectional.fromSTEB(30.0, 20.0, 10.0, 40.0).resolve(TextDirection.rtl),
-    );
-    expect(
-      const EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
-      isNot(const EdgeInsetsDirectional.fromSTEB(30.0, 20.0, 10.0, 40.0).resolve(TextDirection.ltr)),
-    );
-    expect(
-      const EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
-      isNot(const EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.rtl)),
-    );
   });
 
   test('EdgeInsets equality', () {

--- a/packages/flutter/test/rendering/debug_overflow_indicator_test.dart
+++ b/packages/flutter/test/rendering/debug_overflow_indicator_test.dart
@@ -35,8 +35,10 @@ void main() {
     expect(exception, isFlutterError);
     // ignore: avoid_dynamic_calls
     expect(exception.diagnostics.first.level, DiagnosticLevel.summary);
-    // ignore: avoid_dynamic_calls
-    expect(exception.diagnostics.first.toString(), startsWith('A RenderConstraintsTransformBox overflowed by '));
+    expect(
+      exception.diagnostics.first.toString(), // ignore: avoid_dynamic_calls
+      startsWith('A RenderConstraintsTransformBox overflowed by '),
+    );
     expect(find.byType(UnconstrainedBox), paints..rect());
 
     await tester.pumpWidget(

--- a/packages/flutter/test/services/message_codecs_vm_test.dart
+++ b/packages/flutter/test/services/message_codecs_vm_test.dart
@@ -20,7 +20,10 @@ void main() {
       checkEncodeDecode<dynamic>(json, -9223372036854775807);
     });
     test('should encode and decode list with a big number', () {
-      final List<dynamic> message = <dynamic>[-7000000000000000007]; // ignore: avoid_js_rounded_ints, since we check for round-tripping, the actual value doesn't matter!
+      final List<dynamic> message = <dynamic>[
+        // ignore: avoid_js_rounded_ints, since we check for round-tripping, the actual value doesn't matter!
+        -7000000000000000007,
+      ];
       checkEncodeDecode<dynamic>(json, message);
     });
   });

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -617,11 +617,13 @@ void main() {
           // the UnconstrainedBox overflows.
           final dynamic exception = tester.takeException();
           expect(exception, isFlutterError, reason: 'for clip = $clip');
-          // ignore: avoid_dynamic_calls
-          expect(exception.diagnostics.first.level, DiagnosticLevel.summary, reason: 'for clip = $clip');
           expect(
-            // ignore: avoid_dynamic_calls
-            exception.diagnostics.first.toString(),
+            exception.diagnostics.first.level, // ignore: avoid_dynamic_calls
+            DiagnosticLevel.summary,
+            reason: 'for clip = $clip',
+          );
+          expect(
+            exception.diagnostics.first.toString(), // ignore: avoid_dynamic_calls
             startsWith('A RenderConstraintsTransformBox overflowed'),
             reason: 'for clip = $clip',
           );

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -155,7 +155,9 @@ void main() {
         })
       )
     ));
-    final TestGesture touchGesture = await tester.createGesture(kind: PointerDeviceKind.touch); // ignore: avoid_redundant_argument_values
+    final TestGesture touchGesture = await tester.createGesture(
+      kind: PointerDeviceKind.touch, // ignore: avoid_redundant_argument_values
+    );
     // Try mouse hovering while scrolling by touch
     await touchGesture.down(tester.getCenter(find.byType(ListView)));
     await tester.pump();

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -541,8 +541,11 @@ void main() {
       ),
     );
 
-    // ignore: avoid_dynamic_calls
-    expect(_getSemanticsDebuggerPainter(debuggerKey: debugger, tester: tester).labelStyle, labelStyle);
+    expect(
+      // ignore: avoid_dynamic_calls
+      _getSemanticsDebuggerPainter(debuggerKey: debugger, tester: tester).labelStyle,
+      labelStyle,
+    );
   });
 
   testWidgets('SemanticsDebugger label for rtl.', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2894,7 +2894,8 @@ class _TestVicinity extends ChildVicinity {
   const _TestVicinity({required super.xIndex, required super.yIndex});
 }
 
-class _TestBaseDelegate extends TwoDimensionalChildDelegate { //ignore: unused_element
+//ignore: unused_element
+class _TestBaseDelegate extends TwoDimensionalChildDelegate {
   // Would fail analysis without covariant
   @override
   Widget? build(BuildContext context, _TestVicinity vicinity) => null;
@@ -2904,7 +2905,8 @@ class _TestBaseDelegate extends TwoDimensionalChildDelegate { //ignore: unused_e
 
 }
 
-class _TestBuilderDelegate extends TwoDimensionalChildBuilderDelegate { //ignore: unused_element
+//ignore: unused_element
+class _TestBuilderDelegate extends TwoDimensionalChildBuilderDelegate {
   _TestBuilderDelegate({required super.builder});
   // Would fail analysis without covariant
   @override
@@ -2913,7 +2915,8 @@ class _TestBuilderDelegate extends TwoDimensionalChildBuilderDelegate { //ignore
   }
 }
 
-class _TestListDelegate extends TwoDimensionalChildListDelegate { //ignore: unused_element
+//ignore: unused_element
+class _TestListDelegate extends TwoDimensionalChildListDelegate {
   _TestListDelegate({required super.children});
   // Would fail analysis without covariant
   @override
@@ -2969,7 +2972,8 @@ Future<void> restoreScrollAndVerify(WidgetTester tester) async {
 // Validates covariant through analysis.
 mixin _SomeDelegateMixin on TwoDimensionalChildDelegate {}
 
-class _SomeRenderTwoDimensionalViewport extends RenderTwoDimensionalViewport { // ignore: unused_element
+// ignore: unused_element
+class _SomeRenderTwoDimensionalViewport extends RenderTwoDimensionalViewport {
   _SomeRenderTwoDimensionalViewport({
     required super.horizontalOffset,
     required super.horizontalAxisDirection,

--- a/packages/flutter_localizations/test/material/time_picker_test.dart
+++ b/packages/flutter_localizations/test/material/time_picker_test.dart
@@ -524,16 +524,20 @@ void main() {
     // ignore: avoid_dynamic_calls
     final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      primaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
+      primaryLabels.map<String>(
+        // ignore: avoid_dynamic_calls
+        (dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!,
+      ),
       labels12To11,
     );
 
     // ignore: avoid_dynamic_calls
     final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
+      selectedLabels.map<String>(
+        // ignore: avoid_dynamic_calls
+        (dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!,
+      ),
       labels12To11,
     );
   });
@@ -546,16 +550,20 @@ void main() {
     // ignore: avoid_dynamic_calls
     final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      primaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
+      primaryLabels.map<String>(
+        // ignore: avoid_dynamic_calls
+        (dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!,
+      ),
       labels12To11,
     );
 
     // ignore: avoid_dynamic_calls
     final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
+      selectedLabels.map<String>(
+        // ignore: avoid_dynamic_calls
+        (dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!,
+      ),
       labels12To11,
     );
   });
@@ -568,16 +576,20 @@ void main() {
     // ignore: avoid_dynamic_calls
     final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      primaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
+      primaryLabels.map<String>(
+        // ignore: avoid_dynamic_calls
+        (dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!,
+      ),
       labels00To23TwoDigit,
     );
 
     // ignore: avoid_dynamic_calls
     final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
+      selectedLabels.map<String>(
+        // ignore: avoid_dynamic_calls
+        (dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!,
+      ),
       labels00To23TwoDigit,
     );
   });
@@ -590,16 +602,20 @@ void main() {
     // ignore: avoid_dynamic_calls
     final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      primaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
+      primaryLabels.map<String>(
+        // ignore: avoid_dynamic_calls
+        (dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!,
+      ),
       labels00To22TwoDigit,
     );
 
     // ignore: avoid_dynamic_calls
     final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
     expect(
-      // ignore: avoid_dynamic_calls
-      selectedLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
+      selectedLabels.map<String>(
+        // ignore: avoid_dynamic_calls
+        (dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!,
+      ),
       labels00To22TwoDigit,
     );
   });

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -1375,8 +1375,10 @@ class _HasGoodToStringDeep extends Matcher {
     const String prefixLineOne = 'PREFIX_LINE_ONE____';
     const String prefixOtherLines = 'PREFIX_OTHER_LINES_';
     final List<String> prefixIssues = <String>[];
-    // ignore: avoid_dynamic_calls
-    String descriptionWithPrefixes = object.toStringDeep(prefixLineOne: prefixLineOne, prefixOtherLines: prefixOtherLines) as String;
+    String descriptionWithPrefixes =
+        // ignore: avoid_dynamic_calls
+        object.toStringDeep(prefixLineOne: prefixLineOne, prefixOtherLines: prefixOtherLines)
+            as String;
     if (descriptionWithPrefixes.endsWith('\n')) {
       // Trim off trailing \n as the remaining calculations assume
       // the description does not end with a trailing \n.

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -259,7 +259,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   Locale get locale => _localeTestValue ?? _platformDispatcher.locale;
   Locale? _localeTestValue;
   /// Hides the real locale and reports the given [localeTestValue] instead.
-  set localeTestValue(Locale localeTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set localeTestValue(Locale localeTestValue) {
     _localeTestValue = localeTestValue;
     onLocaleChanged?.call();
   }
@@ -274,7 +275,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   List<Locale> get locales => _localesTestValue ?? _platformDispatcher.locales;
   List<Locale>? _localesTestValue;
   /// Hides the real locales and reports the given [localesTestValue] instead.
-  set localesTestValue(List<Locale> localesTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set localesTestValue(List<Locale> localesTestValue) {
     _localesTestValue = localesTestValue;
     onLocaleChanged?.call();
   }
@@ -296,7 +298,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   String get initialLifecycleState => _initialLifecycleStateTestValue;
   String _initialLifecycleStateTestValue = '';
   /// Sets a faked initialLifecycleState for testing.
-  set initialLifecycleStateTestValue(String state) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set initialLifecycleStateTestValue(String state) {
     _initialLifecycleStateTestValue = state;
   }
 
@@ -310,7 +313,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   double? _textScaleFactorTestValue;
   /// Hides the real text scale factor and reports the given
   /// [textScaleFactorTestValue] instead.
-  set textScaleFactorTestValue(double textScaleFactorTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set textScaleFactorTestValue(double textScaleFactorTestValue) {
     _textScaleFactorTestValue = textScaleFactorTestValue;
     onTextScaleFactorChanged?.call();
   }
@@ -333,7 +337,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   }
   /// Hides the real platform brightness and reports the given
   /// [platformBrightnessTestValue] instead.
-  set platformBrightnessTestValue(Brightness platformBrightnessTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set platformBrightnessTestValue(Brightness platformBrightnessTestValue) {
     _platformBrightnessTestValue = platformBrightnessTestValue;
     onPlatformBrightnessChanged?.call();
   }
@@ -350,7 +355,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   bool? _alwaysUse24HourFormatTestValue;
   /// Hides the real clock format and reports the given
   /// [alwaysUse24HourFormatTestValue] instead.
-  set alwaysUse24HourFormatTestValue(bool alwaysUse24HourFormatTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set alwaysUse24HourFormatTestValue(bool alwaysUse24HourFormatTestValue) {
     _alwaysUse24HourFormatTestValue = alwaysUse24HourFormatTestValue;
   }
 
@@ -370,7 +376,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   @override
   bool get nativeSpellCheckServiceDefined => _nativeSpellCheckServiceDefinedTestValue ?? _platformDispatcher.nativeSpellCheckServiceDefined;
   bool? _nativeSpellCheckServiceDefinedTestValue;
-  set nativeSpellCheckServiceDefinedTestValue(bool nativeSpellCheckServiceDefinedTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set nativeSpellCheckServiceDefinedTestValue(bool nativeSpellCheckServiceDefinedTestValue) {
     _nativeSpellCheckServiceDefinedTestValue = nativeSpellCheckServiceDefinedTestValue;
   }
 
@@ -383,7 +390,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   @override
   bool get supportsShowingSystemContextMenu => _supportsShowingSystemContextMenu ?? _platformDispatcher.supportsShowingSystemContextMenu;
   bool? _supportsShowingSystemContextMenu;
-  set supportsShowingSystemContextMenu(bool value) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set supportsShowingSystemContextMenu(bool value) {
     _supportsShowingSystemContextMenu = value;
   }
 
@@ -397,7 +405,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   bool? _brieflyShowPasswordTestValue;
   /// Hides the real [brieflyShowPassword] and reports the given
   /// `brieflyShowPasswordTestValue` instead.
-  set brieflyShowPasswordTestValue(bool brieflyShowPasswordTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set brieflyShowPasswordTestValue(bool brieflyShowPasswordTestValue) {
     _brieflyShowPasswordTestValue = brieflyShowPasswordTestValue;
   }
 
@@ -439,7 +448,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   String? _defaultRouteNameTestValue;
   /// Hides the real default route name and reports the given
   /// [defaultRouteNameTestValue] instead.
-  set defaultRouteNameTestValue(String defaultRouteNameTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set defaultRouteNameTestValue(String defaultRouteNameTestValue) {
     _defaultRouteNameTestValue = defaultRouteNameTestValue;
   }
 
@@ -459,7 +469,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   bool? _semanticsEnabledTestValue;
   /// Hides the real semantics enabled and reports the given
   /// [semanticsEnabledTestValue] instead.
-  set semanticsEnabledTestValue(bool semanticsEnabledTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set semanticsEnabledTestValue(bool semanticsEnabledTestValue) {
     _semanticsEnabledTestValue = semanticsEnabledTestValue;
     onSemanticsEnabledChanged?.call();
   }
@@ -493,7 +504,8 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   ///
   /// Consider using [FakeAccessibilityFeatures] to provide specific
   /// values for the various accessibility features under test.
-  set accessibilityFeaturesTestValue(AccessibilityFeatures accessibilityFeaturesTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set accessibilityFeaturesTestValue(AccessibilityFeatures accessibilityFeaturesTestValue) {
     _accessibilityFeaturesTestValue = accessibilityFeaturesTestValue;
     onAccessibilityFeaturesChanged?.call();
   }
@@ -1298,7 +1310,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set devicePixelRatioTestValue(double devicePixelRatio) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set devicePixelRatioTestValue(double devicePixelRatio) {
     _view.devicePixelRatio = devicePixelRatio;
   }
 
@@ -1327,7 +1340,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set physicalSizeTestValue (Size physicalSizeTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set physicalSizeTestValue (Size physicalSizeTestValue) {
     _view.physicalSize = physicalSizeTestValue;
   }
 
@@ -1358,7 +1372,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set viewInsetsTestValue(ViewPadding value) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set viewInsetsTestValue(ViewPadding value) {
     _view.viewInsets = value is FakeViewPadding ? value : FakeViewPadding._wrap(value);
   }
 
@@ -1389,7 +1404,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set viewPaddingTestValue(ViewPadding value) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set viewPaddingTestValue(ViewPadding value) {
     _view.viewPadding = value is FakeViewPadding ? value : FakeViewPadding._wrap(value);
   }
 
@@ -1419,7 +1435,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set paddingTestValue(ViewPadding value) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set paddingTestValue(ViewPadding value) {
     _view.padding = value is FakeViewPadding ? value : FakeViewPadding._wrap(value);
   }
 
@@ -1446,7 +1463,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set gestureSettingsTestValue(GestureSettings gestureSettingsTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set gestureSettingsTestValue(GestureSettings gestureSettingsTestValue) {
     _view.gestureSettings = gestureSettingsTestValue;
   }
 
@@ -1473,7 +1491,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set displayFeaturesTestValue(List<DisplayFeature> displayFeaturesTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set displayFeaturesTestValue(List<DisplayFeature> displayFeaturesTestValue) {
     _view.displayFeatures = displayFeaturesTestValue;
   }
 
@@ -1503,7 +1522,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set systemGestureInsetsTestValue(ViewPadding value) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set systemGestureInsetsTestValue(ViewPadding value) {
     _view.systemGestureInsets = value is FakeViewPadding ? value : FakeViewPadding._wrap(value);
   }
 
@@ -1644,7 +1664,8 @@ class TestWindow implements SingletonFlutterWindow {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.9.0-0.1.pre.'
   )
-  set nativeSpellCheckServiceDefinedTestValue(bool nativeSpellCheckServiceDefinedTestValue) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set nativeSpellCheckServiceDefinedTestValue(bool nativeSpellCheckServiceDefinedTestValue) {
     platformDispatcher.nativeSpellCheckServiceDefinedTestValue = nativeSpellCheckServiceDefinedTestValue;
   }
 

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -120,8 +120,9 @@ Future<int> run(
         // We already hit some error, so don't return success. The error path
         // (which should be in progress) is responsible for calling _exit().
         return 1;
-      } catch (error, stackTrace) { // ignore: avoid_catches_without_on_clauses
         // This catches all exceptions to send to crash logging, etc.
+        // ignore: avoid_catches_without_on_clauses
+      } catch (error, stackTrace) {
         firstError = error;
         firstStackTrace = stackTrace;
         return _handleToolError(error, stackTrace, verbose, args, reportCrashes!, getVersion, shutdownHooks);
@@ -229,7 +230,8 @@ Future<int> _handleToolError(
 
       return exitWithHooks(1, shutdownHooks: shutdownHooks);
     // This catch catches all exceptions to ensure the message below is printed.
-    } catch (error, st) { // ignore: avoid_catches_without_on_clauses
+    // ignore: avoid_catches_without_on_clauses
+    } catch (error, st) {
       globals.stdio.stderrWrite(
         'Unable to generate crash report due to secondary error: $error\n$st\n'
         '${globals.userMessages.flutterToolBugInstructions}\n',

--- a/packages/flutter_tools/lib/src/base/async_guard.dart
+++ b/packages/flutter_tools/lib/src/base/async_guard.dart
@@ -114,7 +114,8 @@ Future<T> asyncGuard<T>(
       }
     // This catches all exceptions so that they can be propagated to the
     // caller-supplied error handling or the completer.
-    } catch (e, s) { // ignore: avoid_catches_without_on_clauses, forwards to Future
+    // ignore: avoid_catches_without_on_clauses, forwards to Future
+    } catch (e, s) {
       handleError(e, s);
     }
   }, onError: (Object e, StackTrace s) {

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -254,7 +254,8 @@ mixin CreateBase on FlutterCommand {
 
     final FileSystemEntityType type = globals.fs.typeSync(projectDirPath);
 
-    switch (type) { // ignore: exhaustive_cases, https://github.com/dart-lang/linter/issues/3017
+    // ignore: exhaustive_cases, https://github.com/dart-lang/linter/issues/3017
+    switch (type) {
       case FileSystemEntityType.file:
         // Do not overwrite files.
         throwToolExit("Invalid project name: '$projectDirPath' - file exists.",

--- a/packages/flutter_tools/lib/src/commands/ide_config.dart
+++ b/packages/flutter_tools/lib/src/commands/ide_config.dart
@@ -264,7 +264,8 @@ class IdeConfigCommand extends FlutterCommand {
 String? _validateFlutterDir(String dirPath, { String? flutterRoot }) {
   final FileSystemEntityType type = globals.fs.typeSync(dirPath);
 
-  switch (type) { // ignore: exhaustive_cases, https://github.com/dart-lang/linter/issues/3017
+  // ignore: exhaustive_cases, https://github.com/dart-lang/linter/issues/3017
+  switch (type) {
     case FileSystemEntityType.link:
       // Do not overwrite links.
       return "Invalid project root dir: '$dirPath' - refers to a link.";

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -197,7 +197,8 @@ class CrashReportSender {
 
     // Catch all exceptions to print the message that makes clear that the
     // crash logger crashed.
-    } catch (sendError, sendStackTrace) { // ignore: avoid_catches_without_on_clauses
+    // ignore: avoid_catches_without_on_clauses
+    } catch (sendError, sendStackTrace) {
       if (sendError is SocketException || sendError is HttpException || sendError is http.ClientException) {
         _logger.printError('Failed to send crash report due to a network error: $sendError');
       } else {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -538,7 +538,8 @@ abstract class FlutterCommand extends Command<void> {
       }
       ddsEnabled = !boolArg('disable-dds');
       // TODO(ianh): enable the following code once google3 is migrated away from --disable-dds (and add test to flutter_command_test.dart)
-      if (false) { // ignore: dead_code, literal_only_boolean_expressions
+      // ignore: dead_code, literal_only_boolean_expressions
+      if (false) {
         if (ddsEnabled) {
           globals.printWarning('${globals.logger.terminal
               .warningMark} The "--no-disable-dds" argument is deprecated and redundant, and should be omitted.');

--- a/packages/flutter_tools/lib/src/test/test_wrapper.dart
+++ b/packages/flutter_tools/lib/src/test/test_wrapper.dart
@@ -5,7 +5,9 @@
 import 'dart:async';
 
 import 'package:test_core/src/executable.dart' as test; // ignore: implementation_imports
-import 'package:test_core/src/platform.dart' as hack show registerPlatformPlugin; // ignore: implementation_imports
+import 'package:test_core/src/platform.dart' // ignore: implementation_imports
+    as hack
+    show registerPlatformPlugin;
 import 'package:test_core/src/platform.dart'; // ignore: implementation_imports
 
 export 'package:test_api/backend.dart' show Runtime;

--- a/packages/flutter_tools/test/general.shard/utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/utils_test.dart
@@ -409,8 +409,11 @@ needs to be wrapped.
   });
 
   testWithoutContext('getSizeAsMB', () async {
-    // ignore: avoid_redundant_argument_values
-    expect(getSizeAsPlatformMB(10 * 1000 * 1000, platform: FakePlatform(operatingSystem: 'linux')), '10.0MB');
+    expect(
+      // ignore: avoid_redundant_argument_values
+      getSizeAsPlatformMB(10 * 1000 * 1000, platform: FakePlatform(operatingSystem: 'linux')),
+      '10.0MB',
+    );
     expect(getSizeAsPlatformMB(10 * 1000 * 1000, platform: FakePlatform(operatingSystem: 'macos')), '10.0MB');
     expect(getSizeAsPlatformMB(10 * 1000 * 1000, platform: FakePlatform(operatingSystem: 'windows')), '9.5MB');
     expect(getSizeAsPlatformMB(10 * 1000 * 1000, platform: FakePlatform(operatingSystem: 'android')), '10.0MB');

--- a/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
@@ -65,7 +65,8 @@ class PluginEventChannel<T> {
     'Replace calls to the "controller" setter with calls to the "setController" method. '
     'This feature was deprecated after v1.23.0-7.0.pre.'
   )
-  set controller(StreamController<T> controller) { // ignore: avoid_setters_without_getters
+  // ignore: avoid_setters_without_getters
+  set controller(StreamController<T> controller) {
     setController(controller);
   }
 


### PR DESCRIPTION
When running `dart format` over these lines the `// ignore` ended up on a line where it wasn't properly ignoring the lint. This adjusts the placement of `// ignore`s so they will continue to ignore the right thing even after the code is auto formatted.

I am hoping that if we do this now the large PR that formats the entire repo will go in smoother without manual intervention.