### PR TITLE
[Impeller] add opt in flag for SurfaceControl testing.

### DIFF
--- a/engine/src/flutter/common/settings.h
+++ b/engine/src/flutter/common/settings.h
@@ -234,8 +234,8 @@ struct Settings {
   bool enable_impeller = false;
 #endif
 
-  // Force disable the android surface control even where supported.
-  bool disable_surface_control = false;
+  // Enable android surface control swapchains where supported.
+  bool enable_surface_control = false;
 
   // Log a warning during shell initialization if Impeller is not enabled.
   bool warn_on_impeller_opt_out = false;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -483,7 +483,7 @@ void ContextVK::Setup(Settings settings) {
   descriptor_pool_recycler_ = std::move(descriptor_pool_recycler);
   device_name_ = std::string(physical_device_properties.deviceName);
   command_queue_vk_ = std::make_shared<CommandQueueVK>(weak_from_this());
-  should_disable_surface_control_ = settings.disable_surface_control;
+  should_enable_surface_control_ = settings.enable_surface_control;
   should_batch_cmd_buffers_ = !workarounds_.batch_submit_command_buffer_timeout;
   is_valid_ = true;
 
@@ -729,8 +729,8 @@ const std::unique_ptr<DriverInfoVK>& ContextVK::GetDriverInfo() const {
   return driver_info_;
 }
 
-bool ContextVK::GetShouldDisableSurfaceControlSwapchain() const {
-  return should_disable_surface_control_;
+bool ContextVK::GetShouldEnableSurfaceControlSwapchain() const {
+  return should_enable_surface_control_;
 }
 
 RuntimeStageBackend ContextVK::GetRuntimeStageBackend() const {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
@@ -82,7 +82,7 @@ class ContextVK final : public Context,
     fml::UniqueFD cache_directory;
     bool enable_validation = false;
     bool enable_gpu_tracing = false;
-    bool disable_surface_control = false;
+    bool enable_surface_control = false;
     /// If validations are requested but cannot be enabled, log a fatal error.
     bool fatal_missing_validations = false;
 
@@ -227,8 +227,8 @@ class ContextVK final : public Context,
   void DisposeThreadLocalCachedResources() override;
 
   /// @brief Whether the Android Surface control based swapchain should be
-  /// disabled, even if the device is capable of supporting it.
-  bool GetShouldDisableSurfaceControlSwapchain() const;
+  ///        enabled
+  bool GetShouldEnableSurfaceControlSwapchain() const;
 
   // | Context |
   bool EnqueueCommandBuffer(
@@ -292,7 +292,7 @@ class ContextVK final : public Context,
   mutable Mutex desc_pool_mutex_;
   mutable DescriptorPoolMap IPLR_GUARDED_BY(desc_pool_mutex_)
       cached_descriptor_pool_;
-  bool should_disable_surface_control_ = false;
+  bool should_enable_surface_control_ = false;
   bool should_batch_cmd_buffers_ = false;
   std::vector<std::shared_ptr<CommandBuffer>> pending_command_buffers_;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
@@ -56,6 +56,26 @@ std::shared_ptr<SwapchainVK> SwapchainVK::Create(
     return nullptr;
   }
 
+  // Use AHB Swapchains if they are opted in.
+  if (ContextVK::Cast(*context).GetShouldEnableSurfaceControlSwapchain() &&
+      AHBSwapchainVK::IsAvailableOnPlatform()) {
+    FML_LOG(WARNING) << "Using Android SurfaceControl Swapchain.";
+    auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
+        context,             //
+        window.GetHandle(),  //
+        surface,             //
+        window.GetSize(),    //
+        enable_msaa          //
+        ));
+
+    if (ahb_swapchain->IsValid()) {
+      return ahb_swapchain;
+    } else {
+      VALIDATION_LOG
+          << "Could not create AHB swapchain. Falling back to KHR variant.";
+    }
+  }
+
   // Fallback to KHR swapchains if AHB swapchains aren't available.
   return Create(context, std::move(surface), window.GetSize(), enable_msaa);
 }

--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -526,8 +526,8 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.enable_platform_isolates =
       command_line.HasOption(FlagForSwitch(Switch::EnablePlatformIsolates));
 
-  settings.disable_surface_control = command_line.HasOption(
-      FlagForSwitch(Switch::DisableAndroidSurfaceControl));
+  settings.enable_surface_control = command_line.HasOption(
+      FlagForSwitch(Switch::EnableAndroidSurfaceControl));
 
   settings.merged_platform_ui_thread = !command_line.HasOption(
       FlagForSwitch(Switch::DisableMergedPlatformUIThread));

--- a/engine/src/flutter/shell/common/switches.h
+++ b/engine/src/flutter/shell/common/switches.h
@@ -297,9 +297,9 @@ DEF_SWITCH(EnablePlatformIsolates,
 DEF_SWITCH(DisableMergedPlatformUIThread,
            "no-enable-merged-platform-ui-thread",
            "Merge the ui thread and platform thread.")
-DEF_SWITCH(DisableAndroidSurfaceControl,
-           "disable-surface-control",
-           "Disable the SurfaceControl backed swapchain even when supported.")
+DEF_SWITCH(EnableAndroidSurfaceControl,
+           "enable-surface-control",
+           "Enable the SurfaceControl backed swapchain when supported.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);

--- a/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
@@ -47,7 +47,7 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
   settings.cache_directory = fml::paths::GetCachesDirectory();
   settings.enable_validation = p_settings.enable_validation;
   settings.enable_gpu_tracing = p_settings.enable_gpu_tracing;
-  settings.disable_surface_control = p_settings.disable_surface_control;
+  settings.enable_surface_control = p_settings.enable_surface_control;
 
   auto context = impeller::ContextVK::Create(std::move(settings));
 

--- a/engine/src/flutter/shell/platform/android/context/android_context.h
+++ b/engine/src/flutter/shell/platform/android/context/android_context.h
@@ -25,7 +25,7 @@ class AndroidContext {
   struct ContextSettings {
     bool enable_validation = false;
     bool enable_gpu_tracing = false;
-    bool disable_surface_control = false;
+    bool enable_surface_control = false;
     bool quiet = false;
   };
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -49,8 +49,8 @@ public class FlutterLoader {
       "io.flutter.embedding.android.EnableVulkanGPUTracing";
   private static final String DISABLE_MERGED_PLATFORM_UI_THREAD_KEY =
       "io.flutter.embedding.android.DisableMergedPlatformUIThread";
-  private static final String DISABLE_SURFACE_CONTROL =
-      "io.flutter.embedding.android.DisableSurfaceControl";
+  private static final String ENABLE_SURFACE_CONTROL =
+      "io.flutter.embedding.android.EnableSurfaceControl";
 
   /**
    * Set whether leave or clean up the VM after the last shell shuts down. It can be set from app's
@@ -369,8 +369,8 @@ public class FlutterLoader {
           }
         }
 
-        if (metaData.getBoolean(DISABLE_SURFACE_CONTROL, false)) {
-          shellArgs.add("--disable-surface-control");
+        if (metaData.getBoolean(ENABLE_SURFACE_CONTROL, false)) {
+          shellArgs.add("--enable-surface-control");
         }
 
         String backend = metaData.getString(IMPELLER_BACKEND_META_DATA_KEY);

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -44,7 +44,7 @@ AndroidContext::ContextSettings CreateContextSettings(
   AndroidContext::ContextSettings settings;
   settings.enable_gpu_tracing = p_settings.enable_vulkan_gpu_tracing;
   settings.enable_validation = p_settings.enable_vulkan_validation;
-  settings.disable_surface_control = p_settings.disable_surface_control;
+  settings.enable_surface_control = p_settings.enable_surface_control;
   return settings;
 }
 }  // namespace

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -237,11 +237,11 @@ public class FlutterLoaderTest {
   }
 
   @Test
-  public void itSetsDisableSurfaceControlFromMetaData() {
+  public void itSetsEnableSurfaceControlFromMetaData() {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
     Bundle metaData = new Bundle();
-    metaData.putBoolean("io.flutter.embedding.android.DisableSurfaceControl", true);
+    metaData.putBoolean("io.flutter.embedding.android.EnableSurfaceControl", true);
     ctx.getApplicationInfo().metaData = metaData;
 
     FlutterLoader.Settings settings = new FlutterLoader.Settings();
@@ -250,7 +250,7 @@ public class FlutterLoaderTest {
     flutterLoader.ensureInitializationComplete(ctx, null);
     shadowOf(getMainLooper()).idle();
 
-    final String disabledControlArg = "--disable-surface-control";
+    final String disabledControlArg = "--enable-surface-control";
     ArgumentCaptor<String[]> shellArgsCaptor = ArgumentCaptor.forClass(String[].class);
     verify(mockFlutterJNI, times(1))
         .init(eq(ctx), shellArgsCaptor.capture(), anyString(), anyString(), anyString(), anyLong());


### PR DESCRIPTION
Adds an opt in flag for the Android surface control based swapchain. This is off by default, but added for the sake of bug reports and investigation of the functionality.
