### PR TITLE
Rename 'SelectionChangedCause.scribble' to 'SelectionChangedCause.stylusHandwriting'

### DIFF
--- a/packages/flutter/lib/fix_data/fix_services.yaml
+++ b/packages/flutter/lib/fix_data/fix_services.yaml
@@ -84,4 +84,18 @@ transforms:
         kind: 'fragment'
         value: 'arguments[0]'
 
+  # Change
+  - title: "Migrate 'SelectionChangedCause.scribble' to 'SelectionChangedCause.stylusHandwriting'"
+    date: 2025-01-13
+    element:
+      uris: [ 'services.dart' ]
+      constant: 'scribble'
+      inEnum: 'SelectionChangedCause'
+    changes:
+      - kind: 'replacedBy'
+        newElement:
+          uris: [ 'services.dart' ]
+          constant: 'stylusHandwriting'
+          inEnum: 'SelectionChangedCause'
+
 # Before adding a new fix: read instructions at the top of this file.

--- a/packages/flutter/lib/fix_data/fix_services.yaml
+++ b/packages/flutter/lib/fix_data/fix_services.yaml
@@ -84,7 +84,7 @@ transforms:
         kind: 'fragment'
         value: 'arguments[0]'
 
-  # Change
+  # Changes made in https://github.com/flutter/flutter/pull/161518
   - title: "Migrate 'SelectionChangedCause.scribble' to 'SelectionChangedCause.stylusHandwriting'"
     date: 2025-01-13
     element:

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -1191,7 +1191,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField>
       return false;
     }
 
-    if (cause == SelectionChangedCause.scribble) {
+    if (cause == SelectionChangedCause.stylusHandwriting) {
       return true;
     }
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1341,7 +1341,7 @@ class _TextFieldState extends State<TextField>
       return false;
     }
 
-    if (cause == SelectionChangedCause.longPress || cause == SelectionChangedCause.scribble) {
+    if (cause == SelectionChangedCause.longPress || cause == SelectionChangedCause.stylusHandwriting) {
       return true;
     }
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1341,7 +1341,8 @@ class _TextFieldState extends State<TextField>
       return false;
     }
 
