### PR TITLE
Fix paths when running clang-tidy on git diffs

### DIFF
--- a/engine/src/flutter/tools/pkg/git_repo_tools/lib/git_repo_tools.dart
+++ b/engine/src/flutter/tools/pkg/git_repo_tools/lib/git_repo_tools.dart
@@ -87,6 +87,7 @@ final class GitRepo {
       'diff',
       '--name-only',
       '--diff-filter=ACMRT',
+      '--relative',
       mergeBase,
     ]);
     return _gitOutputToList(masterResult);
@@ -111,6 +112,7 @@ final class GitRepo {
       '--no-commit-id',
       '--name-only',
       '--diff-filter=ACMRT', // Added, copied, modified, renamed, or type-changed.
+      '--relative',
       '-r',
       'HEAD',
     ]);

--- a/engine/src/flutter/tools/pkg/git_repo_tools/lib/git_repo_tools.dart
+++ b/engine/src/flutter/tools/pkg/git_repo_tools/lib/git_repo_tools.dart
@@ -87,7 +87,7 @@ final class GitRepo {
       'diff',
       '--name-only',
       '--diff-filter=ACMRT', // Added, copied, modified, renamed, or type-changed.
-      '--relative',  // _gitOutputToList will prepend the CWD so we don't want duplicate sub-paths
+      '--relative', // _gitOutputToList will prepend the CWD so we don't want duplicate sub-paths
       mergeBase,
     ]);
     return _gitOutputToList(masterResult);
@@ -112,7 +112,7 @@ final class GitRepo {
       '--no-commit-id',
       '--name-only',
       '--diff-filter=ACMRT', // Added, copied, modified, renamed, or type-changed.
-      '--relative',  // _gitOutputToList will prepend the CWD so we don't want duplicate sub-paths
+      '--relative', // _gitOutputToList will prepend the CWD so we don't want duplicate sub-paths
       '-r',
       'HEAD',
     ]);

--- a/engine/src/flutter/tools/pkg/git_repo_tools/lib/git_repo_tools.dart
+++ b/engine/src/flutter/tools/pkg/git_repo_tools/lib/git_repo_tools.dart
@@ -86,8 +86,8 @@ final class GitRepo {
       'git',
       'diff',
       '--name-only',
-      '--diff-filter=ACMRT',
-      '--relative',
+      '--diff-filter=ACMRT', // Added, copied, modified, renamed, or type-changed.
+      '--relative',  // _gitOutputToList will prepend the CWD so we don't want duplicate sub-paths
       mergeBase,
     ]);
     return _gitOutputToList(masterResult);
@@ -112,7 +112,7 @@ final class GitRepo {
       '--no-commit-id',
       '--name-only',
       '--diff-filter=ACMRT', // Added, copied, modified, renamed, or type-changed.
-      '--relative',
+      '--relative',  // _gitOutputToList will prepend the CWD so we don't want duplicate sub-paths
       '-r',
       'HEAD',
     ]);

--- a/engine/src/flutter/tools/pkg/git_repo_tools/test/git_repo_tools_test.dart
+++ b/engine/src/flutter/tools/pkg/git_repo_tools/test/git_repo_tools_test.dart
@@ -26,7 +26,7 @@ void main() {
           }
 
           // Succeed calling "git diff --name-only --diff-filter=ACMRT fake-sha-hash".
-          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT $fakeShaHash') {
+          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
             return FakeProcess(stdout: 'file1\nfile2');
           }
 
@@ -62,7 +62,7 @@ void main() {
             return FakeProcess();
           }
 
-          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT $fakeShaHash') {
+          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
             return FakeProcess(stdout: 'file1\nfile2');
           }
 
@@ -91,7 +91,7 @@ void main() {
           }
 
           if (command.join(' ') ==
-              'git diff-tree --no-commit-id --name-only --diff-filter=ACMRT -r HEAD') {
+              'git diff-tree --no-commit-id --name-only --diff-filter=ACMRT --relative -r HEAD') {
             return FakeProcess(stdout: 'file1\nfile2');
           }
 
@@ -120,7 +120,7 @@ void main() {
           }
 
           if (command.join(' ') ==
-              'git diff-tree --no-commit-id --name-only --diff-filter=ACMRT -r HEAD') {
+              'git diff-tree --no-commit-id --name-only --diff-filter=ACMRT --relative -r HEAD') {
             return FakeProcess(stdout: 'file1\nfile2');
           }
 
@@ -164,7 +164,7 @@ void main() {
             return FakeProcess();
           }
 
-          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT $fakeShaHash') {
+          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
             return FakeProcess(stdout: 'file1\nfile2');
           }
 

--- a/engine/src/flutter/tools/pkg/git_repo_tools/test/git_repo_tools_test.dart
+++ b/engine/src/flutter/tools/pkg/git_repo_tools/test/git_repo_tools_test.dart
@@ -26,7 +26,8 @@ void main() {
           }
 
           // Succeed calling "git diff --name-only --diff-filter=ACMRT fake-sha-hash".
-          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
+          if (command.join(' ') ==
+              'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
             return FakeProcess(stdout: 'file1\nfile2');
           }
 
@@ -62,7 +63,8 @@ void main() {
             return FakeProcess();
           }
 
-          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
+          if (command.join(' ') ==
+              'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
             return FakeProcess(stdout: 'file1\nfile2');
           }
 
@@ -164,7 +166,8 @@ void main() {
             return FakeProcess();
           }
 
-          if (command.join(' ') == 'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
+          if (command.join(' ') ==
+              'git diff --name-only --diff-filter=ACMRT --relative $fakeShaHash') {
             return FakeProcess(stdout: 'file1\nfile2');
           }
 


### PR DESCRIPTION
The working directory was `engine/src/flutter` but all of the file names already had those parent directories on them so we'd be trying to find build commands for `engine/src/flutter/engine/src/flutter`. This change tells the git commands to make the file names relative to the working directory (which is already `engine/src/flutter`).

Someone more familiar with the `--lint-head` option should double check its operation since I wasn't sure exactly what it was supposed to do, but the list of files it generated looked correct.