### PR TITLE
Add a special case for the Fuchsia SDK ftl.fidl file in the license script

### DIFF
--- a/engine/src/flutter/ci/licenses_golden/tool_signature
+++ b/engine/src/flutter/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 6bfdfddcd48b997e778d2edcde1ba11f
+Signature: 234e3117f50e69362f815beaffa13970
 

--- a/engine/src/flutter/tools/licenses/lib/main.dart
+++ b/engine/src/flutter/tools/licenses/lib/main.dart
@@ -1032,6 +1032,7 @@ class _RepositoryDirectory extends _RepositoryEntry implements LicenseSource {
     '/flutter/third_party/vulkan-deps/vulkan-validation-layers/src/LICENSE.txt':
         _RepositoryVulkanApacheLicenseFile.new,
     '/fuchsia/sdk/linux/LICENSE.vulkan': _RepositoryFuchsiaSdkLinuxLicenseFile.new,
+    '/fuchsia/sdk/linux/fidl/fuchsia.storage.ftl/ftl.fidl': _RepositorySourceFile.new,
     '/fuchsia/sdk/mac/LICENSE.vulkan': _RepositoryFuchsiaSdkLinuxLicenseFile.new,
     '/third_party/khronos/LICENSE': _RepositoryKhronosLicenseFile.new,
   };


### PR DESCRIPTION
Recent versions of the Fuchsia SDK added a source file named "ftl.fidl".  The _licenseNamePattern in the script thinks this file may be a license because some licenses also use filenames containing "FTL".