### PR TITLE
Updated eglConfigChoose error message and error clause.

### DIFF
--- a/engine/src/flutter/impeller/toolkit/egl/display.cc
+++ b/engine/src/flutter/impeller/toolkit/egl/display.cc
@@ -163,7 +163,6 @@ std::unique_ptr<Config> Display::ChooseConfig(ConfigDescriptor config) const {
   }
 
   if (config_count_out < 1) {
-    FML_LOG(ERROR) << "`eglChooseConfig` responded with zero configs.";
     return nullptr;
   }
 

--- a/engine/src/flutter/impeller/toolkit/egl/display.cc
+++ b/engine/src/flutter/impeller/toolkit/egl/display.cc
@@ -161,8 +161,8 @@ std::unique_ptr<Config> Display::ChooseConfig(ConfigDescriptor config) const {
     return nullptr;
   }
 
-  if (config_count_out != 1u) {
-    IMPELLER_LOG_EGL_ERROR;
+  if (config_count_out < 1u) {
+    FML_LOG(ERROR) << "`eglChooseConfig` responded with zero configs."
     return nullptr;
   }
 

--- a/engine/src/flutter/impeller/toolkit/egl/display.cc
+++ b/engine/src/flutter/impeller/toolkit/egl/display.cc
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "flutter/fml/logging.h"
 #include "impeller/toolkit/egl/context.h"
 #include "impeller/toolkit/egl/surface.h"
 
@@ -161,7 +162,7 @@ std::unique_ptr<Config> Display::ChooseConfig(ConfigDescriptor config) const {
     return nullptr;
   }
 
-  if (config_count_out < 1u) {
+  if (config_count_out < 1) {
     FML_LOG(ERROR) << "`eglChooseConfig` responded with zero configs.";
     return nullptr;
   }

--- a/engine/src/flutter/impeller/toolkit/egl/display.cc
+++ b/engine/src/flutter/impeller/toolkit/egl/display.cc
@@ -162,7 +162,7 @@ std::unique_ptr<Config> Display::ChooseConfig(ConfigDescriptor config) const {
   }
 
   if (config_count_out < 1u) {
-    FML_LOG(ERROR) << "`eglChooseConfig` responded with zero configs."
+    FML_LOG(ERROR) << "`eglChooseConfig` responded with zero configs.";
     return nullptr;
   }
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/160806

- The error message will never say success anymore.
- The error clause is slightly more permissive.  If this resolves the issue though, the driver for the emulator has a bug in it since it shouldn't return `success` and zero configs.  It's probably just indicating that it successfully found zero apropos configs.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
