### PR TITLE
Omit hardcoded `--packages=.dart_tool/package_config.json`.

### DIFF
--- a/packages/flutter_tools/lib/src/test/test_golden_comparator.dart
+++ b/packages/flutter_tools/lib/src/test/test_golden_comparator.dart
@@ -112,7 +112,6 @@ final class TestGoldenComparator {
       _flutterTesterBinPath,
       '--disable-vm-service',
       '--non-interactive',
-      '--packages=${_fileSystem.path.join('.dart_tool', 'package_config.json')}',
       output,
     ];
 

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -400,7 +400,6 @@ void main() {
               'flutter_tester',
               '--disable-vm-service',
               '--non-interactive',
-              '--packages=.dart_tool/package_config.json',
               '',
             ],
             stdout: '{"success": true}\n',

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -396,12 +396,7 @@ void main() {
       () async {
         processManager.addCommand(
           const FakeCommand(
-            command: <String>[
-              'flutter_tester',
-              '--disable-vm-service',
-              '--non-interactive',
-              '',
-            ],
+            command: <String>['flutter_tester', '--disable-vm-service', '--non-interactive', ''],
             stdout: '{"success": true}\n',
           ),
         );

--- a/packages/flutter_tools/test/general.shard/test/test_golden_comparator_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_golden_comparator_test.dart
@@ -222,7 +222,6 @@ FakeCommand _fakeFluterTester(
       pathToBinTool,
       '--disable-vm-service',
       '--non-interactive',
-      '--packages=.dart_tool/package_config.json',
       'compiler_output',
     ],
     stdout: stdout,


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/160219.

This hard-coded package configuration is no longer strictly correct as-of Dart 3.6.0; a pub _workspace_ (https://dart.dev/tools/pub/workspaces) can appear at a higher-level than a package, and if the package is part of the workspace, tooling is expected to (automatically) find `.dart_tool/package_config.json` at a higher-level.

For example, the _engine_ sub-repo uses a [workspace](https://github.com/flutter/flutter/blob/9fd5bddc65c3616a5a0ba9af44e1bd7fe8c99c1d/engine/src/flutter/pubspec.yaml#L82), which means that, for example, `%ENGINE%/tools/engine_tool/.dart_tool/package_config.json` will _never_ exist (it will be at `%ENGINE%/.dart_tools/package_config.json`.

As currently defined, the test-golden comparator interface will fail with a package that uses workspaces. By removing the flag (and letting automatic `--packages` resolution occur), I _believe_ the problem is automatically resolved (but I'll let CI prove that for us).