### PR TITLE
[DisplayList] remove obsolete use of Skia geometry objects in DL utils

### DIFF
--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -914,7 +914,7 @@ void DisplayListBuilder::TransformReset() {
     // became singular while we were accumulating the current layer.
     // In either case, we should no longer be accumulating any
     // contents so we set the layer tracking transform to a singular one.
-    layer_local_state().setTransform(SkMatrix::Scale(0.0f, 0.0f));
+    layer_local_state().setTransform(DlMatrix::MakeScale({0.0f, 0.0f, 0.0f}));
   }
 
   global_state().setIdentity();
@@ -1050,8 +1050,8 @@ void DisplayListBuilder::ClipPath(const DlPath& path,
       return;
     }
   }
-  global_state().clipPath(path.GetSkPath(), clip_op, is_aa);
-  layer_local_state().clipPath(path.GetSkPath(), clip_op, is_aa);
+  global_state().clipPath(path, clip_op, is_aa);
+  layer_local_state().clipPath(path, clip_op, is_aa);
   if (global_state().is_cull_rect_empty() ||
       layer_local_state().is_cull_rect_empty()) {
     current_info().is_nop = true;
@@ -1488,7 +1488,7 @@ void DisplayListBuilder::drawAtlas(const sk_sp<DlImage> atlas,
     const DlRect& src = tex[i];
     xform[i].toQuad(src.GetWidth(), src.GetHeight(), quad);
     for (int j = 0; j < 4; j++) {
-      accumulator.accumulate(quad[j]);
+      accumulator.accumulate(ToDlPoint(quad[j]));
     }
   }
   if (accumulator.is_empty() ||

--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -819,8 +819,8 @@ void DisplayListBuilder::Rotate(DlScalar degrees) {
   if (SkScalarMod(degrees, 360.0) != 0.0) {
     checkForDeferredSave();
     Push<RotateOp>(0, degrees);
-    global_state().rotate(degrees);
-    layer_local_state().rotate(degrees);
+    global_state().rotate(DlDegrees(degrees));
+    layer_local_state().rotate(DlDegrees(degrees));
   }
 }
 void DisplayListBuilder::Skew(DlScalar sx, DlScalar sy) {

--- a/engine/src/flutter/display_list/utils/dl_accumulation_rect.cc
+++ b/engine/src/flutter/display_list/utils/dl_accumulation_rect.cc
@@ -6,7 +6,7 @@
 
 namespace flutter {
 
-void AccumulationRect::accumulate(SkScalar x, SkScalar y) {
+void AccumulationRect::accumulate(DlScalar x, DlScalar y) {
   if (!std::isfinite(x) || !std::isfinite(y)) {
     return;
   }
@@ -28,25 +28,25 @@ void AccumulationRect::accumulate(SkScalar x, SkScalar y) {
   }
 }
 
-void AccumulationRect::accumulate(SkRect r) {
-  if (r.isEmpty()) {
+void AccumulationRect::accumulate(DlRect r) {
+  if (r.IsEmpty()) {
     return;
   }
-  if (r.fLeft < max_x_ && r.fRight > min_x_ &&  //
-      r.fTop < max_y_ && r.fBottom > min_y_) {
+  if (r.GetLeft() < max_x_ && r.GetRight() > min_x_ &&  //
+      r.GetTop() < max_y_ && r.GetBottom() > min_y_) {
     record_overlapping_bounds();
   }
-  if (min_x_ > r.fLeft) {
-    min_x_ = r.fLeft;
+  if (min_x_ > r.GetLeft()) {
+    min_x_ = r.GetLeft();
   }
-  if (min_y_ > r.fTop) {
-    min_y_ = r.fTop;
+  if (min_y_ > r.GetTop()) {
+    min_y_ = r.GetTop();
   }
-  if (max_x_ < r.fRight) {
-    max_x_ = r.fRight;
+  if (max_x_ < r.GetRight()) {
+    max_x_ = r.GetRight();
   }
-  if (max_y_ < r.fBottom) {
-    max_y_ = r.fBottom;
+  if (max_y_ < r.GetBottom()) {
+    max_y_ = r.GetBottom();
   }
 }
 
@@ -78,17 +78,11 @@ DlRect AccumulationRect::GetBounds() const {
              : DlRect();
 }
 
-SkRect AccumulationRect::bounds() const {
-  return (max_x_ >= min_x_ && max_y_ >= min_y_)
-             ? SkRect::MakeLTRB(min_x_, min_y_, max_x_, max_y_)
-             : SkRect::MakeEmpty();
-}
-
 void AccumulationRect::reset() {
-  min_x_ = std::numeric_limits<SkScalar>::infinity();
-  min_y_ = std::numeric_limits<SkScalar>::infinity();
-  max_x_ = -std::numeric_limits<SkScalar>::infinity();
-  max_y_ = -std::numeric_limits<SkScalar>::infinity();
+  min_x_ = std::numeric_limits<DlScalar>::infinity();
+  min_y_ = std::numeric_limits<DlScalar>::infinity();
+  max_x_ = -std::numeric_limits<DlScalar>::infinity();
+  max_y_ = -std::numeric_limits<DlScalar>::infinity();
   overlap_detected_ = false;
 }
 

--- a/engine/src/flutter/display_list/utils/dl_accumulation_rect.h
+++ b/engine/src/flutter/display_list/utils/dl_accumulation_rect.h
@@ -5,11 +5,7 @@
 #ifndef FLUTTER_DISPLAY_LIST_UTILS_DL_ACCUMULATION_RECT_H_
 #define FLUTTER_DISPLAY_LIST_UTILS_DL_ACCUMULATION_RECT_H_
 
-#include <functional>
-
 #include "flutter/display_list/geometry/dl_geometry_types.h"
-#include "flutter/display_list/geometry/dl_rtree.h"
-#include "flutter/fml/logging.h"
 
 namespace flutter {
 
@@ -26,18 +22,15 @@ class AccumulationRect {
  public:
   AccumulationRect() { reset(); }
 
-  void accumulate(SkScalar x, SkScalar y);
-  void accumulate(SkPoint p) { accumulate(p.fX, p.fY); }
+  void accumulate(DlScalar x, DlScalar y);
   void accumulate(DlPoint p) { accumulate(p.x, p.y); }
-  void accumulate(SkRect r);
-  void accumulate(DlRect r) { accumulate(ToSkRect(r)); }
+  void accumulate(DlRect r);
   void accumulate(AccumulationRect& ar);
 
   bool is_empty() const { return min_x_ >= max_x_ || min_y_ >= max_y_; }
   bool is_not_empty() const { return min_x_ < max_x_ && min_y_ < max_y_; }
 
   DlRect GetBounds() const;
-  SkRect bounds() const;
 
   void reset();
 

--- a/engine/src/flutter/display_list/utils/dl_accumulation_rect_unittests.cc
+++ b/engine/src/flutter/display_list/utils/dl_accumulation_rect_unittests.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/display_list/utils/dl_accumulation_rect.h"
-#include "flutter/testing/assertions_skia.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
@@ -13,7 +12,7 @@ TEST(DisplayListAccumulationRect, Constructor) {
   AccumulationRect accumulator;
 
   EXPECT_TRUE(accumulator.is_empty());
-  EXPECT_TRUE(accumulator.bounds().isEmpty());
+  EXPECT_TRUE(accumulator.GetBounds().IsEmpty());
   EXPECT_FALSE(accumulator.overlap_detected());
 }
 
@@ -22,14 +21,14 @@ TEST(DisplayListAccumulationRect, OnePoint) {
   accumulator.accumulate(10.0f, 10.0f);
 
   EXPECT_TRUE(accumulator.is_empty());
-  EXPECT_TRUE(accumulator.bounds().isEmpty());
+  EXPECT_TRUE(accumulator.GetBounds().IsEmpty());
   EXPECT_FALSE(accumulator.overlap_detected());
 }
 
 TEST(DisplayListAccumulationRect, TwoPoints) {
   auto test = [](DlScalar x1, DlScalar y1,  //
                  DlScalar x2, DlScalar y2,  //
-                 SkRect bounds,             //
+                 DlRect bounds,             //
                  bool should_be_empty, bool should_overlap,
                  const std::string& label) {
     {
@@ -38,19 +37,8 @@ TEST(DisplayListAccumulationRect, TwoPoints) {
       accumulator.accumulate(x2, y2);
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
-      EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
-    }
-
-    {
-      AccumulationRect accumulator;
-      accumulator.accumulate(SkPoint::Make(x1, y1));
-      accumulator.accumulate(SkPoint::Make(x2, y2));
-
-      EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
 
@@ -60,19 +48,19 @@ TEST(DisplayListAccumulationRect, TwoPoints) {
       accumulator.accumulate(DlPoint(x2, y2));
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
   };
 
-  test(10.0f, 10.0f, 10.0f, 10.0f, SkRect::MakeLTRB(10.0f, 10.0f, 10.0f, 10.0f),
+  test(10.0f, 10.0f, 10.0f, 10.0f, DlRect::MakeLTRB(10.0f, 10.0f, 10.0f, 10.0f),
        true, false, "Same");
-  test(10.0f, 10.0f, 20.0f, 10.0f, SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 10.0f),
+  test(10.0f, 10.0f, 20.0f, 10.0f, DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 10.0f),
        true, false, "Horizontal");
-  test(10.0f, 10.0f, 10.0f, 20.0f, SkRect::MakeLTRB(10.0f, 10.0f, 10.0f, 20.0f),
+  test(10.0f, 10.0f, 10.0f, 20.0f, DlRect::MakeLTRB(10.0f, 10.0f, 10.0f, 20.0f),
        true, false, "Vertical");
-  test(10.0f, 10.0f, 20.0f, 20.0f, SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),
+  test(10.0f, 10.0f, 20.0f, 20.0f, DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),
        false, false, "Diagonal");
 }
 
@@ -80,7 +68,7 @@ TEST(DisplayListAccumulationRect, ThreePoints) {
   auto test = [](DlScalar x1, DlScalar y1,  //
                  DlScalar x2, DlScalar y2,  //
                  DlScalar x3, DlScalar y3,  //
-                 SkRect bounds,             //
+                 DlRect bounds,             //
                  bool should_be_empty, bool should_overlap,
                  const std::string& label) {
     {
@@ -90,20 +78,8 @@ TEST(DisplayListAccumulationRect, ThreePoints) {
       accumulator.accumulate(x3, y3);
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
-      EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
-    }
-
-    {
-      AccumulationRect accumulator;
-      accumulator.accumulate(SkPoint::Make(x1, y1));
-      accumulator.accumulate(SkPoint::Make(x2, y2));
-      accumulator.accumulate(SkPoint::Make(x3, y3));
-
-      EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
 
@@ -114,36 +90,36 @@ TEST(DisplayListAccumulationRect, ThreePoints) {
       accumulator.accumulate(DlPoint(x3, y3));
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
   };
 
   test(10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f,
-       SkRect::MakeLTRB(10.0f, 10.0f, 10.0f, 10.0f), true, false, "Same");
+       DlRect::MakeLTRB(10.0f, 10.0f, 10.0f, 10.0f), true, false, "Same");
   test(10.0f, 10.0f, 20.0f, 10.0f, 15.0f, 10.0f,
-       SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 10.0f), true, false, "Horizontal");
+       DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 10.0f), true, false, "Horizontal");
   test(10.0f, 10.0f, 10.0f, 20.0f, 10.0f, 15.0f,
-       SkRect::MakeLTRB(10.0f, 10.0f, 10.0f, 20.0f), true, false, "Vertical");
+       DlRect::MakeLTRB(10.0f, 10.0f, 10.0f, 20.0f), true, false, "Vertical");
   test(10.0f, 10.0f, 20.0f, 20.0f, 25.0f, 15.0f,
-       SkRect::MakeLTRB(10.0f, 10.0f, 25.0f, 20.0f), false, false, "Disjoint");
+       DlRect::MakeLTRB(10.0f, 10.0f, 25.0f, 20.0f), false, false, "Disjoint");
   test(10.0f, 10.0f, 20.0f, 20.0f, 15.0f, 15.0f,
-       SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f), false, true, "Inside");
+       DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f), false, true, "Inside");
 }
 
 TEST(DisplayListAccumulationRect, EmptyRect) {
   auto test = [](DlScalar l, DlScalar t, DlScalar r, DlScalar b,  //
-                 SkRect bounds,                                   //
+                 DlRect bounds,                                   //
                  bool should_be_empty, bool should_overlap,
                  const std::string& label) {
     {
       AccumulationRect accumulator;
-      accumulator.accumulate(SkRect::MakeLTRB(l, t, r, b));
+      accumulator.accumulate(DlRect::MakeLTRB(l, t, r, b));
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
 
@@ -152,8 +128,8 @@ TEST(DisplayListAccumulationRect, EmptyRect) {
       accumulator.accumulate(DlRect::MakeLTRB(l, t, r, b));
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
 
@@ -162,12 +138,12 @@ TEST(DisplayListAccumulationRect, EmptyRect) {
       content.accumulate(l, t);
       content.accumulate(r, b);
       EXPECT_EQ(content.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(content.bounds().isEmpty(), should_be_empty) << label;
+      EXPECT_EQ(content.GetBounds().IsEmpty(), should_be_empty) << label;
       // bounds for an accumulation by points may be different than the
       // bounds for an accumulation by the rect they produce because
       // construction by points has no "empty rejection" case.
       if (!should_be_empty) {
-        EXPECT_EQ(content.bounds(), bounds) << label;
+        EXPECT_EQ(content.GetBounds(), bounds) << label;
       }
       EXPECT_EQ(content.overlap_detected(), should_overlap) << label;
 
@@ -175,47 +151,36 @@ TEST(DisplayListAccumulationRect, EmptyRect) {
       accumulator.accumulate(content);
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
   };
 
-  test(10.0f, 10.0f, 10.0f, 10.0f, SkRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),
+  test(10.0f, 10.0f, 10.0f, 10.0f, DlRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),
        true, false, "Singular");
-  test(10.0f, 10.0f, 20.0f, 10.0f, SkRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),
+  test(10.0f, 10.0f, 20.0f, 10.0f, DlRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),
        true, false, "Horizontal Empty");
-  test(10.0f, 10.0f, 10.0f, 20.0f, SkRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),
+  test(10.0f, 10.0f, 10.0f, 20.0f, DlRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),
        true, false, "Vertical Empty");
-  test(10.0f, 10.0f, 20.0f, 20.0f, SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),
+  test(10.0f, 10.0f, 20.0f, 20.0f, DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),
        false, false, "Non-Empty");
 }
 
 TEST(DisplayListAccumulationRect, TwoRects) {
   auto test = [](DlScalar l1, DlScalar t1, DlScalar r1, DlScalar b1,  //
                  DlScalar l2, DlScalar t2, DlScalar r2, DlScalar b2,  //
-                 SkRect bounds,                                       //
+                 DlRect bounds,                                       //
                  bool should_be_empty, bool should_overlap,
                  const std::string& label) {
-    {
-      AccumulationRect accumulator;
-      accumulator.accumulate(SkRect::MakeLTRB(l1, t1, r1, b1));
-      accumulator.accumulate(SkRect::MakeLTRB(l2, t2, r2, b2));
-
-      EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
-      EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
-    }
-
     {
       AccumulationRect accumulator;
       accumulator.accumulate(DlRect::MakeLTRB(l1, t1, r1, b1));
       accumulator.accumulate(DlRect::MakeLTRB(l2, t2, r2, b2));
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
 
@@ -233,39 +198,39 @@ TEST(DisplayListAccumulationRect, TwoRects) {
       accumulator.accumulate(content2);
 
       EXPECT_EQ(accumulator.is_empty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds().isEmpty(), should_be_empty) << label;
-      EXPECT_EQ(accumulator.bounds(), bounds) << label;
+      EXPECT_EQ(accumulator.GetBounds().IsEmpty(), should_be_empty) << label;
+      EXPECT_EQ(accumulator.GetBounds(), bounds) << label;
       EXPECT_EQ(accumulator.overlap_detected(), should_overlap) << label;
     }
   };
 
   test(10.0f, 10.0f, 10.0f, 10.0f,                //
        20.0f, 20.0f, 20.0f, 20.0f,                //
-       SkRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),  //
+       DlRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),  //
        true, false, "Empty + Empty");
   test(10.0f, 10.0f, 20.0f, 10.0f,                //
        10.0f, 10.0f, 10.0f, 20.0f,                //
-       SkRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),  //
+       DlRect::MakeLTRB(0.0f, 0.0f, 0.0f, 0.0f),  //
        true, false, "Horizontal + Vertical");
   test(10.0f, 10.0f, 10.0f, 10.0f,                    //
        15.0f, 15.0f, 20.0f, 20.0f,                    //
-       SkRect::MakeLTRB(15.0f, 15.0f, 20.0f, 20.0f),  //
+       DlRect::MakeLTRB(15.0f, 15.0f, 20.0f, 20.0f),  //
        false, false, "Empty + Non-Empty");
   test(10.0f, 10.0f, 15.0f, 15.0f,                    //
        20.0f, 20.0f, 20.0f, 20.0f,                    //
-       SkRect::MakeLTRB(10.0f, 10.0f, 15.0f, 15.0f),  //
+       DlRect::MakeLTRB(10.0f, 10.0f, 15.0f, 15.0f),  //
        false, false, "Non-Empty + Empty");
   test(10.0f, 10.0f, 15.0f, 15.0f,                    //
        15.0f, 15.0f, 20.0f, 20.0f,                    //
-       SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),  //
+       DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),  //
        false, false, "Abutting");
   test(10.0f, 10.0f, 15.0f, 15.0f,                    //
        16.0f, 16.0f, 20.0f, 20.0f,                    //
-       SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),  //
+       DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),  //
        false, false, "Disjoint");
   test(10.0f, 10.0f, 16.0f, 16.0f,                    //
        15.0f, 15.0f, 20.0f, 20.0f,                    //
-       SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),  //
+       DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f),  //
        false, true, "Overlapping");
 }
 

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.cc
@@ -9,21 +9,7 @@
 
 namespace flutter {
 
-bool DisplayListMatrixClipState::is_3x3(const SkM44& m) {
-  // clang-format off
-  return (                                      m.rc(0, 2) == 0 &&
-                                                m.rc(1, 2) == 0 &&
-          m.rc(2, 0) == 0 && m.rc(2, 1) == 0 && m.rc(2, 2) == 1 && m.rc(2, 3) == 0 &&
-                                                m.rc(3, 2) == 0);
-  // clang-format on
-}
-
 static constexpr DlRect kEmpty = DlRect();
-
-static const DlRect& ProtectEmpty(const SkRect& rect) {
-  // isEmpty protects us against NaN while we normalize any empty cull rects
-  return rect.isEmpty() ? kEmpty : ToDlRect(rect);
-}
 
 static const DlRect& ProtectEmpty(const DlRect& rect) {
   // isEmpty protects us against NaN while we normalize any empty cull rects
@@ -34,35 +20,12 @@ DisplayListMatrixClipState::DisplayListMatrixClipState(const DlRect& cull_rect,
                                                        const DlMatrix& matrix)
     : cull_rect_(ProtectEmpty(cull_rect)), matrix_(matrix) {}
 
-DisplayListMatrixClipState::DisplayListMatrixClipState(const SkRect& cull_rect)
-    : cull_rect_(ProtectEmpty(cull_rect)), matrix_(DlMatrix()) {}
-
-DisplayListMatrixClipState::DisplayListMatrixClipState(const SkRect& cull_rect,
-                                                       const SkMatrix& matrix)
-    : cull_rect_(ProtectEmpty(cull_rect)), matrix_(ToDlMatrix(matrix)) {}
-
-DisplayListMatrixClipState::DisplayListMatrixClipState(const SkRect& cull_rect,
-                                                       const SkM44& matrix)
-    : cull_rect_(ProtectEmpty(cull_rect)), matrix_(ToDlMatrix(matrix)) {}
-
 bool DisplayListMatrixClipState::inverseTransform(
     const DisplayListMatrixClipState& tracker) {
   if (tracker.is_matrix_invertable()) {
     matrix_ = matrix_ * tracker.matrix_.Invert();
     return true;
   }
-  return false;
-}
-
-bool DisplayListMatrixClipState::mapAndClipRect(const SkRect& src,
-                                                SkRect* mapped) const {
-  DlRect dl_mapped = ToDlRect(src).TransformAndClipBounds(matrix_);
-  auto dl_intersected = dl_mapped.Intersection(cull_rect_);
-  if (dl_intersected.has_value()) {
-    *mapped = ToSkRect(dl_intersected.value());
-    return true;
-  }
-  mapped->setEmpty();
   return false;
 }
 

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.h
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.h
@@ -59,8 +59,8 @@ class DisplayListMatrixClipState {
   void skew(DlScalar skx, DlScalar sky) {
     matrix_ = matrix_ * DlMatrix::MakeSkew(skx, sky);
   }
-  void rotate(DlScalar degrees) {
-    matrix_ = matrix_ * DlMatrix::MakeRotationZ(DlDegrees(degrees));
+  void rotate(DlRadians angle) {
+    matrix_ = matrix_ * DlMatrix::MakeRotationZ(angle);
   }
   void transform(const DlMatrix& matrix) { matrix_ = matrix_ * matrix; }
   // clang-format off

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.h
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.h
@@ -11,13 +11,6 @@
 #include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/fml/logging.h"
 
-#include "third_party/skia/include/core/SkM44.h"
-#include "third_party/skia/include/core/SkMatrix.h"
-#include "third_party/skia/include/core/SkPath.h"
-#include "third_party/skia/include/core/SkRRect.h"
-#include "third_party/skia/include/core/SkRect.h"
-#include "third_party/skia/include/core/SkScalar.h"
-
 namespace flutter {
 
 class DisplayListMatrixClipState {
@@ -27,12 +20,7 @@ class DisplayListMatrixClipState {
  public:
   explicit DisplayListMatrixClipState(const DlRect& cull_rect,
                                       const DlMatrix& matrix = DlMatrix());
-  explicit DisplayListMatrixClipState(const SkRect& cull_rect);
-  DisplayListMatrixClipState(const SkRect& cull_rect, const SkMatrix& matrix);
-  DisplayListMatrixClipState(const SkRect& cull_rect, const SkM44& matrix);
   DisplayListMatrixClipState(const DisplayListMatrixClipState& other) = default;
-
-  static bool is_3x3(const SkM44& m44);
 
   // This method should almost never be used as it breaks the encapsulation
   // of the enclosing clips. However it is needed for practical purposes in
@@ -44,65 +32,41 @@ class DisplayListMatrixClipState {
   // Omitting the |cull_rect| argument, or passing nullptr, will restore the
   // cull rect to the initial value it had when the tracker was constructed.
   void resetDeviceCullRect(const DlRect& cull_rect);
-  void resetDeviceCullRect(const SkRect& cull_rect) {
-    resetDeviceCullRect(ToDlRect(cull_rect));
-  }
   void resetLocalCullRect(const DlRect& cull_rect);
-  void resetLocalCullRect(const SkRect& cull_rect) {
-    resetLocalCullRect(ToDlRect(cull_rect));
-  }
 
   bool using_4x4_matrix() const { return !matrix_.IsAffine(); }
   bool is_matrix_invertable() const { return matrix_.IsInvertible(); }
   bool has_perspective() const { return matrix_.HasPerspective(); }
 
   const DlMatrix& matrix() const { return matrix_; }
-  SkM44 matrix_4x4() const { return SkM44::ColMajor(matrix_.m); }
-  SkMatrix matrix_3x3() const { return ToSkMatrix(matrix_); }
 
-  SkRect local_cull_rect() const { return ToSkRect(GetLocalCullCoverage()); }
   DlRect GetLocalCullCoverage() const;
-  SkRect device_cull_rect() const { return ToSkRect(cull_rect_); }
   DlRect GetDeviceCullCoverage() const { return cull_rect_; }
 
   bool rect_covers_cull(const DlRect& content) const;
-  bool rect_covers_cull(const SkRect& content) const {
-    return rect_covers_cull(ToDlRect(content));
-  }
   bool oval_covers_cull(const DlRect& content_bounds) const;
-  bool oval_covers_cull(const SkRect& content_bounds) const {
-    return oval_covers_cull(ToDlRect(content_bounds));
-  }
   bool rrect_covers_cull(const DlRoundRect& content) const;
-  bool rrect_covers_cull(const SkRRect& content) const {
-    return rrect_covers_cull(ToDlRoundRect(content));
-  }
 
   bool content_culled(const DlRect& content_bounds) const;
-  bool content_culled(const SkRect& content_bounds) const {
-    return content_culled(ToDlRect(content_bounds));
-  }
   bool is_cull_rect_empty() const { return cull_rect_.IsEmpty(); }
 
-  void translate(SkScalar tx, SkScalar ty) {
+  void translate(DlScalar tx, DlScalar ty) {
     matrix_ = matrix_.Translate({tx, ty});
   }
-  void scale(SkScalar sx, SkScalar sy) {
+  void scale(DlScalar sx, DlScalar sy) {
     matrix_ = matrix_.Scale({sx, sy, 1.0f});
   }
-  void skew(SkScalar skx, SkScalar sky) {
+  void skew(DlScalar skx, DlScalar sky) {
     matrix_ = matrix_ * DlMatrix::MakeSkew(skx, sky);
   }
-  void rotate(SkScalar degrees) {
+  void rotate(DlScalar degrees) {
     matrix_ = matrix_ * DlMatrix::MakeRotationZ(DlDegrees(degrees));
   }
   void transform(const DlMatrix& matrix) { matrix_ = matrix_ * matrix; }
-  void transform(const SkM44& m44) { transform(ToDlMatrix(m44)); }
-  void transform(const SkMatrix& matrix) { transform(ToDlMatrix(matrix)); }
   // clang-format off
   void transform2DAffine(
-      SkScalar mxx, SkScalar mxy, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myt) {
+      DlScalar mxx, DlScalar mxy, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myt) {
     matrix_ = matrix_ * DlMatrix::MakeColumn(
          mxx,  myx, 0.0f, 0.0f,
          mxy,  myy, 0.0f, 0.0f,
@@ -111,10 +75,10 @@ class DisplayListMatrixClipState {
     );
   }
   void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) {
     matrix_ = matrix_ * DlMatrix::MakeColumn(
         mxx, myx, mzx, mwx,
         mxy, myy, mzy, mwy,
@@ -124,8 +88,6 @@ class DisplayListMatrixClipState {
   }
   // clang-format on
   void setTransform(const DlMatrix& matrix) { matrix_ = matrix; }
-  void setTransform(const SkMatrix& matrix) { matrix_ = ToDlMatrix(matrix); }
-  void setTransform(const SkM44& m44) { matrix_ = ToDlMatrix(m44); }
   void setIdentity() { matrix_ = DlMatrix(); }
   // If the matrix in |other_tracker| is invertible then transform this
   // tracker by the inverse of its matrix and return true. Otherwise,
@@ -137,38 +99,17 @@ class DisplayListMatrixClipState {
     *mapped = src.TransformAndClipBounds(matrix_);
     return matrix_.IsAligned2D();
   }
-  bool mapRect(SkRect* rect) const { return mapRect(*rect, rect); }
-  bool mapRect(const SkRect& src, SkRect* mapped) const {
-    *mapped = ToSkRect(ToDlRect(src).TransformAndClipBounds(matrix_));
-    return matrix_.IsAligned2D();
-  }
 
   /// @brief  Maps the rect by the current matrix and then clips it against
   ///         the current cull rect, returning true if the result is non-empty.
-  bool mapAndClipRect(SkRect* rect) const {
-    return mapAndClipRect(*rect, rect);
-  }
-  bool mapAndClipRect(const SkRect& src, SkRect* mapped) const;
   bool mapAndClipRect(DlRect* rect) const {
     return mapAndClipRect(*rect, rect);
   }
   bool mapAndClipRect(const DlRect& src, DlRect* mapped) const;
 
   void clipRect(const DlRect& rect, ClipOp op, bool is_aa);
-  void clipRect(const SkRect& rect, ClipOp op, bool is_aa) {
-    clipRect(ToDlRect(rect), op, is_aa);
-  }
   void clipOval(const DlRect& bounds, ClipOp op, bool is_aa);
-  void clipOval(const SkRect& bounds, ClipOp op, bool is_aa) {
-    clipRect(ToDlRect(bounds), op, is_aa);
-  }
   void clipRRect(const DlRoundRect& rrect, ClipOp op, bool is_aa);
-  void clipRRect(const SkRRect& rrect, ClipOp op, bool is_aa) {
-    clipRRect(ToDlRoundRect(rrect), op, is_aa);
-  }
-  void clipPath(const SkPath& path, ClipOp op, bool is_aa) {
-    clipPath(DlPath(path), op, is_aa);
-  }
   void clipPath(const DlPath& path, ClipOp op, bool is_aa);
 
  private:

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker_unittests.cc
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker_unittests.cc
@@ -118,7 +118,7 @@ TEST(DisplayListMatrixClipState, Rotate) {
   const DlRect local_cull_rect = DlRect::MakeLTRB(10, -15, 20, -5);
 
   DisplayListMatrixClipState state(cull_rect, matrix);
-  state.rotate(90);
+  state.rotate(DlDegrees(90));
 
   EXPECT_FALSE(state.using_4x4_matrix());
   EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
@@ -532,7 +532,7 @@ TEST(DisplayListMatrixClipState, RectCoverageUnderRotation) {
 
   for (int i = 0; i <= 360; i++) {
     DisplayListMatrixClipState state(cull);
-    state.rotate(i);
+    state.rotate(DlDegrees(i));
     EXPECT_TRUE(state.rect_covers_cull(test_true))
         << "  testing " << test_true << std::endl
         << "    contains " << state.GetLocalCullCoverage() << std::endl
@@ -611,7 +611,7 @@ TEST(DisplayListMatrixClipState, OvalCoverageUnderRotation) {
 
   for (int i = 0; i <= 360; i++) {
     DisplayListMatrixClipState state(cull);
-    state.rotate(i);
+    state.rotate(DlDegrees(i));
     EXPECT_TRUE(state.oval_covers_cull(test_true))
         << "  testing " << test_true << std::endl
         << "    contains " << state.GetLocalCullCoverage() << std::endl

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker_unittests.cc
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker_unittests.cc
@@ -10,568 +10,292 @@ namespace flutter {
 namespace testing {
 
 TEST(DisplayListMatrixClipState, Constructor) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlMatrix matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
+  const DlRect local_cull_rect = DlRect::MakeLTRB(5, 10, 15, 20);
 
-  DisplayListMatrixClipState state1(cull_rect, matrix);
-  DisplayListMatrixClipState state2(cull_rect, m44);
-  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+  DisplayListMatrixClipState state(cull_rect, matrix);
 
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_3x3(), matrix);
-  EXPECT_EQ(state1.matrix_4x4(), m44);
-  EXPECT_EQ(state1.matrix(), dl_matrix);
-
-  EXPECT_FALSE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_3x3(), matrix);
-  EXPECT_EQ(state2.matrix_4x4(), m44);
-  EXPECT_EQ(state2.matrix(), dl_matrix);
-
-  EXPECT_FALSE(state3.using_4x4_matrix());
-  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state3.matrix_3x3(), matrix);
-  EXPECT_EQ(state3.matrix_4x4(), m44);
-  EXPECT_EQ(state3.matrix(), dl_matrix);
-}
-
-TEST(DisplayListMatrixClipState, Constructor4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  // clang-format off
-  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
-                          0, 4, 0.5, 0,
-                          0, 0, 4.0, 0,
-                          0, 0, 0.0, 1);
-  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
-                                               0, 4, 0.5, 0,
-                                               0, 0, 4.0, 0,
-                                               0, 0, 0.0, 1);
-  // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
-
-  DisplayListMatrixClipState state1(cull_rect, m44);
-  DisplayListMatrixClipState state2(dl_cull_rect, dl_matrix);
-
-  EXPECT_TRUE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_4x4(), m44);
-  EXPECT_EQ(state1.matrix(), dl_matrix);
-
-  EXPECT_TRUE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_4x4(), m44);
-  EXPECT_EQ(state2.matrix(), dl_matrix);
+  EXPECT_FALSE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), matrix);
 }
 
 TEST(DisplayListMatrixClipState, TransformTo4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   // clang-format off
-  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
-                          0, 4, 0.5, 0,
-                          0, 0, 4.0, 0,
-                          0, 0, 0.0, 1);
-  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
-                                               0, 4, 0.5, 0,
-                                               0, 0, 4.0, 0,
-                                               0, 0, 0.0, 1);
+  const DlMatrix matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                            0, 4, 0.5, 0,
+                                            0, 0, 4.0, 0,
+                                            0, 0, 0.0, 1);
   // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
+  const DlRect local_cull_rect = DlRect::MakeLTRB(5, 10, 15, 20);
 
-  DisplayListMatrixClipState state1(cull_rect, SkMatrix::I());
-  DisplayListMatrixClipState state2(dl_cull_rect, DlMatrix());
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_FALSE(state2.using_4x4_matrix());
+  DisplayListMatrixClipState state(cull_rect, DlMatrix());
+  EXPECT_FALSE(state.using_4x4_matrix());
 
-  state1.transform(m44);
-  EXPECT_TRUE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_4x4(), m44);
-  EXPECT_EQ(state1.matrix(), dl_matrix);
-
-  state2.transform(dl_matrix);
-  EXPECT_TRUE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_4x4(), m44);
-  EXPECT_EQ(state2.matrix(), dl_matrix);
+  state.transform(matrix);
+  EXPECT_TRUE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), matrix);
 }
 
 TEST(DisplayListMatrixClipState, SetTo4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   // clang-format off
-  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
-                          0, 4, 0.5, 0,
-                          0, 0, 4.0, 0,
-                          0, 0, 0.0, 1);
-  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
-                                               0, 4, 0.5, 0,
-                                               0, 0, 4.0, 0,
-                                               0, 0, 0.0, 1);
+  const DlMatrix matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                            0, 4, 0.5, 0,
+                                            0, 0, 4.0, 0,
+                                            0, 0, 0.0, 1);
   // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
+  const DlRect local_cull_rect = DlRect::MakeLTRB(5, 10, 15, 20);
 
-  DisplayListMatrixClipState state1(cull_rect, SkMatrix::I());
-  DisplayListMatrixClipState state2(dl_cull_rect, DlMatrix());
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_FALSE(state2.using_4x4_matrix());
+  DisplayListMatrixClipState state(cull_rect, DlMatrix());
+  EXPECT_FALSE(state.using_4x4_matrix());
 
-  state1.setTransform(m44);
-  EXPECT_TRUE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_4x4(), m44);
-  EXPECT_EQ(state1.matrix(), dl_matrix);
-
-  state2.setTransform(dl_matrix);
-  EXPECT_TRUE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_4x4(), m44);
-  EXPECT_EQ(state2.matrix(), dl_matrix);
+  state.setTransform(matrix);
+  EXPECT_TRUE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), matrix);
 }
 
 TEST(DisplayListMatrixClipState, Translate) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
-  const SkMatrix translated_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::Translate(5, 1));
-  const SkM44 translated_m44 = SkM44(translated_matrix);
-  const DlMatrix dl_translated_matrix =
-      dl_matrix * DlMatrix::MakeTranslation({5.0, 1.0});
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 9, 10, 19);
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlMatrix matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
+  const DlMatrix translated_matrix =
+      matrix * DlMatrix::MakeTranslation({5.0, 1.0});
+  const DlRect local_cull_rect = DlRect::MakeLTRB(0, 9, 10, 19);
 
