### PR TITLE
Revert "Move the analyzer_benchmark to Mac arm64 devicelab bots"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -361,18 +361,22 @@ targets:
   # This is a benchmark that does not require an attached device. However, we
   # are intentionally running it in the devicelab to ensure that it does not
   # run on a VM in order to avoid noisy results from the benchmark.
-  - name: Mac_arm64 analyzer_benchmark
+  - name: Linux analyzer_benchmark
     bringup: true # Flaky https://github.com/flutter/flutter/issues/161306
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      os: Linux
+      device_type: "mokey"
       test_timeout_secs: "3600" # 1 hour
       dependencies: >-
         [
-          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
+          {"dependency": "android_sdk", "version": "version:35v1"},
+          {"dependency": "open_jdk", "version": "version:17"},
+          {"dependency": "curl", "version": "version:7.64.0"}
         ]
       tags: >
-        ["devicelab", "hostonly", "mac", "arm64"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: analyzer_benchmark
 
   - name: Linux coverage


### PR DESCRIPTION
This reverts commit fe598e7d6f22e176499ede063572aafd9a9ef2b9.

This benchmark can be moved back to the Linux devicelab machines now that https://dart-review.googlesource.com/c/sdk/+/403924 has landed.

Fixes https://github.com/flutter/flutter/issues/161620