### PR TITLE
[FML] Make logging available in constexpr contexts.

### DIFF
--- a/engine/src/flutter/fml/logging.h
+++ b/engine/src/flutter/fml/logging.h
@@ -60,7 +60,25 @@ int GetVlogVerbosity();
 // kLogFatal and above is always true.
 bool ShouldCreateLogMessage(LogSeverity severity);
 
+constexpr bool ShouldCreateLogMessage2(LogSeverity severity, bool true_arg) {
+  if (true_arg) {
+    return ShouldCreateLogMessage(severity);
+  }
+  return false;
+}
+
 [[noreturn]] void KillProcess();
+
+[[noreturn]] constexpr void KillProcess2(bool true_arg) {
+  if (true_arg) {
+    KillProcess();
+  }
+#if defined(_MSC_VER) && !defined(__clang__)
+  __assume(false);
+#else   // defined(_MSC_VER) && !defined(__clang__)
+  __builtin_unreachable();
+#endif  // defined(_MSC_VER) && !defined(__clang__)
+}
 
 }  // namespace fml
 
@@ -77,7 +95,7 @@ bool ShouldCreateLogMessage(LogSeverity severity);
             ::fml::LogMessage(::fml::kLogFatal, 0, 0, nullptr).stream()
 
 #define FML_LOG_IS_ON(severity) \
-  (::fml::ShouldCreateLogMessage(::fml::LOG_##severity))
+  (::fml::ShouldCreateLogMessage2(::fml::LOG_##severity, true))
 
 #define FML_LOG(severity) \
   FML_LAZY_STREAM(FML_LOG_STREAM(severity), FML_LOG_IS_ON(severity))
@@ -109,7 +127,7 @@ bool ShouldCreateLogMessage(LogSeverity severity);
 #define FML_UNREACHABLE()                          \
   {                                                \
     FML_LOG(ERROR) << "Reached unreachable code."; \
-    ::fml::KillProcess();                          \
+    ::fml::KillProcess2(true);                     \
   }
 
 #endif  // FLUTTER_FML_LOGGING_H_

--- a/engine/src/flutter/fml/logging.h
+++ b/engine/src/flutter/fml/logging.h
@@ -60,7 +60,8 @@ int GetVlogVerbosity();
 // kLogFatal and above is always true.
 bool ShouldCreateLogMessage(LogSeverity severity);
 
-constexpr bool ShouldCreateLogMessage2(LogSeverity severity, bool true_arg) {
+constexpr bool ShouldCreateLogMessageConstexpr(LogSeverity severity,
+                                               bool true_arg) {
   if (true_arg) {
     return ShouldCreateLogMessage(severity);
   }
@@ -69,7 +70,7 @@ constexpr bool ShouldCreateLogMessage2(LogSeverity severity, bool true_arg) {
 
 [[noreturn]] void KillProcess();
 
-[[noreturn]] constexpr void KillProcess2(bool true_arg) {
+[[noreturn]] constexpr void KillProcessConstexpr(bool true_arg) {
   if (true_arg) {
     KillProcess();
   }
@@ -95,7 +96,7 @@ constexpr bool ShouldCreateLogMessage2(LogSeverity severity, bool true_arg) {
             ::fml::LogMessage(::fml::kLogFatal, 0, 0, nullptr).stream()
 
 #define FML_LOG_IS_ON(severity) \
-  (::fml::ShouldCreateLogMessage2(::fml::LOG_##severity, true))
+  (::fml::ShouldCreateLogMessageConstexpr(::fml::LOG_##severity, true))
 
 #define FML_LOG(severity) \
   FML_LAZY_STREAM(FML_LOG_STREAM(severity), FML_LOG_IS_ON(severity))
@@ -127,7 +128,7 @@ constexpr bool ShouldCreateLogMessage2(LogSeverity severity, bool true_arg) {
 #define FML_UNREACHABLE()                          \
   {                                                \
     FML_LOG(ERROR) << "Reached unreachable code."; \
-    ::fml::KillProcess2(true);                     \
+    ::fml::KillProcessConstexpr(true);             \
   }
 
 #endif  // FLUTTER_FML_LOGGING_H_


### PR DESCRIPTION
Asking if the logs should be emitted and killing the process (say on unreachable statements) wasn't constexpr. However we managed to use these in constexpr contexts. As I understand, this was because of https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2448r2.html which is available in C++23. This technique makes the methods constexpr safe in C++17.
