### PR TITLE
Normalize localizations with dartfmt in presubmit check

### DIFF
--- a/dev/bots/pubspec.yaml
+++ b/dev/bots/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   analyzer: 6.11.0
   args: 2.6.0
   crypto: 3.0.6
+  dart_style: 2.3.7
   intl: 0.19.0
   file: 7.0.1
   flutter_devicelab:
@@ -77,4 +78,4 @@ dependencies:
 dev_dependencies:
   test_api: 0.7.4
 
-# PUBSPEC CHECKSUM: cbf1
+# PUBSPEC CHECKSUM: e284


### PR DESCRIPTION
Makes the presubmit check independent of whether the files in the repo are dartfmt formatted or not.