### PR TITLE
Fix link to hotfix documentation best practices

### DIFF
--- a/docs/releases/Flutter-Cherrypick-Process.md
+++ b/docs/releases/Flutter-Cherrypick-Process.md
@@ -12,7 +12,7 @@ With branching and branch testability being supported for Flutter & Dart release
 2. Wait about 30 seconds.
 3. If automatic cherry pick succeeds (no merge conflict), a new pull requested will be created and you will receive an email. Edit the cherry-pick details in the PR description of the generated pull request, and a release engineer will follow up on the request.
 4. If automatic cherry pick fails, a comment will be left on the original PR. In this case you will need to follow instructions in the manual cherry-pick section below to manually create a cherry pick PR.
-5. Update CHANGELOG.md following our [best practices](docs/releases/Hotfix-Documentation-Best-Practices.md).
+5. Update CHANGELOG.md following our [best practices](Hotfix-Documentation-Best-Practices.md).
 
 If for some reason, an automated cherry-pick can not be applied, please follow the manual cherry-pick instructions.
 


### PR DESCRIPTION
Currently the [cherrypick process](https://github.com/flutter/flutter/blob/master/docs/releases/Flutter-Cherrypick-Process.md#automatically-create-a-cherry-pick-request) links to: https://github.com/flutter/flutter/blob/master/docs/releases/docs/releases/Hotfix-Documentation-Best-Practices.md

This should be: https://github.com/flutter/flutter/blob/master/docs/releases/Hotfix-Documentation-Best-Practices.md

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