-  DisplayListMatrixClipState state1(cull_rect, matrix);
-  DisplayListMatrixClipState state2(cull_rect, m44);
-  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
-  state1.translate(5, 1);
-  state2.translate(5, 1);
-  state3.translate(5, 1);
+  DisplayListMatrixClipState state(cull_rect, matrix);
+  state.translate(5, 1);
 
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_3x3(), translated_matrix);
-  EXPECT_EQ(state1.matrix_4x4(), translated_m44);
-  EXPECT_EQ(state1.matrix(), dl_translated_matrix);
-
-  EXPECT_FALSE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_3x3(), translated_matrix);
-  EXPECT_EQ(state2.matrix_4x4(), translated_m44);
-  EXPECT_EQ(state2.matrix(), dl_translated_matrix);
-
-  EXPECT_FALSE(state3.using_4x4_matrix());
-  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state3.matrix_3x3(), translated_matrix);
-  EXPECT_EQ(state3.matrix_4x4(), translated_m44);
-  EXPECT_EQ(state3.matrix(), dl_translated_matrix);
+  EXPECT_FALSE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), translated_matrix);
 }
 
 TEST(DisplayListMatrixClipState, Scale) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlMatrix matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
   // Scale factor carefully chosen to multiply cleanly and invert
   // without any non-binary-power-of-2 approximation errors.
