### PR TITLE
Move FlKeyboardManager and FlKeyboardHandler from FlView to FlEngine.

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -14,6 +14,7 @@
 #include "flutter/shell/platform/linux/fl_dart_project_private.h"
 #include "flutter/shell/platform/linux/fl_display_monitor.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
+#include "flutter/shell/platform/linux/fl_keyboard_handler.h"
 #include "flutter/shell/platform/linux/fl_pixel_buffer_texture_private.h"
 #include "flutter/shell/platform/linux/fl_platform_handler.h"
 #include "flutter/shell/platform/linux/fl_plugin_registrar_private.h"
@@ -56,6 +57,12 @@ struct _FlEngine {
 
   // Implements the flutter/platform channel.
   FlPlatformHandler* platform_handler;
+
+  // Process keyboard events.
+  FlKeyboardManager* keyboard_manager;
+
+  // Implements the flutter/keyboard channel.
+  FlKeyboardHandler* keyboard_handler;
 
   // Implements the flutter/mousecursor channel.
   FlMouseCursorHandler* mouse_cursor_handler;
@@ -381,6 +388,14 @@ static void fl_engine_update_semantics_cb(const FlutterSemanticsUpdate2* update,
   }
 }
 
+static void setup_keyboard(FlEngine* self) {
+  g_clear_object(&self->keyboard_manager);
+  self->keyboard_manager = fl_keyboard_manager_new(self);
+  g_clear_object(&self->keyboard_handler);
+  self->keyboard_handler =
+      fl_keyboard_handler_new(self->binary_messenger, self->keyboard_manager);
+}
+
 // Called right before the engine is restarted.
 //
 // This method should reset states to as if the engine has just been started,
@@ -388,6 +403,8 @@ static void fl_engine_update_semantics_cb(const FlutterSemanticsUpdate2* update,
 // Flutter CLI.)
 static void fl_engine_on_pre_engine_restart_cb(void* user_data) {
   FlEngine* self = FL_ENGINE(user_data);
+
+  setup_keyboard(self);
 
   g_signal_emit(self, fl_engine_signals[SIGNAL_ON_PRE_ENGINE_RESTART], 0);
 }
@@ -455,6 +472,8 @@ static void fl_engine_dispose(GObject* object) {
   g_clear_object(&self->binary_messenger);
   g_clear_object(&self->settings_handler);
   g_clear_object(&self->platform_handler);
+  g_clear_object(&self->keyboard_manager);
+  g_clear_object(&self->keyboard_handler);
   g_clear_object(&self->mouse_cursor_handler);
   g_clear_object(&self->task_runner);
 
@@ -645,6 +664,8 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   self->platform_handler = fl_platform_handler_new(self->binary_messenger);
   self->mouse_cursor_handler =
       fl_mouse_cursor_handler_new(self->binary_messenger);
+
+  setup_keyboard(self);
 
   result = self->embedder_api.UpdateSemanticsEnabled(self->engine, TRUE);
   if (result != kSuccess) {
@@ -1236,6 +1257,11 @@ void fl_engine_update_accessibility_features(FlEngine* self, int32_t flags) {
 void fl_engine_request_app_exit(FlEngine* self) {
   g_return_if_fail(FL_IS_ENGINE(self));
   fl_platform_handler_request_app_exit(self->platform_handler);
+}
+
+FlKeyboardManager* fl_engine_get_keyboard_manager(FlEngine* self) {
+  g_return_val_if_fail(FL_IS_ENGINE(self), nullptr);
+  return self->keyboard_manager;
 }
 
 FlMouseCursorHandler* fl_engine_get_mouse_cursor_handler(FlEngine* self) {

--- a/engine/src/flutter/shell/platform/linux/fl_engine_private.h
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_private.h
@@ -9,6 +9,7 @@
 
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_display_monitor.h"
+#include "flutter/shell/platform/linux/fl_keyboard_manager.h"
 #include "flutter/shell/platform/linux/fl_mouse_cursor_handler.h"
 #include "flutter/shell/platform/linux/fl_renderer.h"
 #include "flutter/shell/platform/linux/fl_task_runner.h"
@@ -562,6 +563,16 @@ void fl_engine_update_accessibility_features(FlEngine* engine, int32_t flags);
  * Request the application exits.
  */
 void fl_engine_request_app_exit(FlEngine* engine);
+
+/**
+ * fl_engine_get_keyboard_manager:
+ * @engine: an #FlEngine.
+ *
+ * Gets the keyboard manager used by this engine.
+ *
+ * Returns: a #FlKeyboardManager.
+ */
+FlKeyboardManager* fl_engine_get_keyboard_manager(FlEngine* engine);
 
 /**
  * fl_engine_get_mouse_cursor_handler:

--- a/engine/src/flutter/shell/platform/linux/fl_keyboard_manager.h
+++ b/engine/src/flutter/shell/platform/linux/fl_keyboard_manager.h
@@ -45,6 +45,16 @@ G_DECLARE_FINAL_TYPE(FlKeyboardManager,
  */
 FlKeyboardManager* fl_keyboard_manager_new(FlEngine* engine);
 
+/** fl_keyboard_manager_add_redispatched_event:
+ * @manager: an #FlKeyboardManager.
+ * @event: an event that will be handled by the manager in the future.
+ *
+ * Add an event that will be redispatched and handled by the manager in the
+ * future. When that event is received it will be ignored.
+ */
+void fl_keyboard_manager_add_redispatched_event(FlKeyboardManager* manager,
+                                                FlKeyEvent* event);
+
 /**
  * fl_keyboard_manager_handle_event:
  * @manager: an #FlKeyboardManager.


### PR DESCRIPTION
There can only be one handler that is shared between the views.

Move event redispatch matcher back into FlKeyboardManager -  if a redispatched event was moved between views due to a focus change it would not be matched against.