### PR TITLE
fix: appbar leading width is not square for custom toolbar height

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1002,12 +1002,16 @@ class _AppBarState extends State<AppBar> {
         // a size of 48x48, and a highlight size of 40x40. Users can also put other
         // type of widgets on leading with the original config.
         leading = ConstrainedBox(
-          constraints: BoxConstraints.tightFor(width: widget.leadingWidth ?? _kLeadingWidth),
+          constraints: BoxConstraints.tightFor(
+            width: widget.leadingWidth ?? appBarTheme.leadingWidth ?? _kLeadingWidth,
+          ),
           child: leading,
         );
       } else {
         leading = ConstrainedBox(
-          constraints: BoxConstraints.tightFor(width: widget.leadingWidth ?? _kLeadingWidth),
+          constraints: BoxConstraints.tightFor(
+            width: widget.leadingWidth ?? appBarTheme.leadingWidth ?? _kLeadingWidth,
+          ),
           child: leading,
         );
       }

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -42,6 +42,7 @@ class AppBarTheme with Diagnosticable {
     this.actionsIconTheme,
     this.centerTitle,
     this.titleSpacing,
+    this.leadingWidth,
     this.toolbarHeight,
     this.toolbarTextStyle,
     this.titleTextStyle,
@@ -122,6 +123,10 @@ class AppBarTheme with Diagnosticable {
   ///
   /// If null, [AppBar] uses default value of [NavigationToolbar.kMiddleSpacing].
   final double? titleSpacing;
+
+  /// Overrides the default value of the [AppBar.leadingWidth]
+  /// property in all descendant [AppBar] widgets.
+  final double? leadingWidth;
 
   /// Overrides the default value of the [AppBar.toolbarHeight]
   /// property in all descendant [AppBar] widgets.

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -178,6 +178,7 @@ class AppBarTheme with Diagnosticable {
     IconThemeData? iconTheme,
     bool? centerTitle,
     double? titleSpacing,
+    double? leadingWidth,
     double? toolbarHeight,
     TextStyle? toolbarTextStyle,
     TextStyle? titleTextStyle,
@@ -200,6 +201,7 @@ class AppBarTheme with Diagnosticable {
       actionsIconTheme: actionsIconTheme ?? this.actionsIconTheme,
       centerTitle: centerTitle ?? this.centerTitle,
       titleSpacing: titleSpacing ?? this.titleSpacing,
+      leadingWidth: leadingWidth ?? this.leadingWidth,
       toolbarHeight: toolbarHeight ?? this.toolbarHeight,
       toolbarTextStyle: toolbarTextStyle ?? this.toolbarTextStyle,
       titleTextStyle: titleTextStyle ?? this.titleTextStyle,
@@ -232,6 +234,7 @@ class AppBarTheme with Diagnosticable {
       actionsIconTheme: IconThemeData.lerp(a?.actionsIconTheme, b?.actionsIconTheme, t),
       centerTitle: t < 0.5 ? a?.centerTitle : b?.centerTitle,
       titleSpacing: lerpDouble(a?.titleSpacing, b?.titleSpacing, t),
+      leadingWidth: lerpDouble(a?.leadingWidth, b?.leadingWidth, t),
       toolbarHeight: lerpDouble(a?.toolbarHeight, b?.toolbarHeight, t),
       toolbarTextStyle: TextStyle.lerp(a?.toolbarTextStyle, b?.toolbarTextStyle, t),
       titleTextStyle: TextStyle.lerp(a?.titleTextStyle, b?.titleTextStyle, t),
@@ -253,6 +256,7 @@ class AppBarTheme with Diagnosticable {
     actionsIconTheme,
     centerTitle,
     titleSpacing,
+    leadingWidth,
     toolbarHeight,
     toolbarTextStyle,
     titleTextStyle,
@@ -280,6 +284,7 @@ class AppBarTheme with Diagnosticable {
         other.actionsIconTheme == actionsIconTheme &&
         other.centerTitle == centerTitle &&
         other.titleSpacing == titleSpacing &&
+        other.leadingWidth == leadingWidth &&
         other.toolbarHeight == toolbarHeight &&
         other.toolbarTextStyle == toolbarTextStyle &&
         other.titleTextStyle == titleTextStyle &&
@@ -309,6 +314,7 @@ class AppBarTheme with Diagnosticable {
     );
     properties.add(DiagnosticsProperty<bool>('centerTitle', centerTitle, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('titleSpacing', titleSpacing, defaultValue: null));
+    properties.add(DiagnosticsProperty<double>('leadingWidth', leadingWidth, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('toolbarHeight', toolbarHeight, defaultValue: null));
     properties.add(
       DiagnosticsProperty<TextStyle>('toolbarTextStyle', toolbarTextStyle, defaultValue: null),

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -761,6 +761,38 @@ void main() {
     expect(navToolBar.middleSpacing, 40);
   });
 
+  testWidgets('AppBar uses AppBarTheme.leadingWidth', (WidgetTester tester) async {
+    const double kLeadingWidth = 80;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(appBarTheme: const AppBarTheme(leadingWidth: kLeadingWidth)),
+        home: Scaffold(appBar: AppBar(leading: const Icon(Icons.chevron_left))),
+      ),
+    );
+
+    final NavigationToolbar navToolBar = tester.widget(find.byType(NavigationToolbar));
+    final BoxConstraints leadingConstraints = (navToolBar.leading! as ConstrainedBox).constraints;
+    expect(leadingConstraints.maxWidth, kLeadingWidth);
+    expect(leadingConstraints.minWidth, kLeadingWidth);
+  });
+
+  testWidgets('AppBar.leadingWidth takes priority over AppBarTheme.leadingWidth', (
+    WidgetTester tester,
+  ) async {
+    const double kLeadingWidth = 80;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(appBarTheme: const AppBarTheme(leadingWidth: kLeadingWidth)),
+        home: Scaffold(appBar: AppBar(leading: const Icon(Icons.chevron_left), leadingWidth: 40)),
+      ),
+    );
+
+    final NavigationToolbar navToolBar = tester.widget(find.byType(NavigationToolbar));
+    final BoxConstraints leadingConstraints = (navToolBar.leading! as ConstrainedBox).constraints;
+    expect(leadingConstraints.maxWidth, 40);
+    expect(leadingConstraints.minWidth, 40);
+  });
+
   testWidgets('SliverAppBar uses AppBarTheme.titleSpacing', (WidgetTester tester) async {
     const double kTitleSpacing = 10;
     await tester.pumpWidget(
@@ -789,6 +821,42 @@ void main() {
 
     final NavigationToolbar navToolbar = tester.widget(find.byType(NavigationToolbar));
     expect(navToolbar.middleSpacing, 40);
+  });
+
+  testWidgets('SliverAppBar uses AppBarTheme.leadingWidth', (WidgetTester tester) async {
+    const double kLeadingWidth = 80;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(appBarTheme: const AppBarTheme(leadingWidth: kLeadingWidth)),
+        home: const CustomScrollView(
+          slivers: <Widget>[SliverAppBar(leading: Icon(Icons.chevron_left))],
+        ),
+      ),
+    );
+
+    final NavigationToolbar navToolBar = tester.widget(find.byType(NavigationToolbar));
+    final BoxConstraints leadingConstraints = (navToolBar.leading! as ConstrainedBox).constraints;
+    expect(leadingConstraints.maxWidth, kLeadingWidth);
+    expect(leadingConstraints.minWidth, kLeadingWidth);
+  });
+
+  testWidgets('SliverAppBar.leadingWidth takes priority over AppBarTheme.leadingWidth ', (
+    WidgetTester tester,
+  ) async {
+    const double kLeadingWidth = 80;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(appBarTheme: const AppBarTheme(leadingWidth: kLeadingWidth)),
+        home: const CustomScrollView(
+          slivers: <Widget>[SliverAppBar(leading: Icon(Icons.chevron_left), leadingWidth: 40)],
+        ),
+      ),
+    );
+
+    final NavigationToolbar navToolBar = tester.widget(find.byType(NavigationToolbar));
+    final BoxConstraints leadingConstraints = (navToolBar.leading! as ConstrainedBox).constraints;
+    expect(leadingConstraints.maxWidth, 40);
+    expect(leadingConstraints.minWidth, 40);
   });
 
   testWidgets('SliverAppBar.medium uses AppBarTheme properties', (WidgetTester tester) async {
@@ -1100,6 +1168,7 @@ void main() {
       iconTheme: IconThemeData(color: Color(0xff000004)),
       centerTitle: true,
       titleSpacing: 40.0,
+      leadingWidth: 96,
       toolbarHeight: 96,
       toolbarTextStyle: TextStyle(color: Color(0xff000005)),
       titleTextStyle: TextStyle(color: Color(0xff000006)),
@@ -1125,6 +1194,7 @@ void main() {
         'iconTheme: IconThemeData#00000(color: ${const Color(0xff000004)})',
         'centerTitle: true',
         'titleSpacing: 40.0',
+        'leadingWidth: 96.0',
         'toolbarHeight: 96.0',
         'toolbarTextStyle: TextStyle(inherit: true, color: ${const Color(0xff000005)})',
         'titleTextStyle: TextStyle(inherit: true, color: ${const Color(0xff000006)})',


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Fixes #161301 

This change allows setting custom `leadingWidth` in the `AppBarTheme` along with `toolbarHeight`.
