### PR TITLE
Add 2 retries for hybrid composition platform views.

### DIFF
--- a/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
@@ -56,6 +56,7 @@ void main() async {
           nativeDriver.screenshot(),
           matchesGoldenFile('$goldenPrefix.blue_orange_gradient_portrait.png'),
         );
+        break;
       } on TestFailure catch (e) {
         if (retriesLeft == 0) {
           rethrow;

--- a/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
@@ -44,10 +44,26 @@ void main() async {
   });
 
   test('should screenshot and match a blue -> orange gradient', () async {
-    await expectLater(
-      nativeDriver.screenshot(),
-      matchesGoldenFile('$goldenPrefix.blue_orange_gradient_portrait.png'),
-    );
+    // TODO(matanlurey): Determining if this is a failure (the screen is always black on CI)
+    // or timing dependent (if we would have waited X more seconds it would have rendered).
+    // See:
+    // - Vulkan: https://github.com/flutter/flutter/issues/162362
+    // - OpenGLES: https://github.com/flutter/flutter/issues/162363
+    int retriesLeft = 2;
+    do {
+      try {
+        await expectLater(
+          nativeDriver.screenshot(),
+          matchesGoldenFile('$goldenPrefix.blue_orange_gradient_portrait.png'),
+        );
+      } on TestFailure catch (e) {
+        if (retriesLeft == 0) {
+          rethrow;
+        }
+        print('Caught: $e. Retrying...');
+        retriesLeft--;
+      }
+    } while (retriesLeft > 0);
   }, timeout: Timeout.none);
 
   test('should rotate landscape and screenshot the gradient', () async {


### PR DESCRIPTION
Trying to figure out if flake reports https://github.com/flutter/flutter/issues/162362 and https://github.com/flutter/flutter/issues/162363 are related to https://github.com/flutter/flutter/issues/162310.

I was unable to reproduce locally:

```sh
dart tool/deflake.dart lib/platform_view/hybrid_composition_platform_view_main.dart
```

... so either the Mac Android emulators don't show this behavior, or perhaps its just the slowness of CI VMs.

Either way, this should try taking a screenshot 2 more times (which has built-in waits/sleeps), so if the problem persists that means there is a more critical HC problem (the screen is _always_ drawn black sometimes) versus a more transient problem (it "takes longer").