### PR TITLE
[DisplayList] Migrate DlVertices onto Impeller/DisplayList geometry classes

### DIFF
--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
@@ -752,8 +752,8 @@ std::shared_ptr<DlVertices> GetTestVertices(SkPoint center,
   }
 
   final_vertex_count = vertices.size();
-  return DlVertices::Make(mode, vertices.size(), vertices.data(), nullptr,
-                          colors.data());
+  return DlVertices::Make(mode, vertices.size(), ToDlPoints(vertices.data()),
+                          nullptr, colors.data());
 }
 
 std::string VertexModeToString(DlVertexMode mode) {

--- a/engine/src/flutter/display_list/benchmarking/dl_complexity_unittests.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_complexity_unittests.cc
@@ -293,7 +293,7 @@ TEST(DisplayListComplexity, DrawArc) {
 TEST(DisplayListComplexity, DrawVertices) {
   auto points = GetTestPoints();
   auto vertices = DlVertices::Make(DlVertexMode::kTriangles, points.size(),
-                                   points.data(), nullptr, nullptr);
+                                   ToDlPoints(points.data()), nullptr, nullptr);
   DisplayListBuilder builder;
   builder.DrawVertices(vertices, DlBlendMode::kSrc, DlPaint());
   auto display_list = builder.Build();

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5066,14 +5066,13 @@ TEST_F(DisplayListTest, ClipPathRRectNonCulling) {
 
 TEST_F(DisplayListTest, RecordLargeVertices) {
   constexpr size_t vertex_count = 2000000;
-  auto points = std::vector<SkPoint>();
+  auto points = std::vector<DlPoint>();
   points.reserve(vertex_count);
   auto colors = std::vector<DlColor>();
   colors.reserve(vertex_count);
   for (size_t i = 0; i < vertex_count; i++) {
     colors.emplace_back(DlColor(-i));
-    points.emplace_back(((i & 1) == 0) ? SkPoint::Make(-i, i)
-                                       : SkPoint::Make(i, i));
+    points.emplace_back(((i & 1) == 0) ? DlPoint(-i, i) : DlPoint(i, i));
   }
   ASSERT_EQ(points.size(), vertex_count);
   ASSERT_EQ(colors.size(), vertex_count);
@@ -5552,7 +5551,7 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
   test_draw_points(PointMode::kPolygon);
 
   test_bounded("DrawVerticesTriangles", [](DlCanvas& builder) {
-    SkPoint points[6] = {
+    DlPoint points[6] = {
         {draw_rect.left(), draw_rect.top()},
         {draw_rect.right(), draw_rect.top()},
         {draw_rect.right(), draw_rect.bottom()},
@@ -5567,7 +5566,7 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
   });
 
   test_bounded("DrawVerticesTriangleStrip", [](DlCanvas& builder) {
-    SkPoint points[6] = {
+    DlPoint points[6] = {
         {draw_rect.left(), draw_rect.top()},
         {draw_rect.right(), draw_rect.top()},
         {draw_rect.right(), draw_rect.bottom()},
@@ -5582,8 +5581,8 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
   });
 
   test_bounded("DrawVerticesTriangleFan", [](DlCanvas& builder) {
-    SkPoint points[6] = {
-        draw_rect.center(),
+    DlPoint points[6] = {
+        ToDlPoint(draw_rect.center()),
         {draw_rect.left(), draw_rect.top()},
         {draw_rect.right(), draw_rect.top()},
         {draw_rect.right(), draw_rect.bottom()},

--- a/engine/src/flutter/display_list/dl_vertices.h
+++ b/engine/src/flutter/display_list/dl_vertices.h
@@ -9,8 +9,6 @@
 
 #include "flutter/display_list/dl_color.h"
 
-#include "third_party/skia/include/core/SkRect.h"
-
 namespace flutter {
 
 //------------------------------------------------------------------------------
@@ -117,7 +115,7 @@ class DlVertices {
     /// @brief Copies the indicated list of points as vertices.
     ///
     /// fails if vertices have already been supplied.
-    void store_vertices(const SkPoint points[]);
+    void store_vertices(const DlPoint vertices[]);
 
     /// @brief Copies the indicated list of float pairs as vertices.
     ///
@@ -128,7 +126,7 @@ class DlVertices {
     ///
     /// fails if texture coordinates have already been supplied or if they
     /// were not promised by the flags.has_texture_coordinates.
-    void store_texture_coordinates(const SkPoint points[]);
+    void store_texture_coordinates(const DlPoint points[]);
 
     /// @brief Copies the indicated list of float pairs as texture coordinates.
     ///
@@ -183,8 +181,8 @@ class DlVertices {
   /// non-null and the index_count is positive (>0).
   static std::shared_ptr<DlVertices> Make(DlVertexMode mode,
                                           int vertex_count,
-                                          const SkPoint vertices[],
-                                          const SkPoint texture_coordinates[],
+                                          const DlPoint vertices[],
+                                          const DlPoint texture_coordinates[],
                                           const DlColor colors[],
                                           int index_count = 0,
                                           const uint16_t indices[] = nullptr,
@@ -194,8 +192,7 @@ class DlVertices {
   size_t size() const;
 
   /// Returns the bounds of the vertices.
-  SkRect bounds() const { return bounds_; }
-  DlRect GetBounds() const { return ToDlRect(bounds_); }
+  DlRect GetBounds() const { return bounds_; }
 
   /// Returns the vertex mode that defines how the vertices (or the indices)
   /// are turned into triangles.
@@ -206,14 +203,14 @@ class DlVertices {
   int vertex_count() const { return vertex_count_; }
 
   /// Returns a pointer to the vertex information. Should be non-null.
-  const SkPoint* vertices() const {
-    return static_cast<const SkPoint*>(pod(vertices_offset_));
+  const DlPoint* vertex_data() const {
+    return static_cast<const DlPoint*>(pod(vertices_offset_));
   }
 
   /// Returns a pointer to the vertex texture coordinate
   /// or null if none were provided.
-  const SkPoint* texture_coordinates() const {
-    return static_cast<const SkPoint*>(pod(texture_coordinates_offset_));
+  const DlPoint* texture_coordinate_data() const {
+    return static_cast<const DlPoint*>(pod(texture_coordinates_offset_));
   }
 
   /// Returns a pointer to the vertex colors
@@ -243,12 +240,12 @@ class DlVertices {
   // the class body and all of its arrays, such as in Builder.
   DlVertices(DlVertexMode mode,
              int vertex_count,
-             const SkPoint vertices[],
-             const SkPoint texture_coordinates[],
+             const DlPoint vertices[],
+             const DlPoint texture_coordinates[],
              const DlColor colors[],
              int index_count,
              const uint16_t indices[],
-             const SkRect* bounds = nullptr);
+             const DlRect* bounds = nullptr);
 
   // This constructor is specifically used by the DlVertices::Builder to
   // establish the object before the copying of data is requested.
@@ -273,7 +270,7 @@ class DlVertices {
   int index_count_;
   size_t indices_offset_;
 
-  SkRect bounds_;
+  DlRect bounds_;
 
   const void* pod(int offset) const {
     if (offset <= 0) {

--- a/engine/src/flutter/display_list/dl_vertices_unittests.cc
+++ b/engine/src/flutter/display_list/dl_vertices_unittests.cc
@@ -16,8 +16,8 @@ TEST(DisplayListVertices, MakeWithZeroAndNegativeVerticesAndIndices) {
       DlVertexMode::kTriangles, 0, nullptr, nullptr, nullptr, 0, nullptr);
   EXPECT_NE(vertices1, nullptr);
   EXPECT_EQ(vertices1->vertex_count(), 0);
-  EXPECT_EQ(vertices1->vertices(), nullptr);
-  EXPECT_EQ(vertices1->texture_coordinates(), nullptr);
+  EXPECT_EQ(vertices1->vertex_data(), nullptr);
+  EXPECT_EQ(vertices1->texture_coordinate_data(), nullptr);
   EXPECT_EQ(vertices1->colors(), nullptr);
   EXPECT_EQ(vertices1->index_count(), 0);
   EXPECT_EQ(vertices1->indices(), nullptr);
@@ -26,8 +26,8 @@ TEST(DisplayListVertices, MakeWithZeroAndNegativeVerticesAndIndices) {
       DlVertexMode::kTriangles, -1, nullptr, nullptr, nullptr, -1, nullptr);
   EXPECT_NE(vertices2, nullptr);
   EXPECT_EQ(vertices2->vertex_count(), 0);
-  EXPECT_EQ(vertices2->vertices(), nullptr);
-  EXPECT_EQ(vertices2->texture_coordinates(), nullptr);
+  EXPECT_EQ(vertices2->vertex_data(), nullptr);
+  EXPECT_EQ(vertices2->texture_coordinate_data(), nullptr);
   EXPECT_EQ(vertices2->colors(), nullptr);
   EXPECT_EQ(vertices2->index_count(), 0);
   EXPECT_EQ(vertices2->indices(), nullptr);
@@ -36,15 +36,15 @@ TEST(DisplayListVertices, MakeWithZeroAndNegativeVerticesAndIndices) {
 }
 
 TEST(DisplayListVertices, MakeWithTexAndColorAndIndices) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
   DlColor colors[3] = {
       DlColor::kRed(),
@@ -60,17 +60,17 @@ TEST(DisplayListVertices, MakeWithTexAndColorAndIndices) {
       DlVertexMode::kTriangles, 3, coords, texture_coords, colors, 6, indices);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_NE(vertices->colors(), nullptr);
   ASSERT_NE(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
-    ASSERT_EQ(vertices->texture_coordinates()[i], texture_coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i], texture_coords[i]);
     ASSERT_EQ(vertices->colors()[i], colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
@@ -80,15 +80,15 @@ TEST(DisplayListVertices, MakeWithTexAndColorAndIndices) {
 }
 
 TEST(DisplayListVertices, MakeWithTexAndColor) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
   DlColor colors[3] = {
       DlColor::kRed(),
@@ -100,32 +100,32 @@ TEST(DisplayListVertices, MakeWithTexAndColor) {
       DlVertexMode::kTriangles, 3, coords, texture_coords, colors, 6, nullptr);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_NE(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
-    ASSERT_EQ(vertices->texture_coordinates()[i], texture_coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i], texture_coords[i]);
     ASSERT_EQ(vertices->colors()[i], colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, MakeWithTexAndIndices) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -136,17 +136,17 @@ TEST(DisplayListVertices, MakeWithTexAndIndices) {
       DlVertexMode::kTriangles, 3, coords, texture_coords, nullptr, 6, indices);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_NE(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
-    ASSERT_EQ(vertices->texture_coordinates()[i], texture_coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i], texture_coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
   for (int i = 0; i < 6; i++) {
@@ -155,10 +155,10 @@ TEST(DisplayListVertices, MakeWithTexAndIndices) {
 }
 
 TEST(DisplayListVertices, MakeWithColorAndIndices) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
   DlColor colors[3] = {
       DlColor::kRed(),
@@ -174,16 +174,16 @@ TEST(DisplayListVertices, MakeWithColorAndIndices) {
       DlVertexMode::kTriangles, 3, coords, nullptr, colors, 6, indices);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_NE(vertices->colors(), nullptr);
   ASSERT_NE(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
     ASSERT_EQ(vertices->colors()[i], colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
@@ -193,41 +193,41 @@ TEST(DisplayListVertices, MakeWithColorAndIndices) {
 }
 
 TEST(DisplayListVertices, MakeWithTex) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
 
   std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, texture_coords, nullptr, 6, nullptr);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
-    ASSERT_EQ(vertices->texture_coordinates()[i], texture_coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i], texture_coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, MakeWithColor) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
   DlColor colors[3] = {
       DlColor::kRed(),
@@ -239,26 +239,26 @@ TEST(DisplayListVertices, MakeWithColor) {
       DlVertexMode::kTriangles, 3, coords, nullptr, colors, 6, nullptr);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_NE(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
     ASSERT_EQ(vertices->colors()[i], colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, MakeWithIndices) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -269,16 +269,16 @@ TEST(DisplayListVertices, MakeWithIndices) {
       DlVertexMode::kTriangles, 3, coords, nullptr, nullptr, 6, indices);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_NE(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
   for (int i = 0; i < 6; i++) {
@@ -287,35 +287,35 @@ TEST(DisplayListVertices, MakeWithIndices) {
 }
 
 TEST(DisplayListVertices, MakeWithNoOptionalData) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
 
   std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, nullptr, nullptr, 6, nullptr);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, MakeWithIndicesButZeroIndexCount) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -326,25 +326,25 @@ TEST(DisplayListVertices, MakeWithIndicesButZeroIndexCount) {
       DlVertexMode::kTriangles, 3, coords, nullptr, nullptr, 0, indices);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, MakeWithIndicesButNegativeIndexCount) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -355,16 +355,16 @@ TEST(DisplayListVertices, MakeWithIndicesButNegativeIndexCount) {
       DlVertexMode::kTriangles, 3, coords, nullptr, nullptr, -5, indices);
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
@@ -417,8 +417,8 @@ TEST(DisplayListVertices, BuildWithZeroAndNegativeVerticesAndIndices) {
   std::shared_ptr<DlVertices> vertices1 = builder1.build();
   EXPECT_NE(vertices1, nullptr);
   EXPECT_EQ(vertices1->vertex_count(), 0);
-  EXPECT_EQ(vertices1->vertices(), nullptr);
-  EXPECT_EQ(vertices1->texture_coordinates(), nullptr);
+  EXPECT_EQ(vertices1->vertex_data(), nullptr);
+  EXPECT_EQ(vertices1->texture_coordinate_data(), nullptr);
   EXPECT_EQ(vertices1->colors(), nullptr);
   EXPECT_EQ(vertices1->index_count(), 0);
   EXPECT_EQ(vertices1->indices(), nullptr);
@@ -428,8 +428,8 @@ TEST(DisplayListVertices, BuildWithZeroAndNegativeVerticesAndIndices) {
   std::shared_ptr<DlVertices> vertices2 = builder2.build();
   EXPECT_NE(vertices2, nullptr);
   EXPECT_EQ(vertices2->vertex_count(), 0);
-  EXPECT_EQ(vertices2->vertices(), nullptr);
-  EXPECT_EQ(vertices2->texture_coordinates(), nullptr);
+  EXPECT_EQ(vertices2->vertex_data(), nullptr);
+  EXPECT_EQ(vertices2->texture_coordinate_data(), nullptr);
   EXPECT_EQ(vertices2->colors(), nullptr);
   EXPECT_EQ(vertices2->index_count(), 0);
   EXPECT_EQ(vertices2->indices(), nullptr);
@@ -438,15 +438,15 @@ TEST(DisplayListVertices, BuildWithZeroAndNegativeVerticesAndIndices) {
 }
 
 TEST(DisplayListVertices, BuildWithTexAndColorAndIndices) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
   DlColor colors[3] = {
       DlColor::kRed(),
@@ -467,17 +467,17 @@ TEST(DisplayListVertices, BuildWithTexAndColorAndIndices) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_NE(vertices->colors(), nullptr);
   ASSERT_NE(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
-    ASSERT_EQ(vertices->texture_coordinates()[i], texture_coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i], texture_coords[i]);
     ASSERT_EQ(vertices->colors()[i], colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
@@ -502,15 +502,15 @@ TEST(DisplayListVertices, BuildWithTexAndColorAndIndices) {
 }
 
 TEST(DisplayListVertices, BuildWithTexAndColor) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
   DlColor colors[3] = {
       DlColor::kRed(),
@@ -526,32 +526,32 @@ TEST(DisplayListVertices, BuildWithTexAndColor) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_NE(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
-    ASSERT_EQ(vertices->texture_coordinates()[i], texture_coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i], texture_coords[i]);
     ASSERT_EQ(vertices->colors()[i], colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, BuildWithTexAndIndices) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -566,17 +566,17 @@ TEST(DisplayListVertices, BuildWithTexAndIndices) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_NE(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
-    ASSERT_EQ(vertices->texture_coordinates()[i], texture_coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i], texture_coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
   for (int i = 0; i < 6; i++) {
@@ -585,10 +585,10 @@ TEST(DisplayListVertices, BuildWithTexAndIndices) {
 }
 
 TEST(DisplayListVertices, BuildWithColorAndIndices) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
   SkColor colors[3] = {
       SK_ColorRED,
@@ -608,16 +608,16 @@ TEST(DisplayListVertices, BuildWithColorAndIndices) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_NE(vertices->colors(), nullptr);
   ASSERT_NE(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
     ASSERT_EQ(vertices->colors()[i], colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
@@ -627,15 +627,15 @@ TEST(DisplayListVertices, BuildWithColorAndIndices) {
 }
 
 TEST(DisplayListVertices, BuildWithTexUsingPoints) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
 
   Builder builder(DlVertexMode::kTriangles, 3,  //
@@ -645,17 +645,17 @@ TEST(DisplayListVertices, BuildWithTexUsingPoints) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
-    ASSERT_EQ(vertices->texture_coordinates()[i], texture_coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i], texture_coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
@@ -679,33 +679,35 @@ TEST(DisplayListVertices, BuildWithTexUsingFloats) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_NE(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_NE(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i].fX, coords[i * 2 + 0]);
-    ASSERT_EQ(vertices->vertices()[i].fY, coords[i * 2 + 1]);
-    ASSERT_EQ(vertices->texture_coordinates()[i].fX, texture_coords[i * 2 + 0]);
-    ASSERT_EQ(vertices->texture_coordinates()[i].fY, texture_coords[i * 2 + 1]);
+    ASSERT_EQ(vertices->vertex_data()[i].x, coords[i * 2 + 0]);
+    ASSERT_EQ(vertices->vertex_data()[i].y, coords[i * 2 + 1]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i].x,
+              texture_coords[i * 2 + 0]);
+    ASSERT_EQ(vertices->texture_coordinate_data()[i].y,
+              texture_coords[i * 2 + 1]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, BuildUsingFloatsSameAsPoints) {
-  SkPoint coord_points[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coord_points[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coord_points[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coord_points[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
 
   float coord_floats[6] = {
@@ -735,10 +737,10 @@ TEST(DisplayListVertices, BuildUsingFloatsSameAsPoints) {
 }
 
 TEST(DisplayListVertices, BuildWithColor) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
   SkColor colors[3] = {
       SK_ColorRED,
@@ -753,26 +755,26 @@ TEST(DisplayListVertices, BuildWithColor) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_NE(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
     ASSERT_EQ(vertices->colors()[i], colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, BuildWithIndices) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -785,16 +787,16 @@ TEST(DisplayListVertices, BuildWithIndices) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_NE(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
   for (int i = 0; i < 6; i++) {
@@ -803,10 +805,10 @@ TEST(DisplayListVertices, BuildWithIndices) {
 }
 
 TEST(DisplayListVertices, BuildWithNoOptionalData) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
 
   Builder builder(DlVertexMode::kTriangles, 3, Builder::kNone, 0);
@@ -814,25 +816,25 @@ TEST(DisplayListVertices, BuildWithNoOptionalData) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, BuildWithNegativeIndexCount) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
 
   Builder builder(DlVertexMode::kTriangles, 3, Builder::kNone, -5);
@@ -840,30 +842,30 @@ TEST(DisplayListVertices, BuildWithNegativeIndexCount) {
   std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
-  ASSERT_NE(vertices->vertices(), nullptr);
-  ASSERT_EQ(vertices->texture_coordinates(), nullptr);
+  ASSERT_NE(vertices->vertex_data(), nullptr);
+  ASSERT_EQ(vertices->texture_coordinate_data(), nullptr);
   ASSERT_EQ(vertices->colors(), nullptr);
   ASSERT_EQ(vertices->indices(), nullptr);
 
-  ASSERT_EQ(vertices->bounds(), SkRect::MakeLTRB(2, 3, 15, 20));
+  ASSERT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(2, 3, 15, 20));
   ASSERT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
-    ASSERT_EQ(vertices->vertices()[i], coords[i]);
+    ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }
 
 TEST(DisplayListVertices, TestEquals) {
-  SkPoint coords[3] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
+  DlPoint coords[3] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
   };
-  SkPoint texture_coords[3] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
+  DlPoint texture_coords[3] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
   };
   DlColor colors[3] = {
       DlColor::kRed(),
@@ -883,29 +885,29 @@ TEST(DisplayListVertices, TestEquals) {
 }
 
 TEST(DisplayListVertices, TestNotEquals) {
-  SkPoint coords[4] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
-      SkPoint::Make(53, 62),
+  DlPoint coords[4] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
+      DlPoint(53, 62),
   };
-  SkPoint wrong_coords[4] = {
-      SkPoint::Make(2, 3),
-      SkPoint::Make(5, 6),
-      SkPoint::Make(15, 20),
-      SkPoint::Make(57, 62),
+  DlPoint wrong_coords[4] = {
+      DlPoint(2, 3),
+      DlPoint(5, 6),
+      DlPoint(15, 20),
+      DlPoint(57, 62),
   };
-  SkPoint texture_coords[4] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 120),
-      SkPoint::Make(153, 162),
+  DlPoint texture_coords[4] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 120),
+      DlPoint(153, 162),
   };
-  SkPoint wrong_texture_coords[4] = {
-      SkPoint::Make(102, 103),
-      SkPoint::Make(105, 106),
-      SkPoint::Make(115, 121),
-      SkPoint::Make(153, 162),
+  DlPoint wrong_texture_coords[4] = {
+      DlPoint(102, 103),
+      DlPoint(105, 106),
+      DlPoint(115, 121),
+      DlPoint(153, 162),
   };
   DlColor colors[4] = {
       DlColor::kRed(),

--- a/engine/src/flutter/display_list/skia/dl_sk_conversions.cc
+++ b/engine/src/flutter/display_list/skia/dl_sk_conversions.cc
@@ -292,9 +292,10 @@ sk_sp<SkVertices> ToSk(const std::shared_ptr<DlVertices>& vertices) {
     sk_colors_ptr = sk_colors.data();
   }
   return SkVertices::MakeCopy(ToSk(vertices->mode()), vertices->vertex_count(),
-                              vertices->vertices(),
-                              vertices->texture_coordinates(), sk_colors_ptr,
-                              vertices->index_count(), vertices->indices());
+                              ToSkPoints(vertices->vertex_data()),
+                              ToSkPoints(vertices->texture_coordinate_data()),
+                              sk_colors_ptr, vertices->index_count(),
+                              vertices->indices());
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/display_list/testing/dl_rendering_unittests.cc
+++ b/engine/src/flutter/display_list/testing/dl_rendering_unittests.cc
@@ -3361,8 +3361,8 @@ TEST_F(DisplayListRendering, DrawVerticesWithColors) {
       SK_ColorRED,  SK_ColorBLUE,   SK_ColorGREEN,
       SK_ColorCYAN, SK_ColorYELLOW, SK_ColorMAGENTA,
   };
-  const std::shared_ptr<DlVertices> dl_vertices =
-      DlVertices::Make(DlVertexMode::kTriangles, 6, pts, nullptr, dl_colors);
+  const std::shared_ptr<DlVertices> dl_vertices = DlVertices::Make(
+      DlVertexMode::kTriangles, 6, ToDlPoints(pts), nullptr, dl_colors);
   const auto sk_vertices =
       SkVertices::MakeCopy(SkVertices::VertexMode::kTriangles_VertexMode, 6,
                            pts, nullptr, sk_colors);
@@ -3408,8 +3408,8 @@ TEST_F(DisplayListRendering, DrawVerticesWithImage) {
       SkPoint::Make(0, 0),
       SkPoint::Make(kRenderWidth, 0),
   };
-  const std::shared_ptr<DlVertices> dl_vertices =
-      DlVertices::Make(DlVertexMode::kTriangles, 6, pts, tex, nullptr);
+  const std::shared_ptr<DlVertices> dl_vertices = DlVertices::Make(
+      DlVertexMode::kTriangles, 6, ToDlPoints(pts), ToDlPoints(tex), nullptr);
   const auto sk_vertices = SkVertices::MakeCopy(
       SkVertices::VertexMode::kTriangles_VertexMode, 6, pts, tex, nullptr);
 

--- a/engine/src/flutter/display_list/testing/dl_test_snippets.h
+++ b/engine/src/flutter/display_list/testing/dl_test_snippets.h
@@ -209,13 +209,13 @@ static const SkMatrix kTestMatrix2 = SkMatrix::RotateDeg(45);
 static const std::shared_ptr<DlVertices> kTestVertices1 =
     DlVertices::Make(DlVertexMode::kTriangles,  //
                      3,
-                     kTestPoints,
+                     ToDlPoints(kTestPoints),
                      nullptr,
                      kColors);
 static const std::shared_ptr<DlVertices> kTestVertices2 =
     DlVertices::Make(DlVertexMode::kTriangleFan,  //
                      3,
-                     kTestPoints,
+                     ToDlPoints(kTestPoints),
                      nullptr,
                      kColors);
 

--- a/engine/src/flutter/flow/stopwatch_dl.cc
+++ b/engine/src/flutter/flow/stopwatch_dl.cc
@@ -149,7 +149,7 @@ std::shared_ptr<DlVertices> DlVertexPainter::IntoVertices(
   return DlVertices::Make(
       /*mode=*/DlVertexMode::kTriangles,
       /*vertex_count=*/vertices_.size(),
-      /*vertices=*/reinterpret_cast<SkPoint*>(vertices_.data()),
+      /*vertices=*/vertices_.data(),
       /*texture_coordinates=*/nullptr,
       /*colors=*/colors_.data(),
       /*index_count=*/0,

--- a/engine/src/flutter/flow/stopwatch_dl_unittests.cc
+++ b/engine/src/flutter/flow/stopwatch_dl_unittests.cc
@@ -9,14 +9,14 @@
 namespace flutter {
 namespace testing {
 
-static SkRect MakeRectFromVertices(SkPoint vertices[6]) {
+static DlRect MakeRectFromVertices(DlPoint vertices[6]) {
   // "Combine" the vertices to form a rectangle.
-  auto const left = std::min(vertices[0].x(), vertices[5].x());
-  auto const top = std::min(vertices[0].y(), vertices[1].y());
-  auto const right = std::max(vertices[1].x(), vertices[2].x());
-  auto const bottom = std::max(vertices[2].y(), vertices[3].y());
+  auto const left = std::min(vertices[0].x, vertices[5].x);
+  auto const top = std::min(vertices[0].y, vertices[1].y);
+  auto const right = std::max(vertices[1].x, vertices[2].x);
+  auto const bottom = std::max(vertices[2].y, vertices[3].y);
 
-  return SkRect::MakeLTRB(left, top, right, bottom);
+  return DlRect::MakeLTRB(left, top, right, bottom);
 }
 
 TEST(DlVertexPainter, DrawRectIntoVertices) {
@@ -37,22 +37,22 @@ TEST(DlVertexPainter, DrawRectIntoVertices) {
   EXPECT_EQ(vertices->mode(), DlVertexMode::kTriangles);
   EXPECT_EQ(vertices->vertex_count(), 3 * 2 * 2);
 
-  auto const points = vertices->vertices();
+  auto const points = vertices->vertex_data();
 
   {
     // Extract the first 6 vertices (first rectangle).
-    SkPoint first_rect_vertices[6];
+    DlPoint first_rect_vertices[6];
     std::copy(points, points + 6, first_rect_vertices);
     EXPECT_EQ(MakeRectFromVertices(first_rect_vertices),
-              SkRect::MakeLTRB(0, 0, 10, 10));
+              DlRect::MakeLTRB(0, 0, 10, 10));
   }
 
   {
     // Extract the next 6 vertices (second rectangle).
-    SkPoint second_rect_vertices[6];
+    DlPoint second_rect_vertices[6];
     std::copy(points + 6, points + 12, second_rect_vertices);
     EXPECT_EQ(MakeRectFromVertices(second_rect_vertices),
-              SkRect::MakeLTRB(10, 10, 20, 20));
+              DlRect::MakeLTRB(10, 10, 20, 20));
   }
 
   // Verify the colors (first 6 vertices are red, next 6 are blue).

--- a/engine/src/flutter/impeller/display_list/aiks_dl_vertices_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_vertices_unittests.cc
@@ -23,9 +23,9 @@ using namespace flutter;
 namespace {
 std::shared_ptr<DlVertices> MakeVertices(
     DlVertexMode mode,
-    std::vector<SkPoint> vertices,
+    std::vector<DlPoint> vertices,
     std::vector<uint16_t> indices,
-    std::vector<SkPoint> texture_coordinates,
+    std::vector<DlPoint> texture_coordinates,
     std::vector<DlColor> colors) {
   DlVertices::Builder::Flags flags(
       {{texture_coordinates.size() > 0, colors.size() > 0}});
@@ -55,9 +55,11 @@ TEST_P(AiksTest, VerticesGeometryUVPositionData) {
   paint.setColorSource(
       DlColorSource::MakeImage(image, DlTileMode::kClamp, DlTileMode::kClamp));
 
-  std::vector<SkPoint> vertex_coordinates = {SkPoint::Make(0, 0),
-                                             SkPoint::Make(size.width, 0),
-                                             SkPoint::Make(0, size.height)};
+  std::vector<DlPoint> vertex_coordinates = {
+      DlPoint(0, 0),
+      DlPoint(size.width, 0),
+      DlPoint(0, size.height),
+  };
   auto vertices = MakeVertices(DlVertexMode::kTriangleStrip, vertex_coordinates,
                                {0, 1, 2}, {}, {});
 
@@ -78,9 +80,11 @@ TEST_P(AiksTest, VerticesGeometryUVPositionDataWithTranslate) {
       DlColorSource::MakeImage(image, DlTileMode::kClamp, DlTileMode::kClamp,
                                DlImageSampling::kLinear, &matrix));
 
-  std::vector<SkPoint> positions = {SkPoint::Make(0, 0),
-                                    SkPoint::Make(size.width, 0),
-                                    SkPoint::Make(0, size.height)};
+  std::vector<DlPoint> positions = {
+      DlPoint(0, 0),
+      DlPoint(size.width, 0),
+      DlPoint(0, size.height),
+  };
   auto vertices =
       MakeVertices(DlVertexMode::kTriangleStrip, positions, {0, 1, 2}, {}, {});
 
@@ -99,10 +103,10 @@ TEST_P(AiksTest, VerticesGeometryColorUVPositionData) {
   paint.setColorSource(
       DlColorSource::MakeImage(image, DlTileMode::kClamp, DlTileMode::kClamp));
 
-  std::vector<SkPoint> positions = {
-      SkPoint::Make(0, 0),           SkPoint::Make(size.width, 0),
-      SkPoint::Make(0, size.height), SkPoint::Make(size.width, 0),
-      SkPoint::Make(0, 0),           SkPoint::Make(size.width, size.height),
+  std::vector<DlPoint> positions = {
+      DlPoint(0, 0),           DlPoint(size.width, 0),
+      DlPoint(0, size.height), DlPoint(size.width, 0),
+      DlPoint(0, 0),           DlPoint(size.width, size.height),
   };
   std::vector<DlColor> colors = {
       DlColor::kRed().withAlpha(128),   DlColor::kBlue().withAlpha(128),
@@ -127,10 +131,10 @@ TEST_P(AiksTest, VerticesGeometryColorUVPositionDataAdvancedBlend) {
   paint.setColorSource(
       DlColorSource::MakeImage(image, DlTileMode::kClamp, DlTileMode::kClamp));
 
-  std::vector<SkPoint> positions = {
-      SkPoint::Make(0, 0),           SkPoint::Make(size.width, 0),
-      SkPoint::Make(0, size.height), SkPoint::Make(size.width, 0),
-      SkPoint::Make(0, 0),           SkPoint::Make(size.width, size.height),
+  std::vector<DlPoint> positions = {
+      DlPoint(0, 0),           DlPoint(size.width, 0),
+      DlPoint(0, size.height), DlPoint(size.width, 0),
+      DlPoint(0, 0),           DlPoint(size.width, size.height),
   };
   std::vector<DlColor> colors = {
       DlColor::kRed().modulateOpacity(0.5),
@@ -155,16 +159,16 @@ TEST_P(AiksTest, CanConvertTriangleFanToTriangles) {
   auto center_to_flat = 1.73 / 2 * hexagon_radius;
 
   // clang-format off
-  std::vector<SkPoint> vertices = {
-    SkPoint::Make(hex_start.x, hex_start.y),
-    SkPoint::Make(hex_start.x + center_to_flat, hex_start.y + 0.5 * hexagon_radius),
-    SkPoint::Make(hex_start.x + center_to_flat, hex_start.y + 1.5 * hexagon_radius),
-    SkPoint::Make(hex_start.x + center_to_flat, hex_start.y + 1.5 * hexagon_radius),
-    SkPoint::Make(hex_start.x, hex_start.y + 2 * hexagon_radius),
-    SkPoint::Make(hex_start.x, hex_start.y + 2 * hexagon_radius),
-    SkPoint::Make(hex_start.x - center_to_flat, hex_start.y + 1.5 * hexagon_radius),
-    SkPoint::Make(hex_start.x - center_to_flat, hex_start.y + 1.5 * hexagon_radius),
-    SkPoint::Make(hex_start.x - center_to_flat, hex_start.y + 0.5 * hexagon_radius)
+  std::vector<DlPoint> vertices = {
+    DlPoint(hex_start.x, hex_start.y),
+    DlPoint(hex_start.x + center_to_flat, hex_start.y + 0.5 * hexagon_radius),
+    DlPoint(hex_start.x + center_to_flat, hex_start.y + 1.5 * hexagon_radius),
+    DlPoint(hex_start.x + center_to_flat, hex_start.y + 1.5 * hexagon_radius),
+    DlPoint(hex_start.x, hex_start.y + 2 * hexagon_radius),
+    DlPoint(hex_start.x, hex_start.y + 2 * hexagon_radius),
+    DlPoint(hex_start.x - center_to_flat, hex_start.y + 1.5 * hexagon_radius),
+    DlPoint(hex_start.x - center_to_flat, hex_start.y + 1.5 * hexagon_radius),
+    DlPoint(hex_start.x - center_to_flat, hex_start.y + 0.5 * hexagon_radius)
   };
   // clang-format on
   auto paint = flutter::DlPaint(flutter::DlColor::kDarkGrey());
@@ -179,9 +183,11 @@ TEST_P(AiksTest, CanConvertTriangleFanToTriangles) {
 TEST_P(AiksTest, DrawVerticesSolidColorTrianglesWithoutIndices) {
   // Use negative coordinates and then scale the transform by -1, -1 to make
   // sure coverage is taking the transform into account.
-  std::vector<SkPoint> positions = {SkPoint::Make(-100, -300),
-                                    SkPoint::Make(-200, -100),
-                                    SkPoint::Make(-300, -300)};
+  std::vector<DlPoint> positions = {
+      DlPoint(-100, -300),
+      DlPoint(-200, -100),
+      DlPoint(-300, -300),
+  };
   std::vector<flutter::DlColor> colors = {flutter::DlColor::kWhite(),
                                           flutter::DlColor::kGreen(),
                                           flutter::DlColor::kWhite()};
@@ -201,9 +207,11 @@ TEST_P(AiksTest, DrawVerticesSolidColorTrianglesWithoutIndices) {
 }
 
 TEST_P(AiksTest, DrawVerticesLinearGradientWithoutIndices) {
-  std::vector<SkPoint> positions = {SkPoint::Make(100, 300),
-                                    SkPoint::Make(200, 100),
-                                    SkPoint::Make(300, 300)};
+  std::vector<DlPoint> positions = {
+      DlPoint(100, 300),
+      DlPoint(200, 100),
+      DlPoint(300, 300),
+  };
 
   auto vertices = flutter::DlVertices::Make(
       flutter::DlVertexMode::kTriangles, 3, positions.data(),
@@ -227,12 +235,16 @@ TEST_P(AiksTest, DrawVerticesLinearGradientWithoutIndices) {
 }
 
 TEST_P(AiksTest, DrawVerticesLinearGradientWithTextureCoordinates) {
-  std::vector<SkPoint> positions = {SkPoint::Make(100, 300),
-                                    SkPoint::Make(200, 100),
-                                    SkPoint::Make(300, 300)};
-  std::vector<SkPoint> texture_coordinates = {SkPoint::Make(300, 100),
-                                              SkPoint::Make(100, 200),
-                                              SkPoint::Make(300, 300)};
+  std::vector<DlPoint> positions = {
+      DlPoint(100, 300),
+      DlPoint(200, 100),
+      DlPoint(300, 300),
+  };
+  std::vector<DlPoint> texture_coordinates = {
+      DlPoint(300, 100),
+      DlPoint(100, 200),
+      DlPoint(300, 300),
+  };
 
   auto vertices = flutter::DlVertices::Make(
       flutter::DlVertexMode::kTriangles, 3, positions.data(),
@@ -258,11 +270,16 @@ TEST_P(AiksTest, DrawVerticesLinearGradientWithTextureCoordinates) {
 TEST_P(AiksTest, DrawVerticesImageSourceWithTextureCoordinates) {
   auto texture = CreateTextureForFixture("embarcadero.jpg");
   auto dl_image = DlImageImpeller::Make(texture);
-  std::vector<SkPoint> positions = {SkPoint::Make(100, 300),
-                                    SkPoint::Make(200, 100),
-                                    SkPoint::Make(300, 300)};
-  std::vector<SkPoint> texture_coordinates = {
-      SkPoint::Make(0, 0), SkPoint::Make(100, 200), SkPoint::Make(200, 100)};
+  std::vector<DlPoint> positions = {
+      DlPoint(100, 300),
+      DlPoint(200, 100),
+      DlPoint(300, 300),
+  };
+  std::vector<DlPoint> texture_coordinates = {
+      DlPoint(0, 0),
+      DlPoint(100, 200),
+      DlPoint(200, 100),
+  };
 
   auto vertices = flutter::DlVertices::Make(
       flutter::DlVertexMode::kTriangles, 3, positions.data(),
@@ -284,14 +301,19 @@ TEST_P(AiksTest,
        DrawVerticesImageSourceWithTextureCoordinatesAndColorBlending) {
   auto texture = CreateTextureForFixture("embarcadero.jpg");
   auto dl_image = DlImageImpeller::Make(texture);
-  std::vector<SkPoint> positions = {SkPoint::Make(100, 300),
-                                    SkPoint::Make(200, 100),
-                                    SkPoint::Make(300, 300)};
+  std::vector<DlPoint> positions = {
+      DlPoint(100, 300),
+      DlPoint(200, 100),
+      DlPoint(300, 300),
+  };
   std::vector<flutter::DlColor> colors = {flutter::DlColor::kWhite(),
                                           flutter::DlColor::kGreen(),
                                           flutter::DlColor::kWhite()};
-  std::vector<SkPoint> texture_coordinates = {
-      SkPoint::Make(0, 0), SkPoint::Make(100, 200), SkPoint::Make(200, 100)};
+  std::vector<DlPoint> texture_coordinates = {
+      DlPoint(0, 0),
+      DlPoint(100, 200),
+      DlPoint(200, 100),
+  };
 
   auto vertices = flutter::DlVertices::Make(
       flutter::DlVertexMode::kTriangles, 3, positions.data(),
@@ -310,9 +332,12 @@ TEST_P(AiksTest,
 }
 
 TEST_P(AiksTest, DrawVerticesSolidColorTrianglesWithIndices) {
-  std::vector<SkPoint> positions = {
-      SkPoint::Make(100, 300), SkPoint::Make(200, 100), SkPoint::Make(300, 300),
-      SkPoint::Make(200, 500)};
+  std::vector<DlPoint> positions = {
+      DlPoint(100, 300),
+      DlPoint(200, 100),
+      DlPoint(300, 300),
+      DlPoint(200, 500),
+  };
   std::vector<uint16_t> indices = {0, 1, 2, 0, 2, 3};
 
   auto vertices = flutter::DlVertices::Make(
@@ -330,9 +355,12 @@ TEST_P(AiksTest, DrawVerticesSolidColorTrianglesWithIndices) {
 }
 
 TEST_P(AiksTest, DrawVerticesPremultipliesColors) {
-  std::vector<SkPoint> positions = {
-      SkPoint::Make(100, 300), SkPoint::Make(200, 100), SkPoint::Make(300, 300),
-      SkPoint::Make(200, 500)};
+  std::vector<DlPoint> positions = {
+      DlPoint(100, 300),
+      DlPoint(200, 100),
+      DlPoint(300, 300),
+      DlPoint(200, 500),
+  };
   auto color = flutter::DlColor::kBlue().withAlpha(0x99);
   std::vector<uint16_t> indices = {0, 1, 2, 0, 2, 3};
   std::vector<flutter::DlColor> colors = {color, color, color, color};
@@ -347,16 +375,19 @@ TEST_P(AiksTest, DrawVerticesPremultipliesColors) {
   paint.setBlendMode(flutter::DlBlendMode::kSrcOver);
   paint.setColor(flutter::DlColor::kRed());
 
-  builder.DrawRect(SkRect::MakeLTRB(0, 0, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 400, 400), paint);
   builder.DrawVertices(vertices, flutter::DlBlendMode::kDst, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, DrawVerticesWithInvalidIndices) {
-  std::vector<SkPoint> positions = {
-      SkPoint::Make(100, 300), SkPoint::Make(200, 100), SkPoint::Make(300, 300),
-      SkPoint::Make(200, 500)};
+  std::vector<DlPoint> positions = {
+      DlPoint(100, 300),
+      DlPoint(200, 100),
+      DlPoint(300, 300),
+      DlPoint(200, 500),
+  };
   std::vector<uint16_t> indices = {0, 1, 2, 0, 2, 3, 99, 100, 101};
 
   auto vertices = flutter::DlVertices::Make(
@@ -364,14 +395,14 @@ TEST_P(AiksTest, DrawVerticesWithInvalidIndices) {
       /*texture_coordinates=*/nullptr, /*colors=*/nullptr, indices.size(),
       indices.data());
 
-  EXPECT_EQ(vertices->bounds(), SkRect::MakeLTRB(100, 100, 300, 500));
+  EXPECT_EQ(vertices->GetBounds(), DlRect::MakeLTRB(100, 100, 300, 500));
 
   flutter::DisplayListBuilder builder;
   flutter::DlPaint paint;
   paint.setBlendMode(flutter::DlBlendMode::kSrcOver);
   paint.setColor(flutter::DlColor::kRed());
 
-  builder.DrawRect(SkRect::MakeLTRB(0, 0, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 400, 400), paint);
   builder.DrawVertices(vertices, flutter::DlBlendMode::kSrc, paint);
 
   AiksContext renderer(GetContext(), nullptr);
@@ -383,11 +414,11 @@ TEST_P(AiksTest, DrawVerticesWithInvalidIndices) {
 // All four vertices should form a solid red rectangle with no gaps.
 // The blue rectangle drawn under them should not be visible.
 TEST_P(AiksTest, DrawVerticesTextureCoordinatesWithFragmentShader) {
-  std::vector<SkPoint> positions_lt = {
-      SkPoint::Make(0, 0),    //
-      SkPoint::Make(50, 0),   //
-      SkPoint::Make(0, 50),   //
-      SkPoint::Make(50, 50),  //
+  std::vector<DlPoint> positions_lt = {
+      DlPoint(0, 0),    //
+      DlPoint(50, 0),   //
+      DlPoint(0, 50),   //
+      DlPoint(50, 50),  //
   };
 
   auto vertices_lt = flutter::DlVertices::Make(
@@ -397,11 +428,11 @@ TEST_P(AiksTest, DrawVerticesTextureCoordinatesWithFragmentShader) {
       /*index_count=*/0,
       /*indices=*/nullptr);
 
-  std::vector<SkPoint> positions_rt = {
-      SkPoint::Make(50, 0),    //
-      SkPoint::Make(100, 0),   //
-      SkPoint::Make(50, 50),   //
-      SkPoint::Make(100, 50),  //
+  std::vector<DlPoint> positions_rt = {
+      DlPoint(50, 0),    //
+      DlPoint(100, 0),   //
+      DlPoint(50, 50),   //
+      DlPoint(100, 50),  //
   };
 
   auto vertices_rt = flutter::DlVertices::Make(
@@ -411,11 +442,11 @@ TEST_P(AiksTest, DrawVerticesTextureCoordinatesWithFragmentShader) {
       /*index_count=*/0,
       /*indices=*/nullptr);
 
-  std::vector<SkPoint> positions_lb = {
-      SkPoint::Make(0, 50),    //
-      SkPoint::Make(50, 50),   //
-      SkPoint::Make(0, 100),   //
-      SkPoint::Make(50, 100),  //
+  std::vector<DlPoint> positions_lb = {
+      DlPoint(0, 50),    //
+      DlPoint(50, 50),   //
+      DlPoint(0, 100),   //
+      DlPoint(50, 100),  //
   };
 
   auto vertices_lb = flutter::DlVertices::Make(
@@ -425,11 +456,11 @@ TEST_P(AiksTest, DrawVerticesTextureCoordinatesWithFragmentShader) {
       /*index_count=*/0,
       /*indices=*/nullptr);
 
-  std::vector<SkPoint> positions_rb = {
-      SkPoint::Make(50, 50),    //
-      SkPoint::Make(100, 50),   //
-      SkPoint::Make(50, 100),   //
-      SkPoint::Make(100, 100),  //
+  std::vector<DlPoint> positions_rb = {
+      DlPoint(50, 50),    //
+      DlPoint(100, 50),   //
+      DlPoint(50, 100),   //
+      DlPoint(100, 100),  //
   };
 
   auto vertices_rb = flutter::DlVertices::Make(
@@ -460,7 +491,7 @@ TEST_P(AiksTest, DrawVerticesTextureCoordinatesWithFragmentShader) {
 
   builder.Scale(GetContentScale().x, GetContentScale().y);
   builder.Save();
-  builder.DrawRect(SkRect::MakeLTRB(0, 0, 100, 100), rect_paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), rect_paint);
   builder.DrawVertices(vertices_lt, flutter::DlBlendMode::kSrcOver, paint);
   builder.DrawVertices(vertices_rt, flutter::DlBlendMode::kSrcOver, paint);
   builder.DrawVertices(vertices_lb, flutter::DlBlendMode::kSrcOver, paint);
@@ -474,11 +505,11 @@ TEST_P(AiksTest, DrawVerticesTextureCoordinatesWithFragmentShader) {
 // The blue rectangle drawn under them should not be visible.
 TEST_P(AiksTest,
        DrawVerticesTextureCoordinatesWithFragmentShaderNonZeroOrigin) {
-  std::vector<SkPoint> positions_lt = {
-      SkPoint::Make(200, 200),  //
-      SkPoint::Make(250, 200),  //
-      SkPoint::Make(200, 250),  //
-      SkPoint::Make(250, 250),  //
+  std::vector<DlPoint> positions_lt = {
+      DlPoint(200, 200),  //
+      DlPoint(250, 200),  //
+      DlPoint(200, 250),  //
+      DlPoint(250, 250),  //
   };
 
   auto vertices = flutter::DlVertices::Make(
@@ -513,7 +544,7 @@ TEST_P(AiksTest,
   paint.setColorSource(color_source);
 
   builder.Scale(GetContentScale().x, GetContentScale().y);
-  builder.DrawRect(SkRect::MakeLTRB(200, 200, 250, 250), rect_paint);
+  builder.DrawRect(DlRect::MakeLTRB(200, 200, 250, 250), rect_paint);
   builder.DrawVertices(vertices, flutter::DlBlendMode::kSrcOver, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));

--- a/engine/src/flutter/impeller/display_list/dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_unittests.cc
@@ -1462,9 +1462,9 @@ TEST_P(DisplayListTest, DrawVerticesBlendModes) {
     }
     ImGui::End();
 
-    std::vector<SkPoint> positions = {SkPoint::Make(100, 300),
-                                      SkPoint::Make(200, 100),
-                                      SkPoint::Make(300, 300)};
+    std::vector<DlPoint> positions = {DlPoint(100, 300),  //
+                                      DlPoint(200, 100),  //
+                                      DlPoint(300, 300)};
     std::vector<flutter::DlColor> colors = {
         toColor(color0).modulateOpacity(dst_alpha),
         toColor(color1).modulateOpacity(dst_alpha),

--- a/engine/src/flutter/shell/common/dl_op_spy_unittests.cc
+++ b/engine/src/flutter/shell/common/dl_op_spy_unittests.cc
@@ -370,15 +370,15 @@ TEST(DlOpSpy, DrawVertices) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    const SkPoint vertices[] = {
-        SkPoint::Make(5, 5),
-        SkPoint::Make(5, 15),
-        SkPoint::Make(15, 5),
+    const DlPoint vertices[] = {
+        DlPoint(5, 5),
+        DlPoint(5, 15),
+        DlPoint(15, 5),
     };
-    const SkPoint texture_coordinates[] = {
-        SkPoint::Make(5, 5),
-        SkPoint::Make(15, 5),
-        SkPoint::Make(5, 15),
+    const DlPoint texture_coordinates[] = {
+        DlPoint(5, 5),
+        DlPoint(15, 5),
+        DlPoint(5, 15),
     };
     const DlColor colors[] = {
         DlColor::kBlack(),
@@ -396,15 +396,15 @@ TEST(DlOpSpy, DrawVertices) {
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    const SkPoint vertices[] = {
-        SkPoint::Make(5, 5),
-        SkPoint::Make(5, 15),
-        SkPoint::Make(15, 5),
+    const DlPoint vertices[] = {
+        DlPoint(5, 5),
+        DlPoint(5, 15),
+        DlPoint(15, 5),
     };
-    const SkPoint texture_coordinates[] = {
-        SkPoint::Make(5, 5),
-        SkPoint::Make(15, 5),
-        SkPoint::Make(5, 15),
+    const DlPoint texture_coordinates[] = {
+        DlPoint(5, 5),
+        DlPoint(15, 5),
+        DlPoint(5, 15),
     };
     const DlColor colors[] = {
         DlColor::kBlack(),

--- a/engine/src/flutter/testing/display_list_testing.cc
+++ b/engine/src/flutter/testing/display_list_testing.cc
@@ -189,10 +189,6 @@ std::ostream& operator<<(std::ostream& os, const SaveLayerOptions& options) {
             << ")";
 }
 
-static std::ostream& operator<<(std::ostream& os, const SkPoint& point) {
-  return os << "SkPoint(" << point.fX << ", " << point.fY << ")";
-}
-
 static std::ostream& operator<<(std::ostream& os, const SkRect& rect) {
   return os << "SkRect("
             << "left: " << rect.fLeft << ", "
@@ -873,8 +869,8 @@ void DisplayListStreamDispatcher::drawVertices(const std::shared_ptr<DlVertices>
   startl() << "drawVertices("
                << "DlVertices("
                    << vertices->mode() << ", ";
-                   out_array("vertices", vertices->vertex_count(), vertices->vertices()) << ", ";
-                   out_array("texture_coords", vertices->vertex_count(), vertices->texture_coordinates()) << ", ";
+                   out_array("vertices", vertices->vertex_count(), vertices->vertex_data()) << ", ";
+                   out_array("texture_coords", vertices->vertex_count(), vertices->texture_coordinate_data()) << ", ";
                    out_array("colors", vertices->vertex_count(), vertices->colors()) << ", ";
                    out_array("indices", vertices->index_count(), vertices->indices())
                    << "), " << mode << ");" << std::endl;


### PR DESCRIPTION
DlVertices was already half migrated onto the DL geometry classes, this completes the conversion.