### PR TITLE
Use the in-tree engine by default when using `--local-engine` or `--local-web-sdk`

### DIFF
--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -18,12 +18,9 @@ import '../dart/package_map.dart';
 /// The flutter tool can be run with the output files of one or more engine builds
 /// replacing the cached artifacts. Typically this is done by setting the
 /// `--local-engine` command line flag to the name of the desired engine variant
-/// (e.g. "host_debug_unopt"). Provided that the `flutter/` and `engine/` directories
-/// are located adjacent to one another, the output folder will be located
-/// automatically.
-///
-/// For scenarios where the engine is not adjacent to flutter, the
-/// `--local-engine-src-path` can be provided to give an exact path.
+/// (e.g. "host_debug_unopt"). The `--local-engine-src-path` can be provided to
+/// give an exact path to the engine subtree. If it is not specified, the `engine`
+/// subfolder in this repository is used.
 ///
 /// For more information on local engines, see README.md.
 class LocalEngineLocator {
@@ -77,7 +74,7 @@ class LocalEngineLocator {
 
       // If engineSourcePath is still not set, try to determine it by flutter root.
       engineSourcePath ??= _tryEnginePath(
-        _fileSystem.path.join(_fileSystem.directory(_flutterRoot).parent.path, 'engine', 'src'),
+        _fileSystem.path.join(_fileSystem.directory(_flutterRoot).path, 'engine', 'src'),
       );
     }
 

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/runner/local_engine.dart';
 
 import '../../src/common.dart';
 
-const String kEngineRoot = '/flutter/engine';
+const String kEngineRoot = '/flutter/flutter/engine';
 const String kArbitraryEngineRoot = '/arbitrary/engine';
 const String kPackageConfig = '.dart_tool/package_config.json';
 
@@ -372,11 +372,11 @@ void main() {
         localHostEngine: 'host_debug',
       ),
       matchesEngineBuildPaths(
-        hostEngine: 'flutter/engine/src/out/host_debug',
-        targetEngine: 'flutter/engine/src/out/ios_debug',
+        hostEngine: 'flutter/flutter/engine/src/out/host_debug',
+        targetEngine: 'flutter/flutter/engine/src/out/ios_debug',
       ),
     );
-    expect(logger.traceText, contains('Local engine source at flutter/engine/src'));
+    expect(logger.traceText, contains('Local engine source at flutter/flutter/engine/src'));
   });
 
   testWithoutContext('fails if --local-engine is specified and --local-engine-src-path '


### PR DESCRIPTION
Now that we're in a monorepo, it makes sense to use the in-tree engine by default when using `--local-engine` or `--local-web-sdk` rather than looking for a sibling directory like we used to.