-  const SkMatrix scaled_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::Scale(0.5, 2));
-  const SkM44 scaled_m44 = SkM44(scaled_matrix);
-  const DlMatrix scaled_dl_matrix = dl_matrix.Scale({0.5, 2, 1});
-  const SkRect local_cull_rect = SkRect::MakeLTRB(10, 5, 30, 10);
+  const DlMatrix scaled_matrix = matrix.Scale({0.5, 2, 1});
+  const DlRect local_cull_rect = DlRect::MakeLTRB(10, 5, 30, 10);
 
-  DisplayListMatrixClipState state1(cull_rect, matrix);
-  DisplayListMatrixClipState state2(cull_rect, m44);
-  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
-  state1.scale(0.5, 2);
-  state2.scale(0.5, 2);
-  state3.scale(0.5, 2);
+  DisplayListMatrixClipState state(cull_rect, matrix);
+  state.scale(0.5, 2);
 
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_3x3(), scaled_matrix);
-  EXPECT_EQ(state1.matrix_4x4(), scaled_m44);
-  EXPECT_EQ(state1.matrix(), scaled_dl_matrix);
-
-  EXPECT_FALSE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_3x3(), scaled_matrix);
-  EXPECT_EQ(state2.matrix_4x4(), scaled_m44);
-  EXPECT_EQ(state2.matrix(), scaled_dl_matrix);
-
-  EXPECT_FALSE(state3.using_4x4_matrix());
-  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state3.matrix_3x3(), scaled_matrix);
-  EXPECT_EQ(state3.matrix_4x4(), scaled_m44);
-  EXPECT_EQ(state3.matrix(), scaled_dl_matrix);
+  EXPECT_FALSE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), scaled_matrix);
 }
 
 TEST(DisplayListMatrixClipState, Skew) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
