### PR TITLE
[CP][Impeller] remove Adreno denylist entries. (#161740)

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -329,15 +329,6 @@ bool DriverInfoVK::IsEmulator() const {
 }
 
 bool DriverInfoVK::IsKnownBadDriver() const {
-  if (adreno_gpu_.has_value()) {
-    AdrenoGPU adreno = adreno_gpu_.value();
-    // 630 is the lowest version I've tested on the still works.
-    // I suspect earlier 600s should work but this is waiting on
-    // more devices for testing.
-    if (adreno < AdrenoGPU::kAdreno630) {
-      return true;
-    }
-  }
   // Disable Maleoon series GPUs, see:
   // https://github.com/flutter/flutter/issues/156623
   if (vendor_ == VendorVK::kHuawei) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
@@ -163,16 +163,15 @@ TEST(DriverInfoVKTest, DriverParsingAdreno) {
 }
 
 TEST(DriverInfoVKTest, DisabledDevices) {
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 620"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 610"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 530"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 512"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 509"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 508"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 506"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 505"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 504"));
-
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 620"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 610"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 530"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 512"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 509"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 508"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 506"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 505"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 504"));
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 630"));
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 640"));
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 650"));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/161209

testing on a 540 and everything seems to work now that we have the Adreno specific workarounds added to the renderer. Its possible there are some bugs that only exist on the early 600s but I guess we'll find out.
