### PR TITLE
Fix broken link to Hot Reload gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Information on how to get started can be found in our
 [Material]: https://docs.flutter.dev/development/ui/widgets/material
 [Skia]: https://skia.org/
 [Dart platform]: https://dart.dev/
-[Hot reload animation]: https://github.com/flutter/website/blob/main/src/assets/images/docs/tools/android-studio/hot-reload.gif?raw=true
+[Hot reload animation]: https://github.com/flutter/website/blob/main/src/content/assets/images/docs/tools/android-studio/hot-reload.gif?raw=true
 [Hot reload]: https://docs.flutter.dev/development/tools/hot-reload
 [Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter
 [IntelliJ / Android Studio]: https://plugins.jetbrains.com/plugin/9212-flutter


### PR DESCRIPTION
Something looked off in the README.