### PR TITLE
Clarify where `gclient` is run from.

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -6,7 +6,7 @@ Flutter engine uses `gclient` to manage dependencies.
 
 If you've already cloned the flutter repository:
 
-1. Copy one of the `engine/scripts/*.gclient` to the root folder as `.gclient`:
+1. Copy one of the `engine/scripts/*.gclient` to the [root](../) folder as `.gclient`:
     1. Googlers: copy `rbe.gclient` to enable faster builds with [RBE](https://github.com/flutter/flutter/blob/master/engine/src/flutter/docs/rbe/rbe.md)
     2. Everyone else: copy `standard.gclient`
-2. run `gclient sync` from the root folder
+2. run `gclient sync` from the [root](../) folder

--- a/engine/README.md
+++ b/engine/README.md
@@ -9,4 +9,4 @@ If you've already cloned the flutter repository:
 1. Copy one of the `engine/scripts/*.gclient` to the root folder as `.gclient`:
     1. Googlers: copy `rbe.gclient` to enable faster builds with [RBE](https://github.com/flutter/flutter/blob/master/engine/src/flutter/docs/rbe/rbe.md)
     2. Everyone else: copy `standard.gclient`
-2. run `gclient sync`
+2. run `gclient sync` from the root folder


### PR DESCRIPTION
If `gclient` is not run from the root errors occur such as: `Error: client not configured; see 'gclient config'`.