### PR TITLE
[Impeller] move barrier setting out of render pass builder.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -24,8 +24,6 @@
 #include "impeller/renderer/backend/vulkan/sampler_vk.h"
 #include "impeller/renderer/backend/vulkan/shared_object_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
-#include "vulkan/vulkan.hpp"
-#include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
 
@@ -91,15 +89,8 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
             attachment.texture->GetTextureDescriptor().format,        //
             attachment.texture->GetTextureDescriptor().sample_count,  //
             attachment.load_action,                                   //
-            attachment.store_action,                                  //
-            TextureVK::Cast(*attachment.texture).GetLayout()          //
+            attachment.store_action                                   //
         );
-        TextureVK::Cast(*attachment.texture)
-            .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
-        if (attachment.resolve_texture) {
-          TextureVK::Cast(*attachment.resolve_texture)
-              .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
-        }
         return true;
       });
 
@@ -203,6 +194,15 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   pass_info.setClearValueCount(clear_count);
 
   command_buffer_vk_.beginRenderPass(pass_info, vk::SubpassContents::eInline);
+
+  if (resolve_image_vk_) {
+    TextureVK::Cast(*resolve_image_vk_)
+        .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
+  }
+  if (color_image_vk_) {
+    TextureVK::Cast(*color_image_vk_)
+        .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
+  }
 
   // Set the initial viewport.
   const auto vp = Viewport{.rect = Rect::MakeSize(target_size)};

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -12,7 +12,6 @@
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
-#include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
 


### PR DESCRIPTION
Refactoring to make sure that we're always tracking the correct layout state.
