### PR TITLE
[SwiftPM] Turn on by default

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -15,6 +15,10 @@ Future<void> main() async {
   await task(() async {
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_plugin_test.');
     try {
+      section('Use CocoaPods');
+
+      await flutter('config', options: <String>['--no-enable-swift-package-manager']);
+
       section('Lint integration_test');
 
       await inDirectory(tempDir, () async {

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -52,7 +52,7 @@ abstract class FeatureFlags {
   bool get isPreviewDeviceEnabled => true;
 
   /// Whether Swift Package Manager dependency management is enabled.
-  bool get isSwiftPackageManagerEnabled => false;
+  bool get isSwiftPackageManagerEnabled => true;
 
   /// Whether apps are automatically migrated to add Swift Package Manager
   /// integration. Requires [isSwiftPackageManagerEnabled].
@@ -174,13 +174,10 @@ const Feature previewDevice = Feature(
 );
 
 /// Enable Swift Package Manager as a darwin dependency manager.
-const Feature swiftPackageManager = Feature(
+const Feature swiftPackageManager = Feature.fullyEnabled(
   name: 'support for Swift Package Manager for iOS and macOS',
   configSetting: 'enable-swift-package-manager',
   environmentOverride: 'FLUTTER_SWIFT_PACKAGE_MANAGER',
-  master: FeatureChannelSetting(available: true),
-  beta: FeatureChannelSetting(available: true),
-  stable: FeatureChannelSetting(available: true),
 );
 
 /// Enable migrating iOS and macOS apps to add Swift Package Manager integration.

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -410,12 +410,12 @@ void main() {
 
     group('Swift Package Manager feature', () {
       testWithoutContext('availability and default enabled', () {
-        expect(swiftPackageManager.master.enabledByDefault, false);
-        expect(swiftPackageManager.master.available, true);
-        expect(swiftPackageManager.beta.enabledByDefault, false);
-        expect(swiftPackageManager.beta.available, true);
-        expect(swiftPackageManager.stable.enabledByDefault, false);
-        expect(swiftPackageManager.stable.available, true);
+        expect(swiftPackageManager.master.enabledByDefault, isTrue);
+        expect(swiftPackageManager.master.available, isTrue);
+        expect(swiftPackageManager.beta.enabledByDefault, isTrue);
+        expect(swiftPackageManager.beta.available, isTrue);
+        expect(swiftPackageManager.stable.enabledByDefault, isTrue);
+        expect(swiftPackageManager.stable.available, isTrue);
       });
 
       testWithoutContext('can be enabled', () {
@@ -427,12 +427,12 @@ void main() {
 
     group('Swift Package Manager app migration feature', () {
       testWithoutContext('availability and default enabled', () {
-        expect(swiftPackageManagerMigration.master.enabledByDefault, false);
-        expect(swiftPackageManagerMigration.master.available, true);
-        expect(swiftPackageManagerMigration.beta.enabledByDefault, false);
-        expect(swiftPackageManagerMigration.beta.available, true);
-        expect(swiftPackageManagerMigration.stable.enabledByDefault, false);
-        expect(swiftPackageManagerMigration.stable.available, true);
+        expect(swiftPackageManagerMigration.master.enabledByDefault, isFalse);
+        expect(swiftPackageManagerMigration.master.available, isTrue);
+        expect(swiftPackageManagerMigration.beta.enabledByDefault, isFalse);
+        expect(swiftPackageManagerMigration.beta.available, isTrue);
+        expect(swiftPackageManagerMigration.stable.enabledByDefault, isFalse);
+        expect(swiftPackageManagerMigration.stable.available, isTrue);
       });
 
       testWithoutContext('requires Swift Package Manager feature', () {


### PR DESCRIPTION
This turns on Swift Package Manager by default:

1. New apps will have Swift Package Manager integration
2. New plugins will support Swift Package Manager
3. Existing apps will continue to use CocoaPods. They can migrate to SwiftPM using `flutter config --enable-swift-package-manager-migration`.

See this mini design doc: https://github.com/flutter/flutter/issues/151567#issuecomment-2455941279

Here's the PR that updates the SwiftPM docs: https://github.com/flutter/website/pull/11495

Part of https://github.com/flutter/flutter/issues/151567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
