### PR TITLE
Ensure engine.version is up to date in the monorepo

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -121,7 +121,7 @@ GOTO :after_subroutine
     REM PowerShell command must have exit code set in order to prevent all non-zero exit codes from being translated
     REM into 1. The exit code 2 is used to detect the case where the major version is incorrect and there should be
     REM no subsequent retries.
-    %powershell_executable% -ExecutionPolicy Bypass -NoProfile -Command "Unblock-File -Path '%update_engine_bin%'; & '%update_dart_bin%'; exit $LASTEXITCODE;"
+    %powershell_executable% -ExecutionPolicy Bypass -NoProfile -Command "Unblock-File -Path '%update_engine_bin%'; & '%update_engine_bin%'; exit $LASTEXITCODE;"
     IF "%ERRORLEVEL%" EQU "2" (
       EXIT 1
     )
@@ -129,6 +129,8 @@ GOTO :after_subroutine
       ECHO Error: Unable to determine engine version... 1>&2
       EXIT 1
     )
+    REM Do not fall through - return from subroutine
+    EXIT /B
 
   :do_sdk_update_and_snapshot
     REM Detect which PowerShell executable is available on the Host

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -82,7 +82,7 @@ GOTO :after_subroutine
   REM The following IF conditions are all linked with a logical OR. However,
   REM there is no OR operator in batch and a GOTO construct is used as replacement.
 
-  GOTO do_ensure_engine_version
+  CALL :do_ensure_engine_version
   IF NOT EXIST "%engine_stamp%" GOTO do_sdk_update_and_snapshot
   SET /P dart_required_version=<"%engine_version_path%"
   SET /P dart_installed_version=<"%engine_stamp%"

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -113,6 +113,9 @@ function _wait_for_lock () {
 function upgrade_flutter () (
   mkdir -p "$FLUTTER_ROOT/bin/cache"
 
+  # Ensure the engine.version is populated
+  "$FLUTTER_ROOT/bin/internal/update_engine_version.sh"
+
   local revision="$(cd "$FLUTTER_ROOT"; git rev-parse HEAD)"
   local compilekey="$revision:$FLUTTER_TOOL_ARGS"
 

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -20,38 +20,6 @@ $cachePath = "$flutterRoot\bin\cache"
 $dartSdkPath = "$cachePath\dart-sdk"
 $dartSdkLicense = "$cachePath\LICENSE.dart_sdk_archive.md"
 $engineStamp = "$cachePath\engine-dart-sdk.stamp"
-$engineRealm = ""
-
-# Test for fusion repository
-if ((Test-Path "$flutterRoot\DEPS" -PathType Leaf) -and (Test-Path "$flutterRoot\engine\src\.gn" -PathType Leaf)) {
-    # Calculate the engine hash from tracked git files.
-    $branch = (git -C "$flutterRoot" rev-parse --abbrev-ref HEAD)
-    if ($null -eq $Env:LUCI_CONTEXT) {
-        $ErrorActionPreference = "Continue"
-        git -C "$flutterRoot" remote get-url upstream *> $null
-        $exitCode = $?
-        $ErrorActionPreference = "Stop"
-        if ($exitCode) {
-            $engineVersion = (git -C "$flutterRoot"  merge-base HEAD upstream/master)
-        } else {
-            $engineVersion = (git -C "$flutterRoot"  merge-base HEAD origin/master)
-        }
-    }
-    else {
-        $engineVersion = (git -C "$flutterRoot" rev-parse HEAD)
-    }
-
-    if (($branch -ne "stable" -and $branch -ne "beta")) {
-        # Write the engine version out so downstream tools know what to look for.
-        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-        [System.IO.File]::WriteAllText("$flutterRoot\bin\internal\engine.version", $engineVersion, $utf8NoBom)
-
-        # The realm on CI is passed in.
-        if ($Env:FLUTTER_REALM) {
-            [System.IO.File]::WriteAllText("$flutterRoot\bin\internal\engine.realm", $Env:FLUTTER_REALM, $utf8NoBom)
-        }
-    }
-}
 $engineVersion = (Get-Content "$flutterRoot\bin\internal\engine.version")
 $engineRealm = (Get-Content "$flutterRoot\bin\internal\engine.realm")
 

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -19,39 +19,8 @@ FLUTTER_ROOT="$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")"
 DART_SDK_PATH="$FLUTTER_ROOT/bin/cache/dart-sdk"
 DART_SDK_PATH_OLD="$DART_SDK_PATH.old"
 ENGINE_STAMP="$FLUTTER_ROOT/bin/cache/engine-dart-sdk.stamp"
-ENGINE_REALM=""
 OS="$(uname -s)"
 
-# Test for fusion repository
-if [ -f "$FLUTTER_ROOT/DEPS" ] && [ -f "$FLUTTER_ROOT/engine/src/.gn" ]; then
-  BRANCH=$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)
-  # In a fusion repository; the engine.version comes from the git hashes.
-  if [ -z "${LUCI_CONTEXT}" ]; then
-    set +e
-    # Run the git command and capture the exit code
-    git -C "$FLUTTER_ROOT" remote get-url upstream > /dev/null 2>&1
-    exit_code=$?
-    set -e
-
-    if [[ $exit_code -eq 0 ]]; then
-      ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" merge-base HEAD upstream/master)
-    else
-      ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" merge-base HEAD origin/master)
-    fi
-  else
-    ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" rev-parse HEAD)
-  fi
-
-  if [[ "$BRANCH" != "stable" && "$BRANCH" != "beta" ]]; then
-    # Write the engine version out so downstream tools know what to look for.
-    echo $ENGINE_VERSION > "$FLUTTER_ROOT/bin/internal/engine.version"
-
-    # The realm on CI is passed in.
-    if [ -n "${FLUTTER_REALM}" ]; then
-      echo $FLUTTER_REALM > "$FLUTTER_ROOT/bin/internal/engine.realm"
-    fi
-  fi
-fi
 ENGINE_VERSION=$(cat "$FLUTTER_ROOT/bin/internal/engine.version")
 ENGINE_REALM=$(cat "$FLUTTER_ROOT/bin/internal/engine.realm" | tr -d '[:space:]')
 

