### PR TITLE
Introduce `DefaultAnimationStyle` widget

### DIFF
--- a/packages/flutter/lib/src/animation/animation_style.dart
+++ b/packages/flutter/lib/src/animation/animation_style.dart
@@ -6,8 +6,8 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart' show TickerProvider;
 
-import 'curves.dart';
 import 'tween.dart';
 
 /// Used to override the default parameters of an animation.
@@ -105,4 +105,27 @@ class AnimationStyle with Diagnosticable {
       DiagnosticsProperty<Duration>('reverseDuration', reverseDuration, defaultValue: null),
     );
   }
+}
+
+/// An animation that interfaces with an [AnimationProvider].
+///
+/// Typically, this interface is used to allow animations to inherit
+/// fallback [Duration] and [Curve] values from the ambient [DefaultAnimationStyle].
+abstract interface class StyledAnimation<T> implements Animation<T> {
+  /// Called when the associated [AnimationProvider] is updated
+  /// with a new [AnimationStyle].
+  void updateStyle(AnimationStyle newStyle);
+}
+
+/// A [TickerProvider] that can also provide a relevant [AnimationStyle].
+///
+/// Any [StyledAnimation]s registered via [registerAnimation] will be given
+/// fallback [Duration] and [Curve] values, typically from the ambient
+/// [DefaultAnimationStyle].
+abstract interface class AnimationProvider implements TickerProvider {
+  /// Registers the [StyledAnimation] object with this provider.
+  ///
+  /// [StyledAnimation.updateStyle] is called immediately, and then called again
+  /// each time there's a relevant change.
+  void registerAnimation(StyledAnimation<Object?> animation);
 }