-  const SkMatrix skewed_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::Skew(.25, 0));
-  const SkM44 skewed_m44 = SkM44(skewed_matrix);
-  const DlMatrix skewed_dl_matrix = dl_matrix * DlMatrix::MakeSkew(0.25, 0);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 10, 12.5, 20);
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlMatrix matrix = DlMatrix::MakeScale({4, 4, 1});
+  const DlMatrix skewed_matrix = matrix * DlMatrix::MakeSkew(0.25, 0);
+  const DlRect local_cull_rect = DlRect::MakeLTRB(0, 10, 12.5, 20);
 
-  DisplayListMatrixClipState state1(cull_rect, matrix);
-  DisplayListMatrixClipState state2(cull_rect, m44);
-  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
-  state1.skew(.25, 0);
-  state2.skew(.25, 0);
-  state3.skew(.25, 0);
+  DisplayListMatrixClipState state(cull_rect, matrix);
+  state.skew(.25, 0);
 
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_3x3(), skewed_matrix);
-  EXPECT_EQ(state1.matrix_4x4(), skewed_m44);
-  EXPECT_EQ(state1.matrix(), skewed_dl_matrix);
-
-  EXPECT_FALSE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_3x3(), skewed_matrix);
-  EXPECT_EQ(state2.matrix_4x4(), skewed_m44);
-  EXPECT_EQ(state2.matrix(), skewed_dl_matrix);
-
-  EXPECT_FALSE(state3.using_4x4_matrix());
-  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state3.matrix_3x3(), skewed_matrix);
-  EXPECT_EQ(state3.matrix_4x4(), skewed_m44);
-  EXPECT_EQ(state3.matrix(), skewed_dl_matrix);
+  EXPECT_FALSE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), skewed_matrix);
 }
 
 TEST(DisplayListMatrixClipState, Rotate) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
