### PR TITLE
`AnimationStyle` methods

### DIFF
--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -91,29 +91,18 @@ class AnimationStyle with Diagnosticable {
       return a;
     }
     return AnimationStyle(
-      curve: _lerpCurve(a?.curve, b?.curve, t),
-      duration: _lerpDuration(a?.duration, b?.duration, t),
-      reverseCurve: _lerpCurve(a?.reverseCurve, b?.reverseCurve, t),
-      reverseDuration: _lerpDuration(a?.reverseDuration, b?.reverseDuration, t),
-    );
-  }
-  
-  static Duration? _lerpDuration(Duration? a, Duration? b, double t) {
-    if (t == 0.0) {
-      return a;
-    }
-    if (t == 1.0) {
-      return b;
-    }
-    if (a == null || b == null) {
-      return a ?? b;
-    }
-    return Duration(
-      microseconds: (a.inMicroseconds * (1.0 - t) + b.inMicroseconds * t).round(),
+      curve: _lerp(a?.curve, b?.curve, t, _LerpedCurve.new),
+      duration: _lerp(a?.duration, b?.duration, t, _lerpDuration),
+      reverseCurve: _lerp(a?.reverseCurve, b?.reverseCurve, t, _LerpedCurve.new),
+      reverseDuration: _lerp(a?.reverseDuration, b?.reverseDuration, t, _lerpDuration),
     );
   }
 
