### PR TITLE
Move the analyzer_benchmark to Mac arm64 devicelab bots

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -361,7 +361,7 @@ targets:
   # This is a benchmark that does not require an attached device. However, we
   # are intentionally running it in the devicelab to ensure that it does not
   # run on a VM in order to avoid noisy results from the benchmark.
-  - name: Mac analyzer_benchmark
+  - name: Mac_arm64 analyzer_benchmark
     bringup: true # Flaky https://github.com/flutter/flutter/issues/161306
     recipe: devicelab/devicelab_drone
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -361,22 +361,18 @@ targets:
   # This is a benchmark that does not require an attached device. However, we
   # are intentionally running it in the devicelab to ensure that it does not
   # run on a VM in order to avoid noisy results from the benchmark.
-  - name: Linux analyzer_benchmark
+  - name: Mac analyzer_benchmark
     bringup: true # Flaky https://github.com/flutter/flutter/issues/161306
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      os: Linux
-      device_type: "mokey"
       test_timeout_secs: "3600" # 1 hour
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:35v1"},
-          {"dependency": "open_jdk", "version": "version:17"},
-          {"dependency": "curl", "version": "version:7.64.0"}
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
         ]
       tags: >
-        ["devicelab", "android", "linux", "mokey"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: analyzer_benchmark
 
   - name: Linux coverage


### PR DESCRIPTION
The arm64 Macs should have more memory than the Linux machines that are available in the devicelab.  The analyzer benchmark spawns a Dart analysis server process that has a peak memory consumption of around 7GB, which may be activating the OOM killer on the Linux bots.

See https://github.com/flutter/flutter/issues/161306