### PR TITLE
[Impeller] Make glIsTexture mockable for use by the ReactorGLES.NameUntrackedHandle test

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -36,6 +36,7 @@ class IMockGLESImpl {
                                       GLuint64* result) {}
   virtual void DeleteQueriesEXT(GLsizei size, const GLuint* queries) {}
   virtual void GenBuffers(GLsizei n, GLuint* buffers) {}
+  virtual GLboolean IsTexture(GLuint texture) { return true; }
 };
 
 class MockGLESImpl : public IMockGLESImpl {
@@ -70,6 +71,7 @@ class MockGLESImpl : public IMockGLESImpl {
               (GLsizei size, const GLuint* queries),
               (override));
   MOCK_METHOD(void, GenBuffers, (GLsizei n, GLuint* buffers), (override));
+  MOCK_METHOD(GLboolean, IsTexture, (GLuint texture), (override));
 };
 
 /// @brief      Provides a mocked version of the |ProcTableGLES| class.

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/reactor_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/reactor_unittests.cc
@@ -17,6 +17,7 @@ namespace impeller {
 namespace testing {
 
 using ::testing::_;
+using ::testing::NiceMock;
 
 class TestWorker : public ReactorGLES::Worker {
  public:
@@ -96,13 +97,14 @@ TEST(ReactorGLES, UntrackedHandle) {
 }
 
 TEST(ReactorGLES, NameUntrackedHandle) {
-  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+  auto mock_gles_impl = std::make_unique<NiceMock<MockGLESImpl>>();
 
   EXPECT_CALL(*mock_gles_impl, GenTextures(1, _))
       .WillOnce([](GLsizei size, GLuint* queries) { queries[0] = 1234; });
   EXPECT_CALL(*mock_gles_impl,
               ObjectLabelKHR(_, 1234, _, ::testing::StrEq("hello, joe!")))
       .Times(1);
+  ON_CALL(*mock_gles_impl, IsTexture).WillByDefault(::testing::Return(GL_TRUE));
 
   std::shared_ptr<MockGLES> mock_gles =
       MockGLES::Init(std::move(mock_gles_impl));


### PR DESCRIPTION
ReactorGLES.NameUntrackedHandle calls SetDebugLabel, which invokes glIsTexture.  glIsTexture should return a GLboolean.  But the mock GLES resolver was mapping glIsTexture to a no-op function with a void return type.

This change makes glIsTexture mockable so the test can ensure that it returns the appropriate result.