### PR TITLE
[Android] HC++ plumbing.

### DIFF
--- a/engine/src/flutter/shell/platform/android/android_context_gl_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_gl_unittests.cc
@@ -170,7 +170,7 @@ TEST(AndroidSurfaceGL, CreateSnapshopSurfaceWhenOnscreenSurfaceIsNotNull) {
       std::make_unique<AndroidSurfaceGLSkia>(android_context);
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(
       nullptr, /*is_fake_window=*/true);
-  android_surface->SetNativeWindow(window);
+  android_surface->SetNativeWindow(window, nullptr);
   auto onscreen_surface = android_surface->GetOnscreenSurface();
   EXPECT_NE(onscreen_surface, nullptr);
   android_surface->CreateSnapshotSurface();

--- a/engine/src/flutter/shell/platform/android/android_surface_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_gl_impeller.cc
@@ -74,7 +74,8 @@ bool AndroidSurfaceGLImpeller::ResourceContextClearCurrent() {
 
 // |AndroidSurface|
 bool AndroidSurfaceGLImpeller::SetNativeWindow(
-    fml::RefPtr<AndroidNativeWindow> window) {
+    fml::RefPtr<AndroidNativeWindow> window,
+    const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) {
   native_window_ = std::move(window);
   return RecreateOnscreenSurfaceAndMakeOnscreenContextCurrent();
 }

--- a/engine/src/flutter/shell/platform/android/android_surface_gl_impeller.h
+++ b/engine/src/flutter/shell/platform/android/android_surface_gl_impeller.h
@@ -43,7 +43,9 @@ class AndroidSurfaceGLImpeller final : public GPUSurfaceGLDelegate,
   bool ResourceContextClearCurrent() override;
 
   // |AndroidSurface|
-  bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
+  bool SetNativeWindow(
+      fml::RefPtr<AndroidNativeWindow> window,
+      const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) override;
 
   // |AndroidSurface|
   std::unique_ptr<Surface> CreateSnapshotSurface() override;

--- a/engine/src/flutter/shell/platform/android/android_surface_gl_skia.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_gl_skia.cc
@@ -100,7 +100,8 @@ bool AndroidSurfaceGLSkia::ResourceContextClearCurrent() {
 }
 
 bool AndroidSurfaceGLSkia::SetNativeWindow(
-    fml::RefPtr<AndroidNativeWindow> window) {
+    fml::RefPtr<AndroidNativeWindow> window,
+    const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) {
   FML_DCHECK(IsValid());
   FML_DCHECK(window);
   native_window_ = window;

--- a/engine/src/flutter/shell/platform/android/android_surface_gl_skia.h
+++ b/engine/src/flutter/shell/platform/android/android_surface_gl_skia.h
@@ -46,7 +46,9 @@ class AndroidSurfaceGLSkia final : public GPUSurfaceGLDelegate,
   bool ResourceContextClearCurrent() override;
 
   // |AndroidSurface|
-  bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
+  bool SetNativeWindow(
+      fml::RefPtr<AndroidNativeWindow> window,
+      const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) override;
 
   // |AndroidSurface|
   virtual std::unique_ptr<Surface> CreateSnapshotSurface() override;

--- a/engine/src/flutter/shell/platform/android/android_surface_software.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_software.cc
@@ -150,7 +150,8 @@ bool AndroidSurfaceSoftware::OnScreenSurfaceResize(const SkISize& size) {
 }
 
 bool AndroidSurfaceSoftware::SetNativeWindow(
-    fml::RefPtr<AndroidNativeWindow> window) {
+    fml::RefPtr<AndroidNativeWindow> window,
+    const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) {
   native_window_ = std::move(window);
   if (!(native_window_ && native_window_->IsValid())) {
     return false;

--- a/engine/src/flutter/shell/platform/android/android_surface_software.h
+++ b/engine/src/flutter/shell/platform/android/android_surface_software.h
@@ -43,7 +43,9 @@ class AndroidSurfaceSoftware final : public AndroidSurface,
   bool OnScreenSurfaceResize(const SkISize& size) override;
 
   // |AndroidSurface|
-  bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
+  bool SetNativeWindow(
+      fml::RefPtr<AndroidNativeWindow> window,
+      const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) override;
 
   // |GPUSurfaceSoftwareDelegate|
   sk_sp<SkSurface> AcquireBackingStore(const SkISize& size) override;

--- a/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
@@ -81,7 +81,8 @@ bool AndroidSurfaceVKImpeller::ResourceContextClearCurrent() {
 }
 
 bool AndroidSurfaceVKImpeller::SetNativeWindow(
-    fml::RefPtr<AndroidNativeWindow> window) {
+    fml::RefPtr<AndroidNativeWindow> window,
+    const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) {
   if (window && (native_window_ == window)) {
     return OnScreenSurfaceResize(window->GetSize());
   }

--- a/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.h
+++ b/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.h
@@ -45,7 +45,9 @@ class AndroidSurfaceVKImpeller : public AndroidSurface {
   std::shared_ptr<impeller::Context> GetImpellerContext() override;
 
   // |AndroidSurface|
-  bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
+  bool SetNativeWindow(
+      fml::RefPtr<AndroidNativeWindow> window,
+      const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) override;
 
  private:
   std::shared_ptr<impeller::SurfaceContextVK> surface_context_vk_;

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -267,7 +267,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFlutterView) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info]() {
+      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -295,7 +295,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFlutterView) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
 
         return android_surface_mock;
       });
@@ -484,7 +484,7 @@ TEST(AndroidExternalViewEmbedder, OverlayCoverTwoPlatformViews) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info]() {
+      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -504,7 +504,7 @@ TEST(AndroidExternalViewEmbedder, OverlayCoverTwoPlatformViews) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
         return android_surface_mock;
       });
   auto embedder = std::make_unique<AndroidExternalViewEmbedder>(
@@ -586,7 +586,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrameOverlayComposition) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info]() {
+      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -606,7 +606,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrameOverlayComposition) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
         return android_surface_mock;
       });
   auto embedder = std::make_unique<AndroidExternalViewEmbedder>(
@@ -693,7 +693,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFramePlatformViewWithoutAnyOverlay) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info]() {
+      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -713,7 +713,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFramePlatformViewWithoutAnyOverlay) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
         return android_surface_mock;
       });
   auto embedder = std::make_unique<AndroidExternalViewEmbedder>(
@@ -785,7 +785,7 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info]() {
+      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -804,7 +804,7 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
 
         return android_surface_mock;
       });
