### PR TITLE
[impeller] prevent PowerVR from using Vulkan backend.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -334,6 +334,14 @@ bool DriverInfoVK::IsKnownBadDriver() const {
   if (vendor_ == VendorVK::kHuawei) {
     return true;
   }
+  // https://github.com/flutter/flutter/issues/161122
+  // https://github.com/flutter/flutter/issues/160960
+  // https://github.com/flutter/flutter/issues/160866
+  // https://github.com/flutter/flutter/issues/160804
+  // https://github.com/flutter/flutter/issues/160406
+  if (vendor_ == VendorVK::kImgTec) {
+    return true;
+  }
   return false;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
@@ -222,7 +222,7 @@ TEST(DriverInfoVKTest, CanUseFramebufferFetch) {
   EXPECT_TRUE(CanUseFramebufferFetch("Mali-G51", false));
 }
 
-TEST(DriverInfoVKTest, AllPoweVRDisabled) {
+TEST(DriverInfoVKTest, AllPowerVRDisabled) {
   auto const context =
       MockVulkanContextBuilder()
           .SetPhysicalPropertiesCallback(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
@@ -222,4 +222,17 @@ TEST(DriverInfoVKTest, CanUseFramebufferFetch) {
   EXPECT_TRUE(CanUseFramebufferFetch("Mali-G51", false));
 }
 
+TEST(DriverInfoVKTest, AllPoweVRDisabled) {
+  auto const context =
+      MockVulkanContextBuilder()
+          .SetPhysicalPropertiesCallback(
+              [](VkPhysicalDevice device, VkPhysicalDeviceProperties* prop) {
+                prop->vendorID = 0x1010;
+                prop->deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+              })
+          .Build();
+
+  EXPECT_TRUE(context->GetDriverInfo()->IsKnownBadDriver());
+}
+
 }  // namespace impeller::testing


### PR DESCRIPTION
Almost all remaining blackscreen or rendering bugs/crashes are PowerVR hardware. Based on common knowledge that several large engines prevent PowerVR completely, we'll also block PowerVR until we have time to accumulate the necessary workarounds.