### PR TITLE
Reland "[Impeller] Migrate unit tests off of Skia geometry classes (#161855)"

### DIFF
--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -1793,7 +1793,7 @@ TEST_F(DisplayListTest, FlutterSvgIssue661BoundsWereEmpty) {
                              {32.3f, 14.615f},    //
                              {32.3f, 19.34f});
   path_builder1.Close();
-  DlPath dl_path1 = DlPath(path_builder1.TakePath(DlPathFillType::kNonZero));
+  DlPath dl_path1 = DlPath(path_builder1, DlPathFillType::kNonZero);
 
   DlPathBuilder path_builder2;
   path_builder2.MoveTo({37.5f, 19.33f});
@@ -1806,7 +1806,7 @@ TEST_F(DisplayListTest, FlutterSvgIssue661BoundsWereEmpty) {
                              {37.495f, 11.756f},  //
                              {37.5f, 19.33f});
   path_builder2.Close();
-  DlPath dl_path2 = DlPath(path_builder2.TakePath(DlPathFillType::kNonZero));
+  DlPath dl_path2 = DlPath(path_builder2, DlPathFillType::kNonZero);
 
   DisplayListBuilder builder;
   DlPaint paint = DlPaint(DlColor::kWhite()).setAntiAlias(true);
@@ -4878,7 +4878,7 @@ TEST_F(DisplayListTest, ClipPathNonCulling) {
   path_builder.LineTo({1000.0f, 0.0f});
   path_builder.LineTo({0.0f, 1000.0f});
   path_builder.Close();
-  DlPath path = DlPath(path_builder.TakePath());
+  DlPath path = DlPath(path_builder);
 
   // Double checking that the path does indeed contain the clip. But,
   // sadly, the Builder will not check paths for coverage to this level

--- a/engine/src/flutter/display_list/geometry/dl_path.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path.cc
@@ -62,6 +62,33 @@ DlPath DlPath::MakeRoundRectXY(const DlRect& rect,
       counter_clock_wise ? SkPathDirection::kCCW : SkPathDirection::kCW));
 }
 
+DlPath DlPath::MakeLine(const DlPoint& a, const DlPoint& b) {
+  return DlPath(SkPath::Line(ToSkPoint(a), ToSkPoint(b)));
+}
+
+DlPath DlPath::MakePoly(const DlPoint pts[],
+                        int count,
+                        bool close,
+                        DlPathFillType fill_type) {
+  return DlPath(
+      SkPath::Polygon(ToSkPoints(pts), count, close, ToSkFillType(fill_type)));
+}
+
+DlPath DlPath::MakeArc(const DlRect& bounds,
+                       DlDegrees start,
+                       DlDegrees end,
+                       bool use_center) {
+  SkPath path;
+  if (use_center) {
+    path.moveTo(ToSkPoint(bounds.GetCenter()));
+  }
+  path.arcTo(ToSkRect(bounds), start.degrees, end.degrees, !use_center);
+  if (use_center) {
+    path.close();
+  }
+  return DlPath(path);
+}
+
 const SkPath& DlPath::GetSkPath() const {
   auto& sk_path = data_->sk_path;
   auto& path = data_->path;
@@ -207,14 +234,22 @@ bool DlPath::IsVolatile() const {
   return GetSkPath().isVolatile();
 }
 
+bool DlPath::IsConvex() const {
+  if (data_->sk_path_original) {
+    auto& sk_path = data_->sk_path;
+    FML_DCHECK(sk_path.has_value());
+    return sk_path.has_value() && sk_path->isConvex();
+  } else {
+    auto& path = data_->path;
+    FML_DCHECK(path.has_value());
+    return path.has_value() && path->IsConvex();
+  }
+}
+
 DlPath DlPath::operator+(const DlPath& other) const {
   SkPath path = GetSkPath();
   path.addPath(other.GetSkPath());
   return DlPath(path);
-}
-
-DlPath::Data::Data(const SkPath& path) : sk_path(path) {
-  FML_DCHECK(!SkPathFillType_IsInverse(path.getFillType()));
 }
 
 SkPath DlPath::ConvertToSkiaPath(const Path& path, const DlPoint& shift) {
@@ -338,26 +373,16 @@ Path DlPath::ConvertToImpellerPath(const SkPath& path, const DlPoint& shift) {
     }
   } while (verb != SkPath::Verb::kDone_Verb);
 
-  FillType fill_type;
-  switch (path.getFillType()) {
-    case SkPathFillType::kWinding:
-      fill_type = FillType::kNonZero;
-      break;
-    case SkPathFillType::kEvenOdd:
-      fill_type = FillType::kOdd;
-      break;
-    case SkPathFillType::kInverseWinding:
-    case SkPathFillType::kInverseEvenOdd:
-      FML_UNREACHABLE();
-  }
-  builder.SetConvexity(path.isConvex() ? Convexity::kConvex
-                                       : Convexity::kUnknown);
+  DlRect bounds = ToDlRect(path.getBounds());
   if (!shift.IsZero()) {
     builder.Shift(shift);
+    bounds = bounds.Shift(shift);
   }
-  auto sk_bounds = path.getBounds().makeOutset(shift.x, shift.y);
-  builder.SetBounds(ToDlRect(sk_bounds));
-  return builder.TakePath(fill_type);
+
+  builder.SetConvexity(path.isConvex() ? Convexity::kConvex
+                                       : Convexity::kUnknown);
+  builder.SetBounds(bounds);
+  return builder.TakePath(ToDlFillType(path.getFillType()));
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/impeller/display_list/aiks_dl_atlas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_atlas_unittests.cc
@@ -16,7 +16,6 @@
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/scalar.h"
-#include "include/core/SkRefCnt.h"
 
 namespace impeller {
 namespace testing {

--- a/engine/src/flutter/impeller/display_list/aiks_dl_blend_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blend_unittests.cc
@@ -23,7 +23,6 @@
 #include "impeller/playground/playground.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/renderer/testing/mocks.h"
-#include "include/core/SkMatrix.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // This is for tests of Canvas that are interested the results of rendering
@@ -62,19 +61,19 @@ static BlendModeSelection GetBlendModeSelection() {
 TEST_P(AiksTest, CanRenderAdvancedBlendColorFilterWithSaveLayer) {
   DisplayListBuilder builder;
 
-  SkRect layer_rect = SkRect::MakeXYWH(0, 0, 500, 500);
+  DlRect layer_rect = DlRect::MakeXYWH(0, 0, 500, 500);
   builder.ClipRect(layer_rect);
 
   DlPaint save_paint;
   save_paint.setColorFilter(DlColorFilter::MakeBlend(
       DlColor::RGBA(0, 1, 0, 0.5), DlBlendMode::kDifference));
-  builder.SaveLayer(&layer_rect, &save_paint);
+  builder.SaveLayer(layer_rect, &save_paint);
 
   DlPaint paint;
   paint.setColor(DlColor::kBlack());
   builder.DrawPaint(paint);
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 300, 300), paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -91,13 +90,13 @@ TEST_P(AiksTest, BlendModeShouldCoverWholeScreen) {
   builder.SaveLayer(nullptr, &paint);
 
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 400, 400), paint);
 
   paint.setBlendMode(DlBlendMode::kSrc);
   builder.SaveLayer(nullptr, &paint);
 
   paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(200, 200, 200, 200), paint);
+  builder.DrawRect(DlRect::MakeXYWH(200, 200, 200, 200), paint);
 
   builder.Restore();
   builder.Restore();
@@ -132,7 +131,7 @@ TEST_P(AiksTest, DrawPaintWithAdvancedBlendOverFilter) {
   paint.setColor(DlColor::kWhite());
   builder.DrawPaint(paint);
   paint.setColor(DlColor::kBlack());
-  builder.DrawCircle(SkPoint{300, 300}, 200, paint);
+  builder.DrawCircle(DlPoint(300, 300), 200, paint);
   paint.setColor(DlColor::kGreen());
   paint.setBlendMode(DlBlendMode::kScreen);
   builder.DrawPaint(paint);
@@ -147,7 +146,7 @@ TEST_P(AiksTest, DrawAdvancedBlendPartlyOffscreen) {
   draw_paint.setColor(DlColor::kBlue());
   builder.DrawPaint(draw_paint);
   builder.Scale(2, 2);
-  builder.ClipRect(SkRect::MakeLTRB(0, 0, 200, 200));
+  builder.ClipRect(DlRect::MakeLTRB(0, 0, 200, 200));
 
   std::vector<DlColor> colors = {DlColor::RGBA(0.9568, 0.2627, 0.2118, 1.0),
                                  DlColor::RGBA(0.1294, 0.5882, 0.9529, 1.0)};
@@ -166,7 +165,7 @@ TEST_P(AiksTest, DrawAdvancedBlendPartlyOffscreen) {
       ));
   paint.setBlendMode(DlBlendMode::kLighten);
 
-  builder.DrawCircle(SkPoint{100, 100}, 100, paint);
+  builder.DrawCircle(DlPoint(100, 100), 100, paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
@@ -176,21 +175,21 @@ TEST_P(AiksTest, PaintBlendModeIsRespected) {
   // Default is kSourceOver.
 
   paint.setColor(DlColor::RGBA(1, 0, 0, 0.5));
-  builder.DrawCircle(SkPoint{150, 200}, 100, paint);
+  builder.DrawCircle(DlPoint(150, 200), 100, paint);
 
   paint.setColor(DlColor::RGBA(0, 1, 0, 0.5));
-  builder.DrawCircle(SkPoint{250, 200}, 100, paint);
+  builder.DrawCircle(DlPoint(250, 200), 100, paint);
 
   paint.setBlendMode(DlBlendMode::kPlus);
 
   paint.setColor(DlColor::kRed());
-  builder.DrawCircle(SkPoint{450, 250}, 100, paint);
+  builder.DrawCircle(DlPoint(450, 250), 100, paint);
 
   paint.setColor(DlColor::kGreen());
-  builder.DrawCircle(SkPoint{550, 250}, 100, paint);
+  builder.DrawCircle(DlPoint(550, 250), 100, paint);
 
   paint.setColor(DlColor::kBlue());
-  builder.DrawCircle(SkPoint{500, 150}, 100, paint);
+  builder.DrawCircle(DlPoint(500, 150), 100, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -225,7 +224,7 @@ TEST_P(AiksTest, ColorFilterBlend) {
       builder.Scale(0.4, 0.4);
       {
         DlPaint dstPaint;
-        builder.DrawImage(dst_image, SkPoint{0, 0},
+        builder.DrawImage(dst_image, DlPoint(0, 0),
                           DlImageSampling::kMipmapLinear, &dstPaint);
       }
       {
@@ -237,7 +236,7 @@ TEST_P(AiksTest, ColorFilterBlend) {
                                        DlBlendMode::kSrcIn);
           srcPaint.setColorFilter(color_filter);
         }
-        builder.DrawImage(src_image, SkPoint{0, 0},
+        builder.DrawImage(src_image, DlPoint(0, 0),
                           DlImageSampling::kMipmapLinear, &srcPaint);
       }
       builder.Restore();
@@ -282,7 +281,7 @@ TEST_P(AiksTest, ColorFilterAdvancedBlend) {
       builder.Scale(0.4, 0.4);
       {
         DlPaint dstPaint;
-        builder.DrawImage(dst_image, SkPoint{0, 0},
+        builder.DrawImage(dst_image, DlPoint(0, 0),
                           DlImageSampling::kMipmapLinear, &dstPaint);
       }
       {
@@ -294,7 +293,7 @@ TEST_P(AiksTest, ColorFilterAdvancedBlend) {
                                        DlBlendMode::kSrcIn);
           srcPaint.setColorFilter(color_filter);
         }
-        builder.DrawImage(src_image, SkPoint{0, 0},
+        builder.DrawImage(src_image, DlPoint(0, 0),
                           DlImageSampling::kMipmapLinear, &srcPaint);
       }
       builder.Restore();
@@ -374,7 +373,7 @@ TEST_P(AiksTest, ColorFilterAdvancedBlendNoFbFetch) {
       builder.Scale(0.4, 0.4);
       {
         DlPaint dstPaint;
-        builder.DrawImage(dst_image, SkPoint{0, 0},
+        builder.DrawImage(dst_image, DlPoint(0, 0),
                           DlImageSampling::kMipmapLinear, &dstPaint);
       }
       {
@@ -386,7 +385,7 @@ TEST_P(AiksTest, ColorFilterAdvancedBlendNoFbFetch) {
                                        DlBlendMode::kMultiply);
           srcPaint.setColorFilter(color_filter);
         }
-        builder.DrawImage(src_image, SkPoint{0, 0},
+        builder.DrawImage(src_image, DlPoint(0, 0),
                           DlImageSampling::kMipmapLinear, &srcPaint);
       }
       builder.Restore();
@@ -414,16 +413,15 @@ TEST_P(AiksTest, BlendModePlusAlphaWideGamut) {
   paint.setBlendMode(DlBlendMode::kPlus);
   paint.setColor(DlColor::kRed());
 
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 400, 400), paint);
   paint.setColor(DlColor::kWhite());
 
   auto rect = Rect::MakeXYWH(100, 100, 400, 400).Expand(-100, -100);
   builder.DrawImageRect(
       DlImageImpeller::Make(texture),
-      SkRect::MakeSize(
-          SkSize::Make(texture->GetSize().width, texture->GetSize().height)),
-      SkRect::MakeLTRB(rect.GetLeft(), rect.GetTop(), rect.GetRight(),
-                       rect.GetBottom()),
+      DlRect::MakeWH(texture->GetSize().width, texture->GetSize().height),
+      DlRect::MakeLTRB(rect.GetLeft(), rect.GetTop(),  //
+                       rect.GetRight(), rect.GetBottom()),
       DlImageSampling::kMipmapLinear, &paint);
   builder.Restore();
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -449,17 +447,16 @@ TEST_P(AiksTest, BlendModePlusAlphaColorFilterWideGamut) {
   builder.SaveLayer(nullptr, &save_paint);
 
   paint.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 400, 400), paint);
 
   paint.setColor(DlColor::kWhite());
 
   auto rect = Rect::MakeXYWH(100, 100, 400, 400).Expand(-100, -100);
   builder.DrawImageRect(
       DlImageImpeller::Make(texture),
-      SkRect::MakeSize(
-          SkSize::Make(texture->GetSize().width, texture->GetSize().height)),
-      SkRect::MakeLTRB(rect.GetLeft(), rect.GetTop(), rect.GetRight(),
-                       rect.GetBottom()),
+      DlRect::MakeWH(texture->GetSize().width, texture->GetSize().height),
+      DlRect::MakeLTRB(rect.GetLeft(), rect.GetTop(),  //
+                       rect.GetRight(), rect.GetBottom()),
       DlImageSampling::kMipmapLinear, &paint);
   builder.Restore();
 
@@ -479,7 +476,7 @@ TEST_P(AiksTest, ForegroundBlendSubpassCollapseOptimization) {
 
   DlPaint paint;
   paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 200, 200), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 200, 200), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -489,12 +486,12 @@ TEST_P(AiksTest, ClearBlend) {
 
   DlPaint blue;
   blue.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600.0, 600.0), blue);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600.0, 600.0), blue);
 
   DlPaint clear;
   clear.setBlendMode(DlBlendMode::kClear);
 
-  builder.DrawCircle(SkPoint{300.0, 300.0}, 200.0, clear);
+  builder.DrawCircle(DlPoint(300.0, 300.0), 200.0, clear);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -533,7 +530,7 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
   for (const auto& color : source_colors) {
     builder.Save();
     {
-      builder.ClipRect(SkRect::MakeXYWH(25, 25, 100, 100));
+      builder.ClipRect(DlRect::MakeXYWH(25, 25, 100, 100));
       // Perform the blend in a SaveLayer so that the initial backdrop color is
       // fully transparent black. SourceOver blend the result onto the parent
       // pass.
@@ -554,7 +551,7 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
           DlPaint paint;
           paint.setColor(
               DlColor::RGBA(color.red, color.green, color.blue, color.alpha));
-          builder.DrawRect(SkRect::MakeXYWH(25, 25, 100, 100), paint);
+          builder.DrawRect(DlRect::MakeXYWH(25, 25, 100, 100), paint);
         }
         builder.Restore();
       }
@@ -580,7 +577,7 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
     auto dest = destination_color.Blend(color, blend_mode);
     paint.setColor(DlColor::RGBA(dest.red, dest.green, dest.blue, dest.alpha));
     paint.setBlendMode(DlBlendMode::kSrcOver);
-    builder.DrawRect(SkRect::MakeXYWH(25, 25, 100, 100), paint);
+    builder.DrawRect(DlRect::MakeXYWH(25, 25, 100, 100), paint);
     builder.Translate(100, 0);
   }
   builder.Restore();
@@ -599,14 +596,14 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
   {
     DlPaint paint;
     paint.setColor(DlColor::RGBA(41 / 255.0, 41 / 255.0, 41 / 255.0, 1));
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 800, 400), paint);
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 800, 400), paint);
   }
 
   DlPaint square_paint;
   square_paint.setColor(DlColor::RGBA(15 / 255.0, 15 / 255.0, 15 / 255.0, 1));
   for (int y = 0; y < 400 / 8; y++) {
     for (int x = 0; x < 800 / 16; x++) {
-      builder.DrawRect(SkRect::MakeXYWH(x * 16 + (y % 2) * 8, y * 8, 8, 8),
+      builder.DrawRect(DlRect::MakeXYWH(x * 16 + (y % 2) * 8, y * 8, 8, 8),
                        square_paint);
     }
   }
@@ -617,12 +614,12 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
   builder.Save();
   builder.SaveLayer(nullptr, &paint);
   {
-    builder.DrawImage(dst_image, SkPoint{0, 0}, DlImageSampling::kMipmapLinear,
+    builder.DrawImage(dst_image, DlPoint(0, 0), DlImageSampling::kMipmapLinear,
                       &paint);
 
     paint.setColor(DlColor::kWhite().withAlpha(src_alpha * 255));
     paint.setBlendMode(static_cast<DlBlendMode>(blend_mode));
-    builder.DrawImage(src_image, SkPoint{0, 0}, DlImageSampling::kMipmapLinear,
+    builder.DrawImage(src_image, DlPoint(0, 0), DlImageSampling::kMipmapLinear,
                       &paint);
   }
   builder.Restore();
@@ -634,7 +631,7 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
   DlPaint save_paint;
   builder.SaveLayer(nullptr, &save_paint);
   {
-    builder.DrawImage(dst_image, SkPoint{400, 0},
+    builder.DrawImage(dst_image, DlPoint(400, 0),
                       DlImageSampling::kMipmapLinear, nullptr);
 
     DlPaint save_paint;
@@ -642,7 +639,7 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
     save_paint.setBlendMode(static_cast<DlBlendMode>(blend_mode));
     builder.SaveLayer(nullptr, &save_paint);
     {
-      builder.DrawImage(src_image, SkPoint{400, 0},
+      builder.DrawImage(src_image, DlPoint(400, 0),
                         DlImageSampling::kMipmapLinear, nullptr);
     }
     builder.Restore();
@@ -725,7 +722,7 @@ TEST_P(AiksTest, ForegroundPipelineBlendAppliesTransformCorrectly) {
       DlColor::RGBA(255.0f / 255.0f, 165.0f / 255.0f, 0.0f / 255.0f, 1.0f),
       DlBlendMode::kSrcIn));
 
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint{200, 200},
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(200, 200),
                     DlImageSampling::kMipmapLinear, &image_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -743,7 +740,7 @@ TEST_P(AiksTest, ForegroundAdvancedBlendAppliesTransformCorrectly) {
       DlColor::RGBA(255.0f / 255.0f, 165.0f / 255.0f, 0.0f / 255.0f, 1.0f),
       DlBlendMode::kColorDodge));
 
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint{200, 200},
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(200, 200),
                     DlImageSampling::kMipmapLinear, &image_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -766,7 +763,7 @@ TEST_P(AiksTest, FramebufferAdvancedBlendCoverage) {
   DlPaint image_paint;
   image_paint.setBlendMode(DlBlendMode::kMultiply);
 
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint{20, 20},
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(20, 20),
                     DlImageSampling::kMipmapLinear, &image_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -808,8 +805,8 @@ TEST_P(AiksTest, ColorWheel) {
       auto color = color_wheel_sampler(r).WithAlpha(1.0f - normalized_distance);
       paint.setColor(
           DlColor::RGBA(color.red, color.green, color.blue, color.alpha));
-      SkPoint position = SkPoint::Make(distance * std::sin(r.radians),
-                                       -distance * std::cos(r.radians));
+      DlPoint position = DlPoint(distance * std::sin(r.radians),
+                                 -distance * std::cos(r.radians));
 
       builder.DrawCircle(position, 9 + normalized_distance * 3, paint);
     }
@@ -875,11 +872,11 @@ TEST_P(AiksTest, ColorWheel) {
       const Scalar x = std::sin(k2Pi / 3);
       const Scalar y = -std::cos(k2Pi / 3);
       paint.setColor(color0);
-      builder.DrawCircle(SkPoint::Make(-x * 45, y * 45), 65, paint);
+      builder.DrawCircle(DlPoint(-x * 45, y * 45), 65, paint);
       paint.setColor(color1);
-      builder.DrawCircle(SkPoint::Make(0, -45), 65, paint);
+      builder.DrawCircle(DlPoint(0, -45), 65, paint);
       paint.setColor(color2);
-      builder.DrawCircle(SkPoint::Make(x * 45, y * 45), 65, paint);
+      builder.DrawCircle(DlPoint(x * 45, y * 45), 65, paint);
     }
     builder.Restore();
 
@@ -916,9 +913,9 @@ TEST_P(AiksTest, AdvancedBlendColorFilterWithDestinationOpacity) {
   save_paint.setColorFilter(DlColorFilter::MakeBlend(DlColor::kTransparent(),
                                                      DlBlendMode::kSaturation));
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 300, 300),
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 300, 300),
                    DlPaint(DlColor::kMaroon()));
-  builder.DrawRect(SkRect::MakeXYWH(200, 200, 300, 300),
+  builder.DrawRect(DlRect::MakeXYWH(200, 200, 300, 300),
                    DlPaint(DlColor::kBlue()));
   builder.Restore();
 

--- a/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
@@ -20,8 +20,6 @@
 #include "impeller/display_list/dl_image_impeller.h"
 #include "impeller/playground/widgets.h"
 #include "impeller/renderer/testing/mocks.h"
-#include "include/core/SkRRect.h"
-#include "include/core/SkRect.h"
 #include "third_party/imgui/imgui.h"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,9 +49,9 @@ TEST_P(AiksTest, SolidColorOvalsMaskBlurTinySigma) {
 
     builder.Save();
     builder.Translate(100 + (i * 100), 100);
-    SkRRect rrect =
-        SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 60.0f, 160.0f), 50, 100);
-    builder.DrawRRect(rrect, paint);
+    DlRoundRect rrect =
+        DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 60.0f, 160.0f), 50, 100);
+    builder.DrawRoundRect(rrect, paint);
     builder.Restore();
   }
 
