### PR TITLE
[web] Correctly read the repetitionCount for images

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/image_decoder.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/image_decoder.dart
@@ -244,7 +244,7 @@ class ResizingCodec implements ui.Codec {
   );
 
   @override
-  int get repetitionCount => delegate.frameCount;
+  int get repetitionCount => delegate.repetitionCount;
 }
 
 BitmapSize? scaledImageSize(int width, int height, int? targetWidth, int? targetHeight) {

--- a/engine/src/flutter/lib/web_ui/test/ui/image_decoder_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/image_decoder_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests(emulateTesterEnvironment: false, setUpTestViewDimensions: false);
+
+  test('$ResizingCodec gives correct repetition count for GIFs', () async {
+    final ui.Codec codec = await renderer.instantiateImageCodecFromUrl(
+      Uri(path: '/test_images/required.gif'),
+    );
+    final ui.Codec resizingCodec = ResizingCodec(codec);
+    expect(resizingCodec.repetitionCount, 0);
+  });
+}


### PR DESCRIPTION
There was a bug in `ResizingCodec` where it returned `frameCount` instead of `repetitionCount` in the `repetitionCount` getter, causing animated images to stop animating even if they were set to loop infinitely.

Fixes https://github.com/flutter/flutter/issues/161800

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
