### PR TITLE
Try running the `Linux analyze` as a "release builder"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -350,6 +350,13 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      # This is to instruct the queues to eagerly run Linux analze.
+      #
+      # We would like to see, both earlier in runs, and in the merge group,
+      # to validate the build.
+      #
+      # See https://github.com/flutter/flutter/issues/162329.
+      release_build: "true"
       shard: analyze
       dependencies: >-
         [


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/162329.

I am not sure if this will work.

If it _does_ work, I am not sure we want to implement it this way (all though it is the simplest, as it's already working).

The goal is to run `Linux analyze` in the merge queue, similar to building engine artifacts. If it fails, we want to bail.