### PR TITLE
fix: Avoid noise when image is decoded in CanvasKit

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/image_decoder.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/image_decoder.dart
@@ -114,6 +114,12 @@ abstract class BrowserImageDecoder implements ui.Codec {
           // Flutter doesn't give the developer a way to customize this, so if this
           // is an animated image we should prefer the animated track.
           preferAnimation: true.toJS,
+
+          // Workaround for https://github.com/flutter/flutter/issues/91093
+          // Both `desiredWidth` and `desiredHeight` must be smaller than the final
+          // displayed size, but also at least 1.
+          desiredWidth: 1.toJS,
+          desiredHeight: 1.toJS,
         ),
       );
 


### PR DESCRIPTION
fix #91093

When trying to display a high resolution image in a small area, CanvasKit adds noise. This problem is avoided by specifying `desiredWidth` and `desiredHeight`.

<details>

<summary>Sample app code</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MainApp());
}

class MainApp extends StatelessWidget {
  const MainApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: MyPage(),
    );
  }
}

class MyPage extends StatelessWidget {
  const MyPage({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: Image.network(
          'https://picsum.photos/id/167/1800/1800',
          width: 100,
          height: 100,
        ),
      ),
    );
  }
}
```

</details>

stable branch (flutter 3.27.1)

| html renderer | canvaskit |
| :---: | :---: |
| <img width="300" alt="stable_html" src="https://github.com/user-attachments/assets/1d08eb7f-23ba-4c68-9466-470170290a10" /> | <img width="300" alt="stable_canvaskit" src="https://github.com/user-attachments/assets/a89c4714-9b23-4de4-806c-033cbffe9233" /> |

Comparing canvaskit with the html renderer in flutter 3.27.1, we can see that noise is displayed in the canvaskit image. To make the issue clearer, a 1800x1800 image is displayed in a 100x100 area.

The `desiredWidth` and `desiredHeight` would result in the following table.

| 1 | 99 | 999 | 9999 | 9999999 | 0 | null |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| <img width="300" alt="1" src="https://github.com/user-attachments/assets/d0da8727-90b0-4153-b0ab-14ca44874850" /> | <img width="300" alt="99" src="https://github.com/user-attachments/assets/16f915ca-4ee9-4c2e-8686-fc9de2ad2171" /> | <img width="300" alt="999" src="https://github.com/user-attachments/assets/9d288644-6c34-4285-be1a-48ea6f92111e" /> | <img width="300" alt="9999" src="https://github.com/user-attachments/assets/b43571dc-31b1-4cad-9575-8a963ebd0ffb" /> | <img width="300" alt="9999999" src="https://github.com/user-attachments/assets/08d2a064-5626-4341-9bac-9a4dd18767cb" /> | <img width="300" alt="0" src="https://github.com/user-attachments/assets/3847893a-fc4b-4c0b-bd85-2db6515e17c9" /> | <img width="300" alt="null" src="https://github.com/user-attachments/assets/37c28feb-1d1b-4a6f-b278-4007c0331f09" /> |

Since the displayed area is 100x100, it can be seen that 1 and 99 images have no noise, while noise is added to those above 999. Larger than 100, and 0 and null images appear to have noise.

Based on the above, I specified 1 for `desiredWidth` and `desiredHeight`.

However, I could not find the internal implementation of the decoder from the [ImageDecoder docs](https://www.w3.org/TR/webcodecs/#imagedecoderinit-interface). For this reason, I would be very happy if someone familiar with this implementation could review it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
