### PR TITLE
[DisplayList] Move nested canvas enums into their own TU.

### DIFF
--- a/engine/src/flutter/display_list/BUILD.gn
+++ b/engine/src/flutter/display_list/BUILD.gn
@@ -45,6 +45,8 @@ source_set("display_list") {
     "dl_storage.cc",
     "dl_storage.h",
     "dl_tile_mode.h",
+    "dl_types.cc",
+    "dl_types.h",
     "dl_vertices.cc",
     "dl_vertices.h",
     "effects/color_filters/dl_blend_color_filter.cc",

--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
@@ -852,13 +852,13 @@ std::vector<SkPoint> GetTestPoints(size_t count, SkISize canvas_size) {
   return points;
 }
 
-std::string PointModeToString(DlCanvas::PointMode mode) {
+std::string PointModeToString(DlPointMode mode) {
   switch (mode) {
-    case DlCanvas::PointMode::kLines:
+    case DlPointMode::kLines:
       return "Lines";
-    case DlCanvas::PointMode::kPolygon:
+    case DlPointMode::kPolygon:
       return "Polygon";
-    case DlCanvas::PointMode::kPoints:
+    case DlPointMode::kPoints:
     default:
       return "Points";
   }
@@ -873,21 +873,21 @@ std::string PointModeToString(DlCanvas::PointMode mode) {
 void BM_DrawPoints(benchmark::State& state,
                    BackendType backend_type,
                    unsigned attributes,
-                   DlCanvas::PointMode mode) {
+                   DlPointMode mode) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
   DlPaint paint = GetPaintForRun(attributes);
 
   switch (mode) {
-    case DlCanvas::PointMode::kPoints:
+    case DlPointMode::kPoints:
       AnnotateAttributes(attributes, state,
                          DisplayListOpFlags::kDrawPointsAsPointsFlags);
       break;
-    case DlCanvas::PointMode::kLines:
+    case DlPointMode::kLines:
       AnnotateAttributes(attributes, state,
                          DisplayListOpFlags::kDrawPointsAsLinesFlags);
       break;
-    case DlCanvas::PointMode::kPolygon:
+    case DlPointMode::kPolygon:
       AnnotateAttributes(attributes, state,
                          DisplayListOpFlags::kDrawPointsAsPolygonFlags);
       break;
@@ -998,11 +998,11 @@ void BM_DrawImage(benchmark::State& state,
   surface_provider->Snapshot(filename);
 }
 
-std::string ConstraintToString(DlCanvas::SrcRectConstraint constraint) {
+std::string ConstraintToString(DlSrcRectConstraint constraint) {
   switch (constraint) {
-    case DlCanvas::SrcRectConstraint::kStrict:
+    case DlSrcRectConstraint::kStrict:
       return "Strict";
-    case DlCanvas::SrcRectConstraint::kFast:
+    case DlSrcRectConstraint::kFast:
       return "Fast";
     default:
       return "Unknown";
@@ -1017,7 +1017,7 @@ void BM_DrawImageRect(benchmark::State& state,
                       BackendType backend_type,
                       unsigned attributes,
                       DlImageSampling options,
-                      DlCanvas::SrcRectConstraint constraint,
+                      DlSrcRectConstraint constraint,
                       bool upload_bitmap) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;

--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.h
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.h
@@ -69,7 +69,7 @@ void BM_DrawPath(benchmark::State& state,
 void BM_DrawPoints(benchmark::State& state,
                    BackendType backend_type,
                    unsigned attributes,
-                   DlCanvas::PointMode mode);
+                   DlPointMode mode);
 void BM_DrawVertices(benchmark::State& state,
                      BackendType backend_type,
                      unsigned attributes,
@@ -83,7 +83,7 @@ void BM_DrawImageRect(benchmark::State& state,
                       BackendType backend_type,
                       unsigned attributes,
                       DlImageSampling options,
-                      DlCanvas::SrcRectConstraint constraint,
+                      DlSrcRectConstraint constraint,
                       bool upload_bitmap);
 void BM_DrawImageNine(benchmark::State& state,
                       BackendType backend_type,
@@ -205,7 +205,7 @@ void BM_SaveLayer(benchmark::State& state,
   BENCHMARK_CAPTURE(BM_DrawPoints, Points/BACKEND,                      \
                     BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    DlCanvas::PointMode::kPoints)                       \
+                    DlPointMode::kPoints)                       \
       ->RangeMultiplier(2)                                              \
       ->Range(1024, 32768)                                              \
       ->UseRealTime()                                                   \
@@ -214,7 +214,7 @@ void BM_SaveLayer(benchmark::State& state,
   BENCHMARK_CAPTURE(BM_DrawPoints, Lines/BACKEND,                       \
                     BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    DlCanvas::PointMode::kLines)                        \
+                    DlPointMode::kLines)                        \
       ->RangeMultiplier(2)                                              \
       ->Range(1024, 32768)                                              \
       ->UseRealTime()                                                   \
@@ -223,7 +223,7 @@ void BM_SaveLayer(benchmark::State& state,
   BENCHMARK_CAPTURE(BM_DrawPoints, Polygon/BACKEND,                     \
                     BackendType::k##BACKEND##Backend,                   \
                     ATTRIBUTES,                                         \
-                    DlCanvas::PointMode::kPolygon)                      \
+                    DlPointMode::kPolygon)                      \
       ->RangeMultiplier(2)                                              \
       ->Range(1024, 32768)                                              \
       ->UseRealTime()                                                   \
@@ -349,7 +349,7 @@ void BM_SaveLayer(benchmark::State& state,
       BackendType::k##BACKEND##Backend,                                 \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
-      DlCanvas::SrcRectConstraint::kStrict, false)                      \
+      DlSrcRectConstraint::kStrict, false)                              \
       ->RangeMultiplier(2)                                              \
       ->Range(32, 256)                                                  \
       ->UseRealTime()                                                   \
@@ -360,7 +360,7 @@ void BM_SaveLayer(benchmark::State& state,
       BackendType::k##BACKEND##Backend,                                 \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
-      DlCanvas::SrcRectConstraint::kFast, false)                        \
+      DlSrcRectConstraint::kFast, false)                                \
       ->RangeMultiplier(2)                                              \
       ->Range(32, 256)                                                  \
       ->UseRealTime()                                                   \
@@ -371,7 +371,7 @@ void BM_SaveLayer(benchmark::State& state,
       BackendType::k##BACKEND##Backend,                                 \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
-      DlCanvas::SrcRectConstraint::kStrict, true)                       \
+      DlSrcRectConstraint::kStrict, true)                               \
       ->RangeMultiplier(2)                                              \
       ->Range(32, 256)                                                  \
       ->UseRealTime()                                                   \
@@ -382,7 +382,7 @@ void BM_SaveLayer(benchmark::State& state,
       BackendType::k##BACKEND##Backend,                                 \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
-      DlCanvas::SrcRectConstraint::kFast, true)                         \
+      DlSrcRectConstraint::kFast, true)                                 \
       ->RangeMultiplier(2)                                              \
       ->Range(32, 256)                                                  \
       ->UseRealTime()                                                   \

--- a/engine/src/flutter/display_list/benchmarking/dl_builder_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_builder_benchmarks.cc
@@ -131,7 +131,7 @@ static void BM_DisplayListBuilderWithClipRect(
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
     DisplayListBuilder builder(prepare_rtree);
-    builder.ClipRect(clip_bounds, DlCanvas::ClipOp::kIntersect, true);
+    builder.ClipRect(clip_bounds, DlClipOp::kIntersect, true);
     InvokeAllRenderingOps(builder);
     Complete(builder, type);
   }

--- a/engine/src/flutter/display_list/benchmarking/dl_complexity_gl.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_complexity_gl.cc
@@ -428,7 +428,7 @@ void DisplayListGLComplexityCalculator::GLHelper::drawArc(
 }
 
 void DisplayListGLComplexityCalculator::GLHelper::drawPoints(
-    DlCanvas::PointMode mode,
+    DlPointMode mode,
     uint32_t count,
     const DlPoint points[]) {
   if (IsComplex()) {
@@ -437,7 +437,7 @@ void DisplayListGLComplexityCalculator::GLHelper::drawPoints(
   unsigned int complexity;
 
   if (IsAntiAliased()) {
-    if (mode == DlCanvas::PointMode::kPoints) {
+    if (mode == DlPointMode::kPoints) {
       if (IsHairline()) {
         // This is a special case, it triggers an extremely fast path.
         // m = 1/4500
@@ -448,7 +448,7 @@ void DisplayListGLComplexityCalculator::GLHelper::drawPoints(
         // c = 0
         complexity = count * 400;
       }
-    } else if (mode == DlCanvas::PointMode::kLines) {
+    } else if (mode == DlPointMode::kLines) {
       if (IsHairline()) {
         // m = 1/750
         // c = 0
@@ -470,12 +470,12 @@ void DisplayListGLComplexityCalculator::GLHelper::drawPoints(
       }
     }
   } else {
-    if (mode == DlCanvas::PointMode::kPoints) {
+    if (mode == DlPointMode::kPoints) {
       // Hairline vs non hairline makes no difference for points without AA.
       // m = 1/18000
       // c = 0.25
       complexity = (count + 4500) * 100 / 9;
-    } else if (mode == DlCanvas::PointMode::kLines) {
+    } else if (mode == DlPointMode::kLines) {
       if (IsHairline()) {
         // m = 1/8500
         // c = 0.25

--- a/engine/src/flutter/display_list/benchmarking/dl_complexity_gl.h
+++ b/engine/src/flutter/display_list/benchmarking/dl_complexity_gl.h
@@ -56,7 +56,7 @@ class DisplayListGLComplexityCalculator
                  DlScalar start_degrees,
                  DlScalar sweep_degrees,
                  bool use_center) override;
-    void drawPoints(DlCanvas::PointMode mode,
+    void drawPoints(DlPointMode mode,
                     uint32_t count,
                     const DlPoint points[]) override;
     void drawVertices(const std::shared_ptr<DlVertices>& vertices,

--- a/engine/src/flutter/display_list/benchmarking/dl_complexity_helper.h
+++ b/engine/src/flutter/display_list/benchmarking/dl_complexity_helper.h
@@ -149,12 +149,13 @@ class ComplexityCalculatorHelper
       const DlRect& dst,
       DlImageSampling sampling,
       bool render_with_attributes,
-      SrcRectConstraint constraint = SrcRectConstraint::kFast) override {
+      DlSrcRectConstraint constraint = DlSrcRectConstraint::kFast) override {
     if (IsComplex()) {
       return;
     }
     ImageRect(image->dimensions(), image->isTextureBacked(),
-              render_with_attributes, constraint == SrcRectConstraint::kStrict);
+              render_with_attributes,
+              constraint == DlSrcRectConstraint::kStrict);
   }
 
   void drawAtlas(const sk_sp<DlImage> atlas,

--- a/engine/src/flutter/display_list/benchmarking/dl_complexity_metal.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_complexity_metal.cc
@@ -412,7 +412,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawArc(
 }
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawPoints(
-    DlCanvas::PointMode mode,
+    DlPointMode mode,
     uint32_t count,
     const DlPoint points[]) {
   if (IsComplex()) {
@@ -427,12 +427,12 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawPoints(
     // c = 0.75
     complexity = (count + 12000) * 25 / 2;
   } else {
-    if (mode == DlCanvas::PointMode::kPolygon) {
+    if (mode == DlPointMode::kPolygon) {
       // m = 1/1250
       // c = 1
       complexity = (count + 1250) * 160;
     } else {
-      if (IsHairline() && mode == DlCanvas::PointMode::kPoints) {
+      if (IsHairline() && mode == DlPointMode::kPoints) {
         // This is a special case, it triggers an extremely fast path.
         // m = 1/14500
         // c = 0

--- a/engine/src/flutter/display_list/benchmarking/dl_complexity_metal.h
+++ b/engine/src/flutter/display_list/benchmarking/dl_complexity_metal.h
@@ -56,7 +56,7 @@ class DisplayListMetalComplexityCalculator
                  DlScalar start_degrees,
                  DlScalar sweep_degrees,
                  bool use_center) override;
-    void drawPoints(DlCanvas::PointMode mode,
+    void drawPoints(DlPointMode mode,
                     uint32_t count,
                     const DlPoint points[]) override;
     void drawVertices(const std::shared_ptr<DlVertices>& vertices,

--- a/engine/src/flutter/display_list/benchmarking/dl_complexity_unittests.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_complexity_unittests.cc
@@ -328,17 +328,17 @@ TEST(DisplayListComplexity, DrawTextBlob) {
 TEST(DisplayListComplexity, DrawPoints) {
   auto points = GetTestPoints();
   DisplayListBuilder builder_lines;
-  builder_lines.DrawPoints(DlCanvas::PointMode::kLines, points.size(),
-                           points.data(), DlPaint());
+  builder_lines.DrawPoints(DlPointMode::kLines, points.size(), points.data(),
+                           DlPaint());
   auto display_list_lines = builder_lines.Build();
 
   DisplayListBuilder builder_points;
-  builder_points.DrawPoints(DlCanvas::PointMode::kPoints, points.size(),
-                            points.data(), DlPaint());
+  builder_points.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
+                            DlPaint());
   auto display_list_points = builder_points.Build();
 
   DisplayListBuilder builder_polygon;
-  builder_polygon.DrawPoints(DlCanvas::PointMode::kPolygon, points.size(),
+  builder_polygon.DrawPoints(DlPointMode::kPolygon, points.size(),
                              points.data(), DlPaint());
   auto display_list_polygon = builder_polygon.Build();
 

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -43,9 +43,6 @@ namespace testing {
 static std::vector<testing::DisplayListInvocationGroup> allGroups =
     CreateAllGroups();
 
-using ClipOp = DlCanvas::ClipOp;
-using PointMode = DlCanvas::PointMode;
-
 template <typename BaseT>
 class DisplayListTestBase : public BaseT {
  public:
@@ -544,7 +541,7 @@ TEST_F(DisplayListTest, BuilderClipBoundsAfterClipRect) {
   DlRect clip_rect = DlRect::MakeLTRB(10, 10, 20, 20);
   DlRect clip_bounds = DlRect::MakeLTRB(10, 10, 20, 20);
   DisplayListBuilder builder(cull_rect);
-  builder.ClipRect(clip_rect, ClipOp::kIntersect, false);
+  builder.ClipRect(clip_rect, DlClipOp::kIntersect, false);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
@@ -554,7 +551,7 @@ TEST_F(DisplayListTest, BuilderClipBoundsAfterClipRRect) {
   DlRoundRect clip_rrect = DlRoundRect::MakeRectXY(clip_rect, 2, 2);
   DlRect clip_bounds = DlRect::MakeLTRB(10, 10, 20, 20);
   DisplayListBuilder builder(cull_rect);
-  builder.ClipRoundRect(clip_rrect, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip_rrect, DlClipOp::kIntersect, false);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
@@ -564,7 +561,7 @@ TEST_F(DisplayListTest, BuilderClipBoundsAfterClipPath) {
                      DlPath::MakeRectLTRB(15, 15, 20, 20);
   DlRect clip_bounds = DlRect::MakeLTRB(10, 10, 20, 20);
   DisplayListBuilder builder(cull_rect);
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
+  builder.ClipPath(clip_path, DlClipOp::kIntersect, false);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
 }
 
@@ -589,7 +586,7 @@ TEST_F(DisplayListTest, UnclippedSaveLayerContentAccountsForFilter) {
   DisplayListBuilder builder;
   builder.Save();
   {
-    builder.ClipRect(clip_rect, ClipOp::kIntersect, false);
+    builder.ClipRect(clip_rect, DlClipOp::kIntersect, false);
     builder.SaveLayer(cull_rect, &layer_paint);
     {  //
       builder.DrawRect(draw_rect, DlPaint());
@@ -623,7 +620,7 @@ TEST_F(DisplayListTest, ClippedSaveLayerContentAccountsForFilter) {
   DisplayListBuilder builder;
   builder.Save();
   {
-    builder.ClipRect(clip_rect, ClipOp::kIntersect, false);
+    builder.ClipRect(clip_rect, DlClipOp::kIntersect, false);
     builder.SaveLayer(cull_rect, &layer_paint);
     {  //
       builder.DrawRect(draw_rect, DlPaint());
@@ -1177,9 +1174,9 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
       paint););
   RUN_TESTS(canvas.DrawArc(DlRect::MakeLTRB(0, 0, 10, 10), 0, math::kPi, true,
                            paint););
-  RUN_TESTS2(
-      canvas.DrawPoints(PointMode::kPoints, TestPointCount, kTestPoints, paint);
-      , false);
+  RUN_TESTS2(canvas.DrawPoints(DlPointMode::kPoints, TestPointCount,
+                               kTestPoints, paint);
+             , false);
   RUN_TESTS2(canvas.DrawVertices(kTestVertices1, DlBlendMode::kSrc, paint);
              , false);
   RUN_TESTS(canvas.DrawImage(kTestImage1, DlPoint(), kLinearSampling, &paint););
@@ -1188,11 +1185,11 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
   RUN_TESTS(canvas.DrawImageRect(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
                                  DlRect::MakeLTRB(0, 0, 10, 10),
                                  kNearestSampling, &paint,
-                                 DlCanvas::SrcRectConstraint::kFast););
+                                 DlSrcRectConstraint::kFast););
   RUN_TESTS2(
       canvas.DrawImageRect(kTestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
                            DlRect::MakeLTRB(0, 0, 10, 10), kNearestSampling,
-                           nullptr, DlCanvas::SrcRectConstraint::kFast);
+                           nullptr, DlSrcRectConstraint::kFast);
       , true);
   RUN_TESTS(canvas.DrawImageNine(kTestImage2, DlIRect::MakeLTRB(20, 20, 30, 30),
                                  DlRect::MakeLTRB(0, 0, 20, 20),
@@ -1812,7 +1809,7 @@ TEST_F(DisplayListTest, FlutterSvgIssue661BoundsWereEmpty) {
   DlPaint paint = DlPaint(DlColor::kWhite()).setAntiAlias(true);
   {
     builder.Save();
-    builder.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
+    builder.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), DlClipOp::kIntersect,
                      true);
     {
       builder.Save();
@@ -1821,7 +1818,7 @@ TEST_F(DisplayListTest, FlutterSvgIssue661BoundsWereEmpty) {
       {
         builder.Save();
         builder.ClipRect(DlRect::MakeLTRB(1172, 245, 1218, 294),
-                         ClipOp::kIntersect, true);
+                         DlClipOp::kIntersect, true);
         {
           builder.SaveLayer(std::nullopt, nullptr, nullptr);
           {
@@ -1960,7 +1957,7 @@ TEST_F(DisplayListTest, FullTransformAffectsCurrentTransform) {
 TEST_F(DisplayListTest, ClipRectAffectsClipBounds) {
   DisplayListBuilder builder;
   DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  builder.ClipRect(clip_bounds, ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds, DlClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -1969,7 +1966,7 @@ TEST_F(DisplayListTest, ClipRectAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, false);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), DlClipOp::kIntersect, false);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipCoverage(), clip_bounds);
   ASSERT_NE(builder.GetDestinationClipCoverage(), clip_bounds);
@@ -1999,7 +1996,7 @@ TEST_F(DisplayListTest, ClipRectDoAAAffectsClipBounds) {
   DisplayListBuilder builder;
   DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
   DlRect clip_expanded_bounds = DlRect::MakeLTRB(10, 11, 21, 26);
-  builder.ClipRect(clip_bounds, ClipOp::kIntersect, true);
+  builder.ClipRect(clip_bounds, DlClipOp::kIntersect, true);
 
   // Save initial return values for testing restored values
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -2008,7 +2005,7 @@ TEST_F(DisplayListTest, ClipRectDoAAAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, true);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), DlClipOp::kIntersect, true);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipCoverage(), clip_expanded_bounds);
   ASSERT_NE(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
@@ -2039,16 +2036,16 @@ TEST_F(DisplayListTest, ClipRectAffectsClipBoundsWithMatrix) {
   DlRect clip_bounds_1 = DlRect::MakeLTRB(0, 0, 10, 10);
   DlRect clip_bounds_2 = DlRect::MakeLTRB(10, 10, 20, 20);
   builder.Save();
-  builder.ClipRect(clip_bounds_1, ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds_1, DlClipOp::kIntersect, false);
   builder.Translate(10, 0);
-  builder.ClipRect(clip_bounds_1, ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds_1, DlClipOp::kIntersect, false);
   ASSERT_TRUE(builder.GetDestinationClipCoverage().IsEmpty());
   builder.Restore();
 
   builder.Save();
-  builder.ClipRect(clip_bounds_1, ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds_1, DlClipOp::kIntersect, false);
   builder.Translate(-10, -10);
-  builder.ClipRect(clip_bounds_2, ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds_2, DlClipOp::kIntersect, false);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds_1);
   builder.Restore();
 }
@@ -2057,7 +2054,7 @@ TEST_F(DisplayListTest, ClipRRectAffectsClipBounds) {
   DisplayListBuilder builder;
   DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
   DlRoundRect clip = DlRoundRect::MakeRectXY(clip_bounds, 3, 2);
-  builder.ClipRoundRect(clip, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip, DlClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -2066,7 +2063,7 @@ TEST_F(DisplayListTest, ClipRRectAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, false);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), DlClipOp::kIntersect, false);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipCoverage(), clip_bounds);
   ASSERT_NE(builder.GetDestinationClipCoverage(), clip_bounds);
@@ -2097,7 +2094,7 @@ TEST_F(DisplayListTest, ClipRRectDoAAAffectsClipBounds) {
   DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
   DlRect clip_expanded_bounds = DlRect::MakeLTRB(10, 11, 21, 26);
   DlRoundRect clip = DlRoundRect::MakeRectXY(clip_bounds, 3, 2);
-  builder.ClipRoundRect(clip, ClipOp::kIntersect, true);
+  builder.ClipRoundRect(clip, DlClipOp::kIntersect, true);
 
   // Save initial return values for testing restored values
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -2106,7 +2103,7 @@ TEST_F(DisplayListTest, ClipRRectDoAAAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, true);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), DlClipOp::kIntersect, true);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipCoverage(), clip_expanded_bounds);
   ASSERT_NE(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
@@ -2140,16 +2137,16 @@ TEST_F(DisplayListTest, ClipRRectAffectsClipBoundsWithMatrix) {
   DlRoundRect clip2 = DlRoundRect::MakeRectXY(clip_bounds_2, 3, 2);
 
   builder.Save();
-  builder.ClipRoundRect(clip1, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip1, DlClipOp::kIntersect, false);
   builder.Translate(10, 0);
-  builder.ClipRoundRect(clip1, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip1, DlClipOp::kIntersect, false);
   ASSERT_TRUE(builder.GetDestinationClipCoverage().IsEmpty());
   builder.Restore();
 
   builder.Save();
-  builder.ClipRoundRect(clip1, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip1, DlClipOp::kIntersect, false);
   builder.Translate(-10, -10);
-  builder.ClipRoundRect(clip2, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip2, DlClipOp::kIntersect, false);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds_1);
   builder.Restore();
 }
@@ -2159,7 +2156,7 @@ TEST_F(DisplayListTest, ClipPathAffectsClipBounds) {
   DlPath clip = DlPath::MakeCircle(DlPoint(10.2f, 11.3f), 2.0f) +
                 DlPath::MakeCircle(DlPoint(20.4f, 25.7f), 2.0f);
   DlRect clip_bounds = DlRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
-  builder.ClipPath(clip, ClipOp::kIntersect, false);
+  builder.ClipPath(clip, DlClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -2168,7 +2165,7 @@ TEST_F(DisplayListTest, ClipPathAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, false);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), DlClipOp::kIntersect, false);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipCoverage(), clip_bounds);
   ASSERT_NE(builder.GetDestinationClipCoverage(), clip_bounds);
@@ -2199,7 +2196,7 @@ TEST_F(DisplayListTest, ClipPathDoAAAffectsClipBounds) {
   DlPath clip = DlPath::MakeCircle(DlPoint(10.2f, 11.3f), 2.0f) +
                 DlPath::MakeCircle(DlPoint(20.4f, 25.7f), 2.0f);
   DlRect clip_expanded_bounds = DlRect::MakeLTRB(8, 9, 23, 28);
-  builder.ClipPath(clip, ClipOp::kIntersect, true);
+  builder.ClipPath(clip, DlClipOp::kIntersect, true);
 
   // Save initial return values for testing restored values
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -2208,7 +2205,7 @@ TEST_F(DisplayListTest, ClipPathDoAAAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), ClipOp::kIntersect, true);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 15, 15), DlClipOp::kIntersect, true);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipCoverage(), clip_expanded_bounds);
   ASSERT_NE(builder.GetDestinationClipCoverage(), clip_expanded_bounds);
@@ -2243,16 +2240,16 @@ TEST_F(DisplayListTest, ClipPathAffectsClipBoundsWithMatrix) {
                  DlPath::MakeCircle(DlPoint(17.5f, 17.5f), 2.5);
 
   builder.Save();
-  builder.ClipPath(clip1, ClipOp::kIntersect, false);
+  builder.ClipPath(clip1, DlClipOp::kIntersect, false);
   builder.Translate(10, 0);
-  builder.ClipPath(clip1, ClipOp::kIntersect, false);
+  builder.ClipPath(clip1, DlClipOp::kIntersect, false);
   ASSERT_TRUE(builder.GetDestinationClipCoverage().IsEmpty());
   builder.Restore();
 
   builder.Save();
-  builder.ClipPath(clip1, ClipOp::kIntersect, false);
+  builder.ClipPath(clip1, DlClipOp::kIntersect, false);
   builder.Translate(-10, -10);
-  builder.ClipPath(clip2, ClipOp::kIntersect, false);
+  builder.ClipPath(clip2, DlClipOp::kIntersect, false);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), clip_bounds);
   builder.Restore();
 }
@@ -2261,7 +2258,7 @@ TEST_F(DisplayListTest, DiffClipRectDoesNotAffectClipBounds) {
   DisplayListBuilder builder;
   DlRect diff_clip = DlRect::MakeLTRB(0, 0, 15, 15);
   DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  builder.ClipRect(clip_bounds, ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds, DlClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -2269,7 +2266,7 @@ TEST_F(DisplayListTest, DiffClipRectDoesNotAffectClipBounds) {
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
-  builder.ClipRect(diff_clip, ClipOp::kDifference, false);
+  builder.ClipRect(diff_clip, DlClipOp::kDifference, false);
   ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
@@ -2281,7 +2278,7 @@ TEST_F(DisplayListTest, DiffClipRRectDoesNotAffectClipBounds) {
   DlRect clip_bounds = DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
   DlRoundRect clip =
       DlRoundRect::MakeRectXY(DlRect::MakeLTRB(10.2, 11.3, 20.4, 25.7), 3, 2);
-  builder.ClipRoundRect(clip, ClipOp::kIntersect, false);
+  builder.ClipRoundRect(clip, DlClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -2289,7 +2286,7 @@ TEST_F(DisplayListTest, DiffClipRRectDoesNotAffectClipBounds) {
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
-  builder.ClipRoundRect(diff_clip, ClipOp::kDifference, false);
+  builder.ClipRoundRect(diff_clip, DlClipOp::kDifference, false);
   ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
@@ -2300,7 +2297,7 @@ TEST_F(DisplayListTest, DiffClipPathDoesNotAffectClipBounds) {
   DlPath clip = DlPath::MakeCircle(DlPoint(10.2, 11.3), 2) +
                 DlPath::MakeCircle(DlPoint(20.4, 25.7), 2);
   DlRect clip_bounds = DlRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
-  builder.ClipPath(clip, ClipOp::kIntersect, false);
+  builder.ClipPath(clip, DlClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
   DlRect initial_local_bounds = builder.GetLocalClipCoverage();
@@ -2308,7 +2305,7 @@ TEST_F(DisplayListTest, DiffClipPathDoesNotAffectClipBounds) {
   ASSERT_EQ(initial_local_bounds, clip_bounds);
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
-  builder.ClipPath(diff_clip, ClipOp::kDifference, false);
+  builder.ClipPath(diff_clip, DlClipOp::kDifference, false);
   ASSERT_EQ(builder.GetLocalClipCoverage(), initial_local_bounds);
   ASSERT_EQ(builder.GetDestinationClipCoverage(), initial_destination_bounds);
 }
@@ -2318,7 +2315,7 @@ TEST_F(DisplayListTest, FlatDrawPointsProducesBounds) {
   DlPoint vertical_points[2] = {DlPoint(10, 10), DlPoint(10, 20)};
   {
     DisplayListBuilder builder;
-    builder.DrawPoints(PointMode::kPolygon, 2, horizontal_points, DlPaint());
+    builder.DrawPoints(DlPointMode::kPolygon, 2, horizontal_points, DlPaint());
     DlRect bounds = builder.Build()->GetBounds();
     EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
     EXPECT_TRUE(bounds.Contains(DlPoint(20, 10)));
@@ -2326,7 +2323,7 @@ TEST_F(DisplayListTest, FlatDrawPointsProducesBounds) {
   }
   {
     DisplayListBuilder builder;
-    builder.DrawPoints(PointMode::kPolygon, 2, vertical_points, DlPaint());
+    builder.DrawPoints(DlPointMode::kPolygon, 2, vertical_points, DlPaint());
     DlRect bounds = builder.Build()->GetBounds();
     EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
     EXPECT_TRUE(bounds.Contains(DlPoint(10, 20)));
@@ -2334,7 +2331,7 @@ TEST_F(DisplayListTest, FlatDrawPointsProducesBounds) {
   }
   {
     DisplayListBuilder builder;
-    builder.DrawPoints(PointMode::kPoints, 1, horizontal_points, DlPaint());
+    builder.DrawPoints(DlPointMode::kPoints, 1, horizontal_points, DlPaint());
     DlRect bounds = builder.Build()->GetBounds();
     EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
   }
@@ -2342,7 +2339,7 @@ TEST_F(DisplayListTest, FlatDrawPointsProducesBounds) {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setStrokeWidth(2);
-    builder.DrawPoints(PointMode::kPolygon, 2, horizontal_points, paint);
+    builder.DrawPoints(DlPointMode::kPolygon, 2, horizontal_points, paint);
     DlRect bounds = builder.Build()->GetBounds();
     EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
     EXPECT_TRUE(bounds.Contains(DlPoint(20, 10)));
@@ -2352,7 +2349,7 @@ TEST_F(DisplayListTest, FlatDrawPointsProducesBounds) {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setStrokeWidth(2);
-    builder.DrawPoints(PointMode::kPolygon, 2, vertical_points, paint);
+    builder.DrawPoints(DlPointMode::kPolygon, 2, vertical_points, paint);
     DlRect bounds = builder.Build()->GetBounds();
     EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
     EXPECT_TRUE(bounds.Contains(DlPoint(10, 20)));
@@ -2362,7 +2359,7 @@ TEST_F(DisplayListTest, FlatDrawPointsProducesBounds) {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setStrokeWidth(2);
-    builder.DrawPoints(PointMode::kPoints, 1, horizontal_points, paint);
+    builder.DrawPoints(DlPointMode::kPoints, 1, horizontal_points, paint);
     DlRect bounds = builder.Build()->GetBounds();
     EXPECT_TRUE(bounds.Contains(DlPoint(10, 10)));
     EXPECT_EQ(bounds, DlRect::MakeLTRB(9, 9, 11, 11));
@@ -2559,8 +2556,8 @@ TEST_F(DisplayListTest, CollapseMultipleNestedSaveRestore) {
       {
         builder1.Translate(10, 10);
         builder1.Scale(2, 2);
-        builder1.ClipRect(DlRect::MakeLTRB(10, 10, 20, 20), ClipOp::kIntersect,
-                          false);
+        builder1.ClipRect(DlRect::MakeLTRB(10, 10, 20, 20),
+                          DlClipOp::kIntersect, false);
         builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
       }
       builder1.Restore();
@@ -2575,7 +2572,7 @@ TEST_F(DisplayListTest, CollapseMultipleNestedSaveRestore) {
   {
     builder2.Translate(10, 10);
     builder2.Scale(2, 2);
-    builder2.ClipRect(DlRect::MakeLTRB(10, 10, 20, 20), ClipOp::kIntersect,
+    builder2.ClipRect(DlRect::MakeLTRB(10, 10, 20, 20), DlClipOp::kIntersect,
                       false);
     builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
@@ -2880,7 +2877,7 @@ TEST_F(DisplayListTest, ClipRectTriggersDeferredSave) {
   {
     builder1.Save();
     {
-      builder1.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
+      builder1.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), DlClipOp::kIntersect,
                         true);
       builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
@@ -2897,7 +2894,7 @@ TEST_F(DisplayListTest, ClipRectTriggersDeferredSave) {
   DisplayListBuilder builder2;
   builder2.Save();
   {
-    builder2.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
+    builder2.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100), DlClipOp::kIntersect,
                       true);
     builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
@@ -2918,7 +2915,7 @@ TEST_F(DisplayListTest, ClipRRectTriggersDeferredSave) {
   {
     builder1.Save();
     {
-      builder1.ClipRoundRect(kTestRRect, ClipOp::kIntersect, true);
+      builder1.ClipRoundRect(kTestRRect, DlClipOp::kIntersect, true);
 
       builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
@@ -2934,7 +2931,7 @@ TEST_F(DisplayListTest, ClipRRectTriggersDeferredSave) {
 
   DisplayListBuilder builder2;
   builder2.Save();
-  builder2.ClipRoundRect(kTestRRect, ClipOp::kIntersect, true);
+  builder2.ClipRoundRect(kTestRRect, DlClipOp::kIntersect, true);
 
   builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   builder2.Restore();
@@ -2954,7 +2951,7 @@ TEST_F(DisplayListTest, ClipPathTriggersDeferredSave) {
   {
     builder1.Save();
     {
-      builder1.ClipPath(kTestPath1, ClipOp::kIntersect, true);
+      builder1.ClipPath(kTestPath1, DlClipOp::kIntersect, true);
       builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
     builder1.Restore();
@@ -2970,7 +2967,7 @@ TEST_F(DisplayListTest, ClipPathTriggersDeferredSave) {
   DisplayListBuilder builder2;
   builder2.Save();
   {
-    builder2.ClipPath(kTestPath1, ClipOp::kIntersect, true);
+    builder2.ClipPath(kTestPath1, DlClipOp::kIntersect, true);
     builder2.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
   }
   builder2.Restore();
@@ -3196,7 +3193,7 @@ TEST_F(DisplayListTest, NOPClipDoesNotTriggerDeferredSave) {
   {
     builder1.Save();
     {
-      builder1.ClipRect(DlRect::MakeLTRB(0, NaN, NaN, 0), ClipOp::kIntersect,
+      builder1.ClipRect(DlRect::MakeLTRB(0, NaN, NaN, 0), DlClipOp::kIntersect,
                         true);
       builder1.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
     }
@@ -3221,7 +3218,8 @@ TEST_F(DisplayListTest, RTreeOfClippedSaveLayerFilterScene) {
   DlPaint default_paint = DlPaint();
   DlPaint filter_paint = DlPaint().setImageFilter(&filter);
   builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), default_paint);
-  builder.ClipRect(DlRect::MakeLTRB(50, 50, 60, 60), ClipOp::kIntersect, false);
+  builder.ClipRect(DlRect::MakeLTRB(50, 50, 60, 60), DlClipOp::kIntersect,
+                   false);
   builder.SaveLayer(std::nullopt, &filter_paint);
   // the following rectangle will be expanded to 23,23,87,87
   // by the SaveLayer filter during the restore operation
@@ -3377,8 +3375,7 @@ TEST_F(DisplayListTest, DrawSaveDrawCannotInheritOpacity) {
   DisplayListBuilder builder;
   builder.DrawCircle(DlPoint(10, 10), 5, DlPaint());
   builder.Save();
-  builder.ClipRect(DlRect::MakeLTRB(0, 0, 20, 20), DlCanvas::ClipOp::kIntersect,
-                   false);
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 20, 20), DlClipOp::kIntersect, false);
   builder.DrawRect(DlRect::MakeLTRB(5, 5, 15, 15), DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
@@ -3494,7 +3491,7 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
           builder.DrawArc(DlRect::MakeLTRB(10, 10, 20, 20), 45, 90, true,
                           paint);
           DlPoint pts[] = {DlPoint(10, 10), DlPoint(20, 20)};
-          builder.DrawPoints(PointMode::kLines, 2, pts, paint);
+          builder.DrawPoints(DlPointMode::kLines, 2, pts, paint);
           builder.DrawVertices(kTestVertices1, DlBlendMode::kSrcOver, paint);
           builder.DrawImage(kTestImage1, DlPoint(10, 10),
                             DlImageSampling::kLinear, &paint);
@@ -3561,15 +3558,15 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
             });
   run_tests("Empty rect clip",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
-              builder.ClipRect(DlRect(), ClipOp::kIntersect, false);
+              builder.ClipRect(DlRect(), DlClipOp::kIntersect, false);
             });
   run_tests("Empty rrect clip",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
-              builder.ClipRoundRect(DlRoundRect(), ClipOp::kIntersect, false);
+              builder.ClipRoundRect(DlRoundRect(), DlClipOp::kIntersect, false);
             });
   run_tests("Empty path clip",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
-              builder.ClipPath(DlPath(), ClipOp::kIntersect, false);
+              builder.ClipPath(DlPath(), DlClipOp::kIntersect, false);
             });
   run_tests("Transparent SaveLayer",  //
             [](DisplayListBuilder& builder, DlPaint& paint) {
@@ -4517,7 +4514,7 @@ TEST_F(DisplayListTest, DrawDisplayListForwardsBackdropFlag) {
 struct ClipExpectation {
   std::variant<DlRect, DlRoundRect, DlPath> shape;
   bool is_oval;
-  ClipOp clip_op;
+  DlClipOp clip_op;
   bool is_aa;
 
   std::string shape_name() {
@@ -4577,7 +4574,7 @@ class ClipExpector : public virtual DlOpReceiver,
   }
 
   ClipExpector& addExpectation(const DlRect& rect,
-                               ClipOp clip_op = ClipOp::kIntersect,
+                               DlClipOp clip_op = DlClipOp::kIntersect,
                                bool is_aa = false) {
     clip_expectations_.push_back({
         .shape = rect,
@@ -4589,7 +4586,7 @@ class ClipExpector : public virtual DlOpReceiver,
   }
 
   ClipExpector& addOvalExpectation(const DlRect& rect,
-                                   ClipOp clip_op = ClipOp::kIntersect,
+                                   DlClipOp clip_op = DlClipOp::kIntersect,
                                    bool is_aa = false) {
     clip_expectations_.push_back({
         .shape = rect,
@@ -4601,7 +4598,7 @@ class ClipExpector : public virtual DlOpReceiver,
   }
 
   ClipExpector& addExpectation(const DlRoundRect& rrect,
-                               ClipOp clip_op = ClipOp::kIntersect,
+                               DlClipOp clip_op = DlClipOp::kIntersect,
                                bool is_aa = false) {
     clip_expectations_.push_back({
         .shape = rrect,
@@ -4613,7 +4610,7 @@ class ClipExpector : public virtual DlOpReceiver,
   }
 
   ClipExpector& addExpectation(const DlPath& path,
-                               ClipOp clip_op = ClipOp::kIntersect,
+                               DlClipOp clip_op = DlClipOp::kIntersect,
                                bool is_aa = false) {
     clip_expectations_.push_back({
         .shape = path,
@@ -4624,24 +4621,18 @@ class ClipExpector : public virtual DlOpReceiver,
     return *this;
   }
 
-  void clipRect(const DlRect& rect,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {
+  void clipRect(const DlRect& rect, DlClipOp clip_op, bool is_aa) override {
     check(rect, clip_op, is_aa);
   }
-  void clipOval(const DlRect& bounds,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {
+  void clipOval(const DlRect& bounds, DlClipOp clip_op, bool is_aa) override {
     check(bounds, clip_op, is_aa, true);
   }
   void clipRoundRect(const DlRoundRect& rrect,
-                     DlCanvas::ClipOp clip_op,
+                     DlClipOp clip_op,
                      bool is_aa) override {
     check(rrect, clip_op, is_aa);
   }
-  void clipPath(const DlPath& path,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {
+  void clipPath(const DlPath& path, DlClipOp clip_op, bool is_aa) override {
     check(path, clip_op, is_aa);
   }
 
@@ -4650,7 +4641,7 @@ class ClipExpector : public virtual DlOpReceiver,
   std::vector<ClipExpectation> clip_expectations_;
 
   template <typename T>
-  void check(T shape, ClipOp clip_op, bool is_aa, bool is_oval = false) {
+  void check(T shape, DlClipOp clip_op, bool is_aa, bool is_oval = false) {
     ASSERT_LT(index_, clip_expectations_.size())
         << label() << std::endl
         << "extra clip shape = " << shape << (is_oval ? " (oval)" : "");
@@ -4691,13 +4682,13 @@ TEST_F(DisplayListTest, ClipRectCullingPixel6a) {
   auto clip = DlRect::MakeLTRB(0.0f, 0.0f, 1080.0f / DPR, 2400.0f / DPR);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(frame, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(frame, DlClipOp::kIntersect, false);
   cull_builder.Scale(DPR, DPR);
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(frame, ClipOp::kIntersect, false);
+  expector.addExpectation(frame, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4705,12 +4696,12 @@ TEST_F(DisplayListTest, ClipRectCulling) {
   auto clip = DlRect::MakeLTRB(10.0f, 10.0f, 20.0f, 20.0f);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipRect(clip.Expand(1.0f, 1.0f), ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip.Expand(1.0f, 1.0f), DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4719,13 +4710,13 @@ TEST_F(DisplayListTest, ClipRectNonCulling) {
   auto smaller_clip = clip.Expand(-1.0f, -1.0f);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipRect(smaller_clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipRect(smaller_clip, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
-  expector.addExpectation(smaller_clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
+  expector.addExpectation(smaller_clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4734,14 +4725,14 @@ TEST_F(DisplayListTest, ClipRectNestedCulling) {
   auto larger_clip = clip.Expand(1.0f, 1.0f);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
   cull_builder.Save();
-  cull_builder.ClipRect(larger_clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(larger_clip, DlClipOp::kIntersect, false);
   cull_builder.Restore();
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4751,15 +4742,15 @@ TEST_F(DisplayListTest, ClipRectNestedNonCulling) {
 
   DisplayListBuilder cull_builder;
   cull_builder.Save();
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
   cull_builder.Restore();
   // Should not be culled because we have restored the prior clip
-  cull_builder.ClipRect(larger_clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(larger_clip, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
-  expector.addExpectation(larger_clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
+  expector.addExpectation(larger_clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4769,16 +4760,16 @@ TEST_F(DisplayListTest, ClipRectNestedCullingComplex) {
   auto smallest_clip = clip.Expand(-2.0f, -2.0f);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
   cull_builder.Save();
-  cull_builder.ClipRect(smallest_clip, ClipOp::kIntersect, false);
-  cull_builder.ClipRect(smaller_clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(smallest_clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipRect(smaller_clip, DlClipOp::kIntersect, false);
   cull_builder.Restore();
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
-  expector.addExpectation(smallest_clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
+  expector.addExpectation(smallest_clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4788,18 +4779,18 @@ TEST_F(DisplayListTest, ClipRectNestedNonCullingComplex) {
   auto smallest_clip = clip.Expand(-2.0f, -2.0f);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
   cull_builder.Save();
-  cull_builder.ClipRect(smallest_clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(smallest_clip, DlClipOp::kIntersect, false);
   cull_builder.Restore();
   // Would not be culled if it was inside the clip
-  cull_builder.ClipRect(smaller_clip, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(smaller_clip, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
-  expector.addExpectation(smallest_clip, ClipOp::kIntersect, false);
-  expector.addExpectation(smaller_clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
+  expector.addExpectation(smallest_clip, DlClipOp::kIntersect, false);
+  expector.addExpectation(smaller_clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4812,12 +4803,12 @@ TEST_F(DisplayListTest, ClipOvalCulling) {
   auto encompassing_oval = clip.Expand(2.072f, 2.072f);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipOval(encompassing_oval, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipOval(encompassing_oval, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4830,13 +4821,14 @@ TEST_F(DisplayListTest, ClipOvalNonCulling) {
   auto non_encompassing_oval = clip.Expand(2.071f, 2.071f);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipOval(non_encompassing_oval, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipOval(non_encompassing_oval, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
-  expector.addOvalExpectation(non_encompassing_oval, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
+  expector.addOvalExpectation(non_encompassing_oval, DlClipOp::kIntersect,
+                              false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4846,12 +4838,12 @@ TEST_F(DisplayListTest, ClipRRectCulling) {
   ASSERT_FALSE(rrect.IsOval());
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipRoundRect(rrect, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipRoundRect(rrect, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4861,13 +4853,13 @@ TEST_F(DisplayListTest, ClipRRectNonCulling) {
   ASSERT_FALSE(rrect.IsOval());
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipRoundRect(rrect, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipRoundRect(rrect, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
-  expector.addExpectation(rrect, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
+  expector.addExpectation(rrect, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4891,13 +4883,13 @@ TEST_F(DisplayListTest, ClipPathNonCulling) {
   ASSERT_TRUE(path.Contains(clip.GetLeftBottom()));
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipPath(path, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipPath(path, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
-  expector.addExpectation(path, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
+  expector.addExpectation(path, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4906,12 +4898,12 @@ TEST_F(DisplayListTest, ClipPathRectCulling) {
   DlPath path = DlPath::MakeRect(clip.Expand(1.0f, 1.0f));
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipPath(path, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipPath(path, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4921,14 +4913,14 @@ TEST_F(DisplayListTest, ClipPathRectNonCulling) {
   DlPath path = DlPath::MakeRect(smaller_clip);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipPath(path, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipPath(path, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   // Builder will not cull this clip, but it will turn it into a ClipRect
-  expector.addExpectation(smaller_clip, ClipOp::kIntersect, false);
+  expector.addExpectation(smaller_clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4942,12 +4934,12 @@ TEST_F(DisplayListTest, ClipPathOvalCulling) {
   DlPath path = DlPath::MakeOval(encompassing_oval);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipPath(path, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipPath(path, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4961,14 +4953,15 @@ TEST_F(DisplayListTest, ClipPathOvalNonCulling) {
   DlPath path = DlPath::MakeOval(non_encompassing_oval);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipPath(path, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipPath(path, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   // Builder will not cull this clip, but it will turn it into a ClipOval
-  expector.addOvalExpectation(non_encompassing_oval, ClipOp::kIntersect, false);
+  expector.addOvalExpectation(non_encompassing_oval, DlClipOp::kIntersect,
+                              false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4978,12 +4971,12 @@ TEST_F(DisplayListTest, ClipPathRRectCulling) {
   ASSERT_FALSE(path.IsOval());
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipPath(path, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipPath(path, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -4994,14 +4987,14 @@ TEST_F(DisplayListTest, ClipPathRRectNonCulling) {
   DlPath path = DlPath::MakeRoundRect(rrect);
 
   DisplayListBuilder cull_builder;
-  cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
-  cull_builder.ClipPath(path, ClipOp::kIntersect, false);
+  cull_builder.ClipRect(clip, DlClipOp::kIntersect, false);
+  cull_builder.ClipPath(path, DlClipOp::kIntersect, false);
   auto cull_dl = cull_builder.Build();
 
   CLIP_EXPECTOR(expector);
-  expector.addExpectation(clip, ClipOp::kIntersect, false);
+  expector.addExpectation(clip, DlClipOp::kIntersect, false);
   // Builder will not cull this clip, but it will turn it into a ClipRRect
-  expector.addExpectation(rrect, ClipOp::kIntersect, false);
+  expector.addExpectation(rrect, DlClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -5149,14 +5142,14 @@ TEST_F(DisplayListTest, ClipRectRRectPromoteToClipRect) {
   DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
 
   DisplayListBuilder builder;
-  builder.ClipRoundRect(DlRoundRect::MakeRect(clip_rect), ClipOp::kIntersect,
+  builder.ClipRoundRect(DlRoundRect::MakeRect(clip_rect), DlClipOp::kIntersect,
                         false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.ClipRect(clip_rect, ClipOp::kIntersect, false);
+  expected.ClipRect(clip_rect, DlClipOp::kIntersect, false);
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
@@ -5168,14 +5161,14 @@ TEST_F(DisplayListTest, ClipOvalRRectPromoteToClipOval) {
   DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
 
   DisplayListBuilder builder;
-  builder.ClipRoundRect(DlRoundRect::MakeOval(clip_rect), ClipOp::kIntersect,
+  builder.ClipRoundRect(DlRoundRect::MakeOval(clip_rect), DlClipOp::kIntersect,
                         false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.ClipOval(clip_rect, ClipOp::kIntersect, false);
+  expected.ClipOval(clip_rect, DlClipOp::kIntersect, false);
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
@@ -5189,13 +5182,13 @@ TEST_F(DisplayListTest, ClipRectPathPromoteToClipRect) {
   ASSERT_TRUE(clip_path.IsRect(nullptr));
 
   DisplayListBuilder builder;
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
+  builder.ClipPath(clip_path, DlClipOp::kIntersect, false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.ClipRect(clip_rect, ClipOp::kIntersect, false);
+  expected.ClipRect(clip_rect, DlClipOp::kIntersect, false);
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
@@ -5209,13 +5202,13 @@ TEST_F(DisplayListTest, ClipOvalPathPromoteToClipOval) {
   ASSERT_TRUE(clip_path.IsOval(nullptr));
 
   DisplayListBuilder builder;
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
+  builder.ClipPath(clip_path, DlClipOp::kIntersect, false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.ClipOval(clip_rect, ClipOp::kIntersect, false);
+  expected.ClipOval(clip_rect, DlClipOp::kIntersect, false);
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
@@ -5230,13 +5223,13 @@ TEST_F(DisplayListTest, ClipRRectPathPromoteToClipRRect) {
   ASSERT_TRUE(clip_path.IsRoundRect());
 
   DisplayListBuilder builder;
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
+  builder.ClipPath(clip_path, DlClipOp::kIntersect, false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.ClipRoundRect(clip_rrect, ClipOp::kIntersect, false);
+  expected.ClipRoundRect(clip_rrect, DlClipOp::kIntersect, false);
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
@@ -5251,13 +5244,13 @@ TEST_F(DisplayListTest, ClipRectRRectPathPromoteToClipRect) {
   ASSERT_TRUE(clip_path.IsRoundRect());
 
   DisplayListBuilder builder;
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
+  builder.ClipPath(clip_path, DlClipOp::kIntersect, false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.ClipRect(clip_rect, ClipOp::kIntersect, false);
+  expected.ClipRect(clip_rect, DlClipOp::kIntersect, false);
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
@@ -5272,13 +5265,13 @@ TEST_F(DisplayListTest, ClipOvalRRectPathPromoteToClipOval) {
   ASSERT_TRUE(clip_path.IsRoundRect());
 
   DisplayListBuilder builder;
-  builder.ClipPath(clip_path, ClipOp::kIntersect, false);
+  builder.ClipPath(clip_path, DlClipOp::kIntersect, false);
   // Include a rendering op in case DlBuilder ever removes unneeded clips
   builder.DrawRect(draw_rect, DlPaint());
   auto dl = builder.Build();
 
   DisplayListBuilder expected;
-  expected.ClipOval(clip_rect, ClipOp::kIntersect, false);
+  expected.ClipOval(clip_rect, DlClipOp::kIntersect, false);
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
@@ -5391,7 +5384,7 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
     builder.DrawPath(path, DlPaint());
   });
 
-  auto test_draw_points = [&test_bounded](PointMode mode) {
+  auto test_draw_points = [&test_bounded](DlPointMode mode) {
     std::stringstream ss;
     ss << "DrawPoints(" << mode << ")";
     test_bounded(ss.str(), [mode](DlCanvas& builder) {
@@ -5413,9 +5406,9 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
     });
   };
 
-  test_draw_points(PointMode::kPoints);
-  test_draw_points(PointMode::kLines);
-  test_draw_points(PointMode::kPolygon);
+  test_draw_points(DlPointMode::kPoints);
+  test_draw_points(DlPointMode::kLines);
+  test_draw_points(DlPointMode::kPolygon);
 
   test_bounded("DrawVerticesTriangles", [](DlCanvas& builder) {
     DlPoint points[6] = {
@@ -5766,17 +5759,17 @@ TEST_F(DisplayListTest, RecordManyLargeDisplayListOperations) {
   // 2050 points is sizeof(DlPoint) * 2050 = 16400 bytes, this is more
   // than the page size of 16384 bytes.
   std::vector<DlPoint> points(2050);
-  builder.DrawPoints(PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      DlPaint{});
-  builder.DrawPoints(PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      DlPaint{});
-  builder.DrawPoints(PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      DlPaint{});
-  builder.DrawPoints(PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      DlPaint{});
-  builder.DrawPoints(PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      DlPaint{});
-  builder.DrawPoints(PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      DlPaint{});
 
   EXPECT_TRUE(!!builder.Build());
@@ -5786,7 +5779,7 @@ TEST_F(DisplayListTest, RecordSingleLargeDisplayListOperation) {
   DisplayListBuilder builder;
 
   std::vector<DlPoint> points(40000);
-  builder.DrawPoints(PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      DlPaint{});
 
   EXPECT_TRUE(!!builder.Build());

--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -505,7 +505,7 @@ void DisplayListBuilder::saveLayer(const DlRect& bounds,
     // in a rotated or skewed coordinate system (but it will work
     // conservatively).
     if (in_options.bounds_from_caller()) {
-      current_info().global_state.clipRect(bounds, ClipOp::kIntersect, false);
+      current_info().global_state.clipRect(bounds, DlClipOp::kIntersect, false);
     }
   }
 
@@ -928,7 +928,7 @@ void DisplayListBuilder::Transform(const DlMatrix& matrix) {
 }
 
 void DisplayListBuilder::ClipRect(const DlRect& rect,
-                                  ClipOp clip_op,
+                                  DlClipOp clip_op,
                                   bool is_aa) {
   if (!rect.IsFinite()) {
     return;
@@ -936,8 +936,7 @@ void DisplayListBuilder::ClipRect(const DlRect& rect,
   if (current_info().is_nop) {
     return;
   }
-  if (current_info().has_valid_clip &&
-      clip_op == DlCanvas::ClipOp::kIntersect &&
+  if (current_info().has_valid_clip && clip_op == DlClipOp::kIntersect &&
       layer_local_state().rect_covers_cull(rect)) {
     return;
   }
@@ -951,16 +950,16 @@ void DisplayListBuilder::ClipRect(const DlRect& rect,
   current_info().has_valid_clip = true;
   checkForDeferredSave();
   switch (clip_op) {
-    case ClipOp::kIntersect:
+    case DlClipOp::kIntersect:
       Push<ClipIntersectRectOp>(0, rect, is_aa);
       break;
-    case ClipOp::kDifference:
+    case DlClipOp::kDifference:
       Push<ClipDifferenceRectOp>(0, rect, is_aa);
       break;
   }
 }
 void DisplayListBuilder::ClipOval(const DlRect& bounds,
-                                  ClipOp clip_op,
+                                  DlClipOp clip_op,
                                   bool is_aa) {
   if (!bounds.IsFinite()) {
     return;
@@ -968,8 +967,7 @@ void DisplayListBuilder::ClipOval(const DlRect& bounds,
   if (current_info().is_nop) {
     return;
   }
-  if (current_info().has_valid_clip &&
-      clip_op == DlCanvas::ClipOp::kIntersect &&
+  if (current_info().has_valid_clip && clip_op == DlClipOp::kIntersect &&
       layer_local_state().oval_covers_cull(bounds)) {
     return;
   }
@@ -983,16 +981,16 @@ void DisplayListBuilder::ClipOval(const DlRect& bounds,
   current_info().has_valid_clip = true;
   checkForDeferredSave();
   switch (clip_op) {
-    case ClipOp::kIntersect:
+    case DlClipOp::kIntersect:
       Push<ClipIntersectOvalOp>(0, bounds, is_aa);
       break;
-    case ClipOp::kDifference:
+    case DlClipOp::kDifference:
       Push<ClipDifferenceOvalOp>(0, bounds, is_aa);
       break;
   }
 }
 void DisplayListBuilder::ClipRoundRect(const DlRoundRect& rrect,
-                                       ClipOp clip_op,
+                                       DlClipOp clip_op,
                                        bool is_aa) {
   if (rrect.IsRect()) {
     ClipRect(rrect.GetBounds(), clip_op, is_aa);
@@ -1005,8 +1003,7 @@ void DisplayListBuilder::ClipRoundRect(const DlRoundRect& rrect,
   if (current_info().is_nop) {
     return;
   }
-  if (current_info().has_valid_clip &&
-      clip_op == DlCanvas::ClipOp::kIntersect &&
+  if (current_info().has_valid_clip && clip_op == DlClipOp::kIntersect &&
       layer_local_state().rrect_covers_cull(rrect)) {
     return;
   }
@@ -1020,16 +1017,16 @@ void DisplayListBuilder::ClipRoundRect(const DlRoundRect& rrect,
   current_info().has_valid_clip = true;
   checkForDeferredSave();
   switch (clip_op) {
-    case ClipOp::kIntersect:
+    case DlClipOp::kIntersect:
       Push<ClipIntersectRoundRectOp>(0, rrect, is_aa);
       break;
-    case ClipOp::kDifference:
+    case DlClipOp::kDifference:
       Push<ClipDifferenceRoundRectOp>(0, rrect, is_aa);
       break;
   }
 }
 void DisplayListBuilder::ClipPath(const DlPath& path,
-                                  ClipOp clip_op,
+                                  DlClipOp clip_op,
                                   bool is_aa) {
   if (current_info().is_nop) {
     return;
@@ -1060,10 +1057,10 @@ void DisplayListBuilder::ClipPath(const DlPath& path,
   current_info().has_valid_clip = true;
   checkForDeferredSave();
   switch (clip_op) {
-    case ClipOp::kIntersect:
+    case DlClipOp::kIntersect:
       Push<ClipIntersectPathOp>(0, path, is_aa);
       break;
-    case ClipOp::kDifference:
+    case DlClipOp::kDifference:
       Push<ClipDifferencePathOp>(0, path, is_aa);
       break;
   }
@@ -1267,18 +1264,18 @@ void DisplayListBuilder::DrawArc(const DlRect& bounds,
 }
 
 DisplayListAttributeFlags DisplayListBuilder::FlagsForPointMode(
-    PointMode mode) {
+    DlPointMode mode) {
   switch (mode) {
-    case DlCanvas::PointMode::kPoints:
+    case DlPointMode::kPoints:
       return kDrawPointsAsPointsFlags;
-    case PointMode::kLines:
+    case DlPointMode::kLines:
       return kDrawPointsAsLinesFlags;
-    case PointMode::kPolygon:
+    case DlPointMode::kPolygon:
       return kDrawPointsAsPolygonFlags;
   }
   FML_UNREACHABLE();
 }
-void DisplayListBuilder::drawPoints(PointMode mode,
+void DisplayListBuilder::drawPoints(DlPointMode mode,
                                     uint32_t count,
                                     const DlPoint pts[]) {
   if (count == 0) {
@@ -1302,13 +1299,13 @@ void DisplayListBuilder::drawPoints(PointMode mode,
 
   void* data_ptr;
   switch (mode) {
-    case PointMode::kPoints:
+    case DlPointMode::kPoints:
       data_ptr = Push<DrawPointsOp>(bytes, count);
       break;
-    case PointMode::kLines:
+    case DlPointMode::kLines:
       data_ptr = Push<DrawLinesOp>(bytes, count);
       break;
-    case PointMode::kPolygon:
+    case DlPointMode::kPolygon:
       data_ptr = Push<DrawPolygonOp>(bytes, count);
       break;
     default:
@@ -1329,7 +1326,7 @@ void DisplayListBuilder::drawPoints(PointMode mode,
   CheckLayerOpacityCompatibility();
   UpdateLayerResult(result);
 }
-void DisplayListBuilder::DrawPoints(PointMode mode,
+void DisplayListBuilder::DrawPoints(DlPointMode mode,
                                     uint32_t count,
                                     const DlPoint pts[],
                                     const DlPaint& paint) {
@@ -1408,7 +1405,7 @@ void DisplayListBuilder::drawImageRect(const sk_sp<DlImage> image,
                                        const DlRect& dst,
                                        DlImageSampling sampling,
                                        bool render_with_attributes,
-                                       SrcRectConstraint constraint) {
+                                       DlSrcRectConstraint constraint) {
   DisplayListAttributeFlags flags = render_with_attributes
                                         ? kDrawImageRectWithPaintFlags
                                         : kDrawImageRectFlags;
@@ -1426,7 +1423,7 @@ void DisplayListBuilder::DrawImageRect(const sk_sp<DlImage>& image,
                                        const DlRect& dst,
                                        DlImageSampling sampling,
                                        const DlPaint* paint,
-                                       SrcRectConstraint constraint) {
+                                       DlSrcRectConstraint constraint) {
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawImageRectWithPaintFlags);

--- a/engine/src/flutter/display_list/dl_builder.h
+++ b/engine/src/flutter/display_list/dl_builder.h
@@ -107,19 +107,19 @@ class DisplayListBuilder final : public virtual DlCanvas,
 
   // |DlCanvas|
   void ClipRect(const DlRect& rect,
-                ClipOp clip_op = ClipOp::kIntersect,
+                DlClipOp clip_op = DlClipOp::kIntersect,
                 bool is_aa = false) override;
   // |DlCanvas|
   void ClipOval(const DlRect& bounds,
-                ClipOp clip_op = ClipOp::kIntersect,
+                DlClipOp clip_op = DlClipOp::kIntersect,
                 bool is_aa = false) override;
   // |DlCanvas|
   void ClipRoundRect(const DlRoundRect& rrect,
-                     ClipOp clip_op = ClipOp::kIntersect,
+                     DlClipOp clip_op = DlClipOp::kIntersect,
                      bool is_aa = false) override;
   // |DlCanvas|
   void ClipPath(const DlPath& path,
-                ClipOp clip_op = ClipOp::kIntersect,
+                DlClipOp clip_op = DlClipOp::kIntersect,
                 bool is_aa = false) override;
 
   /// Conservative estimate of the bounds of all outstanding clip operations
@@ -180,7 +180,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
                bool useCenter,
                const DlPaint& paint) override;
   // |DlCanvas|
-  void DrawPoints(PointMode mode,
+  void DrawPoints(DlPointMode mode,
                   uint32_t count,
                   const DlPoint pts[],
                   const DlPaint& paint) override;
@@ -200,7 +200,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
       const DlRect& dst,
       DlImageSampling sampling,
       const DlPaint* paint = nullptr,
-      SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
+      DlSrcRectConstraint constraint = DlSrcRectConstraint::kFast) override;
   // |DlCanvas|
   void DrawImageNine(const sk_sp<DlImage>& image,
                      const DlIRect& center,
@@ -395,21 +395,21 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void transformReset() override { TransformReset(); }
 
   // |DlOpReceiver|
-  void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override {
+  void clipRect(const DlRect& rect, DlClipOp clip_op, bool is_aa) override {
     ClipRect(rect, clip_op, is_aa);
   }
   // |DlOpReceiver|
-  void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override {
+  void clipOval(const DlRect& bounds, DlClipOp clip_op, bool is_aa) override {
     ClipOval(bounds, clip_op, is_aa);
   }
   // |DlOpReceiver|
   void clipRoundRect(const DlRoundRect& rrect,
-                     ClipOp clip_op,
+                     DlClipOp clip_op,
                      bool is_aa) override {
     ClipRoundRect(rrect, clip_op, is_aa);
   }
   // |DlOpReceiver|
-  void clipPath(const DlPath& path, ClipOp clip_op, bool is_aa) override {
+  void clipPath(const DlPath& path, DlClipOp clip_op, bool is_aa) override {
     ClipPath(path, clip_op, is_aa);
   }
 
@@ -445,7 +445,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
                DlScalar sweep,
                bool useCenter) override;
   // |DlOpReceiver|
-  void drawPoints(PointMode mode, uint32_t count, const DlPoint pts[]) override;
+  void drawPoints(DlPointMode mode, uint32_t count, const DlPoint pts[]) override;
   // |DlOpReceiver|
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode) override;
@@ -462,7 +462,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
       const DlRect& dst,
       DlImageSampling sampling,
       bool render_with_attributes,
-      SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
+      DlSrcRectConstraint constraint = DlSrcRectConstraint::kFast) override;
   // |DlOpReceiver|
   void drawImageNine(const sk_sp<DlImage> image,
                      const DlIRect& center,
@@ -773,7 +773,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void onSetColorFilter(const DlColorFilter* filter);
   void onSetMaskFilter(const DlMaskFilter* filter);
 
-  static DisplayListAttributeFlags FlagsForPointMode(PointMode mode);
+  static DisplayListAttributeFlags FlagsForPointMode(DlPointMode mode);
 
   enum class OpResult {
     kNoEffect,

--- a/engine/src/flutter/display_list/dl_op_receiver.h
+++ b/engine/src/flutter/display_list/dl_op_receiver.h
@@ -85,11 +85,6 @@ class DisplayList;
 /// @see        impeller::DlDispatcher
 /// @see        DlOpSpy
 class DlOpReceiver {
- protected:
-  using ClipOp = DlCanvas::ClipOp;
-  using PointMode = DlCanvas::PointMode;
-  using SrcRectConstraint = DlCanvas::SrcRectConstraint;
-
  public:
   // MaxDrawPointsCount * sizeof(DlPoint) must be less than 1 << 32
   static constexpr int kMaxDrawPointsCount = ((1 << 29) - 1);
@@ -291,12 +286,12 @@ class DlOpReceiver {
   // Clears the transformation stack.
   virtual void transformReset() = 0;
 
-  virtual void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) = 0;
-  virtual void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) = 0;
+  virtual void clipRect(const DlRect& rect, DlClipOp clip_op, bool is_aa) = 0;
+  virtual void clipOval(const DlRect& bounds, DlClipOp clip_op, bool is_aa) = 0;
   virtual void clipRoundRect(const DlRoundRect& rrect,
-                             ClipOp clip_op,
+                             DlClipOp clip_op,
                              bool is_aa) = 0;
-  virtual void clipPath(const DlPath& path, ClipOp clip_op, bool is_aa) = 0;
+  virtual void clipPath(const DlPath& path, DlClipOp clip_op, bool is_aa) = 0;
 
   // The following rendering methods all take their rendering attributes
   // from the last value set by the attribute methods above (regardless
@@ -323,7 +318,7 @@ class DlOpReceiver {
                        DlScalar start_degrees,
                        DlScalar sweep_degrees,
                        bool use_center) = 0;
-  virtual void drawPoints(PointMode mode,
+  virtual void drawPoints(DlPointMode mode,
                           uint32_t count,
                           const DlPoint points[]) = 0;
   virtual void drawVertices(const std::shared_ptr<DlVertices>& vertices,
@@ -338,7 +333,7 @@ class DlOpReceiver {
       const DlRect& dst,
       DlImageSampling sampling,
       bool render_with_attributes,
-      SrcRectConstraint constraint = SrcRectConstraint::kFast) = 0;
+      DlSrcRectConstraint constraint = DlSrcRectConstraint::kFast) = 0;
   virtual void drawImageNine(const sk_sp<DlImage> image,
                              const DlIRect& center,
                              const DlRect& dst,

--- a/engine/src/flutter/display_list/dl_op_records.h
+++ b/engine/src/flutter/display_list/dl_op_records.h
@@ -503,7 +503,7 @@ struct TransformResetOp final : TransformClipOpBase {
     const shapetype shape;                                                     \
                                                                                \
     void dispatch(DlOpReceiver& receiver) const {                              \
-      receiver.clip##shapename(shape, DlCanvas::ClipOp::k##clipop, is_aa);     \
+      receiver.clip##shapename(shape, DlClipOp::k##clipop, is_aa);             \
     }                                                                          \
   };
 DEFINE_CLIP_SHAPE_OP(Rect, DlRect, Intersect)
@@ -526,7 +526,7 @@ DEFINE_CLIP_SHAPE_OP(RoundRect, DlRoundRect, Difference)
     const DlPath path;                                                    \
                                                                           \
     void dispatch(DlOpReceiver& receiver) const {                         \
-      receiver.clipPath(path, DlCanvas::ClipOp::k##clipop, is_aa);        \
+      receiver.clipPath(path, DlClipOp::k##clipop, is_aa);                \
     }                                                                     \
                                                                           \
     DisplayListCompare equals(const Clip##clipop##PathOp* other) const {  \
@@ -702,7 +702,7 @@ struct DrawArcOp final : DrawOpBase {
                                                                        \
     void dispatch(DlOpReceiver& receiver) const {                      \
       const DlPoint* pts = reinterpret_cast<const DlPoint*>(this + 1); \
-      receiver.drawPoints(DlCanvas::PointMode::mode, count, pts);      \
+      receiver.drawPoints(DlPointMode::mode, count, pts);              \
     }                                                                  \
   };
 DEFINE_DRAW_POINTS_OP(Points, kPoints);
@@ -769,7 +769,7 @@ struct DrawImageRectOp final : DrawOpBase {
                   const DlRect& dst,
                   DlImageSampling sampling,
                   bool render_with_attributes,
-                  DlCanvas::SrcRectConstraint constraint)
+                  DlSrcRectConstraint constraint)
       : DrawOpBase(kType),
         src(src),
         dst(dst),
@@ -782,7 +782,7 @@ struct DrawImageRectOp final : DrawOpBase {
   const DlRect dst;
   const DlImageSampling sampling;
   const bool render_with_attributes;
-  const DlCanvas::SrcRectConstraint constraint;
+  const DlSrcRectConstraint constraint;
   const sk_sp<DlImage> image;
 
   void dispatch(DlOpReceiver& receiver) const {

--- a/engine/src/flutter/display_list/dl_types.cc
+++ b/engine/src/flutter/display_list/dl_types.cc
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/dl_types.h"
+
+namespace flutter {
+
+// Only exists to verify that the types can be cleanly included.
+
+}  // namespace flutter

--- a/engine/src/flutter/display_list/dl_types.h
+++ b/engine/src/flutter/display_list/dl_types.h
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_DL_TYPES_H_
+#define FLUTTER_DISPLAY_LIST_DL_TYPES_H_
+
+namespace flutter {
+
+enum class DlClipOp {
+  kDifference,
+  kIntersect,
+};
+
+enum class DlPointMode {
+  kPoints,   //!< draw each point separately
+  kLines,    //!< draw each separate pair of points as a line segment
+  kPolygon,  //!< draw each pair of overlapping points as a line segment
+};
+
+enum class DlSrcRectConstraint {
+  kStrict,
+  kFast,
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_DL_TYPES_H_

--- a/engine/src/flutter/display_list/skia/dl_sk_canvas.cc
+++ b/engine/src/flutter/display_list/skia/dl_sk_canvas.cc
@@ -139,26 +139,26 @@ DlMatrix DlSkCanvasAdapter::GetMatrix() const {
 }
 
 void DlSkCanvasAdapter::ClipRect(const DlRect& rect,
-                                 ClipOp clip_op,
+                                 DlClipOp clip_op,
                                  bool is_aa) {
   delegate_->clipRect(ToSkRect(rect), ToSk(clip_op), is_aa);
 }
 
 void DlSkCanvasAdapter::ClipOval(const DlRect& bounds,
-                                 ClipOp clip_op,
+                                 DlClipOp clip_op,
                                  bool is_aa) {
   delegate_->clipRRect(SkRRect::MakeOval(ToSkRect(bounds)), ToSk(clip_op),
                        is_aa);
 }
 
 void DlSkCanvasAdapter::ClipRoundRect(const DlRoundRect& rrect,
-                                      ClipOp clip_op,
+                                      DlClipOp clip_op,
                                       bool is_aa) {
   delegate_->clipRRect(ToSkRRect(rrect), ToSk(clip_op), is_aa);
 }
 
 void DlSkCanvasAdapter::ClipPath(const DlPath& path,
-                                 ClipOp clip_op,
+                                 DlClipOp clip_op,
                                  bool is_aa) {
   path.WillRenderSkPath();
   delegate_->clipPath(path.GetSkPath(), ToSk(clip_op), is_aa);
@@ -248,7 +248,7 @@ void DlSkCanvasAdapter::DrawArc(const DlRect& bounds,
   delegate_->drawArc(ToSkRect(bounds), start, sweep, useCenter, ToSk(paint));
 }
 
-void DlSkCanvasAdapter::DrawPoints(PointMode mode,
+void DlSkCanvasAdapter::DrawPoints(DlPointMode mode,
                                    uint32_t count,
                                    const DlPoint pts[],
                                    const DlPaint& paint) {
@@ -277,7 +277,7 @@ void DlSkCanvasAdapter::DrawImageRect(const sk_sp<DlImage>& image,
                                       const DlRect& dst,
                                       DlImageSampling sampling,
                                       const DlPaint* paint,
-                                      SrcRectConstraint constraint) {
+                                      DlSrcRectConstraint constraint) {
   SkOptionalPaint sk_paint(paint);
   sk_sp<SkImage> sk_image = image->skia_image();
   delegate_->drawImageRect(sk_image.get(), ToSkRect(src), ToSkRect(dst),

--- a/engine/src/flutter/display_list/skia/dl_sk_canvas.h
+++ b/engine/src/flutter/display_list/skia/dl_sk_canvas.h
@@ -64,12 +64,12 @@ class DlSkCanvasAdapter final : public virtual DlCanvas {
   /// save stack.
   DlMatrix GetMatrix() const override;
 
-  void ClipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
-  void ClipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void ClipRect(const DlRect& rect, DlClipOp clip_op, bool is_aa) override;
+  void ClipOval(const DlRect& bounds, DlClipOp clip_op, bool is_aa) override;
   void ClipRoundRect(const DlRoundRect& rrect,
-                     ClipOp clip_op,
+                     DlClipOp clip_op,
                      bool is_aa) override;
-  void ClipPath(const DlPath& path, ClipOp clip_op, bool is_aa) override;
+  void ClipPath(const DlPath& path, DlClipOp clip_op, bool is_aa) override;
 
   /// Conservative estimate of the bounds of all outstanding clip operations
   /// measured in the coordinate space within which this DisplayList will
@@ -110,7 +110,7 @@ class DlSkCanvasAdapter final : public virtual DlCanvas {
                DlScalar sweep,
                bool useCenter,
                const DlPaint& paint) override;
-  void DrawPoints(PointMode mode,
+  void DrawPoints(DlPointMode mode,
                   uint32_t count,
                   const DlPoint pts[],
                   const DlPaint& paint) override;
@@ -127,7 +127,7 @@ class DlSkCanvasAdapter final : public virtual DlCanvas {
       const DlRect& dst,
       DlImageSampling sampling,
       const DlPaint* paint = nullptr,
-      SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
+      DlSrcRectConstraint constraint = DlSrcRectConstraint::kFast) override;
   void DrawImageNine(const sk_sp<DlImage>& image,
                      const DlIRect& center,
                      const DlRect& dst,

--- a/engine/src/flutter/display_list/skia/dl_sk_conversions.h
+++ b/engine/src/flutter/display_list/skia/dl_sk_conversions.h
@@ -63,16 +63,15 @@ inline SkSamplingOptions ToSk(DlImageSampling sampling) {
   }
 }
 
-inline SkCanvas::SrcRectConstraint ToSk(
-    DlCanvas::SrcRectConstraint constraint) {
+inline SkCanvas::SrcRectConstraint ToSk(DlSrcRectConstraint constraint) {
   return static_cast<SkCanvas::SrcRectConstraint>(constraint);
 }
 
-inline SkClipOp ToSk(DlCanvas::ClipOp op) {
+inline SkClipOp ToSk(DlClipOp op) {
   return static_cast<SkClipOp>(op);
 }
 
-inline SkCanvas::PointMode ToSk(DlCanvas::PointMode mode) {
+inline SkCanvas::PointMode ToSk(DlPointMode mode) {
   return static_cast<SkCanvas::PointMode>(mode);
 }
 

--- a/engine/src/flutter/display_list/skia/dl_sk_conversions_unittests.cc
+++ b/engine/src/flutter/display_list/skia/dl_sk_conversions_unittests.cc
@@ -92,9 +92,9 @@ TEST(DisplayListSkConversions, ToSkFilterMode) {
 }
 
 TEST(DisplayListSkConversions, ToSkSrcRectConstraint) {
-  ASSERT_EQ(ToSk(DlCanvas::SrcRectConstraint::kFast),
+  ASSERT_EQ(ToSk(DlSrcRectConstraint::kFast),
             SkCanvas::SrcRectConstraint::kFast_SrcRectConstraint);
-  ASSERT_EQ(ToSk(DlCanvas::SrcRectConstraint::kStrict),
+  ASSERT_EQ(ToSk(DlSrcRectConstraint::kStrict),
             SkCanvas::SrcRectConstraint::kStrict_SrcRectConstraint);
 }
 

--- a/engine/src/flutter/display_list/skia/dl_sk_dispatcher.cc
+++ b/engine/src/flutter/display_list/skia/dl_sk_dispatcher.cc
@@ -126,22 +126,22 @@ void DlSkCanvasDispatcher::transformReset() {
 }
 
 void DlSkCanvasDispatcher::clipRect(const DlRect& rect,
-                                    ClipOp clip_op,
+                                    DlClipOp clip_op,
                                     bool is_aa) {
   canvas_->clipRect(ToSkRect(rect), ToSk(clip_op), is_aa);
 }
 void DlSkCanvasDispatcher::clipOval(const DlRect& bounds,
-                                    ClipOp clip_op,
+                                    DlClipOp clip_op,
                                     bool is_aa) {
   canvas_->clipRRect(SkRRect::MakeOval(ToSkRect(bounds)), ToSk(clip_op), is_aa);
 }
 void DlSkCanvasDispatcher::clipRoundRect(const DlRoundRect& rrect,
-                                         ClipOp clip_op,
+                                         DlClipOp clip_op,
                                          bool is_aa) {
   canvas_->clipRRect(ToSkRRect(rrect), ToSk(clip_op), is_aa);
 }
 void DlSkCanvasDispatcher::clipPath(const DlPath& path,
-                                    ClipOp clip_op,
+                                    DlClipOp clip_op,
                                     bool is_aa) {
   path.WillRenderSkPath();
   canvas_->clipPath(path.GetSkPath(), ToSk(clip_op), is_aa);
@@ -202,7 +202,7 @@ void DlSkCanvasDispatcher::drawArc(const DlRect& bounds,
                                    bool useCenter) {
   canvas_->drawArc(ToSkRect(bounds), start, sweep, useCenter, paint());
 }
-void DlSkCanvasDispatcher::drawPoints(PointMode mode,
+void DlSkCanvasDispatcher::drawPoints(DlPointMode mode,
                                       uint32_t count,
                                       const DlPoint pts[]) {
   canvas_->drawPoints(ToSk(mode), count, ToSkPoints(pts), paint());
@@ -224,7 +224,7 @@ void DlSkCanvasDispatcher::drawImageRect(const sk_sp<DlImage> image,
                                          const DlRect& dst,
                                          DlImageSampling sampling,
                                          bool render_with_attributes,
-                                         SrcRectConstraint constraint) {
+                                         DlSrcRectConstraint constraint) {
   canvas_->drawImageRect(image ? image->skia_image() : nullptr, ToSkRect(src),
                          ToSkRect(dst), ToSk(sampling),
                          safe_paint(render_with_attributes), ToSk(constraint));

--- a/engine/src/flutter/display_list/skia/dl_sk_dispatcher.h
+++ b/engine/src/flutter/display_list/skia/dl_sk_dispatcher.h
@@ -51,12 +51,12 @@ class DlSkCanvasDispatcher : public virtual DlOpReceiver,
   // clang-format on
   void transformReset() override;
 
-  void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
-  void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void clipRect(const DlRect& rect, DlClipOp clip_op, bool is_aa) override;
+  void clipOval(const DlRect& bounds, DlClipOp clip_op, bool is_aa) override;
   void clipRoundRect(const DlRoundRect& rrect,
-                     ClipOp clip_op,
+                     DlClipOp clip_op,
                      bool is_aa) override;
-  void clipPath(const DlPath& path, ClipOp clip_op, bool is_aa) override;
+  void clipPath(const DlPath& path, DlClipOp clip_op, bool is_aa) override;
 
   void drawPaint() override;
   void drawColor(DlColor color, DlBlendMode mode) override;
@@ -76,7 +76,9 @@ class DlSkCanvasDispatcher : public virtual DlOpReceiver,
                DlScalar start,
                DlScalar sweep,
                bool useCenter) override;
-  void drawPoints(PointMode mode, uint32_t count, const DlPoint pts[]) override;
+  void drawPoints(DlPointMode mode,
+                  uint32_t count,
+                  const DlPoint pts[]) override;
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
@@ -88,7 +90,7 @@ class DlSkCanvasDispatcher : public virtual DlOpReceiver,
                      const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
-                     SrcRectConstraint constraint) override;
+                     DlSrcRectConstraint constraint) override;
   void drawImageNine(const sk_sp<DlImage> image,
                      const DlIRect& center,
                      const DlRect& dst,

--- a/engine/src/flutter/display_list/testing/dl_rendering_unittests.cc
+++ b/engine/src/flutter/display_list/testing/dl_rendering_unittests.cc
@@ -44,9 +44,6 @@
 namespace flutter {
 namespace testing {
 
-using ClipOp = DlCanvas::ClipOp;
-using PointMode = DlCanvas::PointMode;
-
 constexpr int kTestWidth = 200;
 constexpr int kTestHeight = 200;
 constexpr int kRenderWidth = 100;
@@ -1223,7 +1220,7 @@ class CanvasCompareTester {
                    },
                    [=](const DlSetupContext& ctx) {
                      ctx.canvas->Save();
-                     ctx.canvas->ClipRect(clip, ClipOp::kIntersect, false);
+                     ctx.canvas->ClipRect(clip, DlClipOp::kIntersect, false);
                      DlPaint p2;
                      ctx.canvas->DrawRect(rect, p2);
                      p2.setBlendMode(DlBlendMode::kClear);
@@ -2079,7 +2076,7 @@ class CanvasCompareTester {
                      ctx.canvas->clipRect(r_clip, SkClipOp::kIntersect, false);
                    },
                    [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipRect(r_clip, ClipOp::kIntersect, false);
+                     ctx.canvas->ClipRect(r_clip, DlClipOp::kIntersect, false);
                    }));
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
@@ -2088,7 +2085,7 @@ class CanvasCompareTester {
                      ctx.canvas->clipRect(r_clip, SkClipOp::kIntersect, true);
                    },
                    [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipRect(r_clip, ClipOp::kIntersect, true);
+                     ctx.canvas->ClipRect(r_clip, DlClipOp::kIntersect, true);
                    }));
     RenderWith(testP, env, diff_tolerance,
                CaseParameters(
@@ -2097,7 +2094,7 @@ class CanvasCompareTester {
                      ctx.canvas->clipRect(r_clip, SkClipOp::kDifference, false);
                    },
                    [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipRect(r_clip, ClipOp::kDifference, false);
+                     ctx.canvas->ClipRect(r_clip, DlClipOp::kDifference, false);
                    })
                    .with_diff_clip());
     // Skia lacks clipOval and requires us to make an oval SkRRect
@@ -2110,7 +2107,7 @@ class CanvasCompareTester {
                                            false);
                    },
                    [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipOval(r_clip, ClipOp::kIntersect, false);
+                     ctx.canvas->ClipOval(r_clip, DlClipOp::kIntersect, false);
                    }));
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
@@ -2120,7 +2117,7 @@ class CanvasCompareTester {
                                            true);
                    },
                    [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipOval(r_clip, ClipOp::kIntersect, true);
+                     ctx.canvas->ClipOval(r_clip, DlClipOp::kIntersect, true);
                    }));
     RenderWith(testP, env, diff_tolerance,
                CaseParameters(
@@ -2130,7 +2127,7 @@ class CanvasCompareTester {
                                            false);
                    },
                    [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipOval(r_clip, ClipOp::kDifference, false);
+                     ctx.canvas->ClipOval(r_clip, DlClipOp::kDifference, false);
                    })
                    .with_diff_clip());
     // This test RR clip used to use very small radii, but due to
@@ -2139,16 +2136,16 @@ class CanvasCompareTester {
     // "clip overruns" by the clip OOB pixel testing code. Using less
     // abusively small radii fixes the problem.
     SkRRect rr_clip = SkRRect::MakeRectXY(r_clip, 9, 9);
-    RenderWith(testP, env, intersect_tolerance,
-               CaseParameters(
-                   "Hard ClipRRect with radius of 15.4",
-                   [=](const SkSetupContext& ctx) {
-                     ctx.canvas->clipRRect(rr_clip, SkClipOp::kIntersect,
-                                           false);
-                   },
-                   [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipRRect(rr_clip, ClipOp::kIntersect, false);
-                   }));
+    RenderWith(
+        testP, env, intersect_tolerance,
+        CaseParameters(
+            "Hard ClipRRect with radius of 15.4",
+            [=](const SkSetupContext& ctx) {
+              ctx.canvas->clipRRect(rr_clip, SkClipOp::kIntersect, false);
+            },
+            [=](const DlSetupContext& ctx) {
+              ctx.canvas->ClipRRect(rr_clip, DlClipOp::kIntersect, false);
+            }));
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
                    "AntiAlias ClipRRect with radius of 15.4",
@@ -2156,43 +2153,43 @@ class CanvasCompareTester {
                      ctx.canvas->clipRRect(rr_clip, SkClipOp::kIntersect, true);
                    },
                    [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipRRect(rr_clip, ClipOp::kIntersect, true);
+                     ctx.canvas->ClipRRect(rr_clip, DlClipOp::kIntersect, true);
                    }));
-    RenderWith(testP, env, diff_tolerance,
-               CaseParameters(
-                   "Hard ClipRRect Diff, with radius of 15.4",
-                   [=](const SkSetupContext& ctx) {
-                     ctx.canvas->clipRRect(rr_clip, SkClipOp::kDifference,
-                                           false);
-                   },
-                   [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipRRect(rr_clip, ClipOp::kDifference, false);
-                   })
-                   .with_diff_clip());
+    RenderWith(
+        testP, env, diff_tolerance,
+        CaseParameters(
+            "Hard ClipRRect Diff, with radius of 15.4",
+            [=](const SkSetupContext& ctx) {
+              ctx.canvas->clipRRect(rr_clip, SkClipOp::kDifference, false);
+            },
+            [=](const DlSetupContext& ctx) {
+              ctx.canvas->ClipRRect(rr_clip, DlClipOp::kDifference, false);
+            })
+            .with_diff_clip());
     SkPath path_clip = SkPath();
     path_clip.setFillType(SkPathFillType::kEvenOdd);
     path_clip.addRect(r_clip);
     path_clip.addCircle(kRenderCenterX, kRenderCenterY, 1.0);
-    RenderWith(testP, env, intersect_tolerance,
-               CaseParameters(
-                   "Hard ClipPath inset by 15.4",
-                   [=](const SkSetupContext& ctx) {
-                     ctx.canvas->clipPath(path_clip, SkClipOp::kIntersect,
-                                          false);
-                   },
-                   [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipPath(path_clip, ClipOp::kIntersect, false);
-                   }));
-    RenderWith(testP, env, intersect_tolerance,
-               CaseParameters(
-                   "AntiAlias ClipPath inset by 15.4",
-                   [=](const SkSetupContext& ctx) {
-                     ctx.canvas->clipPath(path_clip, SkClipOp::kIntersect,
-                                          true);
-                   },
-                   [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipPath(path_clip, ClipOp::kIntersect, true);
-                   }));
+    RenderWith(
+        testP, env, intersect_tolerance,
+        CaseParameters(
+            "Hard ClipPath inset by 15.4",
+            [=](const SkSetupContext& ctx) {
+              ctx.canvas->clipPath(path_clip, SkClipOp::kIntersect, false);
+            },
+            [=](const DlSetupContext& ctx) {
+              ctx.canvas->ClipPath(path_clip, DlClipOp::kIntersect, false);
+            }));
+    RenderWith(
+        testP, env, intersect_tolerance,
+        CaseParameters(
+            "AntiAlias ClipPath inset by 15.4",
+            [=](const SkSetupContext& ctx) {
+              ctx.canvas->clipPath(path_clip, SkClipOp::kIntersect, true);
+            },
+            [=](const DlSetupContext& ctx) {
+              ctx.canvas->ClipPath(path_clip, DlClipOp::kIntersect, true);
+            }));
     RenderWith(
         testP, env, diff_tolerance,
         CaseParameters(
@@ -2201,7 +2198,7 @@ class CanvasCompareTester {
               ctx.canvas->clipPath(path_clip, SkClipOp::kDifference, false);
             },
             [=](const DlSetupContext& ctx) {
-              ctx.canvas->ClipPath(path_clip, ClipOp::kDifference, false);
+              ctx.canvas->ClipPath(path_clip, DlClipOp::kDifference, false);
             })
             .with_diff_clip());
   }
@@ -3240,7 +3237,7 @@ TEST_F(DisplayListRendering, DrawPointsAsPoints) {
             ctx.canvas->drawPoints(mode, count, points, p);
           },
           [=](const DlRenderContext& ctx) {
-            auto mode = PointMode::kPoints;
+            auto mode = DlPointMode::kPoints;
             ctx.canvas->DrawPoints(mode, count, points, ctx.paint);
           },
           kDrawPointsAsPointsFlags)
@@ -3292,7 +3289,7 @@ TEST_F(DisplayListRendering, DrawPointsAsLines) {
             ctx.canvas->drawPoints(mode, count, points, p);
           },
           [=](const DlRenderContext& ctx) {
-            auto mode = PointMode::kLines;
+            auto mode = DlPointMode::kLines;
             ctx.canvas->DrawPoints(mode, count, points, ctx.paint);
           },
           kDrawPointsAsLinesFlags));
@@ -3327,7 +3324,7 @@ TEST_F(DisplayListRendering, DrawPointsAsPolygon) {
             ctx.canvas->drawPoints(mode, count1, points1, p);
           },
           [=](const DlRenderContext& ctx) {
-            auto mode = PointMode::kPolygon;
+            auto mode = DlPointMode::kPolygon;
             ctx.canvas->DrawPoints(mode, count1, points1, ctx.paint);
           },
           kDrawPointsAsPolygonFlags));
@@ -3492,9 +3489,9 @@ TEST_F(DisplayListRendering, DrawImageRectNearest) {
                 &ctx.paint, SkCanvas::kFast_SrcRectConstraint);
           },
           [=](const DlRenderContext& ctx) {
-            ctx.canvas->DrawImageRect(
-                ctx.image, src, dst, DlImageSampling::kNearestNeighbor,
-                &ctx.paint, DlCanvas::SrcRectConstraint::kFast);
+            ctx.canvas->DrawImageRect(ctx.image, src, dst,
+                                      DlImageSampling::kNearestNeighbor,
+                                      &ctx.paint, DlSrcRectConstraint::kFast);
           },
           kDrawImageRectWithPaintFlags));
 }
@@ -3510,9 +3507,9 @@ TEST_F(DisplayListRendering, DrawImageRectNearestNoPaint) {
                 nullptr, SkCanvas::kFast_SrcRectConstraint);
           },
           [=](const DlRenderContext& ctx) {
-            ctx.canvas->DrawImageRect(
-                ctx.image, src, dst, DlImageSampling::kNearestNeighbor,  //
-                nullptr, DlCanvas::SrcRectConstraint::kFast);
+            ctx.canvas->DrawImageRect(ctx.image, src, dst,
+                                      DlImageSampling::kNearestNeighbor,  //
+                                      nullptr, DlSrcRectConstraint::kFast);
           },
           kDrawImageRectFlags));
 }
@@ -3528,9 +3525,9 @@ TEST_F(DisplayListRendering, DrawImageRectLinear) {
                 &ctx.paint, SkCanvas::kFast_SrcRectConstraint);
           },
           [=](const DlRenderContext& ctx) {  //
-            ctx.canvas->DrawImageRect(
-                ctx.image, src, dst, DlImageSampling::kLinear,  //
-                &ctx.paint, DlCanvas::SrcRectConstraint::kFast);
+            ctx.canvas->DrawImageRect(ctx.image, src, dst,
+                                      DlImageSampling::kLinear,  //
+                                      &ctx.paint, DlSrcRectConstraint::kFast);
           },
           kDrawImageRectWithPaintFlags));
 }
@@ -3932,7 +3929,7 @@ TEST_F(DisplayListRendering, SaveLayerClippedContentStillFilters) {
         DlPaint layer_paint;
         layer_paint.setImageFilter(layer_filter);
         ctx.canvas->Save();
-        ctx.canvas->ClipRect(kRenderBounds, ClipOp::kIntersect, false);
+        ctx.canvas->ClipRect(kRenderBounds, DlClipOp::kIntersect, false);
         ctx.canvas->SaveLayer(&kTestBounds2, &layer_paint);
         ctx.canvas->DrawRect(draw_rect, ctx.paint);
         ctx.canvas->Restore();

--- a/engine/src/flutter/display_list/testing/dl_test_snippets.cc
+++ b/engine/src/flutter/display_list/testing/dl_test_snippets.cc
@@ -324,8 +324,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
            {5, 96, 2,
             [](DlOpReceiver& r) {
               r.save();
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
@@ -333,8 +333,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
            {5, 120, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(nullptr, SaveLayerOptions::kNoAttributes);
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
@@ -342,8 +342,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
            {5, 120, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
@@ -355,8 +355,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
             [](DlOpReceiver& r) {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kNoAttributes);
               r.drawRect(kTestBounds);
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
@@ -364,8 +364,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
             [](DlOpReceiver& r) {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kWithAttributes);
               r.drawRect(kTestBounds);
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
@@ -373,8 +373,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
             [](DlOpReceiver& r) {
               r.saveLayer(nullptr, SaveLayerOptions::kNoAttributes,
                           &kTestCFImageFilter1);
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
@@ -383,8 +383,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
             [](DlOpReceiver& r) {
               r.saveLayer(nullptr, SaveLayerOptions::kWithAttributes,
                           &kTestCFImageFilter1);
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
@@ -394,8 +394,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kNoAttributes,
                           &kTestCFImageFilter1);
               r.drawRect(kTestBounds);
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
@@ -404,8 +404,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kWithAttributes,
                           &kTestCFImageFilter1);
               r.drawRect(kTestBounds);
-              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25), DlClipOp::kIntersect,
+                         true);
               r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
@@ -480,114 +480,112 @@ std::vector<DisplayListInvocationGroup> CreateAllClipOps() {
        {
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipRect(kTestBounds, DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(kTestBounds, DlClipOp::kIntersect, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipRect(kTestBounds.Shift(1, 1), DlCanvas::ClipOp::kIntersect,
-                         true);
+              r.clipRect(kTestBounds.Shift(1, 1), DlClipOp::kIntersect, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipRect(kTestBounds, DlCanvas::ClipOp::kIntersect, false);
+              r.clipRect(kTestBounds, DlClipOp::kIntersect, false);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipRect(kTestBounds, DlCanvas::ClipOp::kDifference, true);
+              r.clipRect(kTestBounds, DlClipOp::kDifference, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipRect(kTestBounds, DlCanvas::ClipOp::kDifference, false);
+              r.clipRect(kTestBounds, DlClipOp::kDifference, false);
             }},
        }},
       {"ClipOval",
        {
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds, DlCanvas::ClipOp::kIntersect, true);
+              r.clipOval(kTestBounds, DlClipOp::kIntersect, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds.Shift(1, 1), DlCanvas::ClipOp::kIntersect,
-                         true);
+              r.clipOval(kTestBounds.Shift(1, 1), DlClipOp::kIntersect, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds, DlCanvas::ClipOp::kIntersect, false);
+              r.clipOval(kTestBounds, DlClipOp::kIntersect, false);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds, DlCanvas::ClipOp::kDifference, true);
+              r.clipOval(kTestBounds, DlClipOp::kDifference, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds, DlCanvas::ClipOp::kDifference, false);
+              r.clipOval(kTestBounds, DlClipOp::kDifference, false);
             }},
        }},
       {"ClipRRect",
        {
            {1, 56, 0,
             [](DlOpReceiver& r) {
-              r.clipRoundRect(kTestRRect, DlCanvas::ClipOp::kIntersect, true);
+              r.clipRoundRect(kTestRRect, DlClipOp::kIntersect, true);
             }},
            {1, 56, 0,
             [](DlOpReceiver& r) {
-              r.clipRoundRect(kTestRRect.Shift(1, 1),
-                              DlCanvas::ClipOp::kIntersect, true);
+              r.clipRoundRect(kTestRRect.Shift(1, 1), DlClipOp::kIntersect,
+                              true);
             }},
            {1, 56, 0,
             [](DlOpReceiver& r) {
-              r.clipRoundRect(kTestRRect, DlCanvas::ClipOp::kIntersect, false);
+              r.clipRoundRect(kTestRRect, DlClipOp::kIntersect, false);
             }},
            {1, 56, 0,
             [](DlOpReceiver& r) {
-              r.clipRoundRect(kTestRRect, DlCanvas::ClipOp::kDifference, true);
+              r.clipRoundRect(kTestRRect, DlClipOp::kDifference, true);
             }},
            {1, 56, 0,
             [](DlOpReceiver& r) {
-              r.clipRoundRect(kTestRRect, DlCanvas::ClipOp::kDifference, false);
+              r.clipRoundRect(kTestRRect, DlClipOp::kDifference, false);
             }},
        }},
       {"ClipPath",
        {
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPath1, DlCanvas::ClipOp::kIntersect, true);
+              r.clipPath(kTestPath1, DlClipOp::kIntersect, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPath2, DlCanvas::ClipOp::kIntersect, true);
+              r.clipPath(kTestPath2, DlClipOp::kIntersect, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPath3, DlCanvas::ClipOp::kIntersect, true);
+              r.clipPath(kTestPath3, DlClipOp::kIntersect, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPath1, DlCanvas::ClipOp::kIntersect, false);
+              r.clipPath(kTestPath1, DlClipOp::kIntersect, false);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPath1, DlCanvas::ClipOp::kDifference, true);
+              r.clipPath(kTestPath1, DlClipOp::kDifference, true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPath1, DlCanvas::ClipOp::kDifference, false);
+              r.clipPath(kTestPath1, DlClipOp::kDifference, false);
             }},
            // clipPath(rect) becomes clipRect
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPathRect, DlCanvas::ClipOp::kIntersect, true);
+              r.clipPath(kTestPathRect, DlClipOp::kIntersect, true);
             }},
            // clipPath(oval) becomes clipOval
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPathOval, DlCanvas::ClipOp::kIntersect, true);
+              r.clipPath(kTestPathOval, DlClipOp::kIntersect, true);
             }},
            // clipPath(rrect) becomes clipRRect
            {1, 56, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPathRRect, DlCanvas::ClipOp::kIntersect, true);
+              r.clipPath(kTestPathRRect, DlClipOp::kIntersect, true);
             }},
        }},
   };
@@ -768,23 +766,20 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        {
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
-              r.drawPoints(DlCanvas::PointMode::kPoints, TestPointCount,
-                           kTestPoints);
+              r.drawPoints(DlPointMode::kPoints, TestPointCount, kTestPoints);
             }},
            {1, 8 + (TestPointCount - 1) * 8, 1,
             [](DlOpReceiver& r) {
-              r.drawPoints(DlCanvas::PointMode::kPoints, TestPointCount - 1,
+              r.drawPoints(DlPointMode::kPoints, TestPointCount - 1,
                            kTestPoints);
             }},
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
-              r.drawPoints(DlCanvas::PointMode::kLines, TestPointCount,
-                           kTestPoints);
+              r.drawPoints(DlPointMode::kLines, TestPointCount, kTestPoints);
             }},
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
-              r.drawPoints(DlCanvas::PointMode::kPolygon, TestPointCount,
-                           kTestPoints);
+              r.drawPoints(DlPointMode::kPolygon, TestPointCount, kTestPoints);
             }},
        }},
       {"DrawVertices",
@@ -841,48 +836,48 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
-                              DlCanvas::SrcRectConstraint::kFast);
+                              DlSrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
               r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, true,
-                              DlCanvas::SrcRectConstraint::kFast);
+                              DlSrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
               r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
-                              DlCanvas::SrcRectConstraint::kStrict);
+                              DlSrcRectConstraint::kStrict);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
               r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 25, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
-                              DlCanvas::SrcRectConstraint::kFast);
+                              DlSrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
               r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 85, 80),
                               kNearestSampling, false,
-                              DlCanvas::SrcRectConstraint::kFast);
+                              DlSrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
               r.drawImageRect(kTestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
                               DlRect::MakeLTRB(10, 10, 80, 80), kLinearSampling,
-                              false, DlCanvas::SrcRectConstraint::kFast);
+                              false, DlSrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
               r.drawImageRect(kTestImage2, DlRect::MakeLTRB(10, 10, 15, 15),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
-                              DlCanvas::SrcRectConstraint::kFast);
+                              DlSrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
@@ -890,7 +885,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               r.drawImageRect(dl_image, DlRect::MakeLTRB(10, 10, 15, 15),
                               DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
-                              DlCanvas::SrcRectConstraint::kFast);
+                              DlSrcRectConstraint::kFast);
             }},
        }},
       {"DrawImageNine",

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.cc
@@ -42,7 +42,7 @@ bool DisplayListMatrixClipState::mapAndClipRect(const DlRect& src,
 }
 
 void DisplayListMatrixClipState::clipRect(const DlRect& rect,
-                                          ClipOp op,
+                                          DlClipOp op,
                                           bool is_aa) {
   if (rect.IsFinite()) {
     adjustCullRect(rect, op, is_aa);
@@ -50,16 +50,16 @@ void DisplayListMatrixClipState::clipRect(const DlRect& rect,
 }
 
 void DisplayListMatrixClipState::clipOval(const DlRect& bounds,
-                                          ClipOp op,
+                                          DlClipOp op,
                                           bool is_aa) {
   if (!bounds.IsFinite()) {
     return;
   }
   switch (op) {
-    case DlCanvas::ClipOp::kIntersect:
+    case DlClipOp::kIntersect:
       adjustCullRect(bounds, op, is_aa);
       break;
-    case DlCanvas::ClipOp::kDifference:
+    case DlClipOp::kDifference:
       if (oval_covers_cull(bounds)) {
         cull_rect_ = DlRect();
       }
@@ -68,17 +68,17 @@ void DisplayListMatrixClipState::clipOval(const DlRect& bounds,
 }
 
 void DisplayListMatrixClipState::clipRRect(const DlRoundRect& rrect,
-                                           ClipOp op,
+                                           DlClipOp op,
                                            bool is_aa) {
   DlRect bounds = rrect.GetBounds();
   if (rrect.IsRect()) {
     return clipRect(bounds, op, is_aa);
   }
   switch (op) {
-    case ClipOp::kIntersect:
+    case DlClipOp::kIntersect:
       adjustCullRect(bounds, op, is_aa);
       break;
-    case ClipOp::kDifference: {
+    case DlClipOp::kDifference: {
       if (rrect_covers_cull(rrect)) {
         cull_rect_ = DlRect();
         return;
@@ -98,17 +98,17 @@ void DisplayListMatrixClipState::clipRRect(const DlRoundRect& rrect,
 }
 
 void DisplayListMatrixClipState::clipPath(const DlPath& path,
-                                          ClipOp op,
+                                          DlClipOp op,
                                           bool is_aa) {
   DlRect bounds = path.GetBounds();
   if (path.IsRect(nullptr)) {
     return clipRect(bounds, op, is_aa);
   }
   switch (op) {
-    case ClipOp::kIntersect:
+    case DlClipOp::kIntersect:
       adjustCullRect(bounds, op, is_aa);
       break;
-    case ClipOp::kDifference:
+    case DlClipOp::kDifference:
       break;
   }
 }
@@ -148,7 +148,7 @@ void DisplayListMatrixClipState::resetLocalCullRect(const DlRect& cull_rect) {
 }
 
 void DisplayListMatrixClipState::adjustCullRect(const DlRect& clip,
-                                                ClipOp op,
+                                                DlClipOp op,
                                                 bool is_aa) {
   if (cull_rect_.IsEmpty()) {
     // No point in constraining further.
@@ -159,7 +159,7 @@ void DisplayListMatrixClipState::adjustCullRect(const DlRect& clip,
     return;
   }
   switch (op) {
-    case ClipOp::kIntersect: {
+    case DlClipOp::kIntersect: {
       if (clip.IsEmpty()) {
         cull_rect_ = DlRect();
         break;
@@ -172,7 +172,7 @@ void DisplayListMatrixClipState::adjustCullRect(const DlRect& clip,
       cull_rect_ = cull_rect_.Intersection(rect).value_or(DlRect());
       break;
     }
-    case ClipOp::kDifference: {
+    case DlClipOp::kDifference: {
       if (clip.IsEmpty()) {
         break;
       }

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.h
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.h
@@ -14,9 +14,6 @@
 namespace flutter {
 
 class DisplayListMatrixClipState {
- private:
-  using ClipOp = DlCanvas::ClipOp;
-
  public:
   explicit DisplayListMatrixClipState(const DlRect& cull_rect,
                                       const DlMatrix& matrix = DlMatrix());
@@ -107,17 +104,17 @@ class DisplayListMatrixClipState {
   }
   bool mapAndClipRect(const DlRect& src, DlRect* mapped) const;
 
-  void clipRect(const DlRect& rect, ClipOp op, bool is_aa);
-  void clipOval(const DlRect& bounds, ClipOp op, bool is_aa);
-  void clipRRect(const DlRoundRect& rrect, ClipOp op, bool is_aa);
-  void clipPath(const DlPath& path, ClipOp op, bool is_aa);
+  void clipRect(const DlRect& rect, DlClipOp op, bool is_aa);
+  void clipOval(const DlRect& bounds, DlClipOp op, bool is_aa);
+  void clipRRect(const DlRoundRect& rrect, DlClipOp op, bool is_aa);
+  void clipPath(const DlPath& path, DlClipOp op, bool is_aa);
 
  private:
   DlRect cull_rect_;
   DlMatrix matrix_;
 
   bool getLocalCullCorners(DlPoint corners[4]) const;
-  void adjustCullRect(const DlRect& clip, ClipOp op, bool is_aa);
+  void adjustCullRect(const DlRect& clip, DlClipOp op, bool is_aa);
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker_unittests.cc
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker_unittests.cc
@@ -200,20 +200,20 @@ TEST(DisplayListMatrixClipState, ClipDifference) {
                                    const std::string& label) {
     {
       DisplayListMatrixClipState state(cull_rect, DlMatrix());
-      state.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
+      state.clipRect(diff_rect, DlClipOp::kDifference, false);
       EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect) << label;
     }
     {
       DisplayListMatrixClipState state(cull_rect, DlMatrix());
       const DlRoundRect diff_rrect = DlRoundRect::MakeRect(diff_rect);
-      state.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
+      state.clipRRect(diff_rrect, DlClipOp::kDifference, false);
       EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect)
           << label << " (RRect)";
     }
     {
       DisplayListMatrixClipState state(cull_rect, DlMatrix());
       const DlPath diff_path = DlPath::MakeRect(diff_rect);
-      state.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
+      state.clipPath(diff_path, DlClipOp::kDifference, false);
       EXPECT_EQ(state.GetDeviceCullCoverage(), cull_rect)
           << label << " (RRect)";
     }
@@ -225,20 +225,20 @@ TEST(DisplayListMatrixClipState, ClipDifference) {
     EXPECT_TRUE(result_rect.IsEmpty() || cull_rect.Contains(result_rect));
     {
       DisplayListMatrixClipState state(cull_rect, DlMatrix());
-      state.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
+      state.clipRect(diff_rect, DlClipOp::kDifference, false);
       EXPECT_EQ(state.GetDeviceCullCoverage(), result_rect) << label;
     }
     {
       DisplayListMatrixClipState state(cull_rect, DlMatrix());
       const DlRoundRect diff_rrect = DlRoundRect::MakeRect(diff_rect);
-      state.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
+      state.clipRRect(diff_rrect, DlClipOp::kDifference, false);
       EXPECT_EQ(state.GetDeviceCullCoverage(), result_rect)
           << label << " (RRect)";
     }
     {
       DisplayListMatrixClipState state(cull_rect, DlMatrix());
       const DlPath diff_path = DlPath::MakeRect(diff_rect);
-      state.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
+      state.clipPath(diff_path, DlClipOp::kDifference, false);
       EXPECT_EQ(state.GetDeviceCullCoverage(), result_rect)
           << label << " (RRect)";
     }

--- a/engine/src/flutter/display_list/utils/dl_receiver_utils.h
+++ b/engine/src/flutter/display_list/utils/dl_receiver_utils.h
@@ -41,18 +41,12 @@ class IgnoreAttributeDispatchHelper : public virtual DlOpReceiver {
 // A utility class that will ignore all DlOpReceiver methods relating
 // to setting a clip.
 class IgnoreClipDispatchHelper : public virtual DlOpReceiver {
-  void clipRect(const DlRect& rect,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {}
-  void clipOval(const DlRect& bounds,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {}
+  void clipRect(const DlRect& rect, DlClipOp clip_op, bool is_aa) override {}
+  void clipOval(const DlRect& bounds, DlClipOp clip_op, bool is_aa) override {}
   void clipRoundRect(const DlRoundRect& rrect,
-                     DlCanvas::ClipOp clip_op,
+                     DlClipOp clip_op,
                      bool is_aa) override {}
-  void clipPath(const DlPath& path,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {}
+  void clipPath(const DlPath& path, DlClipOp clip_op, bool is_aa) override {}
 };
 
 // A utility class that will ignore all DlOpReceiver methods relating
@@ -103,7 +97,7 @@ class IgnoreDrawDispatchHelper : public virtual DlOpReceiver {
                DlScalar start_degrees,
                DlScalar sweep_degrees,
                bool use_center) override {}
-  void drawPoints(DlCanvas::PointMode mode,
+  void drawPoints(DlPointMode mode,
                   uint32_t count,
                   const DlPoint points[]) override {}
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
@@ -117,7 +111,7 @@ class IgnoreDrawDispatchHelper : public virtual DlOpReceiver {
                      const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
-                     SrcRectConstraint constraint) override {}
+                     DlSrcRectConstraint constraint) override {}
   void drawImageNine(const sk_sp<DlImage> image,
                      const DlIRect& center,
                      const DlRect& dst,

--- a/engine/src/flutter/flow/diff_context.cc
+++ b/engine/src/flutter/flow/diff_context.cc
@@ -143,7 +143,7 @@ DlRect DiffContext::MapRect(const DlRect& rect) {
 }
 
 bool DiffContext::PushCullRect(const DlRect& clip) {
-  state_.matrix_clip.clipRect(clip, DlCanvas::ClipOp::kIntersect, false);
+  state_.matrix_clip.clipRect(clip, DlClipOp::kIntersect, false);
   return !state_.matrix_clip.is_cull_rect_empty();
 }
 

--- a/engine/src/flutter/flow/layers/backdrop_filter_layer_unittests.cc
+++ b/engine/src/flutter/flow/layers/backdrop_filter_layer_unittests.cc
@@ -74,8 +74,7 @@ TEST_F(BackdropFilterLayerTest, EmptyFilter) {
   /* (ClipRect)parent::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.ClipRect(child_bounds, DlCanvas::ClipOp::kIntersect,
-                                false);
+      expected_builder.ClipRect(child_bounds, DlClipOp::kIntersect, false);
       /* (BackdropFilter)layer::Paint */ {
         expected_builder.Save();
         {
@@ -120,8 +119,7 @@ TEST_F(BackdropFilterLayerTest, SimpleFilter) {
   /* (ClipRect)parent::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.ClipRect(child_bounds, DlCanvas::ClipOp::kIntersect,
-                                false);
+      expected_builder.ClipRect(child_bounds, DlClipOp::kIntersect, false);
       /* (BackdropFilter)layer::Paint */ {
         expected_builder.Save();
         {
@@ -169,8 +167,7 @@ TEST_F(BackdropFilterLayerTest, NonSrcOverBlend) {
   /* (ClipRect)parent::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.ClipRect(child_bounds, DlCanvas::ClipOp::kIntersect,
-                                false);
+      expected_builder.ClipRect(child_bounds, DlClipOp::kIntersect, false);
       /* (BackdropFilter)layer::Paint */ {
         expected_builder.Save();
         {
@@ -229,8 +226,7 @@ TEST_F(BackdropFilterLayerTest, MultipleChildren) {
   /* (ClipRect)parent::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.ClipRect(children_bounds, DlCanvas::ClipOp::kIntersect,
-                                false);
+      expected_builder.ClipRect(children_bounds, DlClipOp::kIntersect, false);
       /* (BackdropFilter)layer::Paint */ {
         expected_builder.Save();
         {
@@ -297,8 +293,7 @@ TEST_F(BackdropFilterLayerTest, Nested) {
   /* (ClipRect)parent::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.ClipRect(children_bounds, DlCanvas::ClipOp::kIntersect,
-                                false);
+      expected_builder.ClipRect(children_bounds, DlClipOp::kIntersect, false);
       /* (BackdropFilter)layer1::Paint */ {
         expected_builder.Save();
         {
@@ -390,7 +385,7 @@ TEST_F(BackdropFilterLayerTest, OpacityInheritance) {
   /* ClipRectLayer::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.ClipRect(clip_rect, DlCanvas::ClipOp::kIntersect, false);
+      expected_builder.ClipRect(clip_rect, DlClipOp::kIntersect, false);
       /* OpacityLayer::Paint */ {
         // NOP - it hands opacity down to BackdropFilterLayer
         /* BackdropFilterLayer::Paint */ {

--- a/engine/src/flutter/flow/layers/clip_path_layer_unittests.cc
+++ b/engine/src/flutter/flow/layers/clip_path_layer_unittests.cc
@@ -21,8 +21,6 @@ namespace testing {
 
 using ClipPathLayerTest = LayerTest;
 
-using ClipOp = DlCanvas::ClipOp;
-
 #ifndef NDEBUG
 TEST_F(ClipPathLayerTest, ClipNoneBehaviorDies) {
   EXPECT_DEATH_IF_SUPPORTED(
@@ -430,7 +428,7 @@ TEST_F(ClipPathLayerTest, OpacityInheritancePainting) {
       expected_builder.Translate(offset.x, offset.y);
       /* ClipRectLayer::Paint() */ {
         expected_builder.Save();
-        expected_builder.ClipPath(layer_clip, ClipOp::kIntersect, true);
+        expected_builder.ClipPath(layer_clip, DlClipOp::kIntersect, true);
         /* child layer1 paint */ {
           expected_builder.DrawPath(path1, DlPaint().setAlpha(opacity_alpha));
         }
@@ -480,7 +478,7 @@ TEST_F(ClipPathLayerTest, OpacityInheritanceSaveLayerPainting) {
       expected_builder.Translate(offset.x, offset.y);
       /* ClipRectLayer::Paint() */ {
         expected_builder.Save();
-        expected_builder.ClipPath(layer_clip, ClipOp::kIntersect, true);
+        expected_builder.ClipPath(layer_clip, DlClipOp::kIntersect, true);
         expected_builder.SaveLayer(children_bounds,
                                    &DlPaint().setAlpha(opacity_alpha));
         /* child layer1 paint */ {

--- a/engine/src/flutter/flow/layers/clip_rect_layer_unittests.cc
+++ b/engine/src/flutter/flow/layers/clip_rect_layer_unittests.cc
@@ -20,8 +20,6 @@ namespace testing {
 
 using ClipRectLayerTest = LayerTest;
 
-using ClipOp = DlCanvas::ClipOp;
-
 #ifndef NDEBUG
 TEST_F(ClipRectLayerTest, ClipNoneBehaviorDies) {
   EXPECT_DEATH_IF_SUPPORTED(
@@ -417,7 +415,7 @@ TEST_F(ClipRectLayerTest, OpacityInheritancePainting) {
       expected_builder.Translate(offset.x, offset.y);
       /* ClipRectLayer::Paint() */ {
         expected_builder.Save();
-        expected_builder.ClipRect(clip_rect, ClipOp::kIntersect, true);
+        expected_builder.ClipRect(clip_rect, DlClipOp::kIntersect, true);
         /* child layer1 paint */ {
           expected_builder.DrawPath(path1, DlPaint().setAlpha(opacity_alpha));
         }
@@ -466,7 +464,7 @@ TEST_F(ClipRectLayerTest, OpacityInheritanceSaveLayerPainting) {
       expected_builder.Translate(offset.x, offset.y);
       /* ClipRectLayer::Paint() */ {
         expected_builder.Save();
-        expected_builder.ClipRect(clip_rect, ClipOp::kIntersect, true);
+        expected_builder.ClipRect(clip_rect, DlClipOp::kIntersect, true);
         expected_builder.SaveLayer(children_bounds,
                                    &DlPaint().setAlpha(opacity_alpha));
         /* child layer1 paint */ {

--- a/engine/src/flutter/flow/layers/clip_rrect_layer_unittests.cc
+++ b/engine/src/flutter/flow/layers/clip_rrect_layer_unittests.cc
@@ -20,8 +20,6 @@ namespace testing {
 
 using ClipRRectLayerTest = LayerTest;
 
-using ClipOp = DlCanvas::ClipOp;
-
 #ifndef NDEBUG
 TEST_F(ClipRRectLayerTest, ClipNoneBehaviorDies) {
   const DlRoundRect layer_rrect = DlRoundRect();
@@ -428,7 +426,7 @@ TEST_F(ClipRRectLayerTest, OpacityInheritancePainting) {
       expected_builder.Translate(offset.x, offset.y);
       /* ClipRectLayer::Paint() */ {
         expected_builder.Save();
-        expected_builder.ClipRoundRect(clip_rrect, ClipOp::kIntersect, true);
+        expected_builder.ClipRoundRect(clip_rrect, DlClipOp::kIntersect, true);
         /* child layer1 paint */ {
           expected_builder.DrawPath(path1, DlPaint().setAlpha(opacity_alpha));
         }
@@ -478,7 +476,7 @@ TEST_F(ClipRRectLayerTest, OpacityInheritanceSaveLayerPainting) {
       expected_builder.Translate(offset.x, offset.y);
       /* ClipRectLayer::Paint() */ {
         expected_builder.Save();
-        expected_builder.ClipRoundRect(clip_rrect, ClipOp::kIntersect, true);
+        expected_builder.ClipRoundRect(clip_rrect, DlClipOp::kIntersect, true);
         expected_builder.SaveLayer(children_bounds,
                                    &DlPaint().setAlpha(opacity_alpha));
         /* child layer1 paint */ {

--- a/engine/src/flutter/flow/layers/layer_state_stack.cc
+++ b/engine/src/flutter/flow/layers/layer_state_stack.cc
@@ -56,9 +56,9 @@ class DummyDelegate : public LayerStateStack::Delegate {
   void transform(const DlMatrix& matrix) override {}
   void integralTransform() override {}
 
-  void clipRect(const DlRect& rect, ClipOp op, bool is_aa) override {}
-  void clipRRect(const DlRoundRect& rrect, ClipOp op, bool is_aa) override {}
-  void clipPath(const DlPath& path, ClipOp op, bool is_aa) override {}
+  void clipRect(const DlRect& rect, DlClipOp op, bool is_aa) override {}
+  void clipRRect(const DlRoundRect& rrect, DlClipOp op, bool is_aa) override {}
+  void clipPath(const DlPath& path, DlClipOp op, bool is_aa) override {}
 
  private:
   static void error() {
@@ -115,13 +115,13 @@ class DlCanvasDelegate : public LayerStateStack::Delegate {
     }
   }
 
-  void clipRect(const DlRect& rect, ClipOp op, bool is_aa) override {
+  void clipRect(const DlRect& rect, DlClipOp op, bool is_aa) override {
     canvas_->ClipRect(rect, op, is_aa);
   }
-  void clipRRect(const DlRoundRect& rrect, ClipOp op, bool is_aa) override {
+  void clipRRect(const DlRoundRect& rrect, DlClipOp op, bool is_aa) override {
     canvas_->ClipRoundRect(rrect, op, is_aa);
   }
-  void clipPath(const DlPath& path, ClipOp op, bool is_aa) override {
+  void clipPath(const DlPath& path, DlClipOp op, bool is_aa) override {
     canvas_->ClipPath(path, op, is_aa);
   }
 
@@ -170,13 +170,13 @@ class PrerollDelegate : public LayerStateStack::Delegate {
     }
   }
 
-  void clipRect(const DlRect& rect, ClipOp op, bool is_aa) override {
+  void clipRect(const DlRect& rect, DlClipOp op, bool is_aa) override {
     state().clipRect(rect, op, is_aa);
   }
-  void clipRRect(const DlRoundRect& rrect, ClipOp op, bool is_aa) override {
+  void clipRRect(const DlRoundRect& rrect, DlClipOp op, bool is_aa) override {
     state().clipRRect(rrect, op, is_aa);
   }
-  void clipPath(const DlPath& path, ClipOp op, bool is_aa) override {
+  void clipPath(const DlPath& path, DlClipOp op, bool is_aa) override {
     state().clipPath(path, op, is_aa);
   }
 
@@ -414,8 +414,7 @@ class ClipRectEntry : public LayerStateStack::StateEntry {
       : clip_rect_(clip_rect), is_aa_(is_aa) {}
 
   void apply(LayerStateStack* stack) const override {
-    stack->delegate_->clipRect(clip_rect_, DlCanvas::ClipOp::kIntersect,
-                               is_aa_);
+    stack->delegate_->clipRect(clip_rect_, DlClipOp::kIntersect, is_aa_);
   }
   void update_mutators(MutatorsStack* mutators_stack) const override {
     mutators_stack->PushClipRect(ToSkRect(clip_rect_));
@@ -434,8 +433,7 @@ class ClipRRectEntry : public LayerStateStack::StateEntry {
       : clip_rrect_(clip_rrect), is_aa_(is_aa) {}
 
   void apply(LayerStateStack* stack) const override {
-    stack->delegate_->clipRRect(clip_rrect_, DlCanvas::ClipOp::kIntersect,
-                                is_aa_);
+    stack->delegate_->clipRRect(clip_rrect_, DlClipOp::kIntersect, is_aa_);
   }
   void update_mutators(MutatorsStack* mutators_stack) const override {
     mutators_stack->PushClipRRect(ToSkRRect(clip_rrect_));
@@ -455,8 +453,7 @@ class ClipPathEntry : public LayerStateStack::StateEntry {
   ~ClipPathEntry() override = default;
 
   void apply(LayerStateStack* stack) const override {
-    stack->delegate_->clipPath(clip_path_, DlCanvas::ClipOp::kIntersect,
-                               is_aa_);
+    stack->delegate_->clipPath(clip_path_, DlClipOp::kIntersect, is_aa_);
   }
   void update_mutators(MutatorsStack* mutators_stack) const override {
     mutators_stack->PushClipPath(clip_path_.GetSkPath());

--- a/engine/src/flutter/flow/layers/layer_state_stack.h
+++ b/engine/src/flutter/flow/layers/layer_state_stack.h
@@ -411,9 +411,6 @@ class LayerStateStack {
   friend class ClipPathEntry;
 
   class Delegate {
-   protected:
-    using ClipOp = DlCanvas::ClipOp;
-
    public:
     virtual ~Delegate() = default;
 
@@ -446,9 +443,11 @@ class LayerStateStack {
     virtual void transform(const DlMatrix& matrix) = 0;
     virtual void integralTransform() = 0;
 
-    virtual void clipRect(const DlRect& rect, ClipOp op, bool is_aa) = 0;
-    virtual void clipRRect(const DlRoundRect& rrect, ClipOp op, bool is_aa) = 0;
-    virtual void clipPath(const DlPath& path, ClipOp op, bool is_aa) = 0;
+    virtual void clipRect(const DlRect& rect, DlClipOp op, bool is_aa) = 0;
+    virtual void clipRRect(const DlRoundRect& rrect,
+                           DlClipOp op,
+                           bool is_aa) = 0;
+    virtual void clipPath(const DlPath& path, DlClipOp op, bool is_aa) = 0;
   };
   friend class DummyDelegate;
   friend class DlCanvasDelegate;

--- a/engine/src/flutter/flow/layers/platform_view_layer_unittests.cc
+++ b/engine/src/flutter/flow/layers/platform_view_layer_unittests.cc
@@ -16,8 +16,6 @@ namespace testing {
 
 using PlatformViewLayerTest = LayerTest;
 
-using ClipOp = DlCanvas::ClipOp;
-
 TEST_F(PlatformViewLayerTest, NullViewEmbedderDoesntPrerollCompositeOrPaint) {
   const DlPoint layer_offset = DlPoint();
   const DlSize layer_size = DlSize(8.0f, 8.0f);
@@ -73,13 +71,13 @@ TEST_F(PlatformViewLayerTest, ClippedPlatformViewPrerollsAndPaintsNothing) {
 
   DisplayListBuilder expected_builder;
   expected_builder.Save();
-  expected_builder.ClipRect(parent_clip, ClipOp::kIntersect, false);
+  expected_builder.ClipRect(parent_clip, DlClipOp::kIntersect, false);
 
   // In reality the following save/clip/restore are elided due to reaching
   // a nop state (and the save is then unnecessary), but this is the order
   // of operations that the layers will do...
   expected_builder.Save();
-  expected_builder.ClipRect(child_clip, ClipOp::kIntersect, false);
+  expected_builder.ClipRect(child_clip, DlClipOp::kIntersect, false);
   expected_builder.Restore();
   // End of section that gets ignored during recording
 

--- a/engine/src/flutter/flow/paint_utils.cc
+++ b/engine/src/flutter/flow/paint_utils.cc
@@ -32,7 +32,7 @@ std::shared_ptr<DlColorSource> CreateCheckerboardShader(SkColor c1,
 void DrawCheckerboard(DlCanvas* canvas, const SkRect& rect) {
   // Draw a checkerboard
   canvas->Save();
-  canvas->ClipRect(rect, DlCanvas::ClipOp::kIntersect, false);
+  canvas->ClipRect(rect, DlClipOp::kIntersect, false);
 
   // Secure random number generation isn't needed here.
   // NOLINTBEGIN(clang-analyzer-security.insecureAPI.rand)

--- a/engine/src/flutter/flow/view_slicer.cc
+++ b/engine/src/flutter/flow/view_slicer.cc
@@ -112,8 +112,7 @@ std::unordered_map<int64_t, SkRect> SliceViews(
 
       // Clip the background canvas, so it doesn't contain any of the pixels
       // drawn on the overlay layer.
-      background_canvas->ClipRect(full_joined_rect,
-                                  DlCanvas::ClipOp::kDifference);
+      background_canvas->ClipRect(full_joined_rect, DlClipOp::kDifference);
     }
     slice->render_into(background_canvas);
   }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -826,7 +826,7 @@ TEST_P(AiksTest, CanRenderClippedBackdropFilter) {
 
   // Draw a clipped SaveLayer, where the clip coverage and SaveLayer size are
   // the same.
-  builder.ClipRoundRect(clip_rrect, DlCanvas::ClipOp::kIntersect);
+  builder.ClipRoundRect(clip_rrect, DlClipOp::kIntersect);
 
   DlPaint save_paint;
   auto backdrop_filter = DlImageFilter::MakeColorFilter(
@@ -854,7 +854,7 @@ TEST_P(AiksTest, CanDrawPerspectiveTransformWithClips) {
         paint.setColor(DlColor::kGreen());
         builder.DrawPaint(paint);
         builder.ClipRect(DlRect::MakeLTRB(-180, -180, 180, 180),
-                         DlCanvas::ClipOp::kDifference);
+                         DlClipOp::kDifference);
 
         paint.setColor(DlColor::kBlack());
         builder.DrawPaint(paint);

--- a/engine/src/flutter/impeller/display_list/aiks_dl_clip_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_clip_unittests.cc
@@ -41,14 +41,14 @@ TEST_P(AiksTest, CanRenderDifferenceClips) {
 
   // Cut away eyes/mouth using difference clips.
   builder.ClipPath(DlPath::MakeCircle(DlPoint(-100, -50), 30),
-                   DlCanvas::ClipOp::kDifference);
+                   DlClipOp::kDifference);
   builder.ClipPath(DlPath::MakeCircle(DlPoint(100, -50), 30),
-                   DlCanvas::ClipOp::kDifference);
+                   DlClipOp::kDifference);
 
   DlPathBuilder path_builder;
   path_builder.MoveTo(DlPoint(-100, 50));
   path_builder.QuadraticCurveTo(DlPoint(0, 150), DlPoint(100, 50));
-  builder.ClipPath(DlPath(path_builder), DlCanvas::ClipOp::kDifference);
+  builder.ClipPath(DlPath(path_builder), DlClipOp::kDifference);
 
   // Draw a huge yellow rectangle to prove the clipping works.
   DlPaint paint;
@@ -123,7 +123,7 @@ TEST_P(AiksTest, FramebufferBlendsRespectClips) {
   builder.DrawPaint(paint);
 
   builder.ClipPath(DlPath::MakeCircle(DlPoint(150, 150), 50),
-                   DlCanvas::ClipOp::kIntersect);
+                   DlClipOp::kIntersect);
 
   // Draw a red rectangle that should not show through the circle clip.
   paint.setColor(DlColor::kRed());

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -53,7 +53,7 @@ TEST_P(AiksTest, CanRenderClippedRuntimeEffects) {
   builder.Save();
   builder.ClipRoundRect(
       DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 400, 400), 10.0, 10.0),
-      DlCanvas::ClipOp::kIntersect);
+      DlClipOp::kIntersect);
   builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 400), paint);
   builder.Restore();
 

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -501,7 +501,7 @@ TEST_P(AiksTest, DifferenceClipsMustRenderIdenticallyAcrossBackends) {
   builder.DrawRect(frame, paint);
 
   builder.Save();
-  builder.ClipRect(frame, DlCanvas::ClipOp::kIntersect);
+  builder.ClipRect(frame, DlClipOp::kIntersect);
 
   DlMatrix rect_xform = {
       0.8241262, 0.56640625, 0.0, 0.0, -0.56640625, 0.8241262, 0.0, 0.0,
@@ -517,7 +517,7 @@ TEST_P(AiksTest, DifferenceClipsMustRenderIdenticallyAcrossBackends) {
   builder.DrawRoundRect(rrect, paint);
 
   builder.Save();
-  builder.ClipRect(rect, DlCanvas::ClipOp::kIntersect);
+  builder.ClipRect(rect, DlClipOp::kIntersect);
   builder.Restore();
 
   builder.Restore();

--- a/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
@@ -419,10 +419,10 @@ TEST_P(AiksTest, CanDrawPoints) {
   builder.DrawPaint(background);
   builder.Translate(200, 200);
 
-  builder.DrawPoints(DlCanvas::PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      paint_round);
   builder.Translate(150, 0);
-  builder.DrawPoints(DlCanvas::PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      paint_square);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -459,10 +459,10 @@ TEST_P(AiksTest, CanDrawPointsWithTextureMap) {
   DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
   builder.Translate(200, 200);
 
-  builder.DrawPoints(DlCanvas::PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      paint_round);
   builder.Translate(150, 0);
-  builder.DrawPoints(DlCanvas::PointMode::kPoints, points.size(), points.data(),
+  builder.DrawPoints(DlPointMode::kPoints, points.size(), points.data(),
                      paint_square);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -821,8 +821,7 @@ TEST_P(AiksTest, CanDrawScaledPointsSmallScaleLargeRadius) {
   builder.Translate(200, 200);
   builder.Scale(0.000001, 0.000001);
 
-  builder.DrawPoints(DlCanvas::PointMode::kPoints, point.size(), point.data(),
-                     paint);
+  builder.DrawPoints(DlPointMode::kPoints, point.size(), point.data(), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -842,8 +841,7 @@ TEST_P(AiksTest, CanDrawScaledPointsLargeScaleSmallRadius) {
   builder.Translate(200, 200);
   builder.Scale(1000000, 1000000);
 
-  builder.DrawPoints(DlCanvas::PointMode::kPoints, point.size(), point.data(),
-                     paint);
+  builder.DrawPoints(DlPointMode::kPoints, point.size(), point.data(), paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
@@ -896,8 +894,7 @@ TEST_P(AiksTest, BackdropRestoreUsesCorrectCoverageForFirstRestoredClip) {
 
   DlPaint paint;
   // Add a difference clip that cuts out the bottom right corner
-  builder.ClipRect(DlRect::MakeLTRB(50, 50, 100, 100),
-                   DlCanvas::ClipOp::kDifference);
+  builder.ClipRect(DlRect::MakeLTRB(50, 50, 100, 100), DlClipOp::kDifference);
 
   // Draw a red rectangle that's going to be completely covered by green later.
   paint.setColor(DlColor::kRed());
@@ -995,8 +992,7 @@ TEST_P(AiksTest, DepthValuesForLineMode) {
       DlPoint::MakeXY(0, 100),  DlPoint::MakeXY(400, 500),
       DlPoint::MakeXY(0, 150),  DlPoint::MakeXY(400, 600)};
 
-  builder.DrawPoints(DisplayListBuilder::PointMode::kLines, points.size(),
-                     points.data(),
+  builder.DrawPoints(DlPointMode::kLines, points.size(), points.data(),
                      DlPaint().setColor(DlColor::kBlue()).setStrokeWidth(10));
   builder.Restore();
 
@@ -1024,8 +1020,7 @@ TEST_P(AiksTest, DepthValuesForPolygonMode) {
       DlPoint::MakeXY(0, 100),  DlPoint::MakeXY(400, 500),
       DlPoint::MakeXY(0, 150),  DlPoint::MakeXY(400, 600)};
 
-  builder.DrawPoints(DisplayListBuilder::PointMode::kPolygon, points.size(),
-                     points.data(),
+  builder.DrawPoints(DlPointMode::kPolygon, points.size(), points.data(),
                      DlPaint().setColor(DlColor::kBlue()).setStrokeWidth(10));
   builder.Restore();
 

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -417,19 +417,18 @@ void DlDispatcherBase::transformReset() {
   GetCanvas().Transform(initial_matrix_);
 }
 
-static Entity::ClipOperation ToClipOperation(
-    flutter::DlCanvas::ClipOp clip_op) {
+static Entity::ClipOperation ToClipOperation(flutter::DlClipOp clip_op) {
   switch (clip_op) {
-    case flutter::DlCanvas::ClipOp::kDifference:
+    case flutter::DlClipOp::kDifference:
       return Entity::ClipOperation::kDifference;
-    case flutter::DlCanvas::ClipOp::kIntersect:
+    case flutter::DlClipOp::kIntersect:
       return Entity::ClipOperation::kIntersect;
   }
 }
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::clipRect(const DlRect& rect,
-                                ClipOp clip_op,
+                                flutter::DlClipOp clip_op,
                                 bool is_aa) {
   AUTO_DEPTH_WATCHER(0u);
 
@@ -439,7 +438,7 @@ void DlDispatcherBase::clipRect(const DlRect& rect,
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::clipOval(const DlRect& bounds,
-                                ClipOp clip_op,
+                                flutter::DlClipOp clip_op,
                                 bool is_aa) {
   AUTO_DEPTH_WATCHER(0u);
 
@@ -449,7 +448,7 @@ void DlDispatcherBase::clipOval(const DlRect& bounds,
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::clipRoundRect(const DlRoundRect& rrect,
-                                     ClipOp sk_op,
+                                     flutter::DlClipOp sk_op,
                                      bool is_aa) {
   AUTO_DEPTH_WATCHER(0u);
 
@@ -470,7 +469,9 @@ void DlDispatcherBase::clipRoundRect(const DlRoundRect& rrect,
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::clipPath(const DlPath& path, ClipOp sk_op, bool is_aa) {
+void DlDispatcherBase::clipPath(const DlPath& path,
+                                flutter::DlClipOp sk_op,
+                                bool is_aa) {
   AUTO_DEPTH_WATCHER(0u);
 
   auto clip_op = ToClipOperation(sk_op);
@@ -665,7 +666,7 @@ void DlDispatcherBase::drawArc(const DlRect& oval_bounds,
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawPoints(PointMode mode,
+void DlDispatcherBase::drawPoints(flutter::DlPointMode mode,
                                   uint32_t count,
                                   const DlPoint points[]) {
   AUTO_DEPTH_WATCHER(1u);
@@ -673,7 +674,7 @@ void DlDispatcherBase::drawPoints(PointMode mode,
   Paint paint = paint_;
   paint.style = Paint::Style::kStroke;
   switch (mode) {
-    case flutter::DlCanvas::PointMode::kPoints: {
+    case flutter::DlPointMode::kPoints: {
       // Cap::kButt is also treated as a square.
       PointStyle point_style = paint.stroke_cap == Cap::kRound
                                    ? PointStyle::kRound
@@ -684,14 +685,14 @@ void DlDispatcherBase::drawPoints(PointMode mode,
       }
       GetCanvas().DrawPoints(points, count, radius, paint, point_style);
     } break;
-    case flutter::DlCanvas::PointMode::kLines:
+    case flutter::DlPointMode::kLines:
       for (uint32_t i = 1; i < count; i += 2) {
         Point p0 = points[i - 1];
         Point p1 = points[i];
         GetCanvas().DrawLine(p0, p1, paint, /*reuse_depth=*/i > 1);
       }
       break;
-    case flutter::DlCanvas::PointMode::kPolygon:
+    case flutter::DlPointMode::kPolygon:
       if (count > 1) {
         Point p0 = points[0];
         for (uint32_t i = 1; i < count; i++) {
@@ -728,23 +729,23 @@ void DlDispatcherBase::drawImage(const sk_sp<flutter::DlImage> image,
   const auto src = DlRect::MakeWH(size.width, size.height);
   const auto dest = DlRect::MakeXYWH(point.x, point.y, size.width, size.height);
 
-  drawImageRect(image,                      // image
-                src,                        // source rect
-                dest,                       // destination rect
-                sampling,                   // sampling options
-                render_with_attributes,     // render with attributes
-                SrcRectConstraint::kStrict  // constraint
+  drawImageRect(image,                                 // image
+                src,                                   // source rect
+                dest,                                  // destination rect
+                sampling,                              // sampling options
+                render_with_attributes,                // render with attributes
+                flutter::DlSrcRectConstraint::kStrict  // constraint
   );
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawImageRect(
-    const sk_sp<flutter::DlImage> image,
-    const DlRect& src,
-    const DlRect& dst,
-    flutter::DlImageSampling sampling,
-    bool render_with_attributes,
-    SrcRectConstraint constraint = SrcRectConstraint::kFast) {
+void DlDispatcherBase::drawImageRect(const sk_sp<flutter::DlImage> image,
+                                     const DlRect& src,
+                                     const DlRect& dst,
+                                     flutter::DlImageSampling sampling,
+                                     bool render_with_attributes,
+                                     flutter::DlSrcRectConstraint constraint =
+                                         flutter::DlSrcRectConstraint::kFast) {
   AUTO_DEPTH_WATCHER(1u);
 
   GetCanvas().DrawImageRect(

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.h
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.h
@@ -124,18 +124,24 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void transformReset() override;
 
   // |flutter::DlOpReceiver|
-  void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
+  void clipRect(const DlRect& rect,
+                flutter::DlClipOp clip_op,
+                bool is_aa) override;
 
   // |flutter::DlOpReceiver|
-  void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void clipOval(const DlRect& bounds,
+                flutter::DlClipOp clip_op,
+                bool is_aa) override;
 
   // |flutter::DlOpReceiver|
   void clipRoundRect(const DlRoundRect& rrect,
-                     ClipOp clip_op,
+                     flutter::DlClipOp clip_op,
                      bool is_aa) override;
 
   // |flutter::DlOpReceiver|
-  void clipPath(const DlPath& path, ClipOp clip_op, bool is_aa) override;
+  void clipPath(const DlPath& path,
+                flutter::DlClipOp clip_op,
+                bool is_aa) override;
 
   // |flutter::DlOpReceiver|
   void drawColor(flutter::DlColor color, flutter::DlBlendMode mode) override;
@@ -178,7 +184,7 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
                bool use_center) override;
 
   // |flutter::DlOpReceiver|
-  void drawPoints(PointMode mode,
+  void drawPoints(flutter::DlPointMode mode,
                   uint32_t count,
                   const DlPoint points[]) override;
 
@@ -198,7 +204,7 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
                      const DlRect& dst,
                      flutter::DlImageSampling sampling,
                      bool render_with_attributes,
-                     SrcRectConstraint constraint) override;
+                     flutter::DlSrcRectConstraint constraint) override;
 
   // |flutter::DlOpReceiver|
   void drawImageNine(const sk_sp<flutter::DlImage> image,

--- a/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
@@ -79,7 +79,7 @@ TEST_P(DlGoldenTest, Bug147807) {
     {
       canvas->ClipRoundRect(
           DlRoundRect::MakeOval(DlRect::MakeLTRB(201.25, 10, 361.25, 170)),
-          DlCanvas::ClipOp::kIntersect, true);
+          DlClipOp::kIntersect, true);
       DlRect save_layer_bounds = DlRect::MakeLTRB(201.25, 10, 361.25, 170);
       auto backdrop =
           DlImageFilter::MakeMatrix(DlMatrix::MakeRow(3, 0, 0.0, -280,  //

--- a/engine/src/flutter/impeller/display_list/dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_unittests.cc
@@ -689,7 +689,7 @@ TEST_P(DisplayListTest, CanDrawBackdropFilter) {
     // correctly.
     if (add_clip) {
       builder.ClipRect(DlRect::MakeLTRB(0, 0, 99999, 99999),
-                       flutter::DlCanvas::ClipOp::kIntersect, true);
+                       flutter::DlClipOp::kIntersect, true);
     }
 
     builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(200, 200),
@@ -827,12 +827,11 @@ TEST_P(DisplayListTest, CanDrawPoints) {
   for (auto cap : caps) {
     paint.setStrokeCap(cap);
     builder.Save();
-    builder.DrawPoints(flutter::DlCanvas::PointMode::kPoints, 7, points, paint);
+    builder.DrawPoints(flutter::DlPointMode::kPoints, 7, points, paint);
     builder.Translate(150, 0);
-    builder.DrawPoints(flutter::DlCanvas::PointMode::kLines, 5, points, paint);
+    builder.DrawPoints(flutter::DlPointMode::kLines, 5, points, paint);
     builder.Translate(150, 0);
-    builder.DrawPoints(flutter::DlCanvas::PointMode::kPolygon, 5, points,
-                       paint);
+    builder.DrawPoints(flutter::DlPointMode::kPolygon, 5, points, paint);
     builder.Restore();
     builder.Translate(0, 150);
   }
@@ -1131,7 +1130,7 @@ TEST_P(DisplayListTest, CanDrawPaintWithColorSource) {
   auto clip_bounds = DlRect::MakeWH(300.0, 300.0);
   builder.Save();
   builder.Translate(100, 100);
-  builder.ClipRect(clip_bounds, flutter::DlCanvas::ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds, flutter::DlClipOp::kIntersect, false);
   auto linear =
       flutter::DlColorSource::MakeLinear({0.0, 0.0}, {100.0, 100.0}, 2, colors,
                                          stops, flutter::DlTileMode::kRepeat);
@@ -1141,7 +1140,7 @@ TEST_P(DisplayListTest, CanDrawPaintWithColorSource) {
 
   builder.Save();
   builder.Translate(500, 100);
-  builder.ClipRect(clip_bounds, flutter::DlCanvas::ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds, flutter::DlClipOp::kIntersect, false);
   auto radial = flutter::DlColorSource::MakeRadial(
       {100.0, 100.0}, 100.0, 2, colors, stops, flutter::DlTileMode::kRepeat);
   paint.setColorSource(radial);
@@ -1150,7 +1149,7 @@ TEST_P(DisplayListTest, CanDrawPaintWithColorSource) {
 
   builder.Save();
   builder.Translate(100, 500);
-  builder.ClipRect(clip_bounds, flutter::DlCanvas::ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds, flutter::DlClipOp::kIntersect, false);
   auto sweep =
       flutter::DlColorSource::MakeSweep({100.0, 100.0}, 180.0, 270.0, 2, colors,
                                         stops, flutter::DlTileMode::kRepeat);
@@ -1160,7 +1159,7 @@ TEST_P(DisplayListTest, CanDrawPaintWithColorSource) {
 
   builder.Save();
   builder.Translate(500, 500);
-  builder.ClipRect(clip_bounds, flutter::DlCanvas::ClipOp::kIntersect, false);
+  builder.ClipRect(clip_bounds, flutter::DlClipOp::kIntersect, false);
   auto texture = CreateTextureForFixture("table_mountain_nx.png");
   auto image = flutter::DlColorSource::MakeImage(DlImageImpeller::Make(texture),
                                                  flutter::DlTileMode::kRepeat,

--- a/engine/src/flutter/impeller/display_list/dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_unittests.cc
@@ -1556,7 +1556,7 @@ TEST_P(DisplayListTest, DrawMaskBlursThatMightUseSaveLayers) {
                        normal_if_paint);
     }
   }
-  x builder.Restore();
+  builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/impeller/display_list/dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_unittests.cc
@@ -1556,7 +1556,7 @@ TEST_P(DisplayListTest, DrawMaskBlursThatMightUseSaveLayers) {
                        normal_if_paint);
     }
   }
-  builder.Restore();
+  x builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/impeller/toolkit/interop/dl_builder.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/dl_builder.cc
@@ -66,24 +66,21 @@ void DisplayListBuilder::RestoreToCount(uint32_t count) {
   builder_.RestoreToCount(count);
 }
 
-void DisplayListBuilder::ClipRect(const Rect& rect,
-                                  flutter::DlCanvas::ClipOp op) {
+void DisplayListBuilder::ClipRect(const Rect& rect, flutter::DlClipOp op) {
   builder_.ClipRect(rect, op);
 }
 
-void DisplayListBuilder::ClipOval(const Rect& rect,
-                                  flutter::DlCanvas::ClipOp op) {
+void DisplayListBuilder::ClipOval(const Rect& rect, flutter::DlClipOp op) {
   builder_.ClipOval(rect, op);
 }
 
 void DisplayListBuilder::ClipRoundedRect(const Rect& rect,
                                          const RoundingRadii& radii,
-                                         flutter::DlCanvas::ClipOp op) {
+                                         flutter::DlClipOp op) {
   builder_.ClipRoundRect(RoundRect::MakeRectRadii(rect, radii), op);
 }
 
-void DisplayListBuilder::ClipPath(const Path& path,
-                                  flutter::DlCanvas::ClipOp op) {
+void DisplayListBuilder::ClipPath(const Path& path, flutter::DlClipOp op) {
   builder_.ClipPath(flutter::DlPath(path.GetPath()), op);
 }
 

--- a/engine/src/flutter/impeller/toolkit/interop/dl_builder.h
+++ b/engine/src/flutter/impeller/toolkit/interop/dl_builder.h
@@ -59,15 +59,15 @@ class DisplayListBuilder final
 
   void RestoreToCount(uint32_t count);
 
-  void ClipRect(const Rect& rect, flutter::DlCanvas::ClipOp op);
+  void ClipRect(const Rect& rect, flutter::DlClipOp op);
 
-  void ClipOval(const Rect& rect, flutter::DlCanvas::ClipOp op);
+  void ClipOval(const Rect& rect, flutter::DlClipOp op);
 
   void ClipRoundedRect(const Rect& rect,
                        const RoundingRadii& radii,
-                       flutter::DlCanvas::ClipOp op);
+                       flutter::DlClipOp op);
 
-  void ClipPath(const Path& path, flutter::DlCanvas::ClipOp op);
+  void ClipPath(const Path& path, flutter::DlClipOp op);
 
   void DrawPaint(const Paint& paint);
 

--- a/engine/src/flutter/impeller/toolkit/interop/formats.h
+++ b/engine/src/flutter/impeller/toolkit/interop/formats.h
@@ -274,14 +274,14 @@ constexpr FillType ToImpellerType(ImpellerFillType type) {
   return FillType::kNonZero;
 }
 
-constexpr flutter::DlCanvas::ClipOp ToImpellerType(ImpellerClipOperation op) {
+constexpr flutter::DlClipOp ToImpellerType(ImpellerClipOperation op) {
   switch (op) {
     case kImpellerClipOperationDifference:
-      return flutter::DlCanvas::ClipOp::kDifference;
+      return flutter::DlClipOp::kDifference;
     case kImpellerClipOperationIntersect:
-      return flutter::DlCanvas::ClipOp::kIntersect;
+      return flutter::DlClipOp::kIntersect;
   }
-  return flutter::DlCanvas::ClipOp::kDifference;
+  return flutter::DlClipOp::kDifference;
 }
 
 constexpr Color ToImpellerType(const ImpellerColor& color) {

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -5566,7 +5566,7 @@ base class Vertices extends NativeFieldWrapperClass1 {
 /// Defines how a list of points is interpreted when drawing a set of points.
 ///
 /// Used by [Canvas.drawPoints] and [Canvas.drawRawPoints].
-// These enum values must be kept in sync with DlCanvas::PointMode.
+// These enum values must be kept in sync with DlPointMode.
 enum PointMode {
   /// Draw each point separately.
   ///

--- a/engine/src/flutter/lib/ui/painting/canvas.cc
+++ b/engine/src/flutter/lib/ui/painting/canvas.cc
@@ -162,7 +162,7 @@ void Canvas::clipRect(double left,
                       double top,
                       double right,
                       double bottom,
-                      DlCanvas::ClipOp clipOp,
+                      DlClipOp clipOp,
                       bool doAntiAlias) {
   if (display_list_builder_) {
     builder()->ClipRect(DlRect::MakeLTRB(SafeNarrow(left), SafeNarrow(top),
@@ -173,8 +173,7 @@ void Canvas::clipRect(double left,
 
 void Canvas::clipRRect(const RRect& rrect, bool doAntiAlias) {
   if (display_list_builder_) {
-    builder()->ClipRoundRect(rrect.rrect, DlCanvas::ClipOp::kIntersect,
-                             doAntiAlias);
+    builder()->ClipRoundRect(rrect.rrect, DlClipOp::kIntersect, doAntiAlias);
   }
 }
 
@@ -185,8 +184,7 @@ void Canvas::clipPath(const CanvasPath* path, bool doAntiAlias) {
     return;
   }
   if (display_list_builder_) {
-    builder()->ClipPath(path->path(), DlCanvas::ClipOp::kIntersect,
-                        doAntiAlias);
+    builder()->ClipPath(path->path(), DlClipOp::kIntersect, doAntiAlias);
   }
 }
 
@@ -446,7 +444,7 @@ Dart_Handle Canvas::drawImageRect(const CanvasImage* image,
     const DlPaint* opt_paint =
         paint.paint(dl_paint, kDrawImageRectWithPaintFlags, DlTileMode::kClamp);
     builder()->DrawImageRect(dl_image, src, dst, sampling, opt_paint,
-                             DlCanvas::SrcRectConstraint::kFast);
+                             DlSrcRectConstraint::kFast);
   }
   return Dart_Null();
 }
@@ -511,7 +509,7 @@ void Canvas::drawPicture(Picture* picture) {
 
 void Canvas::drawPoints(Dart_Handle paint_objects,
                         Dart_Handle paint_data,
-                        DlCanvas::PointMode point_mode,
+                        DlPointMode point_mode,
                         const tonic::Float32List& points) {
   Paint paint(paint_objects, paint_data);
 
@@ -522,13 +520,13 @@ void Canvas::drawPoints(Dart_Handle paint_objects,
   if (display_list_builder_) {
     DlPaint dl_paint;
     switch (point_mode) {
-      case DlCanvas::PointMode::kPoints:
+      case DlPointMode::kPoints:
         paint.paint(dl_paint, kDrawPointsAsPointsFlags, DlTileMode::kDecal);
         break;
-      case DlCanvas::PointMode::kLines:
+      case DlPointMode::kLines:
         paint.paint(dl_paint, kDrawPointsAsLinesFlags, DlTileMode::kDecal);
         break;
-      case DlCanvas::PointMode::kPolygon:
+      case DlPointMode::kPolygon:
         paint.paint(dl_paint, kDrawPointsAsPolygonFlags, DlTileMode::kDecal);
         break;
     }

--- a/engine/src/flutter/lib/ui/painting/canvas.h
+++ b/engine/src/flutter/lib/ui/painting/canvas.h
@@ -58,7 +58,7 @@ class Canvas : public RefCountedDartWrappable<Canvas>, DisplayListOpFlags {
                 double top,
                 double right,
                 double bottom,
-                DlCanvas::ClipOp clipOp,
+                DlClipOp clipOp,
                 bool doAntiAlias = true);
   void clipRRect(const RRect& rrect, bool doAntiAlias = true);
   void clipPath(const CanvasPath* path, bool doAntiAlias = true);
@@ -161,7 +161,7 @@ class Canvas : public RefCountedDartWrappable<Canvas>, DisplayListOpFlags {
 
   void drawPoints(Dart_Handle paint_objects,
                   Dart_Handle paint_data,
-                  DlCanvas::PointMode point_mode,
+                  DlPointMode point_mode,
                   const tonic::Float32List& points);
 
   void drawVertices(const Vertices* vertices,

--- a/engine/src/flutter/shell/common/dl_op_spy.cc
+++ b/engine/src/flutter/shell/common/dl_op_spy.cc
@@ -74,7 +74,7 @@ void DlOpSpy::drawArc(const DlRect& oval_bounds,
                       bool use_center) {
   did_draw_ |= will_draw_;
 }
-void DlOpSpy::drawPoints(PointMode mode,
+void DlOpSpy::drawPoints(DlPointMode mode,
                          uint32_t count,
                          const DlPoint points[]) {
   did_draw_ |= will_draw_;
@@ -99,7 +99,7 @@ void DlOpSpy::drawImageRect(const sk_sp<DlImage> image,
                             const DlRect& dst,
                             DlImageSampling sampling,
                             bool render_with_attributes,
-                            SrcRectConstraint constraint) {
+                            DlSrcRectConstraint constraint) {
   did_draw_ = true;
 }
 void DlOpSpy::drawImageNine(const sk_sp<DlImage> image,

--- a/engine/src/flutter/shell/common/dl_op_spy.h
+++ b/engine/src/flutter/shell/common/dl_op_spy.h
@@ -62,7 +62,7 @@ class DlOpSpy final : public virtual DlOpReceiver,
                DlScalar start_degrees,
                DlScalar sweep_degrees,
                bool use_center) override;
-  void drawPoints(PointMode mode,
+  void drawPoints(DlPointMode mode,
                   uint32_t count,
                   const DlPoint points[]) override;
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
@@ -77,7 +77,7 @@ class DlOpSpy final : public virtual DlOpReceiver,
       const DlRect& dst,
       DlImageSampling sampling,
       bool render_with_attributes,
-      SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
+      DlSrcRectConstraint constraint = DlSrcRectConstraint::kFast) override;
   void drawImageNine(const sk_sp<DlImage> image,
                      const DlIRect& center,
                      const DlRect& dst,

--- a/engine/src/flutter/shell/common/dl_op_spy_unittests.cc
+++ b/engine/src/flutter/shell/common/dl_op_spy_unittests.cc
@@ -349,7 +349,7 @@ TEST(DlOpSpy, DrawPoints) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
     const DlPoint points[] = {DlPoint(5, 4)};
-    builder.DrawPoints(DlCanvas::PointMode::kPoints, 1, points, paint);
+    builder.DrawPoints(DlPointMode::kPoints, 1, points, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -359,7 +359,7 @@ TEST(DlOpSpy, DrawPoints) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
     const DlPoint points[] = {DlPoint(5, 4)};
-    builder.DrawPoints(DlCanvas::PointMode::kPoints, 1, points, paint);
+    builder.DrawPoints(DlPointMode::kPoints, 1, points, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);

--- a/engine/src/flutter/shell/platform/android/image_external_texture.cc
+++ b/engine/src/flutter/shell/platform/android/image_external_texture.cc
@@ -38,12 +38,12 @@ void ImageExternalTexture::Paint(PaintContext& context,
   }
   if (dl_image_) {
     context.canvas->DrawImageRect(
-        dl_image_,                                     // image
-        SkRect::Make(dl_image_->bounds()),             // source rect
-        bounds,                                        // destination rect
-        sampling,                                      // sampling
-        context.paint,                                 // paint
-        flutter::DlCanvas::SrcRectConstraint::kStrict  // enforce edges
+        dl_image_,                             // image
+        SkRect::Make(dl_image_->bounds()),     // source rect
+        bounds,                                // destination rect
+        sampling,                              // sampling
+        context.paint,                         // paint
+        flutter::DlSrcRectConstraint::kStrict  // enforce edges
     );
   } else {
     FML_LOG(INFO) << "No DlImage available for ImageExternalTexture to paint.";

--- a/engine/src/flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/engine/src/flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -66,12 +66,12 @@ FLUTTER_ASSERT_ARC
   }
 
   if (_externalImage) {
-    context.canvas->DrawImageRect(_externalImage,                                // image
-                                  SkRect::Make(_externalImage->bounds()),        // source rect
-                                  bounds,                                        // destination rect
-                                  sampling,                                      // sampling
-                                  context.paint,                                 // paint
-                                  flutter::DlCanvas::SrcRectConstraint::kStrict  // enforce edges
+    context.canvas->DrawImageRect(_externalImage,                          // image
+                                  SkRect::Make(_externalImage->bounds()),  // source rect
+                                  bounds,                                  // destination rect
+                                  sampling,                                // sampling
+                                  context.paint,                           // paint
+                                  flutter::DlSrcRectConstraint::kStrict    // enforce edges
     );
   }
 }

--- a/engine/src/flutter/testing/display_list_testing.cc
+++ b/engine/src/flutter/testing/display_list_testing.cc
@@ -205,18 +205,18 @@ extern std::ostream& operator<<(std::ostream& os, const DlPath& path) {
             << ")";
 }
 
-std::ostream& operator<<(std::ostream& os, const DlCanvas::ClipOp& op) {
+std::ostream& operator<<(std::ostream& os, const flutter::DlClipOp& op) {
   switch (op) {
-    case DlCanvas::ClipOp::kDifference: return os << "ClipOp::kDifference";
-    case DlCanvas::ClipOp::kIntersect:  return os << "ClipOp::kIntersect";
+    case flutter::DlClipOp::kDifference: return os << "ClipOp::kDifference";
+    case flutter::DlClipOp::kIntersect:  return os << "ClipOp::kIntersect";
   }
 }
 
-std::ostream& operator<<(std::ostream& os, const DlCanvas::SrcRectConstraint& constraint) {
+std::ostream& operator<<(std::ostream& os, const flutter::DlSrcRectConstraint& constraint) {
   switch (constraint) {
-    case DlCanvas::SrcRectConstraint::kFast:
+    case flutter::DlSrcRectConstraint::kFast:
       return os << "SrcRectConstraint::kFast";
-    case DlCanvas::SrcRectConstraint::kStrict:
+    case flutter::DlSrcRectConstraint::kStrict:
       return os << "SrcRectConstraint::kStrict";
   }
 }
@@ -254,11 +254,11 @@ std::ostream& operator<<(std::ostream& os, const DlBlurStyle& style) {
   }
 }
 
-std::ostream& operator<<(std::ostream& os, const DlCanvas::PointMode& mode) {
+std::ostream& operator<<(std::ostream& os, const flutter::DlPointMode& mode) {
   switch (mode) {
-    case DlCanvas::PointMode::kPoints:  return os << "PointMode::kPoints";
-    case DlCanvas::PointMode::kLines:   return os << "PointMode::kLines";
-    case DlCanvas::PointMode::kPolygon: return os << "PointMode::kPolygon";
+    case flutter::DlPointMode::kPoints:  return os << "PointMode::kPoints";
+    case flutter::DlPointMode::kLines:   return os << "PointMode::kLines";
+    case flutter::DlPointMode::kPolygon: return os << "PointMode::kPolygon";
   }
 }
 
@@ -759,7 +759,7 @@ void DisplayListStreamDispatcher::transformReset() {
   startl() << "transformReset();" << std::endl;
 }
 
-void DisplayListStreamDispatcher::clipRect(const DlRect& rect, ClipOp clip_op,
+void DisplayListStreamDispatcher::clipRect(const DlRect& rect, DlClipOp clip_op,
                                            bool is_aa) {
   startl() << "clipRect("
            << rect << ", "
@@ -767,7 +767,7 @@ void DisplayListStreamDispatcher::clipRect(const DlRect& rect, ClipOp clip_op,
            << "isaa: " << is_aa
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::clipOval(const DlRect& bounds, ClipOp clip_op,
+void DisplayListStreamDispatcher::clipOval(const DlRect& bounds, DlClipOp clip_op,
                                            bool is_aa) {
   startl() << "clipOval("
            << bounds << ", "
@@ -776,7 +776,7 @@ void DisplayListStreamDispatcher::clipOval(const DlRect& bounds, ClipOp clip_op,
            << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::clipRoundRect(const DlRoundRect& rrect,
-                                                ClipOp clip_op,
+                                                DlClipOp clip_op,
                                                 bool is_aa) {
   startl() << "clipRRect("
            << rrect << ", "
@@ -784,7 +784,7 @@ void DisplayListStreamDispatcher::clipRoundRect(const DlRoundRect& rrect,
            << "isaa: " << is_aa
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::clipPath(const DlPath& path, ClipOp clip_op,
+void DisplayListStreamDispatcher::clipPath(const DlPath& path, DlClipOp clip_op,
                                            bool is_aa) {
   startl() << "clipPath("
            << path << ", "
@@ -849,7 +849,7 @@ void DisplayListStreamDispatcher::drawArc(const DlRect& oval_bounds,
            << "use_center: " << use_center
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::drawPoints(PointMode mode,
+void DisplayListStreamDispatcher::drawPoints(DlPointMode mode,
                                              uint32_t count,
                                              const DlPoint points[]) {
   startl() << "drawPoints(" << mode << ", ";
@@ -882,7 +882,7 @@ void DisplayListStreamDispatcher::drawImageRect(const sk_sp<DlImage> image,
                                                 const DlRect& dst,
                                                 DlImageSampling sampling,
                                                 bool render_with_attributes,
-                                                SrcRectConstraint constraint) {
+                                                DlSrcRectConstraint constraint) {
   startl() << "drawImageRect(" << image.get() << "," << std::endl;
   startl() << "              src: " << src << "," << std::endl;
   startl() << "              dst: " << dst << "," << std::endl;

--- a/engine/src/flutter/testing/display_list_testing.h
+++ b/engine/src/flutter/testing/display_list_testing.h
@@ -46,12 +46,11 @@ extern std::ostream& operator<<(std::ostream& os,
                                 const flutter::DlPaint& paint);
 extern std::ostream& operator<<(std::ostream& os,
                                 const flutter::DlBlendMode& mode);
+extern std::ostream& operator<<(std::ostream& os, const flutter::DlClipOp& op);
 extern std::ostream& operator<<(std::ostream& os,
-                                const flutter::DlCanvas::ClipOp& op);
+                                const flutter::DlPointMode& op);
 extern std::ostream& operator<<(std::ostream& os,
-                                const flutter::DlCanvas::PointMode& op);
-extern std::ostream& operator<<(std::ostream& os,
-                                const flutter::DlCanvas::SrcRectConstraint& op);
+                                const flutter::DlSrcRectConstraint& op);
 extern std::ostream& operator<<(std::ostream& os,
                                 const flutter::DlStrokeCap& cap);
 extern std::ostream& operator<<(std::ostream& os,
@@ -131,12 +130,12 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
   // clang-format on
   void transformReset() override;
 
-  void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
-  void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void clipRect(const DlRect& rect, DlClipOp clip_op, bool is_aa) override;
+  void clipOval(const DlRect& bounds, DlClipOp clip_op, bool is_aa) override;
   void clipRoundRect(const DlRoundRect& rrect,
-                     ClipOp clip_op,
+                     DlClipOp clip_op,
                      bool is_aa) override;
-  void clipPath(const DlPath& path, ClipOp clip_op, bool is_aa) override;
+  void clipPath(const DlPath& path, DlClipOp clip_op, bool is_aa) override;
 
   void drawColor(DlColor color, DlBlendMode mode) override;
   void drawPaint() override;
@@ -156,7 +155,7 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
                DlScalar start_degrees,
                DlScalar sweep_degrees,
                bool use_center) override;
-  void drawPoints(PointMode mode,
+  void drawPoints(DlPointMode mode,
                   uint32_t count,
                   const DlPoint points[]) override;
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
@@ -170,7 +169,7 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
                      const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
-                     SrcRectConstraint constraint) override;
+                     DlSrcRectConstraint constraint) override;
   void drawImageNine(const sk_sp<DlImage> image,
                      const DlIRect& center,
                      const DlRect& dst,
@@ -351,50 +350,44 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
     RecordByType(DisplayListOpType::kTransformReset);
   }
 
-  void clipRect(const DlRect& rect,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {
+  void clipRect(const DlRect& rect, DlClipOp clip_op, bool is_aa) override {
     switch (clip_op) {
-      case DlCanvas::ClipOp::kIntersect:
+      case DlClipOp::kIntersect:
         RecordByType(DisplayListOpType::kClipIntersectRect);
         break;
-      case DlCanvas::ClipOp::kDifference:
+      case DlClipOp::kDifference:
         RecordByType(DisplayListOpType::kClipDifferenceRect);
         break;
     }
   }
-  void clipOval(const DlRect& bounds,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {
+  void clipOval(const DlRect& bounds, DlClipOp clip_op, bool is_aa) override {
     switch (clip_op) {
-      case DlCanvas::ClipOp::kIntersect:
+      case DlClipOp::kIntersect:
         RecordByType(DisplayListOpType::kClipIntersectOval);
         break;
-      case DlCanvas::ClipOp::kDifference:
+      case DlClipOp::kDifference:
         RecordByType(DisplayListOpType::kClipDifferenceOval);
         break;
     }
   }
   void clipRoundRect(const DlRoundRect& rrect,
-                     DlCanvas::ClipOp clip_op,
+                     DlClipOp clip_op,
                      bool is_aa) override {
     switch (clip_op) {
-      case DlCanvas::ClipOp::kIntersect:
+      case DlClipOp::kIntersect:
         RecordByType(DisplayListOpType::kClipIntersectRoundRect);
         break;
-      case DlCanvas::ClipOp::kDifference:
+      case DlClipOp::kDifference:
         RecordByType(DisplayListOpType::kClipDifferenceRoundRect);
         break;
     }
   }
-  void clipPath(const DlPath& path,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {
+  void clipPath(const DlPath& path, DlClipOp clip_op, bool is_aa) override {
     switch (clip_op) {
-      case DlCanvas::ClipOp::kIntersect:
+      case DlClipOp::kIntersect:
         RecordByType(DisplayListOpType::kClipIntersectPath);
         break;
-      case DlCanvas::ClipOp::kDifference:
+      case DlClipOp::kDifference:
         RecordByType(DisplayListOpType::kClipDifferencePath);
         break;
     }
@@ -451,17 +444,17 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
                bool use_center) override {
     RecordByType(DisplayListOpType::kDrawArc);
   }
-  void drawPoints(DlCanvas::PointMode mode,
+  void drawPoints(DlPointMode mode,
                   uint32_t count,
                   const DlPoint points[]) override {
     switch (mode) {
-      case DlCanvas::PointMode::kPoints:
+      case DlPointMode::kPoints:
         RecordByType(DisplayListOpType::kDrawPoints);
         break;
-      case DlCanvas::PointMode::kLines:
+      case DlPointMode::kLines:
         RecordByType(DisplayListOpType::kDrawLines);
         break;
-      case DlCanvas::PointMode::kPolygon:
+      case DlPointMode::kPolygon:
         RecordByType(DisplayListOpType::kDrawPolygon);
         break;
     }
@@ -485,7 +478,7 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
                      const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
-                     SrcRectConstraint constraint) override {
+                     DlSrcRectConstraint constraint) override {
     RecordByType(DisplayListOpType::kDrawImageRect);
   }
   void drawImageNine(const sk_sp<DlImage> image,

--- a/engine/src/flutter/third_party/txt/src/skia/paragraph_skia.cc
+++ b/engine/src/flutter/third_party/txt/src/skia/paragraph_skia.cc
@@ -168,7 +168,7 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
   }
 
   void clipRect(const SkRect& rect) override {
-    builder_->ClipRect(rect, DlCanvas::ClipOp::kIntersect, false);
+    builder_->ClipRect(rect, DlClipOp::kIntersect, false);
   }
 
   void translate(SkScalar dx, SkScalar dy) override {


### PR DESCRIPTION
These cause ambiguous compiler reference errors on some GCC versions. And, the errors seem right. But, newer versions of clang seem to resolve that ambiguity by also checking if the references to the types are also references to identical types.

Per the chat with Jim, also added the Dl prefix to those types.

No change in functionality. Just a rename of the types and removal of the now unnecessary typedefs.
