### PR TITLE
**DO NOT MERGE**: Allow configuring whether `SurfaceProducer` automatically trims memory

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -222,6 +222,11 @@ public class FlutterRenderer implements TextureRegistry {
       imageReaderProducers.add(producer);
       Log.v(TAG, "New ImageReaderSurfaceProducer ID: " + id);
       entry = producer;
+
+      // If it is Android 14, there is a bug and background memory *must* be trimmed.
+      if (Build.VERSION.SDK_INT == API_LEVELS.API_34) {
+        producer.setTrimOnMemoryPressure(true);
+      }
     } else {
       // TODO(matanlurey): Actually have the class named "*Producer" to well, produce
       // something. This is a code smell, but does guarantee the paths for both
@@ -442,17 +447,12 @@ public class FlutterRenderer implements TextureRegistry {
     // Flip when debugging to see verbose logs.
     private static final boolean VERBOSE_LOGS = false;
 
-    // We must always cleanup on memory pressure on Android 14 due to a bug in Android.
-    // It is safe to do on all versions so we unconditionally have this set to true.
-    private static final boolean CLEANUP_ON_MEMORY_PRESSURE = true;
-
     private final long id;
 
     private boolean released;
     // Will be true in tests and on Android API < 33.
     private boolean ignoringFence = false;
-
-    private static final boolean trimOnMemoryPressure = CLEANUP_ON_MEMORY_PRESSURE;
+    private boolean trimOnMemoryPressure = false;
 
     // The requested width and height are updated by setSize.
     private int requestedWidth = 1;
@@ -701,6 +701,11 @@ public class FlutterRenderer implements TextureRegistry {
             });
       }
       return r;
+    }
+
+    @Override
+    public void setTrimOnMemoryPressure(boolean trimOnMemoryPressure) {
+      this.trimOnMemoryPressure = trimOnMemoryPressure;
     }
 
     @Override

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java
@@ -61,6 +61,11 @@ final class SurfaceTextureSurfaceProducer
   }
 
   @Override
+  public void setTrimOnMemoryPressure(boolean trimOnMemoryPressure) {
+    // Intentionally blank: SurfaceTextures don't listen to trim memory commands.
+  }
+
+  @Override
   public boolean handlesCropAndRotation() {
     return true;
   }

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -986,6 +986,14 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
       TextureRegistry textureRegistry) {
     if (enableSurfaceProducerRenderTarget && Build.VERSION.SDK_INT >= API_LEVELS.API_29) {
       final TextureRegistry.SurfaceProducer textureEntry = textureRegistry.createSurfaceProducer();
+
+      // TODO(matanlurey): Prior to refactors, ImageReaderSurfaceProducer, which is what is
+      // created when using createSurfaceProducer() on >= API 29, always (unconditionally) trimmed
+      // on memory pressure. Setting this flag manually preserves that behavior, and if future
+      // investigation discovers it is not needed, it can be removed (or this TODO can be replaced
+      // with more confident messaging).
+      textureEntry.setTrimOnMemoryPressure(true);
+
       Log.i(TAG, "PlatformView is using SurfaceProducer backend");
       return new SurfaceProducerPlatformViewRenderTarget(textureEntry);
     }

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -103,6 +103,15 @@ public interface TextureRegistry {
      */
     void setCallback(Callback callback);
 
+    /**
+     * Sets whether to trim memory automatically when memory pressure signals are received.
+     *
+     * <p>On Android 14, the default is <code>true</code>.</p>
+     *
+     * @param trimOnMemoryPressure <code>true</code> to trim.
+     */
+    void setTrimOnMemoryPressure(boolean trimOnMemoryPressure);
+
     /** Callback invoked by {@link #setCallback(Callback)}. */
     interface Callback {
       /**

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -106,7 +106,7 @@ public interface TextureRegistry {
     /**
      * Sets whether to trim memory automatically when memory pressure signals are received.
      *
-     * <p>On Android 14, the default is <code>true</code>.</p>
+     * <p>On Android 14, the default is <code>true</code>.
      *
      * @param trimOnMemoryPressure <code>true</code> to trim.
      */


### PR DESCRIPTION
This is a _path_ towards a _tentative_ fix for https://github.com/flutter/flutter/issues/156488.

The problem is that, for plugins such as `video_player_android`, it is valid to want a video to be playing (in the background) when the app is backgrounded - potentially other external texture based plugins could fall into this same pattern. The current (before this PR) behavior is that for API >= 29, when `TRIM_MEMORY_BACKGROUND` (or higher) is received, we cleanup `ImageReader` instances.

This PR attempts to make the behavior _configurable_, that is, exposes it as a `setXYZ` (we can play around with the method name). For discussion purposes only, I've made the default `false`, but also shown in the PR that if we are worried about regressing (untested) platform views, we can retain the old `true` behavior by setting the flag manually at the creation point.

I could imagine:

- We don't make this configurable and accept background videos will never be supported
- We make this configurable, but keep the default `true`. The `video_player` plugin can set it to `false` itself.
- We make this configurable, but change the default to `false`. Platform views/Android 14 can always set it to `true` (this PR).

Anyway, let's chat after holidays.

/cc @camsim99 @gmackall.