### PR TITLE
Run `android_engine_test` explicitly with both `OpenGLES` and `Vulkan` backends

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1527,25 +1527,25 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux_android_emu flutter_driver_android_test
+  - name: Linux_android_emu flutter_engine_android_vulkan
     recipe: flutter/flutter_drone
     bringup: true
     timeout: 60
     properties:
-      shard: flutter_driver_android
+      shard: flutter_engine_android_vulkan
       tags: >
          ["framework", "hostonly", "shard", "linux"]
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"}
         ]
-      presubmit_max_attempts: "2"
 
-  - name: Linux_android_emu_34 flutter_driver_android_test
+  - name: Linux_android_emu flutter_engine_android_openlges
     recipe: flutter/flutter_drone
+    bringup: true
     timeout: 60
     properties:
-      shard: flutter_driver_android
+      shard: flutter_engine_android_openlges
       tags: >
          ["framework", "hostonly", "shard", "linux"]
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1545,7 +1545,7 @@ targets:
     bringup: true
     timeout: 60
     properties:
-      shard: flutter_engine_android_openlges
+      shard: flutter_engine_android_opengles
       tags: >
          ["framework", "hostonly", "shard", "linux"]
       dependencies: >-

--- a/dev/bots/suite_runners/run_flutter_engine_android_tests.dart
+++ b/dev/bots/suite_runners/run_flutter_engine_android_tests.dart
@@ -1,0 +1,85 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
+import 'package:path/path.dart' as path;
+
+import '../run_command.dart';
+import '../utils.dart';
+
+/// To run this test locally:
+///
+/// 1. Connect an Android device or emulator.
+/// 2. Run `dart pub get` in dev/bots
+/// 3. Run the following command from the root of the Flutter repository:
+///
+/// ```sh
+/// SHARD=flutter_engine_android_vulkan bin/cache/dart-sdk/bin/dart dev/bots/test.dart
+///
+/// # Or
+///
+/// SHARD=flutter_engine_android_openlges bin/cache/dart-sdk/bin/dart dev/bots/test.dart
+/// ```
+///
+/// For debugging, you need to instead run and launch these tests
+/// individually _in_ the `dev/integration_tests/android_engine_test` directory.
+/// Comparisons against goldens cant happen locally.
+Future<void> runFlutterEngineAndroidTests({required String impellerBackend}) async {
+  print('Running Flutter Android Engine (Impeller Backend: $impellerBackend) tests...');
+
+  final String androidEngineTestPath = path.join('dev', 'integration_tests', 'android_engine_test');
+  final io.File androidManifestXml = io.File(
+    path.join(androidEngineTestPath, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'),
+  );
+
+  // Make a copy of the manifest to restore.
+  final String originalManifest = await androidManifestXml.readAsString();
+  final RegExp findImpellerBackend = RegExp(r'ImpellerBackend"\sandroid:value="(.*)"');
+
+  // Replace the backend string.
+  final String replacedManifest = originalManifest.replaceAllMapped(findImpellerBackend, (Match m) {
+    return 'ImpellerBackend" android:value="$impellerBackend"';
+  });
+  await androidManifestXml.writeAsString(replacedManifest);
+
+  final RegExp impellerBackendNotice = RegExp(r'Using the Impeller rendering backend (\(.*\))');
+
+  try {
+    final List<FileSystemEntity> mains = Glob('$androidEngineTestPath/lib/**_main.dart').listSync();
+    for (final FileSystemEntity file in mains) {
+      final CommandResult result = await runCommand('flutter', <String>[
+        'drive',
+        path.relative(file.path, from: androidEngineTestPath),
+        // There are no reason to enable development flags for this test.
+        // Disable them to work around flakiness issues, and in general just
+        // make less things start up unnecessarily.
+        '--no-dds',
+        '--no-enable-dart-profiling',
+        '--test-arguments=test',
+        '--test-arguments=--reporter=expanded',
+      ], workingDirectory: androidEngineTestPath);
+
+      // Check that the application actually ran with the requested backend.
+      final String? stdout = result.flattenedStdout;
+      if (stdout == null) {
+        io.stderr.writeln(result.flattenedStderr);
+        throw StateError('No stdout received from flutter CLI.');
+      }
+      final Match? match = impellerBackendNotice.firstMatch(stdout);
+      if (match == null) {
+        throw StateError('Expected an Impeller run notice, but none found');
+      }
+      final String backend = match.group(1)!.toLowerCase();
+      if (backend != impellerBackend) {
+        throw StateError('Requested "$impellerBackend", got "$backend".');
+      }
+    }
+  } finally {
+    await androidManifestXml.writeAsString(originalManifest);
+  }
+}

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -60,7 +60,7 @@ import 'suite_runners/run_android_java11_integration_tool_tests.dart';
 import 'suite_runners/run_android_preview_integration_tool_tests.dart';
 import 'suite_runners/run_customer_testing_tests.dart';
 import 'suite_runners/run_docs_tests.dart';
-import 'suite_runners/run_flutter_driver_android_tests.dart';
+import 'suite_runners/run_flutter_engine_android_tests.dart';
 import 'suite_runners/run_flutter_packages_tests.dart';
 import 'suite_runners/run_framework_coverage_tests.dart';
 import 'suite_runners/run_framework_tests.dart';
@@ -148,7 +148,10 @@ Future<void> main(List<String> args) async {
       'web_skwasm_tests': webTestsSuite.runWebSkwasmUnitTests,
       // All web integration tests
       'web_long_running_tests': webTestsSuite.webLongRunningTestsRunner,
-      'flutter_driver_android': runFlutterDriverAndroidTests,
+      'flutter_engine_android_vulkan':
+          () => runFlutterEngineAndroidTests(impellerBackend: 'vulkan'),
+      'flutter_engine_android_opengles':
+          () => runFlutterEngineAndroidTests(impellerBackend: 'opengles'),
       'flutter_plugins': flutterPackagesRunner,
       'skp_generator': skpGeneratorTestsRunner,
       'customer_testing': customerTestingRunner,

--- a/dev/integration_tests/android_engine_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_engine_test/android/app/src/main/AndroidManifest.xml
@@ -31,9 +31,8 @@ found in the LICENSE file. -->
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
-        <meta-data
-            android:name="flutterEmbedding"
-            android:value="2" />
+        <meta-data android:name="flutterEmbedding" android:value="2" />
+        <meta-data android:name="io.flutter.embedding.android.ImpellerBackend" android:value="vulkan" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/dev/integration_tests/android_engine_test/test_driver/_impeller_backend.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/_impeller_backend.dart
@@ -1,0 +1,23 @@
+import 'dart:io' as io;
+
+import 'package:path/path.dart' as p;
+
+/// Returns what `ImpellerBackend` was requested in the current application.
+///
+/// This is a high confidence signal that the application is running the
+/// requested backend, but it is not definitive; a test harness might inspect
+/// the output of the `flutter` CLI to be more certain.
+///
+/// See also:
+/// - <https://docs.flutter.dev/perf/impeller#android>
+/// - <https://github.com/flutter/flutter/blob/master/engine/src/flutter/impeller/README.md>
+Future<String> get requestedImpellerBackend async {
+  final io.File androidManifestXml = io.File(
+    p.join('android', 'app', 'src', 'main', 'AndroidManifest.xml'),
+  );
+  final String contents = await androidManifestXml.readAsString();
+  final String backend = _findImpellerBackend.firstMatch(contents)!.group(1)!;
+  return backend;
+}
+
+final RegExp _findImpellerBackend = RegExp(r'ImpellerBackend"\sandroid:value="(.*)"');


### PR DESCRIPTION
🚫 Blocked on https://github.com/flutter/flutter/pull/161349, will proceed after that merges.

---

Closes https://github.com/flutter/flutter/issues/161333.

Refactors and runs the Android engine test suite specifically with the Vulkan and OpenGLES backends, respectively.

Added some additional harness-level checks to make sure we don't get into an unexpected state, i.e. on CI. Note that this temporarily needs to move all of the test suites back to `bringup: true` in order to rename them to `vulkan` and `opengles`.

/cc @zanderso