### PR TITLE
[flutter_tool] Change the startup message for the "flutter daemon" command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -85,7 +85,6 @@ class DaemonCommand extends FlutterCommand {
       ).run();
       return FlutterCommandResult.success();
     }
-    globals.printStatus('Starting device daemon...');
     final Daemon daemon = Daemon(
       DaemonConnection(
         daemonStreams: DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
@@ -93,6 +92,7 @@ class DaemonCommand extends FlutterCommand {
       ),
       notifyingLogger: asLogger<NotifyingLogger>(globals.logger),
     );
+    globals.printStatus('Device daemon started');
     final int code = await daemon.onExit;
     if (code != 0) {
       throwToolExit('Daemon exited with non-zero exit code: $code', exitCode: code);

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -92,7 +92,7 @@ class DaemonCommand extends FlutterCommand {
       ),
       notifyingLogger: asLogger<NotifyingLogger>(globals.logger),
     );
-    globals.printStatus('Device daemon started');
+    globals.printStatus('Device daemon started.');
     final int code = await daemon.onExit;
     if (code != 0) {
       throwToolExit('Daemon exited with non-zero exit code: $code', exitCode: code);

--- a/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
@@ -45,7 +45,7 @@ void main() {
       .where((Map<String, Object?>? value) => value != null)
       .cast<Map<String, Object?>>();
 
-    final [Map<String, Object?> connectedEvent, Map<String, Object?> logMessage] = await Future.wait([
+    final [Map<String, Object?> connectedEvent, Map<String, Object?> logMessage] = await Future.wait(<Future<Map<String, Object?>>>[
       stream.firstWhere((Map<String, Object?> e) => e['event'] == 'daemon.connected'),
       stream.firstWhere((Map<String, Object?> e) => e['event'] == 'daemon.logMessage')
     ]);

--- a/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
@@ -57,7 +57,7 @@ void main() {
     // Check we got the startup message.
     final Map<String, Object?> logParams = logMessage['params']! as Map<String, Object?>;
     expect(logParams['level'], 'status');
-    expect(logParams['message'], 'Device daemon started');
+    expect(logParams['message'], 'Device daemon started.');
   });
 
   testWithoutContext('device.getDevices', () async {

--- a/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
@@ -39,15 +39,18 @@ void main() {
 
     final StreamController<String> stdout = StreamController<String>.broadcast();
     transformToLines(daemonProcess.stdout).listen((String line) => stdout.add(line));
-    final Stream<Map<String, Object?>> stream = stdout
-      .stream
-      .map<Map<String, Object?>?>(parseFlutterResponse)
-      .where((Map<String, Object?>? value) => value != null)
-      .cast<Map<String, Object?>>();
+    final Stream<Map<String, Object?>> stream =
+        stdout.stream
+            .map<Map<String, Object?>?>(parseFlutterResponse)
+            .where((Map<String, Object?>? value) => value != null)
+            .cast<Map<String, Object?>>();
 
-    final [Map<String, Object?> connectedEvent, Map<String, Object?> logMessage] = await Future.wait(<Future<Map<String, Object?>>>[
+    final [
+      Map<String, Object?> connectedEvent,
+      Map<String, Object?> logMessage,
+    ] = await Future.wait(<Future<Map<String, Object?>>>[
       stream.firstWhere((Map<String, Object?> e) => e['event'] == 'daemon.connected'),
-      stream.firstWhere((Map<String, Object?> e) => e['event'] == 'daemon.logMessage')
+      stream.firstWhere((Map<String, Object?> e) => e['event'] == 'daemon.logMessage'),
     ]);
 
     // Check the connected message has a version.


### PR DESCRIPTION
There have been some reports of the Flutter daemon not starting up properly (for ex. https://github.com/flutter/flutter/issues/143625), but it turns out that when starting successfully, it just prints "Starting device daemon..." and then nothing more. This is confusing and can lead users to think other issues are because the daemon hasn't started properly.

There's not a great hook to print that this "finished" starting up (because it does async polling in the background), so I just updated the message of the text and moved it to after the creation of the daemon.

Fixes https://github.com/flutter/flutter/issues/143625

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [N/A] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
