### PR TITLE
Expose Semantics.identifier as Windows UIA AutomationId

### DIFF
--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -291,6 +291,7 @@ void AccessibilityBridge::ConvertFlutterUpdate(const SemanticsNode& node,
   SetIntAttributesFromFlutterUpdate(node_data, node);
   SetIntListAttributesFromFlutterUpdate(node_data, node);
   SetStringListAttributesFromFlutterUpdate(node_data, node);
+  SetIdFromFlutterUpdate(node_data, node);
   SetNameFromFlutterUpdate(node_data, node);
   SetValueFromFlutterUpdate(node_data, node);
   SetTooltipFromFlutterUpdate(node_data, node);
@@ -521,6 +522,12 @@ void AccessibilityBridge::SetStringListAttributesFromFlutterUpdate(
         ax::mojom::StringListAttribute::kCustomActionDescriptions,
         custom_action_description);
   }
+}
+
+void AccessibilityBridge::SetIdFromFlutterUpdate(ui::AXNodeData& node_data,
+                                                 const SemanticsNode& node) {
+  node_data.AddStringAttribute(ax::mojom::StringAttribute::kHtmlId,
+                               node.identifier);
 }
 
 void AccessibilityBridge::SetNameFromFlutterUpdate(ui::AXNodeData& node_data,

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -623,6 +623,9 @@ AccessibilityBridge::FromFlutterSemanticsNode(
         flutter_node.custom_accessibility_actions +
             flutter_node.custom_accessibility_actions_count);
   }
+  if (flutter_node.identifier) {
+    result.identifier = std::string(flutter_node.identifier);
+  }
   return result;
 }
 

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.h
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.h
@@ -226,6 +226,8 @@ class AccessibilityBridge
                                              const SemanticsNode& node);
   void SetStringListAttributesFromFlutterUpdate(ui::AXNodeData& node_data,
                                                 const SemanticsNode& node);
