### PR TITLE
[Impeller] remove API 30 restriction for SurfaceControl testing.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -198,7 +198,7 @@ void AHBSwapchainImplVK::AddFinalCommandBuffer(
   if (!context) {
     return;
   }
-  context->GetCommandQueue()->Submit({cmd_buffer});
+  context->GetCommandQueue()->Submit({std::move(cmd_buffer)});
 }
 
 std::shared_ptr<ExternalFenceVK>

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -194,8 +194,11 @@ bool AHBSwapchainImplVK::Present(
 
 void AHBSwapchainImplVK::AddFinalCommandBuffer(
     std::shared_ptr<CommandBuffer> cmd_buffer) {
-  FML_DCHECK(!pending_cmd_buffer_);
-  pending_cmd_buffer_ = std::move(cmd_buffer);
+  auto context = transients_->GetContext().lock();
+  if (!context) {
+    return;
+  }
+  context->GetCommandQueue()->Submit({cmd_buffer});
 }
 
 std::shared_ptr<ExternalFenceVK>
@@ -210,7 +213,7 @@ AHBSwapchainImplVK::SubmitSignalForPresentReady(
     return nullptr;
   }
 
-  auto command_buffer = pending_cmd_buffer_;
+  auto command_buffer = context->CreateCommandBuffer();
   if (!command_buffer) {
     return nullptr;
   }

--- a/engine/src/flutter/impeller/toolkit/android/surface_control.cc
+++ b/engine/src/flutter/impeller/toolkit/android/surface_control.cc
@@ -55,7 +55,7 @@ bool SurfaceControl::IsAvailableOnPlatform() {
   // we had more time to test all of these older devices maybe we could
   // figure out what the problem is.
   // https://github.com/flutter/flutter/issues/155877
-  return api_level >= 30 && GetProcTable().IsValid() &&
+  return api_level >= 29 && GetProcTable().IsValid() &&
          GetProcTable().ASurfaceControl_createFromWindow.IsAvailable();
 }
 


### PR DESCRIPTION
In order to give a minimal repro for the AHB issues to folks, I need to be able to show that while it _should_ work on API 29 it doesn't in a number of places.. Since this AHB swapchain is off by default this will have no impact on production applications.