### PR TITLE
Make `font-subset` a standalone `run_tests.py` variant.

### DIFF
--- a/engine/src/flutter/ci/builders/linux_unopt.json
+++ b/engine/src/flutter/ci/builders/linux_unopt.json
@@ -67,7 +67,7 @@
                         "--variant",
                         "ci/host_debug_unopt",
                         "--type",
-                        "dart,dart-host,engine",
+                        "dart,dart-host,engine,font-subset",
                         "--engine-capture-core-dump",
                         "--use-sanitizer-suppressions"
                     ]

--- a/engine/src/flutter/ci/builders/mac_unopt.json
+++ b/engine/src/flutter/ci/builders/mac_unopt.json
@@ -47,7 +47,7 @@
                         "--variant",
                         "ci/host_debug_arm64_tests",
                         "--type",
-                        "dart,dart-host,engine",
+                        "dart,dart-host,engine,font-subset",
                         "--engine-capture-core-dump"
                     ]
                 }

--- a/engine/src/flutter/ci/builders/standalone/windows_unopt.json
+++ b/engine/src/flutter/ci/builders/standalone/windows_unopt.json
@@ -38,7 +38,7 @@
                 "--variant",
                 "ci/host_debug_unopt",
                 "--type",
-                "engine",
+                "engine,font-subset",
                 "--engine-capture-core-dump"
             ]
         },

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -1372,7 +1372,7 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
     run_benchmark_tests(build_dir)
     run_engine_benchmarks(build_dir, engine_filter)
 
-  if ('engine' in types or 'font-subset' in types) and 'debug' in build_dir:
+  if 'font-subset' in types:
     cmd = ['python3', 'test.py', '--variant', args.variant]
     if 'arm64' in args.variant:
       cmd += ['--target-cpu', 'arm64']


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/161538.