### PR TITLE
Exclude `*texture*` as matching for `a: text input`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -45,6 +45,7 @@
     - all-globs-to-any-file:
       - '**/*text*'
       - '!**/*context*'
+      - '!**/*texture*'
 
 'd: api docs':
   - changed-files:


### PR DESCRIPTION
... probably save @justinmc and others having to go through engine texture changes :P