### PR TITLE
Mark analyzer_benchmark unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -362,7 +362,6 @@ targets:
   # are intentionally running it in the devicelab to ensure that it does not
   # run on a VM in order to avoid noisy results from the benchmark.
   - name: Linux analyzer_benchmark
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/158243
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:


### PR DESCRIPTION
This should have been marked unflaky when https://github.com/flutter/flutter/issues/158243 was closed.
