### PR TITLE
Propagate environment variables when `flutter drive` is invoked.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -65,6 +65,7 @@ class DriveCommand extends RunCommandBase {
   }) : _flutterDriverFactory = flutterDriverFactory,
        _fileSystem = fileSystem,
        _logger = logger,
+       _platform = platform,
        _fsUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform),
        super(verboseHelp: verboseHelp) {
     requiresPubspecYaml();
@@ -205,6 +206,7 @@ class DriveCommand extends RunCommandBase {
   FlutterDriverFactory? _flutterDriverFactory;
   final FileSystem _fileSystem;
   final Logger _logger;
+  final Platform _platform;
   final FileSystemUtils _fsUtils;
   Timer? timeoutTimer;
   Map<ProcessSignal, Object>? screenshotTokens;
@@ -336,7 +338,7 @@ class DriveCommand extends RunCommandBase {
       final Future<int> testResultFuture = driverService.startTest(
         testFile,
         stringsArg('test-arguments'),
-        <String, String>{},
+        _platform.environment,
         packageConfig,
         chromeBinary: stringArg('chrome-binary'),
         headless: boolArg('headless'),

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -294,6 +294,7 @@ class DriveCommand extends RunCommandBase {
     _flutterDriverFactory ??= FlutterDriverFactory(
       applicationPackageFactory: ApplicationPackageFactory.instance!,
       logger: _logger,
+      platform: _platform,
       processUtils: globals.processUtils,
       dartSdkPath: globals.artifacts!.getArtifactPath(Artifact.engineDartBinary),
       devtoolsLauncher: DevtoolsLauncher.instance!,
@@ -338,7 +339,6 @@ class DriveCommand extends RunCommandBase {
       final Future<int> testResultFuture = driverService.startTest(
         testFile,
         stringsArg('test-arguments'),
-        _platform.environment,
         packageConfig,
         chromeBinary: stringArg('chrome-binary'),
         headless: boolArg('headless'),

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -13,6 +13,7 @@ import 'package:webdriver/async_io.dart' as async_io;
 import '../base/common.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
@@ -29,13 +30,16 @@ class WebDriverService extends DriverService {
   WebDriverService({
     required ProcessUtils processUtils,
     required String dartSdkPath,
+    required Platform platform,
     required Logger logger,
   }) : _processUtils = processUtils,
        _dartSdkPath = dartSdkPath,
+       _platform = platform,
        _logger = logger;
 
   final ProcessUtils _processUtils;
   final String _dartSdkPath;
+  final Platform _platform;
   final Logger _logger;
 
   late ResidentRunner _residentRunner;
@@ -143,7 +147,6 @@ class WebDriverService extends DriverService {
   Future<int> startTest(
     String testFile,
     List<String> arguments,
-    Map<String, String> environment,
     PackageConfig packageConfig, {
     bool? headless,
     String? chromeBinary,
@@ -195,9 +198,9 @@ class WebDriverService extends DriverService {
     final int result = await _processUtils.stream(
       <String>[_dartSdkPath, ...arguments, testFile],
       environment: <String, String>{
+        ..._platform.environment,
         'VM_SERVICE_URL': _webUri.toString(),
         ..._additionalDriverEnvironment(webDriver, browserName, androidEmulator),
-        ...environment,
       },
     );
     await webDriver.quit();

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -10,7 +10,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/async_guard.dart';
 import 'package:flutter_tools/src/base/common.dart';
-import 'package:flutter_tools/src/base/dds.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -489,43 +488,6 @@ void main() {
   );
 
   testUsingContext(
-    'environment variables propogate to the driver script',
-    () async {
-      platform = FakePlatform(environment: <String, String>{'FOO': 'BAR'});
-
-      fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
-      fileSystem.file('lib/main.dart').createSync(recursive: true);
-      fileSystem.file('test_driver/main_test.dart').createSync(recursive: true);
-      fileSystem.file('pubspec.yaml').createSync();
-
-      final Uri vmServiceUri = Uri.parse('http://localhost:1234');
-      fakeDeviceManager.addAttachedDevice(SuccessfulDeviceWithVmService(vmServiceUri));
-
-      final EnvironmentCapturingFakeFlutterDriverService driverService =
-          EnvironmentCapturingFakeFlutterDriverService();
-
-      final DriveCommand command = DriveCommand(
-        fileSystem: fileSystem,
-        logger: logger,
-        platform: platform,
-        signals: signals,
-        flutterDriverFactory: CannedFakeFlutterDriverFactory(driverService),
-      );
-      await createTestCommandRunner(command).run(<String>['drive']);
-
-      expect(driverService.capturedStartTestEnvironment, <String, String>{'FOO': 'BAR'});
-    },
-    overrides: <Type, Generator>{
-      Cache: () => Cache.test(processManager: FakeProcessManager.empty()),
-      FileSystem: () => fileSystem,
-      Platform: () => platform,
-      Pub: FakePub.new,
-      ProcessManager: () => FakeProcessManager.empty(),
-      DeviceManager: () => fakeDeviceManager,
-    },
-  );
-
-  testUsingContext(
     'Port publication not disabled for wireless device',
     () async {
       final DriveCommand command = DriveCommand(
@@ -696,58 +658,6 @@ class ScreenshotDevice extends Fake implements Device {
   }
 }
 
-class SuccessfulDeviceWithVmService extends Fake implements Device {
-  SuccessfulDeviceWithVmService(this._vmServiceUri);
-  final Uri _vmServiceUri;
-
-  @override
-  final String name = 'FakeDevice';
-
-  @override
-  final Category category = Category.mobile;
-
-  @override
-  final String id = 'fake_device';
-
-  @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android;
-
-  @override
-  bool supportsScreenshot = true;
-
-  @override
-  bool get isConnected => true;
-
-  @override
-  Future<LaunchResult> startApp(
-    ApplicationPackage? package, {
-    String? mainPath,
-    String? route,
-    DebuggingOptions? debuggingOptions,
-    Map<String, dynamic>? platformArgs,
-    bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
-    bool ipv6 = false,
-    String? userIdentifier,
-  }) async => LaunchResult.succeeded(vmServiceUri: _vmServiceUri);
-
-  @override
-  DartDevelopmentService get dds => FakeDartDevelopmentService(_vmServiceUri);
-}
-
-class FakeDartDevelopmentService extends Fake implements DartDevelopmentService {
-  FakeDartDevelopmentService(this.uri);
-
-  @override
-  final Uri uri;
-
-  @override
-  Future<void> startDartDevelopmentServiceFromDebuggingOptions(
-    Uri vmServiceUri, {
-    required DebuggingOptions debuggingOptions,
-  }) async {}
-}
-
 class FakePub extends Fake implements Pub {
   @override
   Future<void> get({
@@ -792,7 +702,6 @@ class NeverEndingDriverService extends Fake implements DriverService {
   Future<int> startTest(
     String testFile,
     List<String> arguments,
-    Map<String, String> environment,
     PackageConfig packageConfig, {
     bool? headless,
     String? chromeBinary,
@@ -826,7 +735,6 @@ class FailingFakeDriverService extends Fake implements DriverService {
   Future<int> startTest(
     String testFile,
     List<String> arguments,
-    Map<String, String> environment,
     PackageConfig packageConfig, {
     bool? headless,
     String? chromeBinary,
@@ -837,52 +745,6 @@ class FailingFakeDriverService extends Fake implements DriverService {
     List<String>? browserDimension,
     String? profileMemory,
   }) async => 1;
-}
-
-class CannedFakeFlutterDriverFactory extends Fake implements FlutterDriverFactory {
-  CannedFakeFlutterDriverFactory(this._driverService);
-  final DriverService _driverService;
-
-  @override
-  DriverService createDriverService(bool web) => _driverService;
-}
-
-class EnvironmentCapturingFakeFlutterDriverService extends Fake implements DriverService {
-  Map<String, String>? capturedStartTestEnvironment;
-
-  @override
-  Future<void> start(
-    BuildInfo buildInfo,
-    Device device,
-    DebuggingOptions debuggingOptions, {
-    File? applicationBinary,
-    String? route,
-    String? userIdentifier,
-    String? mainPath,
-    Map<String, Object> platformArgs = const <String, Object>{},
-  }) async {}
-
-  @override
-  Future<void> stop({File? writeSkslOnExit, String? userIdentifier}) async {}
-
-  @override
-  Future<int> startTest(
-    String testFile,
-    List<String> arguments,
-    Map<String, String> environment,
-    PackageConfig packageConfig, {
-    bool? headless,
-    String? chromeBinary,
-    String? browserName,
-    bool? androidEmulator,
-    int? driverPort,
-    List<String> webBrowserFlags = const <String>[],
-    List<String>? browserDimension,
-    String? profileMemory,
-  }) async {
-    capturedStartTestEnvironment = environment;
-    return 0;
-  }
 }
 
 class FakeProcessSignal extends Fake implements io.ProcessSignal {

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/dds.dart';
 import 'package:flutter_tools/src/base/io.dart' as io;
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/convert.dart';
@@ -139,6 +140,7 @@ void main() {
     final DriverService driverService = setUpDriverService(
       processManager: processManager,
       vmService: fakeVmServiceHost.vmService,
+      platform: FakePlatform(environment: <String, String>{'FOO': 'BAR'}),
     );
     final Device device = FakeDevice(
       LaunchResult.succeeded(vmServiceUri: Uri.parse('http://127.0.0.1:63426/1UasC_ihpXY=/')),
@@ -149,12 +151,9 @@ void main() {
       device,
       DebuggingOptions.enabled(BuildInfo.profile, ipv6: true),
     );
-    final int testResult = await driverService.startTest(
-      'foo.test',
-      <String>['--enable-experiment=non-nullable'],
-      <String, String>{'FOO': 'BAR'},
-      PackageConfig(<Package>[Package('test', Uri.base)]),
-    );
+    final int testResult = await driverService.startTest('foo.test', <String>[
+      '--enable-experiment=non-nullable',
+    ], PackageConfig(<Package>[Package('test', Uri.base)]));
 
     expect(testResult, 23);
   });
@@ -180,6 +179,7 @@ void main() {
         processManager: processManager,
         vmService: fakeVmServiceHost.vmService,
         devtoolsLauncher: launcher,
+        platform: FakePlatform(environment: <String, String>{'FOO': 'BAR'}),
       );
       final Device device = FakeDevice(
         LaunchResult.succeeded(vmServiceUri: Uri.parse('http://127.0.0.1:63426/1UasC_ihpXY=/')),
@@ -193,7 +193,6 @@ void main() {
       final int testResult = await driverService.startTest(
         'foo.test',
         <String>['--enable-experiment=non-nullable'],
-        <String, String>{'FOO': 'BAR'},
         PackageConfig(<Package>[Package('test', Uri.base)]),
         profileMemory: 'devtools_memory.json',
       );
@@ -222,6 +221,7 @@ void main() {
       final DriverService driverService = setUpDriverService(
         processManager: processManager,
         vmService: fakeVmServiceHost.vmService,
+        platform: FakePlatform(environment: <String, String>{'FOO': 'BAR'}),
       );
       final Device device = FakeDevice(
         LaunchResult.succeeded(vmServiceUri: Uri.parse('http://127.0.0.1:63426/1UasC_ihpXY=/')),
@@ -232,12 +232,9 @@ void main() {
         device,
         DebuggingOptions.enabled(BuildInfo.profile, ipv6: true),
       );
-      final int testResult = await driverService.startTest(
-        'foo.test',
-        <String>['--enable-experiment=non-nullable'],
-        <String, String>{'FOO': 'BAR'},
-        PackageConfig.empty,
-      );
+      final int testResult = await driverService.startTest('foo.test', <String>[
+        '--enable-experiment=non-nullable',
+      ], PackageConfig.empty);
 
       expect(testResult, 23);
     },
@@ -276,7 +273,6 @@ void main() {
       final int testResult = await driverService.startTest(
         'foo.test',
         <String>[],
-        <String, String>{},
         PackageConfig(<Package>[Package('test', Uri.base)]),
       );
 
@@ -483,6 +479,7 @@ void main() {
 
 FlutterDriverService setUpDriverService({
   Logger? logger,
+  Platform? platform,
   ProcessManager? processManager,
   FlutterVmService? vmService,
   DevtoolsLauncher? devtoolsLauncher,
@@ -491,6 +488,7 @@ FlutterDriverService setUpDriverService({
   return FlutterDriverService(
     applicationPackageFactory: FakeApplicationPackageFactory(FakeApplicationPackage()),
     logger: logger,
+    platform: platform ?? FakePlatform(),
     processUtils: ProcessUtils(
       logger: logger,
       processManager: processManager ?? FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/net.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -411,6 +412,7 @@ WebDriverService setUpDriverService() {
     logger: logger,
     processUtils: ProcessUtils(logger: logger, processManager: FakeProcessManager.any()),
     dartSdkPath: 'dart',
+    platform: FakePlatform(),
   );
 }
 

--- a/packages/flutter_tools/test/integration.shard/driver_environment_test.dart
+++ b/packages/flutter_tools/test/integration.shard/driver_environment_test.dart
@@ -1,0 +1,67 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_data/project.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = fileSystem.systemTempDirectory.createTempSync('driver_environment_test.');
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext('environment variables are passed to the drive script', () async {
+    final Project project = _PrintEnvironmentVariablesInTestDriverProject();
+    await project.setUpIn(tempDir);
+
+    final ProcessResult result = await processManager.run(
+      <String>[flutterBin, 'drive', '-d', 'flutter-tester'],
+      workingDirectory: tempDir.path,
+      environment: <String, String>{'FOO': 'BAR'},
+    );
+
+    printOnFailure('stdout: ${result.stdout}');
+    printOnFailure('stderr: ${result.stderr}');
+    expect(result.exitCode, 0);
+
+    expect(result.stdout.toString(), contains('FOO=BAR'));
+  });
+}
+
+final class _PrintEnvironmentVariablesInTestDriverProject extends Project {
+  @override
+  final String pubspec = '''
+  name: test
+  environment:
+    sdk: ^3.7.0-0
+
+  dependencies:
+    flutter:
+      sdk: flutter
+  ''';
+
+  @override
+  final String main = r'void main() {}';
+
+  @override
+  Future<void> setUpIn(Directory dir) async {
+    await super.setUpIn(dir);
+    writeFile(fileSystem.path.join(dir.path, 'test_driver', 'main_test.dart'), r'''
+import 'dart:io' as io;
+
+void main() {
+  print('FOO=${io.Platform.environment['FOO']}');
+}
+''');
+  }
+}

--- a/packages/flutter_tools/test/web.shard/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/web.shard/web_driver_service_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/drive/web_driver_service.dart';
 import 'package:package_config/package_config_types.dart';
@@ -20,13 +21,13 @@ void main() {
         logger: logger,
         processUtils: ProcessUtils(logger: logger, processManager: FakeProcessManager.empty()),
         dartSdkPath: 'dart',
+        platform: FakePlatform(),
       );
       const String link = 'https://flutter.dev/to/integration-test-on-web';
       try {
         await service.startTest(
           'foo.test',
           <String>[],
-          <String, String>{},
           PackageConfig(<Package>[Package('test', Uri.base)]),
           driverPort: 1,
           headless: true,


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/161449.

~3 LOC, with 203 lines of tests (including an e2e integration test that it actually works).

Feedback welcome!

(The reason I'm working on this is the ability to pass environment variables makes it much easier and less hacky to make `android_engine_test` configurable, i.e. have different expected outputs for OpenGLES/Vulkan, compare screenshots locally for deflaking, etc).