### PR TITLE
`TickerMode` refactor

### DIFF
--- a/packages/flutter/test/widgets/ticker_mode_test.dart
+++ b/packages/flutter/test/widgets/ticker_mode_test.dart
@@ -7,6 +7,15 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  testWidgets('TickerMode takes advantage of InheritedNotifier API', (WidgetTester tester) async {
+    await tester.pumpWidget(const TickerMode(enabled: true, child: SizedBox()));
+
+    expect(
+      find.byWidgetPredicate((Widget widget) => widget is InheritedNotifier),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('Nested TickerMode cannot turn tickers back on', (WidgetTester tester) async {
     int outerTickCount = 0;
     int innerTickCount = 0;


### PR DESCRIPTION
This pull request refactors `TickerMode` to take advantage of the [**InheritedNotifier**](https://main-api.flutter.dev/flutter/widgets/InheritedNotifier-class.html) API.

<br>

Thanks to the listenable returned by [**TickerMode.getNotifier**](https://main-api.flutter.dev/flutter/widgets/TickerMode/getNotifier.html), a ticker provider can update its ticker based on the ancestor `TickerMode` without triggering a rebuild.

Once this pull request lands, the same will be true for the `TickerMode` widget itself!