### PR TITLE
Directional focus edge traversal behavior.

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -42,6 +42,8 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
     super.fullscreenDialog,
     super.allowSnapshotting = true,
     super.barrierDismissible = false,
+    super.traversalEdgeBehavior,
+    super.directionalTraversalEdgeBehavior,
   }) {
     assert(opaque);
   }

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1357,6 +1357,7 @@ class FocusScopeNode extends FocusNode {
     super.skipTraversal,
     super.canRequestFocus,
     this.traversalEdgeBehavior = TraversalEdgeBehavior.closedLoop,
+    this.directionalTraversalEdgeBehavior = TraversalEdgeBehavior.stop,
   }) : super(descendantsAreFocusable: true);
 
   @override
@@ -1372,6 +1373,13 @@ class FocusScopeNode extends FocusNode {
   /// focus traversal takes place [FocusTraversalPolicy] will read this value
   /// and apply the new behavior.
   TraversalEdgeBehavior traversalEdgeBehavior;
+
+  /// Controls the directional transfer of focus when the focus is on the first or last item.
+  ///
+  /// Changing this field value has no immediate effect on the UI. Instead, next time
+  /// focus traversal takes place [FocusTraversalPolicy] will read this value
+  /// and apply the new behavior.
+  TraversalEdgeBehavior directionalTraversalEdgeBehavior;
 
   /// Returns true if this scope is the focused child of its parent scope.
   bool get isFirstFocus => enclosingScope!.focusedChild == this;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1255,6 +1255,12 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 /// {@macro flutter.widgets.navigator.routeTraversalEdgeBehavior}
 const TraversalEdgeBehavior kDefaultRouteTraversalEdgeBehavior = TraversalEdgeBehavior.parentScope;
 
+/// The default value of [Navigator.routeDirectionalTraversalEdgeBehavior].
+///
+/// {@macro flutter.widgets.navigator.routeTraversalEdgeBehavior}
+const TraversalEdgeBehavior kDefaultRouteDirectionalTraversalEdgeBehavior =
+    TraversalEdgeBehavior.stop;
+
 /// A widget that manages a set of child widgets with a stack discipline.
 ///
 /// Many apps have a navigator near the top of their widget hierarchy in order
@@ -1576,6 +1582,7 @@ class Navigator extends StatefulWidget {
     this.requestFocus = true,
     this.restorationScopeId,
     this.routeTraversalEdgeBehavior = kDefaultRouteTraversalEdgeBehavior,
+    this.routeDirectionalTraversalEdgeBehavior = kDefaultRouteDirectionalTraversalEdgeBehavior,
     this.onDidRemovePage,
   });
 
