### PR TITLE
Mark hello_world_macos__compile unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4204,7 +4204,6 @@ targets:
       - DEPS
 
   - name: Mac_benchmark hello_world_macos__compile
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/159542
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60


### PR DESCRIPTION
This should have been marked unflaky when https://github.com/flutter/flutter/issues/159542 was closed.