### PR TITLE
Copy `linux_host_engine` as `linux_host_engine_test`, removing `archives: [...]`.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -319,6 +319,22 @@ targets:
       # at https://github.com/flutter/flutter/issues/152186.
       cores: "8"
 
+  - name: Linux linux_host_engine_test
+    recipe: engine_v2/engine_v2
+    # TODO(matanlurey): https://github.com/flutter/flutter/issues/161406.
+    bringup: true
+    timeout: 120
+    properties:
+      config_name: linux_host_engine_test
+      dependencies: >-
+        [
+          {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
+        ]
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
+
   - name: Linux linux_host_desktop_engine
     recipe: engine_v2/engine_v2
     timeout: 120

--- a/engine/src/flutter/ci/builders/linux_host_engine.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine.json
@@ -5,14 +5,7 @@
         "The only builds in this file should be the builds necessary to produce ",
         "release artifacts. ",
         "Tests to run on linux hosts should go in one of the other linux_ build ",
-        "definition files.",
-        "",
-        "**NOTE**: This file is in the process of moving tests: [ ... ] to the ",
-        "linux_host_engine_test.json file. Once done and bringup: true is removed ",
-        "it will be renamed linux_host_engine_build.json and the tests: [ ... ] ",
-        "below will be removed.",
-        "",
-        "See https://github.com/flutter/flutter/issues/161406."
+        "definition files."
     ],
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/linux_host_engine.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine.json
@@ -5,7 +5,14 @@
         "The only builds in this file should be the builds necessary to produce ",
         "release artifacts. ",
         "Tests to run on linux hosts should go in one of the other linux_ build ",
