### PR TITLE
Adjust tools tests that would be broken by formatting

### DIFF
--- a/dev/automated_tests/flutter_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/flutter_test/exception_handling_expectation.txt
@@ -46,7 +46,7 @@ The following message was thrown running a test:
 Who lives, who dies, who tells your story\?
 
 When the exception was thrown, this was the stack:
-#[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:16:5\)
+#[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:18:5\)
 <<skip until matching line>>
 #[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]widget_tester\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>

--- a/dev/automated_tests/flutter_test/exception_handling_test.dart
+++ b/dev/automated_tests/flutter_test/exception_handling_test.dart
@@ -12,7 +12,9 @@ void main() {
   testWidgets('Exception handling in test harness - FlutterError', (WidgetTester tester) async {
     throw FlutterError('Who lives, who dies, who tells your story?');
   });
-  testWidgets('Exception handling in test harness - uncaught Future error', (WidgetTester tester) async {
+  testWidgets('Exception handling in test harness - uncaught Future error', (
+    WidgetTester tester,
+  ) async {
     Future<void>.error('Who lives, who dies, who tells your story?');
   });
 }

--- a/dev/automated_tests/integration_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/integration_test/exception_handling_expectation.txt
@@ -32,7 +32,7 @@ The following message was thrown running a test:
 Who lives, who dies, who tells your story\?
 
 When the exception was thrown, this was the stack:
-#4      main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]integration_test[/\\]exception_handling_test\.dart:16:5\)
+#4      main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]integration_test[/\\]exception_handling_test\.dart:18:5\)
 <<skip until matching line>>
 The test description was:
   Exception handling in test harness - uncaught Future error

--- a/dev/automated_tests/integration_test/exception_handling_test.dart
+++ b/dev/automated_tests/integration_test/exception_handling_test.dart
@@ -12,7 +12,9 @@ void main() {
   testWidgets('Exception handling in test harness - FlutterError', (WidgetTester tester) async {
     throw FlutterError('Who lives, who dies, who tells your story?');
   });
-  testWidgets('Exception handling in test harness - uncaught Future error', (WidgetTester tester) async {
+  testWidgets('Exception handling in test harness - uncaught Future error', (
+    WidgetTester tester,
+  ) async {
     Future<void>.error('Who lives, who dies, who tells your story?');
   });
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1830,8 +1830,10 @@ class DebugConnectionInfo {
 /// Returns the next platform value for the switcher.
 ///
 /// These values must match what is available in
-/// `packages/flutter/lib/src/foundation/binding.dart`.
+/// `packages/flutter/lib/src/foundation/platform.dart`.
 String nextPlatform(String currentPlatform) {
+  // The following lines are read by a script, which expects a certain format.
+  // dart format off
   const List<String> platforms = <String>[
     'android',
     'iOS',
@@ -1840,6 +1842,7 @@ String nextPlatform(String currentPlatform) {
     'linux',
     'fuchsia',
   ];
+  // dart format on
   final int index = platforms.indexOf(currentPlatform);
   assert(index >= 0, 'unknown platform "$currentPlatform"');
   return platforms[(index + 1) % platforms.length];


### PR DESCRIPTION
These tests depend on line numbers that `dart format` is changing. Pre-format the files in question and adjust the tests so they continue to pass when the entire repo is formatted.