-  const SkMatrix rotated_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::RotateDeg(90));
-  const SkM44 rotated_m44 = SkM44(rotated_matrix);
-  const DlMatrix rotated_dl_matrix =
-      dl_matrix * DlMatrix::MakeRotationZ(DlDegrees(90));
-  const SkRect local_cull_rect = SkRect::MakeLTRB(10, -15, 20, -5);
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlMatrix matrix = DlMatrix::MakeScale({4, 4, 1});
+  const DlMatrix rotated_matrix =
+      matrix * DlMatrix::MakeRotationZ(DlDegrees(90));
+  const DlRect local_cull_rect = DlRect::MakeLTRB(10, -15, 20, -5);
 
-  DisplayListMatrixClipState state1(cull_rect, matrix);
-  DisplayListMatrixClipState state2(cull_rect, m44);
-  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
-  state1.rotate(90);
-  state2.rotate(90);
-  state3.rotate(90);
+  DisplayListMatrixClipState state(cull_rect, matrix);
+  state.rotate(90);
 
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_3x3(), rotated_matrix);
-  EXPECT_EQ(state1.matrix_4x4(), rotated_m44);
-  EXPECT_EQ(state1.matrix(), rotated_dl_matrix);
-
-  EXPECT_FALSE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_3x3(), rotated_matrix);
-  EXPECT_EQ(state2.matrix_4x4(), rotated_m44);
-  EXPECT_EQ(state2.matrix(), rotated_dl_matrix);
-
-  EXPECT_FALSE(state3.using_4x4_matrix());
-  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state3.matrix_3x3(), rotated_matrix);
-  EXPECT_EQ(state3.matrix_4x4(), rotated_m44);
-  EXPECT_EQ(state3.matrix(), rotated_dl_matrix);
+  EXPECT_FALSE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), rotated_matrix);
 }
 
 TEST(DisplayListMatrixClipState, Transform2DAffine) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlMatrix matrix = DlMatrix::MakeScale({4, 4, 1});
 
-  const SkMatrix transformed_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::MakeAll(2, 0, 5,  //
-                                                 0, 2, 6,  //
-                                                 0, 0, 1));
-  const SkM44 transformed_m44 = SkM44(transformed_matrix);
-  const DlMatrix transformed_dl_matrix =
-      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 0,  //
-                                    0, 0, 0, 1);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
+  const DlMatrix transformed_matrix =         //
+      matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                 0, 2, 0, 6,  //
+                                 0, 0, 1, 0,  //
+                                 0, 0, 0, 1);
+  const DlRect local_cull_rect = DlRect::MakeLTRB(0, 2, 5, 7);
 
-  DisplayListMatrixClipState state1(cull_rect, matrix);
-  DisplayListMatrixClipState state2(cull_rect, m44);
-  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
-  state1.transform2DAffine(2, 0, 5,  //
-                           0, 2, 6);
-  state2.transform2DAffine(2, 0, 5,  //
-                           0, 2, 6);
-  state3.transform2DAffine(2, 0, 5,  //
-                           0, 2, 6);
+  DisplayListMatrixClipState state(cull_rect, matrix);
+  state.transform2DAffine(2, 0, 5,  //
+                          0, 2, 6);
 
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(state1.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state1.matrix(), transformed_dl_matrix);
-
-  EXPECT_FALSE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(state2.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state2.matrix(), transformed_dl_matrix);
-
-  EXPECT_FALSE(state3.using_4x4_matrix());
-  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state3.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(state3.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
+  EXPECT_FALSE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), transformed_matrix);
 }
 
 TEST(DisplayListMatrixClipState, TransformFullPerspectiveUsing3x3Matrix) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlMatrix matrix = DlMatrix::MakeScale({4, 4, 1});
 
