### PR TITLE
Mark `Mac_mokey microbenchmarks` as flakey

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4813,6 +4813,7 @@ targets:
   - name: Mac_mokey microbenchmarks
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true # Flaky: codefu
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
Random seed 349875783 is failing half the time.

```
flutter run -v -d IR65S859OJ4HAY6P --profile lib/benchmark_collection.dart --dart-define=seed=349875783
```

I'm concerned that this sometimes passes, which points to some hidden timing bugs.