@@ -88,13 +86,13 @@ sk_sp<flutter::DisplayList> DoGradientOvalStrokeMaskBlur(Vector2 content_Scale,
   {
     DlPaint line_paint;
     line_paint.setColor(DlColor::kWhite());
-    builder.DrawLine(SkPoint{100, 0}, SkPoint{100, 60}, line_paint);
-    builder.DrawLine(SkPoint{0, 30}, SkPoint{200, 30}, line_paint);
+    builder.DrawLine(DlPoint(100, 0), DlPoint(100, 60), line_paint);
+    builder.DrawLine(DlPoint(0, 30), DlPoint(200, 30), line_paint);
   }
 
-  SkRRect rrect =
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 200.0f, 60.0f), 50, 100);
-  builder.DrawRRect(rrect, paint);
+  DlRoundRect rrect =
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 200.0f, 60.0f), 50, 100);
+  builder.DrawRoundRect(rrect, paint);
   builder.Restore();
 
   return builder.Build();
@@ -141,9 +139,9 @@ TEST_P(AiksTest, SolidColorCircleMaskBlurTinySigma) {
 
     builder.Save();
     builder.Translate(100 + (i * 100), 100);
-    SkRRect rrect =
-        SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 100.0f, 100.0f), 100, 100);
-    builder.DrawRRect(rrect, paint);
+    DlRoundRect rrect = DlRoundRect::MakeRectXY(
+        DlRect::MakeXYWH(0, 0, 100.0f, 100.0f), 100, 100);
+    builder.DrawRoundRect(rrect, paint);
     builder.Restore();
   }
 
@@ -156,7 +154,7 @@ TEST_P(AiksTest, CanRenderMaskBlurHugeSigma) {
   DlPaint paint;
   paint.setColor(DlColor::kGreen());
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 99999));
-  builder.DrawCircle(SkPoint{400, 400}, 300, paint);
+  builder.DrawCircle(DlPoint(400, 400), 300, paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -166,7 +164,7 @@ TEST_P(AiksTest, CanRenderForegroundBlendWithMaskBlur) {
   // This case triggers the ForegroundPorterDuffBlend path. The color filter
   // should apply to the color only, and respect the alpha mask.
   DisplayListBuilder builder;
-  builder.ClipRect(SkRect::MakeXYWH(100, 150, 400, 400));
+  builder.ClipRect(DlRect::MakeXYWH(100, 150, 400, 400));
 
   DlPaint paint;
   paint.setColor(DlColor::kWhite());
@@ -176,7 +174,7 @@ TEST_P(AiksTest, CanRenderForegroundBlendWithMaskBlur) {
       DlBlurMaskFilter::Make(DlBlurStyle::kNormal, sigma.sigma));
   paint.setColorFilter(
       DlColorFilter::MakeBlend(DlColor::kGreen(), DlBlendMode::kSrc));
-  builder.DrawCircle(SkPoint{400, 400}, 200, paint);
+  builder.DrawCircle(DlPoint(400, 400), 200, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -185,7 +183,7 @@ TEST_P(AiksTest, CanRenderForegroundAdvancedBlendWithMaskBlur) {
   // This case triggers the ForegroundAdvancedBlend path. The color filter
   // should apply to the color only, and respect the alpha mask.
   DisplayListBuilder builder;
-  builder.ClipRect(SkRect::MakeXYWH(100, 150, 400, 400));
+  builder.ClipRect(DlRect::MakeXYWH(100, 150, 400, 400));
 
   DlPaint paint;
   paint.setColor(
@@ -196,7 +194,7 @@ TEST_P(AiksTest, CanRenderForegroundAdvancedBlendWithMaskBlur) {
       DlBlurMaskFilter::Make(DlBlurStyle::kNormal, sigma.sigma));
   paint.setColorFilter(
       DlColorFilter::MakeBlend(DlColor::kGreen(), DlBlendMode::kColor));
-  builder.DrawCircle(SkPoint{400, 400}, 200, paint);
+  builder.DrawCircle(DlPoint(400, 400), 200, paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -211,20 +209,20 @@ TEST_P(AiksTest, CanRenderBackdropBlurInteractive) {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setColor(DlColor::kCornflowerBlue());
-    builder.DrawCircle(SkPoint{100, 100}, 50, paint);
+    builder.DrawCircle(DlPoint(100, 100), 50, paint);
 
     paint.setColor(DlColor::kGreenYellow());
-    builder.DrawCircle(SkPoint{300, 200}, 100, paint);
+    builder.DrawCircle(DlPoint(300, 200), 100, paint);
 
     paint.setColor(DlColor::kDarkMagenta());
-    builder.DrawCircle(SkPoint{140, 170}, 75, paint);
+    builder.DrawCircle(DlPoint(140, 170), 75, paint);
 
     paint.setColor(DlColor::kOrangeRed());
-    builder.DrawCircle(SkPoint{180, 120}, 100, paint);
+    builder.DrawCircle(DlPoint(180, 120), 100, paint);
 
-    SkRRect rrect =
-        SkRRect::MakeRectXY(SkRect::MakeLTRB(a.x, a.y, b.x, b.y), 20, 20);
-    builder.ClipRRect(rrect);
+    DlRoundRect rrect =
+        DlRoundRect::MakeRectXY(DlRect::MakeLTRB(a.x, a.y, b.x, b.y), 20, 20);
+    builder.ClipRoundRect(rrect);
 
     DlPaint save_paint;
     save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -244,20 +242,20 @@ TEST_P(AiksTest, CanRenderBackdropBlur) {
 
   DlPaint paint;
   paint.setColor(DlColor::kCornflowerBlue());
-  builder.DrawCircle(SkPoint{100, 100}, 50, paint);
+  builder.DrawCircle(DlPoint(100, 100), 50, paint);
 
   paint.setColor(DlColor::kGreenYellow());
-  builder.DrawCircle(SkPoint{300, 200}, 100, paint);
+  builder.DrawCircle(DlPoint(300, 200), 100, paint);
 
   paint.setColor(DlColor::kDarkMagenta());
-  builder.DrawCircle(SkPoint{140, 170}, 75, paint);
+  builder.DrawCircle(DlPoint(140, 170), 75, paint);
 
   paint.setColor(DlColor::kOrangeRed());
-  builder.DrawCircle(SkPoint{180, 120}, 100, paint);
+  builder.DrawCircle(DlPoint(180, 120), 100, paint);
 
-  SkRRect rrect =
-      SkRRect::MakeRectXY(SkRect::MakeLTRB(75, 50, 375, 275), 20, 20);
-  builder.ClipRRect(rrect);
+  DlRoundRect rrect =
+      DlRoundRect::MakeRectXY(DlRect::MakeLTRB(75, 50, 375, 275), 20, 20);
+  builder.ClipRoundRect(rrect);
 
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -274,13 +272,13 @@ TEST_P(AiksTest, CanRenderBackdropBlurWithSingleBackdropId) {
   DisplayListBuilder builder;
 
   DlPaint paint;
-  builder.DrawImage(image, SkPoint::Make(50.0, 50.0),
+  builder.DrawImage(image, DlPoint(50.0, 50.0),
                     DlImageSampling::kNearestNeighbor, &paint);
 
-  SkRRect rrect =
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(50, 250, 100, 100), 20, 20);
+  DlRoundRect rrect =
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(50, 250, 100, 100), 20, 20);
   builder.Save();
-  builder.ClipRRect(rrect);
+  builder.ClipRoundRect(rrect);
 
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -299,14 +297,14 @@ TEST_P(AiksTest, CanRenderMultipleBackdropBlurWithSingleBackdropId) {
   DisplayListBuilder builder;
 
   DlPaint paint;
-  builder.DrawImage(image, SkPoint::Make(50.0, 50.0),
+  builder.DrawImage(image, DlPoint(50.0, 50.0),
                     DlImageSampling::kNearestNeighbor, &paint);
 
   for (int i = 0; i < 6; i++) {
-    SkRRect rrect = SkRRect::MakeRectXY(
-        SkRect::MakeXYWH(50 + (i * 100), 250, 100, 100), 20, 20);
+    DlRoundRect rrect = DlRoundRect::MakeRectXY(
+        DlRect::MakeXYWH(50 + (i * 100), 250, 100, 100), 20, 20);
     builder.Save();
-    builder.ClipRRect(rrect);
+    builder.ClipRoundRect(rrect);
 
     DlPaint save_paint;
     save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -327,14 +325,14 @@ TEST_P(AiksTest,
   DisplayListBuilder builder;
 
   DlPaint paint;
-  builder.DrawImage(image, SkPoint::Make(50.0, 50.0),
+  builder.DrawImage(image, DlPoint(50.0, 50.0),
                     DlImageSampling::kNearestNeighbor, &paint);
 
   for (int i = 0; i < 6; i++) {
-    SkRRect rrect = SkRRect::MakeRectXY(
-        SkRect::MakeXYWH(50 + (i * 100), 250, 100, 100), 20, 20);
+    DlRoundRect rrect = DlRoundRect::MakeRectXY(
+        DlRect::MakeXYWH(50 + (i * 100), 250, 100, 100), 20, 20);
     builder.Save();
-    builder.ClipRRect(rrect);
+    builder.ClipRoundRect(rrect);
 
     DlPaint save_paint;
     save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -354,7 +352,7 @@ TEST_P(AiksTest, CanRenderBackdropBlurHugeSigma) {
 
   DlPaint paint;
   paint.setColor(DlColor::kGreen());
-  builder.DrawCircle(SkPoint{400, 400}, 300, paint);
+  builder.DrawCircle(DlPoint(400, 400), 300, paint);
 
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -369,12 +367,12 @@ TEST_P(AiksTest, CanRenderBackdropBlurHugeSigma) {
 
 TEST_P(AiksTest, CanRenderClippedBlur) {
   DisplayListBuilder builder;
-  builder.ClipRect(SkRect::MakeXYWH(100, 150, 400, 400));
+  builder.ClipRect(DlRect::MakeXYWH(100, 150, 400, 400));
 
   DlPaint paint;
   paint.setColor(DlColor::kGreen());
   paint.setImageFilter(DlImageFilter::MakeBlur(20, 20, DlTileMode::kDecal));
-  builder.DrawCircle(SkPoint{400, 400}, 200, paint);
+  builder.DrawCircle(DlPoint(400, 400), 200, paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -396,8 +394,8 @@ TEST_P(AiksTest, ClippedBlurFilterRendersCorrectlyInteractive) {
         DlBlurMaskFilter::Make(DlBlurStyle::kNormal, sigma.sigma));
     paint.setColor(DlColor::kRed());
 
-    SkPath path = SkPath::Rect(SkRect::MakeLTRB(0, 0, 800, 800));
-    path.addCircle(0, 0, 0.5);
+    DlPath path = DlPath::MakeRect(DlRect::MakeLTRB(0, 0, 800, 800));
+    path = path + DlPath::MakeCircle(DlPoint(0, 0), 0.5);
     builder.DrawPath(path, paint);
     return builder.Build();
   };
@@ -414,8 +412,8 @@ TEST_P(AiksTest, ClippedBlurFilterRendersCorrectly) {
       DlBlurMaskFilter::Make(DlBlurStyle::kNormal, sigma.sigma));
   paint.setColor(DlColor::kRed());
 
-  SkPath path = SkPath::Rect(SkRect::MakeLTRB(0, 0, 800, 800));
-  path.addCircle(0, 0, 0.5);
+  DlPath path = DlPath::MakeRect(DlRect::MakeLTRB(0, 0, 800, 800));
+  path = path + DlPath::MakeCircle(DlPoint(0, 0), 0.5);
   builder.DrawPath(path, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -425,13 +423,13 @@ TEST_P(AiksTest, ClearBlendWithBlur) {
   DisplayListBuilder builder;
   DlPaint paint;
   paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600.0, 600.0), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600.0, 600.0), paint);
 
   DlPaint clear;
   clear.setBlendMode(DlBlendMode::kClear);
   clear.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 20));
 
-  builder.DrawCircle(SkPoint{300.0, 300.0}, 200.0, clear);
+  builder.DrawCircle(DlPoint(300.0, 300.0), 200.0, clear);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -452,7 +450,7 @@ TEST_P(AiksTest, BlurHasNoEdge) {
     paint.setColor(DlColor::kGreen());
     paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, sigma));
 
-    builder.DrawRect(SkRect::MakeXYWH(300, 300, 200, 200), paint);
+    builder.DrawRect(DlRect::MakeXYWH(300, 300, 200, 200), paint);
     return builder.Build();
   };
 
@@ -466,8 +464,8 @@ TEST_P(AiksTest, MaskBlurWithZeroSigmaIsSkipped) {
   paint.setColor(DlColor::kBlue());
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 0));
 
-  builder.DrawCircle(SkPoint{300, 300}, 200, paint);
-  builder.DrawRect(SkRect::MakeLTRB(100, 300, 500, 600), paint);
+  builder.DrawCircle(DlPoint(300, 300), 200, paint);
+  builder.DrawRect(DlRect::MakeLTRB(100, 300, 500, 600), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -509,53 +507,53 @@ static sk_sp<DisplayList> MaskBlurVariantTest(
 
   Scalar y = 50;
   paint.setColor(DlColor::kCrimson().withAlpha(alpha));
-  builder.DrawRect(SkRect::MakeXYWH(x + 25 - radius / 2, y + radius / 2,  //
+  builder.DrawRect(DlRect::MakeXYWH(x + 25 - radius / 2, y + radius / 2,  //
                                     radius, 60.0f - radius),
                    paint);
 
   y += y_spacing;
   paint.setColor(DlColor::kBlue().withAlpha(alpha));
-  builder.DrawCircle(SkPoint{x + 25, y + 25}, radius, paint);
+  builder.DrawCircle(DlPoint{x + 25, y + 25}, radius, paint);
 
   y += y_spacing;
   paint.setColor(DlColor::kGreen().withAlpha(alpha));
-  builder.DrawOval(SkRect::MakeXYWH(x + 25 - radius / 2, y + radius / 2,  //
+  builder.DrawOval(DlRect::MakeXYWH(x + 25 - radius / 2, y + radius / 2,  //
                                     radius, 60.0f - radius),
                    paint);
 
   y += y_spacing;
   paint.setColor(DlColor::kPurple().withAlpha(alpha));
-  SkRRect rrect =
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(x, y, 60.0f, 60.0f), radius, radius);
-  builder.DrawRRect(rrect, paint);
+  DlRoundRect rrect = DlRoundRect::MakeRectXY(
+      DlRect::MakeXYWH(x, y, 60.0f, 60.0f), radius, radius);
+  builder.DrawRoundRect(rrect, paint);
 
   y += y_spacing;
   paint.setColor(DlColor::kOrange().withAlpha(alpha));
 
-  rrect =
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(x, y, 60.0f, 60.0f), radius, 5.0);
-  builder.DrawRRect(rrect, paint);
+  rrect = DlRoundRect::MakeRectXY(DlRect::MakeXYWH(x, y, 60.0f, 60.0f),  //
+                                  radius, 5.0);
+  builder.DrawRoundRect(rrect, paint);
 
   y += y_spacing;
   paint.setColor(DlColor::kMaroon().withAlpha(alpha));
 
   {
-    SkPath path;
-    path.moveTo(x + 0, y + 60);
-    path.lineTo(x + 30, y + 0);
-    path.lineTo(x + 60, y + 60);
-    path.close();
+    DlPathBuilder path_builder;
+    path_builder.MoveTo(DlPoint(x + 0, y + 60));
+    path_builder.LineTo(DlPoint(x + 30, y + 0));
+    path_builder.LineTo(DlPoint(x + 60, y + 60));
+    path_builder.Close();
 
-    builder.DrawPath(path, paint);
+    builder.DrawPath(DlPath(path_builder), paint);
   }
 
   y += y_spacing;
   paint.setColor(DlColor::kMaroon().withAlpha(alpha));
   {
-    SkPath path;
-    path.addArc(SkRect::MakeXYWH(x + 5, y, 50, 50), 90, 180);
-    path.addArc(SkRect::MakeXYWH(x + 25, y, 50, 50), 90, 180);
-    path.close();
+    DlPath path = DlPath::MakeArc(Rect::MakeXYWH(x + 5, y, 50, 50),  //
+                                  Degrees(90), Degrees(180), false) +
+                  DlPath::MakeArc(Rect::MakeXYWH(x + 25, y, 50, 50),  //
+                                  Degrees(90), Degrees(180), false);
     builder.DrawPath(path, paint);
   }
 
@@ -636,18 +634,18 @@ TEST_P(AiksTest, GaussianBlurStyleInner) {
   paint.setColor(DlColor::kGreen());
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kInner, 30));
 
-  SkPath path;
-  path.moveTo(200, 200);
-  path.lineTo(300, 400);
-  path.lineTo(100, 400);
-  path.close();
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(200, 200));
+  path_builder.LineTo(DlPoint(300, 400));
+  path_builder.LineTo(DlPoint(100, 400));
+  path_builder.Close();
 
-  builder.DrawPath(path, paint);
+  builder.DrawPath(DlPath(path_builder), paint);
 
   // Draw another thing to make sure the clip area is reset.
   DlPaint red;
   red.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), red);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), red);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -663,18 +661,18 @@ TEST_P(AiksTest, GaussianBlurStyleOuter) {
   paint.setColor(DlColor::kGreen());
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kOuter, 30));
 
-  SkPath path;
-  path.moveTo(200, 200);
-  path.lineTo(300, 400);
-  path.lineTo(100, 400);
-  path.close();
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(200, 200));
+  path_builder.LineTo(DlPoint(300, 400));
+  path_builder.LineTo(DlPoint(100, 400));
+  path_builder.Close();
 
-  builder.DrawPath(path, paint);
+  builder.DrawPath(DlPath(path_builder), paint);
 
   // Draw another thing to make sure the clip area is reset.
   DlPaint red;
   red.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), red);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), red);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -690,18 +688,18 @@ TEST_P(AiksTest, GaussianBlurStyleSolid) {
   paint.setColor(DlColor::kGreen());
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kSolid, 30));
 
-  SkPath path;
-  path.moveTo(200, 200);
-  path.lineTo(300, 400);
-  path.lineTo(100, 400);
-  path.close();
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(200, 200));
+  path_builder.LineTo(DlPoint(300, 400));
+  path_builder.LineTo(DlPoint(100, 400));
+  path_builder.Close();
 
-  builder.DrawPath(path, paint);
+  builder.DrawPath(DlPath(path_builder), paint);
 
   // Draw another thing to make sure the clip area is reset.
   DlPaint red;
   red.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), red);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), red);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -724,11 +722,11 @@ TEST_P(AiksTest, MaskBlurTexture) {
 
     builder.DrawImage(
         DlImageImpeller::Make(CreateTextureForFixture("boston.jpg")),
-        SkPoint{200, 200}, DlImageSampling::kNearestNeighbor, &paint);
+        DlPoint(200, 200), DlImageSampling::kNearestNeighbor, &paint);
 
     DlPaint red;
     red.setColor(DlColor::kRed());
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), red);
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), red);
 
     return builder.Build();
   };
@@ -753,15 +751,15 @@ TEST_P(AiksTest, MaskBlurDoesntStretchContents) {
 
     std::shared_ptr<Texture> boston = CreateTextureForFixture("boston.jpg");
 
-    builder.Transform(SkMatrix::Translate(100, 100) *
-                      SkMatrix::Scale(0.5, 0.5));
+    builder.Transform(Matrix::MakeTranslation({100, 100}) *
+                      Matrix::MakeScale({0.5, 0.5, 1.0f}));
 
     paint.setColorSource(DlColorSource::MakeImage(
         DlImageImpeller::Make(boston), DlTileMode::kRepeat, DlTileMode::kRepeat,
         DlImageSampling::kMipmapLinear));
     paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, sigma));
 
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, boston->GetSize().width,
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, boston->GetSize().width,
                                       boston->GetSize().height),
                      paint);
 