-  const SkMatrix transformed_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::MakeAll(2, 0, 5,  //
-                                                 0, 2, 6,  //
-                                                 0, 0, 1));
-  const SkM44 transformed_m44 = SkM44(transformed_matrix);
-  const DlMatrix transformed_dl_matrix =
-      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 0,  //
-                                    0, 0, 0, 1);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
+  const DlMatrix transformed_matrix =         //
+      matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                 0, 2, 0, 6,  //
+                                 0, 0, 1, 0,  //
+                                 0, 0, 0, 1);
+  const DlRect local_cull_rect = DlRect::MakeLTRB(0, 2, 5, 7);
 
-  DisplayListMatrixClipState state1(cull_rect, matrix);
-  DisplayListMatrixClipState state2(cull_rect, m44);
-  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
-  state1.transformFullPerspective(2, 0, 0, 5,  //
-                                  0, 2, 0, 6,  //
-                                  0, 0, 1, 0,  //
-                                  0, 0, 0, 1);
-  state2.transformFullPerspective(2, 0, 0, 5,  //
-                                  0, 2, 0, 6,  //
-                                  0, 0, 1, 0,  //
-                                  0, 0, 0, 1);
-  state3.transformFullPerspective(2, 0, 0, 5,  //
-                                  0, 2, 0, 6,  //
-                                  0, 0, 1, 0,  //
-                                  0, 0, 0, 1);
+  DisplayListMatrixClipState state(cull_rect, matrix);
+  state.transformFullPerspective(2, 0, 0, 5,  //
+                                 0, 2, 0, 6,  //
+                                 0, 0, 1, 0,  //
+                                 0, 0, 0, 1);
 
-  EXPECT_FALSE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(state1.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state1.matrix(), transformed_dl_matrix);
-
-  EXPECT_FALSE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(state2.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state2.matrix(), transformed_dl_matrix);
-
-  EXPECT_FALSE(state3.using_4x4_matrix());
-  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state3.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(state3.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
+  EXPECT_FALSE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), transformed_matrix);
 }
 
 TEST(DisplayListMatrixClipState, TransformFullPerspectiveUsing4x4Matrix) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
+  const DlRect cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const DlMatrix matrix = DlMatrix::MakeScale({4, 4, 1});
 
-  const SkM44 transformed_m44 = SkM44(m44, SkM44(2, 0, 0, 5,  //
-                                                 0, 2, 0, 6,  //
-                                                 0, 0, 1, 7,  //
-                                                 0, 0, 0, 1));
-  const DlMatrix transformed_dl_matrix =
-      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 7,  //
-                                    0, 0, 0, 1);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
+  const DlMatrix transformed_matrix =         //
+      matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                 0, 2, 0, 6,  //
+                                 0, 0, 1, 7,  //
+                                 0, 0, 0, 1);
+  const DlRect local_cull_rect = DlRect::MakeLTRB(0, 2, 5, 7);
 
-  DisplayListMatrixClipState state1(cull_rect, matrix);
-  DisplayListMatrixClipState state2(cull_rect, m44);
-  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
-  state1.transformFullPerspective(2, 0, 0, 5,  //
-                                  0, 2, 0, 6,  //
-                                  0, 0, 1, 7,  //
-                                  0, 0, 0, 1);
-  state2.transformFullPerspective(2, 0, 0, 5,  //
-                                  0, 2, 0, 6,  //
-                                  0, 0, 1, 7,  //
-                                  0, 0, 0, 1);
-  state3.transformFullPerspective(2, 0, 0, 5,  //
-                                  0, 2, 0, 6,  //
-                                  0, 0, 1, 7,  //
-                                  0, 0, 0, 1);
+  DisplayListMatrixClipState state(cull_rect, matrix);
+  state.transformFullPerspective(2, 0, 0, 5,  //
+                                 0, 2, 0, 6,  //
+                                 0, 0, 1, 7,  //
+                                 0, 0, 0, 1);
 
-  EXPECT_TRUE(state1.using_4x4_matrix());
-  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state1.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state1.matrix(), transformed_dl_matrix);
-
-  EXPECT_TRUE(state2.using_4x4_matrix());
-  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state2.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state2.matrix(), transformed_dl_matrix);
-
-  EXPECT_TRUE(state3.using_4x4_matrix());
-  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(state3.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
+  EXPECT_TRUE(state.using_4x4_matrix());
+  EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect);
+  EXPECT_EQ(state.GetLocalCullCoverage(), local_cull_rect);
+  EXPECT_EQ(state.matrix(), transformed_matrix);
 }
 
 TEST(DisplayListMatrixClipState, ClipDifference) {
-  SkRect cull_rect = SkRect::MakeLTRB(20, 20, 40, 40);
+  DlRect cull_rect = DlRect::MakeLTRB(20, 20, 40, 40);
 
-  auto non_reducing = [&cull_rect](const SkRect& diff_rect,
+  auto non_reducing = [&cull_rect](const DlRect& diff_rect,
                                    const std::string& label) {
     {
-      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+      DisplayListMatrixClipState state(cull_rect, DlMatrix());
       state.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(state.device_cull_rect(), cull_rect) << label;
+      EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect) << label;
     }
     {
-      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
-      const SkRRect diff_rrect = SkRRect::MakeRect(diff_rect);
+      DisplayListMatrixClipState state(cull_rect, DlMatrix());
+      const DlRoundRect diff_rrect = DlRoundRect::MakeRect(diff_rect);
       state.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(state.device_cull_rect(), cull_rect) << label << " (RRect)";
+      EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect)
+          << label << " (RRect)";
     }
     {
-      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
-      const SkPath diff_path = SkPath().addRect(diff_rect);
+      DisplayListMatrixClipState state(cull_rect, DlMatrix());
+      const DlPath diff_path = DlPath::MakeRect(diff_rect);
       state.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(state.device_cull_rect(), cull_rect) << label << " (RRect)";
+      EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect)
+          << label << " (RRect)";
     }
   };
 
