### PR TITLE
Bump `flutter_template_images` to remove TODO.

### DIFF
--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -179,7 +179,7 @@ class Template {
         for (final String name in names) templatePathProvider.directoryInPackage(name, fileSystem),
       ],
       <Directory>[
-        for (final String name in imageNames)
+        for (final String name in names)
           if ((await templatePathProvider.imageDirectory(name, fileSystem, logger)).existsSync())
             await templatePathProvider.imageDirectory(name, fileSystem, logger),
       ],

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -173,15 +173,6 @@ class Template {
     required Logger logger,
     required TemplateRenderer templateRenderer,
   }) async {
-    // TODO(matanl): Remove this once https://github.com/flutter/packages/pull/8336 is merged and published.
-    // See https://github.com/flutter/flutter/issues/160692.
-    final List<String> imageNames;
-    if (names.contains('app')) {
-      // Emulates what used to happen when app_shared existed. It still exist in package:flutter_template_images.
-      imageNames = <String>[...names, 'app_shared'];
-    } else {
-      imageNames = names;
-    }
     // All named templates are placed in the 'templates' directory
     return Template._(
       <Directory>[

--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -22,7 +22,7 @@ const Map<String, String> kManuallyPinnedDependencies = <String, String>{
   // Add pinned packages here. Please leave a comment explaining why.
   'archive': '3.6.1', // https://github.com/flutter/flutter/issues/115660
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
-  'flutter_template_images': '4.2.0', // Must always exactly match flutter_tools template.
+  'flutter_template_images': '4.3.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912
   'intl':
       '0.19.0', // 0.20.0 introduces new transitive dependencies that are not (yet) cleared in Flutter's allow list.

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -121,4 +121,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: fe3b
+# PUBSPEC CHECKSUM: 233c

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   crypto: 3.0.6
   ffi: 2.1.3
   file: 7.0.1
-  flutter_template_images: 4.2.0
+  flutter_template_images: 4.3.0
   html: 0.15.5
   http: 1.2.2
   intl: 0.19.0


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/160692.

Prior to `flutter_template_images: 4.3.0`, the `app_shared` directory was required.

In 4.3.0 it was forked back out to `app` (https://pub.dev/packages/flutter_template_images/changelog), as the `skeleton` template has been removed, and the `skeleton` template was the (only) reason for `app_shared` (to share code between `app` and `skeleton`).

This is a NOP change tested by existing tests.