### PR TITLE
Mark firebase_release_smoke_test unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -647,7 +647,6 @@ targets:
 
   - name: Linux firebase_release_smoke_test
     recipe: firebaselab/firebaselab
-    bringup: true # https://github.com/flutter/flutter/issues/147335
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
`firebase_release_smoke_test` was [marked flaky](https://github.com/flutter/flutter/pull/147338) due to a firebase outage in April. 
`firebase_android_embedding_v2_smoke_test` was deleted with https://github.com/flutter/flutter/pull/158223.
`firebase_abstract_method_smoke_test` was deleted with #159145

Closes https://github.com/flutter/flutter/issues/147335.