-  auto reducing = [&cull_rect](const SkRect& diff_rect,
-                               const SkRect& result_rect,
+  auto reducing = [&cull_rect](const DlRect& diff_rect,
+                               const DlRect& result_rect,
                                const std::string& label) {
-    EXPECT_TRUE(result_rect.isEmpty() || cull_rect.contains(result_rect));
+    EXPECT_TRUE(result_rect.IsEmpty() || cull_rect.Contains(result_rect));
     {
-      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+      DisplayListMatrixClipState state(cull_rect, DlMatrix());
       state.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(state.device_cull_rect(), result_rect) << label;
+      EXPECT_EQ(state.GetDeviceCullCoverage(), result_rect) << label;
     }
     {
-      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
-      const SkRRect diff_rrect = SkRRect::MakeRect(diff_rect);
+      DisplayListMatrixClipState state(cull_rect, DlMatrix());
+      const DlRoundRect diff_rrect = DlRoundRect::MakeRect(diff_rect);
       state.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(state.device_cull_rect(), result_rect) << label << " (RRect)";
+      EXPECT_EQ(state.GetDeviceCullCoverage(), result_rect)
+          << label << " (RRect)";
     }
     {
-      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
-      const SkPath diff_path = SkPath().addRect(diff_rect);
+      DisplayListMatrixClipState state(cull_rect, DlMatrix());
+      const DlPath diff_path = DlPath::MakeRect(diff_rect);
       state.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(state.device_cull_rect(), result_rect) << label << " (RRect)";
+      EXPECT_EQ(state.GetDeviceCullCoverage(), result_rect)
+          << label << " (RRect)";
     }
   };
 
   // Skim the corners and edge
-  non_reducing(SkRect::MakeLTRB(10, 10, 20, 20), "outside UL corner");
-  non_reducing(SkRect::MakeLTRB(20, 10, 40, 20), "Above");
-  non_reducing(SkRect::MakeLTRB(40, 10, 50, 20), "outside UR corner");
-  non_reducing(SkRect::MakeLTRB(40, 20, 50, 40), "Right");
-  non_reducing(SkRect::MakeLTRB(40, 40, 50, 50), "outside LR corner");
-  non_reducing(SkRect::MakeLTRB(20, 40, 40, 50), "Below");
-  non_reducing(SkRect::MakeLTRB(10, 40, 20, 50), "outside LR corner");
-  non_reducing(SkRect::MakeLTRB(10, 20, 20, 40), "Left");
+  non_reducing(DlRect::MakeLTRB(10, 10, 20, 20), "outside UL corner");
+  non_reducing(DlRect::MakeLTRB(20, 10, 40, 20), "Above");
+  non_reducing(DlRect::MakeLTRB(40, 10, 50, 20), "outside UR corner");
+  non_reducing(DlRect::MakeLTRB(40, 20, 50, 40), "Right");
+  non_reducing(DlRect::MakeLTRB(40, 40, 50, 50), "outside LR corner");
+  non_reducing(DlRect::MakeLTRB(20, 40, 40, 50), "Below");
+  non_reducing(DlRect::MakeLTRB(10, 40, 20, 50), "outside LR corner");
+  non_reducing(DlRect::MakeLTRB(10, 20, 20, 40), "Left");
 
   // Overlap corners
-  non_reducing(SkRect::MakeLTRB(15, 15, 25, 25), "covering UL corner");
-  non_reducing(SkRect::MakeLTRB(35, 15, 45, 25), "covering UR corner");
-  non_reducing(SkRect::MakeLTRB(35, 35, 45, 45), "covering LR corner");
-  non_reducing(SkRect::MakeLTRB(15, 35, 25, 45), "covering LL corner");
+  non_reducing(DlRect::MakeLTRB(15, 15, 25, 25), "covering UL corner");
+  non_reducing(DlRect::MakeLTRB(35, 15, 45, 25), "covering UR corner");
+  non_reducing(DlRect::MakeLTRB(35, 35, 45, 45), "covering LR corner");
+  non_reducing(DlRect::MakeLTRB(15, 35, 25, 45), "covering LL corner");
 
   // Overlap edges, but not across an entire side
-  non_reducing(SkRect::MakeLTRB(20, 15, 39, 25), "Top edge left-biased");
-  non_reducing(SkRect::MakeLTRB(21, 15, 40, 25), "Top edge, right biased");
-  non_reducing(SkRect::MakeLTRB(35, 20, 45, 39), "Right edge, top-biased");
-  non_reducing(SkRect::MakeLTRB(35, 21, 45, 40), "Right edge, bottom-biased");
-  non_reducing(SkRect::MakeLTRB(20, 35, 39, 45), "Bottom edge, left-biased");
-  non_reducing(SkRect::MakeLTRB(21, 35, 40, 45), "Bottom edge, right-biased");
-  non_reducing(SkRect::MakeLTRB(15, 20, 25, 39), "Left edge, top-biased");
-  non_reducing(SkRect::MakeLTRB(15, 21, 25, 40), "Left edge, bottom-biased");
+  non_reducing(DlRect::MakeLTRB(20, 15, 39, 25), "Top edge left-biased");
+  non_reducing(DlRect::MakeLTRB(21, 15, 40, 25), "Top edge, right biased");
+  non_reducing(DlRect::MakeLTRB(35, 20, 45, 39), "Right edge, top-biased");
+  non_reducing(DlRect::MakeLTRB(35, 21, 45, 40), "Right edge, bottom-biased");
+  non_reducing(DlRect::MakeLTRB(20, 35, 39, 45), "Bottom edge, left-biased");
+  non_reducing(DlRect::MakeLTRB(21, 35, 40, 45), "Bottom edge, right-biased");
+  non_reducing(DlRect::MakeLTRB(15, 20, 25, 39), "Left edge, top-biased");
+  non_reducing(DlRect::MakeLTRB(15, 21, 25, 40), "Left edge, bottom-biased");
 
   // Slice all the way through the middle
-  non_reducing(SkRect::MakeLTRB(25, 15, 35, 45), "Vertical interior slice");
-  non_reducing(SkRect::MakeLTRB(15, 25, 45, 35), "Horizontal interior slice");
+  non_reducing(DlRect::MakeLTRB(25, 15, 35, 45), "Vertical interior slice");
+  non_reducing(DlRect::MakeLTRB(15, 25, 45, 35), "Horizontal interior slice");
 
   // Slice off each edge
-  reducing(SkRect::MakeLTRB(20, 15, 40, 25),  //
-           SkRect::MakeLTRB(20, 25, 40, 40),  //
+  reducing(DlRect::MakeLTRB(20, 15, 40, 25),  //
+           DlRect::MakeLTRB(20, 25, 40, 40),  //
            "Slice off top");
-  reducing(SkRect::MakeLTRB(35, 20, 45, 40),  //
-           SkRect::MakeLTRB(20, 20, 35, 40),  //
+  reducing(DlRect::MakeLTRB(35, 20, 45, 40),  //
+           DlRect::MakeLTRB(20, 20, 35, 40),  //
            "Slice off right");
-  reducing(SkRect::MakeLTRB(20, 35, 40, 45),  //
-           SkRect::MakeLTRB(20, 20, 40, 35),  //
+  reducing(DlRect::MakeLTRB(20, 35, 40, 45),  //
+           DlRect::MakeLTRB(20, 20, 40, 35),  //
            "Slice off bottom");
-  reducing(SkRect::MakeLTRB(15, 20, 25, 40),  //
-           SkRect::MakeLTRB(25, 20, 40, 40),  //
+  reducing(DlRect::MakeLTRB(15, 20, 25, 40),  //
+           DlRect::MakeLTRB(25, 20, 40, 40),  //
            "Slice off left");
 
   // cull rect contains diff rect
-  non_reducing(SkRect::MakeLTRB(21, 21, 39, 39), "Contained, non-covering");
+  non_reducing(DlRect::MakeLTRB(21, 21, 39, 39), "Contained, non-covering");
 
-  // cull rect equals diff rect
-  reducing(cull_rect, SkRect::MakeEmpty(), "Perfectly covering");
+  // cull rect equals diff rect results in empty
+  reducing(cull_rect, DlRect(), "Perfectly covering");
 
-  // diff rect contains cull rect
-  reducing(SkRect::MakeLTRB(15, 15, 45, 45), SkRect::MakeEmpty(), "Smothering");
+  // diff rect contains cull rect results in empty
+  reducing(DlRect::MakeLTRB(15, 15, 45, 45), DlRect(), "Smothering");
 }
 
 TEST(DisplayListMatrixClipState, MapAndClipRectTranslation) {
@@ -581,79 +305,79 @@ TEST(DisplayListMatrixClipState, MapAndClipRectTranslation) {
 
   {
     // Empty width in src rect (before and after translation)
-    SkRect rect = SkRect::MakeLTRB(150.0f, 150.0f, 150.0f, 160.0f);
+    DlRect rect = DlRect::MakeLTRB(150.0f, 150.0f, 150.0f, 160.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Empty height in src rect (before and after translation)
-    SkRect rect = SkRect::MakeLTRB(150.0f, 150.0f, 160.0f, 150.0f);
+    DlRect rect = DlRect::MakeLTRB(150.0f, 150.0f, 160.0f, 150.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // rect far outside of clip, even after translation
-    SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+    DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect abuts clip left side after translation
-    SkRect rect = SkRect::MakeLTRB(80.0f, 100.0f, 90.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(80.0f, 100.0f, 90.0f, 110.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect barely grazes clip left side after translation
-    SkRect rect = SkRect::MakeLTRB(80.0f, 100.0f, 91.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(80.0f, 100.0f, 91.0f, 110.0f);
     EXPECT_TRUE(state.mapAndClipRect(&rect));
-    EXPECT_EQ(rect, SkRect::MakeLTRB(100.0f, 120.0f, 101.0f, 130.0f));
+    EXPECT_EQ(rect, DlRect::MakeLTRB(100.0f, 120.0f, 101.0f, 130.0f));
   }
 
   {
     // Rect abuts clip top after translation
-    SkRect rect = SkRect::MakeLTRB(100.0f, 70.0f, 110.0f, 80.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 70.0f, 110.0f, 80.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect barely grazes clip top after translation
-    SkRect rect = SkRect::MakeLTRB(100.0f, 70.0f, 110.0f, 81.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 70.0f, 110.0f, 81.0f);
     EXPECT_TRUE(state.mapAndClipRect(&rect));
-    EXPECT_EQ(rect, SkRect::MakeLTRB(110.0f, 100.0f, 120.0f, 101.0f));
+    EXPECT_EQ(rect, DlRect::MakeLTRB(110.0f, 100.0f, 120.0f, 101.0f));
   }
 
   {
     // Rect abuts clip right side after translation
-    SkRect rect = SkRect::MakeLTRB(190.0f, 100.0f, 200.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(190.0f, 100.0f, 200.0f, 110.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect barely grazes clip right side after translation
-    SkRect rect = SkRect::MakeLTRB(189.0f, 100.0f, 200.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(189.0f, 100.0f, 200.0f, 110.0f);
     EXPECT_TRUE(state.mapAndClipRect(&rect));
-    EXPECT_EQ(rect, SkRect::MakeLTRB(199.0f, 120.0f, 200.0f, 130.0f));
+    EXPECT_EQ(rect, DlRect::MakeLTRB(199.0f, 120.0f, 200.0f, 130.0f));
   }
 
   {
     // Rect abuts clip bottom after translation
-    SkRect rect = SkRect::MakeLTRB(100.0f, 180.0f, 110.0f, 190.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 180.0f, 110.0f, 190.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect barely grazes clip bottom after translation
-    SkRect rect = SkRect::MakeLTRB(100.0f, 179.0f, 110.0f, 190.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 179.0f, 110.0f, 190.0f);
     EXPECT_TRUE(state.mapAndClipRect(&rect));
-    EXPECT_EQ(rect, SkRect::MakeLTRB(110.0f, 199.0f, 120.0f, 200.0f));
+    EXPECT_EQ(rect, DlRect::MakeLTRB(110.0f, 199.0f, 120.0f, 200.0f));
   }
 }
 
@@ -664,79 +388,79 @@ TEST(DisplayListMatrixClipState, MapAndClipRectScale) {
 
   {
     // Empty width in src rect (before and after scaling)
-    SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 100.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 100.0f, 110.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Empty height in src rect (before and after scaling)
-    SkRect rect = SkRect::MakeLTRB(100.0f, 100.0f, 110.0f, 100.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 100.0f, 110.0f, 100.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // rect far outside of clip, even after scaling
-    SkRect rect = SkRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
+    DlRect rect = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect abuts clip left side after scaling
-    SkRect rect = SkRect::MakeLTRB(40.0f, 100.0f, 50.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(40.0f, 100.0f, 50.0f, 110.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect barely grazes clip left side after scaling
-    SkRect rect = SkRect::MakeLTRB(40.0f, 100.0f, 51.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(40.0f, 100.0f, 51.0f, 110.0f);
     EXPECT_TRUE(state.mapAndClipRect(&rect));
-    EXPECT_EQ(rect, SkRect::MakeLTRB(100.0f, 400.0f, 102.0f, 440.0f));
+    EXPECT_EQ(rect, DlRect::MakeLTRB(100.0f, 400.0f, 102.0f, 440.0f));
   }
 
   {
     // Rect abuts clip top after scaling
-    SkRect rect = SkRect::MakeLTRB(100.0f, 15.0f, 110.0f, 25.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 15.0f, 110.0f, 25.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect barely grazes clip top after scaling
-    SkRect rect = SkRect::MakeLTRB(100.0f, 15.0f, 110.0f, 26.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 15.0f, 110.0f, 26.0f);
     EXPECT_TRUE(state.mapAndClipRect(&rect));
-    EXPECT_EQ(rect, SkRect::MakeLTRB(200.0f, 100.0f, 220.0f, 104.0f));
+    EXPECT_EQ(rect, DlRect::MakeLTRB(200.0f, 100.0f, 220.0f, 104.0f));
   }
 
   {
     // Rect abuts clip right side after scaling
-    SkRect rect = SkRect::MakeLTRB(250.0f, 100.0f, 260.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(250.0f, 100.0f, 260.0f, 110.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect barely grazes clip right side after scaling
-    SkRect rect = SkRect::MakeLTRB(249.0f, 100.0f, 260.0f, 110.0f);
+    DlRect rect = DlRect::MakeLTRB(249.0f, 100.0f, 260.0f, 110.0f);
     EXPECT_TRUE(state.mapAndClipRect(&rect));
-    EXPECT_EQ(rect, SkRect::MakeLTRB(498.0f, 400.0f, 500.0f, 440.0f));
+    EXPECT_EQ(rect, DlRect::MakeLTRB(498.0f, 400.0f, 500.0f, 440.0f));
   }
 
   {
     // Rect abuts clip bottom after scaling
-    SkRect rect = SkRect::MakeLTRB(100.0f, 125.0f, 110.0f, 135.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 125.0f, 110.0f, 135.0f);
     EXPECT_FALSE(state.mapAndClipRect(&rect));
-    EXPECT_TRUE(rect.isEmpty());
+    EXPECT_TRUE(rect.IsEmpty());
   }
 
   {
     // Rect barely grazes clip bottom after scaling
-    SkRect rect = SkRect::MakeLTRB(100.0f, 124.0f, 110.0f, 135.0f);
+    DlRect rect = DlRect::MakeLTRB(100.0f, 124.0f, 110.0f, 135.0f);
     EXPECT_TRUE(state.mapAndClipRect(&rect));
-    EXPECT_EQ(rect, SkRect::MakeLTRB(200.0f, 496.0f, 220.0f, 500.0f));
+    EXPECT_EQ(rect, DlRect::MakeLTRB(200.0f, 496.0f, 220.0f, 500.0f));
   }
 }
 
@@ -811,21 +535,21 @@ TEST(DisplayListMatrixClipState, RectCoverageUnderRotation) {
     state.rotate(i);
     EXPECT_TRUE(state.rect_covers_cull(test_true))
         << "  testing " << test_true << std::endl
-        << "    contains " << state.local_cull_rect() << std::endl
+        << "    contains " << state.GetLocalCullCoverage() << std::endl
         << "    at " << i << " degrees";
     if ((i % 90) == 45) {
       // The cull rect is largest when viewed at multiples of 45
       // degrees so we will fail to contain it at those angles
       EXPECT_FALSE(state.rect_covers_cull(test_false))
           << "  testing " << test_false << std::endl
-          << "    contains " << state.local_cull_rect() << std::endl
+          << "    contains " << state.GetLocalCullCoverage() << std::endl
           << "    at " << i << " degrees";
     } else {
       // At other angles, the cull rect is not quite so big as to encroach
       // upon the expanded test rectangle.
       EXPECT_TRUE(state.rect_covers_cull(test_false))
           << "  testing " << test_false << std::endl
-          << "    contains " << state.local_cull_rect() << std::endl
+          << "    contains " << state.GetLocalCullCoverage() << std::endl
           << "    at " << i << " degrees";
     }
   }
@@ -890,29 +614,31 @@ TEST(DisplayListMatrixClipState, OvalCoverageUnderRotation) {
     state.rotate(i);
     EXPECT_TRUE(state.oval_covers_cull(test_true))
         << "  testing " << test_true << std::endl
-        << "    contains " << state.local_cull_rect() << std::endl
+        << "    contains " << state.GetLocalCullCoverage() << std::endl
         << "    at " << i << " degrees";
     EXPECT_FALSE(state.oval_covers_cull(test_false))
         << "  testing " << test_false << std::endl
-        << "    contains " << state.local_cull_rect() << std::endl
+        << "    contains " << state.GetLocalCullCoverage() << std::endl
         << "    at " << i << " degrees";
   }
 }
 
 TEST(DisplayListMatrixClipState, RRectCoverage) {
-  SkRect cull = SkRect::MakeLTRB(-50.0f, -50.0f, 50.0f, 50.0f);
+  DlRect cull = DlRect::MakeLTRB(-50.0f, -50.0f, 50.0f, 50.0f);
   DisplayListMatrixClipState state(cull);
   // test_bounds need to contain
-  SkRect test = cull.makeOutset(2.0f, 2.0f);
+  DlRect test = cull.Expand(2.0f, 2.0f);
 
   // RRect of cull with no corners covers
-  EXPECT_TRUE(state.rrect_covers_cull(SkRRect::MakeRectXY(cull, 0.0f, 0.0f)));
+  EXPECT_TRUE(
+      state.rrect_covers_cull(DlRoundRect::MakeRectXY(cull, 0.0f, 0.0f)));
   // RRect of cull with even the tiniest corners does not cover
   EXPECT_FALSE(
-      state.rrect_covers_cull(SkRRect::MakeRectXY(cull, 0.01f, 0.01f)));
+      state.rrect_covers_cull(DlRoundRect::MakeRectXY(cull, 0.01f, 0.01f)));
 
   // Expanded by 2.0 and then with a corner of 2.0 obviously still covers
-  EXPECT_TRUE(state.rrect_covers_cull(SkRRect::MakeRectXY(test, 2.0f, 2.0f)));
+  EXPECT_TRUE(
+      state.rrect_covers_cull(DlRoundRect::MakeRectXY(test, 2.0f, 2.0f)));
   // The corner point of the cull rect is at (c-2, c-2) relative to the
   // corner of the rrect bounds so we compute its distance to the center
   // of the circular part and compare it to the radius of the corner (c)
@@ -935,10 +661,11 @@ TEST(DisplayListMatrixClipState, RRectCoverage) {
   // c > 8 +/- sqrt(64 - 32) / 2
   // c > ~6.828
   // corners set to 6.82 should still cover the cull rect
-  EXPECT_TRUE(state.rrect_covers_cull(SkRRect::MakeRectXY(test, 6.82f, 6.82f)));
+  EXPECT_TRUE(
+      state.rrect_covers_cull(DlRoundRect::MakeRectXY(test, 6.82f, 6.82f)));
   // but corners set to 6.83 should not cover the cull rect
   EXPECT_FALSE(
-      state.rrect_covers_cull(SkRRect::MakeRectXY(test, 6.84f, 6.84f)));
+      state.rrect_covers_cull(DlRoundRect::MakeRectXY(test, 6.84f, 6.84f)));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/flow/diff_context.cc
+++ b/engine/src/flutter/flow/diff_context.cc
@@ -144,7 +144,7 @@ DlRect DiffContext::MapRect(const DlRect& rect) {
 
 bool DiffContext::PushCullRect(const DlRect& clip) {
   state_.matrix_clip.clipRect(clip, DlCanvas::ClipOp::kIntersect, false);
-  return !state_.matrix_clip.device_cull_rect().isEmpty();
+  return !state_.matrix_clip.is_cull_rect_empty();
 }
 
 const DlMatrix& DiffContext::GetMatrix() const {


### PR DESCRIPTION
Accomplishes the `AccumulationRect and MatrixClipTracker` task in https://github.com/flutter/flutter/issues/161456

Remove legacy Skia geometry APIs from the DisplayList utils classes (accumulation rect and matrix/clip state tracker) as well as the small number of remaining uses of them (mostly from their own unit tests).