### PR TITLE
Do not block vertical drag gestures in CupertinoSheetRoute body

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -669,12 +669,10 @@ class _CupertinoDownGestureDetectorState<T> extends State<_CupertinoDownGestureD
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      fit: StackFit.passthrough,
-      children: <Widget>[
-        widget.child,
-        Listener(onPointerDown: _handlePointerDown, behavior: HitTestBehavior.translucent),
-      ],
+    return Listener(
+      onPointerDown: _handlePointerDown,
+      behavior: HitTestBehavior.translucent,
+      child: widget.child,
     );
   }
 }

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -895,7 +895,7 @@ void main() {
 
       await gesture.down(const Offset(100, 100));
 
-      // Need 2 events to form a valid drag
+      // Need 2 events to form a valid drag.
       await tester.pump(const Duration(milliseconds: 100));
       await gesture.moveTo(const Offset(100, 80), timeStamp: const Duration(milliseconds: 100));
       await tester.pump(const Duration(milliseconds: 200));
@@ -907,6 +907,9 @@ void main() {
 
       // Final position should be higher.
       expect(endPosition, lessThan(startPosition));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -844,5 +844,69 @@ void main() {
 
       expect(find.text('Page 1'), findsOneWidget);
     });
+
+    testWidgets('Sheet should not block nested scroll', (WidgetTester tester) async {
+      final GlobalKey homeKey = GlobalKey();
+
+      Widget sheetScaffoldContent(BuildContext context) {
+        return ListView(
+          children: const <Widget>[
+            Text('Top of Scroll'),
+            SizedBox(width: double.infinity, height: 100),
+            Text('Middle of Scroll'),
+            SizedBox(width: double.infinity, height: 100),
+          ],
+        );
+      }
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoPageScaffold(
+            key: homeKey,
+            child: Center(
+              child: Column(
+                children: <Widget>[
+                  const Text('Page 1'),
+                  CupertinoButton(
+                    onPressed: () {
+                      showCupertinoSheet<void>(
+                        context: homeKey.currentContext!,
+                        pageBuilder: (BuildContext context) {
+                          return CupertinoPageScaffold(child: sheetScaffoldContent(context));
+                        },
+                      );
+                    },
+                    child: const Text('Push Page 2'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Push Page 2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Top of Scroll'), findsOneWidget);
+      final double startPosition = tester.getTopLeft(find.text('Middle of Scroll')).dy;
+
+      final TestGesture gesture = await tester.createGesture();
+
+      await gesture.down(const Offset(100, 100));
+
+      // Need 2 events to form a valid drag
+      await tester.pump(const Duration(milliseconds: 100));
+      await gesture.moveTo(const Offset(100, 80), timeStamp: const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 200));
+      await gesture.moveTo(const Offset(100, 50), timeStamp: const Duration(milliseconds: 200));
+
+      await tester.pumpAndSettle();
+
+      final double endPosition = tester.getTopLeft(find.text('Middle of Scroll')).dy;
+
+      // Final position should be higher.
+      expect(endPosition, lessThan(startPosition));
+    });
   });
 }


### PR DESCRIPTION
Fixes #161623.

Changes how the VerticalGestureRecognizer watches the sheet body. Before it stacked over the sheet and won all gesture arenas with vertical drags, so it didn't allow scrolling in the sheet. Now it has the sheet content as its child, so it will defer to child vertical gestures. This PR will allow scrolling to work in the sheet, but further work needs to be done to improve scrolling and drag to dismiss working together, see #161687.


https://github.com/user-attachments/assets/71bee654-2d0d-499d-9d27-403188138fb5



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
