### PR TITLE
[fix] Scroll Listener does not trigger when keyboard is dismissed #160740.

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -436,7 +436,10 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   ///    destination offset.
   // ignore: use_setters_to_change_properties, (API is intended to discourage setting value)
   void correctPixels(double value) {
-    _pixels = value;
+    // Fix https://github.com/flutter/flutter/issues/160740.
+    // We cannot set `_pixels` when it is not null; otherwise, `_pixels` will always equal the new `value` in `jumpTo`
+    // of `ScrollPositionWithSingleContext` when the keyboard hides.
+    _pixels ??= value;
   }
 
   /// Apply a layout-time correction to the scroll offset.


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/160740.




Exmaple of Single block:

https://github.com/user-attachments/assets/901e528d-7e2b-4057-8b29-66de84533ef5

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: ScrollColorChangePage(),
    );
  }
}

class ScrollColorChangePage extends StatefulWidget {
  const ScrollColorChangePage({super.key});

  @override
  ScrollColorChangePageState createState() => ScrollColorChangePageState();
}

class ScrollColorChangePageState extends State<ScrollColorChangePage> {
  final ScrollController _scrollController = ScrollController();
  Color _headerColor = Colors.blue;

  @override
  void initState() {
    super.initState();
    _scrollController.addListener(_onScroll);
  }

  @override
  void dispose() {
    _scrollController.removeListener(_onScroll);
    _scrollController.dispose();
    super.dispose();
  }

  void _onScroll() {
    final scrollOffset = _scrollController.offset;
    print(scrollOffset);
    setState(() {
      _headerColor = Color.lerp(Colors.blue, Colors.red, scrollOffset / 100) ?? Colors.blue;
    });
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: CustomScrollView(
        controller: _scrollController,
        slivers: [
          SliverToBoxAdapter(
            child: Container(
              height: 300,
              color: _headerColor,
            ),
          ),
          const SliverToBoxAdapter(
            child: Padding(
              padding: EdgeInsets.only(top: 300),
              child: TextField(
                decoration: InputDecoration(
                  border: OutlineInputBorder(),
                  labelText: 'Enter text here',
                ),
              ),
            ),
          ),
        ],
      ),
    );
  }
}
```


Exmaple of Double block:

https://github.com/user-attachments/assets/8f2d559c-ec34-42fa-9706-07ba77c67243

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: ScrollColorChangePage(),
    );
  }
}

class ScrollColorChangePage extends StatefulWidget {
  const ScrollColorChangePage({super.key});

  @override
  ScrollColorChangePageState createState() => ScrollColorChangePageState();
}

class ScrollColorChangePageState extends State<ScrollColorChangePage> {
  final ScrollController _scrollController = ScrollController();
  Color _headerColor = Colors.blue;

  @override
  void initState() {
    super.initState();
    _scrollController.addListener(_onScroll);
  }

  @override
  void dispose() {
    _scrollController.removeListener(_onScroll);
    _scrollController.dispose();
    super.dispose();
  }

  void _onScroll() {
    final scrollOffset = _scrollController.offset;
    print(scrollOffset);
    setState(() {
      _headerColor = Color.lerp(Colors.blue, Colors.red, scrollOffset / 100) ?? Colors.blue;
    });
  }

  @override
  Widget build(BuildContext context) {
    return GestureDetector(
      onTap: () {
        FocusScope.of(context).unfocus();
      },
      child: Scaffold(
        body: ListView(
          controller: _scrollController,
          children: [
            Container(
              height: 300,
              color: Colors.yellow,
            ),
            Container(
              height: 300,
              color: _headerColor,
            ),
            Padding(
              padding: EdgeInsets.only(top: 300, bottom: 300),
              child: TextField(
                decoration: InputDecoration(
                  border: OutlineInputBorder(),
                  labelText: 'Enter text here',
                ),
              ),
            ),
          ],
        ),
      ),
    );
  }
}
```



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

