### PR TITLE
Fix skwasm target in wasm_debug_unopt build.

### DIFF
--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -280,6 +280,9 @@ config("compiler") {
     if (wasm_use_pthreads) {
       cflags += [ "-pthread" ]
       ldflags += [ "-pthread" ]
+    } if (wasm_shared_memory) {
+      cflags += [ "-sSHARED_MEMORY=1" ]
+      ldflags += [ "-sSHARED_MEMORY=1" ]
     }
     ldflags += [
       "-s",

--- a/engine/src/build/toolchain/wasm.gni
+++ b/engine/src/build/toolchain/wasm.gni
@@ -12,6 +12,7 @@ declare_args() {
   emsdk_dir = rebase_path("//flutter/prebuilts/emsdk")
 
   wasm_use_pthreads = false
+  wasm_shared_memory = false
   wasm_use_dwarf = false
 }
 

--- a/engine/src/flutter/lib/web_ui/skwasm/BUILD.gn
+++ b/engine/src/flutter/lib/web_ui/skwasm/BUILD.gn
@@ -47,7 +47,6 @@ template("skwasm_variant") {
       "-lexports.js",
       "-sEXPORTED_FUNCTIONS=[stackAlloc]",
       "-sEXPORTED_RUNTIME_METHODS=[addFunction,wasmExports,wasmMemory,stackAlloc]",
-      "-sSHARED_MEMORY=1",
       "-sINCOMING_MODULE_JS_API=[instantiateWasm,noExitRuntime,mainScriptUrlOrBlob]",
       "-sUSE_ES6_IMPORT_META=0",
       "--js-library",
@@ -76,7 +75,6 @@ template("skwasm_variant") {
 
     if (is_debug) {
       ldflags += [
-        "-sDEMANGLE_SUPPORT=1",
         "-sASSERTIONS=1",
         "-sGL_ASSERTIONS=1",
       ]

--- a/engine/src/flutter/skia/modules/canvaskit/BUILD.gn
+++ b/engine/src/flutter/skia/modules/canvaskit/BUILD.gn
@@ -63,7 +63,6 @@ canvaskit_wasm_lib("canvaskit") {
   if (is_debug) {
     ldflags += [
       "-O0",
-      "-sDEMANGLE_SUPPORT=1",
       "-sASSERTIONS=1",
       "-sGL_ASSERTIONS=1",
       "-g3",

--- a/engine/src/flutter/third_party/canvaskit/BUILD.gn
+++ b/engine/src/flutter/third_party/canvaskit/BUILD.gn
@@ -109,8 +109,10 @@ wasm_toolchain("skwasm_st") {
     skia_use_no_png_encode = true
     skia_use_libpng_encode = false
 
-    # skwasm_st is singlethreaded
+    # skwasm_st doesn't use pthreads, but does pass the shared memory flag in order
+    # to be compatible with the way app modules import the memory object.
     wasm_use_pthreads = false
+    wasm_shared_memory = true
     wasm_prioritize_size = true
   }
 }


### PR DESCRIPTION
Fixes a couple issues in the skwasm build rules:
* `DEMANGLE_SUPPORT` is deprecated in emscripten, so just remove it.
* `sSHARED_MEMORY=1` needs to be added to the cflags so that emscripten appends the proper feature flags (`-matomics` and `-mbulk-memory`) when doing the compile so that the flags match the linking step.