### PR TITLE
Fixed repeated strings for incompatible Gradle or AGP version in `create` command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -1156,8 +1156,7 @@ String getIncompatibleJavaGradleAgpMessageHeader(
 The configured version of Java detected may conflict with the $incompatibleDependency version in your new Flutter $projectType.
 
 To keep the default AGP version $incompatibleDependencyVersion, download a compatible Java version
-(Java 17 <= $validJavaRangeMessage Java version < Java 21). Configure this Java version
-globally for Flutter by running:
+$validJavaRangeMessage. Configure this Java version globally for Flutter by running:
 
   flutter config --jdk-dir=<JDK_DIRECTORY>
 ''';

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -1155,7 +1155,7 @@ String getIncompatibleJavaGradleAgpMessageHeader(
   return '''
 The configured version of Java detected may conflict with the $incompatibleDependency version in your new Flutter $projectType.
 
-To keep the default AGP version $incompatibleDependencyVersion, download a compatible Java version
+To keep the default $incompatibleDependencyVersion, download a compatible Java version
 $validJavaRangeMessage. Configure this Java version globally for Flutter by running:
 
   flutter config --jdk-dir=<JDK_DIRECTORY>

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -4457,6 +4457,44 @@ void main() {
     overrides: <Type, Generator>{Java: () => null, Logger: () => logger},
   );
 
+  testUsingContext('should return correct warning for incompatible Gradle versions', () async {
+    const String projectType = 'app';
+    final String gradleConflict = getIncompatibleJavaGradleAgpMessageHeader(
+      false,
+      templateDefaultGradleVersion,
+      templateAndroidGradlePluginVersion,
+      projectType,
+    );
+
+    expect(
+      gradleConflict,
+      contains('''
+The configured version of Java detected may conflict with the Gradle version in your new Flutter $projectType.
+
+To keep the default Gradle version $templateDefaultGradleVersion, download a compatible Java version
+'''),
+    );
+  });
+
+  testUsingContext('should return correct warning for incompatible AGP versions', () async {
+    const String projectType = 'app';
+    final String agpConflict = getIncompatibleJavaGradleAgpMessageHeader(
+      true,
+      templateDefaultGradleVersion,
+      templateAndroidGradlePluginVersion,
+      projectType,
+    );
+
+    expect(
+      agpConflict,
+      contains('''
+The configured version of Java detected may conflict with the Android Gradle Plugin (AGP) version in your new Flutter $projectType.
+
+To keep the default AGP version $templateAndroidGradlePluginVersion, download a compatible Java version
+'''),
+    );
+  });
+
   testUsingContext(
     'should not show warning for incompatible Java/template Gradle versions when created project type is irrelevant',
     () async {


### PR DESCRIPTION
Fixed the repeated string which shows the compatible Java version in the create command.

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/143634ef-fb36-40ce-8934-a5237d574821" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
