### PR TITLE
Upstream and Origin check

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -27,7 +27,15 @@ if ((Test-Path "$flutterRoot\DEPS" -PathType Leaf) -and (Test-Path "$flutterRoot
     # Calculate the engine hash from tracked git files.
     $branch = (git -C "$flutterRoot" rev-parse --abbrev-ref HEAD)
     if ($null -eq $Env:LUCI_CONTEXT) {
-        $engineVersion = (git -C "$flutterRoot"  merge-base HEAD upstream/master)
+        $ErrorActionPreference = "Continue"
+        git -C "$flutterRoot" remote get-url upstream *> $null
+        $exitCode = $?
+        $ErrorActionPreference = "Stop"
+        if ($exitCode) {
+            $engineVersion = (git -C "$flutterRoot"  merge-base HEAD upstream/master)
+        } else {
+            $engineVersion = (git -C "$flutterRoot"  merge-base HEAD origin/master)
+        }
     }
     else {
         $engineVersion = (git -C "$flutterRoot" rev-parse HEAD)

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -29,7 +29,7 @@ if [ -f "$FLUTTER_ROOT/DEPS" ] && [ -f "$FLUTTER_ROOT/engine/src/.gn" ]; then
   if [ -z "${LUCI_CONTEXT}" ]; then
     set +e
     # Run the git command and capture the exit code
-    git -C "$flutterRoot" remote get-url upstream > /dev/null 2>&1
+    git -C "$FLUTTER_ROOT" remote get-url upstream > /dev/null 2>&1
     exit_code=$?
     set -e
 

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -27,7 +27,17 @@ if [ -f "$FLUTTER_ROOT/DEPS" ] && [ -f "$FLUTTER_ROOT/engine/src/.gn" ]; then
   BRANCH=$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)
   # In a fusion repository; the engine.version comes from the git hashes.
   if [ -z "${LUCI_CONTEXT}" ]; then
-    ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" merge-base HEAD upstream/master)
+    set +e
+    # Run the git command and capture the exit code
+    git -C "$flutterRoot" remote get-url upstream > /dev/null 2>&1
+    exit_code=$?
+    set -e
+
+    if [[ $exit_code -eq 0 ]]; then
+      ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" merge-base HEAD upstream/master)
+    else
+      ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" merge-base HEAD origin/master)
+    fi
   else
     ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" rev-parse HEAD)
   fi


### PR DESCRIPTION
Several use cases for `origin` as default:

* Some github actions checkout the tree
* Some users download from flutter.dev and then use `master`

Fixes #160558

