### PR TITLE
[native_assets] Preparation existing tests for future of other (i.e. non-Code) assets

### DIFF
--- a/dev/integration_tests/link_hook/hook/build.dart
+++ b/dev/integration_tests/link_hook/hook/build.dart
@@ -9,6 +9,10 @@ import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> args) async {
   await build(args, (BuildConfig config, BuildOutputBuilder output) async {
+    if (!config.supportedAssetTypes.contains(CodeAsset.type)) {
+      return;
+    }
+
     final String assetName;
     if (config.linkingEnabled) {
       // The link hook will be run. So emit an asset with a name that is

--- a/dev/integration_tests/link_hook/hook/build.dart
+++ b/dev/integration_tests/link_hook/hook/build.dart
@@ -36,9 +36,10 @@ void main(List<String> args) async {
     await cbuilder.run(
       config: config,
       output: outputCatcher,
-      logger: Logger('')
-        ..level = Level.ALL
-        ..onRecord.listen((LogRecord record) => print(record.message)),
+      logger:
+          Logger('')
+            ..level = Level.ALL
+            ..onRecord.listen((LogRecord record) => print(record.message)),
     );
     final BuildOutput catchedOutput = BuildOutput(outputCatcher.json);
     output.addDependencies(catchedOutput.dependencies);

--- a/dev/integration_tests/link_hook/hook/build.dart
+++ b/dev/integration_tests/link_hook/hook/build.dart
@@ -36,10 +36,9 @@ void main(List<String> args) async {
     await cbuilder.run(
       config: config,
       output: outputCatcher,
-      logger:
-          Logger('')
-            ..level = Level.ALL
-            ..onRecord.listen((LogRecord record) => print(record.message)),
+      logger: Logger('')
+        ..level = Level.ALL
+        ..onRecord.listen((LogRecord record) => print(record.message)),
     );
     final BuildOutput catchedOutput = BuildOutput(outputCatcher.json);
     output.addDependencies(catchedOutput.dependencies);

--- a/dev/integration_tests/link_hook/hook/link.dart
+++ b/dev/integration_tests/link_hook/hook/link.dart
@@ -6,6 +6,9 @@ import 'package:native_assets_cli/code_assets.dart';
 
 void main(List<String> args) async {
   await link(args, (LinkConfig config, LinkOutputBuilder output) async {
+    if (!config.supportedAssetTypes.contains(CodeAsset.type)) {
+      return;
+    }
     final CodeAsset asset = config.codeAssets.single;
     final String packageName = config.packageName;
     output.codeAssets.add(

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -13,6 +13,7 @@
 @Timeout(Duration(minutes: 10))
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file/file.dart';
@@ -465,14 +466,13 @@ void expectCCompilerIsConfigured(Directory appDirectory) {
       continue;
     }
 
-    final File config = subDir.childFile('config.json');
-    expect(config, exists);
-    final String contents = config.readAsStringSync();
-    // Dry run does not pass compiler info.
-    if (contents.contains('"dry_run": true')) {
+    final File configFile = subDir.childFile('config.json');
+    expect(configFile, exists);
+    final Map<String, Object?> config = json.decode(configFile.readAsStringSync()) as Map<String, Object?>;
+    if (!(config['supported_asset_types']! as List<dynamic>).contains(CodeAsset.type)) {
       continue;
     }
-    expect(contents, contains('"cc": '));
+    expect((config['c_compiler']! as Map<String, Object?>)['cc'], isNotNull);
   }
 }
 

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -468,7 +468,8 @@ void expectCCompilerIsConfigured(Directory appDirectory) {
 
     final File configFile = subDir.childFile('config.json');
     expect(configFile, exists);
-    final Map<String, Object?> config = json.decode(configFile.readAsStringSync()) as Map<String, Object?>;
+    final Map<String, Object?> config =
+        json.decode(configFile.readAsStringSync()) as Map<String, Object?>;
     if (!(config['supported_asset_types']! as List<dynamic>).contains(CodeAsset.type)) {
       continue;
     }

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -180,14 +180,18 @@ FFI_PLUGIN_EXPORT intptr_t add(intptr_t a, intptr_t b) {
 
   // Update builder to build the native library and link it into the main library.
   const String builderSource = r'''
-import 'package:native_toolchain_c/native_toolchain_c.dart';
+
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> args) async {
   await build(args, (config, output) async {
     final packageName = config.packageName;
 
+    if (!config.supportedAssetTypes.contains(CodeAsset.type)) {
+      return;
+    }
     final builders = [
       CBuilder.library(
         name: 'add',


### PR DESCRIPTION
In the future a hook may be invoked multiple times with different `supportedAssetTypes` (soon to be renamed to `buildAssetTypes`).

The hook should only emit those asset types that are in `supportedAssetTypes` - anything else is an error. Right now flutter happens to invoke hooks only with `Code` asset types, but more asset types are coming, for which this PR is a preparation for.