### PR TITLE
Fix lint warning failing the tree

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3660,7 +3660,7 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     final String rawPubspec = await projectDir.childFile('pubspec.yaml').readAsString();
     final Pubspec pubspec = Pubspec.parse(rawPubspec);
-    final Map<String, VersionConstraint?> env = pubspec.environment!;
+    final Map<String, VersionConstraint?> env = pubspec.environment;
     expect(env['flutter']!.allows(Version(3, 3, 0)), true);
     expect(env['flutter']!.allows(Version(3, 2, 9)), false);
   });
@@ -4337,7 +4337,7 @@ void main() {
     final Pubspec pubspec = Pubspec.parse(rawPubspec);
 
     expect(
-      pubspec.environment!['sdk'].toString(),
+      pubspec.environment['sdk'].toString(),
       startsWith('^'),
       reason: 'The caret syntax is recommended over the traditional syntax.',
     );


### PR DESCRIPTION
`dart analyze` fails at tip of tree. Not sure why the tree isnt red but it should be . 

```

warning • packages/flutter_tools/test/commands.shard/permeable/create_test.dart:3663:68 • The '!' will have no effect because the receiver
          can't be null. Try removing the '!' operator. • unnecessary_non_null_assertion
warning • packages/flutter_tools/test/commands.shard/permeable/create_test.dart:4340:26 • The '!' will have no effect because the receiver
          can't be null. Try removing the '!' operator. • unnecessary_non_null_assertion
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