+  void SetIdFromFlutterUpdate(ui::AXNodeData& node_data,
+                              const SemanticsNode& node);
   void SetNameFromFlutterUpdate(ui::AXNodeData& node_data,
                                 const SemanticsNode& node);
   void SetValueFromFlutterUpdate(ui::AXNodeData& node_data,

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.h
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.h
@@ -181,6 +181,7 @@ class AccessibilityBridge
     FlutterTransformation transform;
     std::vector<int32_t> children_in_traversal_order;
     std::vector<int32_t> custom_accessibility_actions;
+    std::string identifier;
   } SemanticsNode;
 
   // See FlutterSemanticsCustomAction in embedder.h

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -48,6 +48,7 @@ TEST(AccessibilityBridgeTest, BasicTest) {
 
   std::vector<int32_t> children{1, 2};
   FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root", &children);
+  root.identifier = "identifier";
   FlutterSemanticsNode2 child1 = CreateSemanticsNode(1, "child 1");
   FlutterSemanticsNode2 child2 = CreateSemanticsNode(2, "child 2");
 
@@ -63,6 +64,7 @@ TEST(AccessibilityBridgeTest, BasicTest) {
   EXPECT_EQ(root_node->GetData().child_ids[0], 1);
   EXPECT_EQ(root_node->GetData().child_ids[1], 2);
   EXPECT_EQ(root_node->GetName(), "root");
+  EXPECT_EQ(root_node->GetAuthorUniqueId(), u"identifier");
 
   EXPECT_EQ(child1_node->GetChildCount(), 0);
   EXPECT_EQ(child1_node->GetName(), "child 1");

--- a/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -60,6 +60,7 @@ TEST(FlutterPlatformNodeDelegateTest, canPerfomActions) {
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -108,6 +109,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetAXNode) {
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -133,6 +135,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
@@ -148,6 +151,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   child1.child_count = 0;
   child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
   child1.rect = {0, 0, 50, 50};  // LTRB
   child1.transform = {0.5, 0, 0, 0, 0.5, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -182,6 +186,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
@@ -197,6 +202,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   child1.child_count = 0;
   child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
   child1.rect = {90, 90, 100, 100};  // LTRB
   child1.transform = {2, 0, 0, 0, 2, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -231,6 +237,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
@@ -246,6 +253,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   child1.child_count = 0;
   child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
   child1.rect = {0, 0, 50, 50};  // LTRB
   child1.transform = {0.5, 0, 0, 0, 0.5, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -254,7 +262,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   auto child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
   auto owner_bridge = child1_node->GetOwnerBridge().lock();
 
-  bool result;
+  bool result = false;
   gfx::RectF bounds = owner_bridge->RelativeToGlobalBounds(
       child1_node->GetAXNode(), result, true);
   EXPECT_EQ(bounds.x(), 0);
@@ -280,6 +288,7 @@ TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
   root.flags2 = &flags;
   root.children_in_traversal_order = nullptr;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -305,6 +314,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode2 child1;
@@ -318,6 +328,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   child1.child_count = 0;
   child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -114,6 +114,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, SendsAccessibilityCreateNotificationFlu
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -177,6 +178,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, NonZeroRootNodeId) {
   node1.children_in_traversal_order = node1_children.data();
   node1.children_in_hit_test_order = node1_children.data();
   node1.custom_accessibility_actions_count = 0;
+  node1.identifier = "";
 
   FlutterSemanticsNode2 node2;
   node2.id = 2;
@@ -193,6 +195,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, NonZeroRootNodeId) {
   node2.tooltip = "";
   node2.child_count = 0;
   node2.custom_accessibility_actions_count = 0;
+  node2.identifier = "";
 
   bridge->AddFlutterSemanticsNodeUpdate(node1);
   bridge->AddFlutterSemanticsNodeUpdate(node2);
@@ -240,6 +243,7 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -288,6 +292,7 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -338,6 +338,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
@@ -354,6 +355,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   child1.tooltip = "";
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
 
   FlutterSemanticsUpdate2 update;
   update.node_count = 2;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -51,6 +51,7 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -89,6 +90,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -131,6 +133,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -175,6 +178,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode2 child1;
@@ -189,6 +193,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   child1.tooltip = "";
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();
@@ -257,6 +262,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
@@ -279,6 +285,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   child1.text_selection_extent = -1;
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
   child1.rect = {0, 0, rectSize, rectSize};  // LTRB
   child1.transform = {transformFactor, 0, 0, 0, transformFactor, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -336,6 +343,7 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
@@ -359,6 +367,7 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   child1.text_selection_extent = -1;
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
   child1.rect = {0, 0, rectSize, rectSize};  // LTRB
   child1.transform = {transformFactor, 0, 0, 0, transformFactor, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(child1);

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -1693,6 +1693,11 @@ typedef struct {
   // The set of semantics flags associated with this node. Prefer to use this
   // over `flags__deprecated__`.
   FlutterSemanticsFlags* flags2;
+  /// An identifier for the semantics node in native accessibility hierarchy.
+  /// This value should not be exposed to the users of the app.
+  /// This is usually used for UI testing with tools that work by querying the
+  /// native accessibility, like UIAutomator, XCUITest, or Appium.
+  const char* identifier;
 } FlutterSemanticsNode2;
 
 /// `FlutterSemanticsCustomAction` ID used as a sentinel to signal the end of a

--- a/engine/src/flutter/shell/platform/embedder/embedder_semantics_update.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_semantics_update.cc
@@ -341,6 +341,7 @@ void EmbedderSemanticsUpdate2::AddNode(const SemanticsNode& node) {
       decreased_value_attributes.count,
       decreased_value_attributes.attributes,
       flags_.back().get(),
+      node.identifier.c_str(),
   });
 }
 

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -301,6 +301,11 @@ TEST_F(EmbedderA11yTest, A11yStringAttributes) {
 
         auto node = update->nodes[0];
 
+        // Verify identifier
+        {
+          ASSERT_EQ(std::string(node->identifier), "identifier");
+        }
+
         // Verify label
         {
           ASSERT_EQ(std::string(node->label), "What is the meaning of life?");

--- a/engine/src/flutter/shell/platform/linux/fl_view_accessible_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_accessible_test.cc
@@ -20,7 +20,8 @@ TEST(FlViewAccessibleTest, BuildTree) {
                                      .label = "root",
                                      .child_count = 2,
                                      .children_in_traversal_order = children,
-                                     .flags2 = &flags};
+                                     .flags2 = &flags,
+                                     .identifier = ""};
   FlutterSemanticsNode2 child1_node = {
       .id = 111, .label = "child 1", .flags2 = &flags};
   FlutterSemanticsNode2 child2_node = {

--- a/engine/src/flutter/third_party/accessibility/ax/ax_enum_util.cc
+++ b/engine/src/flutter/third_party/accessibility/ax/ax_enum_util.cc
@@ -1429,6 +1429,8 @@ const char* ToString(ax::mojom::StringAttribute string_attribute) {
       return "display";
     case ax::mojom::StringAttribute::kFontFamily:
       return "fontFamily";
+    case ax::mojom::StringAttribute::kHtmlId:
+      return "htmlId";
     case ax::mojom::StringAttribute::kHtmlTag:
       return "htmlTag";
     case ax::mojom::StringAttribute::kImageAnnotation:
@@ -1489,6 +1491,8 @@ ax::mojom::StringAttribute ParseStringAttribute(const char* string_attribute) {
     return ax::mojom::StringAttribute::kDisplay;
   if (0 == strcmp(string_attribute, "fontFamily"))
     return ax::mojom::StringAttribute::kFontFamily;
+  if (0 == strcmp(string_attribute, "htmlId"))
+    return ax::mojom::StringAttribute::kHtmlId;
   if (0 == strcmp(string_attribute, "htmlTag"))
     return ax::mojom::StringAttribute::kHtmlTag;
   if (0 == strcmp(string_attribute, "imageAnnotation"))

--- a/engine/src/flutter/third_party/accessibility/ax/ax_enums.h
+++ b/engine/src/flutter/third_party/accessibility/ax/ax_enums.h
@@ -532,6 +532,7 @@ enum class StringAttribute {
   kDisplay,
   // Only present when different from parent.
   kFontFamily,
+  kHtmlId,
   kHtmlTag,
   // Stores an automatic image annotation if one is available. Only valid on
   // ax::mojom::Role::kImage. See kImageAnnotationStatus, too.

--- a/engine/src/flutter/third_party/accessibility/ax/ax_node_data.cc
+++ b/engine/src/flutter/third_party/accessibility/ax/ax_node_data.cc
@@ -1462,6 +1462,9 @@ std::string AXNodeData::ToString() const {
       case ax::mojom::StringAttribute::kFontFamily:
         result += " font-family=" + value;
         break;
+      case ax::mojom::StringAttribute::kHtmlId:
+        result += " html_id=" + value;
+        break;
       case ax::mojom::StringAttribute::kHtmlTag:
         result += " html_tag=" + value;
         break;

--- a/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_delegate_base.cc
+++ b/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_delegate_base.cc
@@ -12,6 +12,7 @@
 #include "ax/ax_role_properties.h"
 #include "ax/ax_tree_data.h"
 #include "base/no_destructor.h"
+#include "base/string_utils.h"
 
 #include "ax_platform_node.h"
 #include "ax_platform_node_base.h"
@@ -629,7 +630,7 @@ std::set<AXPlatformNode*> AXPlatformNodeDelegateBase::GetReverseRelations(
 }
 
 std::u16string AXPlatformNodeDelegateBase::GetAuthorUniqueId() const {
-  return std::u16string();
+  return base::UTF8ToUTF16(GetData().GetStringAttribute(ax::mojom::StringAttribute::kHtmlId));
 }
 
 const AXUniqueId& AXPlatformNodeDelegateBase::GetUniqueId() const {

--- a/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_win.cc
+++ b/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_win.cc
@@ -1197,6 +1197,34 @@ IFACEMETHODIMP AXPlatformNodeWin::put_accName(VARIANT var_id, BSTR put_name) {
 }
 
 //
+// IAccessibleEx implementation.
+//
+
+IFACEMETHODIMP AXPlatformNodeWin::GetObjectForChild(LONG child_id,
+                                                    IAccessibleEx** result) {
+  // No support for child IDs in this implementation.
+  COM_OBJECT_VALIDATE_1_ARG(result);
+  *result = nullptr;
+  return S_OK;
+}
+
+IFACEMETHODIMP AXPlatformNodeWin::GetIAccessiblePair(IAccessible** accessible,
+                                                     LONG* child_id) {
+  COM_OBJECT_VALIDATE_2_ARGS(accessible, child_id);
+  *accessible = static_cast<IAccessible*>(this);
+  (*accessible)->AddRef();
+  *child_id = CHILDID_SELF;
+  return S_OK;
+}
+
+// IAccessibleEx methods not implemented.
+IFACEMETHODIMP
+AXPlatformNodeWin::ConvertReturnedElement(IRawElementProviderSimple* element,
+                                          IAccessibleEx** acc) {
+  return E_NOTIMPL;
+}
+
+//
 // IExpandCollapseProvider implementation.
 //
 
@@ -2571,7 +2599,7 @@ IFACEMETHODIMP AXPlatformNodeWin::QueryService(REFGUID guidService,
                                                void** object) {
   COM_OBJECT_VALIDATE_1_ARG(object);
 
-  if (guidService == IID_IAccessible) {
+  if (guidService == IID_IAccessible || guidService == IID_IAccessibleEx) {
     return QueryInterface(riid, object);
   }
 

--- a/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_win.h
+++ b/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_win.h
@@ -53,6 +53,7 @@ class AXPlatformNodeWin;
 class AX_EXPORT __declspec(uuid("26f5641a-246d-457b-a96d-07f3fae6acf2"))
     AXPlatformNodeWin : public CComObjectRootEx<CComMultiThreadModel>,
                         public IDispatchImpl<IAccessible>,
+                        public IAccessibleEx,
                         public IExpandCollapseProvider,
                         public IGridItemProvider,
                         public IGridProvider,
@@ -79,6 +80,7 @@ class AX_EXPORT __declspec(uuid("26f5641a-246d-457b-a96d-07f3fae6acf2"))
   // an interface.
   COM_INTERFACE_ENTRY(AXPlatformNodeWin)
   COM_INTERFACE_ENTRY(IAccessible)
+  COM_INTERFACE_ENTRY(IAccessibleEx)
   COM_INTERFACE_ENTRY(IDispatch)
   COM_INTERFACE_ENTRY(IExpandCollapseProvider)
   COM_INTERFACE_ENTRY(IGridItemProvider)
@@ -186,6 +188,21 @@ class AX_EXPORT __declspec(uuid("26f5641a-246d-457b-a96d-07f3fae6acf2"))
                                   VARIANT var_id,
                                   LONG* topic_id) override;
   IFACEMETHODIMP put_accName(VARIANT var_id, BSTR put_name) override;
+
+  //
+  // IAccessibleEx methods.
+  //
+
+  IFACEMETHODIMP GetObjectForChild(LONG child_id,
+                                   IAccessibleEx** result) override;
+
+  IFACEMETHODIMP GetIAccessiblePair(IAccessible** accessible,
+                                    LONG* child_id) override;
+
+  // IAccessibleEx methods not implemented.
+  IFACEMETHODIMP
+  ConvertReturnedElement(IRawElementProviderSimple* element,
+                         IAccessibleEx** acc) override;
 
   //
   // IExpandCollapseProvider methods.


### PR DESCRIPTION
Expose Semantics.identifier as Windows AutomationId to ease application automation.

see https://github.com/flutter/flutter/issues/148763

followup to https://github.com/flutter/engine/pull/53729 and https://github.com/flutter/engine/pull/53476

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