@@ -877,7 +877,7 @@ TEST(AndroidExternalViewEmbedder, DoesNotDestroyOverlayLayersOnSizeChange) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info]() {
+      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -896,7 +896,7 @@ TEST(AndroidExternalViewEmbedder, DoesNotDestroyOverlayLayersOnSizeChange) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
 
         return android_surface_mock;
       });

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -24,6 +24,7 @@
 namespace flutter {
 namespace testing {
 
+using ::testing::_;
 using ::testing::ByMove;
 using ::testing::Return;
 
@@ -267,7 +268,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFlutterView) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
+      [gr_context, window, frame_size, framebuffer_info]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -295,7 +296,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFlutterView) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
 
         return android_surface_mock;
       });
@@ -484,7 +485,7 @@ TEST(AndroidExternalViewEmbedder, OverlayCoverTwoPlatformViews) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
+      [gr_context, window, frame_size, framebuffer_info]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -504,7 +505,7 @@ TEST(AndroidExternalViewEmbedder, OverlayCoverTwoPlatformViews) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         return android_surface_mock;
       });
   auto embedder = std::make_unique<AndroidExternalViewEmbedder>(
@@ -586,7 +587,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrameOverlayComposition) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
+      [gr_context, window, frame_size, framebuffer_info]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -606,7 +607,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrameOverlayComposition) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         return android_surface_mock;
       });
   auto embedder = std::make_unique<AndroidExternalViewEmbedder>(
@@ -693,7 +694,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFramePlatformViewWithoutAnyOverlay) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
+      [gr_context, window, frame_size, framebuffer_info]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -713,7 +714,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFramePlatformViewWithoutAnyOverlay) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         return android_surface_mock;
       });
   auto embedder = std::make_unique<AndroidExternalViewEmbedder>(
@@ -785,7 +786,7 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
+      [gr_context, window, frame_size, framebuffer_info]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -804,7 +805,7 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
 
         return android_surface_mock;
       });
