### PR TITLE
added new ScrollViewKeyboardDismissBehavior variant onScroll with tests

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -119,6 +119,12 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// correction.
   factory ViewportOffset.zero() = _FixedViewportOffset.zero;
 
+  /// Whether the current offset change was due to programmatic scroll.
+  ///
+  /// The [isProgrammaticScroll] value turns true only when [moveTo] is
+  /// called.
+  bool isProgrammaticScroll = false;
+
   /// The number of pixels to offset the children in the opposite of the axis direction.
   ///
   /// For example, if the axis direction is down, then the pixel value
@@ -225,11 +231,15 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// like [ScrollPosition] handle it by adjusting [to] to prevent over or
   /// underscroll.
   Future<void> moveTo(double to, {Duration? duration, Curve? curve, bool? clamp}) {
+    isProgrammaticScroll = true;
     if (duration == null || duration == Duration.zero) {
       jumpTo(to);
+      isProgrammaticScroll = false;
       return Future<void>.value();
     } else {
-      return animateTo(to, duration: duration, curve: curve ?? Curves.ease);
+      final Future<void> future = animateTo(to, duration: duration, curve: curve ?? Curves.ease);
+      future.whenComplete(() => isProgrammaticScroll = false);
+      return future;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -104,12 +104,14 @@ abstract class ScrollActivity {
   void dispatchScrollUpdateNotification(
     ScrollMetrics metrics,
     BuildContext context,
-    double scrollDelta,
-  ) {
+    double scrollDelta, {
+    bool programmatic = false,
+  }) {
     ScrollUpdateNotification(
       metrics: metrics,
       context: context,
       scrollDelta: scrollDelta,
+      programmatic: programmatic,
     ).dispatch(context);
   }
 
@@ -495,8 +497,9 @@ class DragScrollActivity extends ScrollActivity {
   void dispatchScrollUpdateNotification(
     ScrollMetrics metrics,
     BuildContext context,
-    double scrollDelta,
-  ) {
+    double scrollDelta, {
+    bool programmatic = false,
+  }) {
     final dynamic lastDetails = _controller!.lastDetails;
     assert(lastDetails is DragUpdateDetails);
     ScrollUpdateNotification(
@@ -504,6 +507,7 @@ class DragScrollActivity extends ScrollActivity {
       context: context,
       scrollDelta: scrollDelta,
       dragDetails: lastDetails as DragUpdateDetails,
+      programmatic: programmatic,
     ).dispatch(context);
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -189,6 +189,7 @@ class ScrollUpdateNotification extends ScrollNotification {
     this.dragDetails,
     this.scrollDelta,
     int? depth,
+    this.programmatic = false,
   }) {
     if (depth != null) {
       _depth = depth;
@@ -204,6 +205,9 @@ class ScrollUpdateNotification extends ScrollNotification {
   /// The distance by which the [Scrollable] was scrolled, in logical pixels.
   final double? scrollDelta;
 
+  /// If this scroll update was programmatic.
+  final bool programmatic;
+
   @override
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
@@ -211,6 +215,7 @@ class ScrollUpdateNotification extends ScrollNotification {
     if (dragDetails != null) {
       description.add('$dragDetails');
     }
+    description.add('programmatic: $programmatic');
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -1046,7 +1046,12 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   /// Called by [setPixels] to report a change to the [pixels] position.
   void didUpdateScrollPositionBy(double delta) {
-    activity!.dispatchScrollUpdateNotification(copyWith(), context.notificationContext!, delta);
+    activity!.dispatchScrollUpdateNotification(
+      copyWith(),
+      context.notificationContext!,
+      delta,
+      programmatic: isProgrammaticScroll,
+    );
   }
 
   /// Called by [beginActivity] to report when an activity has ended.

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -45,6 +45,9 @@ enum ScrollViewKeyboardDismissBehavior {
   /// `onDrag` means that the [ScrollView] will dismiss an on-screen keyboard
   /// when a drag begins.
   onDrag,
+  /// `noDrag` means that the [ScrollView] will dismiss an on-screen keyboard
+  /// when a scroll begins irrespective of a drag.
+  noDrag,
 }
 
 /// A widget that combines a [Scrollable] and a [Viewport] to create an

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -45,9 +45,11 @@ enum ScrollViewKeyboardDismissBehavior {
   /// `onDrag` means that the [ScrollView] will dismiss an on-screen keyboard
   /// when a drag begins.
   onDrag,
-  /// `noDrag` means that the [ScrollView] will dismiss an on-screen keyboard
+
+  /// `onScroll` means that the [ScrollView] will dismiss an on-screen keyboard
   /// when a scroll begins irrespective of a drag.
-  noDrag,
+  /// See https://github.com/flutter/flutter/issues/154515.
+  onScroll,
 }
 
 /// A widget that combines a [Scrollable] and a [Viewport] to create an

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -48,7 +48,12 @@ enum ScrollViewKeyboardDismissBehavior {
 
   /// `onScroll` means that the [ScrollView] will dismiss an on-screen keyboard
   /// when a scroll begins irrespective of a drag.
-  /// See https://github.com/flutter/flutter/issues/154515.
+  // See https://github.com/flutter/flutter/issues/154515.
+  /// It should be used to dismiss the keyboard on all scrolls (with a drag, 
+  /// trackpad, mouse-wheel, etc.)
+  /// Caveat: Since we are watching for all scroll notifications, programmatic
+  /// scrolls will also dismiss the keyboard (e.g opening of on-screen keyboard 
+  /// produces a scroll to keep the field visible).
   onScroll,
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -49,11 +49,8 @@ enum ScrollViewKeyboardDismissBehavior {
   /// `onScroll` means that the [ScrollView] will dismiss an on-screen keyboard
   /// when a scroll begins irrespective of a drag.
   // See https://github.com/flutter/flutter/issues/154515.
-  /// It should be used to dismiss the keyboard on all scrolls (with a drag, 
+  /// It should be used to dismiss the keyboard on all scrolls (with a drag,
   /// trackpad, mouse-wheel, etc.)
-  /// Caveat: Since we are watching for all scroll notifications, programmatic
-  /// scrolls will also dismiss the keyboard (e.g opening of on-screen keyboard 
-  /// produces a scroll to keep the field visible).
   onScroll,
 }
 

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -294,6 +294,19 @@ class SingleChildScrollView extends StatelessWidget {
       );
     }
 
+    if (keyboardDismissBehavior == ScrollViewKeyboardDismissBehavior.onScroll) {
+      scrollable = NotificationListener<ScrollUpdateNotification>(
+        child: scrollable,
+        onNotification: (ScrollUpdateNotification notification) {
+          final FocusScopeNode currentScope = FocusScope.of(context);
+          if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+            FocusManager.instance.primaryFocus?.unfocus();
+          }
+          return false;
+        },
+      );
+    }
+
     return effectivePrimary && scrollController != null
         // Further descendant ScrollViews will not inherit the same
         // PrimaryScrollController

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -299,7 +299,9 @@ class SingleChildScrollView extends StatelessWidget {
         child: scrollable,
         onNotification: (ScrollUpdateNotification notification) {
           final FocusScopeNode currentScope = FocusScope.of(context);
-          if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+          if (!currentScope.hasPrimaryFocus &&
+              currentScope.hasFocus &&
+              !notification.programmatic) {
             FocusManager.instance.primaryFocus?.unfocus();
           }
           return false;

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -1078,6 +1078,46 @@ void main() {
     await tester.pumpAndSettle();
     expect(textField.focusNode!.hasFocus, isFalse);
 
+    // ScrollViewKeyboardDismissBehavior.onDrag don't dismiss keyboard on scroll with no drag
+    await boilerplate(ScrollViewKeyboardDismissBehavior.onDrag);
+
+    finder = find.byType(TextField).first;
+    textField = tester.widget(finder);
+    await tester.showKeyboard(finder);
+    expect(textField.focusNode!.hasFocus, isTrue);
+
+    final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
+    final Offset scrollStart = tester.getCenter(find.byType(SingleChildScrollView));
+    testPointer.hover(scrollStart);
+    await tester.sendEventToBinding(testPointer.scroll(Offset(scrollStart.dx, scrollStart.dy - 100)));
+    await tester.pumpAndSettle();
+    expect(textField.focusNode!.hasFocus, isTrue);
+
+    // ScrollViewKeyboardDismissBehavior.noDrag dismiss keyboard on scroll with no drag
+    await boilerplate(ScrollViewKeyboardDismissBehavior.noDrag);
+
+    finder = find.byType(TextField).first;
+    textField = tester.widget(finder);
+    await tester.showKeyboard(finder);
+    expect(textField.focusNode!.hasFocus, isTrue);
+
+    testPointer.hover(scrollStart);
+    await tester.sendEventToBinding(testPointer.scroll(Offset(scrollStart.dx, scrollStart.dy - 100)));
+    await tester.pumpAndSettle();
+    expect(textField.focusNode!.hasFocus, isFalse);
+
+    // ScrollViewKeyboardDismissBehavior.noDrag dismiss keyboard on scroll with drag
+    await boilerplate(ScrollViewKeyboardDismissBehavior.noDrag);
+
+    finder = find.byType(TextField).first;
+    textField = tester.widget(finder);
+    await tester.showKeyboard(finder);
+    expect(textField.focusNode!.hasFocus, isTrue);
+
+    await tester.dragUntilVisible(finder, find.byType(SingleChildScrollView), const Offset(0.0, -40.0));
+    await tester.pumpAndSettle();
+    expect(textField.focusNode!.hasFocus, isFalse);
+
     // ScrollViewKeyboardDismissBehavior.manual does no dismiss the keyboard
     await boilerplate(ScrollViewKeyboardDismissBehavior.manual);
 

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1093,8 +1095,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(textField.focusNode!.hasFocus, isTrue);
 
-    // ScrollViewKeyboardDismissBehavior.noDrag dismiss keyboard on scroll with no drag
-    await boilerplate(ScrollViewKeyboardDismissBehavior.noDrag);
+    // ScrollViewKeyboardDismissBehavior.onScroll dismiss keyboard on scroll with no drag
+    await boilerplate(ScrollViewKeyboardDismissBehavior.onScroll);
 
     finder = find.byType(TextField).first;
     textField = tester.widget(finder);
@@ -1106,8 +1108,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(textField.focusNode!.hasFocus, isFalse);
 
-    // ScrollViewKeyboardDismissBehavior.noDrag dismiss keyboard on scroll with drag
-    await boilerplate(ScrollViewKeyboardDismissBehavior.noDrag);
+    // ScrollViewKeyboardDismissBehavior.onScroll dismiss keyboard on scroll with drag
+    await boilerplate(ScrollViewKeyboardDismissBehavior.onScroll);
 
     finder = find.byType(TextField).first;
     textField = tester.widget(finder);

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -1126,7 +1126,7 @@ void main() {
     finder = find.byType(TextField).last;
     textField = tester.widget(finder);
 
-    final lastFocusNode = focusNodes.last;
+    final FocusNode lastFocusNode = focusNodes.last;
     lastFocusNode.requestFocus();
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -1120,6 +1120,19 @@ void main() {
     await tester.pumpAndSettle();
     expect(textField.focusNode!.hasFocus, isFalse);
 
+    // ScrollViewKeyboardDismissBehavior.onScroll doesn't dismiss keyboard on programmatic scroll
+    await boilerplate(ScrollViewKeyboardDismissBehavior.onScroll);
+
+    finder = find.byType(TextField).last;
+    textField = tester.widget(finder);
+
+    final lastFocusNode = focusNodes.last;
+    lastFocusNode.requestFocus();
+    await tester.pumpAndSettle();
+
+    expect(textField.focusNode!.hasFocus, isTrue);
+
+
     // ScrollViewKeyboardDismissBehavior.manual does no dismiss the keyboard
     await boilerplate(ScrollViewKeyboardDismissBehavior.manual);
 


### PR DESCRIPTION
Previously `ScrollViewKeyboardDismissBehavior` was limited in handling scroll events, proposal in this PR is to introduce a new variant `onScroll` which is for dismissing on-screen keyboard for all user-initiated scrolls which includes (non-drag) scrolls common on desktops (mouse scroll, two-finger scrolls) (#154515).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.