-        "definition files."
+        "definition files.",
+        "",
+        "**NOTE**: This file is in the process of moving tests: [ ... ] to the ",
+        "linux_host_engine_test.json file. Once done and bringup: true is removed ",
+        "it will be renamed linux_host_engine_build.json and the tests: [ ... ] ",
+        "below will be removed.",
+        "",
+        "See https://github.com/flutter/flutter/issues/161406."
     ],
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -16,7 +16,7 @@
             },
             "gn": [
                 "--target-dir",
-                "ci/host_debug",
+                "ci/host_debug_test",
                 "--runtime-mode",
                 "debug",
                 "--prebuilt-dart-sdk",
@@ -24,10 +24,10 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "ci/host_debug_unit_tests",
+            "name": "ci/host_debug_test",
             "description": "Builds host-side unit tests for Linux.",
             "ninja": {
-                "config": "ci/host_debug_unit_tests",
+                "config": "ci/host_debug_test",
                 "targets": [
                     "flutter:unittests"
                 ]
@@ -39,7 +39,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "ci/host_debug",
+                        "ci/host_debug_test",
                         "--type",
                         "dart,dart-host",
                         "--engine-capture-core-dump"
@@ -59,7 +59,7 @@
             },
             "gn": [
                 "--target-dir",
-                "ci/host_profile",
+                "ci/host_profile_test",
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
@@ -68,10 +68,10 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "ci/host_profile_unit_tests",
+            "name": "ci/host_profile_test",
             "description": "Builds host-side unit tests for Linux.",
             "ninja": {
-                "config": "ci/host_profile_unit_tests",
+                "config": "ci/host_profile_test",
                 "targets": [
                     "flutter:unittests"
                 ]
@@ -95,7 +95,7 @@
             },
             "gn": [
                 "--target-dir",
-                "ci/host_release",
+                "ci/host_release_test",
                 "--runtime-mode",
                 "release",
                 "--prebuilt-dart-sdk",
@@ -103,11 +103,13 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "ci/host_release_unit_tests",
+            "name": "ci/host_release_test",
             "description": "Builds host-side unit tests and benchmarks for Linux.",
             "ninja": {
-                "config": "ci/host_release_unit_tests",
+                "config": "ci/host_release_test",
                 "targets": [
+                    "flutter:unittests",
+                    "flutter/build/archives:flutter_patched_sdk",
                     "flutter/display_list:display_list_benchmarks",
                     "flutter/display_list:display_list_builder_benchmarks",
                     "flutter/display_list:display_list_region_benchmarks",
@@ -116,8 +118,7 @@
                     "flutter/impeller/geometry:geometry_benchmarks",
                     "flutter/lib/ui:ui_benchmarks",
                     "flutter/shell/common:shell_benchmarks",
-                    "flutter/third_party/txt:txt_benchmarks",
-                    "flutter/build/archives:flutter_patched_sdk"
+                    "flutter/third_party/txt:txt_benchmarks"
                 ]
             },
             "tests": [
@@ -127,7 +128,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "ci/host_release",
+                        "ci/host_release_test",
                         "--type",
                         "dart,dart-host,engine,benchmarks",
                         "--engine-capture-core-dump"
@@ -138,7 +139,7 @@
                     "name": "Generate metrics test",
                     "script": "flutter/testing/benchmark/generate_metrics.sh",
                     "parameters": [
-                        "ci/host_release"
+                        "ci/host_release_test"
                     ]
                 },
                 {
@@ -146,7 +147,7 @@
                     "name": "Upload metrics dry-run",
                     "script": "flutter/testing/benchmark/upload_metrics.sh",
                     "parameters": [
-                        "ci/host_release",
+                        "ci/host_release_test",
                         "--no-upload"
                     ]
                 }

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -1,0 +1,156 @@
+{
+    "_comment": [
+        "The builds defined in this file should only contain tests, ",
+        "and the file should not contain builds that produce artifacts. "
+    ],
+    "builds": [
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/host_debug",
+                "--runtime-mode",
+                "debug",
+                "--prebuilt-dart-sdk",
+                "--build-embedder-examples",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/host_debug_unit_tests",
+            "description": "Builds host-side unit tests for Linux.",
+            "ninja": {
+                "config": "ci/host_debug_unit_tests",
+                "targets": [
+                    "flutter:unittests"
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_debug",
+                    "script": "flutter/testing/run_tests.py",
+                    "parameters": [
+                        "--variant",
+                        "ci/host_debug",
+                        "--type",
+                        "dart,dart-host",
+                        "--engine-capture-core-dump"
+                    ]
+                }
+            ]
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/host_profile",
+                "--runtime-mode",
+                "profile",
+                "--no-lto",
+                "--prebuilt-dart-sdk",
+                "--build-embedder-examples",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/host_profile_unit_tests",
+            "description": "Builds host-side unit tests for Linux.",
+            "ninja": {
+                "config": "ci/host_profile_unit_tests",
+                "targets": [
+                    "flutter:unittests"
+                ]
+            }
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "dependencies": [
+                {
+                    "dependency": "goldctl",
+                    "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
+                }
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/host_release",
+                "--runtime-mode",
+                "release",
+                "--prebuilt-dart-sdk",
+                "--build-embedder-examples",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/host_release_unit_tests",
+            "description": "Builds host-side unit tests and benchmarks for Linux.",
+            "ninja": {
+                "config": "ci/host_release_unit_tests",
+                "targets": [
+                    "flutter/display_list:display_list_benchmarks",
+                    "flutter/display_list:display_list_builder_benchmarks",
+                    "flutter/display_list:display_list_region_benchmarks",
+                    "flutter/display_list:display_list_transform_benchmarks",
+                    "flutter/fml:fml_benchmarks",
+                    "flutter/impeller/geometry:geometry_benchmarks",
+                    "flutter/lib/ui:ui_benchmarks",
+                    "flutter/shell/common:shell_benchmarks",
+                    "flutter/third_party/txt:txt_benchmarks",
+                    "flutter/build/archives:flutter_patched_sdk"
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_release",
+                    "script": "flutter/testing/run_tests.py",
+                    "parameters": [
+                        "--variant",
+                        "ci/host_release",
+                        "--type",
+                        "dart,dart-host,engine,benchmarks",
+                        "--engine-capture-core-dump"
+                    ]
+                },
+                {
+                    "language": "bash",
+                    "name": "Generate metrics test",
+                    "script": "flutter/testing/benchmark/generate_metrics.sh",
+                    "parameters": [
+                        "ci/host_release"
+                    ]
+                },
+                {
+                    "language": "bash",
+                    "name": "Upload metrics dry-run",
+                    "script": "flutter/testing/benchmark/upload_metrics.sh",
+                    "parameters": [
+                        "ci/host_release",
+                        "--no-upload"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -1372,13 +1372,7 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
     run_benchmark_tests(build_dir)
     run_engine_benchmarks(build_dir, engine_filter)
 
-  variants_to_skip = ['host_release', 'host_profile']
-
-  def should_skip(variant):
-    matches = [variant for variant in variants_to_skip if variant in args.variant]
-    return len(matches) > 0
-
-  if ('engine' in types or 'font-subset' in types) and not should_skip(args.variant):
+  if ('engine' in types or 'font-subset' in types) and 'debug' in build_dir:
     cmd = ['python3', 'test.py', '--variant', args.variant]
     if 'arm64' in args.variant:
       cmd += ['--target-cpu', 'arm64']


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/161406.

The goal is to, assuming this is WAI, move the `bringup: true` build (the newly created one) to presubmit, and then in a follow-up PR, remove the `tests: [...]` (and test dependencies) from `linux_host_engine.json`, meaning that it would be a build/archive only builder, and this _new_ builder would be a build/test one.

We talked about it being hypothetically better to _not_ build the engine multiple times, and decided for now to depend on RBE and not try to create stages or download artifacts created from another builder, but if @zanderso has another suggestion here is the place to chime in :)

(Btw if we like this approach, I'll create a task list of every builder that needs to be migrated)