### PR TITLE
Adjustments to FocusHighlightMode handling

### DIFF
--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -142,6 +142,8 @@ mixin SemanticsBinding on BindingBase {
         arguments is ByteData
             ? action.copyWith(arguments: const StandardMessageCodec().decodeMessage(arguments))
             : action;
+    // Listeners may get added/removed while the iteration is in progress. Since the list cannot
+    // be modified while iterating, we are creating a local copy for the iteration.
     final List<ValueSetter<ui.SemanticsActionEvent>> localListeners = _semanticsActionListeners
         .toList(growable: false);
     for (final ValueSetter<ui.SemanticsActionEvent> listener in localListeners) {

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -75,6 +75,23 @@ mixin SemanticsBinding on BindingBase {
     _semanticsEnabled.removeListener(listener);
   }
 
+  final ObserverList<ValueSetter<ui.SemanticsActionEvent>> _semanticsActionListeners =
+      ObserverList<ValueSetter<ui.SemanticsActionEvent>>();
+
+  /// Adds a listener that is called for every [SemanticsActionEvent] received.
+  ///
+  /// The listeners are called before [performSemanticsAction] is invoked.
+  ///
+  /// To remove the listener, call [removeSemanticsActionListener].
+  void addSemanticsActionListener(ValueSetter<ui.SemanticsActionEvent> listener) {
+    _semanticsActionListeners.add(listener);
+  }
+
+  /// Removes a listener previously added with [addSemanticsActionListener].
+  void removeSemanticsActionListener(ValueSetter<ui.SemanticsActionEvent> listener) {
+    _semanticsActionListeners.remove(listener);
+  }
+
   /// The number of clients registered to listen for semantics.
   ///
   /// The number is increased whenever [ensureSemantics] is called and decreased
@@ -125,6 +142,13 @@ mixin SemanticsBinding on BindingBase {
         arguments is ByteData
             ? action.copyWith(arguments: const StandardMessageCodec().decodeMessage(arguments))
             : action;
+    final List<ValueSetter<ui.SemanticsActionEvent>> localListeners = _semanticsActionListeners
+        .toList(growable: false);
+    for (final ValueSetter<ui.SemanticsActionEvent> listener in localListeners) {
+      if (_semanticsActionListeners.contains(listener)) {
+        listener(decodedAction);
+      }
+    }
     performSemanticsAction(decodedAction);
   }
 

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -2182,8 +2182,10 @@ class _HighlightModeManager {
       case PointerDeviceKind.touch:
       case PointerDeviceKind.stylus:
       case PointerDeviceKind.invertedStylus:
-        _lastInteractionWasTouch = true;
-        updateMode();
+        if (_lastInteractionWasTouch != true) {
+          _lastInteractionWasTouch = true;
+          updateMode();
+        }
       case PointerDeviceKind.mouse:
       case PointerDeviceKind.trackpad:
       case PointerDeviceKind.unknown:
@@ -2191,10 +2193,13 @@ class _HighlightModeManager {
   }
 
   bool handleKeyMessage(KeyMessage message) {
-    // Update highlightMode first, since things responding to the keys might
-    // look at the highlight mode, and it should be accurate.
-    _lastInteractionWasTouch = false;
-    updateMode();
+    // ignore: use_if_null_to_convert_nulls_to_bools
+    if (_lastInteractionWasTouch != false) {
+      // Update highlightMode first, since things responding to the keys might
+      // look at the highlight mode, and it should be accurate.
+      _lastInteractionWasTouch = false;
+      updateMode();
+    }
 
     assert(_focusDebug(() => 'Received key event $message'));
     if (FocusManager.instance.primaryFocus == null) {
@@ -2288,7 +2293,9 @@ class _HighlightModeManager {
   }
 
   void handleSemanticsAction(SemanticsActionEvent semanticsActionEvent) {
-    if (kIsWeb && semanticsActionEvent.type == SemanticsAction.focus) {
+    if (kIsWeb &&
+        semanticsActionEvent.type == SemanticsAction.focus &&
+        _lastInteractionWasTouch != true) {
       _lastInteractionWasTouch = true;
       updateMode();
     }

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -2065,9 +2065,9 @@ class _HighlightModeManager {
     }
   }
 
-  // If set, indicates if the last interaction detected was touch or not. If
-  // null, no interactions have occurred yet.
-  bool? _lastInteractionWasTouch;
+  // If null, no interactions have occurred yet and the default highlight mode for the current
+  // platform applies.
+  bool? _lastInteractionRequiresTraditionalHighlights;
 
   FocusHighlightMode get highlightMode => _highlightMode ?? _defaultModeForPlatform;
   FocusHighlightMode? _highlightMode;
@@ -2182,8 +2182,8 @@ class _HighlightModeManager {
       case PointerDeviceKind.touch:
       case PointerDeviceKind.stylus:
       case PointerDeviceKind.invertedStylus:
-        if (_lastInteractionWasTouch != true) {
-          _lastInteractionWasTouch = true;
+        if (_lastInteractionRequiresTraditionalHighlights != true) {
+          _lastInteractionRequiresTraditionalHighlights = true;
           updateMode();
         }
       case PointerDeviceKind.mouse:
@@ -2194,10 +2194,10 @@ class _HighlightModeManager {
 
   bool handleKeyMessage(KeyMessage message) {
     // ignore: use_if_null_to_convert_nulls_to_bools
-    if (_lastInteractionWasTouch != false) {
+    if (_lastInteractionRequiresTraditionalHighlights != false) {
       // Update highlightMode first, since things responding to the keys might
       // look at the highlight mode, and it should be accurate.
-      _lastInteractionWasTouch = false;
+      _lastInteractionRequiresTraditionalHighlights = false;
       updateMode();
     }
 
@@ -2295,8 +2295,8 @@ class _HighlightModeManager {
   void handleSemanticsAction(SemanticsActionEvent semanticsActionEvent) {
     if (kIsWeb &&
         semanticsActionEvent.type == SemanticsAction.focus &&
-        _lastInteractionWasTouch != true) {
-      _lastInteractionWasTouch = true;
+        _lastInteractionRequiresTraditionalHighlights != true) {
+      _lastInteractionRequiresTraditionalHighlights = true;
       updateMode();
     }
   }
@@ -2307,14 +2307,14 @@ class _HighlightModeManager {
     final FocusHighlightMode newMode;
     switch (strategy) {
       case FocusHighlightStrategy.automatic:
-        if (_lastInteractionWasTouch == null) {
+        if (_lastInteractionRequiresTraditionalHighlights == null) {
           // If we don't have any information about the last interaction yet,
           // then just rely on the default value for the platform, which will be
           // determined based on the target platform if _highlightMode is not
           // set.
           return;
         }
-        if (_lastInteractionWasTouch!) {
+        if (_lastInteractionRequiresTraditionalHighlights!) {
           newMode = FocusHighlightMode.touch;
         } else {
           newMode = FocusHighlightMode.traditional;

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../widgets/semantics_tester.dart';
 
 const double _defaultBorderWidth = 1.0;
@@ -692,6 +693,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // focusColor
+    FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
@@ -748,6 +750,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // focusColor
+    FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {
@@ -811,6 +814,7 @@ void main() {
     await hoverGesture.moveTo(Offset.zero);
 
     // focusColor
+    FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -482,6 +482,7 @@ void main() {
     await hoverGesture.moveTo(Offset.zero);
 
     // focusColor
+    FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     focusNode.requestFocus();
     await tester.pumpAndSettle();
     inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) {

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -1519,19 +1519,19 @@ void main() {
         kind: PointerDeviceKind.mouse,
       );
       await gesture.up();
-      expect(callCount, equals(3));
-      expect(lastMode, FocusHighlightMode.traditional);
-      expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.traditional));
+      expect(callCount, equals(2));
+      expect(lastMode, FocusHighlightMode.touch);
+      expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.touch));
       await tester.tap(find.byType(Container), warnIfMissed: false);
-      expect(callCount, equals(4));
+      expect(callCount, equals(2));
       expect(lastMode, FocusHighlightMode.touch);
       expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.touch));
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-      expect(callCount, equals(5));
+      expect(callCount, equals(3));
       expect(lastMode, FocusHighlightMode.traditional);
       expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.traditional));
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTouch;
-      expect(callCount, equals(6));
+      expect(callCount, equals(4));
       expect(lastMode, FocusHighlightMode.touch);
       expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.touch));
     });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/158527

Adjustments:
* Using the mouse/trackpad does no longer change `FocusHighlightMode`s (this matches observed behavior on Android)
* Changing focus via a11y on the web forces `FocusHighlightModes.touch`, which hides the visual input focus indication from non-Textfields. The reason here is in order to give something input focus on the web it also has to have a11y focus, which is indicated separately.