### PR TITLE
deprecate `UniqueWidget`

### DIFF
--- a/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
+++ b/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
@@ -23,6 +23,16 @@
 #     * ListWheelScrollView: fix_list_wheel_scroll_view.yaml
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/160569
+  - title: "Migrate to StatefulWidget"
+    date: 2023-11-29
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      class: 'UniqueWidget'
+    changes:
+      - kind: 'rename'
+        newName: 'StatefulWidget'
+
   # Changes made in https://github.com/flutter/flutter/pull/139260
   - title: "Migrate to focusNode.enclosingScope!"
     date: 2023-11-29

--- a/packages/flutter/lib/src/widgets/unique_widget.dart
+++ b/packages/flutter/lib/src/widgets/unique_widget.dart
@@ -17,11 +17,21 @@ import 'framework.dart';
 ///
 /// When subclassing [UniqueWidget], provide the corresponding [State] subclass
 /// as the type argument.
+@Deprecated(
+  'Use StatefulWidget instead. '
+  'Any widget can use a global key. '
+  'This feature was deprecated after v3.28.0-0.1.pre.',
+)
 abstract class UniqueWidget<T extends State<StatefulWidget>> extends StatefulWidget {
   /// Creates a widget that has exactly one inflated instance in the tree.
   ///
   /// The [key] argument is required because it identifies the unique inflated
   /// instance of this widget.
+  @Deprecated(
+    'Use StatefulWidget instead. '
+    'Any widget can use a global key. '
+    'This feature was deprecated after v3.28.0-0.1.pre.',
+  )
   const UniqueWidget({required GlobalKey<T> super.key});
 
   @override
@@ -30,6 +40,11 @@ abstract class UniqueWidget<T extends State<StatefulWidget>> extends StatefulWid
   /// The state for the unique inflated instance of this widget.
   ///
   /// Might be null if the widget is not currently in the tree.
+  @Deprecated(
+    'Use the key directly. '
+    'Flutter widgets should follow a declarative style. '
+    'This feature was deprecated after v3.28.0-0.1.pre.',
+  )
   T? get currentState {
     final GlobalKey<T> globalKey = key! as GlobalKey<T>;
     return globalKey.currentState;

--- a/packages/flutter/test_fixes/widgets/widgets.dart
+++ b/packages/flutter/test_fixes/widgets/widgets.dart
@@ -12,6 +12,9 @@ void main() {
   Object object;
   TickerProvider vsync;
 
+  // Changes made in https://github.com/flutter/flutter/pull/160569
+  UniqueWidget widget;
+
   // Changes made in https://github.com/flutter/flutter/pull/123352
   WidgetsBinding.instance.renderViewElement;
 

--- a/packages/flutter/test_fixes/widgets/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets/widgets.dart.expect
@@ -12,6 +12,9 @@ void main() {
   Object object;
   TickerProvider vsync;
 
+  // Changes made in https://github.com/flutter/flutter/pull/160569
+  StatefulWidget widget;
+
   // Changes made in https://github.com/flutter/flutter/pull/123352
   WidgetsBinding.instance.rootElement;
 


### PR DESCRIPTION
This is my New Year's resolution.
(unfortunately it does not fix #150459)

<br>

UniqueWidget should be removed for 2 reasons:

### Promote a declarative programming style

UniqueWidget's design goes against Flutter's [declarative UI style](https://docs.flutter.dev/get-started/flutter-for/declarative) by promoting access to a `State` through a `Widget` instance.

### Reduce Tech Debt

I wasted at least 20 minutes of my life trying to come up with a good use for UniqueWidget, only to realize that it's far more useful to interface with a global key directly.

Removing this widget will mitigate the time wasted by Flutter developers down the road.

<br><br>

A data-driven fix was added, so that the one person using this API will have a smoother transition. Wishing you the best of luck, Matias!