### PR TITLE
Initialize dartLoader.rootDirectories so the Web stack trace mapper can convert package source paths

### DIFF
--- a/dev/integration_tests/web/lib/stack_trace.dart
+++ b/dev/integration_tests/web/lib/stack_trace.dart
@@ -32,8 +32,8 @@ const List<StackFrame> expectedDebugStackFrames = <StackFrame>[
   StackFrame(
     number: -1,
     packageScheme: 'package',
-    package: 'packages',
-    packagePath: 'web_integration/stack_trace.dart',
+    package: 'web_integration',
+    packagePath: 'stack_trace.dart',
     line: 119,
     column: 3,
     className: '<unknown>',
@@ -43,8 +43,8 @@ const List<StackFrame> expectedDebugStackFrames = <StackFrame>[
   StackFrame(
     number: -1,
     packageScheme: 'package',
-    package: 'packages',
-    packagePath: 'web_integration/stack_trace.dart',
+    package: 'web_integration',
+    packagePath: 'stack_trace.dart',
     line: 114,
     column: 3,
     className: '<unknown>',
@@ -54,8 +54,8 @@ const List<StackFrame> expectedDebugStackFrames = <StackFrame>[
   StackFrame(
     number: -1,
     packageScheme: 'package',
-    package: 'packages',
-    packagePath: 'web_integration/stack_trace.dart',
+    package: 'web_integration',
+    packagePath: 'stack_trace.dart',
     line: 109,
     column: 3,
     className: '<unknown>',

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -1031,6 +1031,7 @@ class WebDevFS implements DevFS {
               entrypoint: entrypoint,
               nullAssertions: nullAssertions,
               nativeNullAssertions: nativeNullAssertions,
+          loaderRootDirectory: _baseUri.toString(),
             ),
       );
       // TODO(zanderso): refactor the asset code in this and the regular devfs to

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -1031,7 +1031,7 @@ class WebDevFS implements DevFS {
               entrypoint: entrypoint,
               nullAssertions: nullAssertions,
               nativeNullAssertions: nativeNullAssertions,
-          loaderRootDirectory: _baseUri.toString(),
+              loaderRootDirectory: _baseUri.toString(),
             ),
       );
       // TODO(zanderso): refactor the asset code in this and the regular devfs to

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -466,6 +466,7 @@ String generateMainModule({
   required bool nullAssertions,
   required bool nativeNullAssertions,
   String bootstrapModule = 'main_module.bootstrap',
+  String loaderRootDirectory = '',
 }) {
   // The typo below in "EXTENTION" is load-bearing, package:build depends on it.
   return '''
@@ -489,7 +490,7 @@ define("$bootstrapModule", ["$entrypoint", "dart_sdk"], function(app, dart_sdk) 
   child.main();
 
   window.\$dartLoader = {};
-  window.\$dartLoader.rootDirectories = [];
+  window.\$dartLoader.rootDirectories = ["$loaderRootDirectory"];
   if (window.\$requireLoader) {
     window.\$requireLoader.getModuleLibraries = dart_sdk.dart.getModuleLibraries;
   }

--- a/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
@@ -154,7 +154,7 @@ void main() {
   });
 
   test('generateMainModule sets rootDirectories', () {
-    final String root = 'http://localhost:12345';
+    const String root = 'http://localhost:12345';
     final String result = generateMainModule(
       entrypoint: 'foo/bar/main.js',
       nullAssertions: false,

--- a/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
@@ -154,7 +154,7 @@ void main() {
   });
 
   test('generateMainModule sets rootDirectories', () {
-    String root = 'http://localhost:12345';
+    final String root = 'http://localhost:12345';
     final String result = generateMainModule(
       entrypoint: 'foo/bar/main.js',
       nullAssertions: false,

--- a/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
@@ -153,6 +153,18 @@ void main() {
     expect(result, contains('''dart_sdk.dart.nativeNonNullAsserts(false);'''));
   });
 
+  test('generateMainModule sets rootDirectories', () {
+    String root = 'http://localhost:12345';
+    final String result = generateMainModule(
+      entrypoint: 'foo/bar/main.js',
+      nullAssertions: false,
+      nativeNullAssertions: false,
+      loaderRootDirectory: root,
+    );
+
+    expect(result, contains('''window.\$dartLoader.rootDirectories = ["$root"];'''));
+  });
+
   test('generateTestBootstrapFileContents embeds urls correctly', () {
     final String result = generateTestBootstrapFileContents(
       'foo.dart.js',


### PR DESCRIPTION
See https://dart.googlesource.com/sdk/+/refs/heads/main/pkg/dev_compiler/web/stack_trace_mapper.dart

Fixes https://github.com/flutter/flutter/issues/158109