@@ -877,7 +878,7 @@ TEST(AndroidExternalViewEmbedder, DoesNotDestroyOverlayLayersOnSizeChange) {
   auto frame_size = SkISize::Make(1000, 1000);
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context, window, frame_size, framebuffer_info, jni_mock]() {
+      [gr_context, window, frame_size, framebuffer_info]() {
         auto surface_frame_1 = std::make_unique<SurfaceFrame>(
             SkSurfaces::Null(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
@@ -896,7 +897,7 @@ TEST(AndroidExternalViewEmbedder, DoesNotDestroyOverlayLayersOnSizeChange) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
 
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, jni_mock));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
 
         return android_surface_mock;
       });

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool.cc
@@ -45,7 +45,7 @@ std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
         jni_facade->FlutterViewCreateOverlaySurface();
 
     FML_CHECK(java_metadata->window);
-    android_surface->SetNativeWindow(java_metadata->window);
+    android_surface->SetNativeWindow(java_metadata->window, jni_facade);
 
     std::unique_ptr<Surface> surface =
         android_surface->CreateGPUSurface(gr_context);

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
@@ -15,6 +15,7 @@
 namespace flutter {
 namespace testing {
 
+using ::testing::_;
 using ::testing::ByMove;
 using ::testing::Return;
 
@@ -54,7 +55,7 @@ TEST(SurfacePool, GetLayerAllocateOneLayer) {
       std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
         auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
@@ -85,7 +86,7 @@ TEST(SurfacePool, GetUnusedLayers) {
       std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
         auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
@@ -124,7 +125,7 @@ TEST(SurfacePool, GetLayerRecycle) {
         EXPECT_CALL(*android_surface_mock,
                     CreateGPUSurface(gr_context_2.get()));
         // Set the native window once.
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
@@ -167,7 +168,7 @@ TEST(SurfacePool, GetLayerAllocateTwoLayers) {
       std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
         auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
@@ -206,7 +207,7 @@ TEST(SurfacePool, DestroyLayers) {
       std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
         auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
@@ -235,7 +236,7 @@ TEST(SurfacePool, DestroyLayersFrameSizeChanged) {
       std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
         auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
-        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
+        EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -148,8 +148,8 @@ void PlatformViewAndroid::NotifyCreated(
     fml::TaskRunner::RunNowOrPostTask(
         task_runners_.GetRasterTaskRunner(),
         [&latch, surface = android_surface_.get(),
-         native_window = std::move(native_window)]() {
-          surface->SetNativeWindow(native_window);
+         native_window = std::move(native_window), jni_facade = jni_facade_]() {
+          surface->SetNativeWindow(native_window, jni_facade);
           latch.Signal();
         });
     latch.Wait();
@@ -165,9 +165,9 @@ void PlatformViewAndroid::NotifySurfaceWindowChanged(
     fml::TaskRunner::RunNowOrPostTask(
         task_runners_.GetRasterTaskRunner(),
         [&latch, surface = android_surface_.get(),
-         native_window = std::move(native_window)]() {
+         native_window = std::move(native_window), jni_facade = jni_facade_]() {
           surface->TeardownOnScreenContext();
-          surface->SetNativeWindow(native_window);
+          surface->SetNativeWindow(native_window, jni_facade);
           latch.Signal();
         });
     latch.Wait();

--- a/engine/src/flutter/shell/platform/android/surface/android_surface.h
+++ b/engine/src/flutter/shell/platform/android/surface/android_surface.h
@@ -39,7 +39,9 @@ class AndroidSurface {
 
   virtual bool ResourceContextClearCurrent() = 0;
 
-  virtual bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) = 0;
+  virtual bool SetNativeWindow(
+      fml::RefPtr<AndroidNativeWindow> window,
+      const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade) = 0;
 
   virtual std::unique_ptr<Surface> CreateSnapshotSurface();
 

--- a/engine/src/flutter/shell/platform/android/surface/android_surface_mock.h
+++ b/engine/src/flutter/shell/platform/android/surface/android_surface_mock.h
@@ -35,7 +35,8 @@ class AndroidSurfaceMock final : public GPUSurfaceGLDelegate,
 
   MOCK_METHOD(bool,
               SetNativeWindow,
-              (fml::RefPtr<AndroidNativeWindow> window),
+              (fml::RefPtr<AndroidNativeWindow> window,
+               const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade),
               (override));
 
   // |GPUSurfaceGLDelegate|


### PR DESCRIPTION
We'll need the JNI fascade to create the surface transaction for HC++ mode. Split into a separate PR so that the "real" HC++ PR isn't 5000 lines long.
