### PR TITLE
fix(SnackBar): standardize naming conventions

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -159,8 +159,8 @@ class _SnackBarActionState extends State<SnackBarAction> {
   Widget build(BuildContext context) {
     final SnackBarThemeData defaults =
         Theme.of(context).useMaterial3
-            ? _SnackbarDefaultsM3(context)
-            : _SnackbarDefaultsM2(context);
+            ? _SnackBarDefaultsM3(context)
+            : _SnackBarDefaultsM2(context);
     final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
 
     MaterialStateColor resolveForegroundColor() {
@@ -611,7 +611,7 @@ class _SnackBarState extends State<SnackBar> {
     final bool isThemeDark = theme.brightness == Brightness.dark;
     final Color buttonColor = isThemeDark ? colorScheme.primary : colorScheme.secondary;
     final SnackBarThemeData defaults =
-        theme.useMaterial3 ? _SnackbarDefaultsM3(context) : _SnackbarDefaultsM2(context);
+        theme.useMaterial3 ? _SnackBarDefaultsM3(context) : _SnackBarDefaultsM2(context);
 
     // SnackBar uses a theme that is the opposite brightness from
     // the surrounding theme.
@@ -867,8 +867,8 @@ class _SnackBarState extends State<SnackBar> {
 }
 
 // Hand coded defaults based on Material Design 2.
-class _SnackbarDefaultsM2 extends SnackBarThemeData {
-  _SnackbarDefaultsM2(BuildContext context)
+class _SnackBarDefaultsM2 extends SnackBarThemeData {
+  _SnackBarDefaultsM2(BuildContext context)
     : _theme = Theme.of(context),
       _colors = Theme.of(context).colorScheme,
       super(elevation: 6.0);
@@ -916,7 +916,7 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
   double get actionOverflowThreshold => 0.25;
 }
 
-// BEGIN GENERATED TOKEN PROPERTIES - Snackbar
+// BEGIN GENERATED TOKEN PROPERTIES - SnackBar
 
 // Do not edit by hand. The code between the "BEGIN GENERATED" and
 // "END GENERATED" comments are generated from data in the Material
@@ -924,8 +924,8 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
 //   dev/tools/gen_defaults/bin/gen_defaults.dart.
 
 // dart format off
-class _SnackbarDefaultsM3 extends SnackBarThemeData {
-    _SnackbarDefaultsM3(this.context);
+class _SnackBarDefaultsM3 extends SnackBarThemeData {
+  _SnackBarDefaultsM3(this.context);
 
   final BuildContext context;
   late final ThemeData _theme = Theme.of(context);
@@ -985,4 +985,4 @@ class _SnackbarDefaultsM3 extends SnackBarThemeData {
 }
 // dart format on
 
-// END GENERATED TOKEN PROPERTIES - Snackbar
+// END GENERATED TOKEN PROPERTIES - SnackBar


### PR DESCRIPTION
While studying the code, I noticed a very minor issue: specifically, the naming inconsistency between SnackBar and _SnackbarDefaultsM3, which looks quite uncomfortable.

https://github.com/flutter/flutter/blob/f545df54ffc88e8b5e5d08b27f5ec196f84955da/packages/flutter/lib/src/material/snack_bar.dart#L273

https://github.com/flutter/flutter/blob/f545df54ffc88e8b5e5d08b27f5ec196f84955da/packages/flutter/lib/src/material/snack_bar.dart#L927

I think using Snackbar alongside the existing SnackBar naming doesn’t feel quite right. Since _SnackbarDefaultsM3 is intended for internal use, adjusting it here won’t cause any impact but will unify the naming. Most importantly, it will eliminate the wavy underline warnings in Android Studio.


https://github.com/flutter/flutter/blob/f545df54ffc88e8b5e5d08b27f5ec196f84955da/packages/flutter/test/material/snack_bar_test.dart#L1885

Additionally, I noticed that naming in this area seems inconsistent. If needed, I can adjust those as well.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
