### PR TITLE
Don't install xcode when doing `local_engine` web builds on mac.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -50,7 +50,7 @@ targets:
     enabled_branches:
       - master
     recipe: engine_v2/engine_v2
-    bringup: true
+    #bringup: true
     properties:
       config_name: local_engine
     # local_engine schedules a bunch of other builds, so it's likely to timeout waiting for those builds to run.

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -50,7 +50,7 @@ targets:
     enabled_branches:
       - master
     recipe: engine_v2/engine_v2
-    #bringup: true
+    bringup: true
     properties:
       config_name: local_engine
     # local_engine schedules a bunch of other builds, so it's likely to timeout waiting for those builds to run.

--- a/engine/src/flutter/ci/builders/local_engine.json
+++ b/engine/src/flutter/ci/builders/local_engine.json
@@ -1004,7 +1004,7 @@
       "name": "macos/wasm_release",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac"
+        "os=Mac-13|Mac-14"
       ],
       "gclient_variables": {
         "download_android_deps": false,
@@ -1029,7 +1029,7 @@
       "name": "macos/wasm_debug_unopt",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac"
+        "os=Mac-13|Mac-14"
       ],
       "gclient_variables": {
         "download_android_deps": false,

--- a/engine/src/flutter/ci/builders/local_engine.json
+++ b/engine/src/flutter/ci/builders/local_engine.json
@@ -1023,6 +1023,11 @@
           "flutter/web_sdk:flutter_web_sdk_archive"
         ]
       },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "skip_xcode_install": true
+        }
+      },
       "cas_archive": false
     },
     {
@@ -1048,6 +1053,11 @@
         "targets": [
           "flutter/web_sdk:flutter_web_sdk_archive"
         ]
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "skip_xcode_install": true
+        }
       },
       "cas_archive": false
     }


### PR DESCRIPTION
We don't actually need Xcode installed to do web builds on a Mac, since it uses emscripten. We can specify to skip the install via the property added here: https://flutter-review.googlesource.com/c/recipes/+/62500