### PR TITLE
Allow integration test helpers to work on substrings instead of whole strings

### DIFF
--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -102,6 +102,12 @@ void main() {
                   },
                 ),
                 Barrier.contains('Performing hot reload...', logging: true),
+                Multiple(
+                  <Pattern>[RegExp('Reloaded .*')],
+                  handler: (String line) {
+                    return 'q';
+                  },
+                ),
               ],
               Barrier.contains('Application finished.'),
             ],

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -72,7 +72,7 @@ void main() {
             <String>['run', '-d$device', '--$buildMode'],
             exampleDirectory.path,
             <Transition>[
-              Multiple(
+              Multiple.contains(
                 <Pattern>['Flutter run key commands.'],
                 handler: (String line) {
                   if (buildMode == 'debug') {
@@ -85,7 +85,7 @@ void main() {
                 },
               ),
               if (buildMode == 'debug') ...<Transition>[
-                Barrier('Performing hot reload...'.padRight(progressMessageWidth), logging: true),
+                Barrier.contains('Performing hot reload...', logging: true),
                 Multiple(
                   <Pattern>[RegExp('Reloaded .*')],
                   handler: (String line) {
@@ -93,7 +93,7 @@ void main() {
                     return 'R';
                   },
                 ),
-                Barrier('Performing hot restart...'.padRight(progressMessageWidth)),
+                Barrier.contains('Performing hot restart...'),
                 Multiple(
                   <Pattern>[RegExp('Restarted application .*')],
                   handler: (String line) {
@@ -101,15 +101,9 @@ void main() {
                     return 'r';
                   },
                 ),
-                Barrier('Performing hot reload...'.padRight(progressMessageWidth), logging: true),
-                Multiple(
-                  <Pattern>[RegExp('Reloaded .*')],
-                  handler: (String line) {
-                    return 'q';
-                  },
-                ),
+                Barrier.contains('Performing hot reload...', logging: true),
               ],
-              const Barrier('Application finished.'),
+              Barrier.contains('Application finished.'),
             ],
             logging: false,
           );

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -33,39 +33,49 @@ import 'test_utils.dart' show fileSystem;
 import 'transition_test_utils.dart';
 
 void main() {
-  testWithoutContext('flutter run writes and clears pidfile appropriately', () async {
-    final String tempDirectory = fileSystem.systemTempDirectory.createTempSync('flutter_overall_experience_test.').resolveSymbolicLinksSync();
-    final String pidFile = fileSystem.path.join(tempDirectory, 'flutter.pid');
-    final String testDirectory = fileSystem.path.join(flutterRoot, 'examples', 'hello_world');
-    bool? existsDuringTest;
-    try {
-      expect(fileSystem.file(pidFile).existsSync(), isFalse);
-      final ProcessTestResult result = await runFlutter(
-        <String>['run', '-dflutter-tester', '--pid-file', pidFile],
-        testDirectory,
-        <Transition>[
-          Barrier('q Quit (terminate the application on the device).', handler: (String line) {
-            existsDuringTest = fileSystem.file(pidFile).existsSync();
-            return 'q';
-          }),
-          Barrier('Application finished.'),
-        ],
-      );
-      expect(existsDuringTest, isNot(isNull));
-      expect(existsDuringTest, isTrue);
-      expect(result.exitCode, 0, reason: 'subprocess failed; $result');
-      expect(fileSystem.file(pidFile).existsSync(), isFalse);
-      // This first test ignores the stdout and stderr, so that if the
-      // first run outputs "building flutter", or the "there's a new
-      // flutter" banner, or other such first-run messages, they won't
-      // fail the tests. This does mean that running this test first is
-      // actually important in the case where you're running the tests
-      // manually. (On CI, all those messages are expected to be seen
-      // long before we get here, e.g. because we run "flutter doctor".)
-    } finally {
-      tryToDelete(fileSystem.directory(tempDirectory));
-    }
-  }, skip: Platform.isWindows); // [intended] Windows doesn't support sending signals so we don't care if it can store the PID.
+  testWithoutContext(
+    'flutter run writes and clears pidfile appropriately',
+    () async {
+      final String tempDirectory =
+          fileSystem.systemTempDirectory
+              .createTempSync('flutter_overall_experience_test.')
+              .resolveSymbolicLinksSync();
+      final String pidFile = fileSystem.path.join(tempDirectory, 'flutter.pid');
+      final String testDirectory = fileSystem.path.join(flutterRoot, 'examples', 'hello_world');
+      bool? existsDuringTest;
+      try {
+        expect(fileSystem.file(pidFile).existsSync(), isFalse);
+        final ProcessTestResult result = await runFlutter(
+          <String>['run', '-dflutter-tester', '--pid-file', pidFile],
+          testDirectory,
+          <Transition>[
+            Barrier(
+              'q Quit (terminate the application on the device).',
+              handler: (String line) {
+                existsDuringTest = fileSystem.file(pidFile).existsSync();
+                return 'q';
+              },
+            ),
+            Barrier('Application finished.'),
+          ],
+        );
+        expect(existsDuringTest, isNot(isNull));
+        expect(existsDuringTest, isTrue);
+        expect(result.exitCode, 0, reason: 'subprocess failed; $result');
+        expect(fileSystem.file(pidFile).existsSync(), isFalse);
+        // This first test ignores the stdout and stderr, so that if the
+        // first run outputs "building flutter", or the "there's a new
+        // flutter" banner, or other such first-run messages, they won't
+        // fail the tests. This does mean that running this test first is
+        // actually important in the case where you're running the tests
+        // manually. (On CI, all those messages are expected to be seen
+        // long before we get here, e.g. because we run "flutter doctor".)
+      } finally {
+        tryToDelete(fileSystem.directory(tempDirectory));
+      }
+    },
+    skip: Platform.isWindows,
+  ); // [intended] Windows doesn't support sending signals so we don't care if it can store the PID.
 
   testWithoutContext('flutter run handle SIGUSR1/2 run', () async {
     final String tempDirectory =
@@ -119,9 +129,12 @@ void main() {
           ),
           Barrier('Performing hot restart...'.padRight(progressMessageWidth)),
           // This could look like 'Restarted application in 1,237ms.'
-          Multiple(<Pattern>[RegExp(r'^Restarted application in .+m?s.$'), 'called main', 'called paint'], handler: (String line) {
-            return 'q';
-          }),
+          Multiple(
+            <Pattern>[RegExp(r'^Restarted application in .+m?s.$'), 'called main', 'called paint'],
+            handler: (String line) {
+              return 'q';
+            },
+          ),
           Barrier('Application finished.'),
         ],
         logging:
@@ -200,15 +213,24 @@ void main() {
             },
           ),
           Barrier('Performing hot restart...'.padRight(progressMessageWidth)),
-          Multiple(<Pattern>['ready', 'called main', 'called paint'], handler: (String line) {
-            return 'p';
-          }),
-          Multiple(<Pattern>['ready', 'called paint', 'called debugPaintSize'], handler: (String line) {
-            return 'p';
-          }),
-          Multiple(<Pattern>['ready', 'called paint'], handler: (String line) {
-            return 'q';
-          }),
+          Multiple(
+            <Pattern>['ready', 'called main', 'called paint'],
+            handler: (String line) {
+              return 'p';
+            },
+          ),
+          Multiple(
+            <Pattern>['ready', 'called paint', 'called debugPaintSize'],
+            handler: (String line) {
+              return 'p';
+            },
+          ),
+          Multiple(
+            <Pattern>['ready', 'called paint'],
+            handler: (String line) {
+              return 'q';
+            },
+          ),
           Barrier('Application finished.'),
         ],
         logging:
@@ -356,12 +378,18 @@ void main() {
       <String>['run', '-dflutter-tester'],
       testDirectory,
       <Transition>[
-        Barrier(finalLine, handler: (String line) {
-          return 'h';
-        }),
-        Barrier(finalLine, handler: (String line) {
-          return 'q';
-        }),
+        Barrier(
+          finalLine,
+          handler: (String line) {
+            return 'h';
+          },
+        ),
+        Barrier(
+          finalLine,
+          handler: (String line) {
+            return 'q';
+          },
+        ),
         Barrier('Application finished.'),
       ],
     );

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -33,50 +33,39 @@ import 'test_utils.dart' show fileSystem;
 import 'transition_test_utils.dart';
 
 void main() {
-  testWithoutContext(
-    'flutter run writes and clears pidfile appropriately',
-    () async {
-      final String tempDirectory =
-          fileSystem.systemTempDirectory
-              .createTempSync('flutter_overall_experience_test.')
-              .resolveSymbolicLinksSync();
-      final String pidFile = fileSystem.path.join(tempDirectory, 'flutter.pid');
-      final String testDirectory = fileSystem.path.join(flutterRoot, 'examples', 'hello_world');
-      bool? existsDuringTest;
-      try {
-        expect(fileSystem.file(pidFile).existsSync(), isFalse);
-        final ProcessTestResult result = await runFlutter(
-          <String>['run', '-dflutter-tester', '--pid-file', pidFile],
-          testDirectory,
-          <Transition>[
-            Barrier(
-              'q Quit (terminate the application on the device).',
-              handler: (String line) {
-                existsDuringTest = fileSystem.file(pidFile).existsSync();
-                return 'q';
-              },
-            ),
-            const Barrier('Application finished.'),
-          ],
-        );
-        expect(existsDuringTest, isNot(isNull));
-        expect(existsDuringTest, isTrue);
-        expect(result.exitCode, 0, reason: 'subprocess failed; $result');
-        expect(fileSystem.file(pidFile).existsSync(), isFalse);
-        // This first test ignores the stdout and stderr, so that if the
-        // first run outputs "building flutter", or the "there's a new
-        // flutter" banner, or other such first-run messages, they won't
-        // fail the tests. This does mean that running this test first is
-        // actually important in the case where you're running the tests
-        // manually. (On CI, all those messages are expected to be seen
-        // long before we get here, e.g. because we run "flutter doctor".)
-      } finally {
-        tryToDelete(fileSystem.directory(tempDirectory));
-      }
-    },
-    // [intended] Windows doesn't support sending signals so we don't care if it can store the PID.
-    skip: Platform.isWindows,
-  );
+  testWithoutContext('flutter run writes and clears pidfile appropriately', () async {
+    final String tempDirectory = fileSystem.systemTempDirectory.createTempSync('flutter_overall_experience_test.').resolveSymbolicLinksSync();
+    final String pidFile = fileSystem.path.join(tempDirectory, 'flutter.pid');
+    final String testDirectory = fileSystem.path.join(flutterRoot, 'examples', 'hello_world');
+    bool? existsDuringTest;
+    try {
+      expect(fileSystem.file(pidFile).existsSync(), isFalse);
+      final ProcessTestResult result = await runFlutter(
+        <String>['run', '-dflutter-tester', '--pid-file', pidFile],
+        testDirectory,
+        <Transition>[
+          Barrier('q Quit (terminate the application on the device).', handler: (String line) {
+            existsDuringTest = fileSystem.file(pidFile).existsSync();
+            return 'q';
+          }),
+          Barrier('Application finished.'),
+        ],
+      );
+      expect(existsDuringTest, isNot(isNull));
+      expect(existsDuringTest, isTrue);
+      expect(result.exitCode, 0, reason: 'subprocess failed; $result');
+      expect(fileSystem.file(pidFile).existsSync(), isFalse);
+      // This first test ignores the stdout and stderr, so that if the
+      // first run outputs "building flutter", or the "there's a new
+      // flutter" banner, or other such first-run messages, they won't
+      // fail the tests. This does mean that running this test first is
+      // actually important in the case where you're running the tests
+      // manually. (On CI, all those messages are expected to be seen
+      // long before we get here, e.g. because we run "flutter doctor".)
+    } finally {
+      tryToDelete(fileSystem.directory(tempDirectory));
+    }
+  }, skip: Platform.isWindows); // [intended] Windows doesn't support sending signals so we don't care if it can store the PID.
 
   testWithoutContext('flutter run handle SIGUSR1/2 run', () async {
     final String tempDirectory =
@@ -130,13 +119,10 @@ void main() {
           ),
           Barrier('Performing hot restart...'.padRight(progressMessageWidth)),
           // This could look like 'Restarted application in 1,237ms.'
-          Multiple(
-            <Pattern>[RegExp(r'^Restarted application in .+m?s.$'), 'called main', 'called paint'],
-            handler: (String line) {
-              return 'q';
-            },
-          ),
-          const Barrier('Application finished.'),
+          Multiple(<Pattern>[RegExp(r'^Restarted application in .+m?s.$'), 'called main', 'called paint'], handler: (String line) {
+            return 'q';
+          }),
+          Barrier('Application finished.'),
         ],
         logging:
             false, // we ignore leading log lines to avoid making this test sensitive to e.g. the help message text
@@ -214,25 +200,16 @@ void main() {
             },
           ),
           Barrier('Performing hot restart...'.padRight(progressMessageWidth)),
-          Multiple(
-            <Pattern>['ready', 'called main', 'called paint'],
-            handler: (String line) {
-              return 'p';
-            },
-          ),
-          Multiple(
-            <Pattern>['ready', 'called paint', 'called debugPaintSize'],
-            handler: (String line) {
-              return 'p';
-            },
-          ),
-          Multiple(
-            <Pattern>['ready', 'called paint'],
-            handler: (String line) {
-              return 'q';
-            },
-          ),
-          const Barrier('Application finished.'),
+          Multiple(<Pattern>['ready', 'called main', 'called paint'], handler: (String line) {
+            return 'p';
+          }),
+          Multiple(<Pattern>['ready', 'called paint', 'called debugPaintSize'], handler: (String line) {
+            return 'p';
+          }),
+          Multiple(<Pattern>['ready', 'called paint'], handler: (String line) {
+            return 'q';
+          }),
+          Barrier('Application finished.'),
         ],
         logging:
             false, // we ignore leading log lines to avoid making this test sensitive to e.g. the help message text
@@ -379,19 +356,13 @@ void main() {
       <String>['run', '-dflutter-tester'],
       testDirectory,
       <Transition>[
-        Barrier(
-          finalLine,
-          handler: (String line) {
-            return 'h';
-          },
-        ),
-        Barrier(
-          finalLine,
-          handler: (String line) {
-            return 'q';
-          },
-        ),
-        const Barrier('Application finished.'),
+        Barrier(finalLine, handler: (String line) {
+          return 'h';
+        }),
+        Barrier(finalLine, handler: (String line) {
+          return 'q';
+        }),
+        Barrier('Application finished.'),
       ],
     );
     expect(result.exitCode, 0);

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -74,8 +74,9 @@ void main() {
         tryToDelete(fileSystem.directory(tempDirectory));
       }
     },
+    // [intended] Windows doesn't support sending signals so we don't care if it can store the PID.
     skip: Platform.isWindows,
-  ); // [intended] Windows doesn't support sending signals so we don't care if it can store the PID.
+  );
 
   testWithoutContext('flutter run handle SIGUSR1/2 run', () async {
     final String tempDirectory =

--- a/packages/flutter_tools/test/integration.shard/transition_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/transition_test_utils.dart
@@ -26,7 +26,7 @@ void debugPrint(String message) {
 typedef LineHandler = String? Function(String line);
 
 abstract class Transition {
-  const Transition({this.handler, this.logging});
+  const Transition({this.handler, this.logging, required this.contains});
 
   /// Callback that is invoked when the transition matches.
   ///
@@ -40,12 +40,15 @@ abstract class Transition {
   /// The default value, null, leaves the logging state unaffected.
   final bool? logging;
 
+  /// Whether to check the line for containing a substring or an exact match.
+  final bool contains;
+
   bool matches(String line);
 
   @protected
   bool lineMatchesPattern(String line, Pattern pattern) {
     if (pattern is String) {
-      return line == pattern;
+      return contains ? line.contains(pattern) : line == pattern;
     }
     return line.contains(pattern);
   }
@@ -53,7 +56,7 @@ abstract class Transition {
   @protected
   String describe(Pattern pattern) {
     if (pattern is String) {
-      return '"$pattern"';
+      return contains ? '"...$pattern..."' : '"$pattern"';
     }
     if (pattern is RegExp) {
       return '/${pattern.pattern}/';
@@ -63,7 +66,9 @@ abstract class Transition {
 }
 
 class Barrier extends Transition {
-  const Barrier(this.pattern, {super.handler, super.logging});
+  Barrier(this.pattern, {super.handler, super.logging}) : super(contains: false);
+  Barrier.contains(this.pattern, {super.handler, super.logging}) : super(contains: true);
+
   final Pattern pattern;
 
   @override
@@ -74,9 +79,20 @@ class Barrier extends Transition {
 }
 
 class Multiple extends Transition {
-  Multiple(List<Pattern> patterns, {super.handler, super.logging})
-    : _originalPatterns = patterns,
-      patterns = patterns.toList();
+  Multiple(
+    List<Pattern> patterns, {
+    super.handler,
+    super.logging,
+  })  : _originalPatterns = patterns,
+        patterns = patterns.toList(),
+        super(contains: false);
+  Multiple.contains(
+    List<Pattern> patterns, {
+    super.handler,
+    super.logging,
+  })  : _originalPatterns = patterns,
+        patterns = patterns.toList(),
+        super(contains: true);
 
   final List<Pattern> _originalPatterns;
   final List<Pattern> patterns;

--- a/packages/flutter_tools/test/integration.shard/transition_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/transition_test_utils.dart
@@ -76,20 +76,14 @@ class Barrier extends Transition {
 }
 
 class Multiple extends Transition {
-  Multiple(
-    List<Pattern> patterns, {
-    super.handler,
-    super.logging,
-  })  : _originalPatterns = patterns,
-        patterns = patterns.toList(),
-        contains = false;
-  Multiple.contains(
-    List<Pattern> patterns, {
-    super.handler,
-    super.logging,
-  })  : _originalPatterns = patterns,
-        patterns = patterns.toList(),
-        contains = true;
+  Multiple(List<Pattern> patterns, {super.handler, super.logging})
+    : _originalPatterns = patterns,
+      patterns = patterns.toList(),
+      contains = false;
+  Multiple.contains(List<Pattern> patterns, {super.handler, super.logging})
+    : _originalPatterns = patterns,
+      patterns = patterns.toList(),
+      contains = true;
 
   final List<Pattern> _originalPatterns;
   final List<Pattern> patterns;


### PR DESCRIPTION
The integration test framework that waits for transitions and (optionally) takes actions on transitions allows to match patterns.

If one uses a RegExp pattern than the framework only checks whether a line contains the given RegExp pattern.

If one uses a String pattern it matches it exactly.

=> We add a `Barrier.contains()` and `Multiple.contains()` that allow matching a line with if it contains the String (just like in RegExp)

=> This makes tests simpler as they don't have to know about the exact padding of progres bar etc. Those may be irrelevant for the purpose of the integration test and only complicate it.