@@ -777,15 +775,15 @@ TEST_P(AiksTest, GaussianBlurAtPeripheryVertical) {
   builder.Scale(GetContentScale().x, GetContentScale().y);
 
   paint.setColor(DlColor::kLimeGreen());
-  SkRRect rrect = SkRRect::MakeRectXY(
-      SkRect::MakeLTRB(0, 0, GetWindowSize().width, 100), 10, 10);
-  builder.DrawRRect(rrect, paint);
+  DlRoundRect rrect = DlRoundRect::MakeRectXY(
+      DlRect::MakeLTRB(0, 0, GetWindowSize().width, 100), 10, 10);
+  builder.DrawRoundRect(rrect, paint);
 
   paint.setColor(DlColor::kMagenta());
-  rrect = SkRRect::MakeRectXY(
-      SkRect::MakeLTRB(0, 110, GetWindowSize().width, 210), 10, 10);
-  builder.DrawRRect(rrect, paint);
-  builder.ClipRect(SkRect::MakeLTRB(100, 0, 200, GetWindowSize().height));
+  rrect = DlRoundRect::MakeRectXY(
+      DlRect::MakeLTRB(0, 110, GetWindowSize().width, 210), 10, 10);
+  builder.DrawRoundRect(rrect, paint);
+  builder.ClipRect(DlRect::MakeLTRB(100, 0, 200, GetWindowSize().height));
 
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -805,17 +803,17 @@ TEST_P(AiksTest, GaussianBlurAtPeripheryHorizontal) {
   std::shared_ptr<Texture> boston = CreateTextureForFixture("boston.jpg");
   builder.DrawImageRect(
       DlImageImpeller::Make(boston),
-      SkRect::MakeXYWH(0, 0, boston->GetSize().width, boston->GetSize().height),
-      SkRect::MakeLTRB(0, 0, GetWindowSize().width, 100),
+      DlRect::MakeXYWH(0, 0, boston->GetSize().width, boston->GetSize().height),
+      DlRect::MakeLTRB(0, 0, GetWindowSize().width, 100),
       DlImageSampling::kNearestNeighbor);
 
   DlPaint paint;
   paint.setColor(DlColor::kMagenta());
 
-  SkRRect rrect = SkRRect::MakeRectXY(
-      SkRect::MakeLTRB(0, 110, GetWindowSize().width, 210), 10, 10);
-  builder.DrawRRect(rrect, paint);
-  builder.ClipRect(SkRect::MakeLTRB(0, 50, GetWindowSize().width, 150));
+  DlRoundRect rrect = DlRoundRect::MakeRectXY(
+      DlRect::MakeLTRB(0, 110, GetWindowSize().width, 210), 10, 10);
+  builder.DrawRoundRect(rrect, paint);
+  builder.ClipRect(DlRect::MakeLTRB(0, 50, GetWindowSize().width, 150));
 
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -851,18 +849,17 @@ TEST_P(AiksTest, GaussianBlurAnimatedBackdrop) {
     DisplayListBuilder builder;
     builder.Scale(GetContentScale().x, GetContentScale().y);
     Scalar y = amp * sin(freq * 2.0 * M_PI * count / 60);
-    builder.DrawImage(
-        DlImageImpeller::Make(boston),
-        SkPoint::Make(1024 / 2 - boston->GetSize().width / 2,
-                      (768 / 2 - boston->GetSize().height / 2) + y),
-        DlImageSampling::kMipmapLinear);
+    builder.DrawImage(DlImageImpeller::Make(boston),
+                      DlPoint(1024 / 2 - boston->GetSize().width / 2,
+                              (768 / 2 - boston->GetSize().height / 2) + y),
+                      DlImageSampling::kMipmapLinear);
     static PlaygroundPoint point_a(Point(100, 100), 20, Color::Red());
     static PlaygroundPoint point_b(Point(900, 700), 20, Color::Red());
     auto [handle_a, handle_b] = DrawPlaygroundLine(point_a, point_b);
 
     builder.ClipRect(
-        SkRect::MakeLTRB(handle_a.x, handle_a.y, handle_b.x, handle_b.y));
-    builder.ClipRect(SkRect::MakeLTRB(100, 100, 900, 700));
+        DlRect::MakeLTRB(handle_a.x, handle_a.y, handle_b.x, handle_b.y));
+    builder.ClipRect(DlRect::MakeLTRB(100, 100, 900, 700));
 
     DlPaint paint;
     paint.setBlendMode(DlBlendMode::kSrc);
@@ -899,17 +896,17 @@ TEST_P(AiksTest, GaussianBlurStyleInnerGradient) {
       /*tile_mode=*/DlTileMode::kMirror));
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kInner, 30));
 
-  SkPath path;
-  path.moveTo(200, 200);
-  path.lineTo(300, 400);
-  path.lineTo(100, 400);
-  path.close();
-  builder.DrawPath(path, paint);
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(200, 200));
+  path_builder.LineTo(DlPoint(300, 400));
+  path_builder.LineTo(DlPoint(100, 400));
+  path_builder.Close();
+  builder.DrawPath(DlPath(path_builder), paint);
 
   // Draw another thing to make sure the clip area is reset.
   DlPaint red;
   red.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), red);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), red);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -936,17 +933,17 @@ TEST_P(AiksTest, GaussianBlurStyleSolidGradient) {
       /*tile_mode=*/DlTileMode::kMirror));
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kSolid, 30));
 
-  SkPath path;
-  path.moveTo(200, 200);
-  path.lineTo(300, 400);
-  path.lineTo(100, 400);
-  path.close();
-  builder.DrawPath(path, paint);
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(200, 200));
+  path_builder.LineTo(DlPoint(300, 400));
+  path_builder.LineTo(DlPoint(100, 400));
+  path_builder.Close();
+  builder.DrawPath(DlPath(path_builder), paint);
 
   // Draw another thing to make sure the clip area is reset.
   DlPaint red;
   red.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), red);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), red);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
@@ -972,17 +969,17 @@ TEST_P(AiksTest, GaussianBlurStyleOuterGradient) {
       /*tile_mode=*/DlTileMode::kMirror));
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kOuter, 30));
 
-  SkPath path;
-  path.moveTo(200, 200);
-  path.lineTo(300, 400);
-  path.lineTo(100, 400);
-  path.close();
-  builder.DrawPath(path, paint);
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(200, 200));
+  path_builder.LineTo(DlPoint(300, 400));
+  path_builder.LineTo(DlPoint(100, 400));
+  path_builder.Close();
+  builder.DrawPath(DlPath(path_builder), paint);
 
   // Draw another thing to make sure the clip area is reset.
   DlPaint red;
   red.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), red);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), red);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
@@ -1002,15 +999,15 @@ TEST_P(AiksTest, GaussianBlurScaledAndClipped) {
 
   auto rect =
       Rect::MakeLTRB(center.x, center.y, center.x, center.y).Expand(clip_size);
-  builder.ClipRect(SkRect::MakeLTRB(rect.GetLeft(), rect.GetTop(),
+  builder.ClipRect(DlRect::MakeLTRB(rect.GetLeft(), rect.GetTop(),
                                     rect.GetRight(), rect.GetBottom()));
   builder.Translate(center.x, center.y);
   builder.Scale(0.6, 0.6);
 
-  SkRect sk_bounds = SkRect::MakeLTRB(bounds.GetLeft(), bounds.GetTop(),
+  DlRect sk_bounds = DlRect::MakeLTRB(bounds.GetLeft(), bounds.GetTop(),
                                       bounds.GetRight(), bounds.GetBottom());
   Rect dest = bounds.Shift(-image_center);
-  SkRect sk_dst = SkRect::MakeLTRB(dest.GetLeft(), dest.GetTop(),
+  DlRect sk_dst = DlRect::MakeLTRB(dest.GetLeft(), dest.GetTop(),
                                    dest.GetRight(), dest.GetBottom());
   builder.DrawImageRect(DlImageImpeller::Make(boston), /*src=*/sk_bounds,
                         /*dst=*/sk_dst, DlImageSampling::kNearestNeighbor,
@@ -1055,15 +1052,15 @@ TEST_P(AiksTest, GaussianBlurRotatedAndClippedInteractive) {
 
     builder.Scale(GetContentScale().x, GetContentScale().y);
     builder.ClipRect(
-        SkRect::MakeLTRB(handle_a.x, handle_a.y, handle_b.x, handle_b.y));
+        DlRect::MakeLTRB(handle_a.x, handle_a.y, handle_b.x, handle_b.y));
     builder.Translate(center.x, center.y);
     builder.Scale(scale, scale);
     builder.Rotate(rotation);
 
-    SkRect sk_bounds = SkRect::MakeLTRB(bounds.GetLeft(), bounds.GetTop(),
+    DlRect sk_bounds = DlRect::MakeLTRB(bounds.GetLeft(), bounds.GetTop(),
                                         bounds.GetRight(), bounds.GetBottom());
     Rect dest = bounds.Shift(-image_center);
-    SkRect sk_dst = SkRect::MakeLTRB(dest.GetLeft(), dest.GetTop(),
+    DlRect sk_dst = DlRect::MakeLTRB(dest.GetLeft(), dest.GetTop(),
                                      dest.GetRight(), dest.GetBottom());
     builder.DrawImageRect(DlImageImpeller::Make(boston), /*src=*/sk_bounds,
                           /*dst=*/sk_dst, DlImageSampling::kNearestNeighbor,
@@ -1081,7 +1078,7 @@ TEST_P(AiksTest, GaussianBlurOneDimension) {
   builder.Scale(0.5, 0.5);
 
   std::shared_ptr<Texture> boston = CreateTextureForFixture("boston.jpg");
-  builder.DrawImage(DlImageImpeller::Make(boston), SkPoint{100, 100}, {});
+  builder.DrawImage(DlImageImpeller::Make(boston), DlPoint(100, 100), {});
 
   DlPaint paint;
   paint.setBlendMode(DlBlendMode::kSrc);
@@ -1113,7 +1110,7 @@ TEST_P(AiksTest, GaussianBlurRotatedAndClipped) {
 
   auto clip_bounds =
       Rect::MakeLTRB(center.x, center.y, center.x, center.y).Expand(clip_size);
-  builder.ClipRect(SkRect::MakeLTRB(clip_bounds.GetLeft(), clip_bounds.GetTop(),
+  builder.ClipRect(DlRect::MakeLTRB(clip_bounds.GetLeft(), clip_bounds.GetTop(),
                                     clip_bounds.GetRight(),
                                     clip_bounds.GetBottom()));
   builder.Translate(center.x, center.y);
@@ -1123,10 +1120,10 @@ TEST_P(AiksTest, GaussianBlurRotatedAndClipped) {
   auto dst_rect = bounds.Shift(-image_center);
   builder.DrawImageRect(
       DlImageImpeller::Make(boston), /*src=*/
-      SkRect::MakeLTRB(bounds.GetLeft(), bounds.GetTop(), bounds.GetRight(),
+      DlRect::MakeLTRB(bounds.GetLeft(), bounds.GetTop(), bounds.GetRight(),
                        bounds.GetBottom()),
       /*dst=*/
-      SkRect::MakeLTRB(dst_rect.GetLeft(), dst_rect.GetTop(),
+      DlRect::MakeLTRB(dst_rect.GetLeft(), dst_rect.GetTop(),
                        dst_rect.GetRight(), dst_rect.GetBottom()),
       DlImageSampling::kMipmapLinear, &paint);
 
@@ -1165,9 +1162,9 @@ TEST_P(AiksTest, GaussianBlurRotatedNonUniform) {
     builder.Scale(scale, scale);
     builder.Rotate(rotation);
 
-    SkRRect rrect =
-        SkRRect::MakeRectXY(SkRect::MakeXYWH(-100, -100, 200, 200), 10, 10);
-    builder.DrawRRect(rrect, paint);
+    DlRoundRect rrect =
+        DlRoundRect::MakeRectXY(DlRect::MakeXYWH(-100, -100, 200, 200), 10, 10);
+    builder.DrawRoundRect(rrect, paint);
     return builder.Build();
   };
 
@@ -1179,27 +1176,23 @@ TEST_P(AiksTest, BlurredRectangleWithShader) {
   builder.Scale(GetContentScale().x, GetContentScale().y);
 
   auto paint_lines = [&builder](Scalar dx, Scalar dy, DlPaint paint) {
-    auto draw_line = [&builder, &paint](SkPoint a, SkPoint b) {
-      SkPath line = SkPath::Line(a, b);
+    auto draw_line = [&builder, &paint](DlPoint a, DlPoint b) {
+      DlPath line = DlPath::MakeLine(a, b);
       builder.DrawPath(line, paint);
     };
     paint.setStrokeWidth(5);
     paint.setDrawStyle(DlDrawStyle::kStroke);
-    draw_line(SkPoint::Make(dx + 100, dy + 100),
-              SkPoint::Make(dx + 200, dy + 200));
-    draw_line(SkPoint::Make(dx + 100, dy + 200),
-              SkPoint::Make(dx + 200, dy + 100));
-    draw_line(SkPoint::Make(dx + 150, dy + 100),
-              SkPoint::Make(dx + 200, dy + 150));
-    draw_line(SkPoint::Make(dx + 100, dy + 150),
-              SkPoint::Make(dx + 150, dy + 200));
+    draw_line(DlPoint(dx + 100, dy + 100), DlPoint(dx + 200, dy + 200));
+    draw_line(DlPoint(dx + 100, dy + 200), DlPoint(dx + 200, dy + 100));
+    draw_line(DlPoint(dx + 150, dy + 100), DlPoint(dx + 200, dy + 150));
+    draw_line(DlPoint(dx + 100, dy + 150), DlPoint(dx + 150, dy + 200));
   };
 
   AiksContext renderer(GetContext(), nullptr);
   DisplayListBuilder recorder_builder;
   for (int x = 0; x < 5; ++x) {
     for (int y = 0; y < 5; ++y) {
-      SkRect rect = SkRect::MakeXYWH(x * 20, y * 20, 20, 20);
+      DlRect rect = DlRect::MakeXYWH(x * 20, y * 20, 20, 20);
       DlPaint paint;
       paint.setColor(((x + y) & 1) == 0 ? DlColor::kYellow()
                                         : DlColor::kBlue());
@@ -1216,18 +1209,18 @@ TEST_P(AiksTest, BlurredRectangleWithShader) {
 
   DlPaint paint;
   paint.setColor(DlColor::kDarkGreen());
-  builder.DrawRect(SkRect::MakeLTRB(0, 0, 300, 600), paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 300, 600), paint);
 
   paint.setColorSource(image_source);
-  builder.DrawRect(SkRect::MakeLTRB(100, 100, 200, 200), paint);
+  builder.DrawRect(DlRect::MakeLTRB(100, 100, 200, 200), paint);
 
   paint.setColorSource(nullptr);
   paint.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeLTRB(300, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeLTRB(300, 0, 600, 600), paint);
 
   paint.setColorSource(image_source);
   paint.setImageFilter(blur_filter);
-  builder.DrawRect(SkRect::MakeLTRB(400, 100, 500, 200), paint);
+  builder.DrawRect(DlRect::MakeLTRB(400, 100, 500, 200), paint);
 
   paint.setImageFilter(nullptr);
   paint_lines(0, 300, paint);
@@ -1285,7 +1278,7 @@ TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
 
   auto blur_filter = DlImageFilter::MakeBlur(20, 20, DlTileMode::kDecal);
   paint.setImageFilter(blur_filter);
-  builder.DrawImage(texture, SkPoint::Make(200, 200), {}, &paint);
+  builder.DrawImage(texture, DlPoint(200, 200), {}, &paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
@@ -1298,16 +1291,16 @@ TEST_P(AiksTest, GaussianBlurSolidColorTinyMipMap) {
   for (int32_t i = 1; i < 5; ++i) {
     DisplayListBuilder builder;
     Scalar fi = i;
-    SkPath path;
-    path.moveTo(100, 100);
-    path.lineTo(100 + fi, 100 + fi);
+    DlPathBuilder path_builder;
+    path_builder.MoveTo(DlPoint(100, 100));
+    path_builder.LineTo(DlPoint(100 + fi, 100 + fi));
 
     DlPaint paint;
     paint.setColor(DlColor::kChartreuse());
     auto blur_filter = DlImageFilter::MakeBlur(0.1, 0.1, DlTileMode::kClamp);
     paint.setImageFilter(blur_filter);
 
-    builder.DrawPath(path, paint);
+    builder.DrawPath(DlPath(path_builder), paint);
 
     auto image = DisplayListToTexture(builder.Build(), {1024, 768}, renderer);
     EXPECT_TRUE(image) << " length " << i;
@@ -1325,14 +1318,14 @@ TEST_P(AiksTest, GaussianBlurBackdropTinyMipMap) {
     ISize clip_size = ISize(i, i);
     builder.Save();
     builder.ClipRect(
-        SkRect::MakeXYWH(400, 400, clip_size.width, clip_size.height));
+        DlRect::MakeXYWH(400, 400, clip_size.width, clip_size.height));
 
     DlPaint paint;
     paint.setColor(DlColor::kGreen());
     auto blur_filter = DlImageFilter::MakeBlur(0.1, 0.1, DlTileMode::kDecal);
     paint.setImageFilter(blur_filter);
 
-    builder.DrawCircle(SkPoint{400, 400}, 200, paint);
+    builder.DrawCircle(DlPoint(400, 400), 200, paint);
     builder.Restore();
 
     auto image = DisplayListToTexture(builder.Build(), {1024, 768}, renderer);
@@ -1347,7 +1340,7 @@ TEST_P(AiksTest,
   DisplayListBuilder builder;
 
   DlPaint paint;
-  builder.DrawImage(image, SkPoint::Make(50.0, 50.0),
+  builder.DrawImage(image, DlPoint(50.0, 50.0),
                     DlImageSampling::kNearestNeighbor, &paint);
 
   for (int i = 0; i < 6; i++) {
@@ -1356,10 +1349,10 @@ TEST_P(AiksTest,
       paint.setColor(DlColor::kWhite().withAlphaF(0.95));
       builder.SaveLayer(nullptr, &paint);
     }
-    SkRRect rrect = SkRRect::MakeRectXY(
-        SkRect::MakeXYWH(50 + (i * 100), 250, 100, 100), 20, 20);
+    DlRoundRect rrect = DlRoundRect::MakeRectXY(
+        DlRect::MakeXYWH(50 + (i * 100), 250, 100, 100), 20, 20);
     builder.Save();
-    builder.ClipRRect(rrect);
+    builder.ClipRoundRect(rrect);
 
     DlPaint save_paint;
     save_paint.setBlendMode(DlBlendMode::kSrc);

--- a/engine/src/flutter/impeller/display_list/aiks_dl_clip_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_clip_unittests.cc
@@ -16,25 +16,17 @@ namespace testing {
 
 using namespace flutter;
 
-namespace {
-SkPath CreateCircle(Scalar x, Scalar y, Scalar radius) {
-  SkPath path;
-  path.addCircle(x, y, radius);
-  return path;
-}
-}  // namespace
-
 TEST_P(AiksTest, CanRenderNestedClips) {
   DisplayListBuilder builder;
   DlPaint paint;
   paint.setColor(DlColor::kFuchsia());
 
   builder.Save();
-  builder.ClipPath(CreateCircle(200, 400, 300));
+  builder.ClipPath(DlPath::MakeCircle(DlPoint(200, 400), 300));
   builder.Restore();
-  builder.ClipPath(CreateCircle(600, 400, 300));
-  builder.ClipPath(CreateCircle(400, 600, 300));
-  builder.DrawRect(SkRect::MakeXYWH(200, 200, 400, 400), paint);
+  builder.ClipPath(DlPath::MakeCircle(DlPoint(600, 400), 300));
+  builder.ClipPath(DlPath::MakeCircle(DlPoint(400, 600), 300));
+  builder.DrawRect(DlRect::MakeXYWH(200, 200, 400, 400), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -44,33 +36,36 @@ TEST_P(AiksTest, CanRenderDifferenceClips) {
   builder.Translate(400, 400);
 
   // Limit drawing to face circle with a clip.
-  builder.ClipPath(CreateCircle(0, 0, 200));
+  builder.ClipPath(DlPath::MakeCircle(DlPoint(0, 0), 200));
   builder.Save();
 
   // Cut away eyes/mouth using difference clips.
-  builder.ClipPath(CreateCircle(-100, -50, 30), DlCanvas::ClipOp::kDifference);
-  builder.ClipPath(CreateCircle(100, -50, 30), DlCanvas::ClipOp::kDifference);
+  builder.ClipPath(DlPath::MakeCircle(DlPoint(-100, -50), 30),
+                   DlCanvas::ClipOp::kDifference);
+  builder.ClipPath(DlPath::MakeCircle(DlPoint(100, -50), 30),
+                   DlCanvas::ClipOp::kDifference);
 
-  SkPath path;
-  path.moveTo(-100, 50);
-  path.quadTo(0, 150, 100, 50);
-  builder.ClipPath(path, DlCanvas::ClipOp::kDifference);
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(-100, 50));
+  path_builder.QuadraticCurveTo(DlPoint(0, 150), DlPoint(100, 50));
+  builder.ClipPath(DlPath(path_builder), DlCanvas::ClipOp::kDifference);
 
   // Draw a huge yellow rectangle to prove the clipping works.
   DlPaint paint;
   paint.setColor(DlColor::kYellow());
-  builder.DrawRect(SkRect::MakeXYWH(-1000, -1000, 2000, 2000), paint);
+  builder.DrawRect(DlRect::MakeXYWH(-1000, -1000, 2000, 2000), paint);
 
   // Remove the difference clips and draw hair that partially covers the eyes.
   builder.Restore();
   paint.setColor(DlColor::kMaroon());
-  SkPath path_2;
-  path_2.moveTo(200, -200);
-  path_2.lineTo(-200, -200);
-  path_2.lineTo(-200, -40);
-  path_2.cubicTo({0, -40}, {0, -80}, {200, -80});
+  DlPathBuilder path_builder_2;
+  path_builder_2.MoveTo(DlPoint(200, -200));
+  path_builder_2.LineTo(DlPoint(-200, -200));
+  path_builder_2.LineTo(DlPoint(-200, -40));
+  path_builder_2.CubicCurveTo(DlPoint(0, -40), DlPoint(0, -80),
+                              DlPoint(200, -80));
 
-  builder.DrawPath(path_2, paint);
+  builder.DrawPath(DlPath(path_builder_2), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -86,8 +81,8 @@ TEST_P(AiksTest, CanRenderWithContiguousClipRestores) {
   builder.Save();
 
   // Append two clips, the second resulting in empty coverage.
-  builder.ClipRect(SkRect::MakeXYWH(100, 100, 100, 100));
-  builder.ClipRect(SkRect::MakeXYWH(300, 300, 100, 100));
+  builder.ClipRect(DlRect::MakeXYWH(100, 100, 100, 100));
+  builder.ClipRect(DlRect::MakeXYWH(300, 300, 100, 100));
 
   // Restore to no clips.
   builder.Restore();
@@ -111,8 +106,8 @@ TEST_P(AiksTest, ClipsUseCurrentTransform) {
     builder.Scale(0.8, 0.8);
 
     paint.setColor(colors[i % colors.size()]);
-    builder.ClipPath(CreateCircle(0, 0, 300));
-    builder.DrawRect(SkRect::MakeXYWH(-300, -300, 600, 600), paint);
+    builder.ClipPath(DlPath::MakeCircle(DlPoint(0, 0), 300));
+    builder.DrawRect(DlRect::MakeXYWH(-300, -300, 600, 600), paint);
   }
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -127,17 +122,18 @@ TEST_P(AiksTest, FramebufferBlendsRespectClips) {
   paint.setColor(DlColor::kWhite());
   builder.DrawPaint(paint);
 
-  builder.ClipPath(SkPath::Circle(150, 150, 50), DlCanvas::ClipOp::kIntersect);
+  builder.ClipPath(DlPath::MakeCircle(DlPoint(150, 150), 50),
+                   DlCanvas::ClipOp::kIntersect);
 
   // Draw a red rectangle that should not show through the circle clip.
   paint.setColor(DlColor::kRed());
   paint.setBlendMode(DlBlendMode::kMultiply);
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 100, 100), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 100, 100), paint);
 
   // Draw a green circle that shows through the clip.
   paint.setColor(DlColor::kGreen());
   paint.setBlendMode(DlBlendMode::kSrcOver);
-  builder.DrawCircle(SkPoint::Make(150, 150), 50, paint);
+  builder.DrawCircle(DlPoint(150, 150), 50, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_gradient_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_gradient_unittests.cc
@@ -15,9 +15,6 @@
 #include "flutter/display_list/dl_paint.h"
 #include "flutter/testing/testing.h"
 #include "impeller/playground/widgets.h"
-#include "include/core/SkPath.h"
-#include "include/core/SkRRect.h"
-#include "include/core/SkRect.h"
 
 using namespace flutter;
 ////////////////////////////////////////////////////////////////////////////////
@@ -48,20 +45,10 @@ void CanRenderLinearGradient(AiksTest* aiks_test, DlTileMode tile_mode) {
       {0, 0}, {200, 200}, 2, colors.data(), stops.data(), tile_mode);
   paint.setColorSource(gradient);
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 
-Matrix ToMatrix(const SkMatrix& m) {
-  return Matrix{
-      // clang-format off
-      m[0], m[3], 0, m[6],
-      m[1], m[4], 0, m[7],
-      0,    0,    1, 0,
-      m[2], m[5], 0, m[8],
-      // clang-format on
-  };
-}
 }  // namespace
 
 TEST_P(AiksTest, CanRenderLinearGradientClamp) {
@@ -97,7 +84,7 @@ TEST_P(AiksTest, CanRenderLinearGradientDecalWithColorFilter) {
   paint.setColorFilter(DlColorFilter::MakeBlend(DlColor::kGreen().withAlpha(64),
                                                 DlBlendMode::kSrcOver));
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
@@ -113,7 +100,7 @@ static void CanRenderLinearGradientWithDithering(AiksTest* aiks_test) {
 
   paint.setColorSource(DlColorSource::MakeLinear(
       {0, 0}, {800, 500}, 2, colors.data(), stops.data(), DlTileMode::kClamp));
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 800, 500), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 800, 500), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 
@@ -133,7 +120,7 @@ static void CanRenderRadialGradientWithDithering(AiksTest* aiks_test) {
 
   paint.setColorSource(DlColorSource::MakeRadial(
       {600, 600}, 600, 2, colors.data(), stops.data(), DlTileMode::kClamp));
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 1200, 1200), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 1200, 1200), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 
@@ -156,7 +143,7 @@ static void CanRenderSweepGradientWithDithering(AiksTest* aiks_test) {
       {100, 100}, /*start=*/45, /*end=*/135, 2, colors.data(), stops.data(),
       DlTileMode::kMirror));
 
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 
@@ -179,7 +166,7 @@ static void CanRenderConicalGradientWithDithering(AiksTest* aiks_test) {
                                                   colors.data(), stops.data(),
                                                   DlTileMode::kMirror));
 
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 
@@ -206,7 +193,7 @@ void CanRenderLinearGradientWithOverlappingStops(AiksTest* aiks_test,
                                                  stops.data(), tile_mode));
 
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 500, 500), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 500, 500), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 }  // namespace
@@ -309,7 +296,7 @@ void CanRenderGradientWithIncompleteStops(AiksTest* aiks_test,
         FML_UNREACHABLE();
     }
 
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, test_size, test_size), paint);
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, test_size, test_size), paint);
     builder.Restore();
   }
 
@@ -364,7 +351,7 @@ void CanRenderLinearGradientManyColors(AiksTest* aiks_test,
                                                  stops.data(), tile_mode));
 
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
   builder.Restore();
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
@@ -404,7 +391,7 @@ void CanRenderLinearGradientWayManyColors(AiksTest* aiks_test,
                                                  stops.size(), colors.data(),
                                                  stops.data(), tile_mode));
 
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 }  // namespace
@@ -456,7 +443,7 @@ TEST_P(AiksTest, CanRenderLinearGradientManyColorsUnevenStops) {
                                                    stops.size(), colors.data(),
                                                    stops.data(), tile_mode));
 
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
     return builder.Build();
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
@@ -479,8 +466,8 @@ TEST_P(AiksTest, CanRenderLinearGradientMaskBlur) {
       DlTileMode::kClamp));
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 20));
 
-  builder.DrawCircle(SkPoint{300, 300}, 200, paint);
-  builder.DrawRect(SkRect::MakeLTRB(100, 300, 500, 600), paint);
+  builder.DrawCircle(DlPoint(300, 300), 200, paint);
+  builder.DrawRect(DlRect::MakeLTRB(100, 300, 500, 600), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -519,7 +506,7 @@ TEST_P(AiksTest, CanRenderRadialGradient) {
     paint.setColorSource(DlColorSource::MakeRadial(
         {100, 100}, 100, 2, colors.data(), stops.data(), tile_mode));
 
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
     return builder.Build();
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
@@ -577,7 +564,7 @@ TEST_P(AiksTest, CanRenderRadialGradientManyColors) {
     paint.setColorSource(DlColorSource::MakeRadial(
         {100, 100}, 100, stops.size(), colors.data(), stops.data(), tile_mode));
 
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
     return builder.Build();
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
@@ -599,7 +586,7 @@ void CanRenderSweepGradient(AiksTest* aiks_test, DlTileMode tile_mode) {
       {100, 100}, /*start=*/45, /*end=*/135, /*stop_count=*/2, colors.data(),
       stops.data(), tile_mode));
 
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 }  // namespace
@@ -646,7 +633,7 @@ void CanRenderSweepGradientManyColors(AiksTest* aiks_test,
                                                 stops.size(), colors.data(),
                                                 stops.data(), tile_mode));
 
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(builder.Build()));
 }
 }  // namespace
@@ -669,7 +656,7 @@ TEST_P(AiksTest, CanRenderConicalGradient) {
   DisplayListBuilder builder;
   DlPaint paint;
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, size * 3, size * 3), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, size * 3, size * 3), paint);
   std::vector<DlColor> colors = {
       DlColor(Color::MakeRGBA8(0xF4, 0x43, 0x36, 0xFF).ToARGB()),
       DlColor(Color::MakeRGBA8(0xFF, 0xEB, 0x3B, 0xFF).ToARGB()),
@@ -701,7 +688,7 @@ TEST_P(AiksTest, CanRenderConicalGradient) {
         std::get<2>(array[i]), std::get<3>(array[i]), std::get<0>(array[i]),
         std::get<1>(array[i]), stops.size(), colors.data(), stops.data(),
         DlTileMode::kClamp));
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, size, size), paint);
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, size, size), paint);
     builder.Restore();
   }
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -727,12 +714,12 @@ TEST_P(AiksTest, CanRenderGradientDecalWithBackground) {
   DisplayListBuilder builder;
   DlPaint paint;
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeLTRB(0, 0, 605, 205), paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 605, 205), paint);
   for (int i = 0; i < 3; i++) {
     builder.Save();
     builder.Translate(i * 200.0f, 0);
     paint.setColorSource(color_sources[i]);
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 200, 200), paint);
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 200, 200), paint);
     builder.Restore();
   }
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -779,12 +766,13 @@ TEST_P(AiksTest, GradientStrokesRenderCorrectly) {
                                                    stops.size(), colors.data(),
                                                    stops.data(), tile_mode));
 
