### PR TITLE
Rename `shellPath` to `flutterTesterBinPath`.

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -51,7 +51,7 @@ Future<void> run(List<String> args) async {
   final ArgParser parser =
       ArgParser()
         ..addOption(_kOptionPackages, help: 'The .packages file')
-        ..addOption(_kOptionShell, help: 'The Flutter shell binary')
+        ..addOption(_kOptionShell, help: 'The flutter_tester binary')
         ..addOption(_kOptionTestDirectory, help: 'Directory containing the tests')
         ..addOption(_kOptionSdkRoot, help: 'Path to the SDK platform files')
         ..addOption(_kOptionIcudtl, help: 'Path to the ICU data file')
@@ -83,9 +83,10 @@ Future<void> run(List<String> args) async {
   try {
     Cache.flutterRoot = tempDir.path;
 
-    final String shellPath = globals.fs.file(argResults[_kOptionShell]).resolveSymbolicLinksSync();
-    if (!globals.fs.isFileSync(shellPath)) {
-      throwToolExit('Cannot find Flutter shell at $shellPath');
+    final String flutterTesterBinPath =
+        globals.fs.file(argResults[_kOptionShell]).resolveSymbolicLinksSync();
+    if (!globals.fs.isFileSync(flutterTesterBinPath)) {
+      throwToolExit('Cannot find Flutter shell at $flutterTesterBinPath');
     }
 
     final Directory sdkRootSrc = globals.fs.directory(argResults[_kOptionSdkRoot]);
@@ -106,7 +107,7 @@ Future<void> run(List<String> args) async {
     final Artifacts artifacts = globals.artifacts!;
     final Link testerDestLink = globals.fs.link(artifacts.getArtifactPath(Artifact.flutterTester));
     testerDestLink.parent.createSync(recursive: true);
-    testerDestLink.createSync(globals.fs.path.absolute(shellPath));
+    testerDestLink.createSync(globals.fs.path.absolute(flutterTesterBinPath));
 
     final Directory sdkRootDest = globals.fs.directory(
       artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -56,7 +56,7 @@ typedef PlatformPluginRegistration = void Function(FlutterPlatform platform);
 /// main()`), you can set a VM Service port explicitly.
 FlutterPlatform installHook({
   TestWrapper testWrapper = const TestWrapper(),
-  required String shellPath,
+  required String flutterTesterBinPath,
   required DebuggingOptions debuggingOptions,
   required BuildInfo buildInfo,
   required FileSystem fileSystem,
@@ -91,7 +91,7 @@ FlutterPlatform installHook({
     });
   };
   final FlutterPlatform platform = FlutterPlatform(
-    shellPath: shellPath,
+    flutterTesterBinPath: flutterTesterBinPath,
     debuggingOptions: debuggingOptions,
     watcher: watcher,
     machine: machine,
@@ -298,7 +298,7 @@ typedef Finalizer = Future<void> Function();
 /// The flutter test platform used to integrate with package:test.
 class FlutterPlatform extends PlatformPlugin {
   FlutterPlatform({
-    required this.shellPath,
+    required this.flutterTesterBinPath,
     required this.debuggingOptions,
     required this.buildInfo,
     required this.logger,
@@ -322,7 +322,7 @@ class FlutterPlatform extends PlatformPlugin {
     this.shutdownHooks,
   }) {
     _testGoldenComparator = TestGoldenComparator(
-      flutterTesterBinPath: shellPath,
+      flutterTesterBinPath: flutterTesterBinPath,
       compilerFactory:
           () =>
               compiler ??
@@ -333,7 +333,7 @@ class FlutterPlatform extends PlatformPlugin {
     );
   }
 
-  final String shellPath;
+  final String flutterTesterBinPath;
   final DebuggingOptions debuggingOptions;
   final TestWatcher? watcher;
   final bool? enableVmService;
@@ -496,7 +496,7 @@ class FlutterPlatform extends PlatformPlugin {
       fileSystem: globals.fs,
       processManager: globals.processManager,
       logger: globals.logger,
-      shellPath: shellPath,
+      flutterTesterBinPath: flutterTesterBinPath,
       enableVmService: enableVmService!,
       machine: machine,
       debuggingOptions: debuggingOptions,

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -33,7 +33,7 @@ class FlutterTesterTestDevice extends TestDevice {
     required this.fileSystem,
     required this.processManager,
     required this.logger,
-    required this.shellPath,
+    required this.flutterTesterBinPath,
     required this.debuggingOptions,
     required this.enableVmService,
     required this.machine,
@@ -54,7 +54,7 @@ class FlutterTesterTestDevice extends TestDevice {
   final FileSystem fileSystem;
   final ProcessManager processManager;
   final Logger logger;
-  final String shellPath;
+  final String flutterTesterBinPath;
   final DebuggingOptions debuggingOptions;
   final bool enableVmService;
   final bool? machine;
@@ -89,7 +89,7 @@ class FlutterTesterTestDevice extends TestDevice {
     _server = await bind(host, /*port*/ 0);
     logger.printTrace('test $id: test harness socket server is running at port:${_server!.port}');
     final List<String> command = <String>[
-      shellPath,
+      flutterTesterBinPath,
       if (enableVmService) ...<String>[
         // Some systems drive the _FlutterPlatform class in an unusual way, where
         // only one test file is processed at a time, and the operating

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -218,7 +218,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
 
     final loader.FlutterPlatform platform = loader.installHook(
       testWrapper: testWrapper,
-      shellPath: flutterTesterBinPath,
+      flutterTesterBinPath: flutterTesterBinPath,
       debuggingOptions: debuggingOptions,
       watcher: watcher,
       enableVmService: enableVmService,

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -49,7 +49,7 @@ void main() {
       'explicitVmServicePort is specified and more than one test file',
       () async {
         final FlutterPlatform flutterPlatform = FlutterPlatform(
-          shellPath: '/',
+          flutterTesterBinPath: '/',
           debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, hostVmServicePort: 1234),
           enableVmService: false,
           buildInfo: BuildInfo.debug,
@@ -76,7 +76,7 @@ void main() {
       () {
         final FlutterPlatform flutterPlatform = FlutterPlatform(
           debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-          shellPath: '/',
+          flutterTesterBinPath: '/',
           precompiledDillPath: 'example.dill',
           enableVmService: false,
           buildInfo: BuildInfo.debug,
@@ -103,7 +103,7 @@ void main() {
         final _UnstartableDevice testDevice = _UnstartableDevice();
         final FlutterPlatform flutterPlatform = FlutterPlatform(
           debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-          shellPath: '/',
+          flutterTesterBinPath: '/',
           enableVmService: false,
           integrationTestDevice: testDevice,
           flutterProject: _FakeFlutterProject(),
@@ -146,7 +146,7 @@ void main() {
         final ShutdownHooks shutdownHooks = ShutdownHooks();
         final FlutterPlatform flutterPlatform = FlutterPlatform(
           debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
-          shellPath: '/',
+          flutterTesterBinPath: '/',
           enableVmService: false,
           integrationTestDevice: testDevice,
           flutterProject: _FakeFlutterProject(),
@@ -178,7 +178,7 @@ void main() {
     testUsingContext('installHook creates a FlutterPlatform', () {
       expect(
         () => installHook(
-          shellPath: 'abc',
+          flutterTesterBinPath: 'abc',
           debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, startPaused: true),
           buildInfo: BuildInfo.debug,
           fileSystem: fileSystem,
@@ -190,7 +190,7 @@ void main() {
 
       expect(
         () => installHook(
-          shellPath: 'abc',
+          flutterTesterBinPath: 'abc',
           debuggingOptions: DebuggingOptions.enabled(
             BuildInfo.debug,
             startPaused: true,
@@ -207,7 +207,7 @@ void main() {
       FlutterPlatform? capturedPlatform;
       final Map<String, String> expectedPrecompiledDillFiles = <String, String>{'Key': 'Value'};
       final FlutterPlatform flutterPlatform = installHook(
-        shellPath: 'abc',
+        flutterTesterBinPath: 'abc',
         debuggingOptions: DebuggingOptions.enabled(
           BuildInfo.debug,
           startPaused: true,
@@ -232,7 +232,7 @@ void main() {
       );
 
       expect(identical(capturedPlatform, flutterPlatform), equals(true));
-      expect(flutterPlatform.shellPath, equals('abc'));
+      expect(flutterPlatform.flutterTesterBinPath, equals('abc'));
       expect(flutterPlatform.debuggingOptions.buildInfo, equals(BuildInfo.debug));
       expect(flutterPlatform.debuggingOptions.startPaused, equals(true));
       expect(flutterPlatform.debuggingOptions.disableServiceAuthCodes, equals(true));
@@ -346,7 +346,7 @@ void main() {
         const Device? notAnIntegrationTest = null;
         final FlutterPlatform flutterPlatform = FlutterPlatform(
           debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
-          shellPath: 'flutter_tester',
+          flutterTesterBinPath: 'flutter_tester',
           enableVmService: false,
           // ignore: avoid_redundant_argument_values
           integrationTestDevice: notAnIntegrationTest,
@@ -404,7 +404,7 @@ void main() {
 
         final FlutterPlatform flutterPlatform = FlutterPlatform(
           debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
-          shellPath: 'flutter_tester',
+          flutterTesterBinPath: 'flutter_tester',
           enableVmService: false,
           flutterProject: flutterProject,
           integrationTestDevice: _WorkingDevice(),

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -333,7 +333,7 @@ class TestFlutterTesterDevice extends FlutterTesterTestDevice {
     super.flutterProject,
   }) : super(
          id: 999,
-         shellPath: '/',
+         flutterTesterBinPath: '/',
          logger: BufferLogger.test(),
          debuggingOptions: DebuggingOptions.enabled(
            const BuildInfo(


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/160462.

Maybe there are people who consider `flutter_tester` as the flutter "shell", but this is more explicit.