### PR TITLE
Mark integration_ui_test_test_macos unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4212,7 +4212,6 @@ targets:
       task_name: hello_world_macos__compile
 
   - name: Mac integration_ui_test_test_macos
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/152212
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
This should have been marked unflaky when https://github.com/flutter/flutter/issues/152212 was closed.