### PR TITLE
[Engine] Make `SkiaGoldClient` a NOP when the branch is not `main` or `master`.

### DIFF
--- a/engine/src/flutter/testing/skia_gold_client/test/skia_gold_client_test.dart
+++ b/engine/src/flutter/testing/skia_gold_client/test/skia_gold_client_test.dart
@@ -20,6 +20,7 @@ void main() {
 
   /// Simulating what a presubmit environment would look like.
   const Map<String, String> presubmitEnv = <String, String>{
+    'GIT_BRANCH': 'master',
     'GOLDCTL': 'python tools/goldctl.py',
     'GOLD_TRYJOB': 'flutter/engine/1234567890',
     'LOGDOG_STREAM_PREFIX': 'buildbucket/cr-buildbucket.appspot.com/1234567890/+/logdog',
@@ -28,6 +29,7 @@ void main() {
 
   /// Simulating what a postsubmit environment would look like.
   const Map<String, String> postsubmitEnv = <String, String>{
+    'GIT_BRANCH': 'master',
     'GOLDCTL': 'python tools/goldctl.py',
     'LOGDOG_STREAM_PREFIX': 'buildbucket/cr-buildbucket.appspot.com/1234567890/+/logdog',
     'LUCI_CONTEXT': '{}',
@@ -82,6 +84,74 @@ void main() {
       } on StateError catch (error) {
         expect('$error', contains('GOLDCTL is not set'));
       }
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  test('prints a warning and skips when the git branch is not master or main', () async {
+    final _TestFixture fixture = _TestFixture();
+    try {
+      final SkiaGoldClient client = createClient(
+        fixture,
+        environment: {...presubmitEnv, 'GIT_BRANCH': 'merge-queue-foo'},
+        onRun: (List<String> command) {
+          expect(command, <String>[
+            'python tools/goldctl.py',
+            'auth',
+            '--work-dir',
+            p.join(fixture.workDirectory.path, 'temp'),
+            '--luci',
+          ]);
+          createAuthOptDotJson(fixture.workDirectory.path);
+          return io.ProcessResult(0, 0, '', '');
+        },
+      );
+
+      // In case we change our mind, auth is still expected to work.
+      await client.auth();
+
+      expect(
+        fixture.outputSink.toString(),
+        stringContainsInOrder([
+          'Current git branch',
+          'merge-queue-foo',
+          'is not "main" or "master"',
+        ]),
+      );
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  test('always a success when the git branch is not master or main', () async {
+    final _TestFixture fixture = _TestFixture();
+    try {
+      final SkiaGoldClient client = createClient(
+        fixture,
+        environment: {...presubmitEnv, 'GIT_BRANCH': 'merge-queue-foo'},
+        onRun: (List<String> command) {
+          expect(command, <String>[
+            'python tools/goldctl.py',
+            'auth',
+            '--work-dir',
+            p.join(fixture.workDirectory.path, 'temp'),
+            '--luci',
+          ]);
+          createAuthOptDotJson(fixture.workDirectory.path);
+          return io.ProcessResult(0, 0, '', '');
+        },
+      );
+
+      // In case we change our mind, auth is still expected to work.
+      await client.auth();
+
+      // Always completes OK.
+      await client.addImg(
+        'test-name.foo',
+        io.File(p.join(fixture.workDirectory.path, 'temp', 'golden.png')),
+        screenshotSize: 1000,
+      );
     } finally {
       fixture.dispose();
     }


### PR DESCRIPTION
Unblocks https://github.com/flutter/flutter/pull/160556.

Currently the merge queue runs in post-submit mode, which looks for (and fails to find) digests for PRs that have not yet been submitted, blocking the engine goldens from being enabled/checked in https://github.com/flutter/flutter/pull/160556. This PR is a proposal to fix that by skipping the tests.

We might decide instead that tests should not be running in the merge queue at all, in which case we will _not_ merge this PR and will change how the merge queue works instead. Otherwise this PR is a proof of concept of [aligning implementations with the framework](https://github.com/flutter/flutter/blob/a9b3f6c042d2c24d183a5d0cdc616dab00b8e700/packages/flutter_goldens/lib/flutter_goldens.dart#L338).