-    if (cause == SelectionChangedCause.longPress || cause == SelectionChangedCause.stylusHandwriting) {
+    if (cause == SelectionChangedCause.longPress ||
+        cause == SelectionChangedCause.stylusHandwriting) {
       return true;
     }
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1101,17 +1101,17 @@ enum SelectionChangedCause {
   ///
   /// Currently, this is only supported on iPadOS 14+ via the Scribble feature,
   /// or on Android API 34+ via the Scribe feature.
-  @Deprecated(
-    'Use stylusHandwriting instead. '
-    'This feature was deprecated after v3.28.0-0.1.pre.',
-  )
-  scribble,
+  stylusHandwriting;
 
   /// The user used stylus handwriting to change the selection.
   ///
   /// Currently, this is only supported on iPadOS 14+ via the Scribble feature,
   /// or on Android API 34+ via the Scribe feature.
-  stylusHandwriting,
+  @Deprecated(
+    'Use stylusHandwriting instead. '
+    'This feature was deprecated after v3.28.0-0.1.pre.',
+  )
+  static const SelectionChangedCause scribble = stylusHandwriting;
 }
 
 /// A mixin for manipulating the selection, provided for toolbar or shortcut

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1103,7 +1103,7 @@ enum SelectionChangedCause {
   /// or on Android API 34+ via the Scribe feature.
   @Deprecated(
     'Use stylusHandwriting instead. '
-    'This feature was deprecated after v3.28.0-0.1.pre.'
+    'This feature was deprecated after v3.28.0-0.1.pre.',
   )
   scribble,
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1097,13 +1097,11 @@ enum SelectionChangedCause {
   /// of text.
   drag,
 
-  // TODO(justinmc): Rename this to stylusHandwriting.
-  // https://github.com/flutter/flutter/issues/159223
   /// The user used stylus handwriting to change the selection.
   ///
   /// Currently, this is only supported on iPadOS 14+ via the Scribble feature,
   /// or on Android API 34+ via the Scribe feature.
-  scribble,
+  stylusHandwriting,
 }
 
 /// A mixin for manipulating the selection, provided for toolbar or shortcut

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1101,6 +1101,16 @@ enum SelectionChangedCause {
   ///
   /// Currently, this is only supported on iPadOS 14+ via the Scribble feature,
   /// or on Android API 34+ via the Scribe feature.
+  @Deprecated(
+    'Use stylusHandwriting instead. '
+    'This feature was deprecated after v3.28.0-0.1.pre.'
+  )
+  scribble,
+
+  /// The user used stylus handwriting to change the selection.
+  ///
+  /// Currently, this is only supported on iPadOS 14+ via the Scribble feature,
+  /// or on Android API 34+ via the Scribe feature.
   stylusHandwriting,
 }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4178,7 +4178,6 @@ class EditableTextState extends State<EditableText>
       case SelectionChangedCause.drag:
       case SelectionChangedCause.forcePress:
       case SelectionChangedCause.longPress:
-      case SelectionChangedCause.scribble:
       case SelectionChangedCause.stylusHandwriting:
       case SelectionChangedCause.tap:
       case SelectionChangedCause.toolbar:

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3383,7 +3383,7 @@ class EditableTextState extends State<EditableText>
       // `selection` is the only change.
       SelectionChangedCause cause;
       if (_textInputConnection?.scribbleInProgress ?? false) {
-        cause = SelectionChangedCause.scribble;
+        cause = SelectionChangedCause.stylusHandwriting;
       } else if (_pointOffsetOrigin != null) {
         // For floating cursor selection when force pressing the space bar.
         cause = SelectionChangedCause.forcePress;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -6025,7 +6025,7 @@ class _ScribbleFocusableState extends State<_ScribbleFocusable> implements Scrib
   @override
   void onScribbleFocus(Offset offset) {
     widget.focusNode.requestFocus();
-    renderEditable?.selectPositionAt(from: offset, cause: SelectionChangedCause.scribble);
+    renderEditable?.selectPositionAt(from: offset, cause: SelectionChangedCause.stylusHandwriting);
     widget.updateSelectionRects();
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4178,6 +4178,7 @@ class EditableTextState extends State<EditableText>
       case SelectionChangedCause.drag:
       case SelectionChangedCause.forcePress:
       case SelectionChangedCause.longPress:
+      case SelectionChangedCause.scribble:
       case SelectionChangedCause.stylusHandwriting:
       case SelectionChangedCause.tap:
       case SelectionChangedCause.toolbar:

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4178,7 +4178,7 @@ class EditableTextState extends State<EditableText>
       case SelectionChangedCause.drag:
       case SelectionChangedCause.forcePress:
       case SelectionChangedCause.longPress:
-      case SelectionChangedCause.scribble:
+      case SelectionChangedCause.stylusHandwriting:
       case SelectionChangedCause.tap:
       case SelectionChangedCause.toolbar:
         requestKeyboard();

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2317,7 +2317,7 @@ class TextSelectionGestureDetectorBuilder {
           if (stylusEnabled) {
             Scribe.isFeatureAvailable().then((bool isAvailable) {
               if (isAvailable) {
-                renderEditable.selectPosition(cause: SelectionChangedCause.scribble);
+                renderEditable.selectPosition(cause: SelectionChangedCause.stylusHandwriting);
                 Scribe.startStylusHandwriting();
               }
             });

--- a/packages/flutter/test/widgets/editable_text_scribble_test.dart
+++ b/packages/flutter/test/widgets/editable_text_scribble_test.dart
@@ -173,7 +173,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(selectionCause, SelectionChangedCause.scribble);
+      expect(selectionCause, SelectionChangedCause.stylusHandwriting);
 
       await tester.testTextInput.finishScribbleInteraction();
     },

--- a/packages/flutter/test/widgets/editable_text_scribble_test.dart
+++ b/packages/flutter/test/widgets/editable_text_scribble_test.dart
@@ -210,10 +210,10 @@ void main() {
       );
 
       expect(focusNode.hasFocus, true);
-      expect(selectionCause, SelectionChangedCause.scribble);
+      expect(selectionCause, SelectionChangedCause.stylusHandwriting);
 
       // On web, we should rely on the browser's implementation of Scribble, so the selection changed cause
-      // will never be SelectionChangedCause.scribble.
+      // will never be SelectionChangedCause.stylusHandwriting.
     },
     skip: kIsWeb, // [intended]
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),

--- a/packages/flutter/test_fixes/services/services.dart
+++ b/packages/flutter/test_fixes/services/services.dart
@@ -43,7 +43,7 @@ void main() {
   await SystemChrome.setEnabledSystemUIOverlays(<SystemUiOverlay>[]);
   await SystemChrome.setEnabledSystemUIOverlays(error: '');
 
-  // https://github.com/flutter/flutter/pull/161518
+  // Changes made in https://github.com/flutter/flutter/pull/161518
   final SelectionChangedCause cause = SelectionChangedCause.scribble;
   print(cause);
 }

--- a/packages/flutter/test_fixes/services/services.dart
+++ b/packages/flutter/test_fixes/services/services.dart
@@ -43,7 +43,7 @@ void main() {
   await SystemChrome.setEnabledSystemUIOverlays(<SystemUiOverlay>[]);
   await SystemChrome.setEnabledSystemUIOverlays(error: '');
 
-  // Change
+  // https://github.com/flutter/flutter/pull/161518
   final cause = SelectionChangedCause.scribble;
   print(cause);
 }

--- a/packages/flutter/test_fixes/services/services.dart
+++ b/packages/flutter/test_fixes/services/services.dart
@@ -42,4 +42,8 @@ void main() {
   ]);
   await SystemChrome.setEnabledSystemUIOverlays(<SystemUiOverlay>[]);
   await SystemChrome.setEnabledSystemUIOverlays(error: '');
+
+  // Change
+  final cause = SelectionChangedCause.scribble;
+  print(cause);
 }

--- a/packages/flutter/test_fixes/services/services.dart
+++ b/packages/flutter/test_fixes/services/services.dart
@@ -44,6 +44,6 @@ void main() {
   await SystemChrome.setEnabledSystemUIOverlays(error: '');
 
   // https://github.com/flutter/flutter/pull/161518
-  final cause = SelectionChangedCause.scribble;
+  final SelectionChangedCause cause = SelectionChangedCause.scribble;
   print(cause);
 }

--- a/packages/flutter/test_fixes/services/services.dart
+++ b/packages/flutter/test_fixes/services/services.dart
@@ -44,6 +44,5 @@ void main() {
   await SystemChrome.setEnabledSystemUIOverlays(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/161518
-  final SelectionChangedCause cause = SelectionChangedCause.scribble;
-  print(cause);
+  const CopySelectionTextIntent.cut(SelectionChangedCause.scribble);
 }

--- a/packages/flutter/test_fixes/services/services.dart.expect
+++ b/packages/flutter/test_fixes/services/services.dart.expect
@@ -44,6 +44,6 @@ void main() {
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/161518
-  final cause = SelectionChangedCause.stylusHandwriting;
+  final SelectionChangedCause cause = SelectionChangedCause.stylusHandwriting;
   print(cause);
 }

--- a/packages/flutter/test_fixes/services/services.dart.expect
+++ b/packages/flutter/test_fixes/services/services.dart.expect
@@ -44,6 +44,5 @@ void main() {
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/161518
-  final SelectionChangedCause cause = SelectionChangedCause.stylusHandwriting;
-  print(cause);
+  const CopySelectionTextIntent.cut(SelectionChangedCause.stylusHandwriting);
 }

--- a/packages/flutter/test_fixes/services/services.dart.expect
+++ b/packages/flutter/test_fixes/services/services.dart.expect
@@ -42,4 +42,8 @@ void main() {
   ]);
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: <SystemUiOverlay>[]);
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, error: '');
+
+  // Change
+  final cause = SelectionChangedCause.stylusHandwriting;
+  print(cause);
 }

--- a/packages/flutter/test_fixes/services/services.dart.expect
+++ b/packages/flutter/test_fixes/services/services.dart.expect
@@ -43,7 +43,7 @@ void main() {
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: <SystemUiOverlay>[]);
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, error: '');
 
-  // Change
+  // Changes made in https://github.com/flutter/flutter/pull/161518
   final cause = SelectionChangedCause.stylusHandwriting;
   print(cause);
 }


### PR DESCRIPTION
Rename 'SelectionChangedCause.scribble' to 'SelectionChangedCause.stylusHandwriting'

Fixes #159223 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
