### PR TITLE
Enable duplicate `linux_host_engine_test`.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -321,8 +321,6 @@ targets:
 
   - name: Linux linux_host_engine_test
     recipe: engine_v2/engine_v2
-    # TODO(matanlurey): https://github.com/flutter/flutter/issues/161406.
-    bringup: true
     timeout: 120
     properties:
       config_name: linux_host_engine_test

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -30,7 +30,8 @@
                 "config": "ci/host_debug_test",
                 "targets": [
                     "flutter:unittests",
-                    "flutter/build/dart:copy_dart_sdk"
+                    "flutter/build/dart:copy_dart_sdk",
+                    "flutter/shell/testing"
                 ]
             },
             "tests": [
@@ -75,9 +76,24 @@
                 "config": "ci/host_profile_test",
                 "targets": [
                     "flutter:unittests",
-                    "flutter/build/dart:copy_dart_sdk"
+                    "flutter/build/dart:copy_dart_sdk",
+                    "flutter/shell/testing"
                 ]
-            }
+            },
+             "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_profile",
+                    "script": "flutter/testing/run_tests.py",
+                    "parameters": [
+                        "--variant",
+                        "ci/host_profile",
+                        "--type",
+                        "dart,dart-host,engine",
+                        "--engine-capture-core-dump"
+                    ]
+                }
+            ]
         },
         {
             "drone_dimensions": [
@@ -120,6 +136,7 @@
                     "flutter/impeller/geometry:geometry_benchmarks",
                     "flutter/lib/ui:ui_benchmarks",
                     "flutter/shell/common:shell_benchmarks",
+                    "flutter/shell/testing",
                     "flutter/third_party/txt:txt_benchmarks"
                 ]
             },

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -30,7 +30,7 @@
                 "config": "ci/host_debug_test",
                 "targets": [
                     "flutter:unittests",
-                    "flutter/build/archives:flutter_patched_sdk"
+                    "flutter/build/dart:copy_dart_sdk"
                 ]
             },
             "tests": [
@@ -75,7 +75,7 @@
                 "config": "ci/host_profile_test",
                 "targets": [
                     "flutter:unittests",
-                    "flutter/build/archives:flutter_patched_sdk"
+                    "flutter/build/dart:copy_dart_sdk"
                 ]
             }
         },
@@ -111,7 +111,7 @@
                 "config": "ci/host_release_test",
                 "targets": [
                     "flutter:unittests",
-                    "flutter/build/archives:flutter_patched_sdk",
+                    "flutter/build/dart:copy_dart_sdk",
                     "flutter/display_list:display_list_benchmarks",
                     "flutter/display_list:display_list_builder_benchmarks",
                     "flutter/display_list:display_list_region_benchmarks",

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -75,7 +75,7 @@
                 "config": "ci/host_profile_test",
                 "targets": [
                     "flutter:unittests",
-                    "flutter/build/archives:flutter_patched_sdk",
+                    "flutter/build/archives:flutter_patched_sdk"
                 ]
             }
         },

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -31,7 +31,8 @@
                 "targets": [
                     "flutter:unittests",
                     "flutter/build/dart:copy_dart_sdk",
-                    "flutter/shell/testing"
+                    "flutter/shell/testing",
+                    "flutter/tools/path_ops"
                 ]
             },
             "tests": [
@@ -77,7 +78,8 @@
                 "targets": [
                     "flutter:unittests",
                     "flutter/build/dart:copy_dart_sdk",
-                    "flutter/shell/testing"
+                    "flutter/shell/testing",
+                    "flutter/tools/path_ops"
                 ]
             },
              "tests": [
@@ -137,6 +139,7 @@
                     "flutter/lib/ui:ui_benchmarks",
                     "flutter/shell/common:shell_benchmarks",
                     "flutter/shell/testing",
+                    "flutter/tools/path_ops",
                     "flutter/third_party/txt:txt_benchmarks"
                 ]
             },

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -89,7 +89,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "ci/host_profile",
+                        "ci/host_profile_test",
                         "--type",
                         "dart,dart-host,engine",
                         "--engine-capture-core-dump"

--- a/engine/src/flutter/ci/builders/linux_host_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_test.json
@@ -29,7 +29,8 @@
             "ninja": {
                 "config": "ci/host_debug_test",
                 "targets": [
-                    "flutter:unittests"
+                    "flutter:unittests",
+                    "flutter/build/archives:flutter_patched_sdk"
                 ]
             },
             "tests": [
@@ -73,7 +74,8 @@
             "ninja": {
                 "config": "ci/host_profile_test",
                 "targets": [
-                    "flutter:unittests"
+                    "flutter:unittests",
+                    "flutter/build/archives:flutter_patched_sdk",
                 ]
             }
         },


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/161406.

* Enables (on presubmit), and adds a missing GN target.
* Removes tests from the `linux_host_engine` build.