-    SkPath path;
-    path.moveTo(20, 20);
-    path.quadTo({60, 20}, {60, 60});
-    path.close();
-    path.moveTo(60, 20);
-    path.quadTo({60, 60}, {20, 60});
+    DlPathBuilder path_builder;
+    path_builder.MoveTo(DlPoint(20, 20));
+    path_builder.QuadraticCurveTo(DlPoint(60, 20), DlPoint(60, 60));
+    path_builder.Close();
+    path_builder.MoveTo(DlPoint(60, 20));
+    path_builder.QuadraticCurveTo(DlPoint(60, 60), DlPoint(20, 60));
+    DlPath path(path_builder);
 
     builder.Scale(scale, scale);
 
@@ -796,19 +784,17 @@ TEST_P(AiksTest, GradientStrokesRenderCorrectly) {
       auto [handle_a, handle_b] =
           DrawPlaygroundLine(circle_clip_point_a, circle_clip_point_b);
 
-      SkMatrix screen_to_canvas;
-      if (!builder.GetTransform().invert(&screen_to_canvas)) {
+      Matrix ip_matrix = builder.GetMatrix();
+      if (!ip_matrix.IsInvertible()) {
         return nullptr;
       }
-      Matrix ip_matrix = ToMatrix(screen_to_canvas);
+      ip_matrix = ip_matrix.Invert();
       Point point_a = ip_matrix * handle_a * GetContentScale();
       Point point_b = ip_matrix * handle_b * GetContentScale();
 
       Point middle = (point_a + point_b) / 2;
       auto radius = point_a.GetDistance(middle);
-      SkPath circle;
-      circle.addCircle(middle.x, middle.y, radius);
-      builder.ClipPath(circle);
+      builder.ClipPath(DlPath::MakeCircle(middle, radius));
     }
 
     for (auto join :
@@ -844,10 +830,10 @@ TEST_P(AiksTest, FastGradientTestHorizontal) {
                                                  DlTileMode::kClamp));
 
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 300, 300), paint);
   builder.Translate(400, 0);
-  builder.DrawRRect(SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 300, 300), 4, 4),
-                    paint);
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 300, 300), 4, 4), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -867,10 +853,10 @@ TEST_P(AiksTest, FastGradientTestVertical) {
                                                  DlTileMode::kClamp));
 
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 300, 300), paint);
   builder.Translate(400, 0);
-  builder.DrawRRect(SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 300, 300), 4, 4),
-                    paint);
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 300, 300), 4, 4), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -890,10 +876,10 @@ TEST_P(AiksTest, FastGradientTestHorizontalReversed) {
                                                  DlTileMode::kClamp));
 
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 300, 300), paint);
   builder.Translate(400, 0);
-  builder.DrawRRect(SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 300, 300), 4, 4),
-                    paint);
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 300, 300), 4, 4), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -913,10 +899,10 @@ TEST_P(AiksTest, FastGradientTestVerticalReversed) {
                                                  DlTileMode::kClamp));
 
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 300, 300), paint);
   builder.Translate(400, 0);
-  builder.DrawRRect(SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 300, 300), 4, 4),
-                    paint);
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 300, 300), 4, 4), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -937,10 +923,10 @@ TEST_P(AiksTest, VerifyNonOptimizedGradient) {
                                 stops.data(), DlTileMode::kRepeat));
 
   paint.setColor(DlColor::kWhite());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 300, 300), paint);
   builder.Translate(400, 0);
-  builder.DrawRRect(SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 300, 300), 4, 4),
-                    paint);
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 300, 300), 4, 4), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_opacity_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_opacity_unittests.cc
@@ -9,7 +9,6 @@
 #include "flutter/display_list/dl_color.h"
 #include "flutter/display_list/dl_paint.h"
 #include "flutter/testing/testing.h"
-#include "include/core/SkRect.h"
 
 namespace impeller {
 namespace testing {
@@ -26,7 +25,7 @@ TEST_P(AiksTest, DrawOpacityPeephole) {
   alpha.setColor(DlColor::kRed().modulateOpacity(0.5));
 
   builder.SaveLayer(nullptr, &alpha);
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 100, 100), green);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 100, 100), green);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -46,9 +45,9 @@ TEST_P(AiksTest, CanRenderGroupOpacity) {
   alpha.setColor(DlColor::kRed().modulateOpacity(0.5));
 
   builder.SaveLayer(nullptr, &alpha);
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 100, 100), red);
-  builder.DrawRect(SkRect::MakeXYWH(200, 200, 100, 100), green);
-  builder.DrawRect(SkRect::MakeXYWH(400, 400, 100, 100), blue);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 100, 100), red);
+  builder.DrawRect(DlRect::MakeXYWH(200, 200, 100, 100), green);
+  builder.DrawRect(DlRect::MakeXYWH(400, 400, 100, 100), blue);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -65,11 +64,11 @@ TEST_P(AiksTest, CanRenderGroupOpacityToSavelayer) {
 
   // Create a saveLayer that will forward its opacity to another
   // saveLayer, to verify that we correctly distribute opacity.
-  SkRect bounds = SkRect::MakeLTRB(0, 0, 500, 500);
-  builder.SaveLayer(&bounds, &alpha);
-  builder.SaveLayer(&bounds, &alpha);
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 400, 400), red);
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 450, 450), red);
+  DlRect bounds = DlRect::MakeLTRB(0, 0, 500, 500);
+  builder.SaveLayer(bounds, &alpha);
+  builder.SaveLayer(bounds, &alpha);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 400), red);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 450, 450), red);
   builder.Restore();
   builder.Restore();
 

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -11,9 +11,6 @@
 #include "flutter/display_list/effects/dl_runtime_effect.h"
 #include "flutter/impeller/display_list/aiks_unittests.h"
 
-#include "include/core/SkPath.h"
-#include "include/core/SkRRect.h"
-
 namespace impeller {
 namespace testing {
 
@@ -54,10 +51,10 @@ TEST_P(AiksTest, CanRenderClippedRuntimeEffects) {
 
   DisplayListBuilder builder;
   builder.Save();
-  builder.ClipRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 400, 400), 10.0, 10.0),
+  builder.ClipRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(0, 0, 400, 400), 10.0, 10.0),
       DlCanvas::ClipOp::kIntersect);
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 400), paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -106,7 +103,7 @@ TEST_P(AiksTest, CanRenderRuntimeEffectFilter) {
       uniform_data));
 
   DisplayListBuilder builder;
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 400), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -15,8 +15,6 @@
 #include "flutter/testing/testing.h"
 #include "impeller/geometry/matrix.h"
 #include "impeller/typographer/backends/skia/text_frame_skia.h"
-#include "include/core/SkMatrix.h"
-#include "include/core/SkRect.h"
 
 #include "txt/platform.h"
 
@@ -31,7 +29,7 @@ struct TextRenderOptions {
   Scalar font_size = 50;
   Scalar stroke_width = 1;
   DlColor color = DlColor::kYellow();
-  SkPoint position = SkPoint::Make(100, 200);
+  DlPoint position = DlPoint(100, 200);
   std::shared_ptr<DlMaskFilter> filter;
 };
 
@@ -43,9 +41,9 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
   // Draw the baseline.
   DlPaint paint;
   paint.setColor(DlColor::kAqua().withAlpha(255 * 0.25));
-  canvas.DrawRect(SkRect::MakeXYWH(options.position.x() - 50,
-                                   options.position.y(), 900, 10),
-                  paint);
+  canvas.DrawRect(
+      DlRect::MakeXYWH(options.position.x - 50, options.position.y, 900, 10),
+      paint);
 
   // Mark the point at which the text is drawn.
   paint.setColor(DlColor::kRed().withAlpha(255 * 0.25));
@@ -73,7 +71,7 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
   text_paint.setStrokeWidth(options.stroke_width);
   text_paint.setDrawStyle(options.stroke ? DlDrawStyle::kStroke
                                          : DlDrawStyle::kFill);
-  canvas.DrawTextFrame(frame, options.position.x(), options.position.y(),
+  canvas.DrawTextFrame(frame, options.position.x, options.position.y,
                        text_paint);
   return true;
 }
@@ -192,7 +190,7 @@ TEST_P(AiksTest, TextFrameSubpixelAlignment) {
     builder.Scale(GetContentScale().x, GetContentScale().y);
 
     for (size_t i = 0; i < phase_offsets.size(); i++) {
-      SkPoint position = SkPoint::Make(
+      DlPoint position = DlPoint(
           200 +
               magnitude * std::sin((-phase_offsets[i] * k2Pi * phase_variation +
                                     GetSecondsElapsed() * speed)),  //
@@ -316,17 +314,17 @@ TEST_P(AiksTest, CanRenderTextOutsideBoundaries) {
   text_paint.setColor(DlColor::kBlue().withAlpha(255 * 0.8));
 
   struct {
-    SkPoint position;
+    DlPoint position;
     const char* text;
-  } text[] = {{SkPoint::Make(0, 0), "0F0F0F0"},
-              {SkPoint::Make(1, 2), "789"},
-              {SkPoint::Make(1, 3), "456"},
-              {SkPoint::Make(1, 4), "123"},
-              {SkPoint::Make(0, 6), "0F0F0F0"}};
+  } text[] = {{DlPoint(0, 0), "0F0F0F0"},
+              {DlPoint(1, 2), "789"},
+              {DlPoint(1, 3), "456"},
+              {DlPoint(1, 4), "123"},
+              {DlPoint(0, 6), "0F0F0F0"}};
   for (auto& t : text) {
     builder.Save();
-    builder.Translate(t.position.x() * font_size * 2,
-                      t.position.y() * font_size * 1.1);
+    builder.Translate(t.position.x * font_size * 2,
+                      t.position.y * font_size * 1.1);
     {
       auto blob = SkTextBlob::MakeFromString(t.text, sk_font);
       ASSERT_NE(blob, nullptr);
@@ -347,11 +345,10 @@ TEST_P(AiksTest, TextRotated) {
   paint.setColor(DlColor::ARGB(0.1, 0.1, 0.1, 1.0));
   builder.DrawPaint(paint);
 
-  builder.Transform(SkM44::ColMajor(Matrix(0.25, -0.3, 0, -0.002,  //
-                                           0, 0.5, 0, 0,           //
-                                           0, 0, 0.3, 0,           //
-                                           100, 100, 0, 1.3)
-                                        .m));
+  builder.Transform(Matrix(0.25, -0.3, 0, -0.002,  //
+                           0, 0.5, 0, 0,           //
+                           0, 0, 0.3, 0,           //
+                           100, 100, 0, 1.3));
   ASSERT_TRUE(RenderTextInCanvasSkia(
       GetContext(), builder, "the quick brown fox jumped over the lazy dog!.?",
       "Roboto-Regular.ttf"));
@@ -368,7 +365,7 @@ TEST_P(AiksTest, DrawScaledTextWithPerspectiveNoSaveLayer) {
                          0.0, 0.0, 0.0, 1.0) *  //
                   Matrix::MakeRotationY({Degrees{10}});
 
-  builder.Transform(SkM44::ColMajor(matrix.m));
+  builder.Transform(matrix);
 
   ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), builder, "Hello world",
                                      "Roboto-Regular.ttf"));
@@ -385,11 +382,11 @@ TEST_P(AiksTest, DrawScaledTextWithPerspectiveSaveLayer) {
                   Matrix::MakeRotationY({Degrees{10}});
 
   DlPaint save_paint;
-  SkRect window_bounds =
-      SkRect::MakeXYWH(0, 0, GetWindowSize().width, GetWindowSize().height);
+  DlRect window_bounds =
+      DlRect::MakeXYWH(0, 0, GetWindowSize().width, GetWindowSize().height);
   // Note: bounds were not needed by the AIKS version, which may indicate a bug.
-  builder.SaveLayer(&window_bounds, &save_paint);
-  builder.Transform(SkM44::ColMajor(matrix.m));
+  builder.SaveLayer(window_bounds, &save_paint);
+  builder.Transform(matrix);
 
   ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), builder, "Hello world",
                                      "Roboto-Regular.ttf"));
@@ -406,12 +403,11 @@ TEST_P(AiksTest, CanRenderTextWithLargePerspectiveTransform) {
 
   DlPaint save_paint;
   builder.SaveLayer(nullptr, &save_paint);
-  builder.Transform(SkM44::ColMajor(Matrix(2000, 0, 0, 0,   //
-                                           0, 2000, 0, 0,   //
-                                           0, 0, -1, 9000,  //
-                                           0, 0, -1, 7000   //
-                                           )
-                                        .m));
+  builder.Transform(Matrix(2000, 0, 0, 0,   //
+                           0, 2000, 0, 0,   //
+                           0, 0, -1, 9000,  //
+                           0, 0, -1, 7000   //
+                           ));
 
   ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), builder, "Hello world",
                                      "Roboto-Regular.ttf"));
@@ -432,10 +428,10 @@ TEST_P(AiksTest, CanRenderTextWithPerspectiveTransformInSublist) {
                                   0.0, 0.002, 0.0, 1.0);
 
   DlPaint save_paint;
-  SkRect window_bounds =
-      SkRect::MakeXYWH(0, 0, GetWindowSize().width, GetWindowSize().height);
-  builder.SaveLayer(&window_bounds, &save_paint);
-  builder.Transform(SkM44::ColMajor(matrix.m));
+  DlRect window_bounds =
+      DlRect::MakeXYWH(0, 0, GetWindowSize().width, GetWindowSize().height);
+  builder.SaveLayer(window_bounds, &save_paint);
+  builder.Transform(matrix);
   builder.DrawDisplayList(text_display_list, 1.0f);
   builder.Restore();
 
