### PR TITLE
Consistently set `Cache.flutterRoot` in `create_test.dart`.

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -102,6 +102,12 @@ void main() {
       fs: MemoryFileSystem.test(),
       fakeFlutterVersion: fakeFlutterVersion,
     );
+
+    // Most, but not all, tests will run some variant of "pub get" after creation,
+    // which in turn will check for the presence of the Flutter SDK root. Without
+    // this field set consistently, the order of the tests becomes important *or*
+    // you need to remember to set it everywhere.
+    Cache.flutterRoot = '../..';
   });
 
   tearDown(() {
@@ -359,7 +365,6 @@ void main() {
   });
 
   testUsingContext('cannot create a project in flutter root', () async {
-    Cache.flutterRoot = '../..';
     final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', globals.platform.isWindows ? 'flutter.bat' : 'flutter');
     final ProcessResult exec = await Process.run(
       flutterBin,
@@ -921,8 +926,6 @@ void main() {
 
 
   testUsingContext('androidx is used by default in an app project', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -940,8 +943,6 @@ void main() {
   });
 
   testUsingContext('androidx is used by default in a module project', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -955,8 +956,6 @@ void main() {
   });
 
   testUsingContext('creating a new project should create v2 embedding and never show an Android v1 deprecation warning', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -980,8 +979,6 @@ void main() {
   });
 
   testUsingContext('app supports android and ios by default', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -992,8 +989,6 @@ void main() {
   }, overrides: <Type, Generator>{});
 
   testUsingContext('app does not include android if disabled in config', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1005,8 +1000,6 @@ void main() {
   });
 
   testUsingContext('app does not include ios if disabled in config', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1018,8 +1011,6 @@ void main() {
   });
 
   testUsingContext('app does not include desktop or web by default', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1035,8 +1026,6 @@ void main() {
 
   testUsingContext('plugin does not include desktop or web by default',
       () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1056,8 +1045,6 @@ void main() {
   });
 
   testUsingContext('app supports Linux if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1081,8 +1068,6 @@ void main() {
   });
 
   testUsingContext('plugin supports Linux if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1116,8 +1101,6 @@ void main() {
   });
 
   testUsingContext('app supports macOS if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1143,8 +1126,6 @@ void main() {
   });
 
   testUsingContext('plugin supports macOS if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1175,8 +1156,6 @@ void main() {
   });
 
   testUsingContext('app supports Windows if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1201,8 +1180,6 @@ void main() {
   });
 
   testUsingContext('Windows has correct VERSIONINFO', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1219,8 +1196,6 @@ void main() {
   });
 
   testUsingContext('plugin supports Windows if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1262,8 +1237,6 @@ void main() {
   });
 
   testUsingContext('app supports web if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1289,8 +1262,6 @@ void main() {
   });
 
   testUsingContext('app creates maskable icons for web', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1308,8 +1279,6 @@ void main() {
   });
 
   testUsingContext('plugin uses new platform schema', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1321,8 +1290,6 @@ void main() {
   });
 
   testUsingContext('has correct content and formatting with module template', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1422,8 +1389,6 @@ void main() {
   });
 
   testUsingContext('has correct default content and formatting with app template', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1502,8 +1467,6 @@ void main() {
   });
 
   testUsingContext('has iOS development team with app template', () async {
-    Cache.flutterRoot = '../..';
-
     final Completer<void> completer = Completer<void>();
     final StreamController<List<int>> controller = StreamController<List<int>>();
     const String certificates = '''
@@ -1553,8 +1516,6 @@ void main() {
   });
 
   testUsingContext('Correct info.plist key-value pairs for objc iOS project.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1572,8 +1533,6 @@ void main() {
   });
 
   testUsingContext('Correct info.plist key-value pairs for objc swift project.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1591,8 +1550,6 @@ void main() {
   });
 
   testUsingContext('Correct info.plist key-value pairs for objc iOS module.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1620,8 +1577,6 @@ void main() {
   });
 
   testUsingContext('Correct info.plist key-value pairs for swift iOS module.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1649,8 +1604,6 @@ void main() {
   });
 
   testUsingContext('Correct info.plist key-value pairs for swift iOS plugin.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1668,8 +1621,6 @@ void main() {
   });
 
   testUsingContext('Correct info.plist key-value pairs for objc iOS plugin.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1687,8 +1638,6 @@ void main() {
   });
 
   testUsingContext('should not show --ios-language deprecation warning issue for Swift', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1702,8 +1651,6 @@ void main() {
   });
 
   testUsingContext('should show --ios-language deprecation warning issue for Objective-C', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1717,8 +1664,6 @@ void main() {
   });
 
   testUsingContext('has correct content and formatting with macOS app template', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1757,8 +1702,6 @@ void main() {
   });
 
   testUsingContext('has correct application id for android, bundle id for ios and application id for Linux', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1824,8 +1767,6 @@ void main() {
   });
 
   testUsingContext('can re-gen default template over existing project', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1838,8 +1779,6 @@ void main() {
   });
 
   testUsingContext('can re-gen default template over existing app project with no metadata and detect the type', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1855,8 +1794,6 @@ void main() {
   });
 
   testUsingContext('can re-gen app template over existing app project and detect the type', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1869,8 +1806,6 @@ void main() {
   });
 
   testUsingContext('can re-gen template over existing module project and detect the type', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1883,8 +1818,6 @@ void main() {
   });
 
   testUsingContext('can re-gen default template over existing plugin project and detect the type', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -1897,8 +1830,6 @@ void main() {
   });
 
   testUsingContext('can re-gen default template over existing package project and detect the type', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2097,7 +2028,6 @@ void main() {
   });
 
   testUsingContext('fails when file exists where output directory should be', () async {
-    Cache.flutterRoot = '../..';
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final File existingFile = globals.fs.file(globals.fs.path.join(projectDir.path, 'bad'));
@@ -2111,7 +2041,6 @@ void main() {
   });
 
   testUsingContext('fails overwrite when file exists where output directory should be', () async {
-    Cache.flutterRoot = '../..';
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final File existingFile = globals.fs.file(globals.fs.path.join(projectDir.path, 'bad'));
@@ -2125,7 +2054,6 @@ void main() {
   });
 
   testUsingContext('overwrites existing directory when requested', () async {
-    Cache.flutterRoot = '../..';
     final Directory existingDirectory = globals.fs.directory(globals.fs.path.join(projectDir.path, 'bad'));
     if (!existingDirectory.existsSync()) {
       existingDirectory.createSync(recursive: true);
@@ -2158,8 +2086,6 @@ void main() {
   testUsingContext(
     'invokes pub in online and offline modes',
     () async {
-      Cache.flutterRoot = '../..';
-
       final CreateCommand command = CreateCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2412,8 +2338,6 @@ void main() {
   });
 
   testUsingContext('plugin does not support any platform by default', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2447,8 +2371,6 @@ void main() {
   });
 
   testUsingContext('plugin creates platform interface by default', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2464,8 +2386,6 @@ void main() {
   });
 
   testUsingContext('plugin passes analysis and unit tests', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2479,8 +2399,6 @@ void main() {
   });
 
   testUsingContext('plugin example passes analysis and unit tests', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2494,8 +2412,6 @@ void main() {
   });
 
   testUsingContext('plugin supports ios if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2514,8 +2430,6 @@ void main() {
   });
 
   testUsingContext('plugin supports android if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2536,8 +2450,6 @@ void main() {
   });
 
   testUsingContext('plugin supports web if requested', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2562,8 +2474,6 @@ void main() {
   });
 
   testUsingContext('plugin does not support web if feature is not enabled', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2582,8 +2492,6 @@ void main() {
   });
 
   testUsingContext('create an empty plugin, then add ios', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
@@ -2596,8 +2504,6 @@ void main() {
   });
 
   testUsingContext('create an empty plugin, then add android', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
@@ -2611,8 +2517,6 @@ void main() {
   });
 
   testUsingContext('create an empty plugin, then add linux', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
@@ -2626,8 +2530,6 @@ void main() {
   });
 
   testUsingContext('create an empty plugin, then add macos', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
@@ -2641,8 +2543,6 @@ void main() {
   });
 
   testUsingContext('create an empty plugin, then add windows', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
@@ -2656,8 +2556,6 @@ void main() {
   });
 
   testUsingContext('create an empty plugin, then add web', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
@@ -2671,8 +2569,6 @@ void main() {
   });
 
   testUsingContext('create a plugin with ios, then add macos', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=ios', projectDir.path]);
@@ -2694,8 +2590,6 @@ void main() {
   });
 
   testUsingContext('create a plugin with ios and android', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios,android', projectDir.path]);
@@ -2715,8 +2609,6 @@ void main() {
   });
 
   testUsingContext('plugin includes native Swift unit tests', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2738,8 +2630,6 @@ void main() {
   });
 
   testUsingContext('plugin includes native Kotlin unit tests', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2766,8 +2656,6 @@ void main() {
   });
 
   testUsingContext('plugin includes native Java unit tests', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2795,8 +2683,6 @@ void main() {
   });
 
   testUsingContext('plugin includes native Objective-C unit tests', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2819,8 +2705,6 @@ void main() {
   });
 
   testUsingContext('plugin includes native Windows unit tests', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2841,8 +2725,6 @@ void main() {
   });
 
   testUsingContext('plugin includes native Linux unit tests', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -2863,8 +2745,6 @@ void main() {
   });
 
   testUsingContext('create a module with --platforms throws error.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await expectLater(
@@ -2873,8 +2753,6 @@ void main() {
   });
 
   testUsingContext('create a package with --platforms throws error.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await expectLater(
@@ -2883,8 +2761,6 @@ void main() {
   });
 
   testUsingContext('create an ffi package with --platforms throws error.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await expectLater(
@@ -2895,8 +2771,6 @@ void main() {
   });
 
   testUsingContext('create a plugin with android, delete then re-create folders', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
@@ -2918,8 +2792,6 @@ void main() {
   });
 
   testUsingContext('create a plugin with android, delete then re-create folders while also adding windows', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
@@ -2946,8 +2818,6 @@ void main() {
   });
 
   testUsingContext('flutter create . on and existing plugin does not add android folders if android is not supported in pubspec', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=ios', projectDir.path]);
@@ -2958,8 +2828,6 @@ void main() {
   });
 
   testUsingContext('flutter create . on and existing plugin does not add windows folder even feature is enabled', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
@@ -2972,8 +2840,6 @@ void main() {
   });
 
   testUsingContext('flutter create . on and existing plugin does not add linux folder even feature is enabled', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
@@ -2986,8 +2852,6 @@ void main() {
   });
 
   testUsingContext('flutter create . on and existing plugin does not add web files even feature is enabled', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
@@ -2999,8 +2863,6 @@ void main() {
   });
 
   testUsingContext('flutter create . on and existing plugin does not add macos folder even feature is enabled', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
@@ -3013,8 +2875,6 @@ void main() {
   });
 
   testUsingContext('flutter create . on and existing plugin should show "Your example app code in"', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final String projectDirPath = globals.fs.path.normalize(projectDir.absolute.path);
@@ -3032,8 +2892,6 @@ void main() {
   });
 
   testUsingContext('flutter create -t plugin in an empty folder should not show pubspec.yaml updating suggestion', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
@@ -3045,8 +2903,6 @@ void main() {
   });
 
   testUsingContext('flutter create -t plugin in an existing plugin should show pubspec.yaml updating suggestion', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final String projectDirPath = globals.fs.path.normalize(projectDir.absolute.path);
@@ -3060,8 +2916,6 @@ void main() {
   });
 
   testUsingContext('newly created plugin has min flutter sdk version as 3.3.0', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
@@ -3073,7 +2927,6 @@ void main() {
   });
 
   testUsingContext('newly created iOS plugins has correct min iOS version', () async {
-    Cache.flutterRoot = '../..';
     final String flutterToolsAbsolutePath = globals.fs.path.join(
       Cache.flutterRoot!,
       'packages',
@@ -3119,8 +2972,6 @@ void main() {
   });
 
   testUsingContext('default app uses flutter default versions', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3137,8 +2988,6 @@ void main() {
   });
 
   testUsingContext('Android Java plugin contains namespace', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3159,8 +3008,6 @@ void main() {
   });
 
   testUsingContext('Android FFI plugin contains namespace', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3180,8 +3027,6 @@ void main() {
   });
 
   testUsingContext('Android FFI plugin contains 16kb page support', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3210,8 +3055,6 @@ void main() {
   });
 
   testUsingContext('Android Kotlin plugin contains namespace', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3232,8 +3075,6 @@ void main() {
   });
 
   testUsingContext('Android Java plugin sets explicit compatibility version', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3255,8 +3096,6 @@ void main() {
   });
 
   testUsingContext('Android Kotlin plugin sets explicit compatibility version', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3315,8 +3154,6 @@ void main() {
   });
 
   testUsingContext('Linux plugins handle partially camel-case project names correctly', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3346,8 +3183,6 @@ void main() {
   });
 
   testUsingContext('Windows plugins handle partially camel-case project names correctly', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3390,8 +3225,6 @@ void main() {
   });
 
   testUsingContext('Linux plugins handle project names ending in _plugin correctly', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3426,8 +3259,6 @@ void main() {
   });
 
   testUsingContext('Windows plugins handle project names ending in _plugin correctly', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3471,8 +3302,6 @@ void main() {
   });
 
   testUsingContext('created plugin supports no platforms should print `no platforms` message', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3487,8 +3316,6 @@ void main() {
   });
 
   testUsingContext('created FFI plugin supports no platforms should print `no platforms` message', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3503,8 +3330,6 @@ void main() {
   });
 
   testUsingContext('created plugin with no --platforms flag should not print `no platforms` message if the existing plugin supports a platform.', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3518,8 +3343,6 @@ void main() {
   });
 
   testUsingContext('should show warning when disabled platforms are selected while creating a plugin', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3533,8 +3356,6 @@ void main() {
   });
 
   testUsingContext("shouldn't show warning when only enabled platforms are selected while creating a plugin", () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3548,8 +3369,6 @@ void main() {
   });
 
   testUsingContext('should show warning when disabled platforms are selected while creating a app', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3563,8 +3382,6 @@ void main() {
   });
 
   testUsingContext("shouldn't show warning when only enabled platforms are selected while creating a app", () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3659,8 +3476,6 @@ void main() {
   });
 
   testUsingContext('create an FFI plugin with ios, then add macos', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin_ffi', '--platform=ios', projectDir.path]);
@@ -3748,8 +3563,6 @@ void main() {
   });
 
   testUsingContext('should show warning when disabled platforms are selected while creating an FFI plugin', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3763,8 +3576,6 @@ void main() {
   });
 
   testUsingContext('should not show warning for incompatible Java/template Gradle versions when Java version not found', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3777,8 +3588,6 @@ void main() {
   });
 
   testUsingContext('should not show warning for incompatible Java/template Gradle versions when created project type is irrelevant', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3803,8 +3612,6 @@ void main() {
   });
 
   testUsingContext('should not show warning for incompatible Java/template AGP versions when project type unrelated', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -3822,8 +3629,6 @@ void main() {
   });
 
   testUsingContext('should show warning for incompatible Java/template Gradle versions when detected', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final List<FlutterProjectType> relevantProjectTypes = <FlutterProjectType>[FlutterProjectType.app, FlutterProjectType.skeleton, FlutterProjectType.module];
@@ -3860,8 +3665,6 @@ void main() {
   });
 
   testUsingContext('should show warning for incompatible Java/template AGP versions when detected', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final List<FlutterProjectType> relevantProjectTypes = <FlutterProjectType>[FlutterProjectType.app, FlutterProjectType.skeleton, FlutterProjectType.pluginFfi, FlutterProjectType.module, FlutterProjectType.plugin];
@@ -3904,8 +3707,6 @@ void main() {
   // The Java versions configured in the following tests will need updates as more Java versions are supported by AGP/Gradle:
 
   testUsingContext('should not show warning for incompatible Java/template AGP/Gradle versions when not detected', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final List<FlutterProjectType> relevantProjectTypes = <FlutterProjectType>[FlutterProjectType.app, FlutterProjectType.skeleton, FlutterProjectType.pluginFfi, FlutterProjectType.module, FlutterProjectType.plugin];
@@ -3931,8 +3732,6 @@ void main() {
   });
 
   testUsingContext('should not show warning for incompatible Java/template AGP/Gradle versions when not detected -- maximum compatible Java version', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final List<FlutterProjectType> relevantProjectTypes = <FlutterProjectType>[FlutterProjectType.app, FlutterProjectType.skeleton, FlutterProjectType.pluginFfi, FlutterProjectType.module, FlutterProjectType.plugin];
@@ -3958,8 +3757,6 @@ void main() {
   });
 
   testUsingContext('should not show warning for incompatible Java/template AGP/Gradle versions when not detected -- minimum compatible Java version', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final List<FlutterProjectType> relevantProjectTypes = <FlutterProjectType>[FlutterProjectType.app, FlutterProjectType.skeleton, FlutterProjectType.pluginFfi, FlutterProjectType.module, FlutterProjectType.plugin];
@@ -4044,8 +3841,6 @@ void main() {
   });
 
   testUsingContext('flutter create should show the incompatible java AGP message', () async {
-    Cache.flutterRoot = '../..';
-
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -4067,7 +3862,6 @@ Future<void> _createProject(
   List<String> unexpectedPaths = const <String>[],
   List<String> expectedGitignoreLines = const <String>[],
 }) async {
-  Cache.flutterRoot = '../..';
   final CreateCommand command = CreateCommand();
   final CommandRunner<void> runner = createTestCommandRunner(command);
   await runner.run(<String>[


### PR DESCRIPTION
Without this change, the order that tests run matter and it's easy to add tests without remembering this flag.

(There are existing tests that forgot it too, they just happen to work if shuffled in a way that, well, works)

