### PR TITLE
Update InputDecoration.border documentation

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -3655,8 +3655,8 @@ class InputDecoration {
 
   /// The shape of the border to draw around the decoration's container.
   ///
-  /// If [border] is a [MaterialStateUnderlineInputBorder]
-  /// or [MaterialStateOutlineInputBorder], then the effective border is resolved in the following states:
+  /// If [border] is a [WidgetStateInputBorder] then the effective border is resolved
+  /// in the following states:
   ///  * [WidgetState.disabled].
   ///  * [WidgetState.error].
   ///  * [WidgetState.focused].

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -3656,14 +3656,17 @@ class InputDecoration {
   /// The shape of the border to draw around the decoration's container.
   ///
   /// If [border] is a [MaterialStateUnderlineInputBorder]
-  /// or [MaterialStateOutlineInputBorder], then the effective border can depend on
-  /// the [WidgetState.focused] state, i.e. if the [TextField] is focused or not.
+  /// or [MaterialStateOutlineInputBorder], then the effective border is resolved in the following states:
+  ///  * [WidgetState.disabled].
+  ///  * [WidgetState.error].
+  ///  * [WidgetState.focused].
+  ///  * [WidgetState.hovered].
   ///
   /// If [border] derives from [InputBorder] the border's [InputBorder.borderSide],
   /// i.e. the border's color and width, will be overridden to reflect the input
   /// decorator's state. Only the border's shape is used. If custom  [BorderSide]
-  /// values are desired for a given state, all four borders – [errorBorder],
-  /// [focusedBorder], [enabledBorder], [disabledBorder] – must be set.
+  /// values are desired for a given state, all five borders – [errorBorder],
+  /// [focusedBorder], [enabledBorder], [disabledBorder], [focusedErrorBorder] – must be set.
   ///
   /// The decoration's container is the area which is filled if [filled] is
   /// true and bordered per the [border]. It's the area adjacent to

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -281,7 +281,7 @@ typedef MaterialStateTextStyle = WidgetStateTextStyle;
 ///
 /// This class exists to enable widgets with [OutlineInputBorder] valued properties
 /// to also accept [MaterialStateProperty<OutlineInputBorder>] values. A material
-/// state input border property represents a text style which depends on
+/// state input border property represents an input border which depends on
 /// a widget's "interactive state". This state is represented as a
 /// [Set] of [MaterialState]s, like [MaterialState.pressed],
 /// [MaterialState.focused] and [MaterialState.hovered].
@@ -361,7 +361,7 @@ class _MaterialStateOutlineInputBorder extends MaterialStateOutlineInputBorder {
 ///
 /// This class exists to enable widgets with [UnderlineInputBorder] valued properties
 /// to also accept [MaterialStateProperty<UnderlineInputBorder>] values. A material
-/// state input border property represents a text style which depends on
+/// state input border property represents an input border which depends on
 /// a widget's "interactive state". This state is represented as a
 /// [Set] of [MaterialState]s, like [MaterialState.pressed],
 /// [MaterialState.focused] and [MaterialState.hovered].


### PR DESCRIPTION
## Description

This PR clarifies the InputDecoration.border documentation and fixes two typos.

## Related Issue

Fixes [[Material] Outline TextFields don't respect OutlineInputBorder.color](https://github.com/flutter/flutter/issues/31169)

## Tests

Documentation only