### PR TITLE
Allow the animation to skip a duration before starting.

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -352,7 +352,6 @@ class AnimationController extends Animation<double>
   }
 
   Simulation? _simulation;
-
   Duration? _skipDuration;
 
   /// The current value of the animation.
@@ -473,6 +472,10 @@ class AnimationController extends Animation<double>
   /// If [from] is non-null, it will be set as the current [value] before running
   /// the animation.
   ///
+  /// [skipDuration] is the duration to skip before starting the animation. If the
+  /// animation duration is 1000 milliseconds and [skipDuration] is 200 milliseconds,
+  /// the animation will start from the 200-millisecond mark and end after 800 milliseconds.
+  ///
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
   /// derivative future completes with a [TickerCanceled] error.
@@ -509,6 +512,10 @@ class AnimationController extends Animation<double>
   ///
   /// If [from] is non-null, it will be set as the current [value] before running
   /// the animation.
+  ///
+  /// [skipDuration] is the duration to skip before starting the animation. If the
+  /// animation duration is 1000 milliseconds and [skipDuration] is 200 milliseconds,
+  /// the animation will start from the 200-millisecond mark and end after 800 milliseconds.
   ///
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
@@ -548,6 +555,10 @@ class AnimationController extends Animation<double>
   ///
   /// If [from] is non-null, it will be set as the current [value] before running
   /// the animation.
+  ///
+  /// [skipDuration] is the duration to skip before starting the animation. If the
+  /// animation duration is 1000 milliseconds and [skipDuration] is 200 milliseconds,
+  /// the animation will start from the 200-millisecond mark and end after 800 milliseconds.
   ///
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
@@ -598,6 +609,10 @@ class AnimationController extends Animation<double>
   /// If the `target` argument is the same as the current [value] of the
   /// animation, then this won't animate, and the returned [TickerFuture] will
   /// be already complete.
+  ///
+  /// [skipDuration] is the duration to skip before starting the animation. If the
+  /// animation duration is 1000 milliseconds and [skipDuration] is 200 milliseconds,
+  /// the animation will start from the 200-millisecond mark and end after 800 milliseconds.
   TickerFuture animateTo(
     double target, {
     Duration? duration,
@@ -640,6 +655,10 @@ class AnimationController extends Animation<double>
   /// If the `target` argument is the same as the current [value] of the
   /// animation, then this won't animate, and the returned [TickerFuture] will
   /// be already complete.
+  ///
+  /// [skipDuration] is the duration to skip before starting the animation. If the
+  /// animation duration is 1000 milliseconds and [skipDuration] is 200 milliseconds,
+  /// the animation will start from the 200-millisecond mark and end after 800 milliseconds.
   TickerFuture animateBack(
     double target, {
     Duration? duration,
@@ -799,6 +818,10 @@ class AnimationController extends Animation<double>
   /// is used. See [SpringDescription.withDampingRatio] for how to create a
   /// suitable [SpringDescription].
   ///
+  /// [skipDuration] is the duration to skip before starting the animation. If the
+  /// animation duration is 1000 milliseconds and [skipDuration] is 200 milliseconds,
+  /// the animation will start from the 200-millisecond mark and end after 800 milliseconds.
+  ///
   /// The resulting spring simulation cannot be of type [SpringType.underDamped];
   /// such a spring would oscillate rather than fling.
   ///
@@ -849,6 +872,10 @@ class AnimationController extends Animation<double>
   /// [upperBound]. To avoid this, consider creating the [AnimationController]
   /// using the [AnimationController.unbounded] constructor.
   ///
+  /// [skipDuration] is the duration to skip before starting the animation. If the
+  /// animation duration is 1000 milliseconds and [skipDuration] is 200 milliseconds,
+  /// the animation will start from the 200-millisecond mark and end after 800 milliseconds.
+  ///
   /// Returns a [TickerFuture] that completes when the animation is complete.
   ///
   /// The most recently returned [TickerFuture], if any, is marked as having been
@@ -878,6 +905,10 @@ class AnimationController extends Animation<double>
   /// [AnimationStatus.reverse].
   ///
   /// {@macro flutter.animation.AnimationController.animateWith}
+  ///
+  /// [skipDuration] is the duration to skip before starting the animation. If the
+  /// animation duration is 1000 milliseconds and [skipDuration] is 200 milliseconds,
+  /// the animation will start from the 200-millisecond mark and end after 800 milliseconds.
   ///
   /// The [status] is always [AnimationStatus.reverse] for the entire duration
   /// of the simulation.

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -1343,6 +1343,51 @@ void main() {
       },
     );
   });
+
+  test('Test skipping some duration.', () {
+    final AnimationController controller = AnimationController(
+      duration: const Duration(milliseconds: 100),
+      value: 0.0,
+      vsync: const TestVSync(),
+    );
+
+    expect(controller.value, 0.0);
+    controller.forward(skipDuration: const Duration(milliseconds: 10));
+    tick(Duration.zero);
+    tick(const Duration(milliseconds: 15));
+    expect(controller.value, 0.25);
+    tick(const Duration(milliseconds: 40));
+    expect(controller.value, 0.5);
+    tick(const Duration(milliseconds: 89));
+    expect(controller.value, 0.99);
+    tick(const Duration(milliseconds: 90));
+    expect(controller.value, 1);
+
+    controller.reverse(skipDuration: const Duration(milliseconds: 10));
+    tick(Duration.zero);
+    tick(const Duration(milliseconds: 15));
+    expect(controller.value, 0.75);
+    tick(const Duration(milliseconds: 40));
+    expect(controller.value, 0.5);
+    tick(const Duration(milliseconds: 90));
+    expect(controller.value, 0);
+
+    controller.reset();
+    controller.animateTo(
+      0.6,
+      duration: const Duration(milliseconds: 100),
+      skipDuration: const Duration(milliseconds: 10),
+    );
+    tick(Duration.zero);
+    tick(const Duration(milliseconds: 15));
+    expect(controller.value, 0.15);
+    tick(const Duration(milliseconds: 40));
+    expect(controller.value, 0.3);
+    tick(const Duration(milliseconds: 90));
+    expect(controller.value, 0.6);
+
+    controller.dispose();
+  });
 }
 
 class TestSimulation extends Simulation {

--- a/packages/flutter/test/widgets/magnifier_test.dart
+++ b/packages/flutter/test/widgets/magnifier_test.dart
@@ -17,15 +17,15 @@ class _MockAnimationController extends AnimationController {
   int reverseCalls = 0;
 
   @override
-  TickerFuture forward({double? from}) {
+  TickerFuture forward({double? from, Duration? skipDuration}) {
     forwardCalls++;
-    return super.forward(from: from);
+    return super.forward(from: from, skipDuration: skipDuration);
   }
 
   @override
-  TickerFuture reverse({double? from}) {
+  TickerFuture reverse({double? from, Duration? skipDuration}) {
     reverseCalls++;
-    return super.reverse(from: from);
+    return super.reverse(from: from, skipDuration: skipDuration);
   }
 }
 


### PR DESCRIPTION
Fixes #135282 

When executing an animation with a specific curve, it is difficult to use only a portion of the curve. Although we can specify a partial duration, the full curve is always used. This PR implements a feature that allows the animation controller to skip a duration before starting the animation. For example, if an animation with a duration of 1000 milliseconds skips 200 milliseconds, the animation will start from the 200-millisecond mark and end after 800 milliseconds. This is very effective for cases where only a portion of the animation curve needs to be executed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
