### PR TITLE
Add more entry-point annotations for test-only code.

### DIFF
--- a/examples/api/lib/widgets/navigator/navigator.restorable_push.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push.0.dart
@@ -30,6 +30,7 @@ class RestorablePushExample extends StatefulWidget {
   State<RestorablePushExample> createState() => _RestorablePushExampleState();
 }
 
+@pragma('vm:entry-point')
 class _RestorablePushExampleState extends State<RestorablePushExample> {
   @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart
@@ -30,6 +30,7 @@ class RestorablePushAndRemoveUntilExample extends StatefulWidget {
   State<RestorablePushAndRemoveUntilExample> createState() => _RestorablePushAndRemoveUntilExampleState();
 }
 
+@pragma('vm:entry-point')
 class _RestorablePushAndRemoveUntilExampleState extends State<RestorablePushAndRemoveUntilExample> {
   @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart
@@ -35,6 +35,7 @@ class RestorablePushReplacementExample extends StatefulWidget {
   State<RestorablePushReplacementExample> createState() => _RestorablePushReplacementExampleState();
 }
 
+@pragma('vm:entry-point')
 class _RestorablePushReplacementExampleState extends State<RestorablePushReplacementExample> {
   @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push.0.dart
@@ -30,6 +30,7 @@ class RestorablePushExample extends StatefulWidget {
   State<RestorablePushExample> createState() => _RestorablePushExampleState();
 }
 
+@pragma('vm:entry-point')
 class _RestorablePushExampleState extends State<RestorablePushExample> {
   @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push_and_remove_until.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push_and_remove_until.0.dart
@@ -30,6 +30,7 @@ class RestorablePushAndRemoveUntilExample extends StatefulWidget {
   State<RestorablePushAndRemoveUntilExample> createState() => _RestorablePushAndRemoveUntilExampleState();
 }
 
+@pragma('vm:entry-point')
 class _RestorablePushAndRemoveUntilExampleState extends State<RestorablePushAndRemoveUntilExample> {
   @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push_replacement.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push_replacement.0.dart
@@ -35,6 +35,7 @@ class RestorablePushReplacementExample extends StatefulWidget {
   State<RestorablePushReplacementExample> createState() => _RestorablePushReplacementExampleState();
 }
 
+@pragma('vm:entry-point')
 class _RestorablePushReplacementExampleState extends State<RestorablePushReplacementExample> {
   @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {

--- a/examples/api/lib/widgets/navigator/restorable_route_future.0.dart
+++ b/examples/api/lib/widgets/navigator/restorable_route_future.0.dart
@@ -30,6 +30,7 @@ class MyHome extends StatefulWidget {
   State<MyHome> createState() => _MyHomeState();
 }
 
+@pragma('vm:entry-point')
 class _MyHomeState extends State<MyHome> with RestorationMixin {
   final RestorableInt _lastCount = RestorableInt(0);
   late RestorableRouteFuture<int> _counterRoute;


### PR DESCRIPTION
This change adds entry-point annotations to methods and classes accessed by native code during Flutter tests. Currently, entry point annotations are not checked by the Dart VM when running in JIT mode, only in AOT mode. In order to also enforce entry point annotations in JIT mode, first tests in Flutter must be appropriately annotated to avoid roll failures.

Related issues:
* https://github.com/flutter/flutter/issues/118608
* https://github.com/dart-lang/sdk/issues/50649

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
