### PR TITLE
[ Widget Preview ] Add support for building and launching the widget preview scaffold

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -85,7 +85,10 @@ Future<void> main(List<String> args) async {
   final bool daemon = args.contains('daemon');
   final bool runMachine =
       (args.contains('--machine') && args.contains('run')) ||
-      (args.contains('--machine') && args.contains('attach'));
+      (args.contains('--machine') && args.contains('attach')) ||
+      // `flutter widget-preview start` starts an application that requires a logger
+      // to be setup for machine mode.
+      (args.contains('widget-preview') && args.contains('start'));
 
   // Cache.flutterRoot must be set early because other features use it (e.g.
   // enginePath's initializer uses it). This can only work with the real

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -14,7 +14,6 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
-import '../daemon.dart';
 import '../device.dart';
 import '../features.dart';
 import '../globals.dart' as globals;
@@ -781,18 +780,7 @@ class RunCommand extends RunCommandBase {
 
   @visibleForTesting
   Daemon createMachineDaemon() {
-    final Daemon daemon = Daemon(
-      DaemonConnection(
-        daemonStreams: DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
-        logger: globals.logger,
-      ),
-      notifyingLogger:
-          (globals.logger is NotifyingLogger)
-              ? globals.logger as NotifyingLogger
-              : NotifyingLogger(verbose: globals.logger.isVerbose, parent: globals.logger),
-      logToStdout: true,
-    );
-    return daemon;
+    return Daemon.createMachineDaemon();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -8,21 +8,29 @@ import 'package:meta/meta.dart';
 import '../base/common.dart';
 import '../base/deferred_component.dart';
 import '../base/file_system.dart';
-import '../base/platform.dart';
+import '../base/os.dart';
+import '../build_info.dart';
+import '../bundle.dart' as bundle;
 import '../cache.dart';
 import '../convert.dart';
 import '../dart/pub.dart';
+import '../device.dart';
 import '../flutter_manifest.dart';
 
 import '../globals.dart' as globals;
+import '../linux/build_linux.dart';
+import '../macos/build_macos.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart';
 import '../widget_preview/preview_code_generator.dart';
 import '../widget_preview/preview_detector.dart';
+import '../windows/build_windows.dart';
 import 'create_base.dart';
+import 'daemon.dart';
 
 // TODO(bkonyi): use dependency injection instead of global accessors throughout this file.
 class WidgetPreviewCommand extends FlutterCommand {
+  // TODO(bkonyi): use dependency injection instead of globals for these commands.
   WidgetPreviewCommand() {
     addSubcommand(WidgetPreviewStartCommand());
     addSubcommand(WidgetPreviewCleanCommand());
@@ -78,13 +86,23 @@ class WidgetPreviewStartCommand extends FlutterCommand
     with CreateBase, WidgetPreviewSubCommandMixin {
   WidgetPreviewStartCommand() {
     addPubOptions();
+    argParser.addFlag(
+      kLaunchPreviewer,
+      defaultsTo: true,
+      help: 'Launches the widget preview environment.',
+    );
   }
+
+  static const String kWidgetPreviewScaffoldName = 'widget_preview_scaffold';
+  static const String kLaunchPreviewer = 'launch-previewer';
 
   @override
   String get description => 'Starts the widget preview environment.';
 
   @override
   String get name => 'start';
+
+  bool get launchPreviewer => boolArg(kLaunchPreviewer);
 
   late final PreviewDetector _previewDetector = PreviewDetector(
     logger: globals.logger,
@@ -93,6 +111,9 @@ class WidgetPreviewStartCommand extends FlutterCommand
 
   late final PreviewCodeGenerator _previewCodeGenerator;
 
+  /// The currently running instance of the widget preview scaffold.
+  AppInstance? _widgetPreviewApp;
+
   @override
   Future<FlutterCommandResult> runCommand() async {
     final FlutterProject rootProject = getRootProject();
@@ -100,46 +121,213 @@ class WidgetPreviewStartCommand extends FlutterCommand
 
     // Check to see if a preview scaffold has already been generated. If not,
     // generate one.
-    if (!widgetPreviewScaffold.existsSync()) {
+    final bool generateScaffoldProject = !widgetPreviewScaffold.existsSync();
+    widgetPreviewScaffold.createSync();
+
+    if (generateScaffoldProject) {
       globals.logger.printStatus(
         'Creating widget preview scaffolding at: ${widgetPreviewScaffold.path}',
       );
       await generateApp(
-        <String>['widget_preview_scaffold'],
+        <String>['app', kWidgetPreviewScaffoldName],
         widgetPreviewScaffold,
         createTemplateContext(
           organization: 'flutter',
-          projectName: 'widget_preview_scaffold',
+          projectName: kWidgetPreviewScaffoldName,
           titleCaseProjectName: 'Widget Preview Scaffold',
           flutterRoot: Cache.flutterRoot!,
           dartSdkVersionBounds: '^${globals.cache.dartSdkBuild}',
-          linux: const LocalPlatform().isLinux,
-          macos: const LocalPlatform().isMacOS,
-          windows: const LocalPlatform().isWindows,
+          linux: globals.platform.isLinux,
+          macos: globals.platform.isMacOS,
+          windows: globals.platform.isWindows,
         ),
         overwrite: true,
         generateMetadata: false,
       );
-      await _populatePreviewPubspec(rootProject: rootProject);
+
+      // WARNING: this access of widgetPreviewScaffoldProject needs to happen after we generate the
+      // scaffold project as invoking the getter triggers lazy initialization of the preview scaffold's
+      // FlutterManifest before the scaffold project's pubspec has been generated.
+      // TODO(bkonyi): add logic to rebuild after SDK updates
+      await initialBuild(widgetPreviewScaffoldProject: rootProject.widgetPreviewScaffoldProject);
     }
 
-    // WARNING: this needs to happen after we generate the scaffold project as invoking the
-    // widgetPreviewScaffoldProject getter triggers lazy initialization of the preview scaffold's
-    // FlutterManifest before the scaffold project's pubspec has been generated.
     _previewCodeGenerator = PreviewCodeGenerator(
       widgetPreviewScaffoldProject: rootProject.widgetPreviewScaffoldProject,
       fs: globals.fs,
     );
 
+    // TODO(matanlurey): Remove this comment once flutter_gen is removed.
+    //
+    // Tracking removal: https://github.com/flutter/flutter/issues/102983.
+    //
+    // Populate the pubspec after the initial build to avoid blowing away the package_config.json
+    // which may have manual changes for flutter_gen support.
+    await _populatePreviewPubspec(rootProject: rootProject);
+
     final PreviewMapping initialPreviews = await _previewDetector.initialize(rootProject.directory);
     _previewCodeGenerator.populatePreviewsInGeneratedPreviewScaffold(initialPreviews);
+
+    if (launchPreviewer) {
+      globals.shutdownHooks.addShutdownHook(() async {
+        await _widgetPreviewApp?.stop();
+      });
+      _widgetPreviewApp = await runPreviewEnvironment(
+        widgetPreviewScaffoldProject: rootProject.widgetPreviewScaffoldProject,
+      );
+
+      final int result = await _widgetPreviewApp!.runner.waitForAppToFinish();
+      if (result != 0) {
+        throwToolExit(null, exitCode: result);
+      }
+    }
 
     await _previewDetector.dispose();
     return FlutterCommandResult.success();
   }
 
   void onChangeDetected(PreviewMapping previews) {
-    // TODO(bkonyi): perform hot reload
+    globals.logger.printStatus('Triggering reload based on change to preview set: $previews');
+    _widgetPreviewApp?.restart();
+  }
+
+  /// Builds the application binary for the widget preview scaffold the first time the widget preview
+  /// command is run.
+  ///
+  /// The resulting binary is used to speed up subsequent widget previewer launches by acting as a
+  /// basic scaffold to load previews into using hot reload / restart.
+  Future<void> initialBuild({required FlutterProject widgetPreviewScaffoldProject}) async {
+    // TODO(bkonyi): handle error case where desktop device isn't enabled.
+    await widgetPreviewScaffoldProject.ensureReadyForPlatformSpecificTooling(
+      linuxPlatform: globals.platform.isLinux,
+      macOSPlatform: globals.platform.isMacOS,
+      windowsPlatform: globals.platform.isWindows,
+      allowedPlugins: const <String>[],
+    );
+
+    // Generate initial package_config.json, otherwise the build will fail.
+    await pub.get(
+      context: PubContext.create,
+      project: widgetPreviewScaffoldProject,
+      offline: offline,
+      outputMode: PubOutputMode.summaryOnly,
+    );
+
+    globals.logger.printStatus('Performing initial build of the Widget Preview Scaffold...');
+
+    final BuildInfo buildInfo = BuildInfo(
+      BuildMode.debug,
+      null,
+      treeShakeIcons: false,
+      packageConfigPath: widgetPreviewScaffoldProject.packageConfig.path,
+    );
+
+    if (globals.platform.isMacOS) {
+      await buildMacOS(
+        flutterProject: widgetPreviewScaffoldProject,
+        buildInfo: buildInfo,
+        verboseLogging: false,
+      );
+    } else if (globals.platform.isLinux) {
+      await buildLinux(
+        widgetPreviewScaffoldProject.linux,
+        buildInfo,
+        targetPlatform:
+            globals.os.hostPlatform == HostPlatform.linux_x64
+                ? TargetPlatform.linux_x64
+                : TargetPlatform.linux_arm64,
+        logger: globals.logger,
+      );
+    } else if (globals.platform.isWindows) {
+      await buildWindows(
+        widgetPreviewScaffoldProject.windows,
+        buildInfo,
+        globals.os.hostPlatform == HostPlatform.windows_x64
+            ? TargetPlatform.windows_x64
+            : TargetPlatform.windows_arm64,
+      );
+    } else {
+      throw UnimplementedError();
+    }
+    globals.logger.printStatus('Widget Preview Scaffold initial build complete.');
+  }
+
+  /// Returns the path to a prebuilt widget_preview_scaffold application binary.
+  String prebuiltApplicationBinaryPath({required FlutterProject widgetPreviewScaffoldProject}) {
+    assert(globals.platform.isLinux || globals.platform.isMacOS || globals.platform.isWindows);
+    String path;
+    if (globals.platform.isMacOS) {
+      path = 'build/macos/Build/Products/Debug/widget_preview_scaffold.app';
+    } else if (globals.platform.isLinux) {
+      // TODO(bkonyi): verify on Linux
+      path = 'build/linux/x64/debug/bundle/widget_preview_scaffold';
+    } else if (globals.platform.isWindows) {
+      // TODO(bkonyi): verify on Windows
+      path = 'build/windows/x64/runner/Debug/widget_preview_scaffold.exe';
+    } else {
+      throw StateError('Unknown OS');
+    }
+    path = globals.fs.path.join(widgetPreviewScaffoldProject.directory.path, path);
+    if (globals.fs.typeSync(path) == FileSystemEntityType.notFound) {
+      globals.logger.printStatus(globals.fs.currentDirectory.toString());
+      throw StateError('Could not find prebuilt application binary at $path.');
+    }
+    return path;
+  }
+
+  Future<AppInstance> runPreviewEnvironment({
+    required FlutterProject widgetPreviewScaffoldProject,
+  }) async {
+    final AppInstance app;
+    try {
+      // Since the only target supported by the widget preview scaffold is the host's desktop
+      // device, only a single desktop device should be returned.
+      final List<Device> devices = await globals.deviceManager!.getDevices(
+        filter: DeviceDiscoveryFilter(
+          supportFilter: DeviceDiscoverySupportFilter.excludeDevicesUnsupportedByFlutterOrProject(
+            flutterProject: widgetPreviewScaffoldProject,
+          ),
+          deviceConnectionInterface: DeviceConnectionInterface.attached,
+        ),
+      );
+      assert(devices.length == 1);
+      final Device device = devices.first;
+
+      // We launch from a prebuilt widget preview scaffold instance to reduce launch times after
+      // the first run.
+      final File prebuiltApplicationBinary = globals.fs.file(
+        prebuiltApplicationBinaryPath(widgetPreviewScaffoldProject: widgetPreviewScaffoldProject),
+      );
+      const String? kEmptyRoute = null;
+      const bool kEnableHotReload = true;
+
+      app = await Daemon.createMachineDaemon().appDomain.startApp(
+        device,
+        widgetPreviewScaffoldProject.directory.path,
+        bundle.defaultMainPath,
+        kEmptyRoute, // route
+        DebuggingOptions.enabled(
+          BuildInfo(
+            BuildMode.debug,
+            null,
+            treeShakeIcons: false,
+            packageConfigPath: widgetPreviewScaffoldProject.packageConfig.path,
+          ),
+        ),
+        kEnableHotReload, // hot mode
+        applicationBinary: prebuiltApplicationBinary,
+        trackWidgetCreation: false,
+        projectRootPath: widgetPreviewScaffoldProject.directory.path,
+      );
+    } on Exception catch (error) {
+      throwToolExit(error.toString());
+    }
+    // Immediately perform a hot restart to ensure new previews are loaded into the prebuilt
+    // application.
+    globals.logger.printStatus('Loading previews into the Widget Preview Scaffold...');
+    await app.restart(fullRestart: true);
+    globals.logger.printStatus('Done loading previews.');
+    return app;
   }
 
   @visibleForTesting

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -80,9 +80,9 @@ Future<void> buildLinux(
 
   final Status status = logger.startProgress('Building Linux application...');
   final String buildModeName = buildInfo.mode.cliName;
-  final Directory platformBuildDirectory = globals.fs.directory(
-    getLinuxBuildDirectory(targetPlatform),
-  );
+  final Directory platformBuildDirectory = globals.fs
+      .directory(linuxProject.parent.directory.path)
+      .childDirectory(getLinuxBuildDirectory(targetPlatform));
   final Directory buildDirectory = platformBuildDirectory.childDirectory(buildModeName);
   try {
     await _runCmake(

--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -178,6 +178,7 @@ class BuildableMacOSApp extends MacOSApp {
     }
 
     return globals.fs.path.join(
+      project.parent.directory.path,
       getMacOSBuildDirectory(),
       'Build',
       'Products',

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -112,7 +112,9 @@ Future<void> buildMacOS({
   final ProjectMigration migration = ProjectMigration(migrators);
   await migration.run();
 
-  final Directory flutterBuildDir = globals.fs.directory(getMacOSBuildDirectory());
+  final Directory flutterBuildDir = flutterProject.directory.childDirectory(
+    getMacOSBuildDirectory(),
+  );
   if (!flutterBuildDir.existsSync()) {
     flutterBuildDir.createSync(recursive: true);
   }

--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -52,13 +52,13 @@ class PreviewCodeGenerator {
               b
                 ..body =
                     literalList(<Object?>[
-                      for (final MapEntry<String, List<String>>(
-                            key: String path,
+                      for (final MapEntry<PreviewPath, List<String>>(
+                            key: (path: String _, :Uri uri),
                             value: List<String> previewMethods,
                           )
                           in previews.entries) ...<Object?>[
                         for (final String method in previewMethods)
-                          refer(method, path).call(<Expression>[]),
+                          refer(method, uri.toString()).call(<Expression>[]),
                       ],
                     ]).code
                 ..name = 'previews'

--- a/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
@@ -19,7 +19,15 @@ import '../base/utils.dart';
 import '../globals.dart' as globals;
 import 'preview_code_generator.dart';
 
-typedef PreviewMapping = Map<String, List<String>>;
+/// A path / URI pair used to map previews to a file.
+///
+/// We don't just use a path or a URI as the file watcher doesn't report URIs
+/// (e.g., package:*) but the analyzer APIs do, and the code generator emits
+/// package URIs for preview imports.
+typedef PreviewPath = ({String path, Uri uri});
+
+/// Represents a set of previews for a given file.
+typedef PreviewMapping = Map<PreviewPath, List<String>>;
 
 class PreviewDetector {
   PreviewDetector({required this.logger, required this.onChangeDetected});
@@ -38,7 +46,7 @@ class PreviewDetector {
     final Watcher watcher = Watcher(projectRoot.path);
     // TODO(bkonyi): watch for changes to pubspec.yaml
     _fileWatcher = watcher.events.listen((WatchEvent event) async {
-      final String eventPath = Uri.file(event.path).toString();
+      final String eventPath = event.path;
       // Only trigger a reload when changes to Dart sources are detected. We
       // ignore the generated preview file to avoid getting stuck in a loop.
       if (!eventPath.endsWith('.dart') ||
@@ -49,7 +57,9 @@ class PreviewDetector {
       final PreviewMapping filePreviewsMapping = findPreviewFunctions(
         globals.fs.file(Uri.file(event.path)),
       );
-      if (filePreviewsMapping.isEmpty && !_pathToPreviews.containsKey(eventPath)) {
+      final bool hasExistingPreviews =
+          _pathToPreviews.keys.where((PreviewPath e) => e.path == event.path).isNotEmpty;
+      if (filePreviewsMapping.isEmpty && !hasExistingPreviews) {
         // No previews found or removed, nothing to do.
         return;
       }
@@ -59,20 +69,21 @@ class PreviewDetector {
       }
       if (filePreviewsMapping.isNotEmpty) {
         // The set of previews has changed, but there are still previews in the file.
-        final MapEntry<String, List<String>>(key: String uri, value: List<String> filePreviews) =
-            filePreviewsMapping.entries.first;
-        assert(uri == eventPath);
-        logger.printStatus('Updated previews for $eventPath: $filePreviews');
+        final MapEntry<PreviewPath, List<String>>(
+          key: PreviewPath location,
+          value: List<String> filePreviews,
+        ) = filePreviewsMapping.entries.first;
+        logger.printStatus('Updated previews for ${location.uri}: $filePreviews');
         if (filePreviews.isNotEmpty) {
-          final List<String>? currentPreviewsForFile = _pathToPreviews[eventPath];
+          final List<String>? currentPreviewsForFile = _pathToPreviews[location];
           if (filePreviews != currentPreviewsForFile) {
-            _pathToPreviews[eventPath] = filePreviews;
+            _pathToPreviews[location] = filePreviews;
           }
         }
       } else {
         // The file previously had previews that were removed.
         logger.printStatus('Previews removed from $eventPath');
-        _pathToPreviews.remove(eventPath);
+        _pathToPreviews.removeWhere((PreviewPath e, _) => e.path == eventPath);
       }
       onChangeDetected(_pathToPreviews);
     });
@@ -106,7 +117,8 @@ class PreviewDetector {
         final SomeParsedLibraryResult lib = context.currentSession.getParsedLibrary(filePath);
         if (lib is ParsedLibraryResult) {
           for (final ParsedUnitResult unit in lib.units) {
-            final List<String> previewEntries = previews[unit.uri.toString()] ?? <String>[];
+            final List<String> previewEntries =
+                previews[(path: unit.path, uri: unit.uri)] ?? <String>[];
             for (final SyntacticEntity entity in unit.unit.childEntities) {
               if (entity is FunctionDeclaration && !entity.name.toString().startsWith('_')) {
                 bool foundPreview = false;
@@ -127,7 +139,7 @@ class PreviewDetector {
               }
             }
             if (previewEntries.isNotEmpty) {
-              previews[unit.uri.toString()] = previewEntries;
+              previews[(path: unit.path, uri: unit.uri)] = previewEntries;
             }
           }
         } else {

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview_test.dart
@@ -54,6 +54,7 @@ void main() {
     await runWidgetPreviewCommand(<String>[
       'start',
       ...?arguments,
+      '--no-launch-previewer',
       if (rootProject != null) rootProject.path,
     ]);
     final Directory widgetPreviewScaffoldDir = widgetPreviewScaffoldFromRootProject(

--- a/packages/flutter_tools/test/general.shard/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/general.shard/widget_preview/preview_code_generator_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/widget_preview/preview_code_generator.dart';
+import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
 import 'package:test/test.dart';
 
 import '../../src/context.dart';
@@ -39,9 +40,9 @@ void main() {
         expect(generatedPreviewFile, isNot(exists));
 
         // Populate the generated preview file.
-        codeGenerator.populatePreviewsInGeneratedPreviewScaffold(const <String, List<String>>{
-          'foo.dart': <String>['preview'],
-          'src/bar.dart': <String>['barPreview1', 'barPreview2'],
+        codeGenerator.populatePreviewsInGeneratedPreviewScaffold(<PreviewPath, List<String>>{
+          (path: '', uri: Uri(path: 'foo.dart')): <String>['preview'],
+          (path: '', uri: Uri(path: 'src/bar.dart')): <String>['barPreview1', 'barPreview2'],
         });
         expect(generatedPreviewFile, exists);
 
@@ -59,7 +60,9 @@ import 'foo.dart' as _i1;import 'src/bar.dart' as _i2;import 'package:widget_pre
         expect(generatedPreviewFile.readAsStringSync(), expectedGeneratedPreviewFileContents);
 
         // Regenerate the generated file with no previews.
-        codeGenerator.populatePreviewsInGeneratedPreviewScaffold(const <String, List<String>>{});
+        codeGenerator.populatePreviewsInGeneratedPreviewScaffold(
+          const <PreviewPath, List<String>>{},
+        );
         expect(generatedPreviewFile, exists);
 
         // The generated file should only contain:

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -1,0 +1,88 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:process/process.dart';
+
+import '../src/common.dart';
+import 'test_data/basic_project.dart';
+import 'test_utils.dart';
+
+const List<String> firstLaunchMessages = <String>[
+  'Creating widget preview scaffolding at:',
+  'Performing initial build of the Widget Preview Scaffold...',
+  'Widget Preview Scaffold initial build complete.',
+  'Loading previews into the Widget Preview Scaffold...',
+  'Done loading previews.',
+];
+
+const List<String> subsequentLaunchMessages = <String>[
+  'Loading previews into the Widget Preview Scaffold...',
+  'Done loading previews.',
+];
+
+void main() {
+  late Directory tempDir;
+  Process? process;
+  final BasicProject project = BasicProject();
+  const ProcessManager processManager = LocalProcessManager();
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('widget_preview_test.');
+    await project.setUpIn(tempDir);
+  });
+
+  tearDown(() async {
+    process?.kill();
+    process = null;
+    tryToDelete(tempDir);
+  });
+
+  Future<void> runWidgetPreview({required List<String> expectedMessages}) async {
+    expect(expectedMessages, isNotEmpty);
+    int i = 0;
+    process = await processManager.start(<String>[
+      flutterBin,
+      'widget-preview',
+      'start',
+    ], workingDirectory: tempDir.path);
+
+    final Completer<void> completer = Completer<void>();
+    late final StreamSubscription<String> sub;
+    sub = process!.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((
+      String msg,
+    ) {
+      if (msg.contains(expectedMessages[i])) {
+        ++i;
+      }
+      if (i == expectedMessages.length) {
+        sub.cancel();
+        completer.complete();
+      }
+    });
+
+    await completer.future;
+    process!.kill();
+    process = null;
+  }
+
+  group('flutter widget-preview start', () {
+    testWithoutContext('smoke test', () async {
+      await runWidgetPreview(expectedMessages: firstLaunchMessages);
+    });
+
+    testWithoutContext('does not rebuild project on subsequent runs', () async {
+      // The first run of 'flutter widget-preview start' should generate a new preview scaffold and
+      // pre-build the application.
+      await runWidgetPreview(expectedMessages: firstLaunchMessages);
+
+      // We shouldn't regenerate the scaffold after the initial run.
+      await runWidgetPreview(expectedMessages: subsequentLaunchMessages);
+    });
+  });
+}


### PR DESCRIPTION
This also wires up the preview detector to trigger hot reloads when new previews are detected or previews are removed.

Note: while this change results in lib/generated_preview.dart being generated and updated, it's not currently referenced by lib/main.dart and the preview environment will render a black screen.