### PR TITLE
Add a currently unused `runs_in_merge_queue` property to `Linux analyze`.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -351,6 +351,9 @@ targets:
     timeout: 60
     properties:
       shard: analyze
+      # TODO(matanlurey): Remove or document.
+      # See https://github.com/flutter/flutter/issues/162329.
+      runs_in_merge_queue: true
       dependencies: >-
         [
           {"dependency": "ktlint", "version": "version_1_1_1"}

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -353,7 +353,7 @@ targets:
       shard: analyze
       # TODO(matanlurey): Remove or document.
       # See https://github.com/flutter/flutter/issues/162329.
-      runs_in_merge_queue: true
+      runs_in_merge_queue: "true"
       dependencies: >-
         [
           {"dependency": "ktlint", "version": "version_1_1_1"}


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/162329.

This currently does nothing.