### PR TITLE
OverlayPortal declarative API.

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -1782,6 +1782,7 @@ class _OverlayPortalVisibilityCustom extends OverlayPortalVisibility {
     controller._isNeedsUpdate = false;
     return controller._zOrderIndex;
   }
+
   @override
   bool get _isNeedsUpdate => controller._isNeedsUpdate;
 }
@@ -1879,7 +1880,7 @@ class OverlayPortal extends StatefulWidget {
     this.child,
   }) : _targetRootOverlay = false,
        assert(
-         ((controller == null) != (visibility == null)),
+         (controller == null) != (visibility == null),
          'Either controller or visibility should be set, but not both.',
        );
 
@@ -1894,7 +1895,7 @@ class OverlayPortal extends StatefulWidget {
     this.child,
   }) : _targetRootOverlay = true,
        assert(
-         ((controller == null) != (visibility == null)),
+         (controller == null) != (visibility == null),
          'Either controller or visibility should be set, but not both.',
        );
 


### PR DESCRIPTION
Fixes: #161513 

This PR implements a way to create `OverlayPortal` using a declarative API without the need for `OverlayPortalController`. This allows for fully declarative control over showing and hiding overlay child.

```dart
class TestWidget extends StatefulWidget {
  final bool isShow;
  const TestWidget({
    required this.isShow,
    super.key,
  });

  @override
  State createState() => _TestWidgetState();
}

class _TestWidgetState extends State<TestWidget> {
  @override
  Widget build(BuildContext context) {
    return OverlayPortal(
      visibility: OverlayPortalVisibility.showWhen(widget.isShow),
      overlayChildBuilder: (context) {
        return Center(
          child: Container(
            width: 100,
            height: 100,
            color: Colors.red,
          ),
        );
      },
      child: const Placeholder(),
    );
  }
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
