### PR TITLE
Update SnackBar.onVisible documentation

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -464,6 +464,13 @@ class SnackBar extends StatefulWidget {
   final Animation<double>? animation;
 
   /// Called the first time that the snackbar is visible within a [Scaffold].
+  ///
+  /// When multiple [Scaffold]s are registered to the same [ScaffoldMessengerState],
+  /// [onVisible] is called once for each scaffold.
+  ///
+  /// See also:
+  ///
+  ///  * [ScaffoldMessenger], which manages [SnackBar]s for [Scaffold] descendants.
   final VoidCallback? onVisible;
 
   /// The direction in which the SnackBar can be dismissed.


### PR DESCRIPTION
## Description

This PR updated `SnackBar.onVisible` documentation to explain why it can be call several times.

## Related Issue

Fixes [Snackbar onVisible is called twice](https://github.com/flutter/flutter/issues/162377)

## Tests

Documentation only