### PR TITLE
Fix infinite build loop with `DropdownMenu` and `ListenableBuilder`

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -529,7 +529,11 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         );
       }
     }
-    return TextEditingValue.empty;
+
+    return switch (_localTextEditingController?.value) {
+      TextEditingValue.empty => TextEditingValue.empty,
+      _ => const TextEditingValue(selection: TextSelection.collapsed(offset: 0)),
+    };
   }
 
   @override

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2142,7 +2142,7 @@ void main() {
         listenable: controller,
         builder: (BuildContext context, Widget? child) {
           buildCount += 1;
-          if (buildCount > 10) {
+          if (buildCount > 2) {
             throw StateError('too many builds!');
           }
 


### PR DESCRIPTION
I did a bit of stepping through the debugger to see what was going on with https://github.com/flutter/flutter/issues/160196, and I think I found the culprit:

https://github.com/flutter/flutter/blob/06dd9a35257e9ed07802fb90a416c19266612f84/packages/flutter/lib/src/services/text_input.dart#L832-L836

Parts of the `_DropdownMenuState` logic use `TextSelection.collapsed(offset: 0)`, but `TextEditingValue.empty` uses the empty constructor, which defaults to an offset of `-1`.

The infinite rebuild loop happens because the selection offset is repeatedly switching between `0` and `-1`, and thanks to the `ListenableBuilder`, a rebuild is scheduled each time.

<br><br>

This pull request tweaks the `_initialTextEditingValue` getter to prevent unnecessary notifications.
To verify that this fixes #160196, a test was added using the code sample from that issue.