@@ -533,19 +529,20 @@ TEST_P(AiksTest, DifferenceClipsMustRenderIdenticallyAcrossBackends) {
   builder.Save();
   builder.Transform(path_xform);
 
-  SkPath path;
-  path.moveTo(87.5, 349.5);
-  path.lineTo(25.0, 29.5);
-  path.lineTo(150.0, 118.0);
-  path.lineTo(25.0, 118.0);
-  path.lineTo(150.0, 29.5);
-  path.close();
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(87.5, 349.5));
+  path_builder.LineTo(DlPoint(25.0, 29.5));
+  path_builder.LineTo(DlPoint(150.0, 118.0));
+  path_builder.LineTo(DlPoint(25.0, 118.0));
+  path_builder.LineTo(DlPoint(150.0, 29.5));
+  path_builder.Close();
+  DlPath path(path_builder);
 
   DlColor fill_color(1.0, 1.0, 0.0, 0.0, DlColorSpace::kSRGB);
   DlColor stroke_color(1.0, 0.0, 0.0, 0.0, DlColorSpace::kSRGB);
   paint.setColor(fill_color);
   paint.setDrawStyle(DlDrawStyle::kFill);
-  builder.DrawPath(DlPath(path), paint);
+  builder.DrawPath(path, paint);
 
   paint.setColor(stroke_color);
   paint.setStrokeWidth(2.0);

--- a/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
@@ -23,21 +23,11 @@
 #include "impeller/display_list/dl_dispatcher.h"
 #include "impeller/display_list/dl_image_impeller.h"
 #include "impeller/geometry/scalar.h"
-#include "include/core/SkCanvas.h"
-#include "include/core/SkMatrix.h"
-#include "include/core/SkPath.h"
-#include "include/core/SkRefCnt.h"
 
 namespace impeller {
 namespace testing {
 
 using namespace flutter;
-
-namespace {
-SkRect GetCullRect(ISize window_size) {
-  return SkRect::MakeSize(SkSize::Make(window_size.width, window_size.height));
-}
-}  // namespace
 
 TEST_P(AiksTest, CollapsedDrawPaintInSubpass) {
   DisplayListBuilder builder;
@@ -78,7 +68,7 @@ TEST_P(AiksTest, CollapsedDrawPaintInSubpassBackdropFilter) {
 }
 
 TEST_P(AiksTest, ColorMatrixFilterSubpassCollapseOptimization) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   const float matrix[20] = {
       -1.0, 0,    0,    1.0, 0,  //
@@ -97,13 +87,13 @@ TEST_P(AiksTest, ColorMatrixFilterSubpassCollapseOptimization) {
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 200, 200), draw_paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 200, 200), draw_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, LinearToSrgbFilterSubpassCollapseOptimization) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColorFilter(DlColorFilter::MakeLinearToSrgbGamma());
@@ -114,13 +104,13 @@ TEST_P(AiksTest, LinearToSrgbFilterSubpassCollapseOptimization) {
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 200, 200), draw_paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 200, 200), draw_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, SrgbToLinearFilterSubpassCollapseOptimization) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColorFilter(DlColorFilter::MakeLinearToSrgbGamma());
@@ -131,45 +121,45 @@ TEST_P(AiksTest, SrgbToLinearFilterSubpassCollapseOptimization) {
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 200, 200), draw_paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 200, 200), draw_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, TranslucentSaveLayerDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 300, 300), paint);
 
   DlPaint save_paint;
   save_paint.setColor(DlColor::kBlack().withAlpha(128));
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect(SkRect::MakeXYWH(100, 500, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 500, 300, 300), paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, TranslucentSaveLayerWithBlendColorFilterDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 300, 300), paint);
 
   DlPaint save_paint;
   paint.setColor(DlColor::kBlack().withAlpha(128));
   paint.setColorFilter(
       DlColorFilter::MakeBlend(DlColor::kRed(), DlBlendMode::kDstOver));
   builder.Save();
-  builder.ClipRect(SkRect::MakeXYWH(100, 500, 300, 300));
+  builder.ClipRect(DlRect::MakeXYWH(100, 500, 300, 300));
   builder.SaveLayer(nullptr, &paint);
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 500, 300, 300), draw_paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 500, 300, 300), draw_paint);
   builder.Restore();
   builder.Restore();
 
@@ -177,11 +167,11 @@ TEST_P(AiksTest, TranslucentSaveLayerWithBlendColorFilterDrawsCorrectly) {
 }
 
 TEST_P(AiksTest, TranslucentSaveLayerWithBlendImageFilterDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 300, 300), paint);
 
   DlPaint save_paint;
   save_paint.setColor(DlColor::kBlack().withAlpha(128));
@@ -192,30 +182,30 @@ TEST_P(AiksTest, TranslucentSaveLayerWithBlendImageFilterDrawsCorrectly) {
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 500, 300, 300), draw_paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 500, 300, 300), draw_paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, TranslucentSaveLayerWithColorAndImageFilterDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 100, 300, 300), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 100, 300, 300), paint);
 
   DlPaint save_paint;
   save_paint.setColor(DlColor::kBlack().withAlpha(128));
   save_paint.setColorFilter(
       DlColorFilter::MakeBlend(DlColor::kRed(), DlBlendMode::kDstOver));
   builder.Save();
-  builder.ClipRect(SkRect::MakeXYWH(100, 500, 300, 300));
+  builder.ClipRect(DlRect::MakeXYWH(100, 500, 300, 300));
   builder.SaveLayer(nullptr, &save_paint);
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kBlue());
-  builder.DrawRect(SkRect::MakeXYWH(100, 500, 300, 300), draw_paint);
+  builder.DrawRect(DlRect::MakeXYWH(100, 500, 300, 300), draw_paint);
   builder.Restore();
   builder.Restore();
 
@@ -223,7 +213,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorAndImageFilterDrawsCorrectly) {
 }
 
 TEST_P(AiksTest, ImageFilteredUnboundedSaveLayerWithUnboundedContents) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
   builder.Scale(GetContentScale().x, GetContentScale().y);
 
   DlPaint save_paint;
@@ -240,7 +230,7 @@ TEST_P(AiksTest, ImageFilteredUnboundedSaveLayerWithUnboundedContents) {
     // Contrasting rectangle to see interior blurring
     DlPaint draw_rect;
     draw_rect.setColor(DlColor::kBlue());
-    builder.DrawRect(SkRect::MakeLTRB(125, 125, 175, 175), draw_rect);
+    builder.DrawRect(DlRect::MakeLTRB(125, 125, 175, 175), draw_rect);
   }
   builder.Restore();
 
@@ -248,25 +238,25 @@ TEST_P(AiksTest, ImageFilteredUnboundedSaveLayerWithUnboundedContents) {
 }
 
 TEST_P(AiksTest, TranslucentSaveLayerImageDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, SkPoint{100, 100}, DlImageSampling::kMipmapLinear);
+  builder.DrawImage(image, DlPoint(100, 100), DlImageSampling::kMipmapLinear);
 
   DlPaint paint;
   paint.setColor(DlColor::kBlack().withAlpha(128));
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(image, SkPoint{100, 500}, DlImageSampling::kMipmapLinear);
+  builder.DrawImage(image, DlPoint(100, 500), DlImageSampling::kMipmapLinear);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixColorFilterDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, SkPoint{100, 100}, {});
+  builder.DrawImage(image, DlPoint(100, 100), {});
 
   const float matrix[20] = {
       1, 0, 0, 0, 0,  //
@@ -278,17 +268,17 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixColorFilterDrawsCorrectly) {
   paint.setColor(DlColor::kBlack().withAlpha(128));
   paint.setColorFilter(DlColorFilter::MakeMatrix(matrix));
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(image, SkPoint{100, 500}, {});
+  builder.DrawImage(image, DlPoint(100, 500), {});
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixImageFilterDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, SkPoint{100, 100}, {});
+  builder.DrawImage(image, DlPoint(100, 100), {});
 
   const float matrix[20] = {
       1, 0, 0, 0, 0,  //
@@ -300,7 +290,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixImageFilterDrawsCorrectly) {
   paint.setColor(DlColor::kBlack().withAlpha(128));
   paint.setColorFilter(DlColorFilter::MakeMatrix(matrix));
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(image, SkPoint{100, 500}, {});
+  builder.DrawImage(image, DlPoint(100, 500), {});
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -308,10 +298,10 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixImageFilterDrawsCorrectly) {
 
 TEST_P(AiksTest,
        TranslucentSaveLayerWithColorFilterAndImageFilterDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, SkPoint{100, 100}, {});
+  builder.DrawImage(image, DlPoint(100, 100), {});
 
   const float matrix[20] = {
       1, 0,   0, 0,   0,  //
@@ -326,18 +316,18 @@ TEST_P(AiksTest,
   paint.setColorFilter(
       DlColorFilter::MakeBlend(DlColor::kGreen(), DlBlendMode::kModulate));
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(image, SkPoint{100, 500}, {});
+  builder.DrawImage(image, DlPoint(100, 500), {});
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, TranslucentSaveLayerWithAdvancedBlendModeDrawsCorrectly) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 400), paint);
 
   DlPaint save_paint;
   save_paint.setAlpha(128);
