### PR TITLE
Migrate DisplayList unit tests to DL/Impeller geometry classes

### DIFF
--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.h
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.h
@@ -15,7 +15,6 @@
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/core/SkVertices.h"
 
 namespace flutter {
 namespace testing {
@@ -26,6 +25,12 @@ enum BenchmarkAttributes {
   kFilledStyle = 1 << 1,
   kHairlineStroke = 1 << 2,
   kAntiAliasing = 1 << 3
+};
+
+enum class RRectType {
+  kSimple,
+  kNinePatch,
+  kComplex,
 };
 
 DlPaint GetPaintForRun(unsigned attributes);
@@ -52,11 +57,11 @@ void BM_DrawArc(benchmark::State& state,
 void BM_DrawRRect(benchmark::State& state,
                   BackendType backend_type,
                   unsigned attributes,
-                  SkRRect::Type type);
+                  RRectType type);
 void BM_DrawDRRect(benchmark::State& state,
                    BackendType backend_type,
                    unsigned attributes,
-                   SkRRect::Type type);
+                   RRectType type);
 void BM_DrawPath(benchmark::State& state,
                  BackendType backend_type,
                  unsigned attributes,
@@ -102,7 +107,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawLine
 #define DRAW_LINE_BENCHMARKS(BACKEND, ATTRIBUTES)                       \
   BENCHMARK_CAPTURE(BM_DrawLine, BACKEND,                               \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 2048)                                                 \
@@ -112,7 +117,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawRect
 #define DRAW_RECT_BENCHMARKS(BACKEND, ATTRIBUTES)                       \
   BENCHMARK_CAPTURE(BM_DrawRect, BACKEND,                               \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 2048)                                                 \
@@ -122,7 +127,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawOval
 #define DRAW_OVAL_BENCHMARKS(BACKEND, ATTRIBUTES)                       \
   BENCHMARK_CAPTURE(BM_DrawOval, BACKEND,                               \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 2048)                                                 \
@@ -132,7 +137,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawCircle
 #define DRAW_CIRCLE_BENCHMARKS(BACKEND, ATTRIBUTES)                     \
   BENCHMARK_CAPTURE(BM_DrawCircle, BACKEND,                             \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 2048)                                                 \
@@ -142,7 +147,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawArc
 #define DRAW_ARC_BENCHMARKS(BACKEND, ATTRIBUTES)                        \
   BENCHMARK_CAPTURE(BM_DrawArc, BACKEND,                                \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(128, 2048)                                                \
@@ -153,7 +158,7 @@ void BM_SaveLayer(benchmark::State& state,
 #define DRAW_PATH_BENCHMARKS(BACKEND, ATTRIBUTES)                       \
   BENCHMARK_CAPTURE(BM_DrawPath,                                        \
                     Lines/BACKEND,                                      \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     SkPath::Verb::kLine_Verb)                           \
       ->RangeMultiplier(2)                                              \
@@ -164,7 +169,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPath,                                        \
                     Quads/BACKEND,                                      \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     SkPath::Verb::kQuad_Verb)                           \
       ->RangeMultiplier(2)                                              \
@@ -175,7 +180,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPath,                                        \
                     Conics/BACKEND,                                     \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     SkPath::Verb::kConic_Verb)                          \
       ->RangeMultiplier(2)                                              \
@@ -186,7 +191,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPath,                                        \
                     Cubics/BACKEND,                                     \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     SkPath::Verb::kCubic_Verb)                          \
       ->RangeMultiplier(2)                                              \
@@ -198,7 +203,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawPoints
 #define DRAW_POINTS_BENCHMARKS(BACKEND, ATTRIBUTES)                     \
   BENCHMARK_CAPTURE(BM_DrawPoints, Points/BACKEND,                      \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlCanvas::PointMode::kPoints)                       \
       ->RangeMultiplier(2)                                              \
@@ -207,7 +212,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPoints, Lines/BACKEND,                       \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlCanvas::PointMode::kLines)                        \
       ->RangeMultiplier(2)                                              \
@@ -216,7 +221,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPoints, Polygon/BACKEND,                     \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlCanvas::PointMode::kPolygon)                      \
       ->RangeMultiplier(2)                                              \
@@ -228,7 +233,7 @@ void BM_SaveLayer(benchmark::State& state,
 #define DRAW_VERTICES_BENCHMARKS(BACKEND, ATTRIBUTES)                   \
   BENCHMARK_CAPTURE(BM_DrawVertices,                                    \
                     TriangleStrip/BACKEND,                              \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlVertexMode::kTriangleStrip)                       \
       ->RangeMultiplier(2)                                              \
@@ -239,7 +244,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawVertices,                                    \
                     TriangleFan/BACKEND,                                \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlVertexMode::kTriangleFan)                         \
       ->RangeMultiplier(2)                                              \
@@ -250,7 +255,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawVertices,                                    \
                     Triangles/BACKEND,                                  \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlVertexMode::kTriangles)                           \
       ->RangeMultiplier(2)                                              \
@@ -262,27 +267,27 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawRRect
 #define DRAW_RRECT_BENCHMARKS(BACKEND, ATTRIBUTES)                      \
   BENCHMARK_CAPTURE(BM_DrawRRect, Symmetric/BACKEND,                    \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    SkRRect::Type::kSimple_Type)                        \
+                    RRectType::kSimple)                                 \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 256)                                                  \
       ->UseRealTime()                                                   \
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawRRect, NinePatch/BACKEND,                    \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    SkRRect::Type::kNinePatch_Type)                     \
+                    RRectType::kNinePatch)                              \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 256)                                                  \
       ->UseRealTime()                                                   \
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawRRect, Complex/BACKEND,                      \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    SkRRect::Type::kComplex_Type)                       \
+                    RRectType::kComplex)                                \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 256)                                                  \
       ->UseRealTime()                                                   \
@@ -291,27 +296,27 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawDRRect
 #define DRAW_DRRECT_BENCHMARKS(BACKEND, ATTRIBUTES)                     \
   BENCHMARK_CAPTURE(BM_DrawDRRect, Symmetric/BACKEND,                   \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    SkRRect::Type::kSimple_Type)                        \
+                    RRectType::kSimple)                                 \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 256)                                                  \
       ->UseRealTime()                                                   \
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawDRRect, NinePatch/BACKEND,                   \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    SkRRect::Type::kNinePatch_Type)                     \
+                    RRectType::kNinePatch)                              \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 256)                                                  \
       ->UseRealTime()                                                   \
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawDRRect, Complex/BACKEND,                     \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    SkRRect::Type::kComplex_Type)                       \
+                    RRectType::kComplex)                                \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 256)                                                  \
       ->UseRealTime()                                                   \
@@ -320,18 +325,18 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawImage
 #define DRAW_IMAGE_BENCHMARKS(BACKEND, ATTRIBUTES)                      \
   BENCHMARK_CAPTURE(BM_DrawImage, Texture/BACKEND,                      \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    DlImageSampling::kNearestNeighbor, false)                         \
+                    DlImageSampling::kNearestNeighbor, false)           \
       ->RangeMultiplier(2)                                              \
       ->Range(128, 512)                                                 \
       ->UseRealTime()                                                   \
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawImage, Upload/BACKEND,                       \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    DlImageSampling::kNearestNeighbor, true)                          \
+                    DlImageSampling::kNearestNeighbor, true)            \
       ->RangeMultiplier(2)                                              \
       ->Range(128, 512)                                                 \
       ->UseRealTime()                                                   \
@@ -341,7 +346,7 @@ void BM_SaveLayer(benchmark::State& state,
 #define DRAW_IMAGE_RECT_BENCHMARKS(BACKEND, ATTRIBUTES)                 \
   BENCHMARK_CAPTURE(                                                    \
       BM_DrawImageRect, Texture/Strict/BACKEND,                         \
-      BackendType::k##BACKEND##Backend,                                \
+      BackendType::k##BACKEND##Backend,                                 \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
       DlCanvas::SrcRectConstraint::kStrict, false)                      \
@@ -352,7 +357,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(                                                    \
       BM_DrawImageRect, Texture/Fast/BACKEND,                           \
-      BackendType::k##BACKEND##Backend,                                \
+      BackendType::k##BACKEND##Backend,                                 \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
       DlCanvas::SrcRectConstraint::kFast, false)                        \
@@ -363,7 +368,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(                                                    \
       BM_DrawImageRect, Upload/Strict/BACKEND,                          \
-      BackendType::k##BACKEND##Backend,                                \
+      BackendType::k##BACKEND##Backend,                                 \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
       DlCanvas::SrcRectConstraint::kStrict, true)                       \
@@ -374,7 +379,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(                                                    \
       BM_DrawImageRect, Upload/Fast/BACKEND,                            \
-      BackendType::k##BACKEND##Backend,                                \
+      BackendType::k##BACKEND##Backend,                                 \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
       DlCanvas::SrcRectConstraint::kFast, true)                         \
@@ -386,7 +391,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawImageNine
 #define DRAW_IMAGE_NINE_BENCHMARKS(BACKEND, ATTRIBUTES)                 \
   BENCHMARK_CAPTURE(BM_DrawImageNine, Texture/Nearest/BACKEND,          \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlFilterMode::kNearest, false)                      \
       ->RangeMultiplier(2)                                              \
@@ -395,7 +400,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawImageNine, Upload/Nearest/BACKEND,           \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlFilterMode::kNearest, true)                       \
       ->RangeMultiplier(2)                                              \
@@ -404,7 +409,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawImageNine, Texture/Linear/BACKEND,           \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlFilterMode::kLinear, false)                       \
       ->RangeMultiplier(2)                                              \
@@ -413,7 +418,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawImageNine, Upload/Linear/BACKEND,            \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     DlFilterMode::kLinear, true)                        \
       ->RangeMultiplier(2)                                              \
@@ -424,7 +429,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawTextBlob
 #define DRAW_TEXT_BLOB_BENCHMARKS(BACKEND, ATTRIBUTES)                  \
   BENCHMARK_CAPTURE(BM_DrawTextBlob, BACKEND,                           \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(1, 256)                                                   \
@@ -435,7 +440,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawShadow
 #define DRAW_SHADOW_BENCHMARKS(BACKEND, ATTRIBUTES)                     \
   BENCHMARK_CAPTURE(BM_DrawShadow, Lines/Transparent/BACKEND,           \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     true,                                               \
                     SkPath::Verb::kLine_Verb)                           \
@@ -445,7 +450,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Quads/Transparent/BACKEND,           \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     true,                                               \
                     SkPath::Verb::kQuad_Verb)                           \
@@ -455,7 +460,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Conics/Transparent/BACKEND,          \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     true,                                               \
                     SkPath::Verb::kConic_Verb)                          \
@@ -465,7 +470,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Cubics/Transparent/BACKEND,          \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     true,                                               \
                     SkPath::Verb::kCubic_Verb)                          \
@@ -475,7 +480,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Lines/Opaque/BACKEND,                \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     false,                                              \
                     SkPath::Verb::kLine_Verb)                           \
@@ -485,7 +490,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Quads/Opaque/BACKEND,                \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     false,                                              \
                     SkPath::Verb::kQuad_Verb)                           \
@@ -495,7 +500,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Conics/Opaque/BACKEND,               \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     false,                                              \
                     SkPath::Verb::kConic_Verb)                          \
@@ -505,7 +510,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Cubics/Opaque/BACKEND,               \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     false,                                              \
                     SkPath::Verb::kCubic_Verb)                          \
@@ -517,7 +522,7 @@ void BM_SaveLayer(benchmark::State& state,
 // SaveLayer
 #define SAVE_LAYER_BENCHMARKS(BACKEND, ATTRIBUTES)                      \
   BENCHMARK_CAPTURE(BM_SaveLayer, Depth 1/BACKEND,                      \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     1)                                                  \
       ->RangeMultiplier(2)                                              \
@@ -526,7 +531,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_SaveLayer, Depth 8/BACKEND,                      \
-                    BackendType::k##BACKEND##Backend,                  \
+                    BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
                     8)                                                  \
       ->RangeMultiplier(2)                                              \
@@ -575,11 +580,11 @@ void BM_SaveLayer(benchmark::State& state,
   STROKE_BENCHMARKS(BACKEND, kStrokedStyle | kAntiAliasing)        \
   STROKE_BENCHMARKS(BACKEND, kStrokedStyle | kHairlineStroke)      \
   STROKE_BENCHMARKS(BACKEND, kStrokedStyle | kHairlineStroke |     \
-                             kAntiAliasing)                         \
-  FILL_BENCHMARKS(BACKEND, kFilledStyle)                            \
-  FILL_BENCHMARKS(BACKEND, kFilledStyle | kAntiAliasing)            \
-  ANTI_ALIASING_BENCHMARKS(BACKEND, kEmpty)                         \
-  ANTI_ALIASING_BENCHMARKS(BACKEND, kAntiAliasing)                  \
+                             kAntiAliasing)                        \
+  FILL_BENCHMARKS(BACKEND, kFilledStyle)                           \
+  FILL_BENCHMARKS(BACKEND, kFilledStyle | kAntiAliasing)           \
+  ANTI_ALIASING_BENCHMARKS(BACKEND, kEmpty)                        \
+  ANTI_ALIASING_BENCHMARKS(BACKEND, kAntiAliasing)                 \
   OTHER_BENCHMARKS(BACKEND, kEmpty)
 
 // clang-format on