@@ -1723,6 +1730,12 @@ class Navigator extends StatefulWidget {
   /// not rendered by Flutter.
   /// {@endtemplate}
   final TraversalEdgeBehavior routeTraversalEdgeBehavior;
+
+  /// Controls the directional transfer of focus beyond the first and the last
+  /// items of a focus scope that defines focus traversal of widgets within a route.
+  ///
+  /// {@macro flutter.widgets.navigator.routeTraversalEdgeBehavior}
+  final TraversalEdgeBehavior routeDirectionalTraversalEdgeBehavior;
 
   /// The name for the default route of the application.
   ///

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -25,6 +25,8 @@ abstract class PageRoute<T> extends ModalRoute<T> {
   PageRoute({
     super.settings,
     super.requestFocus,
+    super.traversalEdgeBehavior,
+    super.directionalTraversalEdgeBehavior,
     this.fullscreenDialog = false,
     this.allowSnapshotting = true,
     bool barrierDismissible = false,

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1092,13 +1092,21 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
 
   void _updateFocusScopeNode() {
     final TraversalEdgeBehavior traversalEdgeBehavior;
+    final TraversalEdgeBehavior directionalTraversalEdgeBehavior;
     final ModalRoute<T> route = widget.route;
     if (route.traversalEdgeBehavior != null) {
       traversalEdgeBehavior = route.traversalEdgeBehavior!;
     } else {
       traversalEdgeBehavior = route.navigator!.widget.routeTraversalEdgeBehavior;
     }
+    if (route.directionalTraversalEdgeBehavior != null) {
+      directionalTraversalEdgeBehavior = route.directionalTraversalEdgeBehavior!;
+    } else {
+      directionalTraversalEdgeBehavior =
+          route.navigator!.widget.routeDirectionalTraversalEdgeBehavior;
+    }
     focusScopeNode.traversalEdgeBehavior = traversalEdgeBehavior;
+    focusScopeNode.directionalTraversalEdgeBehavior = directionalTraversalEdgeBehavior;
     if (route.isCurrent && _shouldRequestFocus) {
       route.navigator!.focusNode.enclosingScope?.setFirstFocus(focusScopeNode);
     }
@@ -1231,7 +1239,13 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
 ///  * [Route], which further documents the meaning of the `T` generic type argument.
 abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T> {
   /// Creates a route that blocks interaction with previous routes.
-  ModalRoute({super.settings, super.requestFocus, this.filter, this.traversalEdgeBehavior});
+  ModalRoute({
+    super.settings,
+    super.requestFocus,
+    this.filter,
+    this.traversalEdgeBehavior,
+    this.directionalTraversalEdgeBehavior,
+  });
 
   /// The filter to add to the barrier.
   ///
@@ -1244,6 +1258,12 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///
   /// If set to null, [Navigator.routeTraversalEdgeBehavior] is used.
   final TraversalEdgeBehavior? traversalEdgeBehavior;
+
+  /// Controls the directional transfer of focus beyond the first and the last
+  /// items of a [FocusScopeNode].
+  ///
+  /// If set to null, [Navigator.routeDirectionalTraversalEdgeBehavior] is used.
+  final TraversalEdgeBehavior? directionalTraversalEdgeBehavior;
 
   // The API for general users of this class
 
@@ -2295,7 +2315,13 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 ///   * [Navigator.pop], which is used to dismiss the route.
 abstract class PopupRoute<T> extends ModalRoute<T> {
   /// Initializes the [PopupRoute].
-  PopupRoute({super.settings, super.requestFocus, super.filter, super.traversalEdgeBehavior});
+  PopupRoute({
+    super.settings,
+    super.requestFocus,
+    super.filter,
+    super.traversalEdgeBehavior,
+    super.directionalTraversalEdgeBehavior,
+  });
 
   @override
   bool get opaque => false;
@@ -2497,6 +2523,7 @@ class RawDialogRoute<T> extends PopupRoute<T> {
     super.requestFocus,
     this.anchorPoint,
     super.traversalEdgeBehavior,
+    super.directionalTraversalEdgeBehavior,
   }) : _pageBuilder = pageBuilder,
        _barrierDismissible = barrierDismissible,
        _barrierLabel = barrierLabel,

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -3410,8 +3410,8 @@ void main() {
   });
 
   // This test creates a FocusScopeNode configured to traverse focus in a closed
-  // loop. After traversing one loop, it changes the behavior to leave the
-  // FlutterView, then verifies that the new behavior did indeed take effect.
+  // loop. After traversing one loop, it changes the behavior to `leaveFlutterView` and `stop`,
+  // then verifies that the new behavior did indeed take effect.
   testWidgets('FocusScopeNode.traversalEdgeBehavior takes effect after update', (
     WidgetTester tester,
   ) async {
@@ -3480,6 +3480,18 @@ void main() {
     expect(await nextFocus(), false);
     expect(nodeA.hasFocus, false);
     expect(nodeB.hasFocus, false);
+
+    // Change the behavior and verify that the new behavior is in effect.
+    scope.traversalEdgeBehavior = TraversalEdgeBehavior.stop;
+    expect(scope.traversalEdgeBehavior, TraversalEdgeBehavior.stop);
+
+    // B -> A, but stop at the edge
+    nodeB.requestFocus();
+    await tester.pump();
+    expect(nodeB.hasFocus, true);
+    expect(await nextFocus(), false);
+    expect(nodeA.hasFocus, false);
+    expect(nodeB.hasFocus, true);
 
     // Change the behavior back to closedLoop and verify it's in effect. Also,
     // this time traverse in the opposite direction.
@@ -3557,6 +3569,147 @@ void main() {
     RequestFocusAction().invoke(focusIntentWithCallback);
     await tester.pump();
     expect(calledCallback, isTrue);
+  });
+
+  testWidgets('Edge cases for inDirection', (WidgetTester tester) async {
+    List<bool?> focus = List<bool?>.generate(6, (int _) => null);
+    final List<FocusNode> nodes = List<FocusNode>.generate(
+      6,
+      (int index) => FocusNode(debugLabel: 'Node $index'),
+    );
+    final FocusScopeNode childScope = FocusScopeNode(debugLabel: 'Child Scope');
+    addTearDown(() {
+      for (final FocusNode node in nodes) {
+        node.dispose();
+      }
+      childScope.dispose();
+    });
+
+    Focus makeFocus(int index) {
+      return Focus(
+        debugLabel: '[$index]',
+        focusNode: nodes[index],
+        onFocusChange: (bool isFocused) => focus[index] = isFocused,
+        child: const SizedBox(width: 100, height: 100),
+      );
+    }
+
+    Future<void> pumpApp() async {
+      /// Layout is:
+      ///          [0]
+      /// ---------Child FocusScope---------
+      ///          [1]
+      ///          [2]
+      ///              [3]
+      /// ---------Child FocusScope End---------
+      ///          [4] [5]
+      Widget home = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[makeFocus(0)]),
+          FocusScope(
+            node: childScope,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                makeFocus(1),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    makeFocus(2),
+                    Padding(padding: const EdgeInsets.only(top: 100), child: makeFocus(3)),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          Row(children: <Widget>[makeFocus(4), makeFocus(5)]),
+        ],
+      );
+      // Prevent the arrow keys from scrolling on the web.
+      if (isBrowser) {
+        home = Shortcuts(
+          shortcuts: const <ShortcutActivator, Intent>{
+            SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(
+              TraversalDirection.up,
+            ),
+            SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(
+              TraversalDirection.down,
+            ),
+          },
+          child: home,
+        );
+      }
+      await tester.pumpWidget(MaterialApp(home: home));
+    }
+
+    await pumpApp();
+
+    void clear() {
+      focus = List<bool?>.generate(focus.length, (int _) => null);
+    }
+
+    Future<void> resetTo(int index) async {
+      nodes[index].requestFocus();
+      await tester.pump();
+      clear();
+    }
+
+    // childScope's directionalTraversalEdgeBehavior is TraversalEdgeBehavior.stop
+    // focus is should not change
+    childScope.directionalTraversalEdgeBehavior = TraversalEdgeBehavior.stop;
+    await resetTo(3);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(focus, orderedEquals(<bool?>[null, null, null, null, null, null]));
+    clear();
+    await resetTo(1);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(focus, orderedEquals(<bool?>[null, null, null, null, null, null]));
+    clear();
+
+    // childScope's directionalTraversalEdgeBehavior is TraversalEdgeBehavior.closedLoop
+    // focus is should change in a loop
+    childScope.directionalTraversalEdgeBehavior = TraversalEdgeBehavior.closedLoop;
+    await resetTo(3);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(focus, orderedEquals(<bool?>[null, true, null, false, null, null]));
+    clear();
+    await resetTo(1);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(focus, orderedEquals(<bool?>[null, false, true, null, null, null]));
+    clear();
+
+    // childScope's directionalTraversalEdgeBehavior is TraversalEdgeBehavior.parentScope
+    // focus can change to the parent scope
+    childScope.directionalTraversalEdgeBehavior = TraversalEdgeBehavior.parentScope;
+    await resetTo(3);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(focus, orderedEquals(<bool?>[null, null, null, false, null, true]));
+    clear();
+    await resetTo(1);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(focus, orderedEquals(<bool?>[true, false, null, null, null, null]));
+    clear();
+
+    // childScope's directionalTraversalEdgeBehavior is TraversalEdgeBehavior.leaveFlutterView
+    // focus will be lost
+    childScope.directionalTraversalEdgeBehavior = TraversalEdgeBehavior.leaveFlutterView;
+    await resetTo(3);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(focus, orderedEquals(<bool?>[null, null, null, false, null, null]));
+    clear();
+    await resetTo(1);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(focus, orderedEquals(<bool?>[null, false, null, null, null, null]));
+    clear();
   });
 }
 

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -3711,6 +3711,33 @@ void main() {
     expect(focus, orderedEquals(<bool?>[null, false, null, null, null, null]));
     clear();
   });
+
+  testWidgets('When there is no focused node, the focus can be set to the FocusScopeNode.', (
+    WidgetTester tester,
+  ) async {
+    final FocusScopeNode scope = FocusScopeNode();
+    final FocusScopeNode childScope = FocusScopeNode();
+    final FocusNode nodeA = FocusNode();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusScope(
+          node: scope,
+          child: FocusScope(
+            node: childScope,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 10),
+              child: Focus(focusNode: nodeA, child: const Text('A')),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(scope.focusInDirection(TraversalDirection.down), isTrue);
+    await tester.pump();
+    expect(childScope.hasFocus, isTrue);
+    expect(nodeA.hasFocus, isFalse);
+  });
 }
 
 class TestRoute extends PageRouteBuilder<void> {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -3718,6 +3718,11 @@ void main() {
     final FocusScopeNode scope = FocusScopeNode();
     final FocusScopeNode childScope = FocusScopeNode();
     final FocusNode nodeA = FocusNode();
+    addTearDown(() {
+      scope.dispose();
+      childScope.dispose();
+      nodeA.dispose();
+    });
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2625,6 +2625,37 @@ void main() {
       expect(notifications.last.canHandlePop, isTrue);
     });
   });
+
+  testWidgets("ModalRoute's default directionalTraversalEdgeBehavior is the same as Navigator's", (
+    WidgetTester tester,
+  ) async {
+    Future<void> pumpWith(TraversalEdgeBehavior behavior) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Navigator(
+            key: UniqueKey(),
+            routeDirectionalTraversalEdgeBehavior: behavior,
+            onGenerateRoute: (RouteSettings settings) {
+              return MaterialPageRoute<void>(
+                builder: (BuildContext context) {
+                  return const Center(child: Text('page'));
+                },
+                settings: settings,
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    for (final TraversalEdgeBehavior element in TraversalEdgeBehavior.values) {
+      await pumpWith(element);
+      await tester.pumpAndSettle();
+      final FocusScopeNode focusScope = FocusScope.of(tester.element(find.text('page')));
+      expect(focusScope.directionalTraversalEdgeBehavior, element);
+    }
+  });
 }
 
 double _getOpacity(GlobalKey key, WidgetTester tester) {


### PR DESCRIPTION
Fixes: #160843 

This PR adds edge behavior feature for traversing focus using arrow keys. This allows cycling through the focus within the `FocusScope` in a closed loop using the arrow keys. Which may be needed by TV application developers.

Additionally, as in case #160843, `TraversalEdgeBehavior.parentScope` can be used to allow nested Navigators to traverse focus beyond the Navigator using arrow keys.

```dart
MaterialApp(
  home: Column(
    children: <Widget>[
      makeFocus(0),
      Navigator(
        onGenerateRoute: (RouteSettings settings) {
          return MaterialPageRoute<void>(
            traversalDirectionedEdgeBehavior: TraversalEdgeBehavior.parentScope,
            builder: (BuildContext context) {
              return Column(
                children: <Widget>[
                  makeFocus(1),
                  makeFocus(2),
                ],
              );
            },
          );
        },
      ),
      makeFocus(3),
    ],
  ),
);
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
