### PR TITLE
Fix `showLicensePage` does not inherit ambient `Theme`

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -301,14 +301,20 @@ void showLicensePage({
   String? applicationLegalese,
   bool useRootNavigator = false,
 }) {
+  final CapturedThemes themes = InheritedTheme.capture(
+    from: context,
+    to: Navigator.of(context, rootNavigator: useRootNavigator).context,
+  );
   Navigator.of(context, rootNavigator: useRootNavigator).push(
     MaterialPageRoute<void>(
       builder:
-          (BuildContext context) => LicensePage(
-            applicationName: applicationName,
-            applicationVersion: applicationVersion,
-            applicationIcon: applicationIcon,
-            applicationLegalese: applicationLegalese,
+          (BuildContext context) => themes.wrap(
+            LicensePage(
+              applicationName: applicationName,
+              applicationVersion: applicationVersion,
+              applicationIcon: applicationIcon,
+              applicationLegalese: applicationLegalese,
+            ),
           ),
     ),
   );

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -1851,6 +1851,43 @@ void main() {
       expect(find.byType(AlertDialog), findsNothing);
     }
   });
+
+  testWidgets('showLicensePage inherits ambient Theme', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(
+      colorScheme: ColorScheme.fromSeed(seedColor: const Color(0XFFFF0000)),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Theme(
+          data: theme,
+          child: Builder(
+            builder:
+                (BuildContext context) => ElevatedButton(
+                  onPressed: () {
+                    showAboutDialog(
+                      context: context,
+                      applicationName: 'Sample Test',
+                      applicationVersion: 'v1.0.0', // Version of the app
+                    );
+                  },
+                  child: const Text('Show About Dialog'),
+                ),
+          ),
+        ),
+      ),
+    );
+
+    // Open the dialog.
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('View licenses'));
+    await tester.pumpAndSettle();
+
+    final ThemeData licensePageTheme = Theme.of(tester.element(find.text('Powered by Flutter')));
+    expect(theme.colorScheme.primary, licensePageTheme.colorScheme.primary);
+  });
 }
 
 class FakeLicenseEntry extends LicenseEntry {


### PR DESCRIPTION
Fixes [License page colors cannot be changed when wrapped with `Theme` widget](https://github.com/flutter/flutter/issues/44922)

### Code Sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Scaffold(
        appBar: AppBar(
          title: const Text('Sample'),
        ),
        body: Center(
          child: Theme(
            data: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.green)),
            child: Column(
              spacing: 20,
              mainAxisAlignment: MainAxisAlignment.center,
              children: <Widget>[
                const AboutListTile(
                  icon: Icon(Icons.info_rounded),
                  applicationIcon: Icon(Icons.info_outline), // Icon for the about dialog
                  applicationName: 'Sample Flutter App', // Name of the app
                  applicationVersion: 'v1.0.0', // Version of the app
                  applicationLegalese: '© 2025 Taha Tesser', // Legal information
                  aboutBoxChildren: <Widget>[
                    Padding(
                      padding: EdgeInsets.only(top: 10),
                      child: Text(
                        'This app is a demonstration of the AboutListTile widget in Flutter.',
                      ),
                    ),
                    Padding(
                      padding: EdgeInsets.only(top: 10),
                      child: Text(
                        'Thank you for using our app!',
                      ),
                    ),
                  ], // Icon for the leading section
                  child: Text('AboutListTile'),
                ),
                Builder(builder: (BuildContext context) {
                  return ElevatedButton(
                      onPressed: () {
                        showAboutDialog(
                          context: context,
                          applicationName: 'Sample Flutter App', // Name of the app
                          applicationVersion: 'v1.0.0', // Version of the app
                          applicationLegalese: '© 2025 Taha Tesser', // Legal information
                          children: <Widget>[
                            const Padding(
                              padding: EdgeInsets.only(top: 10),
                              child: Text(
                                'This app is a demonstration of the AboutListTile widget in Flutter.',
                              ),
                            ),
                            const Padding(
                              padding: EdgeInsets.only(top: 10),
                              child: Text(
                                'Thank you for using our app!',
                              ),
                            ),
                          ],
                        );
                      },
                      child: const Text('showAboutDialog'));
                })
              ],
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>

### Before

https://github.com/user-attachments/assets/a76d19b6-a949-42a1-a349-426ad3058bc6

### After

https://github.com/user-attachments/assets/afb8b519-860e-467f-89bd-6e0a1b7be45c

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
