### PR TITLE
Fix issue #156954: Wrong dateHelpText in MaterialLocalizationIt

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -21688,7 +21688,7 @@ class MaterialLocalizationIt extends GlobalMaterialLocalizations {
   String get cutButtonLabel => 'Taglia';
 
   @override
-  String get dateHelpText => 'mm/gg/aaaa';
+  String get dateHelpText => 'gg/mm/aaaa';
 
   @override
   String get dateInputLabel => 'Inserisci data';

--- a/packages/flutter_localizations/lib/src/l10n/material_it.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_it.arb
@@ -56,7 +56,7 @@
   "refreshIndicatorSemanticLabel": "Aggiorna",
   "moreButtonTooltip": "Altro",
   "dateSeparator": "/",
-  "dateHelpText": "mm/gg/aaaa",
+  "dateHelpText": "gg/mm/aaaa",
   "selectYearSemanticsLabel": "Seleziona anno",
   "unspecifiedDate": "Data",
   "unspecifiedDateRange": "Intervallo di date",

--- a/packages/flutter_localizations/test/material/translations_test.dart
+++ b/packages/flutter_localizations/test/material/translations_test.dart
@@ -596,4 +596,15 @@ void main() {
     expect(localizations.copyButtonLabel, '복사');
     expect(localizations.pasteButtonLabel, '붙여넣기');
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/156954
+  testWidgets('Italian translation for dateHelpText', (WidgetTester tester) async {
+    const Locale locale = Locale('it');
+    expect(GlobalCupertinoLocalizations.delegate.isSupported(locale), isTrue);
+    final MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(
+      locale,
+    );
+    expect(localizations, isA<MaterialLocalizationIt>());
+    expect(localizations.dateHelpText, 'gg/mm/aaaa');
+  });
 }


### PR DESCRIPTION
Fix #156954
- Changed current value `dataHelpText` used in `MaterialLocalizationIt` from "mm/gg/aaaa" to "gg/mm/aaaa"
- Wrote test

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
