### PR TITLE
Annotate entrypoints in the "isolate spawner" files generated by `flutter test --experimental-faster-testing`

### DIFF
--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -394,6 +394,7 @@ void createChannelAndConnect(String path, String name, Function testMain) {
   channel.pipe(RemoteListener.start(() => testMain));
 }
 
+@pragma('vm:entry-point')
 void testMain() {
   final String route = PlatformDispatcher.instance.defaultRouteName;
   switch (route) {
@@ -418,6 +419,7 @@ void testMain() {
   }
 }
 
+@pragma('vm:entry-point')
 void main([dynamic sendPort]) {
   if (sendPort is SendPort) {
     final ReceivePort receivePort = ReceivePort();
@@ -495,6 +497,7 @@ Future<void> spawn({
   commandPort.send(<Object>['spawn', port, entrypoint, route]);
 }
 
+@pragma('vm:entry-point')
 void main() async {
   final String route = PlatformDispatcher.instance.defaultRouteName;
 


### PR DESCRIPTION
This fixes the test timeouts (https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20tool_integration_tests_2_5/1951/overview) introduced by the most recent Dart SDK roll (https://github.com/flutter/flutter/commit/895f0e291af00c3d45df0d931900bbad3061b681).