### PR TITLE
Fix TextField intrinsic width when hint is not visible

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2731,6 +2731,7 @@ class InputDecoration {
     this.hintFadeDuration,
     @Deprecated(
       'Use maintainHintSize instead. '
+      'This will maintain both hint height and hint width. '
       'This feature was deprecated after v3.28.0-2.0.pre.',
     )
     this.maintainHintHeight = true,
@@ -2826,6 +2827,7 @@ class InputDecoration {
     this.hintFadeDuration,
     @Deprecated(
       'Use maintainHintSize instead. '
+      'This will maintain both hint height and hint width. '
       'This feature was deprecated after v3.28.0-2.0.pre.',
     )
     this.maintainHintHeight = true,
@@ -3113,6 +3115,7 @@ class InputDecoration {
   /// Defaults to true.
   @Deprecated(
     'Use maintainHintSize instead. '
+    'This will maintain both hint height and hint width. '
     'This feature was deprecated after v3.28.0-2.0.pre.',
   )
   final bool maintainHintHeight;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -563,6 +563,7 @@ class _Decoration {
     required this.borderGap,
     required this.alignLabelWithHint,
     required this.isDense,
+    required this.isEmpty,
     required this.visualDensity,
     this.icon,
     this.input,
@@ -586,6 +587,7 @@ class _Decoration {
   final _InputBorderGap borderGap;
   final bool alignLabelWithHint;
   final bool? isDense;
+  final bool? isEmpty;
   final VisualDensity visualDensity;
   final Widget? icon;
   final Widget? input;
@@ -617,6 +619,7 @@ class _Decoration {
         other.borderGap == borderGap &&
         other.alignLabelWithHint == alignLabelWithHint &&
         other.isDense == isDense &&
+        other.isEmpty == isEmpty &&
         other.visualDensity == visualDensity &&
         other.icon == icon &&
         other.input == input &&
@@ -641,6 +644,7 @@ class _Decoration {
     borderGap,
     alignLabelWithHint,
     isDense,
+    isEmpty,
     visualDensity,
     icon,
     input,
@@ -651,8 +655,7 @@ class _Decoration {
     prefixIcon,
     suffixIcon,
     helperError,
-    counter,
-    container,
+    Object.hash(counter, container),
   );
 }
 
@@ -1154,11 +1157,15 @@ class _RenderDecoration extends RenderBox
 
   @override
   double computeMinIntrinsicWidth(double height) {
+    final double contentWidth =
+        decoration.isEmpty ?? false
+            ? math.max(_minWidth(input, height), _minWidth(hint, height))
+            : _minWidth(input, height);
     return _minWidth(icon, height) +
         (prefixIcon != null ? prefixToInputGap : contentPadding.start) +
         _minWidth(prefixIcon, height) +
         _minWidth(prefix, height) +
-        math.max(_minWidth(input, height), _minWidth(hint, height)) +
+        contentWidth +
         _minWidth(suffix, height) +
         _minWidth(suffixIcon, height) +
         (suffixIcon != null ? inputToSuffixGap : contentPadding.end);
@@ -1166,11 +1173,15 @@ class _RenderDecoration extends RenderBox
 
   @override
   double computeMaxIntrinsicWidth(double height) {
+    final double contentWidth =
+        decoration.isEmpty ?? false
+            ? math.max(_maxWidth(input, height), _maxWidth(hint, height))
+            : _maxWidth(input, height);
     return _maxWidth(icon, height) +
         (prefixIcon != null ? prefixToInputGap : contentPadding.start) +
         _maxWidth(prefixIcon, height) +
         _maxWidth(prefix, height) +
-        math.max(_maxWidth(input, height), _maxWidth(hint, height)) +
+        contentWidth +
         _maxWidth(suffix, height) +
         _maxWidth(suffixIcon, height) +
         (suffixIcon != null ? inputToSuffixGap : contentPadding.end);
@@ -2573,6 +2584,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         borderGap: _borderGap,
         alignLabelWithHint: decoration.alignLabelWithHint ?? false,
         isDense: decoration.isDense,
+        isEmpty: isEmpty,
         visualDensity: themeData.visualDensity,
         icon: icon,
         input: input,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1028,7 +1028,6 @@ class _RenderDecoration extends RenderBox
         hint == null ? 0.0 : getBaseline(hint, boxConstraints.tighten(width: inputWidth));
 
     // The field can be occupied by a hint or by the input itself.
-    // If the hint is not visible do not use it to compute height.
     final double inputHeight = math.max(
       decoration.isEmpty || decoration.maintainHintSize ? hintSize.height : 0.0,
       inputSize.height,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1024,8 +1024,12 @@ class _RenderDecoration extends RenderBox
     final double hintBaseline =
         hint == null ? 0.0 : getBaseline(hint, boxConstraints.tighten(width: inputWidth));
 
-    // The field can be occupied by a hint or by the input itself
-    final double inputHeight = math.max(hintSize.height, inputSize.height);
+    // The field can be occupied by a hint or by the input itself.
+    // If the hint is not visible do not use it to compute height.
+    final double inputHeight = math.max(
+      decoration.isEmpty ? hintSize.height : 0.0,
+      inputSize.height,
+    );
     final double inputInternalBaseline = math.max(inputBaseline, hintBaseline);
 
     final double prefixBaseline = prefix == null ? 0.0 : getBaseline(prefix, contentConstraints);
@@ -1238,7 +1242,10 @@ class _RenderDecoration extends RenderBox
       width - prefixWidth - suffixWidth - prefixIconWidth - suffixIconWidth,
       0.0,
     );
-    final double inputHeight = _lineHeight(availableInputWidth, <RenderBox?>[input, hint]);
+    final double inputHeight = _lineHeight(availableInputWidth, <RenderBox?>[
+      input,
+      if (decoration.isEmpty) hint,
+    ]);
     final double inputMaxHeight = <double>[
       inputHeight,
       prefixHeight,
@@ -1578,7 +1585,9 @@ class _RenderDecoration extends RenderBox
     doPaint(suffix);
     doPaint(prefixIcon);
     doPaint(suffixIcon);
-    doPaint(hint);
+    if (decoration.isEmpty) {
+      doPaint(hint);
+    }
     doPaint(input);
     doPaint(helperError);
     doPaint(counter);

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -587,7 +587,7 @@ class _Decoration {
   final _InputBorderGap borderGap;
   final bool alignLabelWithHint;
   final bool? isDense;
-  final bool? isEmpty;
+  final bool isEmpty;
   final VisualDensity visualDensity;
   final Widget? icon;
   final Widget? input;
@@ -1158,7 +1158,7 @@ class _RenderDecoration extends RenderBox
   @override
   double computeMinIntrinsicWidth(double height) {
     final double contentWidth =
-        decoration.isEmpty ?? false
+        decoration.isEmpty
             ? math.max(_minWidth(input, height), _minWidth(hint, height))
             : _minWidth(input, height);
     return _minWidth(icon, height) +
@@ -1174,7 +1174,7 @@ class _RenderDecoration extends RenderBox
   @override
   double computeMaxIntrinsicWidth(double height) {
     final double contentWidth =
-        decoration.isEmpty ?? false
+        decoration.isEmpty
             ? math.max(_maxWidth(input, height), _maxWidth(hint, height))
             : _maxWidth(input, height);
     return _maxWidth(icon, height) +

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -565,6 +565,7 @@ class _Decoration {
     required this.isDense,
     required this.isEmpty,
     required this.visualDensity,
+    required this.maintainHintSize,
     this.icon,
     this.input,
     this.label,
@@ -589,6 +590,7 @@ class _Decoration {
   final bool? isDense;
   final bool isEmpty;
   final VisualDensity visualDensity;
+  final bool maintainHintSize;
   final Widget? icon;
   final Widget? input;
   final Widget? label;
@@ -621,6 +623,7 @@ class _Decoration {
         other.isDense == isDense &&
         other.isEmpty == isEmpty &&
         other.visualDensity == visualDensity &&
+        other.maintainHintSize == maintainHintSize &&
         other.icon == icon &&
         other.input == input &&
         other.label == label &&
@@ -646,6 +649,7 @@ class _Decoration {
     isDense,
     isEmpty,
     visualDensity,
+    maintainHintSize,
     icon,
     input,
     label,
@@ -654,8 +658,7 @@ class _Decoration {
     suffix,
     prefixIcon,
     suffixIcon,
-    helperError,
-    Object.hash(counter, container),
+    Object.hash(helperError, counter, container),
   );
 }
 
@@ -1027,7 +1030,7 @@ class _RenderDecoration extends RenderBox
     // The field can be occupied by a hint or by the input itself.
     // If the hint is not visible do not use it to compute height.
     final double inputHeight = math.max(
-      decoration.isEmpty ? hintSize.height : 0.0,
+      decoration.isEmpty || decoration.maintainHintSize ? hintSize.height : 0.0,
       inputSize.height,
     );
     final double inputInternalBaseline = math.max(inputBaseline, hintBaseline);
@@ -1162,7 +1165,7 @@ class _RenderDecoration extends RenderBox
   @override
   double computeMinIntrinsicWidth(double height) {
     final double contentWidth =
-        decoration.isEmpty
+        decoration.isEmpty || decoration.maintainHintSize
             ? math.max(_minWidth(input, height), _minWidth(hint, height))
             : _minWidth(input, height);
     return _minWidth(icon, height) +
@@ -1178,7 +1181,7 @@ class _RenderDecoration extends RenderBox
   @override
   double computeMaxIntrinsicWidth(double height) {
     final double contentWidth =
-        decoration.isEmpty
+        decoration.isEmpty || decoration.maintainHintSize
             ? math.max(_maxWidth(input, height), _maxWidth(hint, height))
             : _maxWidth(input, height);
     return _maxWidth(icon, height) +
@@ -2267,7 +2270,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 
     final TextStyle hintStyle = _getInlineHintStyle(themeData, defaults);
     final String? hintText = decoration.hintText;
-    final bool maintainHintHeight = decoration.maintainHintHeight;
+    final bool maintainHintSize = decoration.maintainHintSize;
     Widget? hint;
     if (decoration.hint != null || hintText != null) {
       final Widget hintWidget =
@@ -2284,7 +2287,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
           );
       final bool showHint = isEmpty && !_hasInlineLabel;
       hint =
-          maintainHintHeight
+          maintainHintSize
               ? AnimatedOpacity(
                 opacity: showHint ? 1.0 : 0.0,
                 duration: decoration.hintFadeDuration ?? _kHintFadeTransitionDuration,
@@ -2595,6 +2598,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         isDense: decoration.isDense,
         isEmpty: isEmpty,
         visualDensity: themeData.visualDensity,
+        maintainHintSize: maintainHintSize,
         icon: icon,
         input: input,
         label: label,
@@ -2725,7 +2729,12 @@ class InputDecoration {
     this.hintTextDirection,
     this.hintMaxLines,
     this.hintFadeDuration,
+    @Deprecated(
+      'Use maintainHintSize instead. '
+      'This feature was deprecated after v3.28.0-2.0.pre.',
+    )
     this.maintainHintHeight = true,
+    this.maintainHintSize = true,
     this.error,
     this.errorText,
     this.errorStyle,
@@ -2815,7 +2824,12 @@ class InputDecoration {
     this.hintTextDirection,
     this.hintMaxLines,
     this.hintFadeDuration,
+    @Deprecated(
+      'Use maintainHintSize instead. '
+      'This feature was deprecated after v3.28.0-2.0.pre.',
+    )
     this.maintainHintHeight = true,
+    this.maintainHintSize = true,
     this.filled = false,
     this.fillColor,
     this.focusColor,
@@ -3097,7 +3111,20 @@ class InputDecoration {
   /// it's not visible, if this flag is set to false.
   ///
   /// Defaults to true.
+  @Deprecated(
+    'Use maintainHintSize instead. '
+    'This feature was deprecated after v3.28.0-2.0.pre.',
+  )
   final bool maintainHintHeight;
+
+  /// Whether the input field's size should always be greater than or equal to
+  /// the size of the [hintText], even if the [hintText] is not visible.
+  ///
+  /// The [InputDecorator] widget ignores [hintText] during layout when
+  /// it's not visible, if this flag is set to false.
+  ///
+  /// Defaults to true.
+  final bool maintainHintSize;
 
   /// Optional widget that appears below the [InputDecorator.child] and the border.
   ///
@@ -3785,6 +3812,7 @@ class InputDecoration {
     Duration? hintFadeDuration,
     int? hintMaxLines,
     bool? maintainHintHeight,
+    bool? maintainHintSize,
     Widget? error,
     String? errorText,
     TextStyle? errorStyle,
@@ -3842,6 +3870,7 @@ class InputDecoration {
       hintMaxLines: hintMaxLines ?? this.hintMaxLines,
       hintFadeDuration: hintFadeDuration ?? this.hintFadeDuration,
       maintainHintHeight: maintainHintHeight ?? this.maintainHintHeight,
+      maintainHintSize: maintainHintSize ?? this.maintainHintSize,
       error: error ?? this.error,
       errorText: errorText ?? this.errorText,
       errorStyle: errorStyle ?? this.errorStyle,
@@ -3952,6 +3981,7 @@ class InputDecoration {
         other.hintMaxLines == hintMaxLines &&
         other.hintFadeDuration == hintFadeDuration &&
         other.maintainHintHeight == maintainHintHeight &&
+        other.maintainHintSize == maintainHintSize &&
         other.error == error &&
         other.errorText == errorText &&
         other.errorStyle == errorStyle &&
@@ -4012,6 +4042,7 @@ class InputDecoration {
       hintMaxLines,
       hintFadeDuration,
       maintainHintHeight,
+      maintainHintSize,
       error,
       errorText,
       errorStyle,
@@ -4070,6 +4101,7 @@ class InputDecoration {
       if (hintMaxLines != null) 'hintMaxLines: "$hintMaxLines"',
       if (hintFadeDuration != null) 'hintFadeDuration: "$hintFadeDuration"',
       if (!maintainHintHeight) 'maintainHintHeight: false',
+      if (!maintainHintSize) 'maintainHintSize: false',
       if (error != null) 'error: "$error"',
       if (errorText != null) 'errorText: "$errorText"',
       if (errorStyle != null) 'errorStyle: "$errorStyle"',

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4717,14 +4717,14 @@ void main() {
       expect(hintTextWidget.style!.overflow, decoration.hintStyle!.overflow);
     });
 
-    testWidgets('Widget height collapses from hint height when maintainHintHeight is false', (
+    testWidgets('Widget height collapses from hint height when maintainHintSize is false', (
       WidgetTester tester,
     ) async {
       final String hintText = 'hint' * 20;
       final InputDecoration decoration = InputDecoration(
         hintText: hintText,
         hintMaxLines: 3,
-        maintainHintHeight: false,
+        maintainHintSize: false,
       );
 
       await tester.pumpWidget(buildInputDecorator(decoration: decoration));
@@ -4741,14 +4741,14 @@ void main() {
       expect(inputHeight, hintHeight + 16.0);
     });
 
-    testWidgets('hintFadeDuration applies to hint fade-in when maintainHintHeight is false', (
+    testWidgets('hintFadeDuration applies to hint fade-in when maintainHintSize is false', (
       WidgetTester tester,
     ) async {
       const InputDecoration decoration = InputDecoration(
         hintText: hintText,
         hintMaxLines: 3,
         hintFadeDuration: Duration(milliseconds: 120),
-        maintainHintHeight: false,
+        maintainHintSize: false,
       );
 
       // Build once with empty content.
@@ -4773,14 +4773,14 @@ void main() {
       expect(hintOpacity120ms, 1.0);
     });
 
-    testWidgets('hintFadeDuration applies to hint fade-out when maintainHintHeight is false', (
+    testWidgets('hintFadeDuration applies to hint fade-out when maintainHintSize is false', (
       WidgetTester tester,
     ) async {
       const InputDecoration decoration = InputDecoration(
         hintText: hintText,
         hintMaxLines: 3,
         hintFadeDuration: Duration(milliseconds: 120),
-        maintainHintHeight: false,
+        maintainHintSize: false,
       );
 
       // Build once with empty content.
@@ -8390,26 +8390,52 @@ void main() {
     });
 
     // Regression test for https://github.com/flutter/flutter/issues/93337.
-    testWidgets('depends on content width when decorator is not empty', (
-      WidgetTester tester,
-    ) async {
-      const InputDecoration decorationWithHint = InputDecoration(
-        contentPadding: EdgeInsets.zero,
-        hintText: 'Hint',
-      );
-      const double contentWidth = 20.0;
+    testWidgets(
+      'depends on content width when decorator is not empty and maintainHintSize is false',
+      (WidgetTester tester) async {
+        const InputDecoration decorationWithHint = InputDecoration(
+          contentPadding: EdgeInsets.zero,
+          hintText: 'Hint',
+          maintainHintSize: false,
+        );
+        const double contentWidth = 20.0;
 
-      await tester.pumpWidget(
-        buildInputDecorator(
-          decoration: decorationWithHint,
-          useIntrinsicWidth: true,
-          child: const SizedBox(width: contentWidth),
-        ),
-      );
+        await tester.pumpWidget(
+          buildInputDecorator(
+            decoration: decorationWithHint,
+            useIntrinsicWidth: true,
+            child: const SizedBox(width: contentWidth),
+          ),
+        );
 
-      // The hint width is ignored even if larger than the content width.
-      expect(getDecoratorRect(tester).width, contentWidth);
-    });
+        // The hint width is ignored even if larger than the content width.
+        expect(getDecoratorRect(tester).width, contentWidth);
+      },
+    );
+
+    // Regression test for https://github.com/flutter/flutter/issues/93337.
+    testWidgets(
+      'depends on content width when decorator is not empty and maintainHintSize is true',
+      (WidgetTester tester) async {
+        const InputDecoration decorationWithHint = InputDecoration(
+          contentPadding: EdgeInsets.zero,
+          hintText: 'Hint',
+        );
+        const double contentWidth = 20.0;
+
+        await tester.pumpWidget(
+          buildInputDecorator(
+            decoration: decorationWithHint,
+            useIntrinsicWidth: true,
+            child: const SizedBox(width: contentWidth),
+          ),
+        );
+
+        // The hint width is ignored even if larger than the content width.
+        const double hintTextWidth = 66.0;
+        expect(getDecoratorRect(tester).width, hintTextWidth);
+      },
+    );
   });
 
   testWidgets('Ensure the height of labelStyle remains unchanged when TextField is focused', (

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -8352,6 +8352,64 @@ void main() {
 
       expect(textSizeWithIcons.width, equals(textSizeWithoutIcon.width));
     });
+
+    testWidgets('depends on hint width and content width when decorator is empty', (
+      WidgetTester tester,
+    ) async {
+      const InputDecoration decorationWithHint = InputDecoration(
+        contentPadding: EdgeInsets.zero,
+        hintText: 'Hint',
+      );
+      const double hintTextWidth = 66.0;
+      const double smallContentWidth = 20.0;
+      const double largeContentWidth = 80.0;
+
+      await tester.pumpWidget(
+        buildInputDecorator(
+          decoration: decorationWithHint,
+          useIntrinsicWidth: true,
+          isEmpty: true,
+          child: const SizedBox(width: smallContentWidth),
+        ),
+      );
+
+      // Decorator width depends on the hint because the hint is larger than the content.
+      expect(getDecoratorRect(tester).width, hintTextWidth);
+
+      await tester.pumpWidget(
+        buildInputDecorator(
+          decoration: decorationWithHint,
+          useIntrinsicWidth: true,
+          isEmpty: true,
+          child: const SizedBox(width: largeContentWidth),
+        ),
+      );
+
+      // Decorator width depends on the content because the content is larger than the hint.
+      expect(getDecoratorRect(tester).width, largeContentWidth);
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/93337.
+    testWidgets('depends on content width when decorator is not empty', (
+      WidgetTester tester,
+    ) async {
+      const InputDecoration decorationWithHint = InputDecoration(
+        contentPadding: EdgeInsets.zero,
+        hintText: 'Hint',
+      );
+      const double contentWidth = 20.0;
+
+      await tester.pumpWidget(
+        buildInputDecorator(
+          decoration: decorationWithHint,
+          useIntrinsicWidth: true,
+          child: const SizedBox(width: contentWidth),
+        ),
+      );
+
+      // The hint width is ignored even if larger than the content width.
+      expect(getDecoratorRect(tester).width, contentWidth);
+    });
   });
 
   testWidgets('Ensure the height of labelStyle remains unchanged when TextField is focused', (


### PR DESCRIPTION
## Description

This PR changes the TextField intrinsic width computation for non-empty TextField. 

Before:

When a TextField is non-empty, the intrinsic width can't be smaller than the hint width:

![image](https://github.com/user-attachments/assets/88c42a31-d83e-4eb8-8286-dce5b07ef089)


After:

The width does not depend on the hint when the TextField is non empty.

![image](https://github.com/user-attachments/assets/5b7380f8-4bc8-4d37-974e-0c8f5b08b185)


<details><summary>Code sample</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      title: 'Material App',
      home: Scaffold(
        body: Center(
          child: IntrinsicWidth(
            child: TextField(
              decoration: InputDecoration(
                filled: true,
                hintText: 'Moderately long hint text',
              ),
            ),
          ),
        ),
      ),
    );
  }
}

``` 

</details> 

## Related Issue

Fixes [[TextField] The computation of the intrinsic width of a TextField should include the hint width only when visible](https://github.com/flutter/flutter/issues/93337)

## Tests

Adds 2 tests.