### PR TITLE
[Impeller] remove unused BliPass::EncodeCommands arg and cleanup.

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -105,7 +105,7 @@ bool GenerateMipmap(const std::shared_ptr<Context>& context,
   }
   pass->GenerateMipmap(std::move(texture), label);
 
-  pass->EncodeCommands(context->GetResourceAllocator());
+  pass->EncodeCommands();
   return context->GetCommandQueue()->Submit({buffer}).ok();
 }
 

--- a/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
@@ -519,7 +519,7 @@ TEST_P(AiksTest, MipmapGenerationWorksCorrectly) {
   blit_pass->AddCopy(DeviceBuffer::AsBufferView(std::move(device_buffer)),
                      texture);
   blit_pass->GenerateMipmap(texture);
-  EXPECT_TRUE(blit_pass->EncodeCommands(GetContext()->GetResourceAllocator()));
+  EXPECT_TRUE(blit_pass->EncodeCommands());
   EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({command_buffer}).ok());
 
   auto image = DlImageImpeller::Make(texture);
@@ -579,7 +579,7 @@ TEST_P(AiksTest, SetContentsWithRegion) {
                      IRect::MakeLTRB(50, 50, 150, 150));
 
   auto did_submit =
-      blit_pass->EncodeCommands(GetContext()->GetResourceAllocator()) &&
+      blit_pass->EncodeCommands() &&
       GetContext()->GetCommandQueue()->Submit({std::move(cmd_buffer)}).ok();
   ASSERT_TRUE(did_submit);
 

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1671,8 +1671,7 @@ bool Canvas::BlitToOnscreen() {
     auto blit_pass = command_buffer->CreateBlitPass();
     blit_pass->AddCopy(offscreen_target.GetRenderTargetTexture(),
                        render_target_.GetRenderTargetTexture());
-    if (!blit_pass->EncodeCommands(
-            renderer_.GetContext()->GetResourceAllocator())) {
+    if (!blit_pass->EncodeCommands()) {
       VALIDATION_LOG << "Failed to encode root pass blit command.";
       return false;
     }

--- a/engine/src/flutter/impeller/entity/contents/content_context.cc
+++ b/engine/src/flutter/impeller/entity/contents/content_context.cc
@@ -268,11 +268,10 @@ ContentContext::ContentContext(
     auto buffer_view = host_buffer.Emplace(data);
     blit_pass->AddCopy(buffer_view, empty_texture_);
 
-    if (!blit_pass->EncodeCommands(GetContext()->GetResourceAllocator()) ||
-        !GetContext()
-             ->GetCommandQueue()
-             ->Submit({std::move(cmd_buffer)})
-             .ok()) {
+    if (!blit_pass->EncodeCommands() || !GetContext()
+                                             ->GetCommandQueue()
+                                             ->Submit({std::move(cmd_buffer)})
+                                             .ok()) {
       VALIDATION_LOG << "Failed to create empty texture.";
     }
   }

--- a/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -892,8 +892,7 @@ std::optional<Entity> BlendFilterContents::CreateFramebufferAdvancedBlend(
         foreground_color->Premultiply().ToR8G8B8A8(), /*alignment=*/4);
 
     blit_pass->AddCopy(std::move(buffer_view), foreground_texture);
-    if (!blit_pass->EncodeCommands(
-            renderer.GetContext()->GetResourceAllocator())) {
+    if (!blit_pass->EncodeCommands()) {
       return std::nullopt;
     }
   }

--- a/engine/src/flutter/impeller/entity/contents/gradient_generator.cc
+++ b/engine/src/flutter/impeller/entity/contents/gradient_generator.cc
@@ -41,7 +41,7 @@ std::shared_ptr<Texture> CreateGradientTexture(
   auto blit_pass = cmd_buffer->CreateBlitPass();
   blit_pass->AddCopy(DeviceBuffer::AsBufferView(std::move(buffer)), texture);
 
-  if (!blit_pass->EncodeCommands(context->GetResourceAllocator()) ||
+  if (!blit_pass->EncodeCommands() ||
       !context->GetCommandQueue()->Submit({std::move(cmd_buffer)}).ok()) {
     return nullptr;
   }

--- a/engine/src/flutter/impeller/entity/entity_unittests.cc
+++ b/engine/src/flutter/impeller/entity/entity_unittests.cc
@@ -1646,7 +1646,7 @@ static std::vector<std::shared_ptr<Texture>> CreateTestYUVTextures(
 
   blit_pass->AddCopy(DeviceBuffer::AsBufferView(uv_mapping_buffer), uv_texture);
 
-  if (!blit_pass->EncodeCommands(context->GetResourceAllocator()) ||
+  if (!blit_pass->EncodeCommands() ||
       !context->GetCommandQueue()->Submit({cmd_buffer}).ok()) {
     FML_DLOG(ERROR) << "Could not copy contents into Y/UV texture.";
   }

--- a/engine/src/flutter/impeller/golden_tests/vulkan_screenshotter.mm
+++ b/engine/src/flutter/impeller/golden_tests/vulkan_screenshotter.mm
@@ -39,7 +39,7 @@ std::unique_ptr<Screenshot> ReadTexture(
   bool success = blit_pass->AddCopy(texture, device_buffer);
   FML_CHECK(success);
 
-  success = blit_pass->EncodeCommands(surface_context->GetResourceAllocator());
+  success = blit_pass->EncodeCommands();
   FML_CHECK(success);
 
   fml::AutoResetWaitableEvent latch;

--- a/engine/src/flutter/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/engine/src/flutter/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -100,7 +100,7 @@ bool ImGui_ImplImpeller_Init(
 
     blit_pass->AddCopy(impeller::DeviceBuffer::AsBufferView(device_buffer),
                        bd->font_texture);
-    blit_pass->EncodeCommands(context->GetResourceAllocator());
+    blit_pass->EncodeCommands();
 
     [[maybe_unused]] bool uploaded =
         context->GetCommandQueue()->Submit({command_buffer}).ok();

--- a/engine/src/flutter/impeller/playground/playground.cc
+++ b/engine/src/flutter/impeller/playground/playground.cc
@@ -421,7 +421,7 @@ static std::shared_ptr<Texture> CreateTextureForDecompressedImage(
     blit_pass->SetLabel("Mipmap Blit Pass");
     blit_pass->GenerateMipmap(texture);
   }
-  blit_pass->EncodeCommands(context->GetResourceAllocator());
+  blit_pass->EncodeCommands();
   if (!context->GetCommandQueue()->Submit({command_buffer}).ok()) {
     FML_DLOG(ERROR) << "Failed to submit blit pass command buffer.";
     return nullptr;
@@ -490,7 +490,7 @@ std::shared_ptr<Texture> Playground::CreateTextureCubeForFixture(
                        "", /*mip_level=*/0, /*slice=*/i);
   }
 
-  if (!blit_pass->EncodeCommands(context_->GetResourceAllocator()) ||
+  if (!blit_pass->EncodeCommands() ||
       !context_->GetCommandQueue()->Submit({std::move(cmd_buffer)}).ok()) {
     VALIDATION_LOG << "Could not upload texture to device memory.";
     return nullptr;

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.cc
@@ -41,9 +41,8 @@ void BlitPassGLES::OnSetLabel(std::string_view label) {
     return true;
   }
 
-  const auto& gl = reactor.GetProcTable();
-
 #ifdef IMPELLER_DEBUG
+  const auto& gl = reactor.GetProcTable();
   fml::ScopedCleanupClosure pop_pass_debug_marker(
       [&gl]() { gl.PopDebugGroup(); });
   if (!label.empty()) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.h
@@ -38,8 +38,7 @@ class BlitPassGLES final : public BlitPass,
   void OnSetLabel(std::string_view label) override;
 
   // |BlitPass|
-  bool EncodeCommands(
-      const std::shared_ptr<Allocator>& transients_allocator) const override;
+  bool EncodeCommands() const override;
 
   // |BlitPass|
   bool ResizeTexture(const std::shared_ptr<Texture>& source,

--- a/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.h
@@ -38,8 +38,7 @@ class BlitPassMTL final : public BlitPass {
   void OnSetLabel(std::string_view label) override;
 
   // |BlitPass|
-  bool EncodeCommands(
-      const std::shared_ptr<Allocator>& transients_allocator) const override;
+  bool EncodeCommands() const override;
 
   // |BlitPass|
   bool ResizeTexture(const std::shared_ptr<Texture>& source,

--- a/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.mm
@@ -58,8 +58,7 @@ void BlitPassMTL::OnSetLabel(std::string_view label) {
   [encoder_ setLabel:@(label.data())];
 }
 
-bool BlitPassMTL::EncodeCommands(
-    const std::shared_ptr<Allocator>& transients_allocator) const {
+bool BlitPassMTL::EncodeCommands() const {
   [encoder_ endEncoding];
   did_finish_encoding_ = true;
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/surface_mtl.mm
@@ -253,7 +253,7 @@ bool SurfaceMTL::PreparePresent() const {
     }
     blit_pass->AddCopy(source_texture_, destination_texture_, std::nullopt,
                        clip_rect_->GetOrigin());
-    blit_pass->EncodeCommands(context->GetResourceAllocator());
+    blit_pass->EncodeCommands();
     if (!context->GetCommandQueue()->Submit({blit_command_buffer}).ok()) {
       return false;
     }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -57,8 +57,7 @@ bool BlitPassVK::IsValid() const {
 }
 
 // |BlitPass|
-bool BlitPassVK::EncodeCommands(
-    const std::shared_ptr<Allocator>& transients_allocator) const {
+bool BlitPassVK::EncodeCommands() const {
   return true;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.h
@@ -33,8 +33,7 @@ class BlitPassVK final : public BlitPass {
   void OnSetLabel(std::string_view label) override;
 
   // |BlitPass|
-  bool EncodeCommands(
-      const std::shared_ptr<Allocator>& transients_allocator) const override;
+  bool EncodeCommands() const override;
 
   // |BlitPass|
   bool ResizeTexture(const std::shared_ptr<Texture>& source,

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
@@ -56,7 +56,7 @@ TEST(GPUTracerVK, CanTraceCmdBuffer) {
 
   auto cmd_buffer = context->CreateCommandBuffer();
   auto blit_pass = cmd_buffer->CreateBlitPass();
-  blit_pass->EncodeCommands(context->GetResourceAllocator());
+  blit_pass->EncodeCommands();
 
   auto latch = std::make_shared<fml::CountDownLatch>(1u);
 
@@ -92,7 +92,7 @@ TEST(GPUTracerVK, DoesNotTraceOutsideOfFrameWorkload) {
 
   auto cmd_buffer = context->CreateCommandBuffer();
   auto blit_pass = cmd_buffer->CreateBlitPass();
-  blit_pass->EncodeCommands(context->GetResourceAllocator());
+  blit_pass->EncodeCommands();
 
   auto latch = std::make_shared<fml::CountDownLatch>(1u);
   if (!context->GetCommandQueue()
@@ -128,7 +128,7 @@ TEST(GPUTracerVK, TracesWithPartialFrameOverlap) {
 
   auto cmd_buffer = context->CreateCommandBuffer();
   auto blit_pass = cmd_buffer->CreateBlitPass();
-  blit_pass->EncodeCommands(context->GetResourceAllocator());
+  blit_pass->EncodeCommands();
 
   auto latch = std::make_shared<fml::CountDownLatch>(1u);
   if (!context->GetCommandQueue()

--- a/engine/src/flutter/impeller/renderer/blit_pass.h
+++ b/engine/src/flutter/impeller/renderer/blit_pass.h
@@ -146,13 +146,10 @@ class BlitPass {
   //----------------------------------------------------------------------------
   /// @brief      Encode the recorded commands to the underlying command buffer.
   ///
-  /// @param      transients_allocator  The transients allocator.
-  ///
   /// @return     If the commands were encoded to the underlying command
   ///             buffer.
   ///
-  virtual bool EncodeCommands(
-      const std::shared_ptr<Allocator>& transients_allocator) const = 0;
+  virtual bool EncodeCommands() const = 0;
 
  protected:
   explicit BlitPass();

--- a/engine/src/flutter/impeller/renderer/blit_pass_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/blit_pass_unittests.cc
@@ -141,7 +141,7 @@ TEST_P(BlitPassTest, CanBlitSmallRegionToUninitializedTexture) {
   EXPECT_TRUE(blit_pass->AddCopy(DeviceBuffer::AsBufferView(src), dst,
                                  IRect::MakeLTRB(0, 0, 1, 1), "",
                                  /*mip_level=*/0, /*slice=*/0));
-  EXPECT_TRUE(blit_pass->EncodeCommands(GetContext()->GetResourceAllocator()));
+  EXPECT_TRUE(blit_pass->EncodeCommands());
   EXPECT_TRUE(context->GetCommandQueue()->Submit({std::move(cmd_buffer)}).ok());
 }
 
@@ -195,7 +195,7 @@ TEST_P(BlitPassTest, CanBlitToHigherTextureMipLevels) {
   EXPECT_TRUE(blit_pass->AddCopy(DeviceBuffer::AsBufferView(src), dst,
                                  IRect::MakeLTRB(0, 0, 1, 1), "",
                                  /*mip_level=*/1, /*slice=*/0));
-  EXPECT_TRUE(blit_pass->EncodeCommands(GetContext()->GetResourceAllocator()));
+  EXPECT_TRUE(blit_pass->EncodeCommands());
   EXPECT_TRUE(context->GetCommandQueue()->Submit({std::move(cmd_buffer)}).ok());
 }
 
@@ -234,7 +234,7 @@ TEST_P(BlitPassTest, CanResizeTextures) {
 
   EXPECT_TRUE(blit_pass->AddCopy(DeviceBuffer::AsBufferView(staging), src));
   EXPECT_TRUE(blit_pass->ResizeTexture(src, dst));
-  EXPECT_TRUE(blit_pass->EncodeCommands(GetContext()->GetResourceAllocator()));
+  EXPECT_TRUE(blit_pass->EncodeCommands());
   EXPECT_TRUE(context->GetCommandQueue()->Submit({std::move(cmd_buffer)}).ok());
 }
 
@@ -256,7 +256,7 @@ TEST_P(BlitPassTest, CanResizeTexturesPlayground) {
   ASSERT_TRUE(src);
 
   EXPECT_TRUE(blit_pass->ResizeTexture(src, dst));
-  EXPECT_TRUE(blit_pass->EncodeCommands(GetContext()->GetResourceAllocator()));
+  EXPECT_TRUE(blit_pass->EncodeCommands());
   EXPECT_TRUE(context->GetCommandQueue()->Submit({std::move(cmd_buffer)}).ok());
 
   DisplayListBuilder builder;

--- a/engine/src/flutter/impeller/renderer/renderer_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_unittests.cc
@@ -587,7 +587,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
       // Blit `bridge` to the top left corner of the texture.
       pass->AddCopy(bridge, texture);
 
-      if (!pass->EncodeCommands(context->GetResourceAllocator())) {
+      if (!pass->EncodeCommands()) {
         return false;
       }
     }
@@ -701,7 +701,7 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
 
       // Blit `bridge` to the top left corner of the texture.
       pass->AddCopy(bridge, device_buffer);
-      pass->EncodeCommands(context->GetResourceAllocator());
+      pass->EncodeCommands();
 
       if (!context->GetCommandQueue()->Submit({buffer}).ok()) {
         return false;
@@ -836,7 +836,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
 
       pass->GenerateMipmap(boston, "Boston Mipmap");
 
-      pass->EncodeCommands(context->GetResourceAllocator());
+      pass->EncodeCommands();
     }
 
     first_frame = false;

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -60,10 +60,7 @@ class MockAllocator : public Allocator {
 class MockBlitPass : public BlitPass {
  public:
   MOCK_METHOD(bool, IsValid, (), (const, override));
-  MOCK_METHOD(bool,
-              EncodeCommands,
-              (const std::shared_ptr<Allocator>& transients_allocator),
-              (const, override));
+  MOCK_METHOD(bool, EncodeCommands, (), (const, override));
   MOCK_METHOD(void, OnSetLabel, (std::string_view label), (override));
 
   MOCK_METHOD(bool,

--- a/engine/src/flutter/impeller/renderer/texture_mipmap.cc
+++ b/engine/src/flutter/impeller/renderer/texture_mipmap.cc
@@ -17,7 +17,7 @@ fml::Status AddMipmapGeneration(
   if (!success) {
     return fml::Status(fml::StatusCode::kUnknown, "");
   }
-  success = blit_pass->EncodeCommands(context->GetResourceAllocator());
+  success = blit_pass->EncodeCommands();
   if (!success) {
     return fml::Status(fml::StatusCode::kUnknown, "");
   }

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -536,7 +536,7 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
     std::shared_ptr<BlitPass> blit_pass = cmd_buffer->CreateBlitPass();
 
     fml::ScopedCleanupClosure closure([&]() {
-      blit_pass->EncodeCommands(context.GetResourceAllocator());
+      blit_pass->EncodeCommands();
       if (!context.EnqueueCommandBuffer(std::move(cmd_buffer))) {
         VALIDATION_LOG << "Failed to submit glyph atlas command buffer";
       }
@@ -629,7 +629,7 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
   std::shared_ptr<BlitPass> blit_pass = cmd_buffer->CreateBlitPass();
 
   fml::ScopedCleanupClosure closure([&]() {
-    blit_pass->EncodeCommands(context.GetResourceAllocator());
+    blit_pass->EncodeCommands();
     if (!context.EnqueueCommandBuffer(std::move(cmd_buffer))) {
       VALIDATION_LOG << "Failed to submit glyph atlas command buffer";
     }

--- a/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
@@ -375,7 +375,7 @@ ImageDecoderImpeller::UnsafeUploadTextureToPrivate(
 
     result_texture = std::move(resize_texture);
   }
-  blit_pass->EncodeCommands(context->GetResourceAllocator());
+  blit_pass->EncodeCommands();
 
   if (!context->GetCommandQueue()->Submit({command_buffer}).ok()) {
     std::string decode_error("Failed to submit image decoding command buffer.");

--- a/engine/src/flutter/lib/ui/painting/image_encoding_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_impeller.cc
@@ -170,7 +170,7 @@ void ImageEncodingImpeller::ConvertDlImageToSkImage(
   auto pass = command_buffer->CreateBlitPass();
   pass->SetLabel("BlitTextureToBuffer Blit Pass");
   pass->AddCopy(texture, buffer);
-  pass->EncodeCommands(impeller_context->GetResourceAllocator());
+  pass->EncodeCommands();
   auto completion = [buffer, color_type = color_type.value(), dimensions,
                      encode_task = std::move(encode_task)](
                         impeller::CommandBuffer::Status status) {

--- a/engine/src/flutter/shell/common/rasterizer.cc
+++ b/engine/src/flutter/shell/common/rasterizer.cc
@@ -942,7 +942,7 @@ ScreenshotLayerTreeAsImageImpeller(
   command_buffer->SetLabel("BlitTextureToBuffer Command Buffer");
   auto pass = command_buffer->CreateBlitPass();
   pass->AddCopy(texture, buffer);
-  pass->EncodeCommands(impeller_context->GetResourceAllocator());
+  pass->EncodeCommands();
   fml::AutoResetWaitableEvent latch;
   sk_sp<SkData> sk_data;
   auto completion = [buffer, &buffer_desc, &sk_data,


### PR DESCRIPTION
The TransientsAllocator argument to BlitPass::EncodeCommands is completely unused. Delete it (and add a missing IFDEF around the GLES debug labels.).