### PR TITLE
Update plugin_lint_mac test to always use CocoaPods

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -9,8 +9,8 @@ import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
 
-/// Tests that the Flutter plugin template works. Use `pod lib lint`
-/// to confirm the plugin module can be imported into an app.
+/// Tests that the Flutter plugin template works using CocoaPods integration.
+/// Use `pod lib lint` to confirm the plugin module can be imported into an app.
 Future<void> main() async {
   await task(() async {
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_plugin_test.');
@@ -184,6 +184,15 @@ Future<void> main() async {
       final String objcAppPath = path.join(tempDir.path, objcAppName);
       final File objcPubspec = File(path.join(objcAppPath, 'pubspec.yaml'));
       String pubspecContent = objcPubspec.readAsStringSync();
+      // Use CocoaPods to build the app.
+      pubspecContent = pubspecContent.replaceFirst(
+        '# The following section is specific to Flutter packages.\n'
+            'flutter:\n',
+        '# The following section is specific to Flutter packages.\n'
+            'flutter:\n'
+            '\n'
+            '  disable-swift-package-manager: true\n',
+      );
       // Add (randomly selected) first-party plugins that support iOS and macOS.
       // Add the new plugins we just made.
       pubspecContent = pubspecContent.replaceFirst(


### PR DESCRIPTION
This updates the `plugin_lint_mac` devicelab test to always use CocoaPods. This test checks that plugins pass CocoaPods lints and that Flutter's CocoaPods integeration works as expected. 

These tests are very CocoaPods specific and don't make sense for Swift Package Manager. These tests should continue to use CocoaPods even if Swift Package Manager is on by default.

See this mini design doc: https://github.com/flutter/flutter/issues/151567#issuecomment-2455941279

Here's the PR that updates the SwiftPM docs: https://github.com/flutter/website/pull/11495

Part of https://github.com/flutter/flutter/issues/151567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
