### PR TITLE
Make `DropdownMenu` TextField reactive to label changes

### DIFF
--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2442,6 +2442,178 @@ void main() {
     },
   );
 
+  testWidgets('Rematch selection against the first entry with the same value', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    String selectionLabel = 'Initial label';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: DropdownMenu<TestMenu>(
+                initialSelection: TestMenu.mainMenu0,
+                dropdownMenuEntries: <DropdownMenuEntry<TestMenu>>[
+                  DropdownMenuEntry<TestMenu>(
+                    value: TestMenu.mainMenu0,
+                    label: '$selectionLabel 0',
+                  ),
+                  DropdownMenuEntry<TestMenu>(
+                    value: TestMenu.mainMenu1,
+                    label: '$selectionLabel 1',
+                  ),
+                ],
+                controller: controller,
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () => setState(() => selectionLabel = 'Updated label'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    // Open the menu
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
+
+    // Select the second item
+    await tester.tap(findMenuItemButton('$selectionLabel 1'));
+    await tester.pump();
+
+    // Update dropdownMenuEntries labels
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+
+    expect(controller.text, 'Updated label 1');
+  });
+
+  testWidgets('Forget selection if its value does not map to any entry', (
+    WidgetTester tester,
+  ) async {
+    final TextEditingController controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    String selectionLabel = 'Initial label';
+    bool selectionInEntries = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: Column(
+                children: <Widget>[
+                  DropdownMenu<TestMenu>(
+                    initialSelection: TestMenu.mainMenu0,
+                    dropdownMenuEntries: <DropdownMenuEntry<TestMenu>>[
+                      DropdownMenuEntry<TestMenu>(
+                        value: TestMenu.mainMenu0,
+                        label: '$selectionLabel 0',
+                      ),
+                      if (selectionInEntries)
+                        DropdownMenuEntry<TestMenu>(
+                          value: TestMenu.mainMenu1,
+                          label: '$selectionLabel 1',
+                        ),
+                    ],
+                    controller: controller,
+                  ),
+                  ElevatedButton(
+                    onPressed: () => setState(() => selectionInEntries = !selectionInEntries),
+                    child: null,
+                  ),
+                ],
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () => setState(() => selectionLabel = 'Updated label'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    // Open the menu
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
+
+    // Select the second item
+    await tester.tap(findMenuItemButton('$selectionLabel 1'));
+    await tester.pump();
+
+    // Update dropdownMenuEntries labels
+    await tester.tap(find.byType(FloatingActionButton));
+    // Remove second item from entires
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+
+    expect(controller.text, 'Initial label 1');
+
+    // Put second item back into entries
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+
+    expect(controller.text, 'Initial label 1');
+  });
+
+  testWidgets(
+    'Do not rematch selection if the text field was edited progrmaticlly via controller',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      String selectionLabel = 'Initial label';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Scaffold(
+                body: Column(
+                  children: <Widget>[
+                    DropdownMenu<TestMenu>(
+                      initialSelection: TestMenu.mainMenu0,
+                      dropdownMenuEntries: <DropdownMenuEntry<TestMenu>>[
+                        DropdownMenuEntry<TestMenu>(
+                          value: TestMenu.mainMenu0,
+                          label: '$selectionLabel 0',
+                        ),
+                      ],
+                      controller: controller,
+                    ),
+                    ElevatedButton(
+                      onPressed: () => setState(() => controller.text = 'Controller Value'),
+                      child: null,
+                    ),
+                  ],
+                ),
+                floatingActionButton: FloatingActionButton(
+                  onPressed: () => setState(() => selectionLabel = 'Updated label'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Change the text field value via controller
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      // Update dropdownMenuEntries labels
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pump();
+
+      expect(controller.text, 'Controller Value');
+    },
+  );
+
   testWidgets('The default text input field should not be focused on mobile platforms '
       'when it is tapped', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();


### PR DESCRIPTION
## Description

The current behavior of Flutter regarding `DropdownMenu` text field is very basic: `DropdownMenu` updates the text field once a selection has been made with its coordinating `label`, and nothing more.

If the selection's `label` changes, the text field will still show the old value, although the menu buttons have been updated.

This not only results in the need to write a lot of boilerplate code to match the label to the current selection, but it's also counterintuitive. The `DropdownMenu` should handle rematching by itself.

Issue #155660, touched on this, and a solution was introduced in #155757. It was later reverted due to it restricting some use cases. That issue & solution, however, only address `initialSelection`. If another selection was made and its corresponding `label` was changed, the text field would still show the old value, bringing us back to square one. 

This PR should not conflict with any previous behavior of `DropdownMenu`: any new value provided by `initialSelection` or via controller would not be overwritten by rematching. However, entries with the same value will be mapped to a single label (the first matched entry's label). 

## Related Issues

- Fixes #155660.

## Tests

Added 3 tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.