--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -1,0 +1,48 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+
+# ---------------------------------- NOTE ---------------------------------- #
+#
+# Please keep the logic in this file consistent with the logic in the
+# `update_engine_version.sh` script in the same directory to ensure that Flutter
+# continues to work across all platforms!
+#
+# -------------------------------------------------------------------------- #
+
+$ErrorActionPreference = "Stop"
+
+$progName = Split-Path -parent $MyInvocation.MyCommand.Definition
+$flutterRoot = (Get-Item $progName).parent.parent.FullName
+
+# Test for fusion repository
+if ((Test-Path "$flutterRoot\DEPS" -PathType Leaf) -and (Test-Path "$flutterRoot\engine\src\.gn" -PathType Leaf)) {
+    # Calculate the engine hash from tracked git files.
+    $branch = (git -C "$flutterRoot" rev-parse --abbrev-ref HEAD)
+    if ($null -eq $Env:LUCI_CONTEXT) {
+        $ErrorActionPreference = "Continue"
+        git -C "$flutterRoot" remote get-url upstream *> $null
+        $exitCode = $?
+        $ErrorActionPreference = "Stop"
+        if ($exitCode) {
+            $engineVersion = (git -C "$flutterRoot"  merge-base HEAD upstream/master)
+        } else {
+            $engineVersion = (git -C "$flutterRoot"  merge-base HEAD origin/master)
+        }
+    }
+    else {
+        $engineVersion = (git -C "$flutterRoot" rev-parse HEAD)
+    }
+
+    if (($branch -ne "stable" -and $branch -ne "beta")) {
+        # Write the engine version out so downstream tools know what to look for.
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText("$flutterRoot\bin\internal\engine.version", $engineVersion, $utf8NoBom)
+
+        # The realm on CI is passed in.
+        if ($Env:FLUTTER_REALM) {
+            [System.IO.File]::WriteAllText("$flutterRoot\bin\internal\engine.realm", $Env:FLUTTER_REALM, $utf8NoBom)
+        }
+    }
+}

--- a/bin/internal/update_engine_version.sh
+++ b/bin/internal/update_engine_version.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+
+# ---------------------------------- NOTE ---------------------------------- #
+#
+# Please keep the logic in this file consistent with the logic in the
+# `update_engine_version.ps1` script in the same directory to ensure that Flutter
+# continues to work across all platforms!
+#
+# -------------------------------------------------------------------------- #
+
+set -e
+
+FLUTTER_ROOT="$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")"
+
+# Test for fusion repository
+if [ -f "$FLUTTER_ROOT/DEPS" ] && [ -f "$FLUTTER_ROOT/engine/src/.gn" ]; then
+  BRANCH=$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)
+  # In a fusion repository; the engine.version comes from the git hashes.
+  if [ -z "${LUCI_CONTEXT}" ]; then
+    set +e
+    # Run the git command and capture the exit code
+    git -C "$FLUTTER_ROOT" remote get-url upstream > /dev/null 2>&1
+    exit_code=$?
+    set -e
+
+    if [[ $exit_code -eq 0 ]]; then
+      ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" merge-base HEAD upstream/master)
+    else
+      ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" merge-base HEAD origin/master)
+    fi
+  else
+    ENGINE_VERSION=$(git -C "$FLUTTER_ROOT" rev-parse HEAD)
+  fi
+
+  if [[ "$BRANCH" != "stable" && "$BRANCH" != "beta" ]]; then
+    # Write the engine version out so downstream tools know what to look for.
+    echo $ENGINE_VERSION > "$FLUTTER_ROOT/bin/internal/engine.version"
+
+    # The realm on CI is passed in.
+    if [ -n "${FLUTTER_REALM}" ]; then
+      echo $FLUTTER_REALM > "$FLUTTER_ROOT/bin/internal/engine.realm"
+    fi
+  fi
+fi

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -2556,6 +2556,7 @@ const Set<String> kExecutableAllowlist = <String>{
   'bin/flutter',
   'bin/flutter-dev',
   'bin/internal/update_dart_sdk.sh',
+  'bin/internal/update_engine_version.sh',
 
   'dev/bots/accept_android_sdk_licenses.sh',
   'dev/bots/codelabs_build_test.sh',


### PR DESCRIPTION
`update_dart_sdk.(ps1|sh)` is called too late and needs to be called from `shared.(bat|sh)`.

Fixes #160640 