--- a/packages/flutter/lib/src/widgets/default_animation_style.dart
+++ b/packages/flutter/lib/src/widgets/default_animation_style.dart
@@ -1,0 +1,161 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'implicit_animations.dart';
+library;
+
+import 'package:flutter/animation.dart';
+import 'package:flutter/foundation.dart';
+
+import 'framework.dart';
+import 'inherited_notifier.dart';
+import 'inherited_theme.dart';
+
+/// Defines a default configuration for animation [Duration]s and [Curve]s.
+///
+/// If an [ImplicitlyAnimatedWidget]'s duration or curve is not defined,
+/// it will default to the values specified in the closest ancestor
+/// `DefaultAnimationStyle`, if one exists; otherwise it will use
+/// [fallbackDuration] and/or [fallbackCurve] respectively.
+sealed class DefaultAnimationStyle implements Widget {
+  /// Creates a default configuration for animation [Duration]s and [Curve]s.
+  ///
+  /// The `mergeWithAncestor` parameter defaults to `true`; it determines
+  /// whether null values from the provided `style` are filled in with
+  /// non-null properties from further up in the widget tree, if applicable.
+  const factory DefaultAnimationStyle({
+    Key? key,
+    required AnimationStyle style,
+    bool mergeWithAncestor,
+    required Widget child,
+  }) = _DefaultAnimationStyle;
+
+  /// Creates an [InheritedWidget] that defines a default style
+  /// based on a `ValueListenable` object, typically a [ValueNotifier].
+  ///
+  /// Supplying a notifier directly allows sending notifications without
+  /// needing to rebuild the widget.
+  ///
+  /// The notifier's style is not merged with ancestors in the widget tree.
+  const factory DefaultAnimationStyle.notifier({
+    Key? key,
+    required ValueListenable<AnimationStyle> notifier,
+    required Widget child,
+  }) = _InheritedAnimationStyle;
+
+  /// Returns the [AnimationStyle] corresponding to the nearest ancestor
+  /// [DefaultAnimationStyle] widget.
+  ///
+  /// If no such widget is found, returns an [AnimationStyle] object with
+  /// each property set to `null`.
+  static AnimationStyle of(BuildContext context, {bool createDependency = true}) {
+    final _InheritedAnimationStyle? inherited =
+        createDependency
+            ? context.dependOnInheritedWidgetOfExactType()
+            : context.getInheritedWidgetOfExactType();
+
+    return inherited?.notifier?.value ?? AnimationStyle();
+  }
+
+  /// Returns a [ValueListenable] object from the nearest ancestor
+  /// [DefaultAnimationStyle] widget.
+  ///
+  /// This can be useful for responding to animation style updates
+  /// without notifying the respective [BuildContext] to rebuild.
+  static ValueListenable<AnimationStyle> getNotifier(BuildContext context) {
+    final _InheritedAnimationStyle? inheritedWidget = context.getInheritedWidgetOfExactType();
+    return inheritedWidget?.notifier ?? const _FallbackAnimationStyleListenable();
+  }
+}
+
+class _FallbackAnimationStyleListenable implements ValueListenable<AnimationStyle> {
+  const _FallbackAnimationStyleListenable();
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+
+  @override
+  AnimationStyle get value => AnimationStyle();
+}
+
+class _InheritedAnimationStyle extends InheritedNotifier<ValueListenable<AnimationStyle>>
+    implements DefaultAnimationStyle, InheritedTheme {
+  const _InheritedAnimationStyle({super.key, super.notifier, required super.child});
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return DefaultAnimationStyle(style: notifier!.value, child: child);
+  }
+}
+
+class _DefaultAnimationStyle extends StatefulWidget implements DefaultAnimationStyle {
+  const _DefaultAnimationStyle({
+    super.key,
+    required this.style,
+    this.mergeWithAncestor = true,
+    required this.child,
+  });
+
+  final AnimationStyle style;
+  final bool mergeWithAncestor;
+  final Widget child;
+
+  @override
+  State<_DefaultAnimationStyle> createState() => _DefaultAnimationStyleState();
+}
+
+class _DefaultAnimationStyleState extends State<_DefaultAnimationStyle> {
+  late final ValueNotifier<AnimationStyle> notifier = ValueNotifier<AnimationStyle>(widget.style);
+  late ValueListenable<AnimationStyle> ancestor = DefaultAnimationStyle.getNotifier(context);
+
+  @override
+  void initState() {
+    super.initState();
+    ancestor.addListener(_updateStyle);
+  }
+
+  @override
+  void activate() {
+    super.activate();
+    final ValueListenable<AnimationStyle> newAncestorNotifier = DefaultAnimationStyle.getNotifier(
+      context,
+    );
+    if (newAncestorNotifier == ancestor) {
+      return;
+    }
+    ancestor.removeListener(_updateStyle);
+    ancestor = newAncestorNotifier..addListener(_updateStyle);
+  }
+
+  void _updateStyle() {
+    final AnimationStyle style = widget.style;
+    late final AnimationStyle ancestorStyle = ancestor.value;
+    if (widget.mergeWithAncestor && ancestorStyle is! _FallbackAnimationStyleListenable) {
+      notifier.value = ancestorStyle.copyWith(
+        duration: style.duration,
+        curve: style.curve,
+        reverseDuration: style.reverseDuration,
+        reverseCurve: style.reverseCurve,
+      );
+    } else {
+      notifier.value = style;
+    }
+  }
+
+  @override
+  void dispose() {
+    ancestor.removeListener(_updateStyle);
+    notifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _updateStyle();
+    return DefaultAnimationStyle.notifier(notifier: notifier, child: widget.child);
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -40,6 +40,7 @@ export 'src/widgets/context_menu_button_item.dart';
 export 'src/widgets/context_menu_controller.dart';
 export 'src/widgets/debug.dart';
 export 'src/widgets/decorated_sliver.dart';
+export 'src/widgets/default_animation_style.dart';
 export 'src/widgets/default_selection_style.dart';
 export 'src/widgets/default_text_editing_shortcuts.dart';
 export 'src/widgets/desktop_text_selection_toolbar_layout_delegate.dart';

--- a/packages/flutter/test/widgets/default_animation_style_test.dart
+++ b/packages/flutter/test/widgets/default_animation_style_test.dart
@@ -1,0 +1,44 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('DefaultAnimationStyle notifier value matches widget', (WidgetTester tester) async {
+    late StateSetter setState;
+    AnimationStyle style = AnimationStyle();
+    const Widget child = SizedBox.shrink(key: Key('key'));
+
+    await tester.pumpWidget(StatefulBuilder(
+      builder: (BuildContext context, StateSetter stateSetter) {
+        setState = stateSetter;
+        return DefaultAnimationStyle(style: style, child: child);
+      },
+    ));
+
+    final ValueListenable<AnimationStyle> styleNotifier = DefaultAnimationStyle.getNotifier(
+      tester.element(find.byKey(const Key('key'))),
+    );
+    expect(styleNotifier.value, style);
+
+    setState(() {
+      style = AnimationStyle(curve: Curves.ease);
+    });
+    await tester.pump();
+    expect(styleNotifier.value, style);
+
+    setState(() {
+      style = AnimationStyle(
+        curve: Curves.bounceIn,
+        duration: Durations.extralong4,
+        reverseCurve: const SawTooth(2),
+        reverseDuration: const Duration(days: DateTime.thursday),
+      );
+    });
+    await tester.pump();
+    expect(styleNotifier.value, style);
+  });
+}


### PR DESCRIPTION
- **preparing for: https://github.com/flutter/flutter/pull/154378**

- 📜 **design doc: [flutter.dev/go/default-animation-style](https://flutter.dev/go/default-animation-style)**

<hr>

Changes:
- adds `DefaultAnimationStyle` to the widgets library
- expands on [**TickerProviderStateMixin**](https://main-api.flutter.dev/flutter/widgets/TickerProviderStateMixin-mixin.html) and [**SingleTickerProviderStateMixin**](https://main-api.flutter.dev/flutter/widgets/SingleTickerProviderStateMixin-mixin.html)

Landing this PR will unlock 2 future improvements:
1. An implicitly animated widget (such as [**AnimatedAlign**](https://main-api.flutter.dev/flutter/widgets/AnimatedAlign-class.html)) can inherit its `Duration` and `Curve` from the ambient theme.
2. Animation objects could also inherit from the ancestor `DefaultAnimationStyle` via the existing ticker provider mixins.

<br>

solves https://github.com/flutter/flutter/issues/156248

cc: @caseycrogers @hannah-hyj @johnpryan