### PR TITLE
Don't depend on Dart from FML.

### DIFF
--- a/engine/src/flutter/fml/BUILD.gn
+++ b/engine/src/flutter/fml/BUILD.gn
@@ -113,12 +113,7 @@ source_set("fml") {
     ":string_conversion",
   ]
 
-  deps = [
-    "$dart_src/runtime:dart_api",
-
-    # These need to be in sync with the Fuchsia buildroot.
-    "//flutter/third_party/icu",
-  ]
+  deps = [ "//flutter/third_party/icu" ]
 
   if (enable_backtrace) {
     # This abseil dependency is only used by backtrace.cc.


### PR DESCRIPTION
This was likely a holdover from a time when trace events were routed to the timeline directly.

This was causing standalone QNX builds to also pull in Dart.

No change in functionality and hopefully faster builds for smaller targets.
