### PR TITLE
Pass-through `maxLines` in `DropdownMenu`

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -519,7 +519,8 @@ class DropdownMenu<T> extends StatefulWidget {
   /// to accommodate that number of lines.
   ///
   /// See also:
-  ///  * [TextField.maxLines]
+  ///  * [TextField.maxLines], which specifies the maximum number of lines
+  ///    the [TextField] can display.
   final int? maxLines;
 
   @override

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -514,9 +514,9 @@ class DropdownMenu<T> extends StatefulWidget {
   /// automatically grow to accommodate additional lines as they are entered, up
   /// to the height of its constraints.
   ///
-  /// If this is not null, the provided value must be greater than zero. The text field will restrict
-  /// the input to the given number of lines and take up enough horizontal space
-  /// to accommodate that number of lines.
+  /// If this is not null, the provided value must be greater than zero. The text
+  /// field will restrict the input to the given number of lines and take up enough
+  /// horizontal space to accommodate that number of lines.
   ///
   /// See also:
   ///  * [TextField.maxLines], which specifies the maximum number of lines

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -188,7 +188,7 @@ class DropdownMenu<T> extends StatefulWidget {
     required this.dropdownMenuEntries,
     this.inputFormatters,
     this.closeBehavior = DropdownMenuCloseBehavior.all,
-    this.maxLines,
+    this.maxLines = 1,
   }) : assert(filterCallback == null || enableFilter);
 
   /// Determine if the [DropdownMenu] is enabled.

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -506,8 +506,8 @@ class DropdownMenu<T> extends StatefulWidget {
   /// Specifies the maximum number of lines the selected value can display
   /// in the [DropdownMenu].
   ///
-  /// If this is 1 (the default), the text will not wrap, but will scroll
-  /// horizontally instead.
+  /// If the provided value is 1, then the text will not wrap, but will scroll
+  /// horizontally instead. Defaults to 1. 
   ///
   /// If this is null, there is no limit to the number of lines, and the text
   /// container will start with enough vertical space for one line and

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1026,6 +1026,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           keyboardType: widget.keyboardType,
           textAlign: widget.textAlign,
           textAlignVertical: TextAlignVertical.center,
+          maxLines: widget.maxLines,
           style: effectiveTextStyle,
           controller: _localTextEditingController,
           onEditingComplete: _handleEditingComplete,
@@ -1055,7 +1056,6 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
                     : null,
             suffixIcon: trailingButton,
           ).applyDefaults(effectiveInputDecorationTheme),
-          maxLines: widget.maxLines,
         );
 
         // If [expandedInsets] is not null, the width of the text field should depend

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -514,7 +514,7 @@ class DropdownMenu<T> extends StatefulWidget {
   /// automatically grow to accommodate additional lines as they are entered, up
   /// to the height of its constraints.
   ///
-  /// If this is not null, the value must be greater than zero, and it will lock
+  /// If this is not null, the provided value must be greater than zero. The text field will restrict
   /// the input to the given number of lines and take up enough horizontal space
   /// to accommodate that number of lines.
   ///

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -188,6 +188,7 @@ class DropdownMenu<T> extends StatefulWidget {
     required this.dropdownMenuEntries,
     this.inputFormatters,
     this.closeBehavior = DropdownMenuCloseBehavior.all,
+    this.maxLines,
   }) : assert(filterCallback == null || enableFilter);
 
   /// Determine if the [DropdownMenu] is enabled.
@@ -501,6 +502,9 @@ class DropdownMenu<T> extends StatefulWidget {
   ///
   /// Defaults to [DropdownMenuCloseBehavior.all].
   final DropdownMenuCloseBehavior closeBehavior;
+
+  /// {@macro flutter.widgets.editableText.maxLines}
+  final int? maxLines;
 
   @override
   State<DropdownMenu<T>> createState() => _DropdownMenuState<T>();
@@ -1034,6 +1038,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
                     : null,
             suffixIcon: trailingButton,
           ).applyDefaults(effectiveInputDecorationTheme),
+          maxLines: widget.maxLines,
         );
 
         // If [expandedInsets] is not null, the width of the text field should depend

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -503,7 +503,23 @@ class DropdownMenu<T> extends StatefulWidget {
   /// Defaults to [DropdownMenuCloseBehavior.all].
   final DropdownMenuCloseBehavior closeBehavior;
 
-  /// {@macro flutter.widgets.editableText.maxLines}
+  /// Specifies the maximum number of lines the selected value can display
+  /// in the [DropdownMenu].
+  ///
+  /// If this is 1 (the default), the text will not wrap, but will scroll
+  /// horizontally instead.
+  ///
+  /// If this is null, there is no limit to the number of lines, and the text
+  /// container will start with enough vertical space for one line and
+  /// automatically grow to accommodate additional lines as they are entered, up
+  /// to the height of its constraints.
+  ///
+  /// If this is not null, the value must be greater than zero, and it will lock
+  /// the input to the given number of lines and take up enough horizontal space
+  /// to accommodate that number of lines.
+  ///
+  /// See also:
+  ///  * [TextField.maxLines]
   final int? maxLines;
 
   @override

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -507,7 +507,7 @@ class DropdownMenu<T> extends StatefulWidget {
   /// in the [DropdownMenu].
   ///
   /// If the provided value is 1, then the text will not wrap, but will scroll
-  /// horizontally instead. Defaults to 1. 
+  /// horizontally instead. Defaults to 1.
   ///
   /// If this is null, there is no limit to the number of lines, and the text
   /// container will start with enough vertical space for one line and

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3906,10 +3906,7 @@ void main() {
     Widget buildDropdownMenu({int? maxLines = 1}) {
       return MaterialApp(
         home: Scaffold(
-          body: DropdownMenu<TestMenu>(
-            dropdownMenuEntries: menuChildren,
-            maxLines: maxLines,
-          ),
+          body: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren, maxLines: maxLines),
         ),
       );
     }

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3908,11 +3908,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: SafeArea(
-            child: DropdownMenu<TestMenu>(
-              dropdownMenuEntries: menuChildren,
-            ),
-          ),
+          body: SafeArea(child: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren)),
         ),
       ),
     );
