### PR TITLE
Adds semantics role checks

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1924,6 +1924,7 @@ class _TabBarState extends State<TabBar> {
 
     Widget tabBar = Semantics(
       role: SemanticsRole.tabBar,
+      explicitChildNodes: true,
       child: CustomPaint(
         painter: _indicatorPainter,
         child: _TabStyle(

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -209,12 +209,9 @@ class Tab extends StatelessWidget implements PreferredSizeWidget {
       );
     }
 
-    return Semantics(
-      role: SemanticsRole.tab,
-      child: SizedBox(
-        height: height ?? calculatedHeight,
-        child: Center(widthFactor: 1.0, child: label),
-      ),
+    return SizedBox(
+      height: height ?? calculatedHeight,
+      child: Center(widthFactor: 1.0, child: label),
     );
   }
 
@@ -1909,6 +1906,7 @@ class _TabBarState extends State<TabBar> {
             children: <Widget>[
               wrappedTabs[index],
               Semantics(
+                role: SemanticsRole.tab,
                 selected: index == _currentIndex,
                 label:
                     kIsWeb ? null : localizations.tabLabel(tabIndex: index + 1, tabCount: tabCount),
@@ -1924,6 +1922,7 @@ class _TabBarState extends State<TabBar> {
 
     Widget tabBar = Semantics(
       role: SemanticsRole.tabBar,
+      container: true,
       explicitChildNodes: true,
       child: CustomPaint(
         painter: _indicatorPainter,

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -104,6 +104,10 @@ final int _kUnblockedUserActions =
 /// Function signature for checks in [DebugSemanticsRoleChecks.kChecks].
 ///
 /// The check is run against any `node` that is sent to the platform.
+///
+/// To access the flags and properties, one should call the
+/// [SemanticsNode.getSemanticsData].
+@visibleForTesting
 typedef DebugSemanticsRoleCheck = FlutterError? Function(SemanticsNode node);
 
 /// A static class to conduct semantics role checks.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -115,9 +115,7 @@ typedef DebugSemanticsRoleCheck = FlutterError? Function(SemanticsNode node);
 /// When adding a new [SemanticsRole], one must also add a corresponding check
 /// to [kChecks].
 @visibleForTesting
-class DebugSemanticsRoleChecks {
-  DebugSemanticsRoleChecks._();
-
+sealed class DebugSemanticsRoleChecks {
   /// A map to map each [SemanticsRole] to its check.
   static const Map<SemanticsRole, DebugSemanticsRoleCheck> kChecks =
       <SemanticsRole, DebugSemanticsRoleCheck>{

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -131,20 +131,14 @@ sealed class DebugSemanticsRoleChecks {
 
   static FlutterError? _semanticsTab(SemanticsNode node) {
     final SemanticsData data = node.getSemanticsData();
-    if (!data.hasFlag(SemanticsFlag.hasEnabledState) ||
-        !data.hasFlag(SemanticsFlag.hasSelectedState)) {
-      return FlutterError('A tab needs enabled and selected states');
+    if (!data.hasFlag(SemanticsFlag.hasSelectedState)) {
+      return FlutterError('A tab needs selected states');
     }
 
-    if (!data.hasFlag(SemanticsFlag.isEnabled)) {
-      // disabled tab is not interactable.
-      return null;
-    }
-
-    if (data.hasFlag(SemanticsFlag.isSelected) || data.hasAction(SemanticsAction.tap)) {
+    if (data.hasAction(SemanticsAction.tap)) {
       return null;
     } else {
-      return FlutterError('A enabled tab must have a tap action');
+      return FlutterError('A tab must have a tap action');
     }
   }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -101,6 +101,30 @@ final int _kUnblockedUserActions =
     SemanticsAction.didGainAccessibilityFocus.index |
     SemanticsAction.didLoseAccessibilityFocus.index;
 
+typedef DebugSemanticsRoleCheck = bool Function(SemanticsData node);
+
+@visibleForTesting
+class DebugSemanticsRoleChecks {
+  DebugSemanticsRoleChecks._();
+
+  static const Map<SemanticsRole, DebugSemanticsRoleCheck> kChecks =
+      <SemanticsRole, DebugSemanticsRoleCheck>{SemanticsRole.tab: _semanticsTab};
+
+  static bool _semanticsTab(SemanticsData node) {
+    if (!node.hasFlag(SemanticsFlag.hasEnabledState) ||
+        !node.hasFlag(SemanticsFlag.hasSelectedState)) {
+      return false;
+    }
+
+    if (!node.hasFlag(SemanticsFlag.isEnabled)) {
+      // disabled tab is not interactable.
+      return true;
+    }
+
+    return node.hasFlag(SemanticsFlag.isSelected) || node.hasAction(SemanticsAction.tap);
+  }
+}
+
 /// A tag for a [SemanticsNode].
 ///
 /// Tags can be interpreted by the parent of a [SemanticsNode]

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -135,11 +135,11 @@ sealed class DebugSemanticsRoleChecks {
       return FlutterError('A tab needs selected states');
     }
 
-    if (data.hasAction(SemanticsAction.tap)) {
-      return null;
-    } else {
+    if (!node.areUserActionsBlocked && !data.hasAction(SemanticsAction.tap)) {
       return FlutterError('A tab must have a tap action');
     }
+
+    return null;
   }
 
   static FlutterError? _semanticsTabBar(SemanticsNode node) {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -111,6 +111,9 @@ final int _kUnblockedUserActions =
 typedef DebugSemanticsRoleCheck = FlutterError? Function(SemanticsNode node);
 
 /// A static class to conduct semantics role checks.
+///
+/// When adding a new [SemanticsRole], one must also add a corresponding check
+/// to [kChecks].
 @visibleForTesting
 class DebugSemanticsRoleChecks {
   DebugSemanticsRoleChecks._();

--- a/packages/flutter/test/material/app_bar_sliver_test.dart
+++ b/packages/flutter/test/material/app_bar_sliver_test.dart
@@ -2162,7 +2162,7 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/158158.
   testWidgets('SliverAppBar should update TabBar before TabBar build', (WidgetTester tester) async {
-    final List<Tab> tabs = <Tab>[];
+    final List<Tab> tabs = <Tab>[const Tab(text: 'initial tab')];
 
     await tester.pumpWidget(
       MaterialApp(
@@ -2179,7 +2179,7 @@ void main() {
                           child: const Text('Add Tab'),
                           onPressed: () {
                             setState(() {
-                              tabs.add(Tab(text: 'Tab ${tabs.length + 1}'));
+                              tabs.add(Tab(text: 'Tab ${tabs.length}'));
                             });
                           },
                         ),
@@ -2195,7 +2195,8 @@ void main() {
       ),
     );
 
-    // Initializes with zero tabs.
+    // Initializes with only initial tabs.
+    expect(find.text('initial tab'), findsOneWidget);
     expect(find.text('Tab 1'), findsNothing);
     expect(find.text('Tab 2'), findsNothing);
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -6002,39 +6002,44 @@ void main() {
           label: 'Tab 1 of 2',
           id: 1,
           rect: TestSemantics.fullScreen,
-          role: SemanticsRole.tabBar,
           children: <TestSemantics>[
             TestSemantics(
-              label: 'TAB1${kIsWeb ? '' : '\nTab 1 of 2'}',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isFocusable,
-                SemanticsFlag.isSelected,
-                SemanticsFlag.hasSelectedState,
-              ],
               id: 2,
-              rect: TestSemantics.fullScreen,
-              actions: 1 | SemanticsAction.focus.index,
-              role: SemanticsRole.tab,
+              role: SemanticsRole.tabBar,
+              children: <TestSemantics>[
+                TestSemantics(
+                  label: 'TAB1${kIsWeb ? '' : '\nTab 1 of 2'}',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isFocusable,
+                    SemanticsFlag.isSelected,
+                    SemanticsFlag.hasSelectedState,
+                  ],
+                  id: 3,
+                  rect: TestSemantics.fullScreen,
+                  actions: 1 | SemanticsAction.focus.index,
+                  role: SemanticsRole.tab,
+                ),
+                TestSemantics(
+                  label: 'TAB2${kIsWeb ? '' : '\nTab 2 of 2'}',
+                  flags: <SemanticsFlag>[SemanticsFlag.isFocusable, SemanticsFlag.hasSelectedState],
+                  id: 4,
+                  rect: TestSemantics.fullScreen,
+                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                  role: SemanticsRole.tab,
+                ),
+              ],
             ),
             TestSemantics(
-              label: 'TAB2${kIsWeb ? '' : '\nTab 2 of 2'}',
-              flags: <SemanticsFlag>[SemanticsFlag.isFocusable, SemanticsFlag.hasSelectedState],
-              id: 3,
-              rect: TestSemantics.fullScreen,
-              actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
-              role: SemanticsRole.tab,
-            ),
-            TestSemantics(
-              id: 4,
+              id: 5,
               rect: TestSemantics.fullScreen,
               children: <TestSemantics>[
                 TestSemantics(
-                  id: 6,
+                  id: 7,
                   rect: TestSemantics.fullScreen,
                   actions: <SemanticsAction>[SemanticsAction.scrollLeft],
                   children: <TestSemantics>[
                     TestSemantics(
-                      id: 5,
+                      id: 6,
                       rect: TestSemantics.fullScreen,
                       label: 'PAGE1',
                       role: SemanticsRole.tabPanel,

--- a/packages/flutter/test/widgets/semantics_role_checks_test.dart
+++ b/packages/flutter/test/widgets/semantics_role_checks_test.dart
@@ -5,10 +5,67 @@
 import 'dart:ui';
 
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('All semantics roles has checks', () {
     expect(SemanticsRole.values.toSet(), DebugSemanticsRoleChecks.kChecks.keys.toSet());
+  });
+
+  group('tab', () {
+    testWidgets('failure case, empty', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Semantics(role: SemanticsRole.tab, child: const Text('a tab')),
+        ),
+      );
+      expect(tester.takeException(), isFlutterError);
+    });
+
+    testWidgets('failure case, no tap', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Semantics(
+            role: SemanticsRole.tab,
+            enabled: true,
+            selected: false,
+            child: const Text('a tab'),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isFlutterError);
+    });
+  });
+
+  group('tabBar', () {
+    testWidgets('failure case, empty child', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Semantics(
+            role: SemanticsRole.tabBar,
+            child: const ExcludeSemantics(child: Text('something')),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isFlutterError);
+    });
+
+    testWidgets('failure case, non tab child', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Semantics(
+            role: SemanticsRole.tabBar,
+            explicitChildNodes: true,
+            child: Semantics(child: const Text('some child')),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isFlutterError);
+    });
   });
 }

--- a/packages/flutter/test/widgets/semantics_role_checks_test.dart
+++ b/packages/flutter/test/widgets/semantics_role_checks_test.dart
@@ -24,49 +24,28 @@ void main() {
       final Object? exception = tester.takeException();
       expect(exception, isFlutterError);
       final FlutterError error = exception! as FlutterError;
-      expect(error.message, 'A tab needs enabled and selected states');
+      expect(error.message, 'A tab needs selected states');
     });
 
     testWidgets('failure case, no tap', (WidgetTester tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: Semantics(
-            role: SemanticsRole.tab,
-            enabled: true,
-            selected: false,
-            child: const Text('a tab'),
-          ),
+          child: Semantics(role: SemanticsRole.tab, selected: false, child: const Text('a tab')),
         ),
       );
       final Object? exception = tester.takeException();
       expect(exception, isFlutterError);
       final FlutterError error = exception! as FlutterError;
-      expect(error.message, 'A enabled tab must have a tap action');
+      expect(error.message, 'A tab must have a tap action');
     });
 
-    testWidgets('success case - disabled', (WidgetTester tester) async {
+    testWidgets('success case', (WidgetTester tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
           child: Semantics(
             role: SemanticsRole.tab,
-            enabled: false,
-            selected: false,
-            child: const Text('a tab'),
-          ),
-        ),
-      );
-      expect(tester.takeException(), isNull);
-    });
-
-    testWidgets('success case - enabled', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: Semantics(
-            role: SemanticsRole.tab,
-            enabled: true,
             selected: false,
             onTap: () {},
             child: const Text('a tab'),
@@ -120,8 +99,8 @@ void main() {
             explicitChildNodes: true,
             child: Semantics(
               role: SemanticsRole.tab,
-              enabled: false,
               selected: false,
+              onTap: () {},
               child: const Text('some child'),
             ),
           ),

--- a/packages/flutter/test/widgets/semantics_role_checks_test.dart
+++ b/packages/flutter/test/widgets/semantics_role_checks_test.dart
@@ -21,7 +21,10 @@ void main() {
           child: Semantics(role: SemanticsRole.tab, child: const Text('a tab')),
         ),
       );
-      expect(tester.takeException(), isFlutterError);
+      final Object? exception = tester.takeException();
+      expect(exception, isFlutterError);
+      final FlutterError error = exception! as FlutterError;
+      expect(error.message, 'A tab needs enabled and selected states');
     });
 
     testWidgets('failure case, no tap', (WidgetTester tester) async {
@@ -36,7 +39,41 @@ void main() {
           ),
         ),
       );
-      expect(tester.takeException(), isFlutterError);
+      final Object? exception = tester.takeException();
+      expect(exception, isFlutterError);
+      final FlutterError error = exception! as FlutterError;
+      expect(error.message, 'A enabled tab must have a tap action');
+    });
+
+    testWidgets('success case - disabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Semantics(
+            role: SemanticsRole.tab,
+            enabled: false,
+            selected: false,
+            child: const Text('a tab'),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('success case - enabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Semantics(
+            role: SemanticsRole.tab,
+            enabled: true,
+            selected: false,
+            onTap: () {},
+            child: const Text('a tab'),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
     });
   });
 
@@ -51,7 +88,10 @@ void main() {
           ),
         ),
       );
-      expect(tester.takeException(), isFlutterError);
+      final Object? exception = tester.takeException();
+      expect(exception, isFlutterError);
+      final FlutterError error = exception! as FlutterError;
+      expect(error.message, 'a TabBar cannot be empty');
     });
 
     testWidgets('failure case, non tab child', (WidgetTester tester) async {
@@ -65,7 +105,29 @@ void main() {
           ),
         ),
       );
-      expect(tester.takeException(), isFlutterError);
+      final Object? exception = tester.takeException();
+      expect(exception, isFlutterError);
+      final FlutterError error = exception! as FlutterError;
+      expect(error.message, 'Children of TabBar must have the tab role');
+    });
+
+    testWidgets('Success case', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Semantics(
+            role: SemanticsRole.tabBar,
+            explicitChildNodes: true,
+            child: Semantics(
+              role: SemanticsRole.tab,
+              enabled: false,
+              selected: false,
+              child: const Text('some child'),
+            ),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
     });
   });
 }

--- a/packages/flutter/test/widgets/semantics_role_checks_test.dart
+++ b/packages/flutter/test/widgets/semantics_role_checks_test.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('All semantics roles has checks', () {
+    expect(SemanticsRole.values.toSet(), DebugSemanticsRoleChecks.kChecks.keys.toSet());
+  });
+}


### PR DESCRIPTION
Adds test and error detection system for semantics roles.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
