### PR TITLE
Add FormField.errorBuilder

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1769,7 +1769,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
            if (field.errorText != null || effectiveDecoration.hintText != null) {
              final Widget? error =
                  field.errorText != null && errorBuilder != null
-                     ? errorBuilder(field.errorText!)
+                     ? errorBuilder(state.context, field.errorText!)
                      : null;
              final String? errorText = error == null ? field.errorText : null;
              // Clear the decoration hintText because DropdownButton has its own hint logic.

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1722,6 +1722,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     InputDecoration? decoration,
     super.onSaved,
     super.validator,
+    super.errorBuilder,
     AutovalidateMode? autovalidateMode,
     double? menuMaxHeight,
     bool? enableFeedback,
@@ -1747,10 +1748,8 @@ class DropdownButtonFormField<T> extends FormField<T> {
          autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
          builder: (FormFieldState<T> field) {
            final _DropdownButtonFormFieldState<T> state = field as _DropdownButtonFormFieldState<T>;
-           final InputDecoration decorationArg = decoration ?? const InputDecoration();
-           final InputDecoration effectiveDecoration = decorationArg.applyDefaults(
-             Theme.of(field.context).inputDecorationTheme,
-           );
+           InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
+               .applyDefaults(Theme.of(field.context).inputDecorationTheme);
 
            final bool showSelectedItem =
                items != null &&
@@ -1766,6 +1765,22 @@ class DropdownButtonFormField<T> extends FormField<T> {
                    ? effectiveHint != null
                    : effectiveHint != null || effectiveDisabledHint != null;
            final bool isEmpty = !showSelectedItem && !isHintOrDisabledHintAvailable;
+
+           if (field.errorText != null || effectiveDecoration.hintText != null) {
+             final Widget? error =
+                 field.errorText != null && errorBuilder != null
+                     ? errorBuilder(field.errorText!)
+                     : null;
+             final String? errorText = error == null ? field.errorText : null;
+             // Clear the decoration hintText because DropdownButton has its own hint logic.
+             final String? hintText = effectiveDecoration.hintText != null ? '' : null;
+
+             effectiveDecoration = effectiveDecoration.copyWith(
+               error: error,
+               errorText: errorText,
+               hintText: hintText,
+             );
+           }
 
            // An unfocusable Focus widget so that this widget can detect if its
            // descendants have focus or not.
@@ -1800,11 +1815,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
                      enableFeedback: enableFeedback,
                      alignment: alignment,
                      borderRadius: borderRadius,
-                     // Clear the decoration hintText because DropdownButton has its own hint logic.
-                     inputDecoration: effectiveDecoration.copyWith(
-                       errorText: field.errorText,
-                       hintText: effectiveDecoration.hintText != null ? '' : null,
-                     ),
+                     inputDecoration: effectiveDecoration,
                      isEmpty: isEmpty,
                      padding: padding,
                    ),

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -16,14 +16,6 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show SmartDashesType, SmartQuotesType;
 
-/// Signature for a callback that builds an error widget.
-///
-/// See also:
-///
-///  * [TextFormField.errorBuilder], which is of this type, and passes the result error
-/// given by [TextFormField.validator].
-typedef TextFormFieldErrorBuilder = Widget Function(String errorText);
-
 /// A [FormField] that contains a [TextField].
 ///
 /// This is a convenience widget that wraps a [TextField] widget in a
@@ -158,7 +150,7 @@ class TextFormField extends FormField<String> {
     ValueChanged<String>? onFieldSubmitted,
     super.onSaved,
     super.validator,
-    this.errorBuilder,
+    super.errorBuilder,
     List<TextInputFormatter>? inputFormatters,
     bool? enabled,
     bool? ignorePointers,
@@ -218,8 +210,17 @@ class TextFormField extends FormField<String> {
          autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
          builder: (FormFieldState<String> field) {
            final _TextFormFieldState state = field as _TextFormFieldState;
-           final InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
+           InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
                .applyDefaults(Theme.of(field.context).inputDecorationTheme);
+
+           final String? errorText = field.errorText;
+           if (errorText != null) {
+             effectiveDecoration =
+                 errorBuilder != null
+                     ? effectiveDecoration.copyWith(error: errorBuilder(errorText))
+                     : effectiveDecoration.copyWith(errorText: errorText);
+           }
+
            void onChangedHandler(String value) {
              field.didChange(value);
              onChanged?.call(value);
@@ -325,14 +326,6 @@ class TextFormField extends FormField<String> {
   /// value: when they have inserted or deleted text or reset the form.
   /// {@endtemplate}
   final ValueChanged<String>? onChanged;
-
-  /// Function that returns the widget representing the error to display.
-  /// It is passed the form field validator error string as input.
-  /// The resulting widget is passed to [InputDecoration.error].
-  ///
-  /// If null, the validator error string is passed to
-  /// [InputDecoration.errorText].
-  final TextFormFieldErrorBuilder? errorBuilder;
 
   static Widget _defaultContextMenuBuilder(
     BuildContext context,

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -16,6 +16,14 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show SmartDashesType, SmartQuotesType;
 
+/// Signature for a callback that builds an error widget.
+///
+/// See also:
+///
+///  * [TextFormField.errorBuilder], which is of this type, and passes the result error
+/// given by [TextFormField.validator].
+typedef TextFormFieldErrorBuilder = Widget Function(String errorText);
+
 /// A [FormField] that contains a [TextField].
 ///
 /// This is a convenience widget that wraps a [TextField] widget in a
@@ -150,6 +158,7 @@ class TextFormField extends FormField<String> {
     ValueChanged<String>? onFieldSubmitted,
     super.onSaved,
     super.validator,
+    this.errorBuilder,
     List<TextInputFormatter>? inputFormatters,
     bool? enabled,
     bool? ignorePointers,
@@ -223,7 +232,12 @@ class TextFormField extends FormField<String> {
                restorationId: restorationId,
                controller: state._effectiveController,
                focusNode: focusNode,
-               decoration: effectiveDecoration.copyWith(errorText: field.errorText),
+               decoration:
+                   errorBuilder != null
+                       ? effectiveDecoration.copyWith(
+                         error: field.errorText != null ? errorBuilder(field.errorText!) : null,
+                       )
+                       : effectiveDecoration.copyWith(errorText: field.errorText),
                keyboardType: keyboardType,
                textInputAction: textInputAction,
                style: style,
@@ -311,6 +325,14 @@ class TextFormField extends FormField<String> {
   /// value: when they have inserted or deleted text or reset the form.
   /// {@endtemplate}
   final ValueChanged<String>? onChanged;
+
+  /// Function that returns the widget representing the error to display.
+  /// It is passed the form field validator error string as input.
+  /// The resulting widget is passed to [InputDecoration.error].
+  ///
+  /// If null, the validator error string is passed to
+  /// [InputDecoration.errorText].
+  final TextFormFieldErrorBuilder? errorBuilder;
 
   static Widget _defaultContextMenuBuilder(
     BuildContext context,

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -217,7 +217,7 @@ class TextFormField extends FormField<String> {
            if (errorText != null) {
              effectiveDecoration =
                  errorBuilder != null
-                     ? effectiveDecoration.copyWith(error: errorBuilder(errorText))
+                     ? effectiveDecoration.copyWith(error: errorBuilder(state.context, errorText))
                      : effectiveDecoration.copyWith(errorText: errorText);
            }
 
@@ -233,12 +233,7 @@ class TextFormField extends FormField<String> {
                restorationId: restorationId,
                controller: state._effectiveController,
                focusNode: focusNode,
-               decoration:
-                   errorBuilder != null
-                       ? effectiveDecoration.copyWith(
-                         error: field.errorText != null ? errorBuilder(field.errorText!) : null,
-                       )
-                       : effectiveDecoration.copyWith(errorText: field.errorText),
+               decoration: effectiveDecoration,
                keyboardType: keyboardType,
                textInputAction: textInputAction,
                style: style,

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -421,6 +421,14 @@ class _FormScope extends InheritedWidget {
 /// Used by [FormField.validator].
 typedef FormFieldValidator<T> = String? Function(T? value);
 
+/// Signature for a callback that builds an error widget.
+///
+/// See also:
+///
+///  * [FormField.errorBuilder], which is of this type, and passes the result error
+/// given by [TextFormField.validator].
+typedef FormFieldErrorBuilder = Widget Function(String errorText);
+
 /// Signature for being notified when a form field changes value.
 ///
 /// Used by [FormField.onSaved].
@@ -460,11 +468,17 @@ class FormField<T> extends StatefulWidget {
     this.onSaved,
     this.forceErrorText,
     this.validator,
+    this.errorBuilder,
     this.initialValue,
     this.enabled = true,
     AutovalidateMode? autovalidateMode,
     this.restorationId,
   }) : autovalidateMode = autovalidateMode ?? AutovalidateMode.disabled;
+
+  /// Function that returns the widget representing this form field. It is
+  /// passed the form field state as input, containing the current value and
+  /// validation state of this field.
+  final FormFieldBuilder<T> builder;
 
   /// An optional method to call with the final value when the form is saved via
   /// [FormState.save].
@@ -503,10 +517,13 @@ class FormField<T> extends StatefulWidget {
   /// parameter to a space.
   final FormFieldValidator<T>? validator;
 
-  /// Function that returns the widget representing this form field. It is
-  /// passed the form field state as input, containing the current value and
-  /// validation state of this field.
-  final FormFieldBuilder<T> builder;
+  /// Function that returns the widget representing the error to display.
+  /// It is passed the form field validator error string as input.
+  /// The resulting widget is passed to [InputDecoration.error].
+  ///
+  /// If null, the validator error string is passed to
+  /// [InputDecoration.errorText].
+  final FormFieldErrorBuilder? errorBuilder;
 
   /// An optional value to initialize the form field to, or null otherwise.
   ///

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -427,7 +427,7 @@ typedef FormFieldValidator<T> = String? Function(T? value);
 ///
 ///  * [FormField.errorBuilder], which is of this type, and passes the result error
 /// given by [TextFormField.validator].
-typedef FormFieldErrorBuilder = Widget Function(String errorText);
+typedef FormFieldErrorBuilder = Widget Function(BuildContext context, String errorText);
 
 /// Signature for being notified when a form field changes value.
 ///
@@ -475,9 +475,10 @@ class FormField<T> extends StatefulWidget {
     this.restorationId,
   }) : autovalidateMode = autovalidateMode ?? AutovalidateMode.disabled;
 
-  /// Function that returns the widget representing this form field. It is
-  /// passed the form field state as input, containing the current value and
-  /// validation state of this field.
+  /// Function that returns the widget representing this form field.
+  ///
+  /// It is passed the form field state as input, containing the current value
+  /// and validation state of this field.
   final FormFieldBuilder<T> builder;
 
   /// An optional method to call with the final value when the form is saved via
@@ -518,6 +519,7 @@ class FormField<T> extends StatefulWidget {
   final FormFieldValidator<T>? validator;
 
   /// Function that returns the widget representing the error to display.
+  ///
   /// It is passed the form field validator error string as input.
   /// The resulting widget is passed to [InputDecoration.error].
   ///

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -1229,4 +1229,28 @@ void main() {
     expect(inputDecorator.isFocused, true);
     expect(inputDecorator.decoration.errorText, 'Required');
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/135292.
+  testWidgets('Widget returned by errorBuilder is shown', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: DropdownButtonFormField<String>(
+            items:
+                menuItems.map((String value) {
+                  return DropdownMenuItem<String>(value: value, child: Text(value));
+                }).toList(),
+            onChanged: onChanged,
+            autovalidateMode: AutovalidateMode.always,
+            validator: (String? v) => 'Required',
+            errorBuilder: (String errorText) => Text('**$errorText**'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('**Required**'), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -1243,13 +1243,13 @@ void main() {
             onChanged: onChanged,
             autovalidateMode: AutovalidateMode.always,
             validator: (String? v) => 'Required',
-            errorBuilder: (String errorText) => Text('**$errorText**'),
+            errorBuilder: (BuildContext context, String errorText) => Text('**$errorText**'),
           ),
         ),
       ),
     );
 
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.text('**Required**'), findsOneWidget);
   });

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1665,19 +1665,15 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/135292.
-  testWidgets('TextFormField shows widget returned by errorBuilder', (WidgetTester tester) async {
+  testWidgets('Widget returned by errorBuilder is shown', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
           child: Center(
             child: TextFormField(
               autovalidateMode: AutovalidateMode.always,
-              validator: (String? value) {
-                return 'validation error';
-              },
-              errorBuilder: (String errorText) {
-                return Text('**$errorText**');
-              },
+              validator: (String? value) => 'validation error',
+              errorBuilder: (String errorText) => Text('**$errorText**'),
             ),
           ),
         ),

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1673,14 +1673,14 @@ void main() {
             child: TextFormField(
               autovalidateMode: AutovalidateMode.always,
               validator: (String? value) => 'validation error',
-              errorBuilder: (String errorText) => Text('**$errorText**'),
+              errorBuilder: (BuildContext context, String errorText) => Text('**$errorText**'),
             ),
           ),
         ),
       ),
     );
 
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.text('**validation error**'), findsOneWidget);
   });

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1663,4 +1663,29 @@ void main() {
     expect(find.text(forceErrorText), findsOne);
     expect(find.text(decorationErrorText), findsNothing);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/135292.
+  testWidgets('TextFormField shows widget returned by errorBuilder', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
+              autovalidateMode: AutovalidateMode.always,
+              validator: (String? value) {
+                return 'validation error';
+              },
+              errorBuilder: (String errorText) {
+                return Text('**$errorText**');
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('**validation error**'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Description

This PR adds the `TextFormField.errorBuilder`property which makes it possible to customize the widget used to display the error message.

Implementation based on https://github.com/flutter/flutter/pull/156275#issuecomment-2521651828

## Related Issue

Fixes [Unable to use validator along with error widget in TextFormField](https://github.com/flutter/flutter/issues/133629)
Fixes https://github.com/flutter/flutter/issues/135292

## Tests

Adds 1 tests.