### PR TITLE
Consider changes to `DEPS` and `engine/**` to impact most runIf-guarded builds

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4355,7 +4355,7 @@ targets:
       - dev/**
       - packages/flutter_tools/**
       - bin/**
-      - ..ci.yaml
+      - .ci.yaml
       - engine/**
       - DEPS
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -448,6 +448,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux build_tests_1_5
     recipe: flutter/flutter_drone
@@ -617,6 +619,8 @@ targets:
       - packages/flutter_web_plugins/**
       - packages/integration_test/**
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dartdoc_options.yaml
 
   - name: Linux engine_dependency_proxy_test
@@ -636,6 +640,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux firebase_release_smoke_test
     recipe: firebaselab/firebaselab
@@ -680,6 +686,8 @@ targets:
         ["framework", "hostonly", "shard", "linux"]
     runIf:
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/bots/**
 
   - name: Linux flutter_plugins
@@ -717,6 +725,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux framework_tests_slow
     recipe: flutter/flutter_drone
@@ -743,6 +753,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux framework_tests_misc
     recipe: flutter/flutter_drone
@@ -774,6 +786,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux framework_tests_widgets
     recipe: flutter/flutter_drone
@@ -799,6 +813,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux fuchsia_precache
     recipe: flutter/flutter_drone
@@ -830,6 +846,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux gradle_java8_compile_test
     recipe: devicelab/devicelab_drone
@@ -848,6 +866,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux gradle_plugin_bundle_test
     recipe: devicelab/devicelab_drone
@@ -866,6 +886,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux gradle_plugin_fat_apk_test
     recipe: devicelab/devicelab_drone
@@ -885,6 +907,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux gradle_plugin_light_apk_test
     recipe: devicelab/devicelab_drone
@@ -904,6 +928,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux module_custom_host_app_name_test
     recipe: devicelab/devicelab_drone
@@ -923,6 +949,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux module_host_with_custom_build_test
     recipe: devicelab/devicelab_drone
@@ -942,6 +970,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux build_android_host_app_with_module_aar
     recipe: devicelab/devicelab_drone
@@ -961,6 +991,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux build_android_host_app_with_module_source
     recipe: devicelab/devicelab_drone
@@ -981,6 +1013,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux plugin_dependencies_test
     recipe: devicelab/devicelab_drone
@@ -1000,6 +1034,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux plugin_test
     recipe: devicelab/devicelab_drone
@@ -1023,6 +1059,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux plugin_test_linux
     recipe: devicelab/devicelab_drone
@@ -1043,6 +1081,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux run_debug_test_linux
     recipe: devicelab/devicelab_drone
@@ -1063,6 +1103,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux linux_desktop_impeller
     recipe: devicelab/devicelab_drone
@@ -1098,6 +1140,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux run_release_test_linux
     recipe: devicelab/devicelab_drone
@@ -1118,6 +1162,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux skp_generator
     enabled_branches:
@@ -1136,6 +1182,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux technical_debt__cost
     recipe: devicelab/devicelab_drone
@@ -1163,6 +1211,8 @@ targets:
       - engine/**
       - DEPS
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux tool_integration_tests_1_6
     recipe: flutter/flutter_drone
@@ -1189,6 +1239,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux tool_integration_tests_2_6
     recipe: flutter/flutter_drone
@@ -1215,6 +1267,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux tool_integration_tests_3_6
     recipe: flutter/flutter_drone
@@ -1241,6 +1295,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux tool_integration_tests_4_6
     recipe: flutter/flutter_drone
@@ -1267,6 +1323,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux tool_integration_tests_5_6
     recipe: flutter/flutter_drone
@@ -1293,6 +1351,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux tool_integration_tests_6_6
     recipe: flutter/flutter_drone
@@ -1319,6 +1379,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux android_preview_tool_integration_tests
     recipe: flutter/flutter_drone
@@ -1348,6 +1410,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux android_java11_tool_integration_tests
     recipe: flutter/flutter_drone
@@ -1373,6 +1437,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux android_java11_dependency_smoke_tests
     recipe: devicelab/devicelab_drone
@@ -1392,6 +1458,8 @@ targets:
     runIf:
       - packages/flutter_tools/templates/**
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/devicelab/bin/tasks/android_java11_dependency_smoke_tests.dart
 
   - name: Linux android_java17_dependency_smoke_tests
@@ -1412,6 +1480,8 @@ targets:
     runIf:
       - packages/flutter_tools/templates/**
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
 
   - name: Linux tool_tests_commands
@@ -1433,6 +1503,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux tool_tests_general
     recipe: flutter/flutter_drone
@@ -1453,6 +1525,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux_android_emu flutter_driver_android_test
     recipe: flutter/flutter_drone
@@ -1511,6 +1585,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_benchmarks_skwasm_st
     recipe: devicelab/devicelab_drone
@@ -1529,6 +1605,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_long_running_tests_1_5
     recipe: flutter/flutter_drone
@@ -1551,6 +1629,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_long_running_tests_2_5
     recipe: flutter/flutter_drone
@@ -1573,6 +1653,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_long_running_tests_3_5
     recipe: flutter/flutter_drone
@@ -1595,6 +1677,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_long_running_tests_4_5
     recipe: flutter/flutter_drone
@@ -1617,6 +1701,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_long_running_tests_5_5
     recipe: flutter/flutter_drone
@@ -1639,6 +1725,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tests_0
     recipe: flutter/flutter_drone
@@ -1661,6 +1749,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tests_1
     recipe: flutter/flutter_drone
@@ -1683,6 +1773,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tests_2
     recipe: flutter/flutter_drone
@@ -1705,6 +1797,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tests_3
     recipe: flutter/flutter_drone
@@ -1727,6 +1821,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tests_4
     recipe: flutter/flutter_drone
@@ -1749,6 +1845,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tests_5
     recipe: flutter/flutter_drone
@@ -1771,6 +1869,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tests_6
     recipe: flutter/flutter_drone
@@ -1793,6 +1893,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tests_7_last
     recipe: flutter/flutter_drone
@@ -1815,6 +1917,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_canvaskit_tests_0
     recipe: flutter/flutter_drone
@@ -1837,6 +1941,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_canvaskit_tests_1
     recipe: flutter/flutter_drone
@@ -1859,6 +1965,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_canvaskit_tests_2
     recipe: flutter/flutter_drone
@@ -1881,6 +1989,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_canvaskit_tests_3
     recipe: flutter/flutter_drone
@@ -1903,6 +2013,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_canvaskit_tests_4
     recipe: flutter/flutter_drone
@@ -1925,6 +2037,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_canvaskit_tests_5
     recipe: flutter/flutter_drone
@@ -1947,6 +2061,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_canvaskit_tests_6
     recipe: flutter/flutter_drone
@@ -1969,6 +2085,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_canvaskit_tests_7_last
     recipe: flutter/flutter_drone
@@ -1991,6 +2109,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_skwasm_tests_0
     recipe: flutter/flutter_drone
@@ -2013,6 +2133,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_skwasm_tests_1
     recipe: flutter/flutter_drone
@@ -2035,6 +2157,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_skwasm_tests_2
     recipe: flutter/flutter_drone
@@ -2057,6 +2181,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_skwasm_tests_3
     recipe: flutter/flutter_drone
@@ -2079,6 +2205,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_skwasm_tests_4
     recipe: flutter/flutter_drone
@@ -2123,6 +2251,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_skwasm_tests_6
     recipe: flutter/flutter_drone
@@ -2145,6 +2275,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_skwasm_tests_7_last
     recipe: flutter/flutter_drone
@@ -2167,6 +2299,8 @@ targets:
       - packages/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux web_tool_tests
     recipe: flutter/flutter_drone
@@ -2190,6 +2324,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Linux_android_emu android_defines_test
     recipe: devicelab/devicelab_drone
@@ -3605,6 +3741,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
@@ -3623,6 +3761,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_x64 build_tests_1_4
     recipe: flutter/flutter_drone
@@ -3825,6 +3965,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac flavors_test_macos
     bringup: true # Flaky https://github.com/flutter/flutter/issues/156943
@@ -3862,6 +4004,8 @@ targets:
         ["framework", "hostonly", "shard", "mac"]
     runIf:
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/bots/**
 
   - name: Mac_arm64 flutter_packaging_test
@@ -3875,6 +4019,8 @@ targets:
         ["framework", "hostonly", "shard", "mac"]
     runIf:
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/bots/**
 
   - name: Mac_benchmark flutter_view_macos__start_up
@@ -3910,6 +4056,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac framework_tests_impeller
     recipe: flutter/flutter_drone
@@ -3936,6 +4084,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_x64 framework_tests_misc
     recipe: flutter/flutter_drone
@@ -3965,6 +4115,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 framework_tests_misc
     recipe: flutter/flutter_drone
@@ -3995,6 +4147,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac framework_tests_widgets
     recipe: flutter/flutter_drone
@@ -4021,6 +4175,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac gradle_plugin_bundle_test
     recipe: devicelab/devicelab_drone
@@ -4038,6 +4194,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_benchmark hello_world_macos__compile
     bringup: true # Flaky https://github.com/flutter/flutter/issues/159542
@@ -4078,6 +4236,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac module_host_with_custom_build_test
     recipe: devicelab/devicelab_drone
@@ -4096,6 +4256,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac build_android_host_app_with_module_aar
     recipe: devicelab/devicelab_drone
@@ -4114,6 +4276,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac build_android_host_app_with_module_source
     recipe: devicelab/devicelab_drone
@@ -4133,6 +4297,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 module_test_ios
     recipe: devicelab/devicelab_drone
@@ -4152,6 +4318,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_benchmark platform_view_macos__start_up
     presubmit: false
@@ -4187,7 +4355,9 @@ targets:
       - dev/**
       - packages/flutter_tools/**
       - bin/**
-      - .ci.yaml
+      - ..ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_x64 plugin_lint_mac
     recipe: devicelab/devicelab_drone
@@ -4206,6 +4376,8 @@ targets:
       - packages/integration_test/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 plugin_lint_mac
     recipe: devicelab/devicelab_drone
@@ -4225,6 +4397,8 @@ targets:
       - packages/integration_test/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac plugin_test
     recipe: devicelab/devicelab_drone
@@ -4243,6 +4417,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac plugin_test_ios
     recipe: devicelab/devicelab_drone
@@ -4263,6 +4439,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac plugin_test_macos
     recipe: devicelab/devicelab_drone
@@ -4280,6 +4458,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_x64 tool_host_cross_arch_tests
     recipe: flutter/flutter_drone
@@ -4298,6 +4478,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 tool_host_cross_arch_tests
     recipe: flutter/flutter_drone
@@ -4316,6 +4498,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac tool_integration_tests_1_5
     recipe: flutter/flutter_drone
@@ -4341,6 +4525,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac tool_integration_tests_2_5
     recipe: flutter/flutter_drone
@@ -4366,6 +4552,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac tool_integration_tests_3_5
     recipe: flutter/flutter_drone
@@ -4391,6 +4579,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac tool_integration_tests_4_5
     recipe: flutter/flutter_drone
@@ -4416,6 +4606,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac tool_integration_tests_5_5
     recipe: flutter/flutter_drone
@@ -4441,6 +4633,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_x64 tool_tests_commands
     recipe: flutter/flutter_drone
@@ -4491,6 +4685,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_x64 verify_binaries_codesigned
     enabled_branches:
@@ -4534,6 +4730,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   # mac mokey test
   - name: Mac_arm64_mokey entrypoint_dart_registrant
@@ -4549,6 +4747,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   # mac mokey benchmark
   - name: Mac_mokey hello_world_android__compile
@@ -4649,6 +4849,8 @@ targets:
     presubmit: false
     runIf:
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/**
     timeout: 60
     properties:
@@ -4663,6 +4865,8 @@ targets:
     presubmit: false
     runIf:
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/**
     timeout: 60
     properties:
@@ -4676,6 +4880,8 @@ targets:
     presubmit: false
     runIf:
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/**
     timeout: 60
     properties:
@@ -4850,6 +5056,8 @@ targets:
     runIf:
       - dev/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
@@ -4865,6 +5073,8 @@ targets:
       task_name: hot_mode_dev_cycle_macos_target__benchmark
     runIf:
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/**
 
   - name: Mac_x64_ios integration_test_test_ios
@@ -5280,6 +5490,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 native_ui_tests_macos
     recipe: devicelab/devicelab_drone
@@ -5297,6 +5509,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac channels_integration_test
     recipe: devicelab/devicelab_drone
@@ -5314,6 +5528,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac run_debug_test_macos
     recipe: devicelab/devicelab_drone
@@ -5331,6 +5547,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 run_debug_test_macos
     recipe: devicelab/devicelab_drone
@@ -5348,6 +5566,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 run_release_test_macos
     recipe: devicelab/devicelab_drone
@@ -5366,6 +5586,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Mac_arm64 mac_desktop_impeller
     recipe: devicelab/devicelab_drone
@@ -5578,6 +5800,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows framework_tests_libraries_leak_tracking
     recipe: flutter/flutter_drone
@@ -5609,6 +5833,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows framework_tests_misc
     recipe: flutter/flutter_drone
@@ -5638,6 +5864,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows framework_tests_widgets
     recipe: flutter/flutter_drone
@@ -5663,6 +5891,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows framework_tests_widgets_leak_tracking
     recipe: flutter/flutter_drone
@@ -5694,6 +5924,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows gradle_plugin_bundle_test
     recipe: devicelab/devicelab_drone
@@ -5712,6 +5944,8 @@ targets:
       - dev/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows hot_mode_dev_cycle_win_target__benchmark
     recipe: devicelab/devicelab_drone
@@ -5757,6 +5991,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows module_host_with_custom_build_test
     recipe: devicelab/devicelab_drone
@@ -5776,6 +6012,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows build_android_host_app_with_module_aar
     recipe: devicelab/devicelab_drone
@@ -5795,6 +6033,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows build_android_host_app_with_module_source
     recipe: devicelab/devicelab_drone
@@ -5815,6 +6055,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows platform_channel_sample_test_windows
     recipe: devicelab/devicelab_drone
@@ -5860,6 +6102,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows plugin_test
     bringup: true # Flaky https://github.com/flutter/flutter/issues/148834
@@ -5880,6 +6124,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows plugin_test_windows
     recipe: devicelab/devicelab_drone
@@ -5897,6 +6143,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows_arm64 plugin_test_windows
     recipe: devicelab/devicelab_drone
@@ -5916,6 +6164,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows run_debug_test_windows
     recipe: devicelab/devicelab_drone
@@ -5934,6 +6184,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows_arm64 run_debug_test_windows
     recipe: devicelab/devicelab_drone
@@ -5952,6 +6204,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows run_release_test_windows
     recipe: devicelab/devicelab_drone
@@ -5970,6 +6224,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows_arm64 run_release_test_windows
     recipe: devicelab/devicelab_drone
@@ -5988,6 +6244,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_1_9
     recipe: flutter/flutter_drone
@@ -6012,6 +6270,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_2_9
     recipe: flutter/flutter_drone
@@ -6036,6 +6296,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_3_9
     recipe: flutter/flutter_drone
@@ -6060,6 +6322,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_4_9
     recipe: flutter/flutter_drone
@@ -6084,6 +6348,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_5_9
     recipe: flutter/flutter_drone
@@ -6108,6 +6374,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_6_9
     recipe: flutter/flutter_drone
@@ -6132,6 +6400,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_7_9
     recipe: flutter/flutter_drone
@@ -6156,6 +6426,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_8_9
     recipe: flutter/flutter_drone
@@ -6180,6 +6452,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_integration_tests_9_9
     recipe: flutter/flutter_drone
@@ -6204,6 +6478,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_tests_commands
     recipe: flutter/flutter_drone
@@ -6224,6 +6500,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows tool_tests_general
     recipe: flutter/flutter_drone
@@ -6244,6 +6522,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows web_tool_tests_1_2
     recipe: flutter/flutter_drone
@@ -6266,6 +6546,8 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+      - engine/**
+      - DEPS
 
   - name: Windows web_tool_tests_2_2
     recipe: flutter/flutter_drone
@@ -6287,6 +6569,8 @@ targets:
     - packages/flutter_tools/**
     - bin/**
     - .ci.yaml
+    - engine/**
+    - DEPS
 
   - name: Windows windows_home_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -6566,6 +6850,8 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
     runIf:
       - .ci.yaml
+      - engine/**
+      - DEPS
       - dev/bots/**
 
   - name: Windows windows_startup_test


### PR DESCRIPTION
This was done with `sed` and some manual massaging.

Closes https://github.com/flutter/flutter/issues/160703.

/cc @aam, after this lands we can resume Dart SDK rolls.