-  static Curve? _lerpCurve(Curve? a, Curve? b, double t) {
+  @optionalTypeArgs
+  static T? _lerp<T extends Object>(T? a, T? b, double t, T Function(T a, T b, double t) lerp) {
+    if (identical(a, b)) {
+      return a;
+    }
     if (t == 0.0) {
       return a;
     }
@@ -123,7 +112,13 @@ class AnimationStyle with Diagnosticable {
     if (a == null || b == null) {
       return a ?? b;
     }
-    return _LerpedCurve(a, b, t);
+    return lerp(a, b, t);
+  }
+
+  static Duration _lerpDuration(Duration a, Duration b, double t) {
+    return Duration(
+      microseconds: (a.inMicroseconds * (1.0 - t) + b.inMicroseconds * t).round(),
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -69,6 +69,22 @@ class AnimationStyle with Diagnosticable {
     );
   }
 
+  /// Returns a modified version of the [other] style, where its `null` properties
+  /// are filled in with the non-null properties of this style, where applicable.
+  ///
+  /// If a `null` argument is passed, returns this text style.
+  AnimationStyle merge(AnimationStyle? other) {
+    if (other == null) {
+      return this;
+    }
+    return copyWith(
+      curve: other.curve,
+      duration: other.duration,
+      reverseCurve: other.reverseCurve,
+      reverseDuration: other.reverseDuration,
+    );
+  }
+
   /// Linearly interpolate between two animation styles.
   static AnimationStyle? lerp(AnimationStyle? a, AnimationStyle? b, double t) {
     if (identical(a, b)) {

--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -75,11 +75,39 @@ class AnimationStyle with Diagnosticable {
       return a;
     }
     return AnimationStyle(
-      curve: t < 0.5 ? a?.curve : b?.curve,
-      duration: t < 0.5 ? a?.duration : b?.duration,
-      reverseCurve: t < 0.5 ? a?.reverseCurve : b?.reverseCurve,
-      reverseDuration: t < 0.5 ? a?.reverseDuration : b?.reverseDuration,
+      curve: _lerpCurve(a?.curve, b?.curve, t),
+      duration: _lerpDuration(a?.duration, b?.duration, t),
+      reverseCurve: _lerpCurve(a?.reverseCurve, b?.reverseCurve, t),
+      reverseDuration: _lerpDuration(a?.reverseDuration, b?.reverseDuration, t),
     );
+  }
+  
+  static Duration? _lerpDuration(Duration? a, Duration? b, double t) {
+    if (t == 0.0) {
+      return a;
+    }
+    if (t == 1.0) {
+      return b;
+    }
+    if (a == null || b == null) {
+      return a ?? b;
+    }
+    return Duration(
+      microseconds: (a.inMicroseconds * (1.0 - t) + b.inMicroseconds * t).round(),
+    );
+  }
+
+  static Curve? _lerpCurve(Curve? a, Curve? b, double t) {
+    if (t == 0.0) {
+      return a;
+    }
+    if (t == 1.0) {
+      return b;
+    }
+    if (a == null || b == null) {
+      return a ?? b;
+    }
+    return _LerpedCurve(a, b, t);
   }
 
   @override
@@ -113,4 +141,31 @@ class AnimationStyle with Diagnosticable {
     properties.add(DiagnosticsProperty<Curve>('reverseCurve', reverseCurve, defaultValue: null));
     properties.add(DiagnosticsProperty<Duration>('reverseDuration', reverseDuration, defaultValue: null));
   }
+}
+
+class _LerpedCurve extends Curve {
+  const _LerpedCurve(this.first, this.second, this._t);
+
+  final Curve first;
+  final Curve second;
+  final double _t;
+
+  @override
+  double transform(double t) {
+    final double a = first.transform(t);
+    final double b = second.transform(t);
+
+    return a * (1.0 - _t) + b * _t;
+  }
+
+  @override
+  bool operator==(Object other) {
+    return other is _LerpedCurve
+        && other.first == first
+        && other.second == second
+        && other._t == _t;
+  }
+
+  @override
+  int get hashCode => Object.hash(first, second, _t);
 }

--- a/packages/flutter/test/animation/animation_style_test.dart
+++ b/packages/flutter/test/animation/animation_style_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui show lerpDouble;
+
 import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -37,7 +39,7 @@ void main() {
     expect(identical(AnimationStyle.lerp(data, data, 0.5), data), true);
   });
 
-  testWidgets('default AnimationStyle debugFillProperties', (WidgetTester tester) async {
+  testWidgets('AnimationStyle.lerp smoothly transitions all values', (WidgetTester tester) async {
     final AnimationStyle a = AnimationStyle(
       curve: Curves.ease,
       duration: const Duration(seconds: 1),
@@ -50,10 +52,38 @@ void main() {
       reverseCurve: Curves.linear,
       reverseDuration: const Duration(seconds: 2),
     );
+    final int aForward = a.duration!.inMicroseconds;
+    final int aReverse = a.reverseDuration!.inMicroseconds;
+    final int bForward = b.duration!.inMicroseconds;
+    final int bReverse = b.reverseDuration!.inMicroseconds;
 
     expect(AnimationStyle.lerp(a, b, 0), a);
-    expect(AnimationStyle.lerp(a, b, 0.5), b);
     expect(AnimationStyle.lerp(a, b, 1.0), b);
+
+    const int styleSteps = 5;
+    const int curveSteps = 5;
+    for (int styleStep = 0; styleStep < styleSteps; styleStep += 1) {
+      final double styleTransition = (styleStep + 1) / (styleSteps + 1);
+      final AnimationStyle? lerpedStyle = AnimationStyle.lerp(a, b, styleTransition);
+
+      expect(
+        lerpedStyle?.duration?.inMicroseconds,
+        ui.lerpDouble(aForward, bForward, styleTransition)?.round(),
+      );
+      expect(
+        lerpedStyle?.reverseDuration?.inMicroseconds,
+        ui.lerpDouble(aReverse, bReverse, styleTransition)?.round(),
+      );
+
+      for (int curveStep = 0; curveStep < curveSteps; curveStep += 1) {
+        final double t = (curveStep + 1) / (curveSteps + 1);
+        final double aResult = Curves.ease.transform(t);
+        final double bResult = Curves.linear.transform(t);
+        final double? lerpResult = lerpedStyle?.curve?.transform(t);
+
+        expect(lerpResult, ui.lerpDouble(aResult, bResult, styleTransition));
+      }
+    }
   });
 
   testWidgets('default AnimationStyle debugFillProperties', (WidgetTester tester) async {

--- a/packages/flutter/test/animation/animation_style_test.dart
+++ b/packages/flutter/test/animation/animation_style_test.dart
@@ -33,6 +33,24 @@ void main() {
     expect(copy.reverseDuration, const Duration(seconds: 2));
   });
 
+  testWidgets('AnimationStyle.merge() fills in null properties', (WidgetTester tester) async {
+    final AnimationStyle original = AnimationStyle(
+      curve: Curves.ease,
+      duration: const Duration(seconds: 1),
+      reverseCurve: Curves.ease,
+      reverseDuration: const Duration(seconds: 1),
+    );
+    final AnimationStyle other = AnimationStyle(
+      curve: Curves.linear,
+      duration: const Duration(seconds: 2),
+    );
+    final AnimationStyle merged = original.merge(other);
+    expect(merged.curve, Curves.linear);
+    expect(merged.duration, const Duration(seconds: 2));
+    expect(merged.reverseCurve, Curves.ease);
+    expect(merged.reverseDuration, const Duration(seconds: 1));
+  });
+
   test('AnimationStyle.lerp identical a,b', () {
     expect(AnimationStyle.lerp(null, null, 0), null);
     final AnimationStyle data = AnimationStyle();


### PR DESCRIPTION
This pull request adds an `AnimationStyle.merge()` method (for parity with similar APIs) and updates `AnimationStyle.lerp()` so that it performs an accurate interpolation.

<br>

related: #160563