### PR TITLE
Mark flavors_test_macos unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3975,7 +3975,6 @@ targets:
       - DEPS
 
   - name: Mac flavors_test_macos
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/156943
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60


### PR DESCRIPTION
This should have been marked unflaky when https://github.com/flutter/flutter/issues/156943 was closed.