@@ -3924,10 +3920,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: SafeArea(
-            child: DropdownMenu<TestMenu>(
-              dropdownMenuEntries: menuChildren,
-              maxLines: 2,
-            ),
+            child: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren, maxLines: 2),
           ),
         ),
       ),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3903,27 +3903,23 @@ void main() {
   );
 
   testWidgets('DropdownMenu passes maxLines to TextField', (WidgetTester tester) async {
-    // default
-    await tester.pumpWidget(
-      MaterialApp(
+    Widget buildDropdownMenu({int? maxLines}) {
+      return MaterialApp(
         home: Scaffold(
-          body: SafeArea(child: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren)),
-        ),
-      ),
-    );
-    TextField textField = tester.widget(find.byType(TextField));
-    expect(textField.maxLines, null);
-
-    // custom
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SafeArea(
-            child: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren, maxLines: 2),
+          body: DropdownMenu<TestMenu>(
+            dropdownMenuEntries: menuChildren,
+            maxLines: maxLines,
           ),
         ),
-      ),
-    );
+      );
+    }
+
+    await tester.pumpWidget(buildDropdownMenu());
+    TextField textField = tester.widget(find.byType(TextField));
+    // Default behavior.
+    expect(textField.maxLines, null);
+
+    await tester.pumpWidget(buildDropdownMenu(maxLines: 2));
     textField = tester.widget(find.byType(TextField));
     expect(textField.maxLines, 2);
   });

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3903,7 +3903,7 @@ void main() {
   );
 
   testWidgets('DropdownMenu passes maxLines to TextField', (WidgetTester tester) async {
-    Widget buildDropdownMenu({int? maxLines}) {
+    Widget buildDropdownMenu({int? maxLines = 1}) {
       return MaterialApp(
         home: Scaffold(
           body: DropdownMenu<TestMenu>(

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3901,6 +3901,40 @@ void main() {
     },
     variant: TargetPlatformVariant.all(),
   );
+
+  // Regression test for https://github.com/flutter/flutter/pull/161903
+  testWidgets('DropdownMenu passes maxLines to TextField', (WidgetTester tester) async {
+    // default
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SafeArea(
+            child: DropdownMenu<TestMenu>(
+              dropdownMenuEntries: menuChildren,
+            ),
+          ),
+        ),
+      ),
+    );
+    TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.maxLines, null);
+
+    // custom
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SafeArea(
+            child: DropdownMenu<TestMenu>(
+              dropdownMenuEntries: menuChildren,
+              maxLines: 2,
+            ),
+          ),
+        ),
+      ),
+    );
+    textField = tester.widget(find.byType(TextField));
+    expect(textField.maxLines, 2);
+  });
 }
 
 enum TestMenu {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3903,24 +3903,30 @@ void main() {
   );
 
   testWidgets('DropdownMenu passes maxLines to TextField', (WidgetTester tester) async {
-    Widget buildDropdownMenu({int? maxLines = 1}) {
-      return MaterialApp(
-        home: Scaffold(
-          body: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren, maxLines: maxLines),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(buildDropdownMenu());
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren))),
+    );
     TextField textField = tester.widget(find.byType(TextField));
     // Default behavior.
     expect(textField.maxLines, 1);
 
-    await tester.pumpWidget(buildDropdownMenu(maxLines: null));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren, maxLines: null),
+        ),
+      ),
+    );
     textField = tester.widget(find.byType(TextField));
     expect(textField.maxLines, null);
 
-    await tester.pumpWidget(buildDropdownMenu(maxLines: 2));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenu<TestMenu>(dropdownMenuEntries: menuChildren, maxLines: 2),
+        ),
+      ),
+    );
     textField = tester.widget(find.byType(TextField));
     expect(textField.maxLines, 2);
   });

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3917,6 +3917,10 @@ void main() {
     await tester.pumpWidget(buildDropdownMenu());
     TextField textField = tester.widget(find.byType(TextField));
     // Default behavior.
+    expect(textField.maxLines, 1);
+
+    await tester.pumpWidget(buildDropdownMenu(maxLines: null));
+    textField = tester.widget(find.byType(TextField));
     expect(textField.maxLines, null);
 
     await tester.pumpWidget(buildDropdownMenu(maxLines: 2));

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3902,7 +3902,6 @@ void main() {
     variant: TargetPlatformVariant.all(),
   );
 
-  // Regression test for https://github.com/flutter/flutter/pull/161903
   testWidgets('DropdownMenu passes maxLines to TextField', (WidgetTester tester) async {
     // default
     await tester.pumpWidget(


### PR DESCRIPTION
Pass-through `maxLines` in `DropdownMenu`.

Fixes #161881 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
