### PR TITLE
Fix DropdownMenu icon and item icon misalignment

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -703,7 +703,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       final double padding =
           entry.leadingIcon == null
               ? (leadingPadding ?? _kDefaultHorizontalPadding)
-              : (_kDefaultHorizontalPadding + _kLeadingIconToInputPadding);
+              : _kDefaultHorizontalPadding;
       ButtonStyle effectiveStyle =
           entry.style ??
           switch (textDirection) {
@@ -780,7 +780,13 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         child: MenuItemButton(
           key: enableScrollToHighlight ? buttonItemKeys[i] : null,
           style: effectiveStyle,
-          leadingIcon: entry.leadingIcon,
+          leadingIcon:
+              entry.leadingIcon != null
+                  ? Padding(
+                    padding: const EdgeInsetsDirectional.only(end: _kLeadingIconToInputPadding),
+                    child: entry.leadingIcon,
+                  )
+                  : null,
           trailingIcon: entry.trailingIcon,
           closeOnActivate: widget.closeBehavior == DropdownMenuCloseBehavior.all,
           onPressed:

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1125,6 +1125,60 @@ void main() {
     );
   });
 
+  testWidgets('The icon in the menu button should be aligned with the icon of '
+      'the text field - LTR', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Directionality(
+            textDirection: TextDirection.ltr,
+            child: DropdownMenu<TestMenu>(
+              leadingIcon: const Icon(Icons.search),
+              label: const Text('label'),
+              dropdownMenuEntries: menuChildrenWithIcons,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder dropdownIcon =
+        find.descendant(of: find.byIcon(Icons.search).first, matching: find.byType(RichText)).last;
+
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pumpAndSettle();
+    final Finder itemLeadingIcon = find.byKey(leadingIconKey(TestMenu.mainMenu0)).last;
+
+    expect(tester.getRect(dropdownIcon).left, tester.getRect(itemLeadingIcon).left);
+  });
+
+  testWidgets('The icon in the menu button should be aligned with the icon of '
+      'the text field - RTL', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Directionality(
+            textDirection: TextDirection.rtl,
+            child: DropdownMenu<TestMenu>(
+              leadingIcon: const Icon(Icons.search),
+              label: const Text('label'),
+              dropdownMenuEntries: menuChildrenWithIcons,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder dropdownIcon =
+        find.descendant(of: find.byIcon(Icons.search).first, matching: find.byType(RichText)).last;
+
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pumpAndSettle();
+    final Finder itemLeadingIcon = find.byKey(leadingIconKey(TestMenu.mainMenu0)).last;
+
+    expect(tester.getRect(dropdownIcon).right, tester.getRect(itemLeadingIcon).right);
+  });
+
   testWidgets('DropdownMenu has default trailing icon button', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();
     await tester.pumpWidget(buildTest(themeData, menuChildren));


### PR DESCRIPTION
## Description

This PR ensures that DropdownMenu icon and items icon are horizontally aligned. 

Before:

The item icon is not aligned with the DropdownMenu leading icon:

![Image](https://github.com/user-attachments/assets/c45b199d-a502-4449-834f-7660af4bb0f0)


After:

The item icon is aligned with the DropdownMenu leading icon:

![Image](https://github.com/user-attachments/assets/22a94cbb-c177-4732-b58d-a3ff8b4ac0cd)



## Related Issue

Fixes [DropdownMenu item icon and DropdownMenu.leadingIcon are not aligned horizontally](https://github.com/flutter/flutter/issues/161668)

## Tests

Adds 2 tests.