### PR TITLE
Remove dependency on web_tests/artifacts.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -399,7 +399,7 @@ targets:
       cores: "8"
 
   - name: Linux linux_web_engine_tests
-    #bringup: true
+    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -399,7 +399,7 @@ targets:
       cores: "8"
 
   - name: Linux linux_web_engine_tests
-    bringup: true
+    #bringup: true
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:

--- a/engine/src/flutter/ci/builders/linux_web_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_web_engine_test.json
@@ -220,7 +220,6 @@
         "download_jdk": false
       },
       "dependencies": [
-        "web_tests/artifacts",
         "web_tests/test_bundles/dart2js-html-html",
         "web_tests/test_bundles/dart2js-html-ui",
         "web_tests/test_bundles/dart2js-canvaskit-engine",
@@ -412,7 +411,6 @@
         "download_jdk": false
       },
       "dependencies": [
-        "web_tests/artifacts",
         "web_tests/test_bundles/dart2js-html-html",
         "web_tests/test_bundles/dart2js-html-ui",
         "web_tests/test_bundles/dart2js-canvaskit-engine",
@@ -540,7 +538,6 @@
         "download_jdk": false
       },
       "dependencies": [
-        "web_tests/artifacts",
         "web_tests/test_bundles/dart2js-html-html",
         "web_tests/test_bundles/dart2js-html-ui",
         "web_tests/test_bundles/dart2js-canvaskit-engine",

--- a/engine/src/flutter/ci/builders/linux_web_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_web_engine_test.json
@@ -193,18 +193,14 @@
           "parameters": [
             "check-licenses"
           ],
-          "scripts": [
-            "flutter/lib/web_ui/dev/felt"
-          ]
+          "script": "flutter/lib/web_ui/dev/felt"
         },
         {
           "name": "web engine analysis",
           "parameters": [
             "analyze"
           ],
-          "scripts": [
-            "flutter/lib/web_ui/dev/felt"
-          ]
+          "script": "flutter/lib/web_ui/dev/felt"
         }
       ]
     },

--- a/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
+++ b/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
@@ -115,12 +115,12 @@ class GenerateBuilderJsonCommand extends Command<bool> {
         <String, dynamic>{
           'name': 'check licenses',
           'parameters': <String>['check-licenses'],
-          'scripts': <String>['flutter/lib/web_ui/dev/felt'],
+          'script': 'flutter/lib/web_ui/dev/felt',
         },
         <String, dynamic>{
           'name': 'web engine analysis',
           'parameters': <String>['analyze'],
-          'scripts': <String>['flutter/lib/web_ui/dev/felt'],
+          'script': 'flutter/lib/web_ui/dev/felt',
         },
       ],
     };

--- a/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
+++ b/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
@@ -161,10 +161,7 @@ class GenerateBuilderJsonCommand extends Command<bool> {
         if (cpu != null) 'cpu=$cpu',
       ],
       'gclient_variables': <String, dynamic>{'download_android_deps': false, 'download_jdk': false},
-      'dependencies': <String>[
-        'web_tests/artifacts',
-        ...bundles.map((bundle) => 'web_tests/test_bundles/${bundle.name}'),
-      ],
+      'dependencies': <String>[...bundles.map((bundle) => 'web_tests/test_bundles/${bundle.name}')],
       'test_dependencies': <dynamic>[
         <String, dynamic>{
           'dependency': 'goldctl',


### PR DESCRIPTION
We no longer pass `web_tests/artifacts` via CAS, so we need to remove it as a dependency.