--- a/engine/src/flutter/display_list/benchmarking/dl_builder_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_builder_benchmarks.cc
@@ -127,7 +127,7 @@ static void BM_DisplayListBuilderWithPerspective(
 static void BM_DisplayListBuilderWithClipRect(
     benchmark::State& state,
     DisplayListBuilderBenchmarkType type) {
-  SkRect clip_bounds = SkRect::MakeLTRB(6.5, 7.3, 90.2, 85.7);
+  DlRect clip_bounds = DlRect::MakeLTRB(6.5, 7.3, 90.2, 85.7);
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
     DisplayListBuilder builder(prepare_rtree);
@@ -183,7 +183,7 @@ static void BM_DisplayListBuilderWithSaveLayerAndImageFilter(
     DisplayListBuilderBenchmarkType type) {
   DlPaint layer_paint;
   layer_paint.setImageFilter(&testing::kTestBlurImageFilter1);
-  SkRect layer_bounds = SkRect::MakeLTRB(6.5, 7.3, 35.2, 42.7);
+  DlRect layer_bounds = DlRect::MakeLTRB(6.5, 7.3, 35.2, 42.7);
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
     DisplayListBuilder builder(prepare_rtree);
@@ -191,7 +191,7 @@ static void BM_DisplayListBuilderWithSaveLayerAndImageFilter(
     for (auto& group : allRenderingOps) {
       for (size_t i = 0; i < group.variants.size(); i++) {
         auto& invocation = group.variants[i];
-        builder.SaveLayer(&layer_bounds, &layer_paint);
+        builder.SaveLayer(layer_bounds, &layer_paint);
         invocation.Invoke(receiver);
         builder.Restore();
       }
@@ -282,8 +282,8 @@ static void BM_DisplayListDispatchCull(benchmark::State& state,
     InvokeAllOps(builder);
   }
   auto display_list = builder.Build();
-  SkRect rect = SkRect::MakeLTRB(0, 0, 100, 100);
-  EXPECT_FALSE(rect.contains(display_list->bounds()));
+  DlRect rect = DlRect::MakeLTRB(0, 0, 100, 100);
+  EXPECT_FALSE(rect.Contains(display_list->GetBounds()));
   DlOpReceiverIgnore receiver;
   while (state.KeepRunning()) {
     display_list->Dispatch(receiver, rect);

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -24,12 +24,6 @@
 #include "flutter/testing/display_list_testing.h"
 #include "flutter/testing/testing.h"
 
-#include "third_party/skia/include/core/SkBBHFactory.h"
-#include "third_party/skia/include/core/SkColorFilter.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
-#include "third_party/skia/include/core/SkRSXform.h"
-#include "third_party/skia/include/core/SkSurface.h"
-
 namespace flutter {
 
 DlOpReceiver& DisplayListBuilderTestingAccessor(DisplayListBuilder& builder) {
@@ -129,8 +123,7 @@ class DisplayListTestBase : public BaseT {
     EXPECT_EQ(builder_paint, defaults);
     EXPECT_TRUE(builder_paint.isDefault());
 
-    EXPECT_EQ(builder.GetTransform(), SkMatrix());
-    EXPECT_EQ(builder.GetTransformFullPerspective(), SkM44());
+    EXPECT_EQ(builder.GetMatrix(), DlMatrix());
 
     EXPECT_EQ(builder.GetLocalClipCoverage(), cull_rect);
     EXPECT_EQ(builder.GetDestinationClipCoverage(), cull_rect);
@@ -139,47 +132,46 @@ class DisplayListTestBase : public BaseT {
   }
 
   typedef const std::function<void(DlCanvas&)> DlSetup;
-  typedef const std::function<void(DlCanvas&, DlPaint&, SkRect& rect)>
-      DlRenderer;
+  typedef const std::function<void(DlCanvas&, DlPaint&, DlRect&)> DlRenderer;
 
   static void verify_inverted_bounds(DlSetup& setup,
                                      DlRenderer& renderer,
                                      DlPaint paint,
-                                     SkRect render_rect,
-                                     SkRect expected_bounds,
+                                     DlRect render_rect,
+                                     DlRect expected_bounds,
                                      const std::string& desc) {
     DisplayListBuilder builder;
     setup(builder);
     renderer(builder, paint, render_rect);
     auto dl = builder.Build();
     EXPECT_EQ(dl->op_count(), 1u) << desc;
-    EXPECT_EQ(dl->bounds(), expected_bounds) << desc;
+    EXPECT_EQ(dl->GetBounds(), expected_bounds) << desc;
   }
 
   static void check_inverted_bounds(DlRenderer& renderer,
                                     const std::string& desc) {
-    SkRect rect = SkRect::MakeLTRB(0.0f, 0.0f, 10.0f, 10.0f);
-    SkRect invertedLR = SkRect::MakeLTRB(rect.fRight, rect.fTop,  //
-                                         rect.fLeft, rect.fBottom);
-    SkRect invertedTB = SkRect::MakeLTRB(rect.fLeft, rect.fBottom,  //
-                                         rect.fRight, rect.fTop);
-    SkRect invertedLTRB = SkRect::MakeLTRB(rect.fRight, rect.fBottom,  //
-                                           rect.fLeft, rect.fTop);
+    DlRect rect = DlRect::MakeLTRB(0.0f, 0.0f, 10.0f, 10.0f);
+    DlRect invertedLR = DlRect::MakeLTRB(rect.GetRight(), rect.GetTop(),
+                                         rect.GetLeft(), rect.GetBottom());
+    DlRect invertedTB = DlRect::MakeLTRB(rect.GetLeft(), rect.GetBottom(),
+                                         rect.GetRight(), rect.GetTop());
+    DlRect invertedLTRB = DlRect::MakeLTRB(rect.GetRight(), rect.GetBottom(),
+                                           rect.GetLeft(), rect.GetTop());
     auto empty_setup = [](DlCanvas&) {};
 
-    ASSERT_TRUE(rect.fLeft < rect.fRight);
-    ASSERT_TRUE(rect.fTop < rect.fBottom);
-    ASSERT_FALSE(rect.isEmpty());
-    ASSERT_TRUE(invertedLR.fLeft > invertedLR.fRight);
-    ASSERT_TRUE(invertedLR.isEmpty());
-    ASSERT_TRUE(invertedTB.fTop > invertedTB.fBottom);
-    ASSERT_TRUE(invertedTB.isEmpty());
-    ASSERT_TRUE(invertedLTRB.fLeft > invertedLTRB.fRight);
-    ASSERT_TRUE(invertedLTRB.fTop > invertedLTRB.fBottom);
-    ASSERT_TRUE(invertedLTRB.isEmpty());
+    ASSERT_TRUE(rect.GetLeft() < rect.GetRight());
+    ASSERT_TRUE(rect.GetTop() < rect.GetBottom());
+    ASSERT_FALSE(rect.IsEmpty());
+    ASSERT_TRUE(invertedLR.GetLeft() > invertedLR.GetRight());
+    ASSERT_TRUE(invertedLR.IsEmpty());
+    ASSERT_TRUE(invertedTB.GetTop() > invertedTB.GetBottom());
+    ASSERT_TRUE(invertedTB.IsEmpty());
+    ASSERT_TRUE(invertedLTRB.GetLeft() > invertedLTRB.GetRight());
+    ASSERT_TRUE(invertedLTRB.GetTop() > invertedLTRB.GetBottom());
+    ASSERT_TRUE(invertedLTRB.IsEmpty());
 
     DlPaint ref_paint = DlPaint();
-    SkRect ref_bounds = rect;
+    DlRect ref_bounds = rect;
     verify_inverted_bounds(empty_setup, renderer, ref_paint, invertedLR,
                            ref_bounds, desc + " LR swapped");
     verify_inverted_bounds(empty_setup, renderer, ref_paint, invertedTB,
@@ -196,7 +188,7 @@ class DisplayListTestBase : public BaseT {
                                .setDrawStyle(DlDrawStyle::kStroke)   //
                                .setStrokeJoin(DlStrokeJoin::kRound)  //
                                .setStrokeWidth(2.0f);
-    SkRect stroke_bounds = rect.makeOutset(1.0f, 1.0f);
+    DlRect stroke_bounds = rect.Expand(1.0f, 1.0f);
     verify_inverted_bounds(empty_setup, renderer, stroke_paint, invertedLR,
                            stroke_bounds, desc + " LR swapped, sw 2");
     verify_inverted_bounds(empty_setup, renderer, stroke_paint, invertedTB,
@@ -207,7 +199,7 @@ class DisplayListTestBase : public BaseT {
     DlBlurMaskFilter mask_filter(DlBlurStyle::kNormal, 2.0f);
     DlPaint maskblur_paint = DlPaint()  //
                                  .setMaskFilter(&mask_filter);
-    SkRect maskblur_bounds = rect.makeOutset(6.0f, 6.0f);
+    DlRect maskblur_bounds = rect.Expand(6.0f, 6.0f);
     verify_inverted_bounds(empty_setup, renderer, maskblur_paint, invertedLR,
                            maskblur_bounds, desc + " LR swapped, mask 2");
     verify_inverted_bounds(empty_setup, renderer, maskblur_paint, invertedTB,
@@ -218,7 +210,7 @@ class DisplayListTestBase : public BaseT {
     DlErodeImageFilter erode_filter(2.0f, 2.0f);
     DlPaint erode_paint = DlPaint()  //
                               .setImageFilter(&erode_filter);
-    SkRect erode_bounds = rect.makeInset(2.0f, 2.0f);
+    DlRect erode_bounds = rect.Expand(-2.0f, -2.0f);
     verify_inverted_bounds(empty_setup, renderer, erode_paint, invertedLR,
                            erode_bounds, desc + " LR swapped, erode 2");
     verify_inverted_bounds(empty_setup, renderer, erode_paint, invertedTB,
@@ -293,7 +285,7 @@ TEST_F(DisplayListTest, GeneralReceiverInitialValues) {
 
 TEST_F(DisplayListTest, Iteration) {
   DisplayListBuilder builder;
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   auto dl = builder.Build();
   for (DlIndex i : *dl) {
     EXPECT_EQ(dl->GetOpType(i), DisplayListOpType::kDrawRect)  //
@@ -305,7 +297,7 @@ TEST_F(DisplayListTest, Iteration) {
 
 TEST_F(DisplayListTest, InvalidIndices) {
   DisplayListBuilder builder;
-  builder.DrawRect(kTestSkBounds, DlPaint());
+  builder.DrawRect(kTestBounds, DlPaint());
   auto dl = builder.Build();
   DisplayListGeneralReceiver receiver;
 
@@ -326,7 +318,7 @@ TEST_F(DisplayListTest, InvalidIndices) {
 
 TEST_F(DisplayListTest, ValidIndices) {
   DisplayListBuilder builder;
-  builder.DrawRect(kTestSkBounds, DlPaint());
+  builder.DrawRect(kTestBounds, DlPaint());
   auto dl = builder.Build();
   DisplayListGeneralReceiver receiver;
 
@@ -338,10 +330,10 @@ TEST_F(DisplayListTest, ValidIndices) {
 }
 
 TEST_F(DisplayListTest, BuilderCanBeReused) {
-  DisplayListBuilder builder(kTestSkBounds);
-  builder.DrawRect(kTestSkBounds, DlPaint());
+  DisplayListBuilder builder(kTestBounds);
+  builder.DrawRect(kTestBounds, DlPaint());
   auto dl = builder.Build();
-  builder.DrawRect(kTestSkBounds, DlPaint());
+  builder.DrawRect(kTestBounds, DlPaint());
   auto dl2 = builder.Build();
   ASSERT_TRUE(dl->Equals(dl2));
 }
@@ -371,18 +363,13 @@ TEST_F(DisplayListTest, SaveRestoreRestoresTransform) {
   check_defaults(builder, cull_rect);
 
   builder.Save();
-  builder.Transform(SkMatrix::Scale(10.0f, 10.0f));
+  builder.Transform(DlMatrix::MakeScale({10.0f, 10.0f, 1.0f}));
   builder.Restore();
   check_defaults(builder, cull_rect);
 
   builder.Save();
   builder.Transform2DAffine(1.0f, 0.0f, 12.0f,  //
                             0.0f, 1.0f, 35.0f);
-  builder.Restore();
-  check_defaults(builder, cull_rect);
-
-  builder.Save();
-  builder.Transform(SkM44(SkMatrix::Scale(10.0f, 10.0f)));
   builder.Restore();
   check_defaults(builder, cull_rect);
 
@@ -415,16 +402,12 @@ TEST_F(DisplayListTest, BuildRestoresTransform) {
   builder.Build();
   check_defaults(builder, cull_rect);
 
-  builder.Transform(SkMatrix::Scale(10.0f, 10.0f));
+  builder.Transform(DlMatrix::MakeScale({10.0f, 10.0f, 1.0f}));
   builder.Build();
   check_defaults(builder, cull_rect);
 
   builder.Transform2DAffine(1.0f, 0.0f, 12.0f,  //
                             0.0f, 1.0f, 35.0f);
-  builder.Build();
-  check_defaults(builder, cull_rect);
-
-  builder.Transform(SkM44(SkMatrix::Scale(10.0f, 10.0f)));
   builder.Build();
   check_defaults(builder, cull_rect);
 
@@ -441,17 +424,18 @@ TEST_F(DisplayListTest, SaveRestoreRestoresClip) {
   DisplayListBuilder builder(cull_rect);
 
   builder.Save();
-  builder.ClipRect(SkRect{0.0f, 0.0f, 10.0f, 10.0f});
+  builder.ClipRect(DlRect::MakeLTRB(0.0f, 0.0f, 10.0f, 10.0f));
   builder.Restore();
   check_defaults(builder, cull_rect);
 
   builder.Save();
-  builder.ClipRRect(SkRRect::MakeRectXY({0.0f, 0.0f, 5.0f, 5.0f}, 2.0f, 2.0f));
+  builder.ClipRoundRect(DlRoundRect::MakeRectXY(
+      DlRect::MakeLTRB(0.0f, 0.0f, 5.0f, 5.0f), 2.0f, 2.0f));
   builder.Restore();
   check_defaults(builder, cull_rect);
 
   builder.Save();
-  builder.ClipPath(SkPath().addOval({0.0f, 0.0f, 10.0f, 10.0f}));
+  builder.ClipPath(DlPath::MakeOvalLTRB(0.0f, 0.0f, 10.0f, 10.0f));
   builder.Restore();
   check_defaults(builder, cull_rect);
 }
@@ -460,15 +444,16 @@ TEST_F(DisplayListTest, BuildRestoresClip) {
   DlRect cull_rect = DlRect::MakeLTRB(-10.0f, -10.0f, 500.0f, 500.0f);
   DisplayListBuilder builder(cull_rect);
 
-  builder.ClipRect(SkRect{0.0f, 0.0f, 10.0f, 10.0f});
+  builder.ClipRect(DlRect::MakeLTRB(0.0f, 0.0f, 10.0f, 10.0f));
   builder.Build();
   check_defaults(builder, cull_rect);
 
-  builder.ClipRRect(SkRRect::MakeRectXY({0.0f, 0.0f, 5.0f, 5.0f}, 2.0f, 2.0f));
+  builder.ClipRoundRect(DlRoundRect::MakeRectXY(
+      DlRect::MakeLTRB(0.0f, 0.0f, 5.0f, 5.0f), 2.0f, 2.0f));
   builder.Build();
   check_defaults(builder, cull_rect);
 
-  builder.ClipPath(SkPath().addOval({0.0f, 0.0f, 10.0f, 10.0f}));
+  builder.ClipPath(DlPath::MakeOvalLTRB(0.0f, 0.0f, 10.0f, 10.0f));
   builder.Build();
   check_defaults(builder, cull_rect);
 }
@@ -532,82 +517,80 @@ TEST_F(DisplayListTest, BuildRestoresAttributes) {
 }
 
 TEST_F(DisplayListTest, BuilderBoundsTransformComparedToSkia) {
-  const SkRect frame_rect = SkRect::MakeLTRB(10, 10, 100, 100);
+  const DlRect frame_rect = DlRect::MakeLTRB(10, 10, 100, 100);
   DisplayListBuilder builder(frame_rect);
-  SkPictureRecorder recorder;
-  SkCanvas* canvas = recorder.beginRecording(frame_rect);
-  ASSERT_EQ(builder.GetDestinationClipBounds(),
-            SkRect::Make(canvas->getDeviceClipBounds()));
-  ASSERT_EQ(builder.GetLocalClipBounds().makeOutset(1, 1),
-            canvas->getLocalClipBounds());
-  ASSERT_EQ(builder.GetTransform(), canvas->getTotalMatrix());
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), frame_rect);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), frame_rect);
+  ASSERT_EQ(builder.GetMatrix(), DlMatrix());
 }
 
 TEST_F(DisplayListTest, BuilderInitialClipBounds) {
-  SkRect cull_rect = SkRect::MakeWH(100, 100);
-  SkRect clip_bounds = SkRect::MakeWH(100, 100);
+  DlRect cull_rect = DlRect::MakeWH(100, 100);
+  DlRect clip_bounds = DlRect::MakeWH(100, 100);
   DisplayListBuilder builder(cull_rect);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
 TEST_F(DisplayListTest, BuilderInitialClipBoundsNaN) {
-  SkRect cull_rect = SkRect::MakeWH(SK_ScalarNaN, SK_ScalarNaN);
-  SkRect clip_bounds = SkRect::MakeEmpty();
+  auto NaN = std::numeric_limits<DlScalar>::quiet_NaN();
+  DlRect cull_rect = DlRect::MakeWH(NaN, NaN);
+  DlRect clip_bounds = DlRect();
   DisplayListBuilder builder(cull_rect);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
 TEST_F(DisplayListTest, BuilderClipBoundsAfterClipRect) {
-  SkRect cull_rect = SkRect::MakeWH(100, 100);
-  SkRect clip_rect = SkRect::MakeLTRB(10, 10, 20, 20);
-  SkRect clip_bounds = SkRect::MakeLTRB(10, 10, 20, 20);
+  DlRect cull_rect = DlRect::MakeWH(100, 100);
+  DlRect clip_rect = DlRect::MakeLTRB(10, 10, 20, 20);
+  DlRect clip_bounds = DlRect::MakeLTRB(10, 10, 20, 20);
   DisplayListBuilder builder(cull_rect);
   builder.ClipRect(clip_rect, ClipOp::kIntersect, false);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
 TEST_F(DisplayListTest, BuilderClipBoundsAfterClipRRect) {
-  SkRect cull_rect = SkRect::MakeWH(100, 100);
-  SkRect clip_rect = SkRect::MakeLTRB(10, 10, 20, 20);
-  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 2, 2);
-  SkRect clip_bounds = SkRect::MakeLTRB(10, 10, 20, 20);
+  DlRect cull_rect = DlRect::MakeWH(100, 100);
+  DlRect clip_rect = DlRect::MakeLTRB(10, 10, 20, 20);
+  DlRoundRect clip_rrect = DlRoundRect::MakeRectXY(clip_rect, 2, 2);
+  DlRect clip_bounds = DlRect::MakeLTRB(10, 10, 20, 20);
   DisplayListBuilder builder(cull_rect);
-  builder.ClipRRect(clip_rrect, ClipOp::kIntersect, false);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  builder.ClipRoundRect(clip_rrect, ClipOp::kIntersect, false);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
 TEST_F(DisplayListTest, BuilderClipBoundsAfterClipPath) {
-  SkRect cull_rect = SkRect::MakeWH(100, 100);
-  SkPath clip_path = SkPath().addRect(10, 10, 15, 15).addRect(15, 15, 20, 20);
-  SkRect clip_bounds = SkRect::MakeLTRB(10, 10, 20, 20);
+  DlRect cull_rect = DlRect::MakeWH(100, 100);
+  DlPath clip_path = DlPath::MakeRectLTRB(10, 10, 15, 15) +
+                     DlPath::MakeRectLTRB(15, 15, 20, 20);
+  DlRect clip_bounds = DlRect::MakeLTRB(10, 10, 20, 20);
   DisplayListBuilder builder(cull_rect);
   builder.ClipPath(clip_path, ClipOp::kIntersect, false);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
 TEST_F(DisplayListTest, BuilderInitialClipBoundsNonZero) {
-  SkRect cull_rect = SkRect::MakeLTRB(10, 10, 100, 100);
-  SkRect clip_bounds = SkRect::MakeLTRB(10, 10, 100, 100);
+  DlRect cull_rect = DlRect::MakeLTRB(10, 10, 100, 100);
+  DlRect clip_bounds = DlRect::MakeLTRB(10, 10, 100, 100);
   DisplayListBuilder builder(cull_rect);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
 TEST_F(DisplayListTest, UnclippedSaveLayerContentAccountsForFilter) {
-  SkRect cull_rect = SkRect::MakeLTRB(0.0f, 0.0f, 300.0f, 300.0f);
-  SkRect clip_rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
-  SkRect draw_rect = SkRect::MakeLTRB(50.0f, 140.0f, 101.0f, 160.0f);
+  DlRect cull_rect = DlRect::MakeLTRB(0.0f, 0.0f, 300.0f, 300.0f);
+  DlRect clip_rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect draw_rect = DlRect::MakeLTRB(50.0f, 140.0f, 101.0f, 160.0f);
   auto filter = DlImageFilter::MakeBlur(10.0f, 10.0f, DlTileMode::kDecal);
   DlPaint layer_paint = DlPaint().setImageFilter(filter);
 
-  ASSERT_TRUE(clip_rect.intersects(draw_rect));
-  ASSERT_TRUE(cull_rect.contains(clip_rect));
-  ASSERT_TRUE(cull_rect.contains(draw_rect));
+  ASSERT_TRUE(clip_rect.IntersectsWithRect(draw_rect));
+  ASSERT_TRUE(cull_rect.Contains(clip_rect));
+  ASSERT_TRUE(cull_rect.Contains(draw_rect));
 
   DisplayListBuilder builder;
   builder.Save();
   {
     builder.ClipRect(clip_rect, ClipOp::kIntersect, false);
-    builder.SaveLayer(&cull_rect, &layer_paint);
+    builder.SaveLayer(cull_rect, &layer_paint);
     {  //
       builder.DrawRect(draw_rect, DlPaint());
     }
@@ -619,28 +602,29 @@ TEST_F(DisplayListTest, UnclippedSaveLayerContentAccountsForFilter) {
   EXPECT_EQ(display_list->op_count(), 6u);
   EXPECT_EQ(display_list->total_depth(), 2u);
 
-  SkRect result_rect = draw_rect.makeOutset(30.0f, 30.0f);
-  ASSERT_TRUE(result_rect.intersect(clip_rect));
-  ASSERT_EQ(result_rect, SkRect::MakeLTRB(100.0f, 110.0f, 131.0f, 190.0f));
-  EXPECT_EQ(display_list->bounds(), result_rect);
+  DlRect result_rect = draw_rect.Expand(30.0f, 30.0f);
+  ASSERT_TRUE(result_rect.IntersectsWithRect(clip_rect));
+  result_rect = result_rect.IntersectionOrEmpty(clip_rect);
+  ASSERT_EQ(result_rect, DlRect::MakeLTRB(100.0f, 110.0f, 131.0f, 190.0f));
+  EXPECT_EQ(display_list->GetBounds(), result_rect);
 }
 
 TEST_F(DisplayListTest, ClippedSaveLayerContentAccountsForFilter) {
-  SkRect cull_rect = SkRect::MakeLTRB(0.0f, 0.0f, 300.0f, 300.0f);
-  SkRect clip_rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
-  SkRect draw_rect = SkRect::MakeLTRB(50.0f, 140.0f, 99.0f, 160.0f);
+  DlRect cull_rect = DlRect::MakeLTRB(0.0f, 0.0f, 300.0f, 300.0f);
+  DlRect clip_rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect draw_rect = DlRect::MakeLTRB(50.0f, 140.0f, 99.0f, 160.0f);
   auto filter = DlImageFilter::MakeBlur(10.0f, 10.0f, DlTileMode::kDecal);
   DlPaint layer_paint = DlPaint().setImageFilter(filter);
 
-  ASSERT_FALSE(clip_rect.intersects(draw_rect));
-  ASSERT_TRUE(cull_rect.contains(clip_rect));
-  ASSERT_TRUE(cull_rect.contains(draw_rect));
+  ASSERT_FALSE(clip_rect.IntersectsWithRect(draw_rect));
+  ASSERT_TRUE(cull_rect.Contains(clip_rect));
+  ASSERT_TRUE(cull_rect.Contains(draw_rect));
 
   DisplayListBuilder builder;
   builder.Save();
   {
     builder.ClipRect(clip_rect, ClipOp::kIntersect, false);
-    builder.SaveLayer(&cull_rect, &layer_paint);
+    builder.SaveLayer(cull_rect, &layer_paint);
     {  //
       builder.DrawRect(draw_rect, DlPaint());
     }
@@ -652,10 +636,11 @@ TEST_F(DisplayListTest, ClippedSaveLayerContentAccountsForFilter) {
   EXPECT_EQ(display_list->op_count(), 6u);
   EXPECT_EQ(display_list->total_depth(), 2u);
 
-  SkRect result_rect = draw_rect.makeOutset(30.0f, 30.0f);
-  ASSERT_TRUE(result_rect.intersect(clip_rect));
-  ASSERT_EQ(result_rect, SkRect::MakeLTRB(100.0f, 110.0f, 129.0f, 190.0f));
-  EXPECT_EQ(display_list->bounds(), result_rect);
+  DlRect result_rect = draw_rect.Expand(30.0f, 30.0f);
+  ASSERT_TRUE(result_rect.IntersectsWithRect(clip_rect));
+  result_rect = result_rect.IntersectionOrEmpty(clip_rect);
+  ASSERT_EQ(result_rect, DlRect::MakeLTRB(100.0f, 110.0f, 129.0f, 190.0f));
+  EXPECT_EQ(display_list->GetBounds(), result_rect);
 }
 
 TEST_F(DisplayListTest, OOBSaveLayerContentCulledWithBlurFilter) {
@@ -929,9 +914,9 @@ TEST_F(DisplayListTest, DisplayListsWithVaryingOpComparisons) {
 }
 
 TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
-  SkRect build_bounds = SkRect::MakeLTRB(-100, -100, 200, 200);
-  SkRect save_bounds = SkRect::MakeWH(100, 100);
-  SkRect rect = SkRect::MakeLTRB(30, 30, 70, 70);
+  DlRect build_bounds = DlRect::MakeLTRB(-100, -100, 200, 200);
+  DlRect save_bounds = DlRect::MakeWH(100, 100);
+  DlRect rect = DlRect::MakeLTRB(30, 30, 70, 70);
   // clang-format off
   const float color_matrix[] = {
     0, 0, 0, 0, 0,
@@ -950,17 +935,15 @@ TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
   };
   // clang-format on
   auto alpha_color_filter = DlColorFilter::MakeMatrix(alpha_matrix);
-  sk_sp<SkColorFilter> sk_alpha_color_filter =
-      SkColorFilters::Matrix(alpha_matrix);
 
   {
     // No tricky stuff, just verifying drawing a rect produces rect bounds
     DisplayListBuilder builder(build_bounds);
-    builder.SaveLayer(&save_bounds, nullptr);
+    builder.SaveLayer(save_bounds, nullptr);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), rect);
+    ASSERT_EQ(display_list->GetBounds(), rect);
   }
 
   {
@@ -968,43 +951,25 @@ TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
     DisplayListBuilder builder(build_bounds);
     DlPaint save_paint;
     save_paint.setColorFilter(base_color_filter);
-    builder.SaveLayer(&save_bounds, &save_paint);
+    builder.SaveLayer(save_bounds, &save_paint);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), rect);
+    ASSERT_EQ(display_list->GetBounds(), rect);
   }
 
   {
-    // Now checking how SkPictureRecorder deals with a color filter
-    // that modifies alpha channels (save layer bounds are meaningless
-    // under those circumstances)
-    SkPictureRecorder recorder;
-    SkRTreeFactory rtree_factory;
-    SkCanvas* canvas = recorder.beginRecording(build_bounds, &rtree_factory);
-    SkPaint p1;
-    p1.setColorFilter(sk_alpha_color_filter);
-    canvas->saveLayer(save_bounds, &p1);
-    SkPaint p2;
-    canvas->drawRect(rect, p2);
-    canvas->restore();
-    sk_sp<SkPicture> picture = recorder.finishRecordingAsPicture();
-    ASSERT_EQ(picture->cullRect(), build_bounds);
-  }
-
-  {
-    // Now checking that DisplayList has the same behavior that we
-    // saw in the SkPictureRecorder example above - returning the
-    // cull rect of the DisplayListBuilder when it encounters a
-    // save layer that modifies an unbounded region
+    // Now checking that DisplayList returns the cull rect of the
+    // DisplayListBuilder when it encounters a save layer that modifies
+    // an unbounded region
     DisplayListBuilder builder(build_bounds);
     DlPaint save_paint;
     save_paint.setColorFilter(alpha_color_filter);
-    builder.SaveLayer(&save_bounds, &save_paint);
+    builder.SaveLayer(save_bounds, &save_paint);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), build_bounds);
+    ASSERT_EQ(display_list->GetBounds(), build_bounds);
   }
 
   {
@@ -1013,11 +978,11 @@ TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
     DisplayListBuilder builder(build_bounds);
     DlPaint save_paint;
     save_paint.setColorFilter(alpha_color_filter);
-    builder.SaveLayer(nullptr, &save_paint);
+    builder.SaveLayer(std::nullopt, &save_paint);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), build_bounds);
+    ASSERT_EQ(display_list->GetBounds(), build_bounds);
   }
 
   {
@@ -1027,11 +992,11 @@ TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
     DlColorFilterImageFilter color_filter_image_filter(base_color_filter);
     DlPaint save_paint;
     save_paint.setImageFilter(&color_filter_image_filter);
-    builder.SaveLayer(&save_bounds, &save_paint);
+    builder.SaveLayer(save_bounds, &save_paint);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), rect);
+    ASSERT_EQ(display_list->GetBounds(), rect);
   }
 
   {
@@ -1041,11 +1006,11 @@ TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
     DlColorFilterImageFilter color_filter_image_filter(alpha_color_filter);
     DlPaint save_paint;
     save_paint.setImageFilter(&color_filter_image_filter);
-    builder.SaveLayer(&save_bounds, &save_paint);
+    builder.SaveLayer(save_bounds, &save_paint);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), build_bounds);
+    ASSERT_EQ(display_list->GetBounds(), build_bounds);
   }
 
   {
@@ -1054,11 +1019,11 @@ TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
     DlColorFilterImageFilter color_filter_image_filter(alpha_color_filter);
     DlPaint save_paint;
     save_paint.setImageFilter(&color_filter_image_filter);
-    builder.SaveLayer(nullptr, &save_paint);
+    builder.SaveLayer(std::nullopt, &save_paint);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), build_bounds);
+    ASSERT_EQ(display_list->GetBounds(), build_bounds);
   }
 
   {
@@ -1066,11 +1031,11 @@ TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
     DisplayListBuilder builder(build_bounds);
     DlPaint save_paint;
     save_paint.setBlendMode(DlBlendMode::kClear);
-    builder.SaveLayer(&save_bounds, &save_paint);
+    builder.SaveLayer(save_bounds, &save_paint);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), build_bounds);
+    ASSERT_EQ(display_list->GetBounds(), build_bounds);
   }
 
   {
@@ -1078,61 +1043,36 @@ TEST_F(DisplayListTest, DisplayListSaveLayerBoundsWithAlphaFilter) {
     DisplayListBuilder builder(build_bounds);
     DlPaint save_paint;
     save_paint.setBlendMode(DlBlendMode::kClear);
-    builder.SaveLayer(nullptr, &save_paint);
+    builder.SaveLayer(std::nullopt, &save_paint);
     builder.DrawRect(rect, DlPaint());
     builder.Restore();
     sk_sp<DisplayList> display_list = builder.Build();
-    ASSERT_EQ(display_list->bounds(), build_bounds);
+    ASSERT_EQ(display_list->GetBounds(), build_bounds);
   }
 }
 
-TEST_F(DisplayListTest, NestedOpCountMetricsSameAsSkPicture) {
-  SkPictureRecorder recorder;
-  recorder.beginRecording(SkRect::MakeWH(150, 100));
-  SkCanvas* canvas = recorder.getRecordingCanvas();
-  SkPaint sk_paint;
-  for (int y = 10; y <= 60; y += 10) {
-    for (int x = 10; x <= 60; x += 10) {
-      sk_paint.setColor(((x + y) % 20) == 10 ? SK_ColorRED : SK_ColorBLUE);
-      canvas->drawRect(SkRect::MakeXYWH(x, y, 80, 80), sk_paint);
-    }
-  }
-  SkPictureRecorder outer_recorder;
-  outer_recorder.beginRecording(SkRect::MakeWH(150, 100));
-  canvas = outer_recorder.getRecordingCanvas();
-  canvas->drawPicture(recorder.finishRecordingAsPicture());
-
-  auto picture = outer_recorder.finishRecordingAsPicture();
-  ASSERT_EQ(picture->approximateOpCount(), 1);
-  ASSERT_EQ(picture->approximateOpCount(true), 36);
-
-  DisplayListBuilder builder(SkRect::MakeWH(150, 100));
+TEST_F(DisplayListTest, NestedOpCountMetrics) {
+  DisplayListBuilder builder(DlRect::MakeWH(150, 100));
   DlPaint dl_paint;
   for (int y = 10; y <= 60; y += 10) {
     for (int x = 10; x <= 60; x += 10) {
-      dl_paint.setColor(((x + y) % 20) == 10 ? DlColor(SK_ColorRED)
-                                             : DlColor(SK_ColorBLUE));
-      builder.DrawRect(SkRect::MakeXYWH(x, y, 80, 80), dl_paint);
+      dl_paint.setColor(((x + y) % 20) == 10 ? DlColor::kRed()
+                                             : DlColor::kBlue());
+      builder.DrawRect(DlRect::MakeXYWH(x, y, 80, 80), dl_paint);
     }
   }
 
-  DisplayListBuilder outer_builder(SkRect::MakeWH(150, 100));
+  DisplayListBuilder outer_builder(DlRect::MakeWH(150, 100));
   outer_builder.DrawDisplayList(builder.Build());
   auto display_list = outer_builder.Build();
 
   ASSERT_EQ(display_list->op_count(), 1u);
   ASSERT_EQ(display_list->op_count(true), 36u);
   EXPECT_EQ(display_list->total_depth(), 37u);
-
-  ASSERT_EQ(picture->approximateOpCount(),
-            static_cast<int>(display_list->op_count()));
-  ASSERT_EQ(picture->approximateOpCount(true),
-            static_cast<int>(display_list->op_count(true)));
 }
 
 TEST_F(DisplayListTest, DisplayListFullPerspectiveTransformHandling) {
-  // SkM44 constructor takes row-major order
-  SkM44 sk_matrix = SkM44(
+  auto matrix = DlMatrix::MakeRow(
       // clang-format off
        1,  2,  3,  4,
        5,  6,  7,  8,
@@ -1152,16 +1092,8 @@ TEST_F(DisplayListTest, DisplayListFullPerspectiveTransformHandling) {
         13, 14, 15, 16
         // clang-format on
     );
-    sk_sp<DisplayList> display_list = builder.Build();
-    sk_sp<SkSurface> surface =
-        SkSurfaces::Raster(SkImageInfo::MakeN32Premul(10, 10));
-    SkCanvas* canvas = surface->getCanvas();
-    // We can't use DlSkCanvas.DrawDisplayList as that method protects
-    // the canvas against mutations from the display list being drawn.
-    auto dispatcher = DlSkCanvasDispatcher(surface->getCanvas());
-    display_list->Dispatch(dispatcher);
-    SkM44 dl_matrix = canvas->getLocalToDevice();
-    ASSERT_EQ(sk_matrix, dl_matrix);
+    DlMatrix dl_matrix = builder.GetMatrix();
+    ASSERT_EQ(dl_matrix, matrix);
   }
   {  // Next test !=
     DisplayListBuilder builder;
@@ -1174,16 +1106,8 @@ TEST_F(DisplayListTest, DisplayListFullPerspectiveTransformHandling) {
          4,  8, 12, 16
         // clang-format on
     );
-    sk_sp<DisplayList> display_list = builder.Build();
-    sk_sp<SkSurface> surface =
-        SkSurfaces::Raster(SkImageInfo::MakeN32Premul(10, 10));
-    SkCanvas* canvas = surface->getCanvas();
-    // We can't use DlSkCanvas.DrawDisplayList as that method protects
-    // the canvas against mutations from the display list being drawn.
-    auto dispatcher = DlSkCanvasDispatcher(surface->getCanvas());
-    display_list->Dispatch(dispatcher);
-    SkM44 dl_matrix = canvas->getLocalToDevice();
-    ASSERT_NE(sk_matrix, dl_matrix);
+    DlMatrix dl_matrix = builder.GetMatrix();
+    ASSERT_NE(dl_matrix, matrix);
   }
 }
 
@@ -1191,16 +1115,7 @@ TEST_F(DisplayListTest, DisplayListTransformResetHandling) {
   DisplayListBuilder builder;
   builder.Scale(20.0, 20.0);
   builder.TransformReset();
-  auto display_list = builder.Build();
-  ASSERT_NE(display_list, nullptr);
-  sk_sp<SkSurface> surface =
-      SkSurfaces::Raster(SkImageInfo::MakeN32Premul(10, 10));
-  SkCanvas* canvas = surface->getCanvas();
-  // We can't use DlSkCanvas.DrawDisplayList as that method protects
-  // the canvas against mutations from the display list being drawn.
-  auto dispatcher = DlSkCanvasDispatcher(surface->getCanvas());
-  display_list->Dispatch(dispatcher);
-  ASSERT_TRUE(canvas->getTotalMatrix().isIdentity());
+  ASSERT_TRUE(builder.GetMatrix().IsIdentity());
 }
 
 TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
@@ -1248,64 +1163,69 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
   RUN_TESTS2(canvas.DrawColor(DlColor(SK_ColorRED), DlBlendMode::kSrcOver);
              , true);
   RUN_TESTS2(canvas.DrawColor(DlColor(SK_ColorRED), DlBlendMode::kSrc);, false);
-  RUN_TESTS(canvas.DrawLine(SkPoint{0, 0}, SkPoint{10, 10}, paint););
-  RUN_TESTS(canvas.DrawRect(SkRect{0, 0, 10, 10}, paint););
-  RUN_TESTS(canvas.DrawOval(SkRect{0, 0, 10, 10}, paint););
-  RUN_TESTS(canvas.DrawCircle(SkPoint{10, 10}, 5, paint););
-  RUN_TESTS(
-      canvas.DrawRRect(SkRRect::MakeRectXY({0, 0, 10, 10}, 2, 2), paint););
-  RUN_TESTS(canvas.DrawDRRect(SkRRect::MakeRectXY({0, 0, 10, 10}, 2, 2),
-                              SkRRect::MakeRectXY({2, 2, 8, 8}, 2, 2), paint););
+  RUN_TESTS(canvas.DrawLine(DlPoint(0, 0), DlPoint(10, 10), paint););
+  RUN_TESTS(canvas.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10), paint););
+  RUN_TESTS(canvas.DrawOval(DlRect::MakeLTRB(0, 0, 10, 10), paint););
+  RUN_TESTS(canvas.DrawCircle(DlPoint(10, 10), 5, paint););
+  RUN_TESTS(canvas.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeLTRB(0, 0, 10, 10), 2, 2), paint););
+  RUN_TESTS(canvas.DrawDiffRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeLTRB(0, 0, 10, 10), 2, 2),
+      DlRoundRect::MakeRectXY(DlRect::MakeLTRB(2, 2, 8, 8), 2, 2), paint););
   RUN_TESTS(canvas.DrawPath(
-      SkPath().addOval({0, 0, 10, 10}).addOval({5, 5, 15, 15}), paint););
-  RUN_TESTS(canvas.DrawArc(SkRect{0, 0, 10, 10}, 0, math::kPi, true, paint););
+      DlPath::MakeOvalLTRB(0, 0, 10, 10) + DlPath::MakeOvalLTRB(5, 5, 15, 15),
+      paint););
+  RUN_TESTS(canvas.DrawArc(DlRect::MakeLTRB(0, 0, 10, 10), 0, math::kPi, true,
+                           paint););
   RUN_TESTS2(
       canvas.DrawPoints(PointMode::kPoints, TestPointCount, kTestPoints, paint);
       , false);
   RUN_TESTS2(canvas.DrawVertices(kTestVertices1, DlBlendMode::kSrc, paint);
              , false);
-  RUN_TESTS(
-      canvas.DrawImage(TestImage1, SkPoint{0, 0}, kLinearSampling, &paint););
-  RUN_TESTS2(
-      canvas.DrawImage(TestImage1, SkPoint{0, 0}, kLinearSampling, nullptr);
-      , true);
-  RUN_TESTS(canvas.DrawImageRect(TestImage1, SkIRect{10, 10, 20, 20},
-                                 {0, 0, 10, 10}, kNearestSampling, &paint,
-                                 DlCanvas::SrcRectConstraint::kFast););
-  RUN_TESTS2(canvas.DrawImageRect(TestImage1, SkIRect{10, 10, 20, 20},
-                                  {0, 0, 10, 10}, kNearestSampling, nullptr,
-                                  DlCanvas::SrcRectConstraint::kFast);
+  RUN_TESTS(canvas.DrawImage(kTestImage1, DlPoint(), kLinearSampling, &paint););
+  RUN_TESTS2(canvas.DrawImage(kTestImage1, DlPoint(), kLinearSampling, nullptr);
              , true);
-  RUN_TESTS(canvas.DrawImageNine(TestImage2, SkIRect{20, 20, 30, 30},
-                                 SkRect{0, 0, 20, 20}, DlFilterMode::kLinear,
-                                 &paint););
-  RUN_TESTS2(canvas.DrawImageNine(TestImage2, SkIRect{20, 20, 30, 30},
-                                  SkRect{0, 0, 20, 20}, DlFilterMode::kLinear,
-                                  nullptr);
+  RUN_TESTS(canvas.DrawImageRect(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+                                 DlRect::MakeLTRB(0, 0, 10, 10),
+                                 kNearestSampling, &paint,
+                                 DlCanvas::SrcRectConstraint::kFast););
+  RUN_TESTS2(
+      canvas.DrawImageRect(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+                           DlRect::MakeLTRB(0, 0, 10, 10), kNearestSampling,
+                           nullptr, DlCanvas::SrcRectConstraint::kFast);
+      , true);
+  RUN_TESTS(canvas.DrawImageNine(kTestImage2, DlIRect::MakeLTRB(20, 20, 30, 30),
+                                 DlRect::MakeLTRB(0, 0, 20, 20),
+                                 DlFilterMode::kLinear, &paint););
+  RUN_TESTS2(canvas.DrawImageNine(
+      kTestImage2, DlIRect::MakeLTRB(20, 20, 30, 30),
+      DlRect::MakeLTRB(0, 0, 20, 20), DlFilterMode::kLinear, nullptr);
              , true);
   static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-  static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+  static DlRect texs[] = {
+      DlRect::MakeLTRB(10, 10, 20, 20),
+      DlRect::MakeLTRB(20, 20, 30, 30),
+  };
   RUN_TESTS2(
-      canvas.DrawAtlas(TestImage1, xforms, texs, nullptr, 2,
+      canvas.DrawAtlas(kTestImage1, xforms, texs, nullptr, 2,
                        DlBlendMode::kSrcIn, kNearestSampling, nullptr, &paint);
       , false);
   RUN_TESTS2(
-      canvas.DrawAtlas(TestImage1, xforms, texs, nullptr, 2,
+      canvas.DrawAtlas(kTestImage1, xforms, texs, nullptr, 2,
                        DlBlendMode::kSrcIn, kNearestSampling, nullptr, nullptr);
       , false);
   EXPECT_TRUE(TestDisplayList1->can_apply_group_opacity());
   RUN_TESTS2(canvas.DrawDisplayList(TestDisplayList1);, true);
   {
     static DisplayListBuilder builder;
-    builder.DrawRect(SkRect{0, 0, 10, 10}, DlPaint());
-    builder.DrawRect(SkRect{5, 5, 15, 15}, DlPaint());
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10), DlPaint());
+    builder.DrawRect(DlRect::MakeLTRB(5, 5, 15, 15), DlPaint());
     static auto display_list = builder.Build();
     RUN_TESTS2(canvas.DrawDisplayList(display_list);, false);
   }
   RUN_TESTS2(canvas.DrawTextBlob(GetTestTextBlob(1), 0, 0, paint);, false);
-  RUN_TESTS2(
-      canvas.DrawShadow(kTestPath1, DlColor(SK_ColorBLACK), 1.0, false, 1.0);
-      , false);
+  RUN_TESTS2(canvas.DrawShadow(kTestPath1, DlColor::kBlack(), 1.0, false, 1.0);
+             , false);
 
 #undef RUN_TESTS2
 #undef RUN_TESTS
@@ -1314,7 +1234,7 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
 TEST_F(DisplayListTest, OverlappingOpsDoNotSupportGroupOpacity) {
   DisplayListBuilder builder;
   for (int i = 0; i < 10; i++) {
-    builder.DrawRect(SkRect::MakeXYWH(i * 10, 0, 30, 30), DlPaint());
+    builder.DrawRect(DlRect::MakeXYWH(i * 10, 0, 30, 30), DlPaint());
   }
   auto display_list = builder.Build();
   EXPECT_FALSE(display_list->can_apply_group_opacity());
@@ -1323,7 +1243,7 @@ TEST_F(DisplayListTest, OverlappingOpsDoNotSupportGroupOpacity) {
 TEST_F(DisplayListTest, LineOfNonOverlappingOpsSupportGroupOpacity) {
   DisplayListBuilder builder;
   for (int i = 0; i < 10; i++) {
-    builder.DrawRect(SkRect::MakeXYWH(i * 30, 0, 30, 30), DlPaint());
+    builder.DrawRect(DlRect::MakeXYWH(i * 30, 0, 30, 30), DlPaint());
   }
   auto display_list = builder.Build();
   EXPECT_TRUE(display_list->can_apply_group_opacity());
@@ -1331,20 +1251,20 @@ TEST_F(DisplayListTest, LineOfNonOverlappingOpsSupportGroupOpacity) {
 
 TEST_F(DisplayListTest, CrossOfNonOverlappingOpsSupportGroupOpacity) {
   DisplayListBuilder builder;
-  builder.DrawRect(SkRect::MakeLTRB(200, 200, 300, 300), DlPaint());  // center
-  builder.DrawRect(SkRect::MakeLTRB(100, 200, 200, 300), DlPaint());  // left
-  builder.DrawRect(SkRect::MakeLTRB(200, 100, 300, 200), DlPaint());  // above
-  builder.DrawRect(SkRect::MakeLTRB(300, 200, 400, 300), DlPaint());  // right
-  builder.DrawRect(SkRect::MakeLTRB(200, 300, 300, 400), DlPaint());  // below
+  builder.DrawRect(DlRect::MakeLTRB(200, 200, 300, 300), DlPaint());  // center
+  builder.DrawRect(DlRect::MakeLTRB(100, 200, 200, 300), DlPaint());  // left
+  builder.DrawRect(DlRect::MakeLTRB(200, 100, 300, 200), DlPaint());  // above
+  builder.DrawRect(DlRect::MakeLTRB(300, 200, 400, 300), DlPaint());  // right
+  builder.DrawRect(DlRect::MakeLTRB(200, 300, 300, 400), DlPaint());  // below
   auto display_list = builder.Build();
   EXPECT_TRUE(display_list->can_apply_group_opacity());
 }
 
 TEST_F(DisplayListTest, SaveLayerFalseSupportsGroupOpacityOverlappingChidren) {
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   for (int i = 0; i < 10; i++) {
-    builder.DrawRect(SkRect::MakeXYWH(i * 10, 0, 30, 30), DlPaint());
+    builder.DrawRect(DlRect::MakeXYWH(i * 10, 0, 30, 30), DlPaint());
   }
   builder.Restore();
   auto display_list = builder.Build();
@@ -1354,9 +1274,9 @@ TEST_F(DisplayListTest, SaveLayerFalseSupportsGroupOpacityOverlappingChidren) {
 TEST_F(DisplayListTest, SaveLayerTrueSupportsGroupOpacityOverlappingChidren) {
   DisplayListBuilder builder;
   DlPaint save_paint;
-  builder.SaveLayer(nullptr, &save_paint);
+  builder.SaveLayer(std::nullopt, &save_paint);
   for (int i = 0; i < 10; i++) {
-    builder.DrawRect(SkRect::MakeXYWH(i * 10, 0, 30, 30), DlPaint());
+    builder.DrawRect(DlRect::MakeXYWH(i * 10, 0, 30, 30), DlPaint());
   }
   builder.Restore();
   auto display_list = builder.Build();
@@ -1370,10 +1290,9 @@ TEST_F(DisplayListTest, SaveLayerFalseWithSrcBlendSupportsGroupOpacity) {
   // SaveLayer following it should not use that attribute to base its
   // decisions about group opacity and the draw rect after that comes
   // with its own compatible blend mode.
-  builder.DrawRect(SkRect{0, 0, 0, 0},
-                   DlPaint().setBlendMode(DlBlendMode::kSrc));
-  builder.SaveLayer(nullptr, nullptr);
-  builder.DrawRect(SkRect{0, 0, 10, 10}, DlPaint());
+  builder.DrawRect(DlRect(), DlPaint().setBlendMode(DlBlendMode::kSrc));
+  builder.SaveLayer(std::nullopt, nullptr);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10), DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
   EXPECT_TRUE(display_list->can_apply_group_opacity());
@@ -1383,8 +1302,8 @@ TEST_F(DisplayListTest, SaveLayerTrueWithSrcBlendDoesNotSupportGroupOpacity) {
   DisplayListBuilder builder;
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kSrc);
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{0, 0, 10, 10}, DlPaint());
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10), DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
   EXPECT_FALSE(display_list->can_apply_group_opacity());
@@ -1392,8 +1311,8 @@ TEST_F(DisplayListTest, SaveLayerTrueWithSrcBlendDoesNotSupportGroupOpacity) {
 
 TEST_F(DisplayListTest, SaveLayerFalseSupportsGroupOpacityWithChildSrcBlend) {
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
-  builder.DrawRect(SkRect{0, 0, 10, 10},
+  builder.SaveLayer(std::nullopt, nullptr);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                    DlPaint().setBlendMode(DlBlendMode::kSrc));
   builder.Restore();
   auto display_list = builder.Build();
@@ -1403,8 +1322,8 @@ TEST_F(DisplayListTest, SaveLayerFalseSupportsGroupOpacityWithChildSrcBlend) {
 TEST_F(DisplayListTest, SaveLayerTrueSupportsGroupOpacityWithChildSrcBlend) {
   DisplayListBuilder builder;
   DlPaint save_paint;
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{0, 0, 10, 10},
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                    DlPaint().setBlendMode(DlBlendMode::kSrc));
   builder.Restore();
   auto display_list = builder.Build();
@@ -1414,16 +1333,15 @@ TEST_F(DisplayListTest, SaveLayerTrueSupportsGroupOpacityWithChildSrcBlend) {
 TEST_F(DisplayListTest, SaveLayerBoundsSnapshotsImageFilter) {
   DisplayListBuilder builder;
   DlPaint save_paint;
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{50, 50, 100, 100}, DlPaint());
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(50, 50, 100, 100), DlPaint());
   // This image filter should be ignored since it was not set before SaveLayer
   // And the rect drawn with it will not contribute any more area to the bounds
   DlPaint draw_paint;
   draw_paint.setImageFilter(&kTestBlurImageFilter1);
-  builder.DrawRect(SkRect{70, 70, 80, 80}, draw_paint);
+  builder.DrawRect(DlRect::MakeLTRB(70, 70, 80, 80), draw_paint);
   builder.Restore();
-  SkRect bounds = builder.Build()->bounds();
-  EXPECT_EQ(bounds, SkRect::MakeLTRB(50, 50, 100, 100));
+  EXPECT_EQ(builder.Build()->GetBounds(), DlRect::MakeLTRB(50, 50, 100, 100));
 }
 
 #define SAVE_LAYER_EXPECTOR(name) SaveLayerExpector name(__FILE__, __LINE__)
@@ -1560,9 +1478,9 @@ TEST_F(DisplayListTest, SaveLayerOneSimpleOpInheritsOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1575,8 +1493,8 @@ TEST_F(DisplayListTest, SaveLayerNoAttributesInheritsOpacity) {
       SaveLayerOptions::kNoAttributes.with_can_distribute_opacity());
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  builder.SaveLayer(std::nullopt, nullptr);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1589,10 +1507,10 @@ TEST_F(DisplayListTest, SaveLayerTwoOverlappingOpsDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
-  builder.DrawRect(SkRect{15, 15, 25, 25}, DlPaint());
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
+  builder.DrawRect(DlRect::MakeLTRB(15, 15, 25, 25), DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1610,12 +1528,12 @@ TEST_F(DisplayListTest, NestedSaveLayersMightInheritOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{15, 15, 25, 25}, DlPaint());
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(15, 15, 25, 25), DlPaint());
   builder.Restore();
   builder.Restore();
   builder.Restore();
@@ -1634,10 +1552,10 @@ TEST_F(DisplayListTest, NestedSaveLayersCanBothSupportOpacityOptimization) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.SaveLayer(nullptr, nullptr);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.SaveLayer(std::nullopt, nullptr);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   builder.Restore();
   builder.Restore();
 
@@ -1651,10 +1569,10 @@ TEST_F(DisplayListTest, SaveLayerImageFilterDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
   save_paint.setImageFilter(&kTestBlurImageFilter1);
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1667,10 +1585,10 @@ TEST_F(DisplayListTest, SaveLayerColorFilterDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
   save_paint.setColorFilter(kTestMatrixColorFilter1);
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1683,10 +1601,10 @@ TEST_F(DisplayListTest, SaveLayerSrcBlendDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
   save_paint.setBlendMode(DlBlendMode::kSrc);
-  builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  builder.SaveLayer(std::nullopt, &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1700,11 +1618,11 @@ TEST_F(DisplayListTest, SaveLayerImageFilterOnChildInheritsOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
-  builder.SaveLayer(nullptr, &save_paint);
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
+  builder.SaveLayer(std::nullopt, &save_paint);
   DlPaint draw_paint = save_paint;
   draw_paint.setImageFilter(&kTestBlurImageFilter1);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, draw_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), draw_paint);
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1717,11 +1635,11 @@ TEST_F(DisplayListTest, SaveLayerColorFilterOnChildDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
-  builder.SaveLayer(nullptr, &save_paint);
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
+  builder.SaveLayer(std::nullopt, &save_paint);
   DlPaint draw_paint = save_paint;
   draw_paint.setColorFilter(kTestMatrixColorFilter1);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, draw_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), draw_paint);
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1734,11 +1652,11 @@ TEST_F(DisplayListTest, SaveLayerSrcBlendOnChildDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlPaint save_paint;
-  save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
-  builder.SaveLayer(nullptr, &save_paint);
+  save_paint.setColor(DlColor::kWhite().withAlphaF(0.5f));
+  builder.SaveLayer(std::nullopt, &save_paint);
   DlPaint draw_paint = save_paint;
   draw_paint.setBlendMode(DlBlendMode::kSrc);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, draw_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), draw_paint);
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1748,100 +1666,173 @@ TEST_F(DisplayListTest, SaveLayerSrcBlendOnChildDoesNotInheritOpacity) {
 TEST_F(DisplayListTest, FlutterSvgIssue661BoundsWereEmpty) {
   // See https://github.com/dnfield/flutter_svg/issues/661
 
-  SkPath path1;
-  path1.setFillType(SkPathFillType::kWinding);
-  path1.moveTo(25.54f, 37.52f);
-  path1.cubicTo(20.91f, 37.52f, 16.54f, 33.39f, 13.62f, 30.58f);
-  path1.lineTo(13, 30);
-  path1.lineTo(12.45f, 29.42f);
-  path1.cubicTo(8.39f, 25.15f, 1.61f, 18, 8.37f, 11.27f);
-  path1.cubicTo(10.18f, 9.46f, 12.37f, 9.58f, 14.49f, 11.58f);
-  path1.cubicTo(15.67f, 12.71f, 17.05f, 14.69f, 17.07f, 16.58f);
-  path1.cubicTo(17.0968f, 17.458f, 16.7603f, 18.3081f, 16.14f, 18.93f);
-  path1.cubicTo(15.8168f, 19.239f, 15.4653f, 19.5169f, 15.09f, 19.76f);
-  path1.cubicTo(14.27f, 20.33f, 14.21f, 20.44f, 14.27f, 20.62f);
-  path1.cubicTo(15.1672f, 22.3493f, 16.3239f, 23.9309f, 17.7f, 25.31f);
-  path1.cubicTo(19.0791f, 26.6861f, 20.6607f, 27.8428f, 22.39f, 28.74f);
-  path1.cubicTo(22.57f, 28.8f, 22.69f, 28.74f, 23.25f, 27.92f);
-  path1.cubicTo(23.5f, 27.566f, 23.778f, 27.231f, 24.08f, 26.92f);
-  path1.cubicTo(24.7045f, 26.3048f, 25.5538f, 25.9723f, 26.43f, 26);
-  path1.cubicTo(28.29f, 26, 30.27f, 27.4f, 31.43f, 28.58f);
-  path1.cubicTo(33.43f, 30.67f, 33.55f, 32.9f, 31.74f, 34.7f);
-  path1.cubicTo(30.1477f, 36.4508f, 27.906f, 37.4704f, 25.54f, 37.52f);
-  path1.close();
-  path1.moveTo(11.17f, 12.23f);
-  path1.cubicTo(10.6946f, 12.2571f, 10.2522f, 12.4819f, 9.95f, 12.85f);
-  path1.cubicTo(5.12f, 17.67f, 8.95f, 22.5f, 14.05f, 27.85f);
-  path1.lineTo(14.62f, 28.45f);
-  path1.lineTo(15.16f, 28.96f);
-  path1.cubicTo(20.52f, 34.06f, 25.35f, 37.89f, 30.16f, 33.06f);
-  path1.cubicTo(30.83f, 32.39f, 31.25f, 31.56f, 29.81f, 30.06f);
-  path1.cubicTo(28.9247f, 29.07f, 27.7359f, 28.4018f, 26.43f, 28.16f);
-  path1.cubicTo(26.1476f, 28.1284f, 25.8676f, 28.2367f, 25.68f, 28.45f);
-  path1.cubicTo(25.4633f, 28.6774f, 25.269f, 28.9252f, 25.1f, 29.19f);
-  path1.cubicTo(24.53f, 30.01f, 23.47f, 31.54f, 21.54f, 30.79f);
-  path1.lineTo(21.41f, 30.72f);
-  path1.cubicTo(19.4601f, 29.7156f, 17.6787f, 28.4133f, 16.13f, 26.86f);
-  path1.cubicTo(14.5748f, 25.3106f, 13.2693f, 23.5295f, 12.26f, 21.58f);
-  path1.lineTo(12.2f, 21.44f);
-  path1.cubicTo(11.45f, 19.51f, 12.97f, 18.44f, 13.8f, 17.88f);
-  path1.cubicTo(14.061f, 17.706f, 14.308f, 17.512f, 14.54f, 17.3f);
-  path1.cubicTo(14.7379f, 17.1067f, 14.8404f, 16.8359f, 14.82f, 16.56f);
-  path1.cubicTo(14.5978f, 15.268f, 13.9585f, 14.0843f, 13, 13.19f);
-  path1.cubicTo(12.5398f, 12.642f, 11.8824f, 12.2971f, 11.17f, 12.23f);
-  path1.lineTo(11.17f, 12.23f);
-  path1.close();
-  path1.moveTo(27, 19.34f);
-  path1.lineTo(24.74f, 19.34f);
-  path1.cubicTo(24.7319f, 18.758f, 24.262f, 18.2881f, 23.68f, 18.28f);
-  path1.lineTo(23.68f, 16.05f);
-  path1.lineTo(23.7f, 16.05f);
-  path1.cubicTo(25.5153f, 16.0582f, 26.9863f, 17.5248f, 27, 19.34f);
-  path1.lineTo(27, 19.34f);
-  path1.close();
-  path1.moveTo(32.3f, 19.34f);
-  path1.lineTo(30.07f, 19.34f);
-  path1.cubicTo(30.037f, 15.859f, 27.171f, 13.011f, 23.69f, 13);
-  path1.lineTo(23.69f, 10.72f);
-  path1.cubicTo(28.415f, 10.725f, 32.3f, 14.615f, 32.3f, 19.34f);
-  path1.close();
+  DlPathBuilder path_builder1;
+  path_builder1.MoveTo({25.54f, 37.52f});
+  path_builder1.CubicCurveTo({20.91f, 37.52f},  //
+                             {16.54f, 33.39f},  //
+                             {13.62f, 30.58f});
+  path_builder1.LineTo({13, 30});
+  path_builder1.LineTo({12.45f, 29.42f});
+  path_builder1.CubicCurveTo({8.39f, 25.15f},  //
+                             {1.61f, 18},      //
+                             {8.37f, 11.27f});
+  path_builder1.CubicCurveTo({10.18f, 9.46f},  //
+                             {12.37f, 9.58f},  //
+                             {14.49f, 11.58f});
+  path_builder1.CubicCurveTo({15.67f, 12.71f},  //
+                             {17.05f, 14.69f},  //
+                             {17.07f, 16.58f});
+  path_builder1.CubicCurveTo({17.0968f, 17.458f},   //
+                             {16.7603f, 18.3081f},  //
+                             {16.14f, 18.93f});
+  path_builder1.CubicCurveTo({15.8168f, 19.239f},   //
+                             {15.4653f, 19.5169f},  //
+                             {15.09f, 19.76f});
+  path_builder1.CubicCurveTo({14.27f, 20.33f},  //
+                             {14.21f, 20.44f},  //
+                             {14.27f, 20.62f});
+  path_builder1.CubicCurveTo({15.1672f, 22.3493f},  //
+                             {16.3239f, 23.9309f},  //
+                             {17.7f, 25.31f});
+  path_builder1.CubicCurveTo({19.0791f, 26.6861f},  //
+                             {20.6607f, 27.8428f},  //
+                             {22.39f, 28.74f});
+  path_builder1.CubicCurveTo({22.57f, 28.8f},   //
+                             {22.69f, 28.74f},  //
+                             {23.25f, 27.92f});
+  path_builder1.CubicCurveTo({23.5f, 27.566f},    //
+                             {23.778f, 27.231f},  //
+                             {24.08f, 26.92f});
+  path_builder1.CubicCurveTo({24.7045f, 26.3048f},  //
+                             {25.5538f, 25.9723f},  //
+                             {26.43f, 26});
+  path_builder1.CubicCurveTo({28.29f, 26},     //
+                             {30.27f, 27.4f},  //
+                             {31.43f, 28.58f});
+  path_builder1.CubicCurveTo({33.43f, 30.67f},  //
+                             {33.55f, 32.9f},   //
+                             {31.74f, 34.7f});
+  path_builder1.CubicCurveTo({30.1477f, 36.4508f},  //
+                             {27.906f, 37.4704f},   //
+                             {25.54f, 37.52f});
+  path_builder1.Close();
+  path_builder1.MoveTo({11.17f, 12.23f});
+  path_builder1.CubicCurveTo({10.6946f, 12.2571f},  //
+                             {10.2522f, 12.4819f},  //
+                             {9.95f, 12.85f});
+  path_builder1.CubicCurveTo({5.12f, 17.67f},  //
+                             {8.95f, 22.5f},   //
+                             {14.05f, 27.85f});
+  path_builder1.LineTo({14.62f, 28.45f});
+  path_builder1.LineTo({15.16f, 28.96f});
+  path_builder1.CubicCurveTo({20.52f, 34.06f},  //
+                             {25.35f, 37.89f},  //
+                             {30.16f, 33.06f});
+  path_builder1.CubicCurveTo({30.83f, 32.39f},  //
+                             {31.25f, 31.56f},  //
+                             {29.81f, 30.06f});
+  path_builder1.CubicCurveTo({28.9247f, 29.07f},    //
+                             {27.7359f, 28.4018f},  //
+                             {26.43f, 28.16f});
+  path_builder1.CubicCurveTo({26.1476f, 28.1284f},  //
+                             {25.8676f, 28.2367f},  //
+                             {25.68f, 28.45f});
+  path_builder1.CubicCurveTo({25.4633f, 28.6774f},  //
+                             {25.269f, 28.9252f},   //
+                             {25.1f, 29.19f});
+  path_builder1.CubicCurveTo({24.53f, 30.01f},  //
+                             {23.47f, 31.54f},  //
+                             {21.54f, 30.79f});
+  path_builder1.LineTo({21.41f, 30.72f});
+  path_builder1.CubicCurveTo({19.4601f, 29.7156f},  //
+                             {17.6787f, 28.4133f},  //
+                             {16.13f, 26.86f});
+  path_builder1.CubicCurveTo({14.5748f, 25.3106f},  //
+                             {13.2693f, 23.5295f},  //
+                             {12.26f, 21.58f});
+  path_builder1.LineTo({12.2f, 21.44f});
+  path_builder1.CubicCurveTo({11.45f, 19.51f},  //
+                             {12.97f, 18.44f},  //
+                             {13.8f, 17.88f});
+  path_builder1.CubicCurveTo({14.061f, 17.706f},  //
+                             {14.308f, 17.512f},  //
+                             {14.54f, 17.3f});
+  path_builder1.CubicCurveTo({14.7379f, 17.1067f},  //
+                             {14.8404f, 16.8359f},  //
+                             {14.82f, 16.56f});
+  path_builder1.CubicCurveTo({14.5978f, 15.268f},   //
+                             {13.9585f, 14.0843f},  //
+                             {13, 13.19f});
+  path_builder1.CubicCurveTo({12.5398f, 12.642f},   //
+                             {11.8824f, 12.2971f},  //
+                             {11.17f, 12.23f});
+  path_builder1.LineTo({11.17f, 12.23f});
+  path_builder1.Close();
+  path_builder1.MoveTo({27, 19.34f});
+  path_builder1.LineTo({24.74f, 19.34f});
+  path_builder1.CubicCurveTo({24.7319f, 18.758f},  //
+                             {24.262f, 18.2881f},  //
+                             {23.68f, 18.28f});
+  path_builder1.LineTo({23.68f, 16.05f});
+  path_builder1.LineTo({23.7f, 16.05f});
+  path_builder1.CubicCurveTo({25.5153f, 16.0582f},  //
+                             {26.9863f, 17.5248f},  //
+                             {27, 19.34f});
+  path_builder1.LineTo({27, 19.34f});
+  path_builder1.Close();
+  path_builder1.MoveTo({32.3f, 19.34f});
+  path_builder1.LineTo({30.07f, 19.34f});
+  path_builder1.CubicCurveTo({30.037f, 15.859f},  //
+                             {27.171f, 13.011f},  //
+                             {23.69f, 13});
+  path_builder1.LineTo({23.69f, 10.72f});
+  path_builder1.CubicCurveTo({28.415f, 10.725f},  //
+                             {32.3f, 14.615f},    //
+                             {32.3f, 19.34f});
+  path_builder1.Close();
+  DlPath dl_path1 = DlPath(path_builder1.TakePath(DlPathFillType::kNonZero));
 
-  SkPath path2;
-  path2.setFillType(SkPathFillType::kWinding);
-  path2.moveTo(37.5f, 19.33f);
-  path2.lineTo(35.27f, 19.33f);
-  path2.cubicTo(35.265f, 12.979f, 30.041f, 7.755f, 23.69f, 7.75f);
-  path2.lineTo(23.69f, 5.52f);
-  path2.cubicTo(31.264f, 5.525f, 37.495f, 11.756f, 37.5f, 19.33f);
-  path2.close();
+  DlPathBuilder path_builder2;
+  path_builder2.MoveTo({37.5f, 19.33f});
+  path_builder2.LineTo({35.27f, 19.33f});
+  path_builder2.CubicCurveTo({35.265f, 12.979f},  //
+                             {30.041f, 7.755f},   //
+                             {23.69f, 7.75f});
+  path_builder2.LineTo({23.69f, 5.52f});
+  path_builder2.CubicCurveTo({31.264f, 5.525f},   //
+                             {37.495f, 11.756f},  //
+                             {37.5f, 19.33f});
+  path_builder2.Close();
+  DlPath dl_path2 = DlPath(path_builder2.TakePath(DlPathFillType::kNonZero));
 
   DisplayListBuilder builder;
   DlPaint paint = DlPaint(DlColor::kWhite()).setAntiAlias(true);
   {
     builder.Save();
-    builder.ClipRect(SkRect{0, 0, 100, 100}, ClipOp::kIntersect, true);
+    builder.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
+                     true);
     {
       builder.Save();
       builder.Transform2DAffine(2.17391, 0, -2547.83,  //
                                 0, 2.04082, -500);
       {
         builder.Save();
-        builder.ClipRect(SkRect{1172, 245, 1218, 294}, ClipOp::kIntersect,
-                         true);
+        builder.ClipRect(DlRect::MakeLTRB(1172, 245, 1218, 294),
+                         ClipOp::kIntersect, true);
         {
-          builder.SaveLayer(nullptr, nullptr, nullptr);
+          builder.SaveLayer(std::nullopt, nullptr, nullptr);
           {
             builder.Save();
             builder.Transform2DAffine(1.4375, 0, 1164.09,  //
                                       0, 1.53125, 236.548);
-            builder.DrawPath(path1, paint);
+            builder.DrawPath(DlPath(dl_path1), paint);
             builder.Restore();
           }
           {
             builder.Save();
             builder.Transform2DAffine(1.4375, 0, 1164.09,  //
                                       0, 1.53125, 236.548);
-            builder.DrawPath(path2, paint);
+            builder.DrawPath(DlPath(dl_path2), paint);
             builder.Restore();
           }
           builder.Restore();
@@ -1860,14 +1851,15 @@ TEST_F(DisplayListTest, FlutterSvgIssue661BoundsWereEmpty) {
   // calculations. If these lines have to be revised too often as the DL
   // implementation is improved and maintained, then we can eliminate
   // this test and just rely on the "rounded out" bounds test that follows.
-  SkRect min_bounds = SkRect::MakeLTRB(0, 0.00191, 99.983, 100);
-  SkRect max_bounds = SkRect::MakeLTRB(0, 0.00189, 99.985, 100);
-  ASSERT_TRUE(max_bounds.contains(min_bounds));
-  EXPECT_TRUE(max_bounds.contains(display_list->bounds()));
-  EXPECT_TRUE(display_list->bounds().contains(min_bounds));
+  DlRect min_bounds = DlRect::MakeLTRB(0, 0.00191, 99.983, 100);
+  DlRect max_bounds = DlRect::MakeLTRB(0, 0.00189, 99.985, 100);
+  ASSERT_TRUE(max_bounds.Contains(min_bounds));
+  EXPECT_TRUE(max_bounds.Contains(display_list->GetBounds()));
+  EXPECT_TRUE(display_list->GetBounds().Contains(min_bounds));
 
   // This is the more practical result. The bounds are "almost" 0,0,100x100
-  EXPECT_EQ(display_list->bounds().roundOut(), SkIRect::MakeWH(100, 100));
+  EXPECT_EQ(DlIRect::RoundOut(display_list->GetBounds()),
+            DlIRect::MakeWH(100, 100));
   EXPECT_EQ(display_list->op_count(), 19u);
   EXPECT_EQ(display_list->bytes(), sizeof(DisplayList) + 392u);
   EXPECT_EQ(display_list->total_depth(), 3u);
@@ -1875,548 +1867,502 @@ TEST_F(DisplayListTest, FlutterSvgIssue661BoundsWereEmpty) {
 
 TEST_F(DisplayListTest, TranslateAffectsCurrentTransform) {
   DisplayListBuilder builder;
-  builder.Translate(12.3, 14.5);
-  SkMatrix matrix = SkMatrix::Translate(12.3, 14.5);
-  SkM44 m44 = SkM44(matrix);
-  SkM44 cur_m44 = builder.GetTransformFullPerspective();
-  SkMatrix cur_matrix = builder.GetTransform();
-  ASSERT_EQ(cur_m44, m44);
+  builder.Translate(12.3f, 14.5f);
+  DlMatrix matrix = DlMatrix::MakeTranslation({12.3f, 14.5f});
+  DlMatrix cur_matrix = builder.GetMatrix();
   ASSERT_EQ(cur_matrix, matrix);
   builder.Translate(10, 10);
   // CurrentTransform has changed
-  ASSERT_NE(builder.GetTransformFullPerspective(), m44);
-  ASSERT_NE(builder.GetTransform(), cur_matrix);
+  ASSERT_NE(builder.GetMatrix(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(cur_m44, m44);
   ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST_F(DisplayListTest, ScaleAffectsCurrentTransform) {
   DisplayListBuilder builder;
   builder.Scale(12.3, 14.5);
-  SkMatrix matrix = SkMatrix::Scale(12.3, 14.5);
-  SkM44 m44 = SkM44(matrix);
-  SkM44 cur_m44 = builder.GetTransformFullPerspective();
-  SkMatrix cur_matrix = builder.GetTransform();
-  ASSERT_EQ(cur_m44, m44);
+  DlMatrix matrix = DlMatrix::MakeScale({12.3, 14.5, 1.0f});
+  DlMatrix cur_matrix = builder.GetMatrix();
   ASSERT_EQ(cur_matrix, matrix);
   builder.Translate(10, 10);
   // CurrentTransform has changed
-  ASSERT_NE(builder.GetTransformFullPerspective(), m44);
-  ASSERT_NE(builder.GetTransform(), cur_matrix);
+  ASSERT_NE(builder.GetMatrix(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(cur_m44, m44);
   ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST_F(DisplayListTest, RotateAffectsCurrentTransform) {
   DisplayListBuilder builder;
-  builder.Rotate(12.3);
-  SkMatrix matrix = SkMatrix::RotateDeg(12.3);
-  SkM44 m44 = SkM44(matrix);
-  SkM44 cur_m44 = builder.GetTransformFullPerspective();
-  SkMatrix cur_matrix = builder.GetTransform();
-  ASSERT_EQ(cur_m44, m44);
+  builder.Rotate(12.3f);
+  DlMatrix matrix = DlMatrix::MakeRotationZ(DlDegrees(12.3f));
+  DlMatrix cur_matrix = builder.GetMatrix();
   ASSERT_EQ(cur_matrix, matrix);
   builder.Translate(10, 10);
   // CurrentTransform has changed
-  ASSERT_NE(builder.GetTransformFullPerspective(), m44);
-  ASSERT_NE(builder.GetTransform(), cur_matrix);
+  ASSERT_NE(builder.GetMatrix(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(cur_m44, m44);
   ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST_F(DisplayListTest, SkewAffectsCurrentTransform) {
   DisplayListBuilder builder;
-  builder.Skew(12.3, 14.5);
-  SkMatrix matrix = SkMatrix::Skew(12.3, 14.5);
-  SkM44 m44 = SkM44(matrix);
-  SkM44 cur_m44 = builder.GetTransformFullPerspective();
-  SkMatrix cur_matrix = builder.GetTransform();
-  ASSERT_EQ(cur_m44, m44);
+  builder.Skew(12.3f, 14.5f);
+  DlMatrix matrix = DlMatrix::MakeSkew(12.3f, 14.5f);
+  DlMatrix cur_matrix = builder.GetMatrix();
   ASSERT_EQ(cur_matrix, matrix);
   builder.Translate(10, 10);
   // CurrentTransform has changed
-  ASSERT_NE(builder.GetTransformFullPerspective(), m44);
-  ASSERT_NE(builder.GetTransform(), cur_matrix);
+  ASSERT_NE(builder.GetMatrix(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(cur_m44, m44);
   ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST_F(DisplayListTest, TransformAffectsCurrentTransform) {
   DisplayListBuilder builder;
-  builder.Transform2DAffine(3, 0, 12.3,  //
-                            1, 5, 14.5);
-  SkMatrix matrix = SkMatrix::MakeAll(3, 0, 12.3,  //
-                                      1, 5, 14.5,  //
-                                      0, 0, 1);
-  SkM44 m44 = SkM44(matrix);
-  SkM44 cur_m44 = builder.GetTransformFullPerspective();
-  SkMatrix cur_matrix = builder.GetTransform();
-  ASSERT_EQ(cur_m44, m44);
+  builder.Transform2DAffine(3.0f, 0.0f, 12.3f,  //
+                            1.0f, 5.0f, 14.5f);
+  DlMatrix matrix = DlMatrix::MakeRow(3.0f, 0.0f, 0.0f, 12.3,  //
+                                      1.0f, 5.0f, 0.0f, 14.5,  //
+                                      0.0f, 0.0f, 1.0f, 0.0f,  //
+                                      0.0f, 0.0f, 0.0f, 1.0f   //
+  );
+  DlMatrix cur_matrix = builder.GetMatrix();
   ASSERT_EQ(cur_matrix, matrix);
   builder.Translate(10, 10);
   // CurrentTransform has changed
-  ASSERT_NE(builder.GetTransformFullPerspective(), m44);
-  ASSERT_NE(builder.GetTransform(), cur_matrix);
+  ASSERT_NE(builder.GetMatrix(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(cur_m44, m44);
   ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST_F(DisplayListTest, FullTransformAffectsCurrentTransform) {
   DisplayListBuilder builder;
-  builder.TransformFullPerspective(3, 0, 4, 12.3,  //
-                                   1, 5, 3, 14.5,  //
-                                   0, 0, 7, 16.2,  //
-                                   0, 0, 0, 1);
-  SkMatrix matrix = SkMatrix::MakeAll(3, 0, 12.3,  //
-                                      1, 5, 14.5,  //
-                                      0, 0, 1);
-  SkM44 m44 = SkM44(3, 0, 4, 12.3,  //
-                    1, 5, 3, 14.5,  //
-                    0, 0, 7, 16.2,  //
-                    0, 0, 0, 1);
-  SkM44 cur_m44 = builder.GetTransformFullPerspective();
-  SkMatrix cur_matrix = builder.GetTransform();
-  ASSERT_EQ(cur_m44, m44);
+  builder.TransformFullPerspective(3.0f, 0.0f, 4.0f, 12.3f,  //
+                                   1.0f, 5.0f, 3.0f, 14.5f,  //
+                                   0.0f, 0.0f, 7.0f, 16.2f,  //
+                                   0.0f, 0.0f, 0.0f, 1.0f);
+  DlMatrix matrix = DlMatrix::MakeRow(3.0f, 0.0f, 4.0f, 12.3f,  //
+                                      1.0f, 5.0f, 3.0f, 14.5f,  //
+                                      0.0f, 0.0f, 7.0f, 16.2f,  //
+                                      0.0f, 0.0f, 0.0f, 1.0f);
+  DlMatrix cur_matrix = builder.GetMatrix();
   ASSERT_EQ(cur_matrix, matrix);
   builder.Translate(10, 10);
   // CurrentTransform has changed
-  ASSERT_NE(builder.GetTransformFullPerspective(), m44);
-  ASSERT_NE(builder.GetTransform(), cur_matrix);
+  ASSERT_NE(builder.GetMatrix(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(cur_m44, m44);
   ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST_F(DisplayListTest, ClipRectAffectsClipBounds) {
   DisplayListBuilder builder;
-  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
   builder.ClipRect(clip_bounds, ClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, false);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, false);
   // Both clip bounds have changed
-  ASSERT_NE(builder.GetLocalClipBounds(), clip_bounds);
-  ASSERT_NE(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_NE(builder.GetLocalClipCoverage(), clip_bounds);
+  ASSERT_NE(builder.GetDestinationClipCoverage(), clip_bounds);
   // Previous return values have not changed
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 
   builder.Save();
-  builder.Scale(2, 2);
-  SkRect scaled_clip_bounds = SkRect::MakeLTRB(5.1, 5.65, 10.2, 12.85);
-  ASSERT_EQ(builder.GetLocalClipBounds(), scaled_clip_bounds);
+  builder.Scale(2.0f, 2.0f);
+  DlRect scaled_clip_bounds = DlRect::MakeLTRB(5.1f, 5.65f, 10.2f, 12.85f);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), scaled_clip_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, ClipRectDoAAAffectsClipBounds) {
   DisplayListBuilder builder;
-  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  SkRect clip_expanded_bounds = SkRect::MakeLTRB(10, 11, 21, 26);
+  DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  DlRect clip_expanded_bounds = DlRect::MakeLTRB(10, 11, 21, 26);
   builder.ClipRect(clip_bounds, ClipOp::kIntersect, true);
 
   // Save initial return values for testing restored values
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, true);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, true);
   // Both clip bounds have changed
-  ASSERT_NE(builder.GetLocalClipBounds(), clip_expanded_bounds);
-  ASSERT_NE(builder.GetDestinationClipBounds(), clip_expanded_bounds);
+  ASSERT_NE(builder.GetLocalClipCoverage(), clip_expanded_bounds);
+  ASSERT_NE(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
   // Previous return values have not changed
   ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 
   builder.Save();
   builder.Scale(2, 2);
-  SkRect scaled_expanded_bounds = SkRect::MakeLTRB(5, 5.5, 10.5, 13);
-  ASSERT_EQ(builder.GetLocalClipBounds(), scaled_expanded_bounds);
+  DlRect scaled_expanded_bounds = DlRect::MakeLTRB(5.0f, 5.5f, 10.5f, 13.0f);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), scaled_expanded_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_expanded_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, ClipRectAffectsClipBoundsWithMatrix) {
   DisplayListBuilder builder;
-  SkRect clip_bounds_1 = SkRect::MakeLTRB(0, 0, 10, 10);
-  SkRect clip_bounds_2 = SkRect::MakeLTRB(10, 10, 20, 20);
+  DlRect clip_bounds_1 = DlRect::MakeLTRB(0, 0, 10, 10);
+  DlRect clip_bounds_2 = DlRect::MakeLTRB(10, 10, 20, 20);
   builder.Save();
   builder.ClipRect(clip_bounds_1, ClipOp::kIntersect, false);
   builder.Translate(10, 0);
   builder.ClipRect(clip_bounds_1, ClipOp::kIntersect, false);
-  ASSERT_TRUE(builder.GetDestinationClipBounds().isEmpty());
+  ASSERT_TRUE(builder.GetDestinationClipCoverage().IsEmpty());
   builder.Restore();
 
   builder.Save();
   builder.ClipRect(clip_bounds_1, ClipOp::kIntersect, false);
   builder.Translate(-10, -10);
   builder.ClipRect(clip_bounds_2, ClipOp::kIntersect, false);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds_1);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds_1);
   builder.Restore();
 }
 
 TEST_F(DisplayListTest, ClipRRectAffectsClipBounds) {
   DisplayListBuilder builder;
-  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  SkRRect clip = SkRRect::MakeRectXY(clip_bounds, 3, 2);
-  builder.ClipRRect(clip, ClipOp::kIntersect, false);
+  DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  DlRoundRect clip = DlRoundRect::MakeRectXY(clip_bounds, 3, 2);
+  builder.ClipRoundRect(clip, ClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, false);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, false);
   // Both clip bounds have changed
-  ASSERT_NE(builder.GetLocalClipBounds(), clip_bounds);
-  ASSERT_NE(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_NE(builder.GetLocalClipCoverage(), clip_bounds);
+  ASSERT_NE(builder.GetDestinationClipCoverage(), clip_bounds);
   // Previous return values have not changed
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 
   builder.Save();
   builder.Scale(2, 2);
-  SkRect scaled_clip_bounds = SkRect::MakeLTRB(5.1, 5.65, 10.2, 12.85);
-  ASSERT_EQ(builder.GetLocalClipBounds(), scaled_clip_bounds);
+  DlRect scaled_clip_bounds = DlRect::MakeLTRB(5.1f, 5.65f, 10.2f, 12.85f);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), scaled_clip_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, ClipRRectDoAAAffectsClipBounds) {
   DisplayListBuilder builder;
-  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  SkRect clip_expanded_bounds = SkRect::MakeLTRB(10, 11, 21, 26);
-  SkRRect clip = SkRRect::MakeRectXY(clip_bounds, 3, 2);
-  builder.ClipRRect(clip, ClipOp::kIntersect, true);
+  DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  DlRect clip_expanded_bounds = DlRect::MakeLTRB(10, 11, 21, 26);
+  DlRoundRect clip = DlRoundRect::MakeRectXY(clip_bounds, 3, 2);
+  builder.ClipRoundRect(clip, ClipOp::kIntersect, true);
 
   // Save initial return values for testing restored values
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, true);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, true);
   // Both clip bounds have changed
-  ASSERT_NE(builder.GetLocalClipBounds(), clip_expanded_bounds);
-  ASSERT_NE(builder.GetDestinationClipBounds(), clip_expanded_bounds);
+  ASSERT_NE(builder.GetLocalClipCoverage(), clip_expanded_bounds);
+  ASSERT_NE(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
   // Previous return values have not changed
   ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 
   builder.Save();
   builder.Scale(2, 2);
-  SkRect scaled_expanded_bounds = SkRect::MakeLTRB(5, 5.5, 10.5, 13);
-  ASSERT_EQ(builder.GetLocalClipBounds(), scaled_expanded_bounds);
+  DlRect scaled_expanded_bounds = DlRect::MakeLTRB(5.0f, 5.5f, 10.5f, 13.0f);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), scaled_expanded_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_expanded_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, ClipRRectAffectsClipBoundsWithMatrix) {
   DisplayListBuilder builder;
-  SkRect clip_bounds_1 = SkRect::MakeLTRB(0, 0, 10, 10);
-  SkRect clip_bounds_2 = SkRect::MakeLTRB(10, 10, 20, 20);
-  SkRRect clip1 = SkRRect::MakeRectXY(clip_bounds_1, 3, 2);
-  SkRRect clip2 = SkRRect::MakeRectXY(clip_bounds_2, 3, 2);
+  DlRect clip_bounds_1 = DlRect::MakeLTRB(0, 0, 10, 10);
+  DlRect clip_bounds_2 = DlRect::MakeLTRB(10, 10, 20, 20);
+  DlRoundRect clip1 = DlRoundRect::MakeRectXY(clip_bounds_1, 3, 2);
+  DlRoundRect clip2 = DlRoundRect::MakeRectXY(clip_bounds_2, 3, 2);
 
   builder.Save();
-  builder.ClipRRect(clip1, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip1, ClipOp::kIntersect, false);
   builder.Translate(10, 0);
-  builder.ClipRRect(clip1, ClipOp::kIntersect, false);
-  ASSERT_TRUE(builder.GetDestinationClipBounds().isEmpty());
+  builder.ClipRoundRect(clip1, ClipOp::kIntersect, false);
+  ASSERT_TRUE(builder.GetDestinationClipCoverage().IsEmpty());
   builder.Restore();
 
   builder.Save();
-  builder.ClipRRect(clip1, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip1, ClipOp::kIntersect, false);
   builder.Translate(-10, -10);
-  builder.ClipRRect(clip2, ClipOp::kIntersect, false);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds_1);
+  builder.ClipRoundRect(clip2, ClipOp::kIntersect, false);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds_1);
   builder.Restore();
 }
 
 TEST_F(DisplayListTest, ClipPathAffectsClipBounds) {
   DisplayListBuilder builder;
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
+  DlPath clip = DlPath::MakeCircle(DlPoint(10.2f, 11.3f), 2.0f) +
+                DlPath::MakeCircle(DlPoint(20.4f, 25.7f), 2.0f);
+  DlRect clip_bounds = DlRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
   builder.ClipPath(clip, ClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, false);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, false);
   // Both clip bounds have changed
-  ASSERT_NE(builder.GetLocalClipBounds(), clip_bounds);
-  ASSERT_NE(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_NE(builder.GetLocalClipCoverage(), clip_bounds);
+  ASSERT_NE(builder.GetDestinationClipCoverage(), clip_bounds);
   // Previous return values have not changed
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 
   builder.Save();
   builder.Scale(2, 2);
-  SkRect scaled_clip_bounds = SkRect::MakeLTRB(4.1, 4.65, 11.2, 13.85);
-  ASSERT_EQ(builder.GetLocalClipBounds(), scaled_clip_bounds);
+  DlRect scaled_clip_bounds = DlRect::MakeLTRB(4.1, 4.65, 11.2, 13.85);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), scaled_clip_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, ClipPathDoAAAffectsClipBounds) {
   DisplayListBuilder builder;
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  SkRect clip_expanded_bounds = SkRect::MakeLTRB(8, 9, 23, 28);
+  DlPath clip = DlPath::MakeCircle(DlPoint(10.2f, 11.3f), 2.0f) +
+                DlPath::MakeCircle(DlPoint(20.4f, 25.7f), 2.0f);
+  DlRect clip_expanded_bounds = DlRect::MakeLTRB(8, 9, 23, 28);
   builder.ClipPath(clip, ClipOp::kIntersect, true);
 
   // Save initial return values for testing restored values
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, true);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, true);
   // Both clip bounds have changed
-  ASSERT_NE(builder.GetLocalClipBounds(), clip_expanded_bounds);
-  ASSERT_NE(builder.GetDestinationClipBounds(), clip_expanded_bounds);
+  ASSERT_NE(builder.GetLocalClipCoverage(), clip_expanded_bounds);
+  ASSERT_NE(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
   // Previous return values have not changed
   ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 
   builder.Save();
   builder.Scale(2, 2);
-  SkRect scaled_expanded_bounds = SkRect::MakeLTRB(4, 4.5, 11.5, 14);
-  ASSERT_EQ(builder.GetLocalClipBounds(), scaled_expanded_bounds);
+  DlRect scaled_expanded_bounds = DlRect::MakeLTRB(4.0f, 4.5f, 11.5f, 14.0f);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), scaled_expanded_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_expanded_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
   builder.Restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, ClipPathAffectsClipBoundsWithMatrix) {
   DisplayListBuilder builder;
-  SkRect clip_bounds = SkRect::MakeLTRB(0, 0, 10, 10);
-  SkPath clip1 = SkPath().addCircle(2.5, 2.5, 2.5).addCircle(7.5, 7.5, 2.5);
-  SkPath clip2 = SkPath().addCircle(12.5, 12.5, 2.5).addCircle(17.5, 17.5, 2.5);
+  DlRect clip_bounds = DlRect::MakeLTRB(0, 0, 10, 10);
+  DlPath clip1 = DlPath::MakeCircle(DlPoint(2.5f, 2.5f), 2.5) +
+                 DlPath::MakeCircle(DlPoint(7.5f, 7.5f), 2.5);
+  DlPath clip2 = DlPath::MakeCircle(DlPoint(12.5f, 12.5f), 2.5) +
+                 DlPath::MakeCircle(DlPoint(17.5f, 17.5f), 2.5);
 
   builder.Save();
   builder.ClipPath(clip1, ClipOp::kIntersect, false);
   builder.Translate(10, 0);
   builder.ClipPath(clip1, ClipOp::kIntersect, false);
-  ASSERT_TRUE(builder.GetDestinationClipBounds().isEmpty());
+  ASSERT_TRUE(builder.GetDestinationClipCoverage().IsEmpty());
   builder.Restore();
 
   builder.Save();
   builder.ClipPath(clip1, ClipOp::kIntersect, false);
   builder.Translate(-10, -10);
   builder.ClipPath(clip2, ClipOp::kIntersect, false);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
   builder.Restore();
 }
 
 TEST_F(DisplayListTest, DiffClipRectDoesNotAffectClipBounds) {
   DisplayListBuilder builder;
-  SkRect diff_clip = SkRect::MakeLTRB(0, 0, 15, 15);
-  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  DlRect diff_clip = DlRect::MakeLTRB(0, 0, 15, 15);
+  DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
   builder.ClipRect(clip_bounds, ClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.ClipRect(diff_clip, ClipOp::kDifference, false);
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, DiffClipRRectDoesNotAffectClipBounds) {
   DisplayListBuilder builder;
-  SkRRect diff_clip = SkRRect::MakeRectXY({0, 0, 15, 15}, 1, 1);
-  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  SkRRect clip = SkRRect::MakeRectXY({10.2, 11.3, 20.4, 25.7}, 3, 2);
-  builder.ClipRRect(clip, ClipOp::kIntersect, false);
+  DlRoundRect diff_clip =
+      DlRoundRect::MakeRectXY(DlRect::MakeLTRB(0, 0, 15, 15), 1, 1);
+  DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  DlRoundRect clip =
+      DlRoundRect::MakeRectXY(DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7), 3, 2);
+  builder.ClipRoundRect(clip, ClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
-  builder.ClipRRect(diff_clip, ClipOp::kDifference, false);
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
+  builder.ClipRoundRect(diff_clip, ClipOp::kDifference, false);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, DiffClipPathDoesNotAffectClipBounds) {
   DisplayListBuilder builder;
-  SkPath diff_clip = SkPath().addRect({0, 0, 15, 15});
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
+  DlPath diff_clip = DlPath::MakeRectLTRB(0, 0, 15, 15);
+  DlPath clip = DlPath::MakeCircle(DlPoint(10.2, 11.3), 2) +
+                DlPath::MakeCircle(DlPoint(20.4, 25.7), 2);
+  DlRect clip_bounds = DlRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
   builder.ClipPath(clip, ClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
-  SkRect initial_local_bounds = builder.GetLocalClipBounds();
-  SkRect initial_destination_bounds = builder.GetDestinationClipBounds();
+  DlRect initial_local_bounds = builder.GetLocalClipCoverage();
+  DlRect initial_destination_bounds = builder.GetDestinationClipCoverage();
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.ClipPath(diff_clip, ClipOp::kDifference, false);
-  ASSERT_EQ(builder.GetLocalClipBounds(), initial_local_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), initial_destination_bounds);
-}
-
-TEST_F(DisplayListTest, ClipPathWithInvertFillTypeDoesNotAffectClipBounds) {
-  SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
-  DisplayListBuilder builder(cull_rect);
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  clip.setFillType(SkPathFillType::kInverseWinding);
-  builder.ClipPath(clip, ClipOp::kIntersect, false);
-
-  ASSERT_EQ(builder.GetLocalClipBounds(), cull_rect);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), cull_rect);
-}
-
-TEST_F(DisplayListTest, DiffClipPathWithInvertFillTypeAffectsClipBounds) {
-  SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
-  DisplayListBuilder builder(cull_rect);
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  clip.setFillType(SkPathFillType::kInverseWinding);
-  SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
-  builder.ClipPath(clip, ClipOp::kDifference, false);
-
-  ASSERT_EQ(builder.GetLocalClipBounds(), clip_bounds);
-  ASSERT_EQ(builder.GetDestinationClipBounds(), clip_bounds);
+  ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
+  ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
 
 TEST_F(DisplayListTest, FlatDrawPointsProducesBounds) {
-  SkPoint horizontal_points[2] = {{10, 10}, {20, 10}};
-  SkPoint vertical_points[2] = {{10, 10}, {10, 20}};
+  DlPoint horizontal_points[2] = {DlPoint(10, 10), DlPoint(20, 10)};
+  DlPoint vertical_points[2] = {DlPoint(10, 10), DlPoint(10, 20)};
   {
     DisplayListBuilder builder;
     builder.DrawPoints(PointMode::kPolygon, 2, horizontal_points, DlPaint());
-    SkRect bounds = builder.Build()->bounds();
-    EXPECT_TRUE(bounds.contains(10, 10));
-    EXPECT_TRUE(bounds.contains(20, 10));
-    EXPECT_GE(bounds.width(), 10);
+    DlRect bounds = builder.Build()->GetBounds();
+    EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
+    EXPECT_TRUE(bounds.Contains(DlPoint(20, 10)));
+    EXPECT_GE(bounds.GetWidth(), 10);
   }
   {
     DisplayListBuilder builder;
     builder.DrawPoints(PointMode::kPolygon, 2, vertical_points, DlPaint());
-    SkRect bounds = builder.Build()->bounds();
-    EXPECT_TRUE(bounds.contains(10, 10));
-    EXPECT_TRUE(bounds.contains(10, 20));
-    EXPECT_GE(bounds.height(), 10);
+    DlRect bounds = builder.Build()->GetBounds();
+    EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
+    EXPECT_TRUE(bounds.Contains(DlPoint(10, 20)));
+    EXPECT_GE(bounds.GetHeight(), 10);
   }
   {
     DisplayListBuilder builder;
     builder.DrawPoints(PointMode::kPoints, 1, horizontal_points, DlPaint());
-    SkRect bounds = builder.Build()->bounds();
-    EXPECT_TRUE(bounds.contains(10, 10));
+    DlRect bounds = builder.Build()->GetBounds();
+    EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
   }
   {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setStrokeWidth(2);
     builder.DrawPoints(PointMode::kPolygon, 2, horizontal_points, paint);
-    SkRect bounds = builder.Build()->bounds();
-    EXPECT_TRUE(bounds.contains(10, 10));
-    EXPECT_TRUE(bounds.contains(20, 10));
-    EXPECT_EQ(bounds, SkRect::MakeLTRB(9, 9, 21, 11));
+    DlRect bounds = builder.Build()->GetBounds();
+    EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
+    EXPECT_TRUE(bounds.Contains(DlPoint(20, 10)));
+    EXPECT_EQ(bounds, DlRect::MakeLTRB(9, 9, 21, 11));
   }
   {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setStrokeWidth(2);
     builder.DrawPoints(PointMode::kPolygon, 2, vertical_points, paint);
-    SkRect bounds = builder.Build()->bounds();
-    EXPECT_TRUE(bounds.contains(10, 10));
-    EXPECT_TRUE(bounds.contains(10, 20));
-    EXPECT_EQ(bounds, SkRect::MakeLTRB(9, 9, 11, 21));
+    DlRect bounds = builder.Build()->GetBounds();
+    EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
+    EXPECT_TRUE(bounds.Contains(DlPoint(10, 20)));
+    EXPECT_EQ(bounds, DlRect::MakeLTRB(9, 9, 11, 21));
   }
   {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setStrokeWidth(2);
     builder.DrawPoints(PointMode::kPoints, 1, horizontal_points, paint);
-    SkRect bounds = builder.Build()->bounds();
-    EXPECT_TRUE(bounds.contains(10, 10));
-    EXPECT_EQ(bounds, SkRect::MakeLTRB(9, 9, 11, 11));
+    DlRect bounds = builder.Build()->GetBounds();
+    EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
+    EXPECT_EQ(bounds, DlRect::MakeLTRB(9, 9, 11, 11));
   }
 }
 
@@ -2508,7 +2454,7 @@ TEST_F(DisplayListTest, RTreeOfSaveLayerFilterScene) {
   DlPaint default_paint = DlPaint();
   DlPaint filter_paint = DlPaint().setImageFilter(&filter);
   builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), default_paint);
-  builder.SaveLayer(nullptr, &filter_paint);
+  builder.SaveLayer(std::nullopt, &filter_paint);
   // the following rectangle will be expanded to 50,50,60,60
   // by the SaveLayer filter during the restore operation
   builder.DrawRect(DlRect::MakeLTRB(53, 53, 57, 57), default_paint);
@@ -2561,38 +2507,38 @@ TEST_F(DisplayListTest, NestedDisplayListRTreesAreSparse) {
 TEST_F(DisplayListTest, RemoveUnnecessarySaveRestorePairs) {
   {
     DisplayListBuilder builder;
-    builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+    builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
     builder.Save();  // This save op is unnecessary
-    builder.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
+    builder.DrawRect(DlRect::MakeLTRB(50, 50, 60, 60), DlPaint());
     builder.Restore();
 
     DisplayListBuilder builder2;
-    builder2.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
-    builder2.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(50, 50, 60, 60), DlPaint());
     ASSERT_TRUE(DisplayListsEQ_Verbose(builder.Build(), builder2.Build()));
   }
 
   {
     DisplayListBuilder builder;
-    builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+    builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
     builder.Save();
     {
       builder.Translate(1.0, 1.0);
       builder.Save();
       {  //
-        builder.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
+        builder.DrawRect(DlRect::MakeLTRB(50, 50, 60, 60), DlPaint());
       }
       builder.Restore();
     }
     builder.Restore();
 
     DisplayListBuilder builder2;
-    builder2.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
     builder2.Save();
     {  //
       builder2.Translate(1.0, 1.0);
       {  //
-        builder2.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
+        builder2.DrawRect(DlRect::MakeLTRB(50, 50, 60, 60), DlPaint());
       }
     }
     builder2.Restore();
@@ -2610,8 +2556,9 @@ TEST_F(DisplayListTest, CollapseMultipleNestedSaveRestore) {
       {
         builder1.Translate(10, 10);
         builder1.Scale(2, 2);
-        builder1.ClipRect(SkRect{10, 10, 20, 20}, ClipOp::kIntersect, false);
-        builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+        builder1.ClipRect(DlRect::MakeLTRB(10, 10, 20, 20), ClipOp::kIntersect,
+                          false);
+        builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
       }
       builder1.Restore();
     }
@@ -2625,8 +2572,9 @@ TEST_F(DisplayListTest, CollapseMultipleNestedSaveRestore) {
   {
     builder2.Translate(10, 10);
     builder2.Scale(2, 2);
-    builder2.ClipRect(SkRect{10, 10, 20, 20}, ClipOp::kIntersect, false);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.ClipRect(DlRect::MakeLTRB(10, 10, 20, 20), ClipOp::kIntersect,
+                      false);
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2638,9 +2586,9 @@ TEST_F(DisplayListTest, CollapseNestedSaveAndSaveLayerRestore) {
   DisplayListBuilder builder1;
   builder1.Save();
   {
-    builder1.SaveLayer(nullptr, nullptr);
+    builder1.SaveLayer(std::nullopt, nullptr);
     {
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
       builder1.Scale(2, 2);
     }
     builder1.Restore();
@@ -2649,9 +2597,9 @@ TEST_F(DisplayListTest, CollapseNestedSaveAndSaveLayerRestore) {
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.SaveLayer(nullptr, nullptr);
+  builder2.SaveLayer(std::nullopt, nullptr);
   {
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     builder2.Scale(2, 2);
   }
   builder2.Restore();
@@ -2661,8 +2609,8 @@ TEST_F(DisplayListTest, CollapseNestedSaveAndSaveLayerRestore) {
 }
 
 TEST_F(DisplayListTest, RemoveUnnecessarySaveRestorePairsInSetPaint) {
-  SkRect build_bounds = SkRect::MakeLTRB(-100, -100, 200, 200);
-  SkRect rect = SkRect::MakeLTRB(30, 30, 70, 70);
+  DlRect build_bounds = DlRect::MakeLTRB(-100, -100, 200, 200);
+  DlRect rect = DlRect::MakeLTRB(30, 30, 70, 70);
   // clang-format off
   const float alpha_matrix[] = {
       0, 0, 0, 0, 0,
@@ -2696,7 +2644,7 @@ TEST_F(DisplayListTest, RemoveUnnecessarySaveRestorePairsInSetPaint) {
   {
     DisplayListBuilder builder(build_bounds);
     builder.Save();
-    builder.SaveLayer(&build_bounds);
+    builder.SaveLayer(build_bounds);
     DlPaint paint;
     paint.setImageFilter(&color_filter_image_filter);
     builder.DrawRect(rect, paint);
@@ -2705,7 +2653,7 @@ TEST_F(DisplayListTest, RemoveUnnecessarySaveRestorePairsInSetPaint) {
     sk_sp<DisplayList> display_list1 = builder.Build();
 
     DisplayListBuilder builder2(build_bounds);
-    builder2.SaveLayer(&build_bounds);
+    builder2.SaveLayer(build_bounds);
     DlPaint paint2;
     paint2.setImageFilter(&color_filter_image_filter);
     builder2.DrawRect(rect, paint2);
@@ -2725,14 +2673,14 @@ TEST_F(DisplayListTest, TransformTriggersDeferredSave) {
                                         0, 1, 0, 100,  //
                                         0, 0, 1, 0,    //
                                         0, 0, 0, 1);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 10,   //
                                       0, 1, 0, 100,  //
                                       0, 0, 1, 0,    //
                                       0, 0, 0, 1);
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
@@ -2744,7 +2692,7 @@ TEST_F(DisplayListTest, TransformTriggersDeferredSave) {
                                       0, 1, 0, 100,  //
                                       0, 0, 1, 0,    //
                                       0, 0, 0, 1);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   builder2.Save();
@@ -2753,7 +2701,7 @@ TEST_F(DisplayListTest, TransformTriggersDeferredSave) {
                                       0, 1, 0, 100,  //
                                       0, 0, 1, 0,    //
                                       0, 0, 0, 1);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2768,7 +2716,7 @@ TEST_F(DisplayListTest, Transform2DTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.Transform2DAffine(0, 1, 12, 1, 0, 33);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
   }
@@ -2779,7 +2727,7 @@ TEST_F(DisplayListTest, Transform2DTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.Transform2DAffine(0, 1, 12, 1, 0, 33);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2797,7 +2745,7 @@ TEST_F(DisplayListTest, TransformPerspectiveTriggersDeferredSave) {
                                         1, 0, 0, 33,  //
                                         3, 2, 5, 29,  //
                                         0, 0, 0, 12);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
   }
@@ -2811,7 +2759,7 @@ TEST_F(DisplayListTest, TransformPerspectiveTriggersDeferredSave) {
                                       1, 0, 0, 33,  //
                                       3, 2, 5, 29,  //
                                       0, 0, 0, 12);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2826,7 +2774,7 @@ TEST_F(DisplayListTest, ResetTransformTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.TransformReset();
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
   }
@@ -2837,7 +2785,7 @@ TEST_F(DisplayListTest, ResetTransformTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.TransformReset();
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2852,7 +2800,7 @@ TEST_F(DisplayListTest, SkewTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.Skew(10, 10);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
   }
@@ -2863,7 +2811,7 @@ TEST_F(DisplayListTest, SkewTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.Skew(10, 10);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2878,7 +2826,7 @@ TEST_F(DisplayListTest, TranslateTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.Translate(10, 10);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
   }
@@ -2889,7 +2837,7 @@ TEST_F(DisplayListTest, TranslateTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.Translate(10, 10);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2904,7 +2852,7 @@ TEST_F(DisplayListTest, ScaleTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.Scale(0.5, 0.5);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
   }
@@ -2915,7 +2863,7 @@ TEST_F(DisplayListTest, ScaleTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.Scale(0.5, 0.5);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2929,16 +2877,16 @@ TEST_F(DisplayListTest, ClipRectTriggersDeferredSave) {
   {
     builder1.Save();
     {
-      builder1.ClipRect(SkRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
+      builder1.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
                         true);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 0,  //
                                       0, 1, 0, 0,  //
                                       0, 0, 1, 0,  //
                                       0, 0, 0, 1);
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
@@ -2946,16 +2894,16 @@ TEST_F(DisplayListTest, ClipRectTriggersDeferredSave) {
   DisplayListBuilder builder2;
   builder2.Save();
   {
-    builder2.ClipRect(SkRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
+    builder2.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
                       true);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   builder2.TransformFullPerspective(1, 0, 0, 0,  //
                                     0, 1, 0, 0,  //
                                     0, 0, 1, 0,  //
                                     0, 0, 0, 1);
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -2967,31 +2915,31 @@ TEST_F(DisplayListTest, ClipRRectTriggersDeferredSave) {
   {
     builder1.Save();
     {
-      builder1.ClipRRect(kTestSkRRect, ClipOp::kIntersect, true);
+      builder1.ClipRoundRect(kTestRRect, ClipOp::kIntersect, true);
 
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 0,  //
                                       0, 1, 0, 0,  //
                                       0, 0, 1, 0,  //
                                       0, 0, 0, 1);
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
   builder2.Save();
-  builder2.ClipRRect(kTestSkRRect, ClipOp::kIntersect, true);
+  builder2.ClipRoundRect(kTestRRect, ClipOp::kIntersect, true);
 
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   builder2.Restore();
   builder2.TransformFullPerspective(1, 0, 0, 0,  //
                                     0, 1, 0, 0,  //
                                     0, 0, 1, 0,  //
                                     0, 0, 0, 1);
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3004,14 +2952,14 @@ TEST_F(DisplayListTest, ClipPathTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.ClipPath(kTestPath1, ClipOp::kIntersect, true);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 0,  //
                                       0, 1, 0, 0,  //
                                       0, 0, 1, 0,  //
                                       0, 0, 0, 1);
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
@@ -3020,14 +2968,14 @@ TEST_F(DisplayListTest, ClipPathTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.ClipPath(kTestPath1, ClipOp::kIntersect, true);
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
   builder2.TransformFullPerspective(1, 0, 0, 0,  //
                                     0, 1, 0, 0,  //
                                     0, 0, 1, 0,  //
                                     0, 0, 0, 1);
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3040,17 +2988,17 @@ TEST_F(DisplayListTest, NOPTranslateDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Translate(0, 0);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3063,17 +3011,17 @@ TEST_F(DisplayListTest, NOPScaleDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Scale(1.0, 1.0);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3086,17 +3034,17 @@ TEST_F(DisplayListTest, NOPRotationDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Rotate(360);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3109,17 +3057,17 @@ TEST_F(DisplayListTest, NOPSkewDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Skew(0, 0);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3135,21 +3083,21 @@ TEST_F(DisplayListTest, NOPTransformDoesNotTriggerDeferredSave) {
                                         0, 1, 0, 0,  //
                                         0, 0, 1, 0,  //
                                         0, 0, 0, 1);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 0,  //
                                       0, 1, 0, 0,  //
                                       0, 0, 1, 0,  //
                                       0, 0, 0, 1);
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3162,17 +3110,17 @@ TEST_F(DisplayListTest, NOPTransform2DDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Transform2DAffine(1, 0, 0, 0, 1, 0);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3189,17 +3137,17 @@ TEST_F(DisplayListTest, NOPTransformFullPerspectiveDoesNotTriggerDeferredSave) {
                                           0, 1, 0, 0,  //
                                           0, 0, 1, 0,  //
                                           0, 0, 0, 1);
-        builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+        builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
       }
       builder1.Restore();
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
     auto display_list1 = builder1.Build();
 
     DisplayListBuilder builder2;
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     auto display_list2 = builder2.Build();
 
     ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3216,10 +3164,10 @@ TEST_F(DisplayListTest, NOPTransformFullPerspectiveDoesNotTriggerDeferredSave) {
                                           0, 0, 1, 0,  //
                                           0, 0, 0, 1);
         builder1.TransformReset();
-        builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+        builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
       }
       builder1.Restore();
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
     auto display_list1 = builder1.Build();
@@ -3228,10 +3176,10 @@ TEST_F(DisplayListTest, NOPTransformFullPerspectiveDoesNotTriggerDeferredSave) {
     builder2.Save();
     {
       builder2.TransformReset();
-      builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder2.Restore();
-    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     auto display_list2 = builder2.Build();
 
     ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3239,24 +3187,25 @@ TEST_F(DisplayListTest, NOPTransformFullPerspectiveDoesNotTriggerDeferredSave) {
 }
 
 TEST_F(DisplayListTest, NOPClipDoesNotTriggerDeferredSave) {
+  DlScalar NaN = std::numeric_limits<DlScalar>::quiet_NaN();
   DisplayListBuilder builder1;
   builder1.Save();
   {
     builder1.Save();
     {
-      builder1.ClipRect(SkRect::MakeLTRB(0, SK_ScalarNaN, SK_ScalarNaN, 0),
-                        ClipOp::kIntersect, true);
-      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+      builder1.ClipRect(DlRect::MakeLTRB(0, NaN, NaN, 0), ClipOp::kIntersect,
+                        true);
+      builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+  builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3270,7 +3219,7 @@ TEST_F(DisplayListTest, RTreeOfClippedSaveLayerFilterScene) {
   DlPaint filter_paint = DlPaint().setImageFilter(&filter);
   builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), default_paint);
   builder.ClipRect(DlRect::MakeLTRB(50, 50, 60, 60), ClipOp::kIntersect, false);
-  builder.SaveLayer(nullptr, &filter_paint);
+  builder.SaveLayer(std::nullopt, &filter_paint);
   // the following rectangle will be expanded to 23,23,87,87
   // by the SaveLayer filter during the restore operation
   // but it will then be clipped to 50,50,60,60
@@ -3423,10 +3372,11 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
 
 TEST_F(DisplayListTest, DrawSaveDrawCannotInheritOpacity) {
   DisplayListBuilder builder;
-  builder.DrawCircle(SkPoint{10, 10}, 5, DlPaint());
+  builder.DrawCircle(DlPoint(10, 10), 5, DlPaint());
   builder.Save();
-  builder.ClipRect(SkRect{0, 0, 20, 20}, DlCanvas::ClipOp::kIntersect, false);
-  builder.DrawRect(SkRect{5, 5, 15, 15}, DlPaint());
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 20, 20), DlCanvas::ClipOp::kIntersect,
+                   false);
+  builder.DrawRect(DlRect::MakeLTRB(5, 5, 15, 15), DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
 
@@ -3434,53 +3384,51 @@ TEST_F(DisplayListTest, DrawSaveDrawCannotInheritOpacity) {
 }
 
 TEST_F(DisplayListTest, DrawUnorderedRect) {
-  auto renderer = [](DlCanvas& canvas, DlPaint& paint, SkRect& rect) {
+  auto renderer = [](DlCanvas& canvas, DlPaint& paint, DlRect& rect) {
     canvas.DrawRect(rect, paint);
   };
   check_inverted_bounds(renderer, "DrawRect");
 }
 
 TEST_F(DisplayListTest, DrawUnorderedRoundRect) {
-  auto renderer = [](DlCanvas& canvas, DlPaint& paint, SkRect& rect) {
-    canvas.DrawRRect(SkRRect::MakeRectXY(rect, 2.0f, 2.0f), paint);
+  auto renderer = [](DlCanvas& canvas, DlPaint& paint, DlRect& rect) {
+    canvas.DrawRoundRect(DlRoundRect::MakeRectXY(rect, 2.0f, 2.0f), paint);
   };
   check_inverted_bounds(renderer, "DrawRoundRect");
 }
 
 TEST_F(DisplayListTest, DrawUnorderedOval) {
-  auto renderer = [](DlCanvas& canvas, DlPaint& paint, SkRect& rect) {
+  auto renderer = [](DlCanvas& canvas, DlPaint& paint, DlRect& rect) {
     canvas.DrawOval(rect, paint);
   };
   check_inverted_bounds(renderer, "DrawOval");
 }
 
 TEST_F(DisplayListTest, DrawUnorderedRectangularPath) {
-  auto renderer = [](DlCanvas& canvas, DlPaint& paint, SkRect& rect) {
-    canvas.DrawPath(SkPath().addRect(rect), paint);
+  auto renderer = [](DlCanvas& canvas, DlPaint& paint, DlRect& rect) {
+    canvas.DrawPath(DlPath::MakeRect(rect), paint);
   };
   check_inverted_bounds(renderer, "DrawRectangularPath");
 }
 
 TEST_F(DisplayListTest, DrawUnorderedOvalPath) {
-  auto renderer = [](DlCanvas& canvas, DlPaint& paint, SkRect& rect) {
-    canvas.DrawPath(SkPath().addOval(rect), paint);
+  auto renderer = [](DlCanvas& canvas, DlPaint& paint, DlRect& rect) {
+    canvas.DrawPath(DlPath::MakeOval(rect), paint);
   };
   check_inverted_bounds(renderer, "DrawOvalPath");
 }
 
 TEST_F(DisplayListTest, DrawUnorderedRoundRectPathCW) {
-  auto renderer = [](DlCanvas& canvas, DlPaint& paint, SkRect& rect) {
-    SkPath path = SkPath()  //
-                      .addRoundRect(rect, 2.0f, 2.0f, SkPathDirection::kCW);
+  auto renderer = [](DlCanvas& canvas, DlPaint& paint, DlRect& rect) {
+    DlPath path = DlPath::MakeRoundRectXY(rect, 2.0f, 2.0f, false);
     canvas.DrawPath(path, paint);
   };
   check_inverted_bounds(renderer, "DrawRoundRectPath Clockwise");
 }
 
 TEST_F(DisplayListTest, DrawUnorderedRoundRectPathCCW) {
-  auto renderer = [](DlCanvas& canvas, DlPaint& paint, SkRect& rect) {
-    SkPath path = SkPath()  //
-                      .addRoundRect(rect, 2.0f, 2.0f, SkPathDirection::kCCW);
+  auto renderer = [](DlCanvas& canvas, DlPaint& paint, DlRect& rect) {
+    DlPath path = DlPath::MakeRoundRectXY(rect, 2.0f, 2.0f, true);
     canvas.DrawPath(path, paint);
   };
   check_inverted_bounds(renderer, "DrawRoundRectPath Counter-Clockwise");
@@ -3523,35 +3471,43 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
     run_one_test(
         name + " DrawRect",
         [](DisplayListBuilder& builder, DlPaint& paint) {
-          builder.DrawRect(SkRect{10, 10, 20, 20}, paint);
+          builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), paint);
         },
         expected_op_count, expected_total_depth);
     run_one_test(
         name + " Other Draw Ops",
         [](DisplayListBuilder& builder, DlPaint& paint) {
-          builder.DrawLine(SkPoint{10, 10}, SkPoint{20, 20}, paint);
-          builder.DrawOval(SkRect{10, 10, 20, 20}, paint);
-          builder.DrawCircle(SkPoint{50, 50}, 20, paint);
-          builder.DrawRRect(SkRRect::MakeRectXY({10, 10, 20, 20}, 5, 5), paint);
-          builder.DrawDRRect(SkRRect::MakeRectXY({5, 5, 100, 100}, 5, 5),
-                             SkRRect::MakeRectXY({10, 10, 20, 20}, 5, 5),
-                             paint);
+          builder.DrawLine(DlPoint(10, 10), DlPoint(20, 20), paint);
+          builder.DrawOval(DlRect::MakeLTRB(10, 10, 20, 20), paint);
+          builder.DrawCircle(DlPoint(50, 50), 20, paint);
+          builder.DrawRoundRect(
+              DlRoundRect::MakeRectXY(DlRect::MakeLTRB(10, 10, 20, 20), 5, 5),
+              paint);
+          builder.DrawDiffRoundRect(
+              DlRoundRect::MakeRectXY(DlRect::MakeLTRB(5, 5, 100, 100), 5, 5),
+              DlRoundRect::MakeRectXY(DlRect::MakeLTRB(10, 10, 20, 20), 5, 5),
+              paint);
           builder.DrawPath(kTestPath1, paint);
-          builder.DrawArc(SkRect{10, 10, 20, 20}, 45, 90, true, paint);
-          SkPoint pts[] = {{10, 10}, {20, 20}};
+          builder.DrawArc(DlRect::MakeLTRB(10, 10, 20, 20), 45, 90, true,
+                          paint);
+          DlPoint pts[] = {DlPoint(10, 10), DlPoint(20, 20)};
           builder.DrawPoints(PointMode::kLines, 2, pts, paint);
           builder.DrawVertices(kTestVertices1, DlBlendMode::kSrcOver, paint);
-          builder.DrawImage(TestImage1, SkPoint{10, 10},
+          builder.DrawImage(kTestImage1, DlPoint(10, 10),
                             DlImageSampling::kLinear, &paint);
-          builder.DrawImageRect(TestImage1, SkRect{0.0f, 0.0f, 10.0f, 10.0f},
-                                SkRect{10.0f, 10.0f, 25.0f, 25.0f},
+          builder.DrawImageRect(kTestImage1,
+                                DlRect::MakeLTRB(0.0f, 0.0f, 10.0f, 10.0f),
+                                DlRect::MakeLTRB(10.0f, 10.0f, 25.0f, 25.0f),
                                 DlImageSampling::kLinear, &paint);
-          builder.DrawImageNine(TestImage1, SkIRect{10, 10, 20, 20},
-                                SkRect{10, 10, 100, 100}, DlFilterMode::kLinear,
-                                &paint);
+          builder.DrawImageNine(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+                                DlRect::MakeLTRB(10, 10, 100, 100),
+                                DlFilterMode::kLinear, &paint);
           SkRSXform xforms[] = {{1, 0, 10, 10}, {0, 1, 10, 10}};
-          SkRect rects[] = {{10, 10, 20, 20}, {10, 20, 30, 20}};
-          builder.DrawAtlas(TestImage1, xforms, rects, nullptr, 2,
+          DlRect rects[] = {
+              DlRect::MakeLTRB(10, 10, 20, 20),
+              DlRect::MakeLTRB(10, 20, 30, 20),
+          };
+          builder.DrawAtlas(kTestImage1, xforms, rects, nullptr, 2,
                             DlBlendMode::kSrcOver, DlImageSampling::kLinear,
                             nullptr, &paint);
           builder.DrawTextBlob(GetTestTextBlob(1), 10, 10, paint);
@@ -3567,8 +3523,8 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
     run_one_test(
         name + " SaveLayer",
         [](DisplayListBuilder& builder, DlPaint& paint) {
-          builder.SaveLayer(nullptr, &paint, nullptr);
-          builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+          builder.SaveLayer(std::nullopt, &paint, nullptr);
+          builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
           builder.Restore();
         },
         expected_op_count, expected_total_depth);
@@ -3576,7 +3532,7 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
         name + " inside Save",
         [](DisplayListBuilder& builder, DlPaint& paint) {
           builder.Save();
-          builder.DrawRect(SkRect{10, 10, 20, 20}, paint);
+          builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), paint);
           builder.Restore();
         },
         expected_op_count, expected_total_depth);
@@ -3599,22 +3555,21 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
             });
   run_tests("Empty rect clip",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
-              builder.ClipRect(SkRect::MakeEmpty(), ClipOp::kIntersect, false);
+              builder.ClipRect(DlRect(), ClipOp::kIntersect, false);
             });
   run_tests("Empty rrect clip",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
-              builder.ClipRRect(SkRRect::MakeEmpty(), ClipOp::kIntersect,
-                                false);
+              builder.ClipRoundRect(DlRoundRect(), ClipOp::kIntersect, false);
             });
   run_tests("Empty path clip",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
-              builder.ClipPath(SkPath(), ClipOp::kIntersect, false);
+              builder.ClipPath(DlPath(), ClipOp::kIntersect, false);
             });
   run_tests("Transparent SaveLayer",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
               DlPaint save_paint;
               save_paint.setColor(DlColor::kTransparent());
-              builder.SaveLayer(nullptr, &save_paint);
+              builder.SaveLayer(std::nullopt, &save_paint);
             });
   run_tests("0 alpha SaveLayer",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
@@ -3624,18 +3579,18 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
               // the case of all 1s with a 0 alpha
               save_paint.setColor(DlColor::kWhite());
               save_paint.setAlpha(0);
-              builder.SaveLayer(nullptr, &save_paint);
+              builder.SaveLayer(std::nullopt, &save_paint);
             });
   run_tests("Dst blended SaveLayer",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
               DlPaint save_paint;
               save_paint.setBlendMode(DlBlendMode::kDst);
-              builder.SaveLayer(nullptr, &save_paint);
+              builder.SaveLayer(std::nullopt, &save_paint);
             });
   run_tests(
       "Nop inside SaveLayer",
       [](DisplayListBuilder& builder, DlPaint& paint) {
-        builder.SaveLayer(nullptr, nullptr);
+        builder.SaveLayer(std::nullopt, nullptr);
         paint.setBlendMode(DlBlendMode::kDst);
       },
       2u, 1u);
@@ -3643,8 +3598,8 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
             [](DisplayListBuilder& builder, DlPaint& paint) {
               DlPaint save_paint;
               save_paint.setColor(DlColor::kTransparent());
-              builder.SaveLayer(nullptr, &save_paint);
-              builder.DrawImage(TestImage1, SkPoint{10, 10},
+              builder.SaveLayer(std::nullopt, &save_paint);
+              builder.DrawImage(kTestImage1, DlPoint(10, 10),
                                 DlImageSampling::kLinear);
             });
 }
@@ -3664,9 +3619,6 @@ class SaveLayerBoundsExpector : public virtual DlOpReceiver,
     });
     return *this;
   }
-  SaveLayerBoundsExpector& addComputedExpectation(const SkRect& bounds) {
-    return addComputedExpectation(ToDlRect(bounds));
-  }
 
   SaveLayerBoundsExpector& addSuppliedExpectation(const DlRect& bounds,
                                                   bool clipped = false) {
@@ -3681,10 +3633,6 @@ class SaveLayerBoundsExpector : public virtual DlOpReceiver,
     });
     return *this;
   }
-  SaveLayerBoundsExpector& addSuppliedExpectation(const SkRect& bounds,
-                                                  bool clipped = false) {
-    return addSuppliedExpectation(ToDlRect(bounds), clipped);
-  }
 
   void saveLayer(const DlRect& bounds,
                  const SaveLayerOptions options,
@@ -3698,10 +3646,10 @@ class SaveLayerBoundsExpector : public virtual DlOpReceiver,
     EXPECT_EQ(options.content_is_clipped(),
               expected.options.content_is_clipped())
         << "expected bounds index " << save_layer_count_;
-    if (!SkScalarNearlyEqual(bounds.GetLeft(), expected.bounds.GetLeft()) ||
-        !SkScalarNearlyEqual(bounds.GetTop(), expected.bounds.GetTop()) ||
-        !SkScalarNearlyEqual(bounds.GetRight(), expected.bounds.GetRight()) ||
-        !SkScalarNearlyEqual(bounds.GetBottom(), expected.bounds.GetBottom())) {
+    if (!DlScalarNearlyEqual(bounds.GetLeft(), expected.bounds.GetLeft()) ||
+        !DlScalarNearlyEqual(bounds.GetTop(), expected.bounds.GetTop()) ||
+        !DlScalarNearlyEqual(bounds.GetRight(), expected.bounds.GetRight()) ||
+        !DlScalarNearlyEqual(bounds.GetBottom(), expected.bounds.GetBottom())) {
       EXPECT_EQ(bounds, expected.bounds)
           << "expected bounds index " << save_layer_count_;
     }
@@ -3723,10 +3671,10 @@ class SaveLayerBoundsExpector : public virtual DlOpReceiver,
 };
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, DlPaint());
   }
@@ -3740,13 +3688,13 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfSimpleRect) {
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfMaskBlurredRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
   DlPaint draw_paint;
   auto mask_filter = DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 2.0f);
   draw_paint.setMaskFilter(mask_filter);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, draw_paint);
   }
@@ -3754,19 +3702,19 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfMaskBlurredRect) {
   auto display_list = builder.Build();
 
   SaveLayerBoundsExpector expector;
-  expector.addComputedExpectation(rect.makeOutset(6.0f, 6.0f));
+  expector.addComputedExpectation(rect.Expand(6.0f, 6.0f));
   display_list->Dispatch(expector);
   EXPECT_TRUE(expector.all_bounds_checked());
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfImageBlurredRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
   DlPaint draw_paint;
   auto image_filter = DlImageFilter::MakeBlur(2.0f, 3.0f, DlTileMode::kDecal);
   draw_paint.setImageFilter(image_filter);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, draw_paint);
   }
@@ -3774,19 +3722,19 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfImageBlurredRect) {
   auto display_list = builder.Build();
 
   SaveLayerBoundsExpector expector;
-  expector.addComputedExpectation(rect.makeOutset(6.0f, 9.0f));
+  expector.addComputedExpectation(rect.Expand(6.0f, 9.0f));
   display_list->Dispatch(expector);
   EXPECT_TRUE(expector.all_bounds_checked());
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfStrokedRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
   DlPaint draw_paint;
   draw_paint.setStrokeWidth(5.0f);
   draw_paint.setDrawStyle(DlDrawStyle::kStroke);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, draw_paint);
   }
@@ -3794,17 +3742,17 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfStrokedRect) {
   auto display_list = builder.Build();
 
   SaveLayerBoundsExpector expector;
-  expector.addComputedExpectation(rect.makeOutset(2.5f, 2.5f));
+  expector.addComputedExpectation(rect.Expand(2.5f, 2.5f));
   display_list->Dispatch(expector);
   EXPECT_TRUE(expector.all_bounds_checked());
 }
 
 TEST_F(DisplayListTest, TranslatedSaveLayerBoundsComputationOfSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
 
   DisplayListBuilder builder;
   builder.Translate(10.0f, 10.0f);
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, DlPaint());
   }
@@ -3818,11 +3766,11 @@ TEST_F(DisplayListTest, TranslatedSaveLayerBoundsComputationOfSimpleRect) {
 }
 
 TEST_F(DisplayListTest, ScaledSaveLayerBoundsComputationOfSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
 
   DisplayListBuilder builder;
   builder.Scale(10.0f, 10.0f);
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, DlPaint());
   }
@@ -3836,11 +3784,11 @@ TEST_F(DisplayListTest, ScaledSaveLayerBoundsComputationOfSimpleRect) {
 }
 
 TEST_F(DisplayListTest, RotatedSaveLayerBoundsComputationOfSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
 
   DisplayListBuilder builder;
   builder.Rotate(45.0f);
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, DlPaint());
   }
@@ -3854,12 +3802,12 @@ TEST_F(DisplayListTest, RotatedSaveLayerBoundsComputationOfSimpleRect) {
 }
 
 TEST_F(DisplayListTest, TransformResetSaveLayerBoundsComputationOfSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
-  SkRect rect_doubled = SkMatrix::Scale(2.0f, 2.0f).mapRect(rect);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect_doubled = DlRect::MakeLTRB(200.0f, 200.0f, 400.0f, 400.0f);
 
   DisplayListBuilder builder;
   builder.Scale(10.0f, 10.0f);
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   builder.TransformReset();
   builder.Scale(20.0f, 20.0f);
   // Net local transform for SaveLayer is Scale(2, 2)
@@ -3876,10 +3824,10 @@ TEST_F(DisplayListTest, TransformResetSaveLayerBoundsComputationOfSimpleRect) {
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfTranslatedSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.Translate(10.0f, 10.0f);
     builder.DrawRect(rect, DlPaint());
@@ -3888,16 +3836,16 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfTranslatedSimpleRect) {
   auto display_list = builder.Build();
 
   SaveLayerBoundsExpector expector;
-  expector.addComputedExpectation(rect.makeOffset(10.0f, 10.0f));
+  expector.addComputedExpectation(rect.Shift(10.0f, 10.0f));
   display_list->Dispatch(expector);
   EXPECT_TRUE(expector.all_bounds_checked());
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfScaledSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.Scale(10.0f, 10.0f);
     builder.DrawRect(rect, DlPaint());
@@ -3907,16 +3855,16 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfScaledSimpleRect) {
 
   SaveLayerBoundsExpector expector;
   expector.addComputedExpectation(
-      SkRect::MakeLTRB(1000.0f, 1000.0f, 2000.0f, 2000.0f));
+      DlRect::MakeLTRB(1000.0f, 1000.0f, 2000.0f, 2000.0f));
   display_list->Dispatch(expector);
   EXPECT_TRUE(expector.all_bounds_checked());
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfRotatedSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.Rotate(45.0f);
     builder.DrawRect(rect, DlPaint());
@@ -3924,20 +3872,20 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfRotatedSimpleRect) {
   builder.Restore();
   auto display_list = builder.Build();
 
-  SkMatrix matrix = SkMatrix::RotateDeg(45.0f);
+  DlMatrix matrix = DlMatrix::MakeRotationZ(DlDegrees(45.0f));
   SaveLayerBoundsExpector expector;
-  expector.addComputedExpectation(matrix.mapRect(rect));
+  expector.addComputedExpectation(rect.TransformAndClipBounds(matrix));
   display_list->Dispatch(expector);
   EXPECT_TRUE(expector.all_bounds_checked());
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfNestedSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
-    builder.SaveLayer(nullptr, nullptr);
+    builder.SaveLayer(std::nullopt, nullptr);
     {  //
       builder.DrawRect(rect, DlPaint());
     }
@@ -3954,19 +3902,19 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfNestedSimpleRect) {
 }
 
 TEST_F(DisplayListTest, FloodingSaveLayerBoundsComputationOfSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
   DlPaint save_paint;
   auto color_filter =
       DlColorFilter::MakeBlend(DlColor::kRed(), DlBlendMode::kSrc);
   ASSERT_TRUE(color_filter->modifies_transparent_black());
   save_paint.setColorFilter(color_filter);
-  SkRect clip_rect = rect.makeOutset(100.0f, 100.0f);
+  DlRect clip_rect = rect.Expand(100.0f, 100.0f);
   ASSERT_NE(clip_rect, rect);
-  ASSERT_TRUE(clip_rect.contains(rect));
+  ASSERT_TRUE(clip_rect.Contains(rect));
 
   DisplayListBuilder builder;
   builder.ClipRect(clip_rect);
-  builder.SaveLayer(nullptr, &save_paint);
+  builder.SaveLayer(std::nullopt, &save_paint);
   {  //
     builder.DrawRect(rect, DlPaint());
   }
@@ -3980,21 +3928,21 @@ TEST_F(DisplayListTest, FloodingSaveLayerBoundsComputationOfSimpleRect) {
 }
 
 TEST_F(DisplayListTest, NestedFloodingSaveLayerBoundsComputationOfSimpleRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
   DlPaint save_paint;
   auto color_filter =
       DlColorFilter::MakeBlend(DlColor::kRed(), DlBlendMode::kSrc);
   ASSERT_TRUE(color_filter->modifies_transparent_black());
   save_paint.setColorFilter(color_filter);
-  SkRect clip_rect = rect.makeOutset(100.0f, 100.0f);
+  DlRect clip_rect = rect.Expand(100.0f, 100.0f);
   ASSERT_NE(clip_rect, rect);
-  ASSERT_TRUE(clip_rect.contains(rect));
+  ASSERT_TRUE(clip_rect.Contains(rect));
 
   DisplayListBuilder builder;
   builder.ClipRect(clip_rect);
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {
-    builder.SaveLayer(nullptr, &save_paint);
+    builder.SaveLayer(std::nullopt, &save_paint);
     {  //
       builder.DrawRect(rect, DlPaint());
     }
@@ -4003,7 +3951,7 @@ TEST_F(DisplayListTest, NestedFloodingSaveLayerBoundsComputationOfSimpleRect) {
   builder.Restore();
   auto display_list = builder.Build();
 
-  EXPECT_EQ(display_list->bounds(), clip_rect);
+  EXPECT_EQ(display_list->GetBounds(), clip_rect);
 
   SaveLayerBoundsExpector expector;
   expector.addComputedExpectation(clip_rect);
@@ -4013,20 +3961,20 @@ TEST_F(DisplayListTest, NestedFloodingSaveLayerBoundsComputationOfSimpleRect) {
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfFloodingImageFilter) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
   DlPaint draw_paint;
   auto color_filter =
       DlColorFilter::MakeBlend(DlColor::kRed(), DlBlendMode::kSrc);
   ASSERT_TRUE(color_filter->modifies_transparent_black());
   auto image_filter = DlImageFilter::MakeColorFilter(color_filter);
   draw_paint.setImageFilter(image_filter);
-  SkRect clip_rect = rect.makeOutset(100.0f, 100.0f);
+  DlRect clip_rect = rect.Expand(100.0f, 100.0f);
   ASSERT_NE(clip_rect, rect);
-  ASSERT_TRUE(clip_rect.contains(rect));
+  ASSERT_TRUE(clip_rect.Contains(rect));
 
   DisplayListBuilder builder;
   builder.ClipRect(clip_rect);
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, draw_paint);
   }
@@ -4040,19 +3988,19 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfFloodingImageFilter) {
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsComputationOfFloodingColorFilter) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
   DlPaint draw_paint;
   auto color_filter =
       DlColorFilter::MakeBlend(DlColor::kRed(), DlBlendMode::kSrc);
   ASSERT_TRUE(color_filter->modifies_transparent_black());
   draw_paint.setColorFilter(color_filter);
-  SkRect clip_rect = rect.makeOutset(100.0f, 100.0f);
+  DlRect clip_rect = rect.Expand(100.0f, 100.0f);
   ASSERT_NE(clip_rect, rect);
-  ASSERT_TRUE(clip_rect.contains(rect));
+  ASSERT_TRUE(clip_rect.Contains(rect));
 
   DisplayListBuilder builder;
   builder.ClipRect(clip_rect);
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {  //
     builder.DrawRect(rect, draw_paint);
   }
@@ -4068,11 +4016,11 @@ TEST_F(DisplayListTest, SaveLayerBoundsComputationOfFloodingColorFilter) {
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsClipDetectionSimpleUnclippedRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
-  SkRect save_rect = SkRect::MakeLTRB(50.0f, 50.0f, 250.0f, 250.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect save_rect = DlRect::MakeLTRB(50.0f, 50.0f, 250.0f, 250.0f);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(&save_rect, nullptr);
+  builder.SaveLayer(save_rect, nullptr);
   {  //
     builder.DrawRect(rect, DlPaint());
   }
@@ -4086,12 +4034,12 @@ TEST_F(DisplayListTest, SaveLayerBoundsClipDetectionSimpleUnclippedRect) {
 }
 
 TEST_F(DisplayListTest, SaveLayerBoundsClipDetectionSimpleClippedRect) {
-  SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
-  SkRect save_rect = SkRect::MakeLTRB(50.0f, 50.0f, 110.0f, 110.0f);
-  SkRect content_rect = SkRect::MakeLTRB(100.0f, 100.0f, 110.0f, 110.0f);
+  DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+  DlRect save_rect = DlRect::MakeLTRB(50.0f, 50.0f, 110.0f, 110.0f);
+  DlRect content_rect = DlRect::MakeLTRB(100.0f, 100.0f, 110.0f, 110.0f);
 
   DisplayListBuilder builder;
-  builder.SaveLayer(&save_rect, nullptr);
+  builder.SaveLayer(save_rect, nullptr);
   {  //
     builder.DrawRect(rect, DlPaint());
   }
@@ -4106,26 +4054,26 @@ TEST_F(DisplayListTest, SaveLayerBoundsClipDetectionSimpleClippedRect) {
 
 TEST_F(DisplayListTest, DisjointSaveLayerBoundsProduceEmptySuppliedBounds) {
   // This test was added when we fixed the Builder code to check the
-  // return value of the SkRect::intersect method, but it turns out
+  // return value of the Skia Rect intersect method, but it turns out
   // that the indicated case never happens in practice due to the
   // internal culling during the recording process. It actually passes
   // both before and after the fix, but is here to ensure the right
   // behavior does not regress.
 
-  SkRect layer_bounds = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRect draw_rect = SkRect::MakeLTRB(50.0f, 50.0f, 100.0f, 100.0f);
-  ASSERT_FALSE(layer_bounds.intersects(draw_rect));
-  ASSERT_FALSE(layer_bounds.isEmpty());
-  ASSERT_FALSE(draw_rect.isEmpty());
+  DlRect layer_bounds = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect draw_rect = DlRect::MakeLTRB(50.0f, 50.0f, 100.0f, 100.0f);
+  ASSERT_FALSE(layer_bounds.IntersectsWithRect(draw_rect));
+  ASSERT_FALSE(layer_bounds.IsEmpty());
+  ASSERT_FALSE(draw_rect.IsEmpty());
 
   DisplayListBuilder builder;
-  builder.SaveLayer(&layer_bounds, nullptr);
+  builder.SaveLayer(layer_bounds, nullptr);
   builder.DrawRect(draw_rect, DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
 
   SaveLayerBoundsExpector expector;
-  expector.addSuppliedExpectation(SkRect::MakeEmpty(), false);
+  expector.addSuppliedExpectation(DlRect(), false);
   display_list->Dispatch(expector);
   EXPECT_TRUE(expector.all_bounds_checked());
 }
@@ -4184,33 +4132,34 @@ class DepthExpector : public virtual DlOpReceiver,
 
 TEST_F(DisplayListTest, SaveContentDepthTest) {
   DisplayListBuilder child_builder;
-  child_builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());  // depth 1
+  child_builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20),
+                         DlPaint());  // depth 1
   auto child = child_builder.Build();
 
   DisplayListBuilder builder;
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());  // depth 1
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());  // depth 1
 
   builder.Save();  // covers depth 1->9
   {
     builder.Translate(5, 5);  // triggers deferred save at depth 1
-    builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());  // depth 2
+    builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());  // depth 2
 
     builder.DrawDisplayList(child, 1.0f);  // depth 3 (content) + 4 (self)
 
-    builder.SaveLayer(nullptr, nullptr);  // covers depth 5->6
+    builder.SaveLayer(std::nullopt, nullptr);  // covers depth 5->6
     {
-      builder.DrawRect(SkRect{12, 12, 22, 22}, DlPaint());  // depth 5
-      builder.DrawRect(SkRect{14, 14, 24, 24}, DlPaint());  // depth 6
+      builder.DrawRect(DlRect::MakeLTRB(12, 12, 22, 22), DlPaint());  // depth 5
+      builder.DrawRect(DlRect::MakeLTRB(14, 14, 24, 24), DlPaint());  // depth 6
     }
     builder.Restore();  // layer is restored with depth 6
 
-    builder.DrawRect(SkRect{16, 16, 26, 26}, DlPaint());  // depth 8
-    builder.DrawRect(SkRect{18, 18, 28, 28}, DlPaint());  // depth 9
+    builder.DrawRect(DlRect::MakeLTRB(16, 16, 26, 26), DlPaint());  // depth 8
+    builder.DrawRect(DlRect::MakeLTRB(18, 18, 28, 28), DlPaint());  // depth 9
   }
   builder.Restore();  // save is restored with depth 9
 
-  builder.DrawRect(SkRect{16, 16, 26, 26}, DlPaint());  // depth 10
-  builder.DrawRect(SkRect{18, 18, 28, 28}, DlPaint());  // depth 11
+  builder.DrawRect(DlRect::MakeLTRB(16, 16, 26, 26), DlPaint());  // depth 10
+  builder.DrawRect(DlRect::MakeLTRB(18, 18, 28, 28), DlPaint());  // depth 11
   auto display_list = builder.Build();
 
   EXPECT_EQ(display_list->total_depth(), 11u);
@@ -4235,7 +4184,7 @@ TEST_F(DisplayListTest, FloodingFilteredLayerPushesRestoreOpIndex) {
   // clang-format on
   auto color_filter = DlColorFilter::MakeMatrix(matrix);
   save_paint.setImageFilter(DlImageFilter::MakeColorFilter(color_filter));
-  builder.SaveLayer(nullptr, &save_paint);
+  builder.SaveLayer(std::nullopt, &save_paint);
   int save_layer_id = DisplayListBuilderTestingLastOpIndex(builder);
 
   builder.DrawRect(DlRect::MakeLTRB(120.0f, 120.0f, 125.0f, 125.0f), DlPaint());
@@ -4255,47 +4204,47 @@ TEST_F(DisplayListTest, FloodingFilteredLayerPushesRestoreOpIndex) {
 
 TEST_F(DisplayListTest, TransformingFilterSaveLayerSimpleContentBounds) {
   DisplayListBuilder builder;
-  builder.ClipRect(SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f));
+  builder.ClipRect(DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f));
 
   DlPaint save_paint;
   auto image_filter =
       DlImageFilter::MakeMatrix(DlMatrix::MakeTranslation({100.0f, 100.0f}),
                                 DlImageSampling::kNearestNeighbor);
   save_paint.setImageFilter(image_filter);
-  builder.SaveLayer(nullptr, &save_paint);
+  builder.SaveLayer(std::nullopt, &save_paint);
 
-  builder.DrawRect(SkRect::MakeLTRB(20.0f, 20.0f, 25.0f, 25.0f), DlPaint());
+  builder.DrawRect(DlRect::MakeLTRB(20.0f, 20.0f, 25.0f, 25.0f), DlPaint());
 
   builder.Restore();
 
   auto dl = builder.Build();
-  EXPECT_EQ(dl->bounds(), SkRect::MakeLTRB(120.0f, 120.0f, 125.0f, 125.0f));
+  EXPECT_EQ(dl->GetBounds(), DlRect::MakeLTRB(120.0f, 120.0f, 125.0f, 125.0f));
 }
 
 TEST_F(DisplayListTest, TransformingFilterSaveLayerFloodedContentBounds) {
   DisplayListBuilder builder;
-  builder.ClipRect(SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f));
+  builder.ClipRect(DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f));
 
   DlPaint save_paint;
   auto image_filter =
       DlImageFilter::MakeMatrix(DlMatrix::MakeTranslation({100.0f, 100.0f}),
                                 DlImageSampling::kNearestNeighbor);
   save_paint.setImageFilter(image_filter);
-  builder.SaveLayer(nullptr, &save_paint);
+  builder.SaveLayer(std::nullopt, &save_paint);
 
   builder.DrawColor(DlColor::kBlue(), DlBlendMode::kSrcOver);
 
   builder.Restore();
 
   auto dl = builder.Build();
-  EXPECT_EQ(dl->bounds(), SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f));
+  EXPECT_EQ(dl->GetBounds(), DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f));
 }
 
 TEST_F(DisplayListTest, OpacityIncompatibleRenderOpInsideDeferredSave) {
   {
     // Without deferred save
     DisplayListBuilder builder;
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kClear));
     EXPECT_FALSE(builder.Build()->can_apply_group_opacity());
   }
@@ -4306,7 +4255,7 @@ TEST_F(DisplayListTest, OpacityIncompatibleRenderOpInsideDeferredSave) {
     builder.Save();
     {
       // Nothing to trigger the deferred save...
-      builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+      builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                        DlPaint().setBlendMode(DlBlendMode::kClear));
     }
     // Deferred save was not triggered, did it forward the incompatibility
@@ -4324,7 +4273,7 @@ TEST_F(DisplayListTest, MaxBlendModeEmptyDisplayList) {
 TEST_F(DisplayListTest, MaxBlendModeSimpleRect) {
   auto test = [](DlBlendMode mode) {
     DisplayListBuilder builder;
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setAlpha(0x7f).setBlendMode(mode));
     DlBlendMode expect =
         (mode == DlBlendMode::kDst) ? DlBlendMode::kClear : mode;
@@ -4343,7 +4292,7 @@ TEST_F(DisplayListTest, MaxBlendModeInsideNonDeferredSave) {
   {
     // Trigger the deferred save
     builder.Scale(2.0f, 2.0f);
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kModulate));
   }
   // Save was triggered, did it forward the max blend mode?
@@ -4356,7 +4305,7 @@ TEST_F(DisplayListTest, MaxBlendModeInsideDeferredSave) {
   builder.Save();
   {
     // Nothing to trigger the deferred save...
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kModulate));
   }
   // Deferred save was not triggered, did it forward the max blend mode?
@@ -4366,9 +4315,9 @@ TEST_F(DisplayListTest, MaxBlendModeInsideDeferredSave) {
 
 TEST_F(DisplayListTest, MaxBlendModeInsideSaveLayer) {
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kModulate));
   }
   builder.Restore();
@@ -4384,9 +4333,9 @@ TEST_F(DisplayListTest, MaxBlendModeInsideNonDefaultBlendedSaveLayer) {
   DisplayListBuilder builder;
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kScreen);
-  builder.SaveLayer(nullptr, &save_paint);
+  builder.SaveLayer(std::nullopt, &save_paint);
   {
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kModulate));
   }
   builder.Restore();
@@ -4402,20 +4351,20 @@ TEST_F(DisplayListTest, MaxBlendModeInsideComplexDeferredSaves) {
   DisplayListBuilder builder;
   builder.Save();
   {
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kModulate));
     builder.Save();
     {
       // We want to use a blend mode that is greater than modulate here
       ASSERT_GT(DlBlendMode::kScreen, DlBlendMode::kModulate);
-      builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+      builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                        DlPaint().setBlendMode(DlBlendMode::kScreen));
     }
     builder.Restore();
 
     // We want to use a blend mode that is smaller than modulate here
     ASSERT_LT(DlBlendMode::kSrc, DlBlendMode::kModulate);
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kSrc));
   }
   builder.Restore();
@@ -4430,22 +4379,22 @@ TEST_F(DisplayListTest, MaxBlendModeInsideComplexDeferredSaves) {
 
 TEST_F(DisplayListTest, MaxBlendModeInsideComplexSaveLayers) {
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {
     // outer save layer has Modulate now and Src later - Modulate is larger
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kModulate));
-    builder.SaveLayer(nullptr, nullptr);
+    builder.SaveLayer(std::nullopt, nullptr);
     {
       // inner save layer only has a Screen blend
-      builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+      builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                        DlPaint().setBlendMode(DlBlendMode::kScreen));
     }
     builder.Restore();
 
     // We want to use a blend mode that is smaller than modulate here
     ASSERT_LT(DlBlendMode::kSrc, DlBlendMode::kModulate);
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                      DlPaint().setBlendMode(DlBlendMode::kSrc));
   }
   builder.Restore();
@@ -4472,16 +4421,16 @@ TEST_F(DisplayListTest, BackdropDetectionEmptyDisplayList) {
 
 TEST_F(DisplayListTest, BackdropDetectionSimpleRect) {
   DisplayListBuilder builder;
-  builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10), DlPaint());
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10), DlPaint());
   EXPECT_FALSE(builder.Build()->root_has_backdrop_filter());
 }
 
 TEST_F(DisplayListTest, BackdropDetectionSimpleSaveLayer) {
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr, &kTestBlurImageFilter1);
+  builder.SaveLayer(std::nullopt, nullptr, &kTestBlurImageFilter1);
   {
     // inner content has no backdrop filter
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10), DlPaint());
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10), DlPaint());
   }
   builder.Restore();
   auto dl = builder.Build();
@@ -4498,14 +4447,14 @@ TEST_F(DisplayListTest, BackdropDetectionSimpleSaveLayer) {
 
 TEST_F(DisplayListTest, BackdropDetectionNestedSaveLayer) {
   DisplayListBuilder builder;
-  builder.SaveLayer(nullptr, nullptr);
+  builder.SaveLayer(std::nullopt, nullptr);
   {
     // first inner content does have backdrop filter
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10), DlPaint());
-    builder.SaveLayer(nullptr, nullptr, &kTestBlurImageFilter1);
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10), DlPaint());
+    builder.SaveLayer(std::nullopt, nullptr, &kTestBlurImageFilter1);
     {
       // second inner content has no backdrop filter
-      builder.DrawRect(SkRect::MakeLTRB(10, 10, 20, 20), DlPaint());
+      builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
     }
     builder.Restore();
   }
@@ -4526,7 +4475,7 @@ TEST_F(DisplayListTest, BackdropDetectionNestedSaveLayer) {
 
 TEST_F(DisplayListTest, DrawDisplayListForwardsMaxBlend) {
   DisplayListBuilder child_builder;
-  child_builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+  child_builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                          DlPaint().setBlendMode(DlBlendMode::kMultiply));
   auto child_dl = child_builder.Build();
   EXPECT_EQ(child_dl->max_root_blend_mode(), DlBlendMode::kMultiply);
@@ -4542,8 +4491,8 @@ TEST_F(DisplayListTest, DrawDisplayListForwardsMaxBlend) {
 TEST_F(DisplayListTest, DrawDisplayListForwardsBackdropFlag) {
   DisplayListBuilder child_builder;
   DlBlurImageFilter backdrop(2.0f, 2.0f, DlTileMode::kDecal);
-  child_builder.SaveLayer(nullptr, nullptr, &backdrop);
-  child_builder.DrawRect(SkRect::MakeLTRB(0, 0, 10, 10),
+  child_builder.SaveLayer(std::nullopt, nullptr, &backdrop);
+  child_builder.DrawRect(DlRect::MakeLTRB(0, 0, 10, 10),
                          DlPaint().setBlendMode(DlBlendMode::kMultiply));
   child_builder.Restore();
   auto child_dl = child_builder.Build();
@@ -4568,7 +4517,7 @@ struct ClipExpectation {
   std::string shape_name() {
     switch (shape.index()) {
       case 0:
-        return is_oval ? "SkOval" : "SkRect";
+        return is_oval ? "Oval" : "Rect";
       case 1:
         return "DlRoundRect";
       case 2:
@@ -4621,11 +4570,11 @@ class ClipExpector : public virtual DlOpReceiver,
     }
   }
 
-  ClipExpector& addExpectation(const SkRect& rect,
+  ClipExpector& addExpectation(const DlRect& rect,
                                ClipOp clip_op = ClipOp::kIntersect,
                                bool is_aa = false) {
     clip_expectations_.push_back({
-        .shape = ToDlRect(rect),
+        .shape = rect,
         .is_oval = false,
         .clip_op = clip_op,
         .is_aa = is_aa,
@@ -4633,11 +4582,11 @@ class ClipExpector : public virtual DlOpReceiver,
     return *this;
   }
 
-  ClipExpector& addOvalExpectation(const SkRect& rect,
+  ClipExpector& addOvalExpectation(const DlRect& rect,
                                    ClipOp clip_op = ClipOp::kIntersect,
                                    bool is_aa = false) {
     clip_expectations_.push_back({
-        .shape = ToDlRect(rect),
+        .shape = rect,
         .is_oval = true,
         .clip_op = clip_op,
         .is_aa = is_aa,
@@ -4645,13 +4594,11 @@ class ClipExpector : public virtual DlOpReceiver,
     return *this;
   }
 
-  ClipExpector& addExpectation(const SkRRect& rrect,
+  ClipExpector& addExpectation(const DlRoundRect& rrect,
                                ClipOp clip_op = ClipOp::kIntersect,
                                bool is_aa = false) {
-    auto dl_rrect = ToDlRoundRect(rrect);
-    EXPECT_EQ(ToSkRRect(dl_rrect), rrect);
     clip_expectations_.push_back({
-        .shape = dl_rrect,
+        .shape = rrect,
         .is_oval = false,
         .clip_op = clip_op,
         .is_aa = is_aa,
@@ -4669,12 +4616,6 @@ class ClipExpector : public virtual DlOpReceiver,
         .is_aa = is_aa,
     });
     return *this;
-  }
-
-  ClipExpector& addExpectation(const SkPath& path,
-                               ClipOp clip_op = ClipOp::kIntersect,
-                               bool is_aa = false) {
-    return addExpectation(DlPath(path), clip_op, is_aa);
   }
 
   void clipRect(const DlRect& rect,
@@ -4739,9 +4680,9 @@ TEST_F(DisplayListTest, ClipRectCullingPixel6a) {
   // The test in device space only works under a simple scale, such as we
   // use for DPR adjustments (and which are not always inversion friendly).
 
-  auto frame = SkRect::MakeLTRB(0.0f, 0.0f, 1080.0f, 2400.0f);
+  auto frame = DlRect::MakeLTRB(0.0f, 0.0f, 1080.0f, 2400.0f);
   DlScalar DPR = 2.625f;
-  auto clip = SkRect::MakeLTRB(0.0f, 0.0f, 1080.0f / DPR, 2400.0f / DPR);
+  auto clip = DlRect::MakeLTRB(0.0f, 0.0f, 1080.0f / DPR, 2400.0f / DPR);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(frame, ClipOp::kIntersect, false);
@@ -4755,11 +4696,11 @@ TEST_F(DisplayListTest, ClipRectCullingPixel6a) {
 }
 
 TEST_F(DisplayListTest, ClipRectCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipRect(clip.makeOutset(1.0f, 1.0f), ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip.Expand(1.0f, 1.0f), ClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
@@ -4768,8 +4709,8 @@ TEST_F(DisplayListTest, ClipRectCulling) {
 }
 
 TEST_F(DisplayListTest, ClipRectNonCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto smaller_clip = clip.makeInset(1.0f, 1.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto smaller_clip = clip.Expand(-1.0f, -1.0f);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4783,8 +4724,8 @@ TEST_F(DisplayListTest, ClipRectNonCulling) {
 }
 
 TEST_F(DisplayListTest, ClipRectNestedCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto larger_clip = clip.makeOutset(1.0f, 1.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto larger_clip = clip.Expand(1.0f, 1.0f);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4799,8 +4740,8 @@ TEST_F(DisplayListTest, ClipRectNestedCulling) {
 }
 
 TEST_F(DisplayListTest, ClipRectNestedNonCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto larger_clip = clip.makeOutset(1.0f, 1.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto larger_clip = clip.Expand(1.0f, 1.0f);
 
   DisplayListBuilder cull_builder;
   cull_builder.Save();
@@ -4817,9 +4758,9 @@ TEST_F(DisplayListTest, ClipRectNestedNonCulling) {
 }
 
 TEST_F(DisplayListTest, ClipRectNestedCullingComplex) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto smaller_clip = clip.makeInset(1.0f, 1.0f);
-  auto smallest_clip = clip.makeInset(2.0f, 2.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto smaller_clip = clip.Expand(-1.0f, -1.0f);
+  auto smallest_clip = clip.Expand(-2.0f, -2.0f);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4836,9 +4777,9 @@ TEST_F(DisplayListTest, ClipRectNestedCullingComplex) {
 }
 
 TEST_F(DisplayListTest, ClipRectNestedNonCullingComplex) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto smaller_clip = clip.makeInset(1.0f, 1.0f);
-  auto smallest_clip = clip.makeInset(2.0f, 2.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto smaller_clip = clip.Expand(-1.0f, -1.0f);
+  auto smallest_clip = clip.Expand(-2.0f, -2.0f);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4857,12 +4798,12 @@ TEST_F(DisplayListTest, ClipRectNestedNonCullingComplex) {
 }
 
 TEST_F(DisplayListTest, ClipOvalCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
   // A 10x10 rectangle extends 5x5 from the center to each corner. To have
   // an oval that encompasses that rectangle, the radius must be at least
   // length(5, 5), or 7.071+ so we expand the radius 5 square clip by 2.072
   // on each side to barely contain the corners of the square.
-  auto encompassing_oval = clip.makeOutset(2.072f, 2.072f);
+  auto encompassing_oval = clip.Expand(2.072f, 2.072f);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4875,12 +4816,12 @@ TEST_F(DisplayListTest, ClipOvalCulling) {
 }
 
 TEST_F(DisplayListTest, ClipOvalNonCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
   // A 10x10 rectangle extends 5x5 from the center to each corner. To have
   // an oval that encompasses that rectangle, the radius must be at least
   // length(5, 5), or 7.071+ so we expand the radius 5 square clip by 2.072
   // on each side to barely exclude the corners of the square.
-  auto non_encompassing_oval = clip.makeOutset(2.071f, 2.071f);
+  auto non_encompassing_oval = clip.Expand(2.071f, 2.071f);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4894,13 +4835,13 @@ TEST_F(DisplayListTest, ClipOvalNonCulling) {
 }
 
 TEST_F(DisplayListTest, ClipRRectCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto rrect = SkRRect::MakeRectXY(clip.makeOutset(2.0f, 2.0f), 2.0f, 2.0f);
-  ASSERT_FALSE(rrect.isOval());
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto rrect = DlRoundRect::MakeRectXY(clip.Expand(2.0f, 2.0f), 2.0f, 2.0f);
+  ASSERT_FALSE(rrect.IsOval());
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipRRect(rrect, ClipOp::kIntersect, false);
+  cull_builder.ClipRoundRect(rrect, ClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
@@ -4909,13 +4850,13 @@ TEST_F(DisplayListTest, ClipRRectCulling) {
 }
 
 TEST_F(DisplayListTest, ClipRRectNonCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto rrect = SkRRect::MakeRectXY(clip.makeOutset(1.0f, 1.0f), 4.0f, 4.0f);
-  ASSERT_FALSE(rrect.isOval());
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto rrect = DlRoundRect::MakeRectXY(clip.Expand(1.0f, 1.0f), 4.0f, 4.0f);
+  ASSERT_FALSE(rrect.IsOval());
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipRRect(rrect, ClipOp::kIntersect, false);
+  cull_builder.ClipRoundRect(rrect, ClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
@@ -4925,22 +4866,23 @@ TEST_F(DisplayListTest, ClipRRectNonCulling) {
 }
 
 TEST_F(DisplayListTest, ClipPathNonCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkPath path;
-  path.moveTo(0.0f, 0.0f);
-  path.lineTo(1000.0f, 0.0f);
-  path.lineTo(0.0f, 1000.0f);
-  path.close();
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlPathBuilder path_builder;
+  path_builder.MoveTo({0.0f, 0.0f});
+  path_builder.LineTo({1000.0f, 0.0f});
+  path_builder.LineTo({0.0f, 1000.0f});
+  path_builder.Close();
+  DlPath path = DlPath(path_builder.TakePath());
 
   // Double checking that the path does indeed contain the clip. But,
   // sadly, the Builder will not check paths for coverage to this level
   // of detail. (In particular, path containment of the corners is not
   // authoritative of true containment, but we know in this case that
   // a triangle contains a rect if it contains all 4 corners...)
-  ASSERT_TRUE(path.contains(clip.fLeft, clip.fTop));
-  ASSERT_TRUE(path.contains(clip.fRight, clip.fTop));
-  ASSERT_TRUE(path.contains(clip.fRight, clip.fBottom));
-  ASSERT_TRUE(path.contains(clip.fLeft, clip.fBottom));
+  ASSERT_TRUE(path.Contains(clip.GetLeftTop()));
+  ASSERT_TRUE(path.Contains(clip.GetRightTop()));
+  ASSERT_TRUE(path.Contains(clip.GetRightBottom()));
+  ASSERT_TRUE(path.Contains(clip.GetLeftBottom()));
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4954,9 +4896,8 @@ TEST_F(DisplayListTest, ClipPathNonCulling) {
 }
 
 TEST_F(DisplayListTest, ClipPathRectCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkPath path;
-  path.addRect(clip.makeOutset(1.0f, 1.0f));
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlPath path = DlPath::MakeRect(clip.Expand(1.0f, 1.0f));
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4969,10 +4910,9 @@ TEST_F(DisplayListTest, ClipPathRectCulling) {
 }
 
 TEST_F(DisplayListTest, ClipPathRectNonCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto smaller_clip = clip.makeInset(1.0f, 1.0f);
-  SkPath path;
-  path.addRect(smaller_clip);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto smaller_clip = clip.Expand(-1.0f, -1.0f);
+  DlPath path = DlPath::MakeRect(smaller_clip);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4987,14 +4927,13 @@ TEST_F(DisplayListTest, ClipPathRectNonCulling) {
 }
 
 TEST_F(DisplayListTest, ClipPathOvalCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
   // A 10x10 rectangle extends 5x5 from the center to each corner. To have
   // an oval that encompasses that rectangle, the radius must be at least
   // length(5, 5), or 7.071+ so we expand the radius 5 square clip by 2.072
   // on each side to barely contain the corners of the square.
-  auto encompassing_oval = clip.makeOutset(2.072f, 2.072f);
-  SkPath path;
-  path.addOval(encompassing_oval);
+  auto encompassing_oval = clip.Expand(2.072f, 2.072f);
+  DlPath path = DlPath::MakeOval(encompassing_oval);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -5007,14 +4946,13 @@ TEST_F(DisplayListTest, ClipPathOvalCulling) {
 }
 
 TEST_F(DisplayListTest, ClipPathOvalNonCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
   // A 10x10 rectangle extends 5x5 from the center to each corner. To have
   // an oval that encompasses that rectangle, the radius must be at least
   // length(5, 5), or 7.071+ so we expand the radius 5 square clip by 2.072
   // on each side to barely exclude the corners of the square.
-  auto non_encompassing_oval = clip.makeOutset(2.071f, 2.071f);
-  SkPath path;
-  path.addOval(non_encompassing_oval);
+  auto non_encompassing_oval = clip.Expand(2.071f, 2.071f);
+  DlPath path = DlPath::MakeOval(non_encompassing_oval);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -5029,11 +4967,9 @@ TEST_F(DisplayListTest, ClipPathOvalNonCulling) {
 }
 
 TEST_F(DisplayListTest, ClipPathRRectCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto rrect = SkRRect::MakeRectXY(clip.makeOutset(2.0f, 2.0f), 2.0f, 2.0f);
-  ASSERT_FALSE(rrect.isOval());
-  SkPath path;
-  path.addRRect(rrect);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlPath path = DlPath::MakeRoundRectXY(clip.Expand(2.0f, 2.0f), 2.0f, 2.0f);
+  ASSERT_FALSE(path.IsOval());
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -5046,11 +4982,10 @@ TEST_F(DisplayListTest, ClipPathRRectCulling) {
 }
 
 TEST_F(DisplayListTest, ClipPathRRectNonCulling) {
-  auto clip = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  auto rrect = SkRRect::MakeRectXY(clip.makeOutset(1.0f, 1.0f), 4.0f, 4.0f);
-  ASSERT_FALSE(rrect.isOval());
-  SkPath path;
-  path.addRRect(rrect);
+  auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  auto rrect = DlRoundRect::MakeRectXY(clip.Expand(1.0f, 1.0f), 4.0f, 4.0f);
+  ASSERT_FALSE(rrect.IsOval());
+  DlPath path = DlPath::MakeRoundRect(rrect);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -5084,7 +5019,7 @@ TEST_F(DisplayListTest, RecordLargeVertices) {
   for (int i = 0; i < 1000; i++) {
     DisplayListBuilder builder;
     for (int j = 0; j < 16; j++) {
-      builder.SaveLayer(nullptr, nullptr, backdrop.get());
+      builder.SaveLayer(std::nullopt, nullptr, backdrop.get());
       builder.DrawVertices(vertices, DlBlendMode::kSrcOver, DlPaint());
       builder.Restore();
     }
@@ -5093,10 +5028,10 @@ TEST_F(DisplayListTest, RecordLargeVertices) {
 }
 
 TEST_F(DisplayListTest, DrawRectRRectPromoteToDrawRect) {
-  SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
 
   DisplayListBuilder builder;
-  builder.DrawRRect(SkRRect::MakeRect(rect), DlPaint());
+  builder.DrawRoundRect(DlRoundRect::MakeRect(rect), DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
@@ -5107,10 +5042,10 @@ TEST_F(DisplayListTest, DrawRectRRectPromoteToDrawRect) {
 }
 
 TEST_F(DisplayListTest, DrawOvalRRectPromoteToDrawOval) {
-  SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
 
   DisplayListBuilder builder;
-  builder.DrawRRect(SkRRect::MakeOval(rect), DlPaint());
+  builder.DrawRoundRect(DlRoundRect::MakeOval(rect), DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
@@ -5121,10 +5056,10 @@ TEST_F(DisplayListTest, DrawOvalRRectPromoteToDrawOval) {
 }
 
 TEST_F(DisplayListTest, DrawRectPathPromoteToDrawRect) {
-  SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
 
   DisplayListBuilder builder;
-  builder.DrawPath(SkPath::Rect(rect), DlPaint());
+  builder.DrawPath(DlPath::MakeRect(rect), DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
@@ -5137,10 +5072,10 @@ TEST_F(DisplayListTest, DrawRectPathPromoteToDrawRect) {
 }
 
 TEST_F(DisplayListTest, DrawOvalPathPromoteToDrawOval) {
-  SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
 
   DisplayListBuilder builder;
-  builder.DrawPath(SkPath::Oval(rect), DlPaint());
+  builder.DrawPath(DlPath::MakeOval(rect), DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
@@ -5152,16 +5087,16 @@ TEST_F(DisplayListTest, DrawOvalPathPromoteToDrawOval) {
   ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
 }
 
-TEST_F(DisplayListTest, DrawRRectPathPromoteToDrawRRect) {
-  SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRRect rrect = SkRRect::MakeRectXY(rect, 2.0f, 2.0f);
+TEST_F(DisplayListTest, DrawRRectPathPromoteToDrawRoundRect) {
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRoundRect rrect = DlRoundRect::MakeRectXY(rect, 2.0f, 2.0f);
 
   DisplayListBuilder builder;
-  builder.DrawPath(SkPath::RRect(rrect), DlPaint());
+  builder.DrawPath(DlPath::MakeRoundRect(rrect), DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.DrawRRect(rrect, DlPaint());
+  expected.DrawRoundRect(rrect, DlPaint());
   auto expect_dl = expected.Build();
 
   // Support for this will be re-added soon, until then verify that we
@@ -5169,12 +5104,12 @@ TEST_F(DisplayListTest, DrawRRectPathPromoteToDrawRRect) {
   ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
 }
 
-TEST_F(DisplayListTest, DrawRectRRectPathPromoteToDrawRect) {
-  SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRRect rrect = SkRRect::MakeRect(rect);
+TEST_F(DisplayListTest, DrawRectRoundRectPathPromoteToDrawRect) {
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRoundRect rrect = DlRoundRect::MakeRect(rect);
 
   DisplayListBuilder builder;
-  builder.DrawPath(SkPath::RRect(rrect), DlPaint());
+  builder.DrawPath(DlPath::MakeRoundRect(rrect), DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
@@ -5187,11 +5122,11 @@ TEST_F(DisplayListTest, DrawRectRRectPathPromoteToDrawRect) {
 }
 
 TEST_F(DisplayListTest, DrawOvalRRectPathPromoteToDrawOval) {
-  SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRRect rrect = SkRRect::MakeOval(rect);
+  DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRoundRect rrect = DlRoundRect::MakeOval(rect);
 
   DisplayListBuilder builder;
-  builder.DrawPath(SkPath::RRect(rrect), DlPaint());
+  builder.DrawPath(DlPath::MakeRoundRect(rrect), DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
@@ -5204,11 +5139,12 @@ TEST_F(DisplayListTest, DrawOvalRRectPathPromoteToDrawOval) {
 }
 
 TEST_F(DisplayListTest, ClipRectRRectPromoteToClipRect) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
+  DlRect clip_rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
 
   DisplayListBuilder builder;
-  builder.ClipRRect(SkRRect::MakeRect(clip_rect), ClipOp::kIntersect, false);
+  builder.ClipRoundRect(DlRoundRect::MakeRect(clip_rect), ClipOp::kIntersect,
+                        false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
@@ -5222,11 +5158,12 @@ TEST_F(DisplayListTest, ClipRectRRectPromoteToClipRect) {
 }
 
 TEST_F(DisplayListTest, ClipOvalRRectPromoteToClipOval) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
+  DlRect clip_rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
 
   DisplayListBuilder builder;
-  builder.ClipRRect(SkRRect::MakeOval(clip_rect), ClipOp::kIntersect, false);
+  builder.ClipRoundRect(DlRoundRect::MakeOval(clip_rect), ClipOp::kIntersect,
+                        false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
@@ -5240,11 +5177,10 @@ TEST_F(DisplayListTest, ClipOvalRRectPromoteToClipOval) {
 }
 
 TEST_F(DisplayListTest, ClipRectPathPromoteToClipRect) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
-  SkPath clip_path = SkPath::Rect(clip_rect);
-  ASSERT_TRUE(clip_path.isRect(nullptr));
-  ASSERT_FALSE(clip_path.isInverseFillType());
+  DlRect clip_rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
+  DlPath clip_path = DlPath::MakeRect(clip_rect);
+  ASSERT_TRUE(clip_path.IsRect(nullptr));
 
   DisplayListBuilder builder;
   builder.ClipPath(clip_path, ClipOp::kIntersect, false);
@@ -5261,11 +5197,10 @@ TEST_F(DisplayListTest, ClipRectPathPromoteToClipRect) {
 }
 
 TEST_F(DisplayListTest, ClipOvalPathPromoteToClipOval) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
-  SkPath clip_path = SkPath::Oval(clip_rect);
-  ASSERT_TRUE(clip_path.isOval(nullptr));
-  ASSERT_FALSE(clip_path.isInverseFillType());
+  DlRect clip_rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
+  DlPath clip_path = DlPath::MakeOval(clip_rect);
+  ASSERT_TRUE(clip_path.IsOval(nullptr));
 
   DisplayListBuilder builder;
   builder.ClipPath(clip_path, ClipOp::kIntersect, false);
@@ -5282,12 +5217,11 @@ TEST_F(DisplayListTest, ClipOvalPathPromoteToClipOval) {
 }
 
 TEST_F(DisplayListTest, ClipRRectPathPromoteToClipRRect) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 2.0f, 2.0f);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
-  SkPath clip_path = SkPath::RRect(clip_rrect);
-  ASSERT_TRUE(clip_path.isRRect(nullptr));
-  ASSERT_FALSE(clip_path.isInverseFillType());
+  DlRect clip_rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRoundRect clip_rrect = DlRoundRect::MakeRectXY(clip_rect, 2.0f, 2.0f);
+  DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
+  DlPath clip_path = DlPath::MakeRoundRect(clip_rrect);
+  ASSERT_TRUE(clip_path.IsRoundRect());
 
   DisplayListBuilder builder;
   builder.ClipPath(clip_path, ClipOp::kIntersect, false);
@@ -5296,93 +5230,19 @@ TEST_F(DisplayListTest, ClipRRectPathPromoteToClipRRect) {
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.ClipRRect(clip_rrect, ClipOp::kIntersect, false);
+  expected.ClipRoundRect(clip_rrect, ClipOp::kIntersect, false);
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
-TEST_F(DisplayListTest, ClipRectInversePathNoPromoteToClipRect) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
-  SkPath clip_path = SkPath::Rect(clip_rect);
-  clip_path.toggleInverseFillType();
-  ASSERT_TRUE(clip_path.isRect(nullptr));
-  ASSERT_TRUE(clip_path.isInverseFillType());
-
-  DisplayListBuilder builder;
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
-  // Include a rendering op in case DlBuilder ever removes unneeded clips
-  builder.DrawRect(draw_rect, DlPaint());
-  auto dl = builder.Build();
-
-  // Non-promoting tests can't use DL comparisons to verify that the
-  // promotion isn't happening because the test and expectation builders
-  // would both apply or not apply the same optimization. For this case
-  // we use the CLIP_EXPECTOR instead to see exactly which type of
-  // clip operation was recorded.
-  CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip_path, ClipOp::kIntersect, false);
-  dl->Dispatch(expector);
-}
-
-TEST_F(DisplayListTest, ClipOvalInversePathNoPromoteToClipOval) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
-  SkPath clip_path = SkPath::Oval(clip_rect);
-  clip_path.toggleInverseFillType();
-  ASSERT_TRUE(clip_path.isOval(nullptr));
-  ASSERT_TRUE(clip_path.isInverseFillType());
-
-  DisplayListBuilder builder;
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
-  // Include a rendering op in case DlBuilder ever removes unneeded clips
-  builder.DrawRect(draw_rect, DlPaint());
-  auto dl = builder.Build();
-
-  // Non-promoting tests can't use DL comparisons to verify that the
-  // promotion isn't happening because the test and expectation builders
-  // would both apply or not apply the same optimization. For this case
-  // we use the CLIP_EXPECTOR instead to see exactly which type of
-  // clip operation was recorded.
-  CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip_path, ClipOp::kIntersect, false);
-  dl->Dispatch(expector);
-}
-
-TEST_F(DisplayListTest, ClipRRectInversePathNoPromoteToClipRRect) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 2.0f, 2.0f);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
-  SkPath clip_path = SkPath::RRect(clip_rrect);
-  clip_path.toggleInverseFillType();
-  ASSERT_TRUE(clip_path.isRRect(nullptr));
-  ASSERT_TRUE(clip_path.isInverseFillType());
-
-  DisplayListBuilder builder;
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
-  // Include a rendering op in case DlBuilder ever removes unneeded clips
-  builder.DrawRect(draw_rect, DlPaint());
-  auto dl = builder.Build();
-
-  // Non-promoting tests can't use DL comparisons to verify that the
-  // promotion isn't happening because the test and expectation builders
-  // would both apply or not apply the same optimization. For this case
-  // we use the CLIP_EXPECTOR instead to see exactly which type of
-  // clip operation was recorded.
-  CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip_path, ClipOp::kIntersect, false);
-  dl->Dispatch(expector);
-}
-
 TEST_F(DisplayListTest, ClipRectRRectPathPromoteToClipRect) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRRect clip_rrect = SkRRect::MakeRect(clip_rect);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
-  SkPath clip_path = SkPath::RRect(clip_rrect);
-  ASSERT_TRUE(clip_path.isRRect(nullptr));
-  ASSERT_FALSE(clip_path.isInverseFillType());
+  DlRect clip_rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRoundRect clip_rrect = DlRoundRect::MakeRect(clip_rect);
+  DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
+  DlPath clip_path = DlPath::MakeRoundRect(clip_rrect);
+  ASSERT_TRUE(clip_path.IsRoundRect());
 
   DisplayListBuilder builder;
   builder.ClipPath(clip_path, ClipOp::kIntersect, false);
@@ -5399,12 +5259,11 @@ TEST_F(DisplayListTest, ClipRectRRectPathPromoteToClipRect) {
 }
 
 TEST_F(DisplayListTest, ClipOvalRRectPathPromoteToClipOval) {
-  SkRect clip_rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRRect clip_rrect = SkRRect::MakeOval(clip_rect);
-  SkRect draw_rect = clip_rect.makeOutset(2.0f, 2.0f);
-  SkPath clip_path = SkPath::RRect(clip_rrect);
-  ASSERT_TRUE(clip_path.isRRect(nullptr));
-  ASSERT_FALSE(clip_path.isInverseFillType());
+  DlRect clip_rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRoundRect clip_rrect = DlRoundRect::MakeOval(clip_rect);
+  DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
+  DlPath clip_path = DlPath::MakeRoundRect(clip_rrect);
+  ASSERT_TRUE(clip_path.IsRoundRect());
 
   DisplayListBuilder builder;
   builder.ClipPath(clip_path, ClipOp::kIntersect, false);
@@ -5421,8 +5280,8 @@ TEST_F(DisplayListTest, ClipOvalRRectPathPromoteToClipOval) {
 }
 
 TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
-  static const SkRect root_cull = SkRect::MakeLTRB(100, 100, 200, 200);
-  static const SkRect draw_rect = SkRect::MakeLTRB(110, 110, 190, 190);
+  static const DlRect root_cull = DlRect::MakeLTRB(100, 100, 200, 200);
+  static const DlRect draw_rect = DlRect::MakeLTRB(110, 110, 190, 190);
 
   using Renderer = const std::function<void(DlCanvas&)>;
   auto test_bounded = [](const std::string& label, const Renderer& renderer) {
@@ -5431,18 +5290,18 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
       renderer(builder);
       auto display_list = builder.Build();
 
-      EXPECT_EQ(display_list->bounds(), draw_rect) << label;
+      EXPECT_EQ(display_list->GetBounds(), draw_rect) << label;
       EXPECT_FALSE(display_list->root_is_unbounded()) << label;
     }
 
     {
       DisplayListBuilder builder(root_cull);
-      builder.SaveLayer(nullptr, nullptr);
+      builder.SaveLayer(std::nullopt, nullptr);
       renderer(builder);
       builder.Restore();
       auto display_list = builder.Build();
 
-      EXPECT_EQ(display_list->bounds(), draw_rect) << label;
+      EXPECT_EQ(display_list->GetBounds(), draw_rect) << label;
       EXPECT_FALSE(display_list->root_is_unbounded()) << label;
 
       SAVE_LAYER_EXPECTOR(expector);
@@ -5457,27 +5316,27 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
 
   test_bounded("DrawLine", [](DlCanvas& builder) {
     builder.DrawLine(
-        SkPoint{draw_rect.left() + 1.0f, draw_rect.top() + 1.0f},
-        SkPoint{draw_rect.right() - 1.0f, draw_rect.top() + 1.0f},
+        DlPoint(draw_rect.GetLeft() + 1.0f, draw_rect.GetTop() + 1.0f),
+        DlPoint(draw_rect.GetRight() - 1.0f, draw_rect.GetTop() + 1.0f),
         DlPaint().setStrokeWidth(2.0f).setStrokeCap(DlStrokeCap::kSquare));
     builder.DrawLine(
-        SkPoint{draw_rect.left() + 1.0f, draw_rect.bottom() - 1.0f},
-        SkPoint{draw_rect.right() - 1.0f, draw_rect.bottom() - 1.0f},
+        DlPoint(draw_rect.GetLeft() + 1.0f, draw_rect.GetBottom() - 1.0f),
+        DlPoint(draw_rect.GetRight() - 1.0f, draw_rect.GetBottom() - 1.0f),
         DlPaint().setStrokeWidth(2.0f).setStrokeCap(DlStrokeCap::kSquare));
   });
 
   test_bounded("DrawDashedLine", [](DlCanvas& builder) {
     builder.DrawDashedLine(
-        {draw_rect.left() + 1.0f, draw_rect.top() + 1.0f},
-        {draw_rect.right() - 1.0f, draw_rect.top() + 1.0f},
+        DlPoint(draw_rect.GetLeft() + 1.0f, draw_rect.GetTop() + 1.0f),
+        DlPoint(draw_rect.GetRight() - 1.0f, draw_rect.GetTop() + 1.0f),
         // must fill 80 x 80 square with on dashes at both
         // ends - 40 + 25 + 40 == 105 so it will be on
         // at both ends
         40.0f, 25.0f,
         DlPaint().setStrokeWidth(2.0f).setStrokeCap(DlStrokeCap::kSquare));
     builder.DrawDashedLine(
-        {draw_rect.left() + 1.0f, draw_rect.bottom() - 1.0f},
-        {draw_rect.right() - 1.0f, draw_rect.bottom() - 1.0f},
+        DlPoint(draw_rect.GetLeft() + 1.0f, draw_rect.GetBottom() - 1.0f),
+        DlPoint(draw_rect.GetRight() - 1.0f, draw_rect.GetBottom() - 1.0f),
         // must fill 80 x 80 square with on dashes at both
         // ends - 40 + 25 + 40 == 105 so it will be on
         // at both ends
@@ -5494,17 +5353,19 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
   });
 
   test_bounded("DrawCircle", [](DlCanvas& builder) {
-    builder.DrawCircle(draw_rect.center(), draw_rect.width() * 0.5f, DlPaint());
+    builder.DrawCircle(draw_rect.GetCenter(), draw_rect.GetWidth() * 0.5f,
+                       DlPaint());
   });
 
-  test_bounded("DrawRRect", [](DlCanvas& builder) {
-    builder.DrawRRect(SkRRect::MakeRectXY(draw_rect, 5.0f, 5.0f), DlPaint());
+  test_bounded("DrawRoundRect", [](DlCanvas& builder) {
+    builder.DrawRoundRect(DlRoundRect::MakeRectXY(draw_rect, 5.0f, 5.0f),
+                          DlPaint());
   });
 
-  test_bounded("DrawDRRect", [](DlCanvas& builder) {
-    builder.DrawDRRect(
-        SkRRect::MakeRectXY(draw_rect, 5.0f, 5.0f),
-        SkRRect::MakeRectXY(draw_rect.makeInset(10.0f, 10.0f), 5.0f, 5.0f),
+  test_bounded("DrawDiffRoundRect", [](DlCanvas& builder) {
+    builder.DrawDiffRoundRect(
+        DlRoundRect::MakeRectXY(draw_rect, 5.0f, 5.0f),
+        DlRoundRect::MakeRectXY(draw_rect.Expand(-10.0f, -10.0f), 5.0f, 5.0f),
         DlPaint());
   });
 
@@ -5513,14 +5374,14 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
   });
 
   test_bounded("DrawPathEvenOdd", [](DlCanvas& builder) {
-    SkPath path = SkPath::Rect(draw_rect);
-    path.setFillType(SkPathFillType::kEvenOdd);
+    DlPath path =
+        DlPath::MakeRect(draw_rect).WithFillType(DlPathFillType::kOdd);
     builder.DrawPath(path, DlPaint());
   });
 
   test_bounded("DrawPathWinding", [](DlCanvas& builder) {
-    SkPath path = SkPath::Rect(draw_rect);
-    path.setFillType(SkPathFillType::kWinding);
+    DlPath path =
+        DlPath::MakeRect(draw_rect).WithFillType(DlPathFillType::kNonZero);
     builder.DrawPath(path, DlPaint());
   });
 
@@ -5528,11 +5389,11 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
     std::stringstream ss;
     ss << "DrawPoints(" << mode << ")";
     test_bounded(ss.str(), [mode](DlCanvas& builder) {
-      SkPoint points[4] = {
-          {draw_rect.left() + 1.0f, draw_rect.top() + 1.0f},
-          {draw_rect.right() - 1.0f, draw_rect.top() + 1.0f},
-          {draw_rect.right() - 1.0f, draw_rect.bottom() - 1.0f},
-          {draw_rect.left() + 1.0f, draw_rect.bottom() - 1.0f},
+      DlPoint points[4] = {
+          DlPoint(draw_rect.GetLeft() + 1.0f, draw_rect.GetTop() + 1.0f),
+          DlPoint(draw_rect.GetRight() - 1.0f, draw_rect.GetTop() + 1.0f),
+          DlPoint(draw_rect.GetRight() - 1.0f, draw_rect.GetBottom() - 1.0f),
+          DlPoint(draw_rect.GetLeft() + 1.0f, draw_rect.GetBottom() - 1.0f),
       };
       DlPaint paint;
       paint.setStrokeWidth(2.0f);
@@ -5552,12 +5413,12 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
 
   test_bounded("DrawVerticesTriangles", [](DlCanvas& builder) {
     DlPoint points[6] = {
-        {draw_rect.left(), draw_rect.top()},
-        {draw_rect.right(), draw_rect.top()},
-        {draw_rect.right(), draw_rect.bottom()},
-        {draw_rect.right(), draw_rect.bottom()},
-        {draw_rect.left(), draw_rect.bottom()},
-        {draw_rect.left(), draw_rect.top()},
+        DlPoint(draw_rect.GetLeft(), draw_rect.GetTop()),
+        DlPoint(draw_rect.GetRight(), draw_rect.GetTop()),
+        DlPoint(draw_rect.GetRight(), draw_rect.GetBottom()),
+        DlPoint(draw_rect.GetRight(), draw_rect.GetBottom()),
+        DlPoint(draw_rect.GetLeft(), draw_rect.GetBottom()),
+        DlPoint(draw_rect.GetLeft(), draw_rect.GetTop()),
     };
     DlVertices::Builder vertices(DlVertexMode::kTriangles, 6,
                                  DlVertices::Builder::kNone, 0);
@@ -5567,12 +5428,12 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
 
   test_bounded("DrawVerticesTriangleStrip", [](DlCanvas& builder) {
     DlPoint points[6] = {
-        {draw_rect.left(), draw_rect.top()},
-        {draw_rect.right(), draw_rect.top()},
-        {draw_rect.right(), draw_rect.bottom()},
-        {draw_rect.left(), draw_rect.bottom()},
-        {draw_rect.left(), draw_rect.top()},
-        {draw_rect.right(), draw_rect.top()},
+        DlPoint(draw_rect.GetLeft(), draw_rect.GetTop()),
+        DlPoint(draw_rect.GetRight(), draw_rect.GetTop()),
+        DlPoint(draw_rect.GetRight(), draw_rect.GetBottom()),
+        DlPoint(draw_rect.GetLeft(), draw_rect.GetBottom()),
+        DlPoint(draw_rect.GetLeft(), draw_rect.GetTop()),
+        DlPoint(draw_rect.GetRight(), draw_rect.GetTop()),
     };
     DlVertices::Builder vertices(DlVertexMode::kTriangleStrip, 6,
                                  DlVertices::Builder::kNone, 0);
@@ -5582,11 +5443,11 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
 
   test_bounded("DrawVerticesTriangleFan", [](DlCanvas& builder) {
     DlPoint points[6] = {
-        ToDlPoint(draw_rect.center()),
-        {draw_rect.left(), draw_rect.top()},
-        {draw_rect.right(), draw_rect.top()},
-        {draw_rect.right(), draw_rect.bottom()},
-        {draw_rect.left(), draw_rect.bottom()},
+        draw_rect.GetCenter(),
+        DlPoint(draw_rect.GetLeft(), draw_rect.GetTop()),
+        DlPoint(draw_rect.GetRight(), draw_rect.GetTop()),
+        DlPoint(draw_rect.GetRight(), draw_rect.GetBottom()),
+        DlPoint(draw_rect.GetLeft(), draw_rect.GetBottom()),
     };
     DlVertices::Builder vertices(DlVertexMode::kTriangleFan, 5,
                                  DlVertices::Builder::kNone, 0);
@@ -5595,58 +5456,50 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
   });
 
   test_bounded("DrawImage", [](DlCanvas& builder) {
-    auto image = MakeTestImage(draw_rect.width(), draw_rect.height(), 5);
-    builder.DrawImage(image, SkPoint{draw_rect.left(), draw_rect.top()},
+    auto image = MakeTestImage(draw_rect.GetWidth(), draw_rect.GetHeight(), 5);
+    builder.DrawImage(image, DlPoint(draw_rect.GetLeft(), draw_rect.GetTop()),
                       DlImageSampling::kLinear);
   });
 
   test_bounded("DrawImageRect", [](DlCanvas& builder) {
-    auto image = MakeTestImage(root_cull.width(), root_cull.height(), 5);
+    auto image = MakeTestImage(root_cull.GetWidth(), root_cull.GetHeight(), 5);
     builder.DrawImageRect(image, draw_rect, DlImageSampling::kLinear);
   });
 
   test_bounded("DrawImageNine", [](DlCanvas& builder) {
-    auto image = MakeTestImage(root_cull.width(), root_cull.height(), 5);
-    SkIRect center = image->bounds().makeInset(10, 10);
+    auto image = MakeTestImage(root_cull.GetWidth(), root_cull.GetHeight(), 5);
+    DlIRect center = image->GetBounds().Expand(-10, -10);
     builder.DrawImageNine(image, center, draw_rect, DlFilterMode::kLinear);
   });
 
   test_bounded("DrawTextBlob", [](DlCanvas& builder) {
-    SkFont font = CreateTestFontOfSize(20.0f);
-    sk_sp<SkTypeface> face = font.refTypeface();
-    ASSERT_TRUE(face);
-    ASSERT_TRUE(face->countGlyphs() > 0) << "No glyphs in font";
-    auto blob = SkTextBlob::MakeFromText("Hello", 5, font);
+    auto blob = GetTestTextBlob("Hello");
 
     // Make sure the blob fits within the draw_rect bounds.
-    ASSERT_LT(blob->bounds().width(), draw_rect.width());
-    ASSERT_LT(blob->bounds().height(), draw_rect.height());
+    ASSERT_LT(blob->bounds().width(), draw_rect.GetWidth());
+    ASSERT_LT(blob->bounds().height(), draw_rect.GetHeight());
 
     // Draw once at upper left and again at lower right to fill the bounds.
-    builder.DrawTextBlob(blob, draw_rect.left() - blob->bounds().left(),
-                         draw_rect.top() - blob->bounds().top(), DlPaint());
-    builder.DrawTextBlob(blob, draw_rect.right() - blob->bounds().right(),
-                         draw_rect.bottom() - blob->bounds().bottom(),
+    builder.DrawTextBlob(blob, draw_rect.GetLeft() - blob->bounds().left(),
+                         draw_rect.GetTop() - blob->bounds().top(), DlPaint());
+    builder.DrawTextBlob(blob, draw_rect.GetRight() - blob->bounds().right(),
+                         draw_rect.GetBottom() - blob->bounds().bottom(),
                          DlPaint());
   });
 
   test_bounded("DrawTextFrame", [](DlCanvas& builder) {
-    SkFont font = CreateTestFontOfSize(20.0f);
-    sk_sp<SkTypeface> face = font.refTypeface();
-    ASSERT_TRUE(face);
-    ASSERT_TRUE(face->countGlyphs() > 0) << "No glyphs in font";
-    auto blob = SkTextBlob::MakeFromText("Hello", 5, font);
+    auto blob = GetTestTextBlob("Hello");
     auto frame = impeller::MakeTextFrameFromTextBlobSkia(blob);
 
     // Make sure the blob fits within the draw_rect bounds.
-    ASSERT_LT(blob->bounds().width(), draw_rect.width());
-    ASSERT_LT(blob->bounds().height(), draw_rect.height());
+    ASSERT_LT(blob->bounds().width(), draw_rect.GetWidth());
+    ASSERT_LT(blob->bounds().height(), draw_rect.GetHeight());
 
     // Draw once at upper left and again at lower right to fill the bounds.
-    builder.DrawTextFrame(frame, draw_rect.left() - blob->bounds().left(),
-                          draw_rect.top() - blob->bounds().top(), DlPaint());
-    builder.DrawTextFrame(frame, draw_rect.right() - blob->bounds().right(),
-                          draw_rect.bottom() - blob->bounds().bottom(),
+    builder.DrawTextFrame(frame, draw_rect.GetLeft() - blob->bounds().left(),
+                          draw_rect.GetTop() - blob->bounds().top(), DlPaint());
+    builder.DrawTextFrame(frame, draw_rect.GetRight() - blob->bounds().right(),
+                          draw_rect.GetBottom() - blob->bounds().bottom(),
                           DlPaint());
   });
 
@@ -5655,31 +5508,29 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
     nested_builder.DrawRect(draw_rect, DlPaint());
     auto nested_display_list = nested_builder.Build();
 
-    EXPECT_EQ(nested_display_list->bounds(), draw_rect);
+    EXPECT_EQ(nested_display_list->GetBounds(), draw_rect);
     ASSERT_FALSE(nested_display_list->root_is_unbounded());
 
     builder.DrawDisplayList(nested_display_list);
   });
 
   test_bounded("DrawShadow", [](DlCanvas& builder) {
-    SkPath path = SkPath::Rect(draw_rect.makeInset(20, 20));
+    DlPath path = DlPath::MakeRect(draw_rect.Expand(-20, -20));
     DlScalar elevation = 2.0f;
     DlScalar dpr = 1.0f;
     auto shadow_bounds =
-        DlCanvas::ComputeShadowBounds(path, elevation, dpr, SkMatrix::I());
+        DlCanvas::ComputeShadowBounds(path, elevation, dpr, DlMatrix());
 
     // Make sure the shadow fits within the draw_rect bounds.
-    ASSERT_LT(shadow_bounds.width(), draw_rect.width());
-    ASSERT_LT(shadow_bounds.height(), draw_rect.height());
+    ASSERT_LT(shadow_bounds.GetWidth(), draw_rect.GetWidth());
+    ASSERT_LT(shadow_bounds.GetHeight(), draw_rect.GetHeight());
 
     // Draw once at upper left and again at lower right to fill the bounds.
-    SkPath pathUL =  //
-        SkPath(path).offset(draw_rect.left() - shadow_bounds.left(),
-                            draw_rect.top() - shadow_bounds.top());
+    DlPath pathUL =
+        path.WithOffset(draw_rect.GetLeftTop() - shadow_bounds.GetLeftTop());
     builder.DrawShadow(pathUL, DlColor::kMagenta(), elevation, true, dpr);
-    SkPath pathLR =
-        SkPath(path).offset(draw_rect.right() - shadow_bounds.right(),
-                            draw_rect.bottom() - shadow_bounds.bottom());
+    DlPath pathLR = path.WithOffset(draw_rect.GetRightBottom() -
+                                    shadow_bounds.GetRightBottom());
     builder.DrawShadow(pathLR, DlColor::kMagenta(), elevation, true, dpr);
   });
 
@@ -5728,7 +5579,7 @@ TEST_F(DisplayListTest, UnboundedRenderOpsAreReportedUnlessClipped) {
 
     {
       DisplayListBuilder builder(root_cull);
-      builder.SaveLayer(nullptr, nullptr);
+      builder.SaveLayer(std::nullopt, nullptr);
       renderer(builder);
       builder.Restore();
       auto display_list = builder.Build();
@@ -5750,7 +5601,7 @@ TEST_F(DisplayListTest, UnboundedRenderOpsAreReportedUnlessClipped) {
 
     {
       DisplayListBuilder builder(root_cull);
-      builder.SaveLayer(nullptr, nullptr);
+      builder.SaveLayer(std::nullopt, nullptr);
       builder.ClipRect(clip_rect);
       renderer(builder);
       builder.Restore();
@@ -5782,18 +5633,6 @@ TEST_F(DisplayListTest, UnboundedRenderOpsAreReportedUnlessClipped) {
 
   test_unbounded("Clear", [](DlCanvas& builder) {  //
     builder.Clear(DlColor::kMagenta());
-  });
-
-  test_unbounded("DrawPathEvenOddInverted", [](DlCanvas& builder) {
-    SkPath path = SkPath::Rect(ToSkRect(draw_rect));
-    path.setFillType(SkPathFillType::kInverseEvenOdd);
-    builder.DrawPath(path, DlPaint());
-  });
-
-  test_unbounded("DrawPathWindingInverted", [](DlCanvas& builder) {
-    SkPath path = SkPath::Rect(ToSkRect(draw_rect));
-    path.setFillType(SkPathFillType::kInverseWinding);
-    builder.DrawPath(path, DlPaint());
   });
 
   test_unbounded("DrawUnboundedDisplayList", [](DlCanvas& builder) {
@@ -5832,38 +5671,38 @@ TEST_F(DisplayListTest, UnboundedRenderOpsAreReportedUnlessClipped) {
       "SaveLayerWithBackdropFilter",
       [](DlCanvas& builder) {
         auto filter = DlImageFilter::MakeBlur(3.0f, 3.0f, DlTileMode::kMirror);
-        builder.SaveLayer(nullptr, nullptr, filter.get());
+        builder.SaveLayer(std::nullopt, nullptr, filter.get());
         builder.Restore();
       },
       1);
 }
 
 TEST_F(DisplayListTest, BackdropFilterCulledAlongsideClipAndTransform) {
-  SkRect frame_bounds = SkRect::MakeWH(100.0f, 100.0f);
-  SkRect frame_clip = frame_bounds.makeInset(0.5f, 0.5f);
+  DlRect frame_bounds = DlRect::MakeWH(100.0f, 100.0f);
+  DlRect frame_clip = frame_bounds.Expand(-0.5f, -0.5f);
 
-  SkRect clip_rect = SkRect::MakeLTRB(40.0f, 40.0f, 60.0f, 60.0f);
-  SkRect draw_rect1 = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
-  SkRect draw_rect2 = SkRect::MakeLTRB(45.0f, 20.0f, 55.0f, 55.0f);
-  SkRect cull_rect = SkRect::MakeLTRB(1.0f, 1.0f, 99.0f, 30.0f);
+  DlRect clip_rect = DlRect::MakeLTRB(40.0f, 40.0f, 60.0f, 60.0f);
+  DlRect draw_rect1 = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+  DlRect draw_rect2 = DlRect::MakeLTRB(45.0f, 20.0f, 55.0f, 55.0f);
+  DlRect cull_rect = DlRect::MakeLTRB(1.0f, 1.0f, 99.0f, 30.0f);
   auto bdf_filter = DlImageFilter::MakeBlur(5.0f, 5.0f, DlTileMode::kClamp);
 
-  ASSERT_TRUE(frame_bounds.contains(clip_rect));
-  ASSERT_TRUE(frame_bounds.contains(draw_rect1));
-  ASSERT_TRUE(frame_bounds.contains(draw_rect2));
-  ASSERT_TRUE(frame_bounds.contains(cull_rect));
+  ASSERT_TRUE(frame_bounds.Contains(clip_rect));
+  ASSERT_TRUE(frame_bounds.Contains(draw_rect1));
+  ASSERT_TRUE(frame_bounds.Contains(draw_rect2));
+  ASSERT_TRUE(frame_bounds.Contains(cull_rect));
 
-  ASSERT_TRUE(frame_clip.contains(clip_rect));
-  ASSERT_TRUE(frame_clip.contains(draw_rect1));
-  ASSERT_TRUE(frame_clip.contains(draw_rect2));
-  ASSERT_TRUE(frame_clip.contains(cull_rect));
+  ASSERT_TRUE(frame_clip.Contains(clip_rect));
+  ASSERT_TRUE(frame_clip.Contains(draw_rect1));
+  ASSERT_TRUE(frame_clip.Contains(draw_rect2));
+  ASSERT_TRUE(frame_clip.Contains(cull_rect));
 
-  ASSERT_FALSE(clip_rect.intersects(draw_rect1));
-  ASSERT_TRUE(clip_rect.intersects(draw_rect2));
+  ASSERT_FALSE(clip_rect.IntersectsWithRect(draw_rect1));
+  ASSERT_TRUE(clip_rect.IntersectsWithRect(draw_rect2));
 
-  ASSERT_FALSE(cull_rect.intersects(clip_rect));
-  ASSERT_TRUE(cull_rect.intersects(draw_rect1));
-  ASSERT_TRUE(cull_rect.intersects(draw_rect2));
+  ASSERT_FALSE(cull_rect.IntersectsWithRect(clip_rect));
+  ASSERT_TRUE(cull_rect.IntersectsWithRect(draw_rect1));
+  ASSERT_TRUE(cull_rect.IntersectsWithRect(draw_rect2));
 
   DisplayListBuilder builder(frame_bounds, true);
   builder.Save();
@@ -5874,7 +5713,7 @@ TEST_F(DisplayListTest, BackdropFilterCulledAlongsideClipAndTransform) {
     // Should all be culled below
     builder.ClipRect(clip_rect);
     builder.Translate(0.1f, 0.1f);
-    builder.SaveLayer(nullptr, nullptr, bdf_filter.get());
+    builder.SaveLayer(std::nullopt, nullptr, bdf_filter.get());
     {  //
       builder.DrawRect(clip_rect, DlPaint());
     }
@@ -5948,14 +5787,10 @@ TEST_F(DisplayListTest, RecordSingleLargeDisplayListOperation) {
 }
 
 TEST_F(DisplayListTest, DisplayListDetectsRuntimeEffect) {
-  const auto runtime_effect = DlRuntimeEffect::MakeSkia(
-      SkRuntimeEffect::MakeForShader(
-          SkString("vec4 main(vec2 p) { return vec4(0); }"))
-          .effect);
   auto color_source = DlColorSource::MakeRuntimeEffect(
-      runtime_effect, {}, std::make_shared<std::vector<uint8_t>>());
+      kTestRuntimeEffect1, {}, std::make_shared<std::vector<uint8_t>>());
   auto image_filter = DlImageFilter::MakeRuntimeEffect(
-      runtime_effect, {}, std::make_shared<std::vector<uint8_t>>());
+      kTestRuntimeEffect1, {}, std::make_shared<std::vector<uint8_t>>());
 
   {
     // Default - no runtime effects, supports group opacity
@@ -5994,7 +5829,7 @@ TEST_F(DisplayListTest, DisplayListDetectsRuntimeEffect) {
     DisplayListBuilder builder;
     DlPaint paint;
 
-    builder.SaveLayer(nullptr, nullptr);
+    builder.SaveLayer(std::nullopt, nullptr);
     paint.setColorSource(color_source);
     builder.DrawRect(DlRect::MakeLTRB(0, 0, 50, 50), paint);
     builder.Restore();
@@ -6015,7 +5850,7 @@ TEST_F(DisplayListTest, DisplayListDetectsRuntimeEffect) {
     DisplayListBuilder builder;
     DlPaint paint;
 
-    builder.SaveLayer(nullptr, nullptr);
+    builder.SaveLayer(std::nullopt, nullptr);
     paint.setImageFilter(image_filter);
     builder.DrawRect(DlRect::MakeLTRB(0, 0, 50, 50), paint);
     builder.Restore();
@@ -6037,15 +5872,15 @@ TEST_F(DisplayListTest, DisplayListDetectsRuntimeEffect) {
     DisplayListBuilder builder;
     DlPaint paint;
 
-    builder.SaveLayer(nullptr, nullptr);
+    builder.SaveLayer(std::nullopt, nullptr);
 
-    builder.SaveLayer(nullptr, nullptr);
+    builder.SaveLayer(std::nullopt, nullptr);
     paint.setColorSource(color_source);
     builder.DrawRect(DlRect::MakeLTRB(0, 0, 50, 50), paint);
     paint.setColorSource(nullptr);
     builder.Restore();
 
-    builder.SaveLayer(nullptr, nullptr);
+    builder.SaveLayer(std::nullopt, nullptr);
     paint.setImageFilter(image_filter);
     // Make sure these DrawRects are non-overlapping otherwise the outer
     // SaveLayer and DisplayList will be incompatible due to overlaps

--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -1034,7 +1034,7 @@ void DisplayListBuilder::ClipPath(const DlPath& path,
   if (current_info().is_nop) {
     return;
   }
-  if (!path.IsInverseFillType()) {
+  {
     DlRect rect;
     if (path.IsRect(&rect)) {
       ClipRect(rect, clip_op, is_aa);
@@ -1221,9 +1221,7 @@ void DisplayListBuilder::drawPath(const DlPath& path) {
   DisplayListAttributeFlags flags = kDrawPathFlags;
   OpResult result = PaintResult(current_, flags);
   if (result != OpResult::kNoEffect) {
-    bool is_visible = path.IsInverseFillType()
-                          ? AccumulateUnbounded()
-                          : AccumulateOpBounds(path.GetBounds(), flags);
+    bool is_visible = AccumulateOpBounds(path.GetBounds(), flags);
     if (is_visible) {
       Push<DrawPathOp>(0, path);
       CheckLayerOpacityHairlineCompatibility();

--- a/engine/src/flutter/display_list/dl_canvas.h
+++ b/engine/src/flutter/display_list/dl_canvas.h
@@ -241,16 +241,6 @@ class DlCanvas {
     SaveLayer(ToOptDlRect(bounds), paint, backdrop, backdrop_id);
   }
 
-  void Transform(const SkMatrix* matrix) {
-    if (matrix) {
-      Transform(*matrix);
-    }
-  }
-  void Transform(const SkM44* matrix44) {
-    if (matrix44) {
-      Transform(*matrix44);
-    }
-  }
   void Transform(const SkMatrix& matrix) { Transform(ToDlMatrix(matrix)); }
   void Transform(const SkM44& m44) { Transform(ToDlMatrix(m44)); }
   void SetTransform(const SkMatrix* matrix) {

--- a/engine/src/flutter/display_list/dl_color.h
+++ b/engine/src/flutter/display_list/dl_color.h
@@ -181,12 +181,6 @@ struct DlColor {
   bool operator!=(DlColor const& other) const {
     return !this->operator==(other);
   }
-  bool operator==(uint32_t const& other) const {
-    return argb() == other && color_space_ == DlColorSpace::kSRGB;
-  }
-  bool operator!=(uint32_t const& other) const {
-    return !this->operator==(other);
-  }
 
  private:
   DlScalar alpha_;

--- a/engine/src/flutter/display_list/dl_color_unittests.cc
+++ b/engine/src/flutter/display_list/dl_color_unittests.cc
@@ -6,8 +6,6 @@
 #include "flutter/testing/display_list_testing.h"
 #include "flutter/testing/testing.h"
 
-#include "third_party/skia/include/core/SkColor.h"
-
 namespace flutter {
 namespace testing {
 
@@ -44,13 +42,6 @@ TEST(DisplayListColor, ArrayInterchangeableWithUint32) {
       DlColor(0xF1F2F3F4),
   };
   arraysEqual(ints, colors, 5);
-}
-
-TEST(DisplayListColor, DlColorDirectlyComparesToSkColor) {
-  EXPECT_EQ(DlColor::kBlack(), SK_ColorBLACK);
-  EXPECT_EQ(DlColor::kRed(), SK_ColorRED);
-  EXPECT_EQ(DlColor::kGreen(), SK_ColorGREEN);
-  EXPECT_EQ(DlColor::kBlue(), SK_ColorBLUE);
 }
 
 TEST(DisplayListColor, DlColorFloatConstructor) {

--- a/engine/src/flutter/display_list/dl_paint_unittests.cc
+++ b/engine/src/flutter/display_list/dl_paint_unittests.cc
@@ -5,6 +5,7 @@
 #include "flutter/display_list/dl_paint.h"
 
 #include "flutter/display_list/testing/dl_test_equality.h"
+#include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/display_list/utils/dl_comparable.h"
 #include "gtest/gtest.h"
 
@@ -155,14 +156,10 @@ TEST(DisplayListPaint, ChainingConstructor) {
 }
 
 TEST(DisplayListPaint, PaintDetectsRuntimeEffects) {
-  const auto runtime_effect = DlRuntimeEffect::MakeSkia(
-      SkRuntimeEffect::MakeForShader(
-          SkString("vec4 main(vec2 p) { return vec4(0); }"))
-          .effect);
   auto color_source = DlColorSource::MakeRuntimeEffect(
-      runtime_effect, {}, std::make_shared<std::vector<uint8_t>>());
+      kTestRuntimeEffect1, {}, std::make_shared<std::vector<uint8_t>>());
   auto image_filter = DlImageFilter::MakeRuntimeEffect(
-      runtime_effect, {}, std::make_shared<std::vector<uint8_t>>());
+      kTestRuntimeEffect1, {}, std::make_shared<std::vector<uint8_t>>());
   DlPaint paint;
 
   EXPECT_FALSE(paint.usesRuntimeEffect());

--- a/engine/src/flutter/display_list/dl_vertices_unittests.cc
+++ b/engine/src/flutter/display_list/dl_vertices_unittests.cc
@@ -590,10 +590,10 @@ TEST(DisplayListVertices, BuildWithColorAndIndices) {
       DlPoint(5, 6),
       DlPoint(15, 20),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  uint32_t colors[3] = {
+      0xffff0000,
+      0xff00ffff,
+      0xff00ff00,
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -618,7 +618,7 @@ TEST(DisplayListVertices, BuildWithColorAndIndices) {
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
     ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
-    ASSERT_EQ(vertices->colors()[i], colors[i]);
+    ASSERT_EQ(vertices->colors()[i].argb(), colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 6);
   for (int i = 0; i < 6; i++) {
@@ -742,10 +742,10 @@ TEST(DisplayListVertices, BuildWithColor) {
       DlPoint(5, 6),
       DlPoint(15, 20),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  uint32_t colors[3] = {
+      0xffff0000,
+      0xff00ffff,
+      0xff00ff00,
   };
 
   Builder builder(DlVertexMode::kTriangles, 3,  //
@@ -765,7 +765,7 @@ TEST(DisplayListVertices, BuildWithColor) {
   ASSERT_EQ(vertices->vertex_count(), 3);
   for (int i = 0; i < 3; i++) {
     ASSERT_EQ(vertices->vertex_data()[i], coords[i]);
-    ASSERT_EQ(vertices->colors()[i], colors[i]);
+    ASSERT_EQ(vertices->colors()[i].argb(), colors[i]);
   }
   ASSERT_EQ(vertices->index_count(), 0);
 }

--- a/engine/src/flutter/display_list/geometry/dl_geometry_types.h
+++ b/engine/src/flutter/display_list/geometry/dl_geometry_types.h
@@ -6,6 +6,7 @@
 #define FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_H_
 
 #include "flutter/impeller/geometry/matrix.h"
+#include "flutter/impeller/geometry/path.h"
 #include "flutter/impeller/geometry/rect.h"
 #include "flutter/impeller/geometry/round_rect.h"
 #include "flutter/impeller/geometry/scalar.h"
@@ -30,6 +31,7 @@ using DlISize = impeller::ISize32;
 using DlRect = impeller::Rect;
 using DlIRect = impeller::IRect32;
 using DlRoundRect = impeller::RoundRect;
+using DlRoundingRadii = impeller::RoundingRadii;
 using DlMatrix = impeller::Matrix;
 using DlQuad = impeller::Quad;
 

--- a/engine/src/flutter/display_list/geometry/dl_path.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path.cc
@@ -10,7 +10,13 @@
 
 namespace flutter {
 
-DlPath DlPath::MakeRect(DlRect rect) {
+using Path = impeller::Path;
+using PathBuilder = impeller::PathBuilder;
+using FillType = impeller::FillType;
+using Convexity = impeller::Convexity;
+using ComponentType = impeller::Path::ComponentType;
+
+DlPath DlPath::MakeRect(const DlRect& rect) {
   return DlPath(SkPath::Rect(ToSkRect(rect)));
 }
 
@@ -28,7 +34,7 @@ DlPath DlPath::MakeRectXYWH(DlScalar x,
   return DlPath(SkPath().addRect(SkRect::MakeXYWH(x, y, width, height)));
 }
 
-DlPath DlPath::MakeOval(DlRect bounds) {
+DlPath DlPath::MakeOval(const DlRect& bounds) {
   return DlPath(SkPath::Oval(ToSkRect(bounds)));
 }
 
@@ -39,86 +45,228 @@ DlPath DlPath::MakeOvalLTRB(DlScalar left,
   return DlPath(SkPath::Oval(SkRect::MakeLTRB(left, top, right, bottom)));
 }
 
-const SkPath& DlPath::GetSkPath() const {
-  return data_->sk_path;
+DlPath DlPath::MakeCircle(const DlPoint& center, DlScalar radius) {
+  return DlPath(SkPath::Circle(center.x, center.y, radius));
 }
 
-impeller::Path DlPath::GetPath() const {
-  if (!data_->path.has_value()) {
-    data_->path = ConvertToImpellerPath(data_->sk_path);
-  }
+DlPath DlPath::MakeRoundRect(const DlRoundRect& rrect) {
+  return DlPath(SkPath::RRect(ToSkRRect(rrect)));
+}
 
-  // Covered by check above.
-  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+DlPath DlPath::MakeRoundRectXY(const DlRect& rect,
+                               DlScalar x_radius,
+                               DlScalar y_radius,
+                               bool counter_clock_wise) {
+  return DlPath(SkPath::RRect(
+      ToSkRect(rect), x_radius, y_radius,
+      counter_clock_wise ? SkPathDirection::kCCW : SkPathDirection::kCW));
+}
+
+const SkPath& DlPath::GetSkPath() const {
+  if (data_->sk_path.has_value()) {
+    return data_->sk_path.value();
+  }
+  if (data_->path.has_value()) {
+    data_->sk_path.emplace(ConvertToSkiaPath(data_->path.value()));
+    if (data_->render_count >= kMaxVolatileUses) {
+      data_->sk_path.value().setIsVolatile(false);
+    }
+    return data_->sk_path.value();
+  }
+  data_->sk_path.emplace();
+  return data_->sk_path.value();
+}
+
+Path DlPath::GetPath() const {
+  if (data_->path.has_value()) {
+    return data_->path.value();
+  }
+  if (data_->sk_path.has_value()) {
+    data_->path.emplace(ConvertToImpellerPath(data_->sk_path.value()));
+    return data_->path.value();
+  }
+  data_->path.emplace();
   return data_->path.value();
 }
 
 void DlPath::WillRenderSkPath() const {
   if (data_->render_count >= kMaxVolatileUses) {
-    data_->sk_path.setIsVolatile(false);
+    if (data_->sk_path.has_value()) {
+      data_->sk_path.value().setIsVolatile(false);
+    }
   } else {
     data_->render_count++;
   }
 }
 
-bool DlPath::IsInverseFillType() const {
-  return data_->sk_path.isInverseFillType();
+[[nodiscard]] DlPath DlPath::WithOffset(const DlPoint& offset) const {
+  if (offset.IsZero()) {
+    return *this;
+  }
+  if (!offset.IsFinite()) {
+    return DlPath();
+  }
+  if (data_->path.has_value()) {
+    PathBuilder builder;
+    builder.AddPath(data_->path.value());
+    builder.Shift(offset);
+    return DlPath(builder.TakePath());
+  }
+  if (data_->sk_path.has_value()) {
+    SkPath path = data_->sk_path.value();
+    path = path.offset(offset.x, offset.y);
+    return DlPath(path);
+  }
+  return *this;
+}
+
+[[nodiscard]] DlPath DlPath::WithFillType(DlPathFillType type) const {
+  if (data_->path.has_value()) {
+    if (data_->path.value().GetFillType() == type) {
+      return *this;
+    }
+    PathBuilder builder;
+    builder.AddPath(data_->path.value());
+    return DlPath(builder.TakePath(type));
+  }
+  if (data_->sk_path.has_value()) {
+    SkPathFillType sk_type = ToSkFillType(type);
+    if (data_->sk_path.value().getFillType() == sk_type) {
+      return *this;
+    }
+    SkPath path = data_->sk_path.value();
+    path.setFillType(sk_type);
+    return DlPath(path);
+  }
+  return *this;
 }
 
 bool DlPath::IsRect(DlRect* rect, bool* is_closed) const {
-  return data_->sk_path.isRect(ToSkRect(rect), is_closed);
+  return GetSkPath().isRect(ToSkRect(rect), is_closed);
 }
 
 bool DlPath::IsOval(DlRect* bounds) const {
-  return data_->sk_path.isOval(ToSkRect(bounds));
+  return GetSkPath().isOval(ToSkRect(bounds));
+}
+
+bool DlPath::IsRoundRect(DlRoundRect* rrect) const {
+  SkRRect sk_rrect;
+  bool ret = GetSkPath().isRRect(rrect ? &sk_rrect : nullptr);
+  if (rrect) {
+    *rrect = ToDlRoundRect(sk_rrect);
+  }
+  return ret;
 }
 
 bool DlPath::IsSkRect(SkRect* rect, bool* is_closed) const {
-  return data_->sk_path.isRect(rect, is_closed);
+  return GetSkPath().isRect(rect, is_closed);
 }
 
 bool DlPath::IsSkOval(SkRect* bounds) const {
-  return data_->sk_path.isOval(bounds);
+  return GetSkPath().isOval(bounds);
 }
 
 bool DlPath::IsSkRRect(SkRRect* rrect) const {
-  return data_->sk_path.isRRect(rrect);
+  return GetSkPath().isRRect(rrect);
+}
+
+bool DlPath::Contains(const DlPoint& point) const {
+  return GetSkPath().contains(point.x, point.y);
 }
 
 SkRect DlPath::GetSkBounds() const {
-  return data_->sk_path.getBounds();
+  return GetSkPath().getBounds();
 }
 
 DlRect DlPath::GetBounds() const {
-  return ToDlRect(data_->sk_path.getBounds());
+  if (data_->path.has_value()) {
+    return data_->path.value().GetBoundingBox().value_or(DlRect());
+  }
+  return ToDlRect(GetSkPath().getBounds());
 }
 
 bool DlPath::operator==(const DlPath& other) const {
-  return data_->sk_path == other.data_->sk_path;
+  return GetSkPath() == other.GetSkPath();
 }
 
 bool DlPath::IsConverted() const {
-  return data_->path.has_value();
+  return data_->path.has_value() && data_->sk_path.has_value();
 }
 
 bool DlPath::IsVolatile() const {
-  return data_->sk_path.isVolatile();
+  return GetSkPath().isVolatile();
 }
 
 DlPath DlPath::operator+(const DlPath& other) const {
-  SkPath path = data_->sk_path;
-  path.addPath(other.data_->sk_path);
+  SkPath path = GetSkPath();
+  path.addPath(other.GetSkPath());
   return DlPath(path);
 }
 
-using Path = impeller::Path;
-using PathBuilder = impeller::PathBuilder;
-using FillType = impeller::FillType;
-using Convexity = impeller::Convexity;
+DlPath::Data::Data(const SkPath& path) : sk_path(path) {
+  FML_DCHECK(!SkPathFillType_IsInverse(path.getFillType()));
+}
+
+SkPath DlPath::ConvertToSkiaPath(const Path& path, const DlPoint& shift) {
+  SkPath sk_path;
+  sk_path.setFillType(ToSkFillType(path.GetFillType()));
+  bool subpath_needs_close = false;
+  std::optional<DlPoint> pending_moveto;
+
+  auto resolve_moveto = [&pending_moveto, &sk_path]() {
+    if (pending_moveto.has_value()) {
+      sk_path.moveTo(ToSkPoint(pending_moveto.value()));
+      pending_moveto.reset();
+    }
+  };
+
+  size_t count = path.GetComponentCount();
+  for (size_t i = 0; i < count; i++) {
+    switch (path.GetComponentTypeAtIndex(i)) {
+      case ComponentType::kContour: {
+        impeller::ContourComponent contour;
+        path.GetContourComponentAtIndex(i, contour);
+        if (subpath_needs_close) {
+          sk_path.close();
+        }
+        pending_moveto = contour.destination;
+        subpath_needs_close = contour.IsClosed();
+        break;
+      }
+      case ComponentType::kLinear: {
+        impeller::LinearPathComponent linear;
+        path.GetLinearComponentAtIndex(i, linear);
+        resolve_moveto();
+        sk_path.lineTo(ToSkPoint(linear.p2));
+        break;
+      }
+      case ComponentType::kQuadratic: {
+        impeller::QuadraticPathComponent quadratic;
+        path.GetQuadraticComponentAtIndex(i, quadratic);
+        resolve_moveto();
+        sk_path.quadTo(ToSkPoint(quadratic.cp), ToSkPoint(quadratic.p2));
+        break;
+      }
+      case ComponentType::kCubic: {
+        impeller::CubicPathComponent cubic;
+        path.GetCubicComponentAtIndex(i, cubic);
+        resolve_moveto();
+        sk_path.cubicTo(ToSkPoint(cubic.cp1), ToSkPoint(cubic.cp2),
+                        ToSkPoint(cubic.p2));
+        break;
+      }
+    }
+  }
+  if (subpath_needs_close) {
+    sk_path.close();
+  }
+
+  return sk_path;
+}
 
 Path DlPath::ConvertToImpellerPath(const SkPath& path, const DlPoint& shift) {
-  if (path.isEmpty()) {
-    return impeller::Path{};
+  if (path.isEmpty() || !shift.IsFinite()) {
+    return Path{};
   }
   auto iterator = SkPath::Iter(path, false);
 
@@ -190,14 +338,13 @@ Path DlPath::ConvertToImpellerPath(const SkPath& path, const DlPoint& shift) {
       break;
     case SkPathFillType::kInverseWinding:
     case SkPathFillType::kInverseEvenOdd:
-      // Flutter doesn't expose these path fill types. These are only visible
-      // via the receiver interface. We should never get here.
-      fill_type = FillType::kNonZero;
-      break;
+      FML_UNREACHABLE();
   }
   builder.SetConvexity(path.isConvex() ? Convexity::kConvex
                                        : Convexity::kUnknown);
-  builder.Shift(shift);
+  if (!shift.IsZero()) {
+    builder.Shift(shift);
+  }
   auto sk_bounds = path.getBounds().makeOutset(shift.x, shift.y);
   builder.SetBounds(ToDlRect(sk_bounds));
   return builder.TakePath(fill_type);

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -7,15 +7,19 @@
 
 #include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/impeller/geometry/path.h"
+#include "flutter/impeller/geometry/path_builder.h"
 #include "flutter/third_party/skia/include/core/SkPath.h"
 
 namespace flutter {
+
+using DlPathFillType = impeller::FillType;
+using DlPathBuilder = impeller::PathBuilder;
 
 class DlPath {
  public:
   static constexpr uint32_t kMaxVolatileUses = 2;
 
-  static DlPath MakeRect(DlRect rect);
+  static DlPath MakeRect(const DlRect& rect);
   static DlPath MakeRectLTRB(DlScalar left,
                              DlScalar top,
                              DlScalar right,
@@ -25,14 +29,24 @@ class DlPath {
                              DlScalar width,
                              DlScalar height);
 
-  static DlPath MakeOval(DlRect bounds);
+  static DlPath MakeOval(const DlRect& bounds);
   static DlPath MakeOvalLTRB(DlScalar left,
                              DlScalar top,
                              DlScalar right,
                              DlScalar bottom);
 
+  static DlPath MakeCircle(const DlPoint& center, DlScalar radius);
+
+  static DlPath MakeRoundRect(const DlRoundRect& rrect);
+  static DlPath MakeRoundRectXY(const DlRect& rect,
+                                DlScalar x_radius,
+                                DlScalar y_radius,
+                                bool counter_clock_wise = false);
+
   DlPath() : data_(std::make_shared<Data>(SkPath())) {}
   explicit DlPath(const SkPath& path) : data_(std::make_shared<Data>(path)) {}
+  explicit DlPath(const impeller::Path& path)
+      : data_(std::make_shared<Data>(path)) {}
 
   DlPath(const DlPath& path) = default;
   DlPath(DlPath&& path) = default;
@@ -49,14 +63,18 @@ class DlPath {
   /// @see |kMaxVolatileUses|
   void WillRenderSkPath() const;
 
-  bool IsInverseFillType() const;
+  [[nodiscard]] DlPath WithOffset(const DlPoint& offset) const;
+  [[nodiscard]] DlPath WithFillType(DlPathFillType type) const;
 
-  bool IsRect(DlRect* rect, bool* is_closed = nullptr) const;
-  bool IsOval(DlRect* bounds) const;
+  bool IsRect(DlRect* rect = nullptr, bool* is_closed = nullptr) const;
+  bool IsOval(DlRect* bounds = nullptr) const;
+  bool IsRoundRect(DlRoundRect* rrect = nullptr) const;
 
   bool IsSkRect(SkRect* rect, bool* is_closed = nullptr) const;
   bool IsSkOval(SkRect* bounds) const;
   bool IsSkRRect(SkRRect* rrect) const;
+
+  bool Contains(const DlPoint& point) const;
 
   SkRect GetSkBounds() const;
   DlRect GetBounds() const;
@@ -66,19 +84,45 @@ class DlPath {
 
   bool IsConverted() const;
   bool IsVolatile() const;
+  bool IsEvenOdd() const;
 
   DlPath operator+(const DlPath& other) const;
 
  private:
   struct Data {
-    explicit Data(const SkPath& path) : sk_path(path) {}
+    explicit Data(const SkPath& path);
+    explicit Data(const impeller::Path& path) : path(path) {}
 
-    SkPath sk_path;
+    std::optional<SkPath> sk_path;
     std::optional<impeller::Path> path;
     uint32_t render_count = 0u;
   };
 
+  inline constexpr static DlPathFillType ToDlFillType(SkPathFillType sk_type) {
+    switch (sk_type) {
+      case SkPathFillType::kEvenOdd:
+        return impeller::FillType::kOdd;
+      case SkPathFillType::kWinding:
+        return impeller::FillType::kNonZero;
+      case SkPathFillType::kInverseEvenOdd:
+      case SkPathFillType::kInverseWinding:
+        FML_UNREACHABLE();
+    }
+  }
+
+  inline constexpr static SkPathFillType ToSkFillType(DlPathFillType dl_type) {
+    switch (dl_type) {
+      case impeller::FillType::kOdd:
+        return SkPathFillType::kEvenOdd;
+      case impeller::FillType::kNonZero:
+        return SkPathFillType::kWinding;
+    }
+  }
+
   std::shared_ptr<Data> data_;
+
+  static SkPath ConvertToSkiaPath(const impeller::Path& path,
+                                  const DlPoint& shift = DlPoint());
 
   static impeller::Path ConvertToImpellerPath(const SkPath& path,
                                               const DlPoint& shift = DlPoint());

--- a/engine/src/flutter/display_list/testing/dl_test_snippets.cc
+++ b/engine/src/flutter/display_list/testing/dl_test_snippets.cc
@@ -5,6 +5,7 @@
 #include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/display_list/dl_builder.h"
 #include "flutter/display_list/dl_op_receiver.h"
+#include "flutter/display_list/skia/dl_sk_canvas.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/include/core/SkTypeface.h"
 #include "txt/platform.h"
@@ -13,32 +14,66 @@ namespace flutter {
 namespace testing {
 
 sk_sp<DisplayList> GetSampleDisplayList() {
-  DisplayListBuilder builder(SkRect::MakeWH(150, 100));
-  builder.DrawRect(SkRect::MakeXYWH(10, 10, 80, 80), DlPaint(DlColor::kRed()));
+  DisplayListBuilder builder(DlRect::MakeWH(150, 100));
+  builder.DrawRect(DlRect::MakeXYWH(10, 10, 80, 80), DlPaint(DlColor::kRed()));
   return builder.Build();
 }
 
 sk_sp<DisplayList> GetSampleNestedDisplayList() {
-  DisplayListBuilder builder(SkRect::MakeWH(150, 100));
+  DisplayListBuilder builder(DlRect::MakeWH(150, 100));
   DlPaint paint;
   for (int y = 10; y <= 60; y += 10) {
     for (int x = 10; x <= 60; x += 10) {
       paint.setColor(((x + y) % 20) == 10 ? DlColor(SK_ColorRED)
                                           : DlColor(SK_ColorBLUE));
-      builder.DrawRect(SkRect::MakeXYWH(x, y, 80, 80), paint);
+      builder.DrawRect(DlRect::MakeXYWH(x, y, 80, 80), paint);
     }
   }
-  DisplayListBuilder outer_builder(SkRect::MakeWH(150, 100));
+  DisplayListBuilder outer_builder(DlRect::MakeWH(150, 100));
   outer_builder.DrawDisplayList(builder.Build());
   return outer_builder.Build();
 }
 
 sk_sp<DisplayList> GetSampleDisplayList(int ops) {
-  DisplayListBuilder builder(SkRect::MakeWH(150, 100));
+  DisplayListBuilder builder(DlRect::MakeWH(150, 100));
   for (int i = 0; i < ops; i++) {
     builder.DrawColor(DlColor::kRed(), DlBlendMode::kSrc);
   }
   return builder.Build();
+}
+
+sk_sp<DlImage> MakeTestImage(int w, int h, int checker_size) {
+  sk_sp<SkSurface> surface =
+      SkSurfaces::Raster(SkImageInfo::MakeN32Premul(w, h));
+  DlSkCanvasAdapter canvas(surface->getCanvas());
+  DlPaint p0, p1;
+  p0.setDrawStyle(DlDrawStyle::kFill);
+  p0.setColor(DlColor::kGreen());
+  p1.setDrawStyle(DlDrawStyle::kFill);
+  p1.setColor(DlColor::kBlue());
+  p1.setAlpha(128);
+  for (int y = 0; y < w; y += checker_size) {
+    for (int x = 0; x < h; x += checker_size) {
+      DlPaint& cellp = ((x + y) & 1) == 0 ? p0 : p1;
+      canvas.DrawRect(DlRect::MakeXYWH(x, y, checker_size, checker_size),
+                      cellp);
+    }
+  }
+  return DlImage::Make(surface->makeImageSnapshot());
+}
+
+sk_sp<DlImage> MakeTestImage(int w, int h, DlColor color) {
+  sk_sp<SkSurface> surface;
+  if (!color.isOpaque()) {
+    surface = SkSurfaces::Raster(SkImageInfo::MakeN32Premul(w, h));
+  } else {
+    SkImageInfo info =
+        SkImageInfo::MakeN32(w, h, SkAlphaType::kOpaque_SkAlphaType);
+    surface = SkSurfaces::Raster(info);
+  }
+  SkCanvas* canvas = surface->getCanvas();
+  canvas->drawColor(color.argb());
+  return DlImage::Make(surface->makeImageSnapshot());
 }
 
 // ---------------
@@ -734,22 +769,22 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
               r.drawPoints(DlCanvas::PointMode::kPoints, TestPointCount,
-                           ToDlPoints(kTestPoints));
+                           kTestPoints);
             }},
            {1, 8 + (TestPointCount - 1) * 8, 1,
             [](DlOpReceiver& r) {
               r.drawPoints(DlCanvas::PointMode::kPoints, TestPointCount - 1,
-                           ToDlPoints(kTestPoints));
+                           kTestPoints);
             }},
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
               r.drawPoints(DlCanvas::PointMode::kLines, TestPointCount,
-                           ToDlPoints(kTestPoints));
+                           kTestPoints);
             }},
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
               r.drawPoints(DlCanvas::PointMode::kPolygon, TestPointCount,
-                           ToDlPoints(kTestPoints));
+                           kTestPoints);
             }},
        }},
       {"DrawVertices",
@@ -771,31 +806,31 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        {
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawImage(TestImage1, {10, 10}, kNearestSampling, false);
+              r.drawImage(kTestImage1, {10, 10}, kNearestSampling, false);
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawImage(TestImage1, {10, 10}, kNearestSampling, true);
+              r.drawImage(kTestImage1, {10, 10}, kNearestSampling, true);
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawImage(TestImage1, {20, 10}, kNearestSampling, false);
+              r.drawImage(kTestImage1, {20, 10}, kNearestSampling, false);
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawImage(TestImage1, {10, 20}, kNearestSampling, false);
+              r.drawImage(kTestImage1, {10, 20}, kNearestSampling, false);
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawImage(TestImage1, {10, 10}, kLinearSampling, false);
+              r.drawImage(kTestImage1, {10, 10}, kLinearSampling, false);
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawImage(TestImage2, {10, 10}, kNearestSampling, false);
+              r.drawImage(kTestImage2, {10, 10}, kNearestSampling, false);
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              auto dl_image = DlImage::Make(TestSkImage);
+              auto dl_image = DlImage::Make(kTestSkImage);
               r.drawImage(dl_image, {10, 10}, kNearestSampling, false);
             }},
        }},
@@ -803,55 +838,55 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        {
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, true,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kStrict);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 25, 20),
+              r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 25, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 85, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80), kLinearSampling,
                               false, DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage2, DlRect::MakeLTRB(10, 10, 15, 15),
+              r.drawImageRect(kTestImage2, DlRect::MakeLTRB(10, 10, 15, 15),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              auto dl_image = DlImage::Make(TestSkImage);
+              auto dl_image = DlImage::Make(kTestSkImage);
               r.drawImageRect(dl_image, DlRect::MakeLTRB(10, 10, 15, 15),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
@@ -862,43 +897,43 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        {
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageNine(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageNine(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, true);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 25, 20),
+              r.drawImageNine(kTestImage1, DlIRect::MakeLTRB(10, 10, 25, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageNine(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 85, 80),
                               DlFilterMode::kNearest, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+              r.drawImageNine(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kLinear, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage2, DlIRect::MakeLTRB(10, 10, 15, 15),
+              r.drawImageNine(kTestImage2, DlIRect::MakeLTRB(10, 10, 15, 15),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              auto dl_image = DlImage::Make(TestSkImage);
+              auto dl_image = DlImage::Make(kTestSkImage);
               r.drawImageNine(dl_image, DlIRect::MakeLTRB(10, 10, 15, 15),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, false);
@@ -911,7 +946,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
-              r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
+              r.drawAtlas(kTestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
                           false);
             }},
@@ -920,7 +955,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
-              r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
+              r.drawAtlas(kTestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr, true);
             }},
            {1, 48 + 32 + 8, 1,
@@ -928,7 +963,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static SkRSXform xforms[] = {{0, 1, 0, 0}, {0, 1, 0, 0}};
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
-              r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
+              r.drawAtlas(kTestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
                           false);
             }},
@@ -937,7 +972,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 25, 30, 30)};
-              r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
+              r.drawAtlas(kTestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
                           false);
             }},
@@ -946,7 +981,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
-              r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
+              r.drawAtlas(kTestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kLinearSampling, nullptr, false);
             }},
            {1, 48 + 32 + 8, 1,
@@ -954,7 +989,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
-              r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
+              r.drawAtlas(kTestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kDstIn, kNearestSampling, nullptr,
                           false);
             }},
@@ -964,7 +999,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
               static DlRect cull_rect = DlRect::MakeLTRB(0, 0, 200, 200);
-              r.drawAtlas(TestImage2, xforms, texs, nullptr, 2,
+              r.drawAtlas(kTestImage2, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, &cull_rect,
                           false);
             }},
@@ -974,7 +1009,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
               static DlColor colors[] = {DlColor::kBlue(), DlColor::kGreen()};
-              r.drawAtlas(TestImage1, xforms, texs, colors, 2,
+              r.drawAtlas(kTestImage1, xforms, texs, colors, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
                           false);
             }},
@@ -985,13 +1020,13 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
               static DlColor colors[] = {DlColor::kBlue(), DlColor::kGreen()};
               static DlRect cull_rect = DlRect::MakeLTRB(0, 0, 200, 200);
-              r.drawAtlas(TestImage1, xforms, texs, colors, 2,
+              r.drawAtlas(kTestImage1, xforms, texs, colors, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, &cull_rect,
                           false);
             }},
            {1, 48 + 32 + 8, 1,
             [](DlOpReceiver& r) {
-              auto dl_image = DlImage::Make(TestSkImage);
+              auto dl_image = DlImage::Make(kTestSkImage);
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
               static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
                                       DlRect::MakeLTRB(20, 20, 30, 30)};
@@ -1086,7 +1121,7 @@ std::vector<DisplayListInvocationGroup> CreateAllGroups() {
   return result;
 }
 
-SkFont CreateTestFontOfSize(SkScalar scalar) {
+SkFont CreateTestFontOfSize(DlScalar scalar) {
   static constexpr const char* kTestFontFixture = "Roboto-Regular.ttf";
   auto mapping = flutter::testing::OpenFixtureAsSkData(kTestFontFixture);
   FML_CHECK(mapping);
@@ -1100,11 +1135,15 @@ sk_sp<SkTextBlob> GetTestTextBlob(int index) {
     return it->second;
   }
   std::string text = "TestBlob" + std::to_string(index);
-  sk_sp<SkTextBlob> blob =
-      SkTextBlob::MakeFromText(text.c_str(), text.size(),
-                               CreateTestFontOfSize(20), SkTextEncoding::kUTF8);
+  auto blob = GetTestTextBlob(text);
   text_blobs.insert(std::make_pair(index, blob));
   return blob;
+}
+
+sk_sp<SkTextBlob> GetTestTextBlob(const std::string& text, DlScalar font_size) {
+  return SkTextBlob::MakeFromText(text.c_str(), text.size(),
+                                  CreateTestFontOfSize(font_size),
+                                  SkTextEncoding::kUTF8);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.cc
@@ -137,19 +137,6 @@ void DisplayListMatrixClipState::clipRRect(const DlRoundRect& rrect,
 void DisplayListMatrixClipState::clipPath(const DlPath& path,
                                           ClipOp op,
                                           bool is_aa) {
-  // Map "kDifference of inverse path" to "kIntersect of the original path" and
-  // map "kIntersect of inverse path" to "kDifference of the original path"
-  if (path.IsInverseFillType()) {
-    switch (op) {
-      case ClipOp::kIntersect:
-        op = ClipOp::kDifference;
-        break;
-      case ClipOp::kDifference:
-        op = ClipOp::kIntersect;
-        break;
-    }
-  }
-
   DlRect bounds = path.GetBounds();
   if (path.IsRect(nullptr)) {
     return clipRect(bounds, op, is_aa);

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker_unittests.cc
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker_unittests.cc
@@ -574,30 +574,6 @@ TEST(DisplayListMatrixClipState, ClipDifference) {
   reducing(SkRect::MakeLTRB(15, 15, 45, 45), SkRect::MakeEmpty(), "Smothering");
 }
 
-TEST(DisplayListMatrixClipState, ClipPathWithInvertFillType) {
-  SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
-  DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  clip.setFillType(SkPathFillType::kInverseWinding);
-  state.clipPath(clip, DlCanvas::ClipOp::kIntersect, false);
-
-  EXPECT_EQ(state.local_cull_rect(), cull_rect);
-  EXPECT_EQ(state.device_cull_rect(), cull_rect);
-}
-
-TEST(DisplayListMatrixClipState, DiffClipPathWithInvertFillType) {
-  SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
-  DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
-
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  clip.setFillType(SkPathFillType::kInverseWinding);
-  SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
-  state.clipPath(clip, DlCanvas::ClipOp::kDifference, false);
-
-  EXPECT_EQ(state.local_cull_rect(), clip_bounds);
-  EXPECT_EQ(state.device_cull_rect(), clip_bounds);
-}
-
 TEST(DisplayListMatrixClipState, MapAndClipRectTranslation) {
   DlRect cull_rect = DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
   DlMatrix matrix = DlMatrix::MakeTranslation({10.0f, 20.0f, 1.0f});

--- a/engine/src/flutter/impeller/geometry/path.cc
+++ b/engine/src/flutter/impeller/geometry/path.cc
@@ -170,6 +170,11 @@ void Path::WritePolyline(Scalar scale, VertexWriter& writer) const {
   }
 }
 
+Path::ComponentType Path::GetComponentTypeAtIndex(size_t index) const {
+  auto& components = data_->components;
+  return components[index];
+}
+
 bool Path::GetLinearComponentAtIndex(size_t index,
                                      LinearPathComponent& linear) const {
   auto& components = data_->components;

--- a/engine/src/flutter/impeller/geometry/path.h
+++ b/engine/src/flutter/impeller/geometry/path.h
@@ -157,6 +157,8 @@ class Path {
   /// @brief Whether the line contains a single contour.
   bool IsSingleContour() const;
 
+  ComponentType GetComponentTypeAtIndex(size_t index) const;
+
   bool GetLinearComponentAtIndex(size_t index,
                                  LinearPathComponent& linear) const;
 

--- a/engine/src/flutter/impeller/geometry/round_rect.cc
+++ b/engine/src/flutter/impeller/geometry/round_rect.cc
@@ -23,11 +23,16 @@ static inline void AdjustScale(Scalar& radius1,
   }
 }
 
-RoundRect RoundRect::MakeRectRadii(const Rect& bounds,
+RoundRect RoundRect::MakeRectRadii(const Rect& in_bounds,
                                    const RoundingRadii& in_radii) {
-  if (bounds.IsEmpty() || !bounds.IsFinite() ||  //
+  if (!in_bounds.IsFinite()) {
+    return {};
+  }
+  Rect bounds = in_bounds.GetPositive();
+  if (bounds.IsEmpty() ||  //
       in_radii.AreAllCornersEmpty() || !in_radii.IsFinite()) {
-    // preserve the empty bounds as they might be strokable
+    // pass along the bounds even if empty as it would still have a valid
+    // location and/or 1-dimensional size which might appear when stroked
     return RoundRect(bounds, RoundingRadii());
   }
 

--- a/engine/src/flutter/impeller/geometry/round_rect_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/round_rect_unittests.cc
@@ -360,15 +360,15 @@ TEST(RoundRectTest, DefaultConstructor) {
 }
 
 TEST(RoundRectTest, EmptyRectConstruction) {
-  RoundRect round_rect = RoundRect::MakeRectXY(
-      Rect::MakeLTRB(20.0f, 20.0f, 10.0f, 10.0f), 10.0f, 10.0f);
+  RoundRect round_rect =
+      RoundRect::MakeRect(Rect::MakeLTRB(20.0f, 20.0f, 20.0f, 20.0f));
 
   EXPECT_TRUE(round_rect.IsEmpty());
   EXPECT_FALSE(round_rect.IsRect());
   EXPECT_FALSE(round_rect.IsOval());
   EXPECT_TRUE(round_rect.IsFinite());
   EXPECT_TRUE(round_rect.GetBounds().IsEmpty());
-  EXPECT_EQ(round_rect.GetBounds(), Rect::MakeLTRB(20.0f, 20.0f, 10.0f, 10.0f));
+  EXPECT_EQ(round_rect.GetBounds(), Rect::MakeLTRB(20.0f, 20.0f, 20.0f, 20.0f));
   EXPECT_EQ(round_rect.GetRadii().top_left, Size());
   EXPECT_EQ(round_rect.GetRadii().top_right, Size());
   EXPECT_EQ(round_rect.GetRadii().bottom_left, Size());
@@ -391,9 +391,57 @@ TEST(RoundRectTest, RectConstructor) {
   EXPECT_EQ(round_rect.GetRadii().bottom_right, Size());
 }
 
+TEST(RoundRectTest, InvertedRectConstruction) {
+  RoundRect round_rect =
+      RoundRect::MakeRect(Rect::MakeLTRB(20.0f, 20.0f, 10.0f, 10.0f));
+
+  EXPECT_FALSE(round_rect.IsEmpty());
+  EXPECT_TRUE(round_rect.IsRect());
+  EXPECT_FALSE(round_rect.IsOval());
+  EXPECT_TRUE(round_rect.IsFinite());
+  EXPECT_FALSE(round_rect.GetBounds().IsEmpty());
+  EXPECT_EQ(round_rect.GetBounds(), Rect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f));
+  EXPECT_EQ(round_rect.GetRadii().top_left, Size());
+  EXPECT_EQ(round_rect.GetRadii().top_right, Size());
+  EXPECT_EQ(round_rect.GetRadii().bottom_left, Size());
+  EXPECT_EQ(round_rect.GetRadii().bottom_right, Size());
+}
+
+TEST(RoundRectTest, EmptyOvalConstruction) {
+  RoundRect round_rect = RoundRect::MakeRectXY(
+      Rect::MakeLTRB(20.0f, 20.0f, 20.0f, 20.0f), 10.0f, 10.0f);
+
+  EXPECT_TRUE(round_rect.IsEmpty());
+  EXPECT_FALSE(round_rect.IsRect());
+  EXPECT_FALSE(round_rect.IsOval());
+  EXPECT_TRUE(round_rect.IsFinite());
+  EXPECT_TRUE(round_rect.GetBounds().IsEmpty());
+  EXPECT_EQ(round_rect.GetBounds(), Rect::MakeLTRB(20.0f, 20.0f, 20.0f, 20.0f));
+  EXPECT_EQ(round_rect.GetRadii().top_left, Size());
+  EXPECT_EQ(round_rect.GetRadii().top_right, Size());
+  EXPECT_EQ(round_rect.GetRadii().bottom_left, Size());
+  EXPECT_EQ(round_rect.GetRadii().bottom_right, Size());
+}
+
 TEST(RoundRectTest, OvalConstructor) {
   RoundRect round_rect =
       RoundRect::MakeOval(Rect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f));
+
+  EXPECT_FALSE(round_rect.IsEmpty());
+  EXPECT_FALSE(round_rect.IsRect());
+  EXPECT_TRUE(round_rect.IsOval());
+  EXPECT_TRUE(round_rect.IsFinite());
+  EXPECT_FALSE(round_rect.GetBounds().IsEmpty());
+  EXPECT_EQ(round_rect.GetBounds(), Rect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f));
+  EXPECT_EQ(round_rect.GetRadii().top_left, Size(5.0f, 5.0f));
+  EXPECT_EQ(round_rect.GetRadii().top_right, Size(5.0f, 5.0f));
+  EXPECT_EQ(round_rect.GetRadii().bottom_left, Size(5.0f, 5.0f));
+  EXPECT_EQ(round_rect.GetRadii().bottom_right, Size(5.0f, 5.0f));
+}
+
+TEST(RoundRectTest, InvertedOvalConstruction) {
+  RoundRect round_rect = RoundRect::MakeRectXY(
+      Rect::MakeLTRB(20.0f, 20.0f, 10.0f, 10.0f), 10.0f, 10.0f);
 
   EXPECT_FALSE(round_rect.IsEmpty());
   EXPECT_FALSE(round_rect.IsRect());

--- a/engine/src/flutter/impeller/toolkit/interop/dl_builder.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/dl_builder.cc
@@ -20,9 +20,8 @@ void DisplayListBuilder::Save() {
 void DisplayListBuilder::SaveLayer(const Rect& bounds,
                                    const Paint* paint,
                                    const ImageFilter* backdrop) {
-  const auto sk_bounds = ToSkiaType(bounds);
   builder_.SaveLayer(
-      &sk_bounds,                                       //
+      bounds,                                           //
       paint == nullptr ? nullptr : &paint->GetPaint(),  //
       backdrop == nullptr ? nullptr : backdrop->GetImageFilter().get());
 }
@@ -44,19 +43,15 @@ void DisplayListBuilder::Translate(Point translation) {
 }
 
 Matrix DisplayListBuilder::GetTransform() const {
-  Matrix matrix;
-  builder_.GetTransformFullPerspective().getColMajor(matrix.m);
-  return matrix;
+  return builder_.GetMatrix();
 }
 
 void DisplayListBuilder::SetTransform(const Matrix& matrix) {
-  const auto sk_matrix = SkM44::ColMajor(matrix.m);
-  builder_.SetTransform(&sk_matrix);
+  builder_.SetTransform(matrix);
 }
 
 void DisplayListBuilder::Transform(const Matrix& matrix) {
-  const auto sk_matrix = SkM44::ColMajor(matrix.m);
-  builder_.Transform(&sk_matrix);
+  builder_.Transform(matrix);
 }
 
 void DisplayListBuilder::ResetTransform() {
@@ -73,37 +68,38 @@ void DisplayListBuilder::RestoreToCount(uint32_t count) {
 
 void DisplayListBuilder::ClipRect(const Rect& rect,
                                   flutter::DlCanvas::ClipOp op) {
-  builder_.ClipRect(ToSkiaType(rect), op);
+  builder_.ClipRect(rect, op);
 }
 
 void DisplayListBuilder::ClipOval(const Rect& rect,
                                   flutter::DlCanvas::ClipOp op) {
-  builder_.ClipOval(ToSkiaType(rect), op);
+  builder_.ClipOval(rect, op);
 }
 
 void DisplayListBuilder::ClipRoundedRect(const Rect& rect,
                                          const RoundingRadii& radii,
                                          flutter::DlCanvas::ClipOp op) {
-  builder_.ClipRRect(ToSkiaType(rect, radii), op);
+  builder_.ClipRoundRect(RoundRect::MakeRectRadii(rect, radii), op);
 }
 
 void DisplayListBuilder::ClipPath(const Path& path,
                                   flutter::DlCanvas::ClipOp op) {
-  builder_.ClipPath(path.GetPath(), op);
+  builder_.ClipPath(flutter::DlPath(path.GetPath()), op);
 }
 
 void DisplayListBuilder::DrawRect(const Rect& rect, const Paint& paint) {
-  builder_.DrawRect(ToSkiaType(rect), paint.GetPaint());
+  builder_.DrawRect(rect, paint.GetPaint());
 }
 
 void DisplayListBuilder::DrawOval(const Rect& oval_bounds, const Paint& paint) {
-  builder_.DrawOval(ToSkiaType(oval_bounds), paint.GetPaint());
+  builder_.DrawOval(oval_bounds, paint.GetPaint());
 }
 
 void DisplayListBuilder::DrawRoundedRect(const Rect& rect,
                                          const RoundingRadii& radii,
                                          const Paint& paint) {
-  builder_.DrawRRect(ToSkiaType(rect, radii), paint.GetPaint());
+  builder_.DrawRoundRect(RoundRect::MakeRectRadii(rect, radii),
+                         paint.GetPaint());
 }
 
 void DisplayListBuilder::DrawRoundedRectDifference(
@@ -112,14 +108,15 @@ void DisplayListBuilder::DrawRoundedRectDifference(
     const Rect& inner_rect,
     const RoundingRadii& inner_radii,
     const Paint& paint) {
-  builder_.DrawDRRect(ToSkiaType(outer_rect, outer_radii),  //
-                      ToSkiaType(inner_rect, inner_radii),  //
-                      paint.GetPaint()                      //
+  builder_.DrawDiffRoundRect(
+      RoundRect::MakeRectRadii(outer_rect, outer_radii),  //
+      RoundRect::MakeRectRadii(inner_rect, inner_radii),  //
+      paint.GetPaint()                                    //
   );
 }
 
 void DisplayListBuilder::DrawPath(const Path& path, const Paint& paint) {
-  builder_.DrawPath(path.GetPath(), paint.GetPaint());
+  builder_.DrawPath(flutter::DlPath(path.GetPath()), paint.GetPaint());
 }
 
 void DisplayListBuilder::DrawPaint(const Paint& paint) {
@@ -129,7 +126,7 @@ void DisplayListBuilder::DrawPaint(const Paint& paint) {
 void DisplayListBuilder::DrawLine(const Point& from,
                                   const Point& to,
                                   const Paint& paint) {
-  builder_.DrawLine(ToSkiaType(from), ToSkiaType(to), paint.GetPaint());
+  builder_.DrawLine(from, to, paint.GetPaint());
 }
 
 void DisplayListBuilder::DrawDashedLine(const Point& from,
@@ -159,7 +156,7 @@ void DisplayListBuilder::DrawTexture(const Texture& texture,
                                      flutter::DlImageSampling sampling,
                                      const Paint* paint) {
   builder_.DrawImage(texture.MakeImage(),                             //
-                     ToSkiaType(point),                               //
+                     point,                                           //
                      sampling,                                        //
                      paint == nullptr ? nullptr : &paint->GetPaint()  //
   );
@@ -171,8 +168,8 @@ void DisplayListBuilder::DrawTextureRect(const Texture& texture,
                                          flutter::DlImageSampling sampling,
                                          const Paint* paint) {
   builder_.DrawImageRect(texture.MakeImage(),                             //
-                         ToSkiaType(src_rect),                            //
-                         ToSkiaType(dst_rect),                            //
+                         src_rect,                                        //
+                         dst_rect,                                        //
                          sampling,                                        //
                          paint == nullptr ? nullptr : &paint->GetPaint()  //
   );

--- a/engine/src/flutter/shell/common/dl_op_spy_unittests.cc
+++ b/engine/src/flutter/shell/common/dl_op_spy_unittests.cc
@@ -7,8 +7,6 @@
 #include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/shell/common/dl_op_spy.h"
 #include "flutter/testing/testing.h"
-#include "third_party/skia/include/core/SkBitmap.h"
-#include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkRSXform.h"
 
 namespace flutter {
@@ -47,7 +45,7 @@ TEST(DlOpSpy, SetColor) {
   {  // No Color set.
     DisplayListBuilder builder;
     DlPaint paint;
-    builder.DrawRect(SkRect::MakeWH(5, 5), paint);
+    builder.DrawRect(DlRect::MakeWH(5, 5), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -56,7 +54,7 @@ TEST(DlOpSpy, SetColor) {
   {  // Set transparent color.
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    builder.DrawRect(SkRect::MakeWH(5, 5), paint);
+    builder.DrawRect(DlRect::MakeWH(5, 5), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -65,7 +63,7 @@ TEST(DlOpSpy, SetColor) {
   {  // Set black color.
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    builder.DrawRect(SkRect::MakeWH(5, 5), paint);
+    builder.DrawRect(DlRect::MakeWH(5, 5), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -78,7 +76,7 @@ TEST(DlOpSpy, SetColorSource) {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setColorSource(nullptr);
-    builder.DrawRect(SkRect::MakeWH(5, 5), paint);
+    builder.DrawRect(DlRect::MakeWH(5, 5), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -162,7 +160,7 @@ TEST(DlOpSpy, DrawLine) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    builder.DrawLine(SkPoint::Make(0, 1), SkPoint::Make(1, 2), paint);
+    builder.DrawLine(DlPoint(0, 1), DlPoint(1, 2), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -171,7 +169,7 @@ TEST(DlOpSpy, DrawLine) {
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    builder.DrawLine(SkPoint::Make(0, 1), SkPoint::Make(1, 2), paint);
+    builder.DrawLine(DlPoint(0, 1), DlPoint(1, 2), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -204,7 +202,7 @@ TEST(DlOpSpy, DrawRect) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    builder.DrawRect(SkRect::MakeWH(5, 5), paint);
+    builder.DrawRect(DlRect::MakeWH(5, 5), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -213,7 +211,7 @@ TEST(DlOpSpy, DrawRect) {
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    builder.DrawRect(SkRect::MakeWH(5, 5), paint);
+    builder.DrawRect(DlRect::MakeWH(5, 5), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -225,7 +223,7 @@ TEST(DlOpSpy, DrawOval) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    builder.DrawOval(SkRect::MakeWH(5, 5), paint);
+    builder.DrawOval(DlRect::MakeWH(5, 5), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -234,7 +232,7 @@ TEST(DlOpSpy, DrawOval) {
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    builder.DrawOval(SkRect::MakeWH(5, 5), paint);
+    builder.DrawOval(DlRect::MakeWH(5, 5), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -246,7 +244,7 @@ TEST(DlOpSpy, DrawCircle) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    builder.DrawCircle(SkPoint::Make(5, 5), 1.0, paint);
+    builder.DrawCircle(DlPoint(5, 5), 1.0, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -255,7 +253,7 @@ TEST(DlOpSpy, DrawCircle) {
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    builder.DrawCircle(SkPoint::Make(5, 5), 1.0, paint);
+    builder.DrawCircle(DlPoint(5, 5), 1.0, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -267,7 +265,7 @@ TEST(DlOpSpy, DrawRRect) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    builder.DrawRRect(SkRRect::MakeRect(SkRect::MakeWH(5, 5)), paint);
+    builder.DrawRoundRect(DlRoundRect::MakeRect(DlRect::MakeWH(5, 5)), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -276,7 +274,7 @@ TEST(DlOpSpy, DrawRRect) {
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    builder.DrawRRect(SkRRect::MakeRect(SkRect::MakeWH(5, 5)), paint);
+    builder.DrawRoundRect(DlRoundRect::MakeRect(DlRect::MakeWH(5, 5)), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -289,8 +287,10 @@ TEST(DlOpSpy, DrawPath) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
     paint.setDrawStyle(DlDrawStyle::kStroke);
-    builder.DrawPath(SkPath::Line(SkPoint::Make(0, 1), SkPoint::Make(1, 1)),
-                     paint);
+    DlPathBuilder path_builder;
+    path_builder.MoveTo({0, 1});
+    path_builder.LineTo({1, 1});
+    builder.DrawPath(DlPath(path_builder.TakePath()), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -299,11 +299,11 @@ TEST(DlOpSpy, DrawPath) {
   {  // triangle
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    SkPath path;
-    path.moveTo({0, 0});
-    path.lineTo({1, 0});
-    path.lineTo({0, 1});
-    builder.DrawPath(path, paint);
+    DlPathBuilder path_builder;
+    path_builder.MoveTo({0, 0});
+    path_builder.LineTo({1, 0});
+    path_builder.LineTo({0, 1});
+    builder.DrawPath(DlPath(path_builder.TakePath()), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -313,8 +313,10 @@ TEST(DlOpSpy, DrawPath) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
     paint.setDrawStyle(DlDrawStyle::kStroke);
-    builder.DrawPath(SkPath::Line(SkPoint::Make(0, 1), SkPoint::Make(1, 1)),
-                     paint);
+    DlPathBuilder path_builder;
+    path_builder.MoveTo({0, 1});
+    path_builder.LineTo({1, 1});
+    builder.DrawPath(DlPath(path_builder.TakePath()), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -326,7 +328,7 @@ TEST(DlOpSpy, DrawArc) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    builder.DrawArc(SkRect::MakeWH(5, 5), 0, 1, true, paint);
+    builder.DrawArc(DlRect::MakeWH(5, 5), 0, 1, true, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -335,7 +337,7 @@ TEST(DlOpSpy, DrawArc) {
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    builder.DrawArc(SkRect::MakeWH(5, 5), 0, 1, true, paint);
+    builder.DrawArc(DlRect::MakeWH(5, 5), 0, 1, true, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -347,7 +349,7 @@ TEST(DlOpSpy, DrawPoints) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    const SkPoint points[] = {SkPoint::Make(5, 4)};
+    const DlPoint points[] = {DlPoint(5, 4)};
     builder.DrawPoints(DlCanvas::PointMode::kPoints, 1, points, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
@@ -357,7 +359,7 @@ TEST(DlOpSpy, DrawPoints) {
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    const SkPoint points[] = {SkPoint::Make(5, 4)};
+    const DlPoint points[] = {DlPoint(5, 4)};
     builder.DrawPoints(DlCanvas::PointMode::kPoints, 1, points, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
@@ -425,14 +427,7 @@ TEST(DlOpSpy, Images) {
   {  // DrawImage
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    SkImageInfo info =
-        SkImageInfo::Make(50, 50, SkColorType::kRGBA_8888_SkColorType,
-                          SkAlphaType::kPremul_SkAlphaType);
-    SkBitmap bitmap;
-    bitmap.allocPixels(info, 0);
-    auto sk_image = SkImages::RasterFromBitmap(bitmap);
-    builder.DrawImage(DlImage::Make(sk_image), SkPoint::Make(5, 5),
-                      DlImageSampling::kLinear);
+    builder.DrawImage(kTestImage1, DlPoint(5, 5), DlImageSampling::kLinear);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -441,14 +436,8 @@ TEST(DlOpSpy, Images) {
   {  // DrawImageRect
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    SkImageInfo info =
-        SkImageInfo::Make(50, 50, SkColorType::kRGBA_8888_SkColorType,
-                          SkAlphaType::kPremul_SkAlphaType);
-    SkBitmap bitmap;
-    bitmap.allocPixels(info, 0);
-    auto sk_image = SkImages::RasterFromBitmap(bitmap);
-    builder.DrawImageRect(DlImage::Make(sk_image), SkRect::MakeWH(5, 5),
-                          SkRect::MakeWH(5, 5), DlImageSampling::kLinear);
+    builder.DrawImageRect(kTestImage1, DlRect::MakeWH(5, 5),
+                          DlRect::MakeWH(5, 5), DlImageSampling::kLinear);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -457,14 +446,8 @@ TEST(DlOpSpy, Images) {
   {  // DrawImageNine
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    SkImageInfo info =
-        SkImageInfo::Make(50, 50, SkColorType::kRGBA_8888_SkColorType,
-                          SkAlphaType::kPremul_SkAlphaType);
-    SkBitmap bitmap;
-    bitmap.allocPixels(info, 0);
-    auto sk_image = SkImages::RasterFromBitmap(bitmap);
-    builder.DrawImageNine(DlImage::Make(sk_image), SkIRect::MakeWH(5, 5),
-                          SkRect::MakeWH(5, 5), DlFilterMode::kLinear);
+    builder.DrawImageNine(kTestImage1, DlIRect::MakeWH(5, 5),
+                          DlRect::MakeWH(5, 5), DlFilterMode::kLinear);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -473,17 +456,11 @@ TEST(DlOpSpy, Images) {
   {  // DrawAtlas
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    SkImageInfo info =
-        SkImageInfo::Make(50, 50, SkColorType::kRGBA_8888_SkColorType,
-                          SkAlphaType::kPremul_SkAlphaType);
-    SkBitmap bitmap;
-    bitmap.allocPixels(info, 0);
-    auto sk_image = SkImages::RasterFromBitmap(bitmap);
     const SkRSXform xform[] = {SkRSXform::Make(1, 0, 0, 0)};
-    const SkRect tex[] = {SkRect::MakeXYWH(10, 10, 10, 10)};
-    SkRect cull_rect = SkRect::MakeWH(5, 5);
-    builder.DrawAtlas(DlImage::Make(sk_image), xform, tex, nullptr, 1,
-                      DlBlendMode::kSrc, DlImageSampling::kLinear, &cull_rect);
+    const DlRect tex[] = {DlRect::MakeXYWH(10, 10, 10, 10)};
+    DlRect cull_rect = DlRect::MakeWH(5, 5);
+    builder.DrawAtlas(kTestImage1, xform, tex, nullptr, 1, DlBlendMode::kSrc,
+                      DlImageSampling::kLinear, &cull_rect);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -565,9 +542,7 @@ TEST(DlOpSpy, DrawTextBlob) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
     std::string string = "xx";
-    SkFont font = CreateTestFontOfSize(12);
-    auto text_blob = SkTextBlob::MakeFromString(string.c_str(), font);
-    builder.DrawTextBlob(text_blob, 1, 1, paint);
+    builder.DrawTextBlob(GetTestTextBlob(42), 1, 1, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -577,9 +552,7 @@ TEST(DlOpSpy, DrawTextBlob) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
     std::string string = "xx";
-    SkFont font = CreateTestFontOfSize(12);
-    auto text_blob = SkTextBlob::MakeFromString(string.c_str(), font);
-    builder.DrawTextBlob(text_blob, 1, 1, paint);
+    builder.DrawTextBlob(GetTestTextBlob(43), 1, 1, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -592,8 +565,7 @@ TEST(DlOpSpy, DrawShadow) {
     DisplayListBuilder builder;
     DlPaint paint;
     DlColor color = DlColor::kBlack();
-    SkPath path = SkPath::Line(SkPoint::Make(0, 1), SkPoint::Make(1, 1));
-    builder.DrawShadow(path, color, 1, false, 1);
+    builder.DrawShadow(kTestPath1, color, 1, false, 1);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -603,8 +575,7 @@ TEST(DlOpSpy, DrawShadow) {
     DisplayListBuilder builder;
     DlPaint paint;
     DlColor color = DlColor::kTransparent();
-    SkPath path = SkPath::Line(SkPoint::Make(0, 1), SkPoint::Make(1, 1));
-    builder.DrawShadow(path, color, 1, false, 1);
+    builder.DrawShadow(kTestPath1, color, 1, false, 1);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);


### PR DESCRIPTION
Address the first item in https://github.com/flutter/flutter/issues/161456 (Unit tests in the display_list/ directory)

Some new `DlPath::Make<Shape>` factories were added to make test writing simpler.

`DlPath` is now bi-directional! You can construct one from either an `SkPath` or an `impeller::Path` and it will auto-convert to the other as needed. This allows unit tests with custom paths to rely on `impeller::Path` for path construction instead of `SkPath` (as long as only simple move/line/quad/curve verbs are needed).

`RoundRect` now normalizes the argument rect in all constructors to match Flutter expectations and `SkRRect` legacy behavior. This behavior was already being enforced in `ui.rrect` but the unit tests we have to verify the behavior are written against the `RoundRect` object itself so this was the simplest way to make the unit tests work right, while ensuring that we maintain correct behavior for `ui` objects. Ideally these issues would be tested at the `ui` native interface instead of as unit tests on our internal objects and we should be allowed to decide how we want our internal APIs to behave with regard to this concept.

Skia inverted path types are no longer allowed in `DlPath` and all use of them should be eliminated in the engine (except to test if they crash when used in a debug unit test)

A couple of unit tests for `DlOpSpy` and Impeller's interop package were migrated here along for the ride even though this PR was focused primarily on `display_list/` unit tests.