### PR TITLE
Update two_dimensional_scrollables triage routing

### DIFF
--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -85,6 +85,7 @@ In general the flow chart for team assignment is as follows, stopping as soon as
 - If it's about the Flutter tool, add `team-tool`.
 - If it's about a first-party package:
   - If it's about `go_router` or `go_router_builder`, add `team-go_router`.
+  - If it's about `two_dimensional_scrollables`, add `team-framework`.
   - If it's about `flutter_svg` or `vector_graphics`, add `team-engine`.
   - Otherwise, add `team-ecosystem`.
 - If none of the above apply, add `will need additional triage`.


### PR DESCRIPTION
`two_dimensional_scrollables` is primarily owned by the framework team rather than the ecosystem team.