### PR TITLE
[iOS][Engine] Fix view removal process for AutofillContextAction.cancel

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2675,6 +2675,10 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   [self removeEnableFlutterTextInputViewAccessibilityTimer];
   _activeView.accessibilityEnabled = NO;
   [_activeView resignFirstResponder];
+  // Removes the focus from the `_activeView` (UIView<UITextInput>)
+  // when the user stops typing (keyboard is hidden).
+  // For more details, refer to the discussion at:
+  // https://github.com/flutter/engine/pull/57209#discussion_r1905942577
   [self cleanUpViewHierarchy:YES clearText:YES delayRemoval:NO];
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2675,8 +2675,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   [self removeEnableFlutterTextInputViewAccessibilityTimer];
   _activeView.accessibilityEnabled = NO;
   [_activeView resignFirstResponder];
-  [_activeView removeFromSuperview];
-  [_inputHider removeFromSuperview];
+  [self cleanUpViewHierarchy:YES clearText:YES delayRemoval:NO];
 }
 
 - (void)triggerAutofillSave:(BOOL)saveEntries {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -2691,6 +2691,27 @@ FLUTTER_ASSERT_ARC
   XCTAssertNil(textInputPlugin.activeView.textInputDelegate);
 }
 
+- (void)testAutoFillDoesNotTriggerOnHideButTriggersOnCommit {
+  // Regression test for https://github.com/flutter/flutter/issues/145681.
+  NSMutableDictionary* configuration = self.mutableTemplateCopy;
+  [configuration setValue:@{
+    @"uniqueIdentifier" : @"field1",
+    @"hints" : @[ UITextContentTypePassword ],
+    @"editingValue" : @{@"text" : @""}
+  }
+                   forKey:@"autofill"];
+  [configuration setValue:@[ [configuration copy] ] forKey:@"fields"];
+
+  [self setClientId:123 configuration:configuration];
+  XCTAssertEqual(self.viewsVisibleToAutofill.count, 1ul);
+
+  [self setTextInputHide];
+  // Before the fix in https://github.com/flutter/flutter/pull/160653, it was 0ul.
+  XCTAssertEqual(self.viewsVisibleToAutofill.count, 1ul);
+
+  [self commitAutofillContextAndVerify];
+}
+
 #pragma mark - Accessibility - Tests
 
 - (void)testUITextInputAccessibilityNotHiddenWhenShowed {


### PR DESCRIPTION
Original PR https://github.com/flutter/engine/pull/57209

---

The `removeFromSuperview` in the `hideTextInput` method was triggering the save password, so I changed it to `cleanUpViewHierarchy`.

fix https://github.com/flutter/flutter/issues/145681

sample app code

https://github.com/koji-1009/autofill_cancel_issue

before

https://github.com/user-attachments/assets/c380538b-6783-4706-9a09-4db1c3b761df

after

https://github.com/user-attachments/assets/b6654b80-f383-408d-9820-6fe53279ce14

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
