### PR TITLE
Fix invalid pubspecs in the fuchsia directory.

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/fuchsia/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/fuchsia/pubspec.yaml
@@ -2,5 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+name: fuchsia
+
 environment:
   sdk: ^3.7.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/embedder/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/embedder/pubspec.yaml
@@ -5,6 +5,8 @@
 # The presence of this file is necessary in order to use the dart_library
 # template in BUILD.gn.
 
+name: fuchsia_embedder
+
 environment:
   sdk: ^3.7.0-0
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/vmservice/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/vmservice/pubspec.yaml
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+name: fuchsia_vmservice
+
 environment:
   sdk: ^3.7.0-0
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/kernel/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/kernel/pubspec.yaml
@@ -2,5 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+name: fuchsia_kernel
+
 environment:
   sdk: ^3.7.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols/pubspec.yaml
@@ -5,6 +5,6 @@
 name: profiler_symbols
 environment:
   sdk: ^3.7.0-0
-version: 0
+version: 0.1.0
 description: Extracts a minimal symbols table for the Dart VM profiler
 author: Dart Team <misc@dartlang.org>


### PR DESCRIPTION
These pubspecs are causing issues with the `technical_debt__cost.dart` test. They need to have valid names and version numbers.