### PR TITLE
Enable the Android Engine OpenGLES/Vulkan suites.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1528,7 +1528,6 @@ targets:
 
   - name: Linux_android_emu android_engine_vulkan_tests
     recipe: flutter/flutter_drone
-    bringup: true
     timeout: 60
     properties:
       shard: android_engine_vulkan_tests
@@ -1541,7 +1540,6 @@ targets:
 
   - name: Linux_android_emu android_engine_opengles_tests
     recipe: flutter/flutter_drone
-    bringup: true
     timeout: 60
     properties:
       shard: android_engine_opengles_tests


### PR DESCRIPTION
For some reason they never ran on `bringup: true` (???) but I guess they'll run on presubmit (or not, we'll see).

Closes https://github.com/flutter/flutter/issues/161333.