### PR TITLE
Set meta tag in default index

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -50,10 +50,12 @@ typedef DwdsLauncher =
       required ToolConfiguration toolConfiguration,
     });
 
-// A minimal index for projects that do not yet support web.
+// A minimal index for projects that do not yet support web. A meta tag is used
+// to ensure loaded scripts are always parsed as UTF-8.
 const String _kDefaultIndex = '''
 <html>
     <head>
+        <meta charset='utf-8'>
         <base href="/">
     </head>
     <body>

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -6,14 +6,6 @@ import 'package:package_config/package_config.dart';
 
 /// Used to load prerequisite scripts such as ddc_module_loader.js
 const String _simpleLoaderScript = r'''
-// Declare the character set of the document to align with require.js. Using a
-// meta element is preferable to changing the individual script elements'
-// `charset` as the scripts should inherit the document's character set, and
-// modifying a script element's character set is deprecated.
-var meta = document.createElement('meta');
-meta.charset = 'utf-8';
-document.head.insertBefore(meta, document.head.firstChild);
-
 window.$dartCreateScript = (function() {
   // Find the nonce value. (Note, this is only computed once.)
   var scripts = Array.from(document.getElementsByTagName("script"));


### PR DESCRIPTION
The bootstrapping for the DDC module format and library bundle module format contained a preamble to dynamically set the meta tag to ensure the document is parsed as utf-8. This doesn't work as the page has already been parsed at that point. Instead, it should go in the html directly.

The meta tag should not affect the AMD module format, as require.js already ensures any loaded scripts are parsed as utf-8.

This tag in general is needed to parse this string correctly: https://github.com/dart-lang/sdk/blob/main/sdk/lib/core/uri.dart#L4100

This is a follow-up to PR https://github.com/flutter/flutter/pull/161276.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
