### PR TITLE
[web:a11y] treat empty tappables as buttons

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1771,6 +1771,8 @@ class SemanticsObject {
       return EngineSemanticsRole.link;
     } else if (isHeader) {
       return EngineSemanticsRole.header;
+    } else if (isButtonLike) {
+      return EngineSemanticsRole.button;
     } else {
       return EngineSemanticsRole.generic;
     }
@@ -1852,7 +1854,13 @@ class SemanticsObject {
       hasAction(ui.SemanticsAction.increase) || hasAction(ui.SemanticsAction.decrease);
 
   /// Whether the object represents a button.
+  ///
+  /// See also [isButtonLike].
   bool get isButton => hasFlag(ui.SemanticsFlag.isButton);
+
+  /// Whether the object behaves like a button even if it does not formally have
+  /// the [ui.SemanticsFlag.isButton] flag.
+  bool get isButtonLike => isTappable && !hasChildren;
 
   /// Represents a tappable or clickable widget, such as button, icon button,
   /// "hamburger" menu, etc.


### PR DESCRIPTION
The situation will improve even further when we have proper ARIA roles, but for now if a node is a leaf node and has a tap action, present it to semantics as a button even if the `isButton` flag is missing.

Fixes https://github.com/flutter/flutter/issues/157743