### PR TITLE
deprecate engine ci yaml roller

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -558,9 +558,3 @@ targets:
     timeout: 120
     properties:
       config_name: windows_unopt
-
-  - name: Linux ci_yaml engine roller
-    bringup: true
-    recipe: infra/ci_yaml
-    properties:
-      backfill: "false"


### PR DESCRIPTION
This is no longer working after the monorepo merge: https://github.com/flutter/flutter/issues/160670.

That issue tracks instead teaching the `Linux ci_yaml flutter roller` to roll both sets of configurations.