### PR TITLE
[flutter_tools] unconditionally skip bash test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -120,7 +120,7 @@ echo executed dart binary
     } finally {
       tryToDelete(tempDir);
     }
-  }, skip: platform.isWindows); // [intended] Windows does not use the bash entrypoint
+  }, skip: true); // [intended] https://github.com/flutter/flutter/issues/160689
 }
 
 // A test Dart app that will run until it receives SIGTERM


### PR DESCRIPTION
Work around: https://github.com/flutter/flutter/issues/160689.

I locally verified that we have not regressed what this was testing (that just invoking `//flutter/bin/dart` will not build the flutter tool).