### PR TITLE
Make the encoding of a `YamlNode` to a `String` more explicit.

### DIFF
--- a/packages/flutter_tools/lib/src/base/yaml.dart
+++ b/packages/flutter_tools/lib/src/base/yaml.dart
@@ -1,0 +1,13 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart' show YamlEditor;
+
+/// Converts a [YamlNode] to a valid YAML-formatted [String].
+String encodeYamlAsString(YamlNode contents) {
+  final YamlEditor editor = YamlEditor('');
+  editor.update(const <String>[], contents);
+  return editor.toString();
+}

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -16,6 +16,7 @@ import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/utils.dart';
 import 'base/version.dart';
+import 'base/yaml.dart';
 import 'bundle.dart' as bundle;
 import 'cmake_project.dart';
 import 'dart/package_map.dart';
@@ -317,9 +318,7 @@ class FlutterProject {
   /// sets [manifest] to the [updated] manifest.
   void replacePubspec(FlutterManifest updated) {
     final YamlMap updatedPubspecContents = updated.toYaml();
-    final YamlEditor editor = YamlEditor('');
-    editor.update(const <String>[], updatedPubspecContents);
-    pubspecFile.writeAsStringSync(editor.toString());
+    pubspecFile.writeAsStringSync(encodeYamlAsString(updatedPubspecContents));
     _manifest = updated;
   }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -5,7 +5,6 @@
 import 'package:meta/meta.dart';
 import 'package:xml/xml.dart';
 import 'package:yaml/yaml.dart';
-import 'package:yaml_edit/yaml_edit.dart';
 
 import '../src/convert.dart';
 import 'android/android_builder.dart';

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -7,9 +7,9 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/deferred_component.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/yaml.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
-import 'package:yaml_edit/yaml_edit.dart';
 
 import '../src/common.dart';
 
@@ -1512,9 +1512,7 @@ flutter:
       ],
     );
 
-    final YamlEditor editor = YamlEditor('');
-    editor.update(const <String>[], updatedManifest.toYaml());
-    expect(editor.toString(), '''
+    expect(encodeYamlAsString(updatedManifest.toYaml()), '''
 name: test
 dependencies:
   flutter:


### PR DESCRIPTION
It wasn't clear to me (or @bkonyi, in our [discussion](https://discord.com/channels/608014603317936148/1326246134238285929)) why `yaml_edit` was being used, and now it is!