### PR TITLE
Return TestSamplingClock for `samplingClock`

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1295,6 +1295,9 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     return AutomatedTestWidgetsFlutterBinding.instance;
   }
 
+  @override
+  SamplingClock get samplingClock =>  _TestSamplingClock(_clock!);
+
   FakeAsync? _currentFakeAsync; // set in runTest; cleared in postTest
   Completer<void>? _pendingAsyncTasks;
 


### PR DESCRIPTION
A modest / small proposal: AutomatedTestWidgetsFlutterBinding should probably return the sampling clock that will vend a Stopwatch from the fake clock.  I could be missing something; so have a look.