@@ -346,7 +336,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithAdvancedBlendModeDrawsCorrectly) {
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kGreen());
-  builder.DrawCircle(SkPoint{200, 200}, 100, draw_paint);
+  builder.DrawCircle(DlPoint(200, 200), 100, draw_paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -356,7 +346,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithAdvancedBlendModeDrawsCorrectly) {
 /// The entire screen is green if successful. If failing, no frames will render,
 /// or the entire screen will be transparent black.
 TEST_P(AiksTest, CanRenderTinyOverlappingSubpasses) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColor(DlColor::kRed());
@@ -367,10 +357,10 @@ TEST_P(AiksTest, CanRenderTinyOverlappingSubpasses) {
 
   DlPaint yellow_paint;
   yellow_paint.setColor(DlColor::kYellow());
-  builder.DrawCircle(SkPoint{100, 100}, 0.1, yellow_paint);
+  builder.DrawCircle(DlPoint(100, 100), 0.1, yellow_paint);
   builder.Restore();
   builder.SaveLayer({});
-  builder.DrawCircle(SkPoint{100, 100}, 0.1, yellow_paint);
+  builder.DrawCircle(DlPoint(100, 100), 0.1, yellow_paint);
   builder.Restore();
 
   DlPaint draw_paint;
@@ -381,7 +371,7 @@ TEST_P(AiksTest, CanRenderTinyOverlappingSubpasses) {
 }
 
 TEST_P(AiksTest, CanRenderDestructiveSaveLayer) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
 
   DlPaint paint;
   paint.setColor(DlColor::kRed());
@@ -396,14 +386,14 @@ TEST_P(AiksTest, CanRenderDestructiveSaveLayer) {
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kGreen());
-  builder.DrawCircle(SkPoint{300, 300}, 100, draw_paint);
+  builder.DrawCircle(DlPoint(300, 300), 100, draw_paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(AiksTest, CanDrawPoints) {
-  std::vector<SkPoint> points = {
+  std::vector<DlPoint> points = {
       {0, 0},      //
       {100, 100},  //
       {100, 0},    //
@@ -425,7 +415,7 @@ TEST_P(AiksTest, CanDrawPoints) {
   DlPaint background;
   background.setColor(DlColor::kBlack());
 
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
   builder.DrawPaint(background);
   builder.Translate(200, 200);
 
@@ -443,7 +433,7 @@ TEST_P(AiksTest, CanDrawPointsWithTextureMap) {
       CreateTextureForFixture("table_mountain_nx.png",
                               /*enable_mipmapping=*/true));
 
-  std::vector<SkPoint> points = {
+  std::vector<DlPoint> points = {
       {0, 0},      //
       {100, 100},  //
       {100, 0},    //
@@ -466,7 +456,7 @@ TEST_P(AiksTest, CanDrawPointsWithTextureMap) {
   paint_square.setColorSource(image_src);
   paint_square.setStrokeWidth(200);
 
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
   builder.Translate(200, 200);
 
   builder.DrawPoints(DlCanvas::PointMode::kPoints, points.size(), points.data(),
@@ -526,23 +516,23 @@ TEST_P(AiksTest, MipmapGenerationWorksCorrectly) {
   DisplayListBuilder builder;
   builder.DrawImageRect(
       image,
-      SkRect::MakeSize(
-          SkSize::Make(texture->GetSize().width, texture->GetSize().height)),
-      SkRect::MakeLTRB(0, 0, 100, 100), DlImageSampling::kMipmapLinear);
+      DlRect::MakeWH(texture->GetSize().width, texture->GetSize().height),
+      DlRect::MakeLTRB(0, 0, 100, 100), DlImageSampling::kMipmapLinear);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 // https://github.com/flutter/flutter/issues/146648
 TEST_P(AiksTest, StrokedPathWithMoveToThenCloseDrawnCorrectly) {
-  SkPath path;
-  path.moveTo(0, 400)
-      .lineTo(0, 0)
-      .lineTo(400, 0)
+  DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(0, 400))
+      .LineTo(DlPoint(0, 0))
+      .LineTo(DlPoint(400, 0))
       // MoveTo implicitly adds a contour, ensure that close doesn't
       // add another nearly-empty contour.
-      .moveTo(0, 400)
-      .close();
+      .MoveTo(DlPoint(0, 400))
+      .Close();
+  DlPath path(path_builder);
 
   DisplayListBuilder builder;
   builder.Translate(50, 50);
@@ -585,7 +575,7 @@ TEST_P(AiksTest, SetContentsWithRegion) {
   auto image = DlImageImpeller::Make(bridge);
 
   DisplayListBuilder builder;
-  builder.DrawImage(image, SkPoint{0, 0}, {});
+  builder.DrawImage(image, DlPoint(0, 0), {});
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -608,7 +598,7 @@ TEST_P(AiksTest, ReleasesTextureOnTeardown) {
         DlImageImpeller::Make(texture), DlTileMode::kClamp, DlTileMode::kClamp,
         DlImageSampling::kLinear, nullptr));
 
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, 600, 600), paint);
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, 600, 600), paint);
 
     ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
   }
@@ -648,7 +638,7 @@ TEST_P(AiksTest, MatrixImageFilterMagnify) {
 
     DlPaint rect_paint;
     rect_paint.setAlpha(0.5 * 255);
-    builder.DrawImage(image, SkPoint{0, 0}, DlImageSampling::kLinear,
+    builder.DrawImage(image, DlPoint(0, 0), DlImageSampling::kLinear,
                       &rect_paint);
     builder.Restore();
 
@@ -663,24 +653,24 @@ TEST_P(AiksTest, ImageFilteredSaveLayerWithUnboundedContents) {
   builder.Scale(GetContentScale().x, GetContentScale().y);
 
   auto test = [&builder](const std::shared_ptr<DlImageFilter>& filter) {
-    auto DrawLine = [&builder](const SkPoint& p0, const SkPoint& p1,
+    auto DrawLine = [&builder](const DlPoint& p0, const DlPoint& p1,
                                const DlPaint& p) {
       DlPaint paint = p;
       paint.setDrawStyle(DlDrawStyle::kStroke);
-      builder.DrawPath(SkPath::Line(p0, p1), paint);
+      builder.DrawPath(DlPath::MakeLine(p0, p1), paint);
     };
     // Registration marks for the edge of the SaveLayer
     DlPaint paint;
     paint.setColor(DlColor::kWhite());
-    DrawLine(SkPoint::Make(75, 100), SkPoint::Make(225, 100), paint);
-    DrawLine(SkPoint::Make(75, 200), SkPoint::Make(225, 200), paint);
-    DrawLine(SkPoint::Make(100, 75), SkPoint::Make(100, 225), paint);
-    DrawLine(SkPoint::Make(200, 75), SkPoint::Make(200, 225), paint);
+    DrawLine(DlPoint(75, 100), DlPoint(225, 100), paint);
+    DrawLine(DlPoint(75, 200), DlPoint(225, 200), paint);
+    DrawLine(DlPoint(100, 75), DlPoint(100, 225), paint);
+    DrawLine(DlPoint(200, 75), DlPoint(200, 225), paint);
 
     DlPaint save_paint;
     save_paint.setImageFilter(filter);
-    SkRect bounds = SkRect::MakeLTRB(100, 100, 200, 200);
-    builder.SaveLayer(&bounds, &save_paint);
+    DlRect bounds = DlRect::MakeLTRB(100, 100, 200, 200);
+    builder.SaveLayer(bounds, &save_paint);
 
     {
       // DrawPaint to verify correct behavior when the contents are unbounded.
@@ -690,7 +680,7 @@ TEST_P(AiksTest, ImageFilteredSaveLayerWithUnboundedContents) {
 
       // Contrasting rectangle to see interior blurring
       paint.setColor(DlColor::kBlue());
-      builder.DrawRect(SkRect::MakeLTRB(125, 125, 175, 175), paint);
+      builder.DrawRect(DlRect::MakeLTRB(125, 125, 175, 175), paint);
     }
     builder.Restore();
   };
@@ -763,8 +753,8 @@ TEST_P(AiksTest, MatrixBackdropFilter) {
     rect_paint.setColor(DlColor::kRed());
     rect_paint.setStrokeWidth(4);
     rect_paint.setDrawStyle(DlDrawStyle::kStroke);
-    builder.DrawRect(SkRect::MakeLTRB(0, 0, 300, 300), rect_paint);
-    builder.DrawCircle(SkPoint::Make(200, 200), 100, paint);
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 300, 300), rect_paint);
+    builder.DrawCircle(DlPoint(200, 200), 100, paint);
     // Should render a second circle, centered on the bottom-right-most edge of
     // the circle.
     DlMatrix matrix = DlMatrix::MakeTranslation({(100 + 100 * k1OverSqrt2),
@@ -791,7 +781,7 @@ TEST_P(AiksTest, MatrixSaveLayerFilter) {
   {
     paint.setColor(DlColor::kGreen().withAlpha(255 * 0.5));
     paint.setBlendMode(DlBlendMode::kPlus);
-    builder.DrawCircle(SkPoint{200, 200}, 100, paint);
+    builder.DrawCircle(DlPoint(200, 200), 100, paint);
     // Should render a second circle, centered on the bottom-right-most edge of
     // the circle.
 
@@ -808,7 +798,7 @@ TEST_P(AiksTest, MatrixSaveLayerFilter) {
     DlPaint circle_paint;
     circle_paint.setColor(DlColor::kGreen().withAlpha(255 * 0.5));
     circle_paint.setBlendMode(DlBlendMode::kPlus);
-    builder.DrawCircle(SkPoint{200, 200}, 100, circle_paint);
+    builder.DrawCircle(DlPoint(200, 200), 100, circle_paint);
     builder.Restore();
   }
   builder.Restore();
@@ -818,7 +808,7 @@ TEST_P(AiksTest, MatrixSaveLayerFilter) {
 
 // Regression test for flutter/flutter#152780
 TEST_P(AiksTest, CanDrawScaledPointsSmallScaleLargeRadius) {
-  std::vector<SkPoint> point = {
+  std::vector<DlPoint> point = {
       {0, 0},  //
   };
 
@@ -827,7 +817,7 @@ TEST_P(AiksTest, CanDrawScaledPointsSmallScaleLargeRadius) {
   paint.setColor(DlColor::kRed());
   paint.setStrokeWidth(100 * 1000000);
 
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
   builder.Translate(200, 200);
   builder.Scale(0.000001, 0.000001);
 
@@ -839,7 +829,7 @@ TEST_P(AiksTest, CanDrawScaledPointsSmallScaleLargeRadius) {
 
 // Regression test for flutter/flutter#152780
 TEST_P(AiksTest, CanDrawScaledPointsLargeScaleSmallRadius) {
-  std::vector<SkPoint> point = {
+  std::vector<DlPoint> point = {
       {0, 0},  //
   };
 
@@ -848,7 +838,7 @@ TEST_P(AiksTest, CanDrawScaledPointsLargeScaleSmallRadius) {
   paint.setColor(DlColor::kRed());
   paint.setStrokeWidth(100 * 0.000001);
 
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
   builder.Translate(200, 200);
   builder.Scale(1000000, 1000000);
 
@@ -861,7 +851,7 @@ TEST_P(AiksTest, TransparentShadowProducesCorrectColor) {
   DisplayListBuilder builder;
   builder.Save();
   builder.Scale(1.618, 1.618);
-  SkPath path = SkPath{}.addRect(SkRect::MakeXYWH(0, 0, 200, 100));
+  DlPath path = DlPath::MakeRect(DlRect::MakeXYWH(0, 0, 200, 100));
 
   builder.DrawShadow(path, flutter::DlColor::kTransparent(), 15, false, 1);
   builder.Restore();
@@ -872,7 +862,7 @@ TEST_P(AiksTest, TransparentShadowProducesCorrectColor) {
 // Regression test for https://github.com/flutter/flutter/issues/130613
 TEST_P(AiksTest, DispatcherDoesNotCullPerspectiveTransformedChildDisplayLists) {
   flutter::DisplayListBuilder sub_builder(true);
-  sub_builder.DrawRect(SkRect::MakeXYWH(0, 0, 50, 50),
+  sub_builder.DrawRect(DlRect::MakeXYWH(0, 0, 50, 50),
                        flutter::DlPaint(flutter::DlColor::kRed()));
   auto display_list = sub_builder.Build();
 
@@ -906,18 +896,18 @@ TEST_P(AiksTest, BackdropRestoreUsesCorrectCoverageForFirstRestoredClip) {
 
   DlPaint paint;
   // Add a difference clip that cuts out the bottom right corner
-  builder.ClipRect(SkRect::MakeLTRB(50, 50, 100, 100),
+  builder.ClipRect(DlRect::MakeLTRB(50, 50, 100, 100),
                    DlCanvas::ClipOp::kDifference);
 
   // Draw a red rectangle that's going to be completely covered by green later.
   paint.setColor(DlColor::kRed());
-  builder.DrawRect(SkRect::MakeLTRB(0, 0, 100, 100), paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), paint);
 
   // Add a clip restricting the backdrop filter to the top right corner.
   auto count = builder.GetSaveCount();
   builder.Save();
   {
-    builder.ClipRect(SkRect::MakeLTRB(0, 0, 100, 100));
+    builder.ClipRect(DlRect::MakeLTRB(0, 0, 100, 100));
     {
       // Create a save layer with a backdrop blur filter.
       auto backdrop_filter =
@@ -929,7 +919,7 @@ TEST_P(AiksTest, BackdropRestoreUsesCorrectCoverageForFirstRestoredClip) {
 
   // Finally, overwrite all the previous stuff with green.
   paint.setColor(DlColor::kGreen());
-  builder.DrawRect(SkRect::MakeLTRB(0, 0, 100, 100), paint);
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -938,9 +928,9 @@ TEST_P(AiksTest, CanPictureConvertToImage) {
   DisplayListBuilder recorder_canvas;
   DlPaint paint;
   paint.setColor(DlColor::RGBA(0.9568, 0.2627, 0.2118, 1.0));
-  recorder_canvas.DrawRect(SkRect::MakeXYWH(100.0, 100.0, 600, 600), paint);
+  recorder_canvas.DrawRect(DlRect::MakeXYWH(100.0, 100.0, 600, 600), paint);
   paint.setColor(DlColor::RGBA(0.1294, 0.5882, 0.9529, 1.0));
-  recorder_canvas.DrawRect(SkRect::MakeXYWH(200.0, 200.0, 600, 600), paint);
+  recorder_canvas.DrawRect(DlRect::MakeXYWH(200.0, 200.0, 600, 600), paint);
 
   DisplayListBuilder canvas;
   AiksContext renderer(GetContext(), nullptr);
@@ -950,9 +940,9 @@ TEST_P(AiksTest, CanPictureConvertToImage) {
   auto image =
       DisplayListToTexture(recorder_canvas.Build(), {1000, 1000}, renderer);
   if (image) {
-    canvas.DrawImage(DlImageImpeller::Make(image), SkPoint{}, {});
+    canvas.DrawImage(DlImageImpeller::Make(image), DlPoint(), {});
     paint.setColor(DlColor::RGBA(0.1, 0.1, 0.1, 0.2));
-    canvas.DrawRect(SkRect::MakeSize({1000, 1000}), paint);
+    canvas.DrawRect(DlRect::MakeWH(1000, 1000), paint);
   }
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.Build()));
@@ -974,11 +964,11 @@ TEST_P(AiksTest, CanEmptyPictureConvertToImage) {
   auto result_image =
       DisplayListToTexture(builder.Build(), ISize{1000, 1000}, renderer);
   if (result_image) {
-    recorder_builder.DrawImage(DlImageImpeller::Make(result_image), SkPoint{},
+    recorder_builder.DrawImage(DlImageImpeller::Make(result_image), DlPoint(),
                                {});
 
     paint.setColor(DlColor::RGBA(0.1, 0.1, 0.1, 0.2));
-    recorder_builder.DrawRect(SkRect::MakeSize({1000, 1000}), paint);
+    recorder_builder.DrawRect(DlRect::MakeWH(1000, 1000), paint);
   }
 
   ASSERT_TRUE(OpenPlaygroundHere(recorder_builder.Build()));
@@ -989,7 +979,7 @@ TEST_P(AiksTest, DepthValuesForLineMode) {
   // have the same depth values.
   DisplayListBuilder builder;
 
-  SkPath path = SkPath::Circle(100, 100, 100);
+  DlPath path = DlPath::MakeCircle(DlPoint(100, 100), 100);
 
   builder.DrawPath(path, DlPaint()
                              .setColor(DlColor::kRed())
@@ -1018,7 +1008,7 @@ TEST_P(AiksTest, DepthValuesForPolygonMode) {
   // have the same depth values.
   DisplayListBuilder builder;
 
-  SkPath path = SkPath::Circle(100, 100, 100);
+  DlPath path = DlPath::MakeCircle(DlPoint(100, 100), 100);
 
   builder.DrawPath(path, DlPaint()
                              .setColor(DlColor::kRed())

--- a/engine/src/flutter/impeller/display_list/dl_atlas_geometry.cc
+++ b/engine/src/flutter/impeller/display_list/dl_atlas_geometry.cc
@@ -11,7 +11,6 @@
 #include "impeller/entity/texture_fill.vert.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/point.h"
-#include "third_party/skia/include/core/SkPoint.h"
 
 namespace impeller {
 

--- a/engine/src/flutter/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_golden_blur_unittests.cc
@@ -21,7 +21,7 @@ using impeller::Font;
 namespace {
 struct TextRenderOptions {
   bool stroke = false;
-  SkScalar font_size = 50;
+  DlScalar font_size = 50;
   DlColor color = DlColor::kYellow();
   std::shared_ptr<DlMaskFilter> mask_filter;
 };
@@ -29,7 +29,7 @@ struct TextRenderOptions {
 bool RenderTextInCanvasSkia(DlCanvas* canvas,
                             const std::string& text,
                             const std::string_view& font_fixture,
-                            SkPoint position,
+                            DlPoint position,
                             const TextRenderOptions& options = {}) {
   auto c_font_fixture = std::string(font_fixture);
   auto mapping = flutter::testing::OpenFixtureAsSkData(c_font_fixture.c_str());
@@ -52,7 +52,7 @@ bool RenderTextInCanvasSkia(DlCanvas* canvas,
   // text_paint.stroke_width = 1;
   // text_paint.style =
   //     options.stroke ? Paint::Style::kStroke : Paint::Style::kFill;
-  canvas->DrawTextFrame(frame, position.x(), position.y(), text_paint);
+  canvas->DrawTextFrame(frame, position.x, position.y, text_paint);
   return true;
 }
 
@@ -70,13 +70,13 @@ TEST_P(DlGoldenTest, TextBlurMaskFilterRespectCTM) {
         DlBlurMaskFilter::Make(DlBlurStyle::kNormal, /*sigma=*/10,
                                /*respect_ctm=*/true);
     ASSERT_TRUE(RenderTextInCanvasSkia(canvas, "hello world",
-                                       "Roboto-Regular.ttf",
-                                       SkPoint::Make(101, 101), options));
+                                       "Roboto-Regular.ttf",  //
+                                       DlPoint(101, 101), options));
     options.mask_filter = nullptr;
     options.color = DlColor::kRed();
     ASSERT_TRUE(RenderTextInCanvasSkia(canvas, "hello world",
-                                       "Roboto-Regular.ttf",
-                                       SkPoint::Make(100, 100), options));
+                                       "Roboto-Regular.ttf",  //
+                                       DlPoint(100, 100), options));
   };
 
   DisplayListBuilder builder;
@@ -97,13 +97,13 @@ TEST_P(DlGoldenTest, TextBlurMaskFilterDisrespectCTM) {
         DlBlurMaskFilter::Make(DlBlurStyle::kNormal, /*sigma=*/10,
                                /*respect_ctm=*/false);
     ASSERT_TRUE(RenderTextInCanvasSkia(canvas, "hello world",
-                                       "Roboto-Regular.ttf",
-                                       SkPoint::Make(101, 101), options));
+                                       "Roboto-Regular.ttf",  //
+                                       DlPoint(101, 101), options));
     options.mask_filter = nullptr;
     options.color = DlColor::kRed();
     ASSERT_TRUE(RenderTextInCanvasSkia(canvas, "hello world",
-                                       "Roboto-Regular.ttf",
-                                       SkPoint::Make(100, 100), options));
+                                       "Roboto-Regular.ttf",  //
+                                       DlPoint(100, 100), options));
   };
 
   DisplayListBuilder builder;
@@ -161,13 +161,13 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     canvas->Scale(content_scale.x, content_scale.y);
 
     DlPaint paint;
-    canvas->DrawImage(images[0], SkPoint::Make(10.135, 10.36334),
+    canvas->DrawImage(images[0], DlPoint(10.135, 10.36334),
                       DlImageSampling::kLinear, &paint);
 
-    SkRect save_layer_bounds = SkRect::MakeLTRB(0, 0, 1024, 768);
+    DlRect save_layer_bounds = DlRect::MakeLTRB(0, 0, 1024, 768);
     auto blur = DlImageFilter::MakeBlur(sigma, sigma, DlTileMode::kDecal);
-    canvas->ClipRect(SkRect::MakeLTRB(11.125, 10.3737, 911.25, 755.3333));
-    canvas->SaveLayer(&save_layer_bounds, /*paint=*/nullptr, blur.get());
+    canvas->ClipRect(DlRect::MakeLTRB(11.125, 10.3737, 911.25, 755.3333));
+    canvas->SaveLayer(save_layer_bounds, /*paint=*/nullptr, blur.get());
     canvas->Restore();
   };
 

--- a/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
@@ -44,7 +44,7 @@ TEST_P(DlGoldenTest, CanRenderImage) {
     FML_CHECK(images.size() >= 1);
     DlPaint paint;
     paint.setColor(DlColor::kRed());
-    canvas->DrawImage(images[0], SkPoint::Make(100.0, 100.0),
+    canvas->DrawImage(images[0], DlPoint(100.0, 100.0),
                       DlImageSampling::kLinear, &paint);
   };
 
@@ -65,29 +65,29 @@ TEST_P(DlGoldenTest, Bug147807) {
     canvas->Scale(content_scale.x, content_scale.y);
     DlPaint paint;
     paint.setColor(DlColor(0xfffef7ff));
-    canvas->DrawRect(SkRect::MakeLTRB(0, 0, 375, 667), paint);
+    canvas->DrawRect(DlRect::MakeLTRB(0, 0, 375, 667), paint);
     paint.setColor(DlColor(0xffff9800));
-    canvas->DrawRect(SkRect::MakeLTRB(0, 0, 187.5, 333.5), paint);
+    canvas->DrawRect(DlRect::MakeLTRB(0, 0, 187.5, 333.5), paint);
     paint.setColor(DlColor(0xff9c27b0));
-    canvas->DrawRect(SkRect::MakeLTRB(187.5, 0, 375, 333.5), paint);
+    canvas->DrawRect(DlRect::MakeLTRB(187.5, 0, 375, 333.5), paint);
     paint.setColor(DlColor(0xff4caf50));
-    canvas->DrawRect(SkRect::MakeLTRB(0, 333.5, 187.5, 667), paint);
+    canvas->DrawRect(DlRect::MakeLTRB(0, 333.5, 187.5, 667), paint);
     paint.setColor(DlColor(0xfff44336));
-    canvas->DrawRect(SkRect::MakeLTRB(187.5, 333.5, 375, 667), paint);
+    canvas->DrawRect(DlRect::MakeLTRB(187.5, 333.5, 375, 667), paint);
 
     canvas->Save();
     {
-      canvas->ClipRRect(
-          SkRRect::MakeOval(SkRect::MakeLTRB(201.25, 10, 361.25, 170)),
+      canvas->ClipRoundRect(
+          DlRoundRect::MakeOval(DlRect::MakeLTRB(201.25, 10, 361.25, 170)),
           DlCanvas::ClipOp::kIntersect, true);
-      SkRect save_layer_bounds = SkRect::MakeLTRB(201.25, 10, 361.25, 170);
+      DlRect save_layer_bounds = DlRect::MakeLTRB(201.25, 10, 361.25, 170);
       auto backdrop =
           DlImageFilter::MakeMatrix(DlMatrix::MakeRow(3, 0, 0.0, -280,  //
                                                       0, 3, 0.0, -920,  //
                                                       0, 0, 1.0, 0.0,   //
                                                       0, 0, 0.0, 1.0),
                                     DlImageSampling::kLinear);
-      canvas->SaveLayer(&save_layer_bounds, /*paint=*/nullptr, backdrop.get());
+      canvas->SaveLayer(save_layer_bounds, /*paint=*/nullptr, backdrop.get());
       {
         canvas->Translate(201.25, 10);
         auto paint = DlPaint()
@@ -95,7 +95,7 @@ TEST_P(DlGoldenTest, Bug147807) {
                          .setColor(DlColor(0xff2196f3))
                          .setStrokeWidth(5)
                          .setDrawStyle(DlDrawStyle::kStroke);
-        canvas->DrawCircle(SkPoint::Make(80, 80), 80, paint);
+        canvas->DrawCircle(DlPoint(80, 80), 80, paint);
       }
       canvas->Restore();
     }
@@ -122,14 +122,16 @@ void DrawBlurGrid(DlCanvas* canvas) {
     auto blur_filter = std::make_shared<flutter::DlBlurMaskFilter>(
         flutter::DlBlurStyle::kNormal, blur_radius);
     paint.setMaskFilter(blur_filter);
-    SkRRect rrect;
     Scalar yval = gap + i * (gap + height);
-    rrect.setNinePatch(SkRect::MakeXYWH(gap, yval, width, height), 10, 10, 10,
-                       10);
-    canvas->DrawRRect(rrect, paint);
-    rrect.setNinePatch(SkRect::MakeXYWH(2.0 * gap + width, yval, width, height),
-                       9, 10, 10, 10);
-    canvas->DrawRRect(rrect, paint);
+    canvas->DrawRoundRect(
+        DlRoundRect::MakeNinePatch(DlRect::MakeXYWH(gap, yval, width, height),
+                                   10, 10, 10, 10),
+        paint);
+    canvas->DrawRoundRect(
+        DlRoundRect::MakeNinePatch(
+            DlRect::MakeXYWH(2.0 * gap + width, yval, width, height),  //
+            9, 10, 10, 10),
+        paint);
   }
 }
 }  // namespace
@@ -200,51 +202,64 @@ TEST_P(DlGoldenTest, FastVsGeneralGaussianMaskBlur) {
       DlColor::kMaroon(),
   };
 
-  auto make_rrect_path = [](const SkRect& rect, DlScalar rx,
-                            DlScalar ry) -> SkPath {
-    auto add_corner = [](SkPath& path, SkPoint rCorner, SkPoint rEnd) {
+  auto make_rrect_path = [](const DlRect& rect, DlScalar rx,
+                            DlScalar ry) -> DlPath {
+    auto add_corner = [](DlPathBuilder& path_builder, DlPoint corner,
+                         DlVector2 relative_from, DlVector2 relative_to,
+                         bool first) {
       static const auto magic = impeller::PathBuilder::kArcApproximationMagic;
-      path.rCubicTo(rCorner.fX * (1.0f - magic), rCorner.fY * (1.0f - magic),
-                    rCorner.fX + rEnd.fX * magic, rCorner.fY + rEnd.fY * magic,
-                    rCorner.fX + rEnd.fX, rCorner.fY + rEnd.fY);
+
+      if (first) {
+        path_builder.MoveTo(corner + relative_from);
+      } else {
+        path_builder.LineTo(corner + relative_from);
+      }
+      // These fractions should be (1 - magic) to make a proper rrect
+      // path, but historically these equations were as written here.
+      // On the plus side, they ensure that we will not optimize this
+      // path as "Hey, look, it's an RRect", but the DrawPath gaussians
+      // will otherwise not be identical to the versions drawn with
+      // DrawRoundRect
+      path_builder.CubicCurveTo(corner + relative_from * magic,
+                                corner + relative_to * magic,
+                                corner + relative_to);
     };
 
-    SkPath path;
-    path.moveTo(rect.fRight - rx, rect.fTop);
-    add_corner(path, {rx, 0.0f}, {0.0f, ry});
-    path.lineTo(rect.fRight, rect.fBottom - ry);
-    add_corner(path, {0.0f, ry}, {-rx, 0.0f});
-    path.lineTo(rect.fLeft + rx, rect.fBottom);
-    add_corner(path, {-rx, 0.0f}, {0.0f, -ry});
-    path.lineTo(rect.fLeft, rect.fTop + ry);
-    add_corner(path, {0.0f, -ry}, {rx, 0.0f});
-    path.close();
-    return path;
+    DlPathBuilder path_builder;
+    add_corner(path_builder, rect.GetRightTop(),  //
+               DlVector2(-rx, 0.0f), DlVector2(0.0f, ry), true);
+    add_corner(path_builder, rect.GetRightBottom(),  //
+               DlVector2(0.0f, -ry), DlVector2(-rx, 0.0f), false);
+    add_corner(path_builder, rect.GetLeftBottom(),  //
+               DlVector2(rx, 0.0f), DlVector2(0.0f, -ry), false);
+    add_corner(path_builder, rect.GetLeftTop(),  //
+               DlVector2(0.0f, ry), DlVector2(rx, 0.0f), false);
+    return DlPath(path_builder);
   };
 
   for (size_t i = 0; i < blur_sigmas.size(); i++) {
-    auto rect = SkRect::MakeXYWH(i * 320.0f + 50.0f, 50.0f, 100.0f, 100.0f);
+    auto rect = DlRect::MakeXYWH(i * 320.0f + 50.0f, 50.0f, 100.0f, 100.0f);
     DlPaint paint = DlPaint()  //
                         .setColor(blur_colors[i])
                         .setMaskFilter(DlBlurMaskFilter::Make(
                             DlBlurStyle::kNormal, blur_sigmas[i]));
 
-    builder.DrawRRect(SkRRect::MakeRectXY(rect, 10.0f, 10.0f), paint);
-    rect = rect.makeOffset(150.0f, 0.0f);
+    builder.DrawRoundRect(DlRoundRect::MakeRectXY(rect, 10.0f, 10.0f), paint);
+    rect = rect.Shift(150.0f, 0.0f);
     builder.DrawPath(make_rrect_path(rect, 10.0f, 10.0f), paint);
-    rect = rect.makeOffset(-150.0f, 0.0f);
+    rect = rect.Shift(-150.0f, 0.0f);
 
-    rect = rect.makeOffset(0.0f, 200.0f);
-    builder.DrawRRect(SkRRect::MakeRectXY(rect, 10.0f, 30.0f), paint);
-    rect = rect.makeOffset(150.0f, 0.0f);
+    rect = rect.Shift(0.0f, 200.0f);
+    builder.DrawRoundRect(DlRoundRect::MakeRectXY(rect, 10.0f, 30.0f), paint);
+    rect = rect.Shift(150.0f, 0.0f);
     builder.DrawPath(make_rrect_path(rect, 10.0f, 20.0f), paint);
-    rect = rect.makeOffset(-150.0f, 0.0f);
+    rect = rect.Shift(-150.0f, 0.0f);
 
-    rect = rect.makeOffset(0.0f, 200.0f);
-    builder.DrawRRect(SkRRect::MakeRectXY(rect, 30.0f, 10.0f), paint);
-    rect = rect.makeOffset(150.0f, 0.0f);
+    rect = rect.Shift(0.0f, 200.0f);
+    builder.DrawRoundRect(DlRoundRect::MakeRectXY(rect, 30.0f, 10.0f), paint);
+    rect = rect.Shift(150.0f, 0.0f);
     builder.DrawPath(make_rrect_path(rect, 20.0f, 10.0f), paint);
-    rect = rect.makeOffset(-150.0f, 0.0f);
+    rect = rect.Shift(-150.0f, 0.0f);
   }
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -292,12 +307,12 @@ TEST_P(DlGoldenTest, DashedLinesTest) {
 
     // Make sure the rendering op responds appropriately to clipping
     canvas->Save();
-    SkPath clip_path = SkPath();
-    clip_path.moveTo(275.0f, 225.0f);
-    clip_path.lineTo(325.0f, 275.0f);
-    clip_path.lineTo(275.0f, 325.0f);
-    clip_path.lineTo(225.0f, 275.0f);
-    canvas->ClipPath(clip_path);
+    DlPathBuilder path_builder;
+    path_builder.MoveTo(DlPoint(275.0f, 225.0f));
+    path_builder.LineTo(DlPoint(325.0f, 275.0f));
+    path_builder.LineTo(DlPoint(275.0f, 325.0f));
+    path_builder.LineTo(DlPoint(225.0f, 275.0f));
+    canvas->ClipPath(DlPath(path_builder));
     canvas->DrawColor(DlColor::kYellow());
     draw_one(DlStrokeCap::kRound, 275.0f, 275.0f, 15.0f, 10.0f);
     canvas->Restore();

--- a/engine/src/flutter/impeller/display_list/dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_unittests.cc
@@ -30,10 +30,6 @@
 #include "impeller/geometry/scalar.h"
 #include "impeller/playground/widgets.h"
 #include "third_party/imgui/imgui.h"
-#include "third_party/skia/include/core/SkBlurTypes.h"
-#include "third_party/skia/include/core/SkClipOp.h"
-#include "third_party/skia/include/core/SkPathBuilder.h"
-#include "third_party/skia/include/core/SkRRect.h"
 
 namespace impeller {
 namespace testing {
@@ -48,7 +44,7 @@ INSTANTIATE_PLAYGROUND_SUITE(DisplayListTest);
 
 TEST_P(DisplayListTest, CanDrawRect) {
   flutter::DisplayListBuilder builder;
-  builder.DrawRect(SkRect::MakeXYWH(10, 10, 100, 100),
+  builder.DrawRect(DlRect::MakeXYWH(10, 10, 100, 100),
                    flutter::DlPaint(flutter::DlColor::kBlue()));
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -98,7 +94,7 @@ TEST_P(DisplayListTest, CanDrawTextWithSaveLayer) {
 TEST_P(DisplayListTest, CanDrawImage) {
   auto texture = CreateTextureForFixture("embarcadero.jpg");
   flutter::DisplayListBuilder builder;
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                     flutter::DlImageSampling::kNearestNeighbor, nullptr);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -111,8 +107,11 @@ TEST_P(DisplayListTest, CanDrawCapsAndJoins) {
   paint.setStrokeWidth(30);
   paint.setColor(flutter::DlColor::kRed());
 
-  auto path =
-      SkPathBuilder{}.moveTo(-50, 0).lineTo(0, -50).lineTo(50, 0).snapshot();
+  flutter::DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(-50, 0));
+  path_builder.LineTo(DlPoint(0, -50));
+  path_builder.LineTo(DlPoint(50, 0));
+  flutter::DlPath path(path_builder);
 
   builder.Translate(100, 100);
   {
@@ -197,7 +196,7 @@ TEST_P(DisplayListTest, CanDrawArc) {
     paint.setStrokeCap(cap);
     paint.setStrokeJoin(flutter::DlStrokeJoin::kMiter);
     paint.setStrokeMiter(10);
-    auto rect = SkRect::MakeLTRB(p1.x, p1.y, p2.x, p2.y);
+    auto rect = DlRect::MakeLTRB(p1.x, p1.y, p2.x, p2.y);
     paint.setColor(flutter::DlColor::kGreen());
     paint.setStrokeWidth(2);
     builder.DrawRect(rect, paint);
@@ -271,29 +270,30 @@ TEST_P(DisplayListTest, StrokedPathsDrawCorrectly) {
 
     // Rectangle
     builder.Translate(100, 100);
-    builder.DrawRect(SkRect::MakeSize({100, 100}), paint);
+    builder.DrawRect(DlRect::MakeWH(100, 100), paint);
 
     // Rounded rectangle
     builder.Translate(150, 0);
-    builder.DrawRRect(SkRRect::MakeRectXY(SkRect::MakeSize({100, 50}), 10, 10),
-                      paint);
+    builder.DrawRoundRect(
+        DlRoundRect::MakeRectXY(DlRect::MakeWH(100, 50), 10, 10), paint);
 
     // Double rounded rectangle
     builder.Translate(150, 0);
-    builder.DrawDRRect(
-        SkRRect::MakeRectXY(SkRect::MakeSize({100, 50}), 10, 10),
-        SkRRect::MakeRectXY(SkRect::MakeXYWH(10, 10, 80, 30), 10, 10), paint);
+    builder.DrawDiffRoundRect(
+        DlRoundRect::MakeRectXY(DlRect::MakeWH(100, 50), 10, 10),
+        DlRoundRect::MakeRectXY(DlRect::MakeXYWH(10, 10, 80, 30), 10, 10),
+        paint);
 
     // Contour with duplicate join points
     {
       builder.Translate(150, 0);
-      SkPath path;
-      path.moveTo(0, 0);
-      path.lineTo(0, 0);
-      path.lineTo({100, 0});
-      path.lineTo({100, 0});
-      path.lineTo({100, 100});
-      builder.DrawPath(path, paint);
+      flutter::DlPathBuilder path_builder;
+      path_builder.MoveTo(DlPoint(0, 0));
+      path_builder.LineTo(DlPoint(0, 0));
+      path_builder.LineTo(DlPoint(100, 0));
+      path_builder.LineTo(DlPoint(100, 0));
+      path_builder.LineTo(DlPoint(100, 100));
+      builder.DrawPath(DlPath(path_builder), paint);
     }
 
     // Contour with duplicate start and end points
@@ -303,26 +303,27 @@ TEST_P(DisplayListTest, StrokedPathsDrawCorrectly) {
     {
       builder.Save();
 
-      SkPath line_path;
-      line_path.moveTo(0, 0);
-      line_path.moveTo(0, 0);
-      line_path.lineTo({0, 0});
-      line_path.lineTo({0, 0});
-      line_path.lineTo({50, 50});
-      line_path.lineTo({50, 50});
-      line_path.lineTo({100, 0});
-      line_path.lineTo({100, 0});
+      flutter::DlPathBuilder line_path_builder;
+      line_path_builder.MoveTo(DlPoint(0, 0));
+      line_path_builder.MoveTo(DlPoint(0, 0));
+      line_path_builder.LineTo(DlPoint(0, 0));
+      line_path_builder.LineTo(DlPoint(0, 0));
+      line_path_builder.LineTo(DlPoint(50, 50));
+      line_path_builder.LineTo(DlPoint(50, 50));
+      line_path_builder.LineTo(DlPoint(100, 0));
+      line_path_builder.LineTo(DlPoint(100, 0));
+      DlPath line_path(line_path_builder);
       builder.DrawPath(line_path, paint);
 
       builder.Translate(0, 100);
       builder.DrawPath(line_path, paint);
 
       builder.Translate(0, 100);
-      SkPath line_path2;
-      line_path2.moveTo(0, 0);
-      line_path2.lineTo(0, 0);
-      line_path2.lineTo(0, 0);
-      builder.DrawPath(line_path2, paint);
+      flutter::DlPathBuilder line_path_builder2;
+      line_path_builder2.MoveTo(DlPoint(0, 0));
+      line_path_builder2.LineTo(DlPoint(0, 0));
+      line_path_builder2.LineTo(DlPoint(0, 0));
+      builder.DrawPath(DlPath(line_path_builder2), paint);
 
       builder.Restore();
     }
@@ -332,22 +333,28 @@ TEST_P(DisplayListTest, StrokedPathsDrawCorrectly) {
     {
       builder.Save();
 
-      SkPath cubic_path;
-      cubic_path.moveTo({0, 0});
-      cubic_path.cubicTo(0, 0, 140.0, 100.0, 140, 20);
-      builder.DrawPath(cubic_path, paint);
+      flutter::DlPathBuilder cubic_path;
+      cubic_path.MoveTo(DlPoint(0, 0));
+      cubic_path.CubicCurveTo(DlPoint(0, 0),          //
+                              DlPoint(140.0, 100.0),  //
+                              DlPoint(140, 20));
+      builder.DrawPath(DlPath(cubic_path), paint);
 
       builder.Translate(0, 100);
-      SkPath cubic_path2;
-      cubic_path2.moveTo({0, 0});
-      cubic_path2.cubicTo(0, 0, 0, 0, 150, 150);
-      builder.DrawPath(cubic_path2, paint);
+      flutter::DlPathBuilder cubic_path2;
+      cubic_path2.MoveTo(DlPoint(0, 0));
+      cubic_path2.CubicCurveTo(DlPoint(0, 0),  //
+                               DlPoint(0, 0),  //
+                               DlPoint(150, 150));
+      builder.DrawPath(DlPath(cubic_path2), paint);
 
       builder.Translate(0, 100);
-      SkPath cubic_path3;
-      cubic_path3.moveTo({0, 0});
-      cubic_path3.cubicTo(0, 0, 0, 0, 0, 0);
-      builder.DrawPath(cubic_path3, paint);
+      flutter::DlPathBuilder cubic_path3;
+      cubic_path3.MoveTo(DlPoint(0, 0));
+      cubic_path3.CubicCurveTo(DlPoint(0, 0),  //
+                               DlPoint(0, 0),  //
+                               DlPoint(0, 0));
+      builder.DrawPath(DlPath(cubic_path3), paint);
 
       builder.Restore();
     }
@@ -357,24 +364,24 @@ TEST_P(DisplayListTest, StrokedPathsDrawCorrectly) {
     {
       builder.Save();
 
-      SkPath quad_path;
-      quad_path.moveTo(0, 0);
-      quad_path.moveTo(0, 0);
-      quad_path.quadTo({100, 40}, {50, 80});
-      builder.DrawPath(quad_path, paint);
+      flutter::DlPathBuilder quad_path;
+      quad_path.MoveTo(DlPoint(0, 0));
+      quad_path.MoveTo(DlPoint(0, 0));
+      quad_path.QuadraticCurveTo(DlPoint(100, 40), DlPoint(50, 80));
+      builder.DrawPath(DlPath(quad_path), paint);
 
       builder.Translate(0, 150);
-      SkPath quad_path2;
-      quad_path2.moveTo(0, 0);
-      quad_path2.moveTo(0, 0);
-      quad_path2.quadTo({0, 0}, {100, 100});
-      builder.DrawPath(quad_path2, paint);
+      flutter::DlPathBuilder quad_path2;
+      quad_path2.MoveTo(DlPoint(0, 0));
+      quad_path2.MoveTo(DlPoint(0, 0));
+      quad_path2.QuadraticCurveTo(DlPoint(0, 0), DlPoint(100, 100));
+      builder.DrawPath(DlPath(quad_path2), paint);
 
       builder.Translate(0, 100);
-      SkPath quad_path3;
-      quad_path3.moveTo(0, 0);
-      quad_path3.quadTo({0, 0}, {0, 0});
-      builder.DrawPath(quad_path3, paint);
+      flutter::DlPathBuilder quad_path3;
+      quad_path3.MoveTo(DlPoint(0, 0));
+      quad_path3.QuadraticCurveTo(DlPoint(0, 0), DlPoint(0, 0));
+      builder.DrawPath(DlPath(quad_path3), paint);
 
       builder.Restore();
     }
@@ -391,11 +398,10 @@ TEST_P(DisplayListTest, CanDrawWithOddPathWinding) {
   paint.setDrawStyle(flutter::DlDrawStyle::kFill);
 
   builder.Translate(300, 300);
-  SkPath path;
-  path.setFillType(SkPathFillType::kEvenOdd);
-  path.addCircle(0, 0, 100);
-  path.addCircle(0, 0, 50);
-  builder.DrawPath(path, paint);
+  flutter::DlPathBuilder path_builder;
+  path_builder.AddCircle(DlPoint(0, 0), 100);
+  path_builder.AddCircle(DlPoint(0, 0), 50);
+  builder.DrawPath(DlPath(path_builder, flutter::DlPathFillType::kOdd), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -417,12 +423,12 @@ TEST_P(DisplayListTest, CanDrawAnOpenPath) {
   // 1. (50, height)
   // 2. (width, height)
   // 3. (width, 50)
-  SkPath path;
-  path.moveTo(50, 50);
-  path.lineTo(50, 100);
-  path.lineTo(100, 100);
-  path.lineTo(100, 50);
-  builder.DrawPath(path, paint);
+  flutter::DlPathBuilder path_builder;
+  path_builder.MoveTo(DlPoint(50, 50));
+  path_builder.LineTo(DlPoint(50, 100));
+  path_builder.LineTo(DlPoint(100, 100));
+  path_builder.LineTo(DlPoint(100, 50));
+  builder.DrawPath(DlPath(path_builder), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -437,7 +443,7 @@ TEST_P(DisplayListTest, CanDrawWithMaskBlur) {
     auto filter =
         flutter::DlBlurMaskFilter(flutter::DlBlurStyle::kNormal, 10.0f);
     paint.setMaskFilter(&filter);
-    builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+    builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                       flutter::DlImageSampling::kNearestNeighbor, &paint);
   }
 
@@ -447,7 +453,7 @@ TEST_P(DisplayListTest, CanDrawWithMaskBlur) {
     auto filter =
         flutter::DlBlurMaskFilter(flutter::DlBlurStyle::kOuter, 10.0f);
     paint.setMaskFilter(&filter);
-    builder.DrawArc(SkRect::MakeXYWH(410, 110, 100, 100), 45, 270, true, paint);
+    builder.DrawArc(DlRect::MakeXYWH(410, 110, 100, 100), 45, 270, true, paint);
   }
 
   // Mask blurred text.
@@ -488,7 +494,7 @@ TEST_P(DisplayListTest, StrokedTextNotOffsetFromNormalText) {
   // Draw a blue filled rectangle so the text is easier to see.
   paint.setDrawStyle(flutter::DlDrawStyle::kFill);
   paint.setColor(mat_blue);
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 500, 500), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 500, 500), paint);
 
   // Draw stacked text, with stroked text on top.
   paint.setDrawStyle(flutter::DlDrawStyle::kFill);
@@ -509,7 +515,7 @@ TEST_P(DisplayListTest, IgnoreMaskFilterWhenSavingLayer) {
   flutter::DlPaint paint;
   paint.setMaskFilter(&filter);
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                     flutter::DlImageSampling::kNearestNeighbor);
   builder.Restore();
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -525,7 +531,7 @@ TEST_P(DisplayListTest, CanDrawWithBlendColorFilter) {
     auto filter = flutter::DlColorFilter::MakeBlend(
         flutter::DlColor::kYellow(), flutter::DlBlendMode::kModulate);
     paint.setColorFilter(filter);
-    builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+    builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                       flutter::DlImageSampling::kNearestNeighbor, &paint);
   }
 
@@ -534,7 +540,7 @@ TEST_P(DisplayListTest, CanDrawWithBlendColorFilter) {
     auto filter = flutter::DlColorFilter::MakeBlend(
         flutter::DlColor::kRed(), flutter::DlBlendMode::kScreen);
     paint.setColorFilter(filter);
-    builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(250, 250),
+    builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(250, 250),
                       flutter::DlImageSampling::kNearestNeighbor, &paint);
   }
 
@@ -556,12 +562,12 @@ TEST_P(DisplayListTest, CanDrawWithColorFilterImageFilter) {
   auto image_filter = flutter::DlImageFilter::MakeColorFilter(color_filter);
 
   paint.setImageFilter(image_filter);
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                     flutter::DlImageSampling::kNearestNeighbor, &paint);
 
   builder.Translate(0, 700);
   paint.setColorFilter(color_filter);
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                     flutter::DlImageSampling::kNearestNeighbor, &paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -582,7 +588,7 @@ TEST_P(DisplayListTest, CanDrawWithImageBlurFilter) {
     auto filter = flutter::DlBlurImageFilter(sigma[0], sigma[1],
                                              flutter::DlTileMode::kClamp);
     paint.setImageFilter(&filter);
-    builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(200, 200),
+    builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(200, 200),
                       flutter::DlImageSampling::kNearestNeighbor, &paint);
 
     return builder.Build();
@@ -602,11 +608,11 @@ TEST_P(DisplayListTest, CanDrawWithComposeImageFilter) {
   auto close = std::make_shared<flutter::DlComposeImageFilter>(erode, dilate);
 
   paint.setImageFilter(open.get());
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                     flutter::DlImageSampling::kNearestNeighbor, &paint);
   builder.Translate(0, 700);
   paint.setImageFilter(close.get());
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                     flutter::DlImageSampling::kNearestNeighbor, &paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -636,7 +642,7 @@ TEST_P(DisplayListTest, CanClampTheResultingColorOfColorMatrixFilter) {
   flutter::DisplayListBuilder builder;
   flutter::DlPaint paint;
   paint.setImageFilter(compose.get());
-  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+  builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(100, 100),
                     flutter::DlImageSampling::kNearestNeighbor, &paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -671,25 +677,24 @@ TEST_P(DisplayListTest, CanDrawBackdropFilter) {
     auto filter = flutter::DlBlurImageFilter(sigma[0], sigma[1],
                                              flutter::DlTileMode::kClamp);
 
-    std::optional<SkRect> bounds;
+    std::optional<DlRect> bounds;
     if (use_bounds) {
       static PlaygroundPoint point_a(Point(350, 150), 20, Color::White());
       static PlaygroundPoint point_b(Point(800, 600), 20, Color::White());
       auto [p1, p2] = DrawPlaygroundLine(point_a, point_b);
-      bounds = SkRect::MakeLTRB(p1.x, p1.y, p2.x, p2.y);
+      bounds = DlRect::MakeLTRB(p1.x, p1.y, p2.x, p2.y);
     }
 
     // Insert a clip to test that the backdrop filter handles stencil depths > 0
     // correctly.
     if (add_clip) {
-      builder.ClipRect(SkRect::MakeLTRB(0, 0, 99999, 99999),
+      builder.ClipRect(DlRect::MakeLTRB(0, 0, 99999, 99999),
                        flutter::DlCanvas::ClipOp::kIntersect, true);
     }
 
-    builder.DrawImage(DlImageImpeller::Make(texture), SkPoint::Make(200, 200),
+    builder.DrawImage(DlImageImpeller::Make(texture), DlPoint(200, 200),
                       flutter::DlImageSampling::kNearestNeighbor, nullptr);
-    builder.SaveLayer(bounds.has_value() ? &bounds.value() : nullptr, nullptr,
-                      &filter);
+    builder.SaveLayer(bounds, nullptr, &filter);
 
     if (draw_circle) {
       static PlaygroundPoint center_point(Point(500, 400), 20, Color::Red());
@@ -701,7 +706,7 @@ TEST_P(DisplayListTest, CanDrawBackdropFilter) {
       paint.setStrokeJoin(flutter::DlStrokeJoin::kBevel);
       paint.setStrokeWidth(10);
       paint.setColor(flutter::DlColor::kRed().withAlpha(100));
-      builder.DrawCircle(SkPoint{circle_center.x, circle_center.y}, 100, paint);
+      builder.DrawCircle(DlPoint(circle_center.x, circle_center.y), 100, paint);
     }
 
     return builder.Build();
@@ -717,9 +722,9 @@ TEST_P(DisplayListTest, CanDrawNinePatchImage) {
   auto size = texture->GetSize();
   builder.DrawImageNine(
       DlImageImpeller::Make(texture),
-      SkIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
+      DlIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
                         size.height * 3 / 4),
-      SkRect::MakeLTRB(0, 0, size.width * 2, size.height * 2),
+      DlRect::MakeLTRB(0, 0, size.width * 2, size.height * 2),
       flutter::DlFilterMode::kNearest, nullptr);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -733,9 +738,9 @@ TEST_P(DisplayListTest, CanDrawNinePatchImageCenterWidthBiggerThanDest) {
   auto size = texture->GetSize();
   builder.DrawImageNine(
       DlImageImpeller::Make(texture),
-      SkIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
+      DlIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
                         size.height * 3 / 4),
-      SkRect::MakeLTRB(0, 0, size.width / 2, size.height),
+      DlRect::MakeLTRB(0, 0, size.width / 2, size.height),
       flutter::DlFilterMode::kNearest, nullptr);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -749,9 +754,9 @@ TEST_P(DisplayListTest, CanDrawNinePatchImageCenterHeightBiggerThanDest) {
   auto size = texture->GetSize();
   builder.DrawImageNine(
       DlImageImpeller::Make(texture),
-      SkIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
+      DlIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
                         size.height * 3 / 4),
-      SkRect::MakeLTRB(0, 0, size.width, size.height / 2),
+      DlRect::MakeLTRB(0, 0, size.width, size.height / 2),
       flutter::DlFilterMode::kNearest, nullptr);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -764,9 +769,9 @@ TEST_P(DisplayListTest, CanDrawNinePatchImageCenterBiggerThanDest) {
   auto size = texture->GetSize();
   builder.DrawImageNine(
       DlImageImpeller::Make(texture),
-      SkIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
+      DlIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
                         size.height * 3 / 4),
-      SkRect::MakeLTRB(0, 0, size.width / 2, size.height / 2),
+      DlRect::MakeLTRB(0, 0, size.width / 2, size.height / 2),
       flutter::DlFilterMode::kNearest, nullptr);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -779,9 +784,9 @@ TEST_P(DisplayListTest, CanDrawNinePatchImageCornersScaledDown) {
   auto size = texture->GetSize();
   builder.DrawImageNine(
       DlImageImpeller::Make(texture),
-      SkIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
+      DlIRect::MakeLTRB(size.width / 4, size.height / 4, size.width * 3 / 4,
                         size.height * 3 / 4),
-      SkRect::MakeLTRB(0, 0, size.width / 4, size.height / 4),
+      DlRect::MakeLTRB(0, 0, size.width / 4, size.height / 4),
       flutter::DlFilterMode::kNearest, nullptr);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -792,15 +797,15 @@ TEST_P(DisplayListTest, NinePatchImagePrecision) {
   auto texture = CreateTextureForFixture("nine_patch_corners.png");
   flutter::DisplayListBuilder builder;
   builder.DrawImageNine(DlImageImpeller::Make(texture),
-                        SkIRect::MakeXYWH(10, 10, 1, 1),
-                        SkRect::MakeXYWH(0, 0, 200, 100),
+                        DlIRect::MakeXYWH(10, 10, 1, 1),
+                        DlRect::MakeXYWH(0, 0, 200, 100),
                         flutter::DlFilterMode::kNearest, nullptr);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
 TEST_P(DisplayListTest, CanDrawPoints) {
   flutter::DisplayListBuilder builder;
-  SkPoint points[7] = {
+  DlPoint points[7] = {
       {0, 0},      //
       {100, 100},  //
       {100, 0},    //
@@ -847,10 +852,10 @@ TEST_P(DisplayListTest, CanDrawZeroLengthLine) {
           .setDrawStyle(flutter::DlDrawStyle::kStroke)           //
           .setStrokeCap(flutter::DlStrokeCap::kButt)             //
           .setStrokeWidth(20);
-  SkPath path = SkPath().addPoly({{150, 50}, {150, 50}}, false);
+  DlPath path = DlPath::MakeLine({150, 50}, {150, 50});
   for (auto cap : caps) {
     paint.setStrokeCap(cap);
-    builder.DrawLine(SkPoint{50, 50}, SkPoint{50, 50}, paint);
+    builder.DrawLine(DlPoint(50, 50), DlPoint(50, 50), paint);
     builder.DrawPath(path, paint);
     builder.Translate(0, 150);
   }
@@ -865,27 +870,26 @@ TEST_P(DisplayListTest, CanDrawShadow) {
   builder.Scale(content_scale.x, content_scale.y);
 
   constexpr size_t star_spikes = 5;
-  constexpr SkScalar half_spike_rotation = kPi / star_spikes;
-  constexpr SkScalar radius = 40;
-  constexpr SkScalar spike_size = 10;
-  constexpr SkScalar outer_radius = radius + spike_size;
-  constexpr SkScalar inner_radius = radius - spike_size;
-  std::array<SkPoint, star_spikes * 2> star;
+  constexpr DlScalar half_spike_rotation = kPi / star_spikes;
+  constexpr DlScalar radius = 40;
+  constexpr DlScalar spike_size = 10;
+  constexpr DlScalar outer_radius = radius + spike_size;
+  constexpr DlScalar inner_radius = radius - spike_size;
+  std::array<DlPoint, star_spikes * 2> star;
   for (size_t i = 0; i < star_spikes; i++) {
-    const SkScalar rotation = half_spike_rotation * i * 2;
-    star[i * 2] = SkPoint::Make(50 + std::sin(rotation) * outer_radius,
-                                50 - std::cos(rotation) * outer_radius);
-    star[i * 2 + 1] = SkPoint::Make(
-        50 + std::sin(rotation + half_spike_rotation) * inner_radius,
-        50 - std::cos(rotation + half_spike_rotation) * inner_radius);
+    const DlScalar rotation = half_spike_rotation * i * 2;
+    star[i * 2] = DlPoint(50 + std::sin(rotation) * outer_radius,
+                          50 - std::cos(rotation) * outer_radius);
+    star[i * 2 + 1] =
+        DlPoint(50 + std::sin(rotation + half_spike_rotation) * inner_radius,
+                50 - std::cos(rotation + half_spike_rotation) * inner_radius);
   }
 
-  std::array<SkPath, 4> paths = {
-      SkPath{}.addRect(SkRect::MakeXYWH(0, 0, 200, 100)),
-      SkPath{}.addRRect(
-          SkRRect::MakeRectXY(SkRect::MakeXYWH(20, 0, 200, 100), 30, 30)),
-      SkPath{}.addCircle(100, 50, 50),
-      SkPath{}.addPoly(star.data(), star.size(), true),
+  std::array<DlPath, 4> paths = {
+      DlPath::MakeRect(DlRect::MakeXYWH(0, 0, 200, 100)),
+      DlPath::MakeRoundRectXY(DlRect::MakeXYWH(20, 0, 200, 100), 30, 30),
+      DlPath::MakeCircle(DlPoint(100, 50), 50),
+      DlPath::MakePoly(star.data(), star.size(), true),
   };
   paint.setColor(flutter::DlColor::kWhite());
   builder.DrawPaint(paint);
@@ -924,17 +928,17 @@ TEST_P(DisplayListTest, CanDrawZeroWidthLine) {
           .setDrawStyle(flutter::DlDrawStyle::kStroke)  //
           .setStrokeCap(flutter::DlStrokeCap::kSquare)  //
           .setStrokeWidth(1);
-  SkPath path = SkPath().addPoly({{150, 50}, {160, 50}}, false);
+  DlPath path = DlPath::MakeLine({150, 50}, {160, 50});
   for (auto cap : caps) {
     paint.setStrokeCap(cap);
-    builder.DrawLine(SkPoint{50, 50}, SkPoint{60, 50}, paint);
-    builder.DrawRect(SkRect{45, 45, 65, 55}, outline_paint);
-    builder.DrawLine(SkPoint{100, 50}, SkPoint{100, 50}, paint);
+    builder.DrawLine(DlPoint(50, 50), DlPoint(60, 50), paint);
+    builder.DrawRect(DlRect::MakeLTRB(45, 45, 65, 55), outline_paint);
+    builder.DrawLine(DlPoint{100, 50}, DlPoint{100, 50}, paint);
     if (cap != flutter::DlStrokeCap::kButt) {
-      builder.DrawRect(SkRect{95, 45, 105, 55}, outline_paint);
+      builder.DrawRect(DlRect::MakeLTRB(95, 45, 105, 55), outline_paint);
     }
     builder.DrawPath(path, paint);
-    builder.DrawRect(path.getBounds().makeOutset(5, 5), outline_paint);
+    builder.DrawRect(path.GetBounds().Expand(5, 5), outline_paint);
     builder.Translate(0, 150);
   }
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -998,10 +1002,11 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilter) {
       builder.Scale(content_scale.x, content_scale.y);
 
       // Set the current transform
-      auto ctm_matrix =
-          SkMatrix::MakeAll(ctm_scale[0], ctm_skew[0], ctm_translation[0],  //
-                            ctm_skew[1], ctm_scale[1], ctm_translation[1],  //
-                            0, 0, 1);
+      auto ctm_matrix = Matrix::MakeRow(
+          ctm_scale[0], ctm_skew[0], 0.0f, ctm_translation[0],  //
+          ctm_skew[1], ctm_scale[1], 0.0f, ctm_translation[1],  //
+          0, 0, 1, 0,                                           //
+          0, 0, 0, 1);
       builder.Transform(ctm_matrix);
 
       // Set the matrix filter
@@ -1031,7 +1036,7 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilter) {
         }
       }
 
-      builder.DrawImage(DlImageImpeller::Make(boston), SkPoint{},
+      builder.DrawImage(DlImageImpeller::Make(boston), DlPoint(),
                         flutter::DlImageSampling::kLinear, &paint);
     }
     if (enable_savelayer) {
@@ -1059,22 +1064,22 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilterWhenSavingLayer) {
     builder.Scale(2.0, 2.0);
     flutter::DlPaint paint;
     paint.setColor(flutter::DlColor::kYellow());
-    builder.DrawRect(SkRect::MakeWH(300, 300), paint);
+    builder.DrawRect(DlRect::MakeWH(300, 300), paint);
     paint.setStrokeWidth(1.0);
     paint.setDrawStyle(flutter::DlDrawStyle::kStroke);
     paint.setColor(flutter::DlColor::kBlack().withAlpha(0x80));
-    builder.DrawLine(SkPoint::Make(150, 0), SkPoint::Make(150, 300), paint);
-    builder.DrawLine(SkPoint::Make(0, 150), SkPoint::Make(300, 150), paint);
+    builder.DrawLine(DlPoint(150, 0), DlPoint(150, 300), paint);
+    builder.DrawLine(DlPoint(0, 150), DlPoint(300, 150), paint);
 
     flutter::DlPaint save_paint;
-    SkRect bounds = SkRect::MakeXYWH(100, 100, 100, 100);
+    DlRect bounds = DlRect::MakeXYWH(100, 100, 100, 100);
     Matrix translate_matrix =
         Matrix::MakeTranslation({translation[0], translation[1]});
     if (enable_save_layer) {
       auto filter = flutter::DlMatrixImageFilter(
           translate_matrix, flutter::DlImageSampling::kNearestNeighbor);
       save_paint.setImageFilter(filter.shared());
-      builder.SaveLayer(&bounds, &save_paint);
+      builder.SaveLayer(bounds, &save_paint);
     } else {
       builder.Save();
       builder.Transform(translate_matrix);
@@ -1089,7 +1094,7 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilterWhenSavingLayer) {
 
     save_paint.setImageFilter(filter.shared());
 
-    builder.SaveLayer(&bounds, &save_paint);
+    builder.SaveLayer(bounds, &save_paint);
     flutter::DlPaint paint2;
     paint2.setColor(flutter::DlColor::kBlue());
     builder.DrawRect(bounds, paint2);
@@ -1106,11 +1111,11 @@ TEST_P(DisplayListTest, CanDrawRectWithLinearToSrgbColorFilter) {
   paint.setColor(flutter::DlColor(0xFF2196F3).withAlpha(128));
   flutter::DisplayListBuilder builder;
   paint.setColorFilter(flutter::DlColorFilter::MakeLinearToSrgbGamma());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), paint);
   builder.Translate(0, 200);
 
   paint.setColorFilter(flutter::DlColorFilter::MakeSrgbToLinearGamma());
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, 200, 200), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 200, 200), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -1123,7 +1128,7 @@ TEST_P(DisplayListTest, CanDrawPaintWithColorSource) {
   const float stops[2] = {0.0, 1.0};
   flutter::DlPaint paint;
   flutter::DisplayListBuilder builder;
-  auto clip_bounds = SkRect::MakeWH(300.0, 300.0);
+  auto clip_bounds = DlRect::MakeWH(300.0, 300.0);
   builder.Save();
   builder.Translate(100, 100);
   builder.ClipRect(clip_bounds, flutter::DlCanvas::ClipOp::kIntersect, false);
@@ -1175,10 +1180,10 @@ TEST_P(DisplayListTest, CanBlendDstOverAndDstCorrectly) {
     builder.Translate(100, 100);
     flutter::DlPaint paint;
     paint.setColor(flutter::DlColor::kRed());
-    builder.DrawRect(SkRect::MakeSize({200, 200}), paint);
+    builder.DrawRect(DlRect::MakeWH(200, 200), paint);
     paint.setColor(flutter::DlColor::kBlue().withAlpha(127));
     paint.setBlendMode(flutter::DlBlendMode::kSrcOver);
-    builder.DrawRect(SkRect::MakeSize({200, 200}), paint);
+    builder.DrawRect(DlRect::MakeWH(200, 200), paint);
     builder.Restore();
   }
   {
@@ -1186,10 +1191,10 @@ TEST_P(DisplayListTest, CanBlendDstOverAndDstCorrectly) {
     builder.Translate(300, 100);
     flutter::DlPaint paint;
     paint.setColor(flutter::DlColor::kBlue().withAlpha(127));
-    builder.DrawRect(SkRect::MakeSize({200, 200}), paint);
+    builder.DrawRect(DlRect::MakeWH(200, 200), paint);
     paint.setColor(flutter::DlColor::kRed());
     paint.setBlendMode(flutter::DlBlendMode::kDstOver);
-    builder.DrawRect(SkRect::MakeSize({200, 200}), paint);
+    builder.DrawRect(DlRect::MakeWH(200, 200), paint);
     builder.Restore();
   }
   {
@@ -1197,10 +1202,10 @@ TEST_P(DisplayListTest, CanBlendDstOverAndDstCorrectly) {
     builder.Translate(100, 300);
     flutter::DlPaint paint;
     paint.setColor(flutter::DlColor::kRed());
-    builder.DrawRect(SkRect::MakeSize({200, 200}), paint);
+    builder.DrawRect(DlRect::MakeWH(200, 200), paint);
     paint.setColor(flutter::DlColor::kBlue().withAlpha(127));
     paint.setBlendMode(flutter::DlBlendMode::kSrc);
-    builder.DrawRect(SkRect::MakeSize({200, 200}), paint);
+    builder.DrawRect(DlRect::MakeWH(200, 200), paint);
     builder.Restore();
   }
   {
@@ -1208,10 +1213,10 @@ TEST_P(DisplayListTest, CanBlendDstOverAndDstCorrectly) {
     builder.Translate(300, 300);
     flutter::DlPaint paint;
     paint.setColor(flutter::DlColor::kBlue().withAlpha(127));
-    builder.DrawRect(SkRect::MakeSize({200, 200}), paint);
+    builder.DrawRect(DlRect::MakeWH(200, 200), paint);
     paint.setColor(flutter::DlColor::kRed());
     paint.setBlendMode(flutter::DlBlendMode::kDst);
-    builder.DrawRect(SkRect::MakeSize({200, 200}), paint);
+    builder.DrawRect(DlRect::MakeWH(200, 200), paint);
     builder.Restore();
   }
 
@@ -1243,7 +1248,7 @@ TEST_P(DisplayListTest, CanDrawCorrectlyWithColorFilterAndImageFilter) {
   paint.setColor(flutter::DlColor::kRed());
   paint.setColorFilter(green_color_filter);
   paint.setImageFilter(blue_image_filter);
-  builder.DrawRect(SkRect::MakeLTRB(100, 100, 500, 500), paint);
+  builder.DrawRect(DlRect::MakeLTRB(100, 100, 500, 500), paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
@@ -1278,14 +1283,14 @@ TEST_P(DisplayListTest, MaskBlursApplyCorrectlyToColorSources) {
     builder.Save();
     builder.Translate(100, 0);
     paint.setDrawStyle(flutter::DlDrawStyle::kFill);
-    builder.DrawRRect(SkRRect::MakeRectXY(SkRect::MakeWH(100, 50), 30, 30),
-                      paint);
+    builder.DrawRoundRect(
+        DlRoundRect::MakeRectXY(DlRect::MakeWH(100, 50), 30, 30), paint);
 
     paint.setDrawStyle(flutter::DlDrawStyle::kStroke);
     paint.setStrokeWidth(10);
     builder.Translate(200, 0);
-    builder.DrawRRect(SkRRect::MakeRectXY(SkRect::MakeWH(100, 50), 30, 30),
-                      paint);
+    builder.DrawRoundRect(
+        DlRoundRect::MakeRectXY(DlRect::MakeWH(100, 50), 30, 30), paint);
 
     builder.Restore();
     builder.Translate(0, 100);
@@ -1312,22 +1317,23 @@ TEST_P(DisplayListTest, DrawShapes) {
           .setColor(flutter::DlColor::kWhite())         //
           .setDrawStyle(flutter::DlDrawStyle::kStroke)  //
           .setStrokeWidth(10);
-  SkPath path = SkPath().addPoly({{150, 50}, {160, 50}}, false);
+  DlPath path = DlPath::MakeLine({150, 50}, {160, 50});
 
   builder.Translate(300, 50);
   builder.Scale(0.8, 0.8);
   for (auto join : joins) {
     paint.setStrokeJoin(join);
     stroke_paint.setStrokeJoin(join);
-    builder.DrawRect(SkRect::MakeXYWH(0, 0, 100, 100), paint);
-    builder.DrawRect(SkRect::MakeXYWH(0, 150, 100, 100), stroke_paint);
-    builder.DrawRRect(
-        SkRRect::MakeRectXY(SkRect::MakeXYWH(150, 0, 100, 100), 30, 30), paint);
-    builder.DrawRRect(
-        SkRRect::MakeRectXY(SkRect::MakeXYWH(150, 150, 100, 100), 30, 30),
+    builder.DrawRect(DlRect::MakeXYWH(0, 0, 100, 100), paint);
+    builder.DrawRect(DlRect::MakeXYWH(0, 150, 100, 100), stroke_paint);
+    builder.DrawRoundRect(
+        DlRoundRect::MakeRectXY(DlRect::MakeXYWH(150, 0, 100, 100), 30, 30),
+        paint);
+    builder.DrawRoundRect(
+        DlRoundRect::MakeRectXY(DlRect::MakeXYWH(150, 150, 100, 100), 30, 30),
         stroke_paint);
-    builder.DrawCircle(SkPoint{350, 50}, 50, paint);
-    builder.DrawCircle(SkPoint{350, 200}, 50, stroke_paint);
+    builder.DrawCircle(DlPoint(350, 50), 50, paint);
+    builder.DrawCircle(DlPoint(350, 200), 50, stroke_paint);
     builder.Translate(0, 300);
   }
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -1347,18 +1353,18 @@ TEST_P(DisplayListTest, ClipDrawRRectWithNonCircularRadii) {
           .setDrawStyle(flutter::DlDrawStyle::kStroke)  //
           .setStrokeWidth(10);
 
-  builder.DrawRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(500, 100, 300, 300), 120, 40),
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(500, 100, 300, 300), 120, 40),
       fill_paint);
-  builder.DrawRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(500, 100, 300, 300), 120, 40),
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(500, 100, 300, 300), 120, 40),
       stroke_paint);
 
-  builder.DrawRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(100, 500, 300, 300), 40, 120),
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(100, 500, 300, 300), 40, 120),
       fill_paint);
-  builder.DrawRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(100, 500, 300, 300), 40, 120),
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(100, 500, 300, 300), 40, 120),
       stroke_paint);
 
   flutter::DlPaint reference_paint =                  //
@@ -1367,11 +1373,11 @@ TEST_P(DisplayListTest, ClipDrawRRectWithNonCircularRadii) {
           .setDrawStyle(flutter::DlDrawStyle::kFill)  //
           .setStrokeWidth(10);
 
-  builder.DrawRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(500, 500, 300, 300), 40, 40),
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(500, 500, 300, 300), 40, 40),
       reference_paint);
-  builder.DrawRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(100, 100, 300, 300), 120, 120),
+  builder.DrawRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(100, 100, 300, 300), 120, 120),
       reference_paint);
 
   flutter::DlPaint clip_fill_paint =                  //
@@ -1381,14 +1387,14 @@ TEST_P(DisplayListTest, ClipDrawRRectWithNonCircularRadii) {
           .setStrokeWidth(10);
 
   builder.Save();
-  builder.ClipRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(900, 100, 300, 300), 120, 40));
+  builder.ClipRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(900, 100, 300, 300), 120, 40));
   builder.DrawPaint(clip_fill_paint);
   builder.Restore();
 
   builder.Save();
-  builder.ClipRRect(
-      SkRRect::MakeRectXY(SkRect::MakeXYWH(100, 900, 300, 300), 40, 120));
+  builder.ClipRoundRect(
+      DlRoundRect::MakeRectXY(DlRect::MakeXYWH(100, 900, 300, 300), 40, 120));
   builder.DrawPaint(clip_fill_paint);
   builder.Restore();
 
@@ -1491,7 +1497,7 @@ TEST_P(DisplayListTest, DrawPaintIgnoresMaskFilter) {
   builder.DrawPaint(flutter::DlPaint().setColor(flutter::DlColor::kWhite()));
 
   auto filter = flutter::DlBlurMaskFilter(flutter::DlBlurStyle::kNormal, 10.0f);
-  builder.DrawCircle(SkPoint{300, 300}, 200,
+  builder.DrawCircle(DlPoint(300, 300), 200,
                      flutter::DlPaint().setMaskFilter(&filter));
 
   std::vector<flutter::DlColor> colors = {flutter::DlColor::kGreen(),
@@ -1527,7 +1533,7 @@ TEST_P(DisplayListTest, DrawMaskBlursThatMightUseSaveLayers) {
           .setAlpha(0x7f);
   for (int x = 1; x <= 4; x++) {
     for (int y = 1; y <= 4; y++) {
-      builder.DrawRect(SkRect::MakeXYWH(x * 100, y * 100, 80, 80),
+      builder.DrawRect(DlRect::MakeXYWH(x * 100, y * 100, 80, 80),
                        solid_alpha_paint);
     }
   }
@@ -1547,7 +1553,7 @@ TEST_P(DisplayListTest, DrawMaskBlursThatMightUseSaveLayers) {
           .setAlpha(0x7f);
   for (int x = 1; x <= 4; x++) {
     for (int y = 1; y <= 4; y++) {
-      builder.DrawRect(SkRect::MakeXYWH(x * 100, y * 100, 80, 80),
+      builder.DrawRect(DlRect::MakeXYWH(x * 100, y * 100, 80, 80),
                        normal_if_paint);
     }
   }

--- a/engine/src/flutter/impeller/display_list/dl_vertices_geometry.cc
+++ b/engine/src/flutter/impeller/display_list/dl_vertices_geometry.cc
@@ -8,7 +8,6 @@
 #include "impeller/core/formats.h"
 #include "impeller/display_list/skia_conversions.h"
 #include "impeller/geometry/point.h"
-#include "third_party/skia/include/core/SkPoint.h"
 
 namespace impeller {
 

--- a/engine/src/flutter/impeller/geometry/round_rect.h
+++ b/engine/src/flutter/impeller/geometry/round_rect.h
@@ -38,6 +38,15 @@ struct RoundRect {
     return MakeRectRadii(rect, RoundingRadii::MakeRadii(corner_radii));
   }
 
+  constexpr static RoundRect MakeNinePatch(const Rect& rect,
+                                           Scalar left,
+                                           Scalar top,
+                                           Scalar right,
+                                           Scalar bottom) {
+    return MakeRectRadii(
+        rect, RoundingRadii::MakeNinePatch(left, top, right, bottom));
+  }
+
   static RoundRect MakeRectRadii(const Rect& rect, const RoundingRadii& radii);
 
   constexpr const Rect& GetBounds() const { return bounds_; }

--- a/engine/src/flutter/impeller/geometry/rounding_radii.h
+++ b/engine/src/flutter/impeller/geometry/rounding_radii.h
@@ -25,6 +25,18 @@ struct RoundingRadii {
     return {radii, radii, radii, radii};
   }
 
+  constexpr static RoundingRadii MakeNinePatch(Scalar left,
+                                               Scalar top,
+                                               Scalar right,
+                                               Scalar bottom) {
+    return {
+        .top_left = Size{left, top},
+        .top_right = Size{right, top},
+        .bottom_left = Size(left, bottom),
+        .bottom_right = Size(right, bottom),
+    };
+  }
+
   constexpr bool IsFinite() const {
     return top_left.IsFinite() &&     //
            top_right.IsFinite() &&    //

--- a/engine/src/flutter/impeller/golden_tests/golden_tests.cc
+++ b/engine/src/flutter/impeller/golden_tests/golden_tests.cc
@@ -18,7 +18,6 @@
 #include "impeller/golden_tests/metal_screenshot.h"
 #include "impeller/golden_tests/metal_screenshotter.h"
 #include "impeller/golden_tests/working_directory.h"
-#include "third_party/skia/include/core/SkPaint.h"
 
 namespace impeller {
 namespace testing {
@@ -92,7 +91,7 @@ TEST_F(GoldenTests, ConicalGradient) {
       /*tile_mode=*/flutter::DlTileMode::kClamp  //
       ));
 
-  builder.DrawRect(SkRect::MakeXYWH(10, 10, 250, 250), paint);
+  builder.DrawRect(DlRect::MakeXYWH(10, 10, 250, 250), paint);
 
   auto aiks_context =
       AiksContext(Screenshotter().GetPlayground().GetContext(), nullptr);

--- a/engine/src/flutter/impeller/renderer/blit_pass_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/blit_pass_unittests.cc
@@ -264,7 +264,7 @@ TEST_P(BlitPassTest, CanResizeTexturesPlayground) {
   DlPaint paint;
   paint.setColor(DlColor::kRed());
   auto image = DlImageImpeller::Make(dst);
-  builder.DrawImage(image, SkPoint::Make(100.0, 100.0),
+  builder.DrawImage(image, flutter::DlPoint(100.0, 100.0),
                     DlImageSampling::kNearestNeighbor, &paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/shell/common/dl_op_spy_unittests.cc
+++ b/engine/src/flutter/shell/common/dl_op_spy_unittests.cc
@@ -289,7 +289,7 @@ TEST(DlOpSpy, DrawPath) {
     DlPathBuilder path_builder;
     path_builder.MoveTo({0, 1});
     path_builder.LineTo({1, 1});
-    builder.DrawPath(DlPath(path_builder.TakePath()), paint);
+    builder.DrawPath(DlPath(path_builder), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -302,7 +302,7 @@ TEST(DlOpSpy, DrawPath) {
     path_builder.MoveTo({0, 0});
     path_builder.LineTo({1, 0});
     path_builder.LineTo({0, 1});
-    builder.DrawPath(DlPath(path_builder.TakePath()), paint);
+    builder.DrawPath(DlPath(path_builder), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -315,7 +315,7 @@ TEST(DlOpSpy, DrawPath) {
     DlPathBuilder path_builder;
     path_builder.MoveTo({0, 1});
     path_builder.LineTo({1, 1});
-    builder.DrawPath(DlPath(path_builder.TakePath()), paint);
+    builder.DrawPath(DlPath(path_builder), paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);


### PR DESCRIPTION
Reverts flutter/flutter#162046

The root cause of the test failures seen in the original PR have been fixed.