### PR TITLE
Update `flutter_template_images` to `5.0.0`.

### DIFF
--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -22,7 +22,7 @@ const Map<String, String> kManuallyPinnedDependencies = <String, String>{
   // Add pinned packages here. Please leave a comment explaining why.
   'archive': '3.6.1', // https://github.com/flutter/flutter/issues/115660
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
-  'flutter_template_images': '4.3.0', // Must always exactly match flutter_tools template.
+  'flutter_template_images': '5.0.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912
   'intl':
       '0.19.0', // 0.20.0 introduces new transitive dependencies that are not (yet) cleared in Flutter's allow list.

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   crypto: 3.0.6
   ffi: 2.1.3
   file: 7.0.1
-  flutter_template_images: 4.3.0
+  flutter_template_images: 5.0.0
   html: 0.15.5
   http: 1.2.2
   intl: 0.19.0
@@ -121,4 +121,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 9a42
+# PUBSPEC CHECKSUM: 5640


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/160692.

All references of `skeleton` and `app_shared` have been completely removed, including in `flutter_template_images`.

See https://github.com/flutter/packages/pull/8360.