### PR TITLE
Remove tests, GLFW examples, and non-artifact builds from `linux_host_engine`.

### DIFF
--- a/engine/src/flutter/ci/builders/linux_host_engine.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine.json
@@ -15,12 +15,12 @@
                     "base_path": "out/ci/host_debug/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/ci/host_debug/zip_archives/linux-x64/artifacts.zip",
-                        "out/ci/host_debug/zip_archives/linux-x64/impeller_sdk.zip",
-                        "out/ci/host_debug/zip_archives/linux-x64/linux-x64-embedder.zip",
-                        "out/ci/host_debug/zip_archives/linux-x64/font-subset.zip",
+                        "out/ci/host_debug/zip_archives/dart-sdk-linux-x64.zip",
                         "out/ci/host_debug/zip_archives/flutter_patched_sdk.zip",
-                        "out/ci/host_debug/zip_archives/dart-sdk-linux-x64.zip"
+                        "out/ci/host_debug/zip_archives/linux-x64/artifacts.zip",
+                        "out/ci/host_debug/zip_archives/linux-x64/font-subset.zip",
+                        "out/ci/host_debug/zip_archives/linux-x64/impeller_sdk.zip",
+                        "out/ci/host_debug/zip_archives/linux-x64/linux-x64-embedder.zip"
                     ],
                     "realm": "production"
                 }
@@ -40,94 +40,22 @@
                 "--runtime-mode",
                 "debug",
                 "--prebuilt-dart-sdk",
-                "--build-embedder-examples",
                 "--rbe",
                 "--no-goma"
             ],
             "name": "ci/host_debug",
-            "description": "Produces debug mode Linux host-side tooling and builds host-side unit tests for Linux.",
+            "description": "Produces debug mode Linux host-side tooling.",
             "ninja": {
                 "config": "ci/host_debug",
                 "targets": [
-                    "flutter:unittests",
-                    "flutter/build/archives:artifacts",
                     "flutter/build/archives:dart_sdk_archive",
-                    "flutter/build/archives:embedder",
                     "flutter/build/archives:flutter_patched_sdk",
-                    "flutter/build/dart:copy_dart_sdk",
+                    "flutter/build/archives:artifacts",
                     "flutter/tools/font_subset",
-                    "flutter/impeller/toolkit/interop:sdk"
+                    "flutter/impeller/toolkit/interop:sdk",
+                    "flutter/build/archives:embedder"
                 ]
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_debug",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/host_debug",
-                        "--type",
-                        "dart,dart-host",
-                        "--engine-capture-core-dump"
-                    ]
-                }
-            ]
-        },
-        {
-            "archives": [
-                {
-                    "name": "ci/host_profile",
-                    "base_path": "out/ci/host_profile/zip_archives/",
-                    "type": "gcs",
-                    "include_paths": []
-                }
-            ],
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "download_jdk": false,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/host_profile",
-                "--runtime-mode",
-                "profile",
-                "--no-lto",
-                "--prebuilt-dart-sdk",
-                "--build-embedder-examples",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/host_profile",
-            "description": "Produces profile mode Linux host-side tooling and builds host-side unit tests for Linux.",
-            "ninja": {
-                "config": "ci/host_profile",
-                "targets": [
-                    "flutter/build/dart:copy_dart_sdk",
-                    "flutter/shell/testing",
-                    "flutter/tools/path_ops",
-                    "flutter:unittests"
-                ]
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_profile",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/host_profile",
-                        "--type",
-                        "dart,dart-host,engine",
-                        "--engine-capture-core-dump"
-                    ]
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -162,62 +90,17 @@
                 "--runtime-mode",
                 "release",
                 "--prebuilt-dart-sdk",
-                "--build-embedder-examples",
                 "--rbe",
                 "--no-goma"
             ],
             "name": "ci/host_release",
-            "description": "Produces release mode Linux host-side tooling and builds host-side unit tests and benchmarks for Linux.",
+            "description": "Produces release mode Linux host-side tooling.",
             "ninja": {
                 "config": "ci/host_release",
                 "targets": [
-                    "flutter/build/dart:copy_dart_sdk",
-                    "flutter/display_list:display_list_benchmarks",
-                    "flutter/display_list:display_list_builder_benchmarks",
-                    "flutter/display_list:display_list_region_benchmarks",
-                    "flutter/display_list:display_list_transform_benchmarks",
-                    "flutter/fml:fml_benchmarks",
-                    "flutter/impeller/geometry:geometry_benchmarks",
-                    "flutter/lib/ui:ui_benchmarks",
-                    "flutter/shell/common:shell_benchmarks",
-                    "flutter/shell/testing",
-                    "flutter/third_party/txt:txt_benchmarks",
-                    "flutter/tools/path_ops",
-                    "flutter/build/archives:flutter_patched_sdk",
-                    "flutter:unittests"
+                    "flutter/build/archives:flutter_patched_sdk"
                 ]
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_release",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/host_release",
-                        "--type",
-                        "dart,dart-host,engine,benchmarks",
-                        "--engine-capture-core-dump"
-                    ]
-                },
-                {
-                    "language": "bash",
-                    "name": "Generate metrics test",
-                    "script": "flutter/testing/benchmark/generate_metrics.sh",
-                    "parameters": [
-                        "ci/host_release"
-                    ]
-                },
-                {
-                    "language": "bash",
-                    "name": "Upload metrics dry-run",
-                    "script": "flutter/testing/benchmark/upload_metrics.sh",
-                    "parameters": [
-                        "ci/host_release",
-                        "--no-upload"
-                    ]
-                }
-            ]
+            }
         }
     ],
     "generators": {


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/161406.

This PR does the following:

- Removes `tests: [ ... ]`
- Removes `--build-embedder-examples`
- Entirely removes `host_profile`, as it did not contribute artifacts (built on other builders)
- Some light sorting/re-ordering to make it more obvious which GN target contributed to which include path

The tests for these builds are located in [`linux_host_engine_test.json`](https://github.com/flutter/flutter/blob/master/engine/src/flutter/ci/builders/linux_host_engine_test.json).