### PR TITLE
Fix `DropdownMenu.initialSelection` not reflecting `label` change

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -520,6 +520,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   bool _menuHasEnabledItem = false;
   TextEditingController? _localTextEditingController;
   final FocusNode _internalFocudeNode = FocusNode();
+  T? _currentSelection;
 
   @override
   void initState() {
@@ -529,6 +530,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     } else {
       _localTextEditingController = TextEditingController();
     }
+    _currentSelection = widget.initialSelection;
     _enableSearch = widget.enableSearch;
     filteredEntries = widget.dropdownMenuEntries;
     buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
@@ -584,14 +586,15 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     if (oldWidget.leadingIcon != widget.leadingIcon) {
       refreshLeadingPadding();
     }
-    if (oldWidget.initialSelection != widget.initialSelection) {
-      final int index = filteredEntries.indexWhere(
-        (DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection,
+    if (_currentSelection != null) {
+      final int selectionIndex = filteredEntries.indexWhere(
+        (entry) => entry.value == _currentSelection,
       );
-      if (index != -1) {
+      if (selectionIndex != -1 &&
+          _localTextEditingController?.value.text != filteredEntries[selectionIndex].label) {
         _localTextEditingController?.value = TextEditingValue(
-          text: filteredEntries[index].label,
-          selection: TextSelection.collapsed(offset: filteredEntries[index].label.length),
+          text: filteredEntries[selectionIndex].label,
+          selection: TextSelection.collapsed(offset: filteredEntries[selectionIndex].label.length),
         );
       }
     }
@@ -786,6 +789,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           onPressed:
               entry.enabled && widget.enabled
                   ? () {
+                    _currentSelection = entry.value;
                     _localTextEditingController?.value = TextEditingValue(
                       text: entry.label,
                       selection: TextSelection.collapsed(offset: entry.label.length),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2268,6 +2268,40 @@ void main() {
     },
   );
 
+  testWidgets('Text field content reflects changes in initalSelection corresponding entry label', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    String selectionLabel = 'Initial label';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: DropdownMenu<TestMenu>(
+                initialSelection: TestMenu.mainMenu0,
+                dropdownMenuEntries: <DropdownMenuEntry<TestMenu>>[
+                  DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: selectionLabel),
+                ],
+                controller: controller,
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () => setState(() => selectionLabel = 'Updated label'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+
+    expect(controller.text, 'Updated label');
+  });
+
   testWidgets('The default text input field should not be focused on mobile platforms '
       'when it is tapped', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();


### PR DESCRIPTION
## Description

The PR #160643 introduced a subtle bug that I came across. I filed an Issue and made a hotfix and a regression test for it.

The bug is basically `DropdownMenu.didUpdateWidget()` updating the `_localTextEditingController.value` only upon different `initialSelection`, overlooking a potential label change. This results in noticeable bug, especially with localization in mind.

## Fixes
- Fixes Issue #161729. 

## Difference 

###  Before
![Before](https://github.com/user-attachments/assets/58997184-d25b-4ea1-9f37-2058d268b7ab)

### After
![After](https://github.com/user-attachments/assets/43af8151-d2f0-4b8d-b958-1c2bb99906cd)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
