### PR TITLE
[Impeller] Disable Vulkan on Emulators.

### DIFF
--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -5,7 +5,9 @@
 #define FML_USED_ON_EMBEDDER
 
 #include <android/log.h>
+#include <sys/system_properties.h>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "common/settings.h"
@@ -231,6 +233,11 @@ bool FlutterMain::Register(JNIEnv* env) {
 }
 
 // static
+bool IsDeviceEmulator(std::string_view product_model) {
+  return std::string(product_model).find("gphone") != std::string::npos;
+}
+
+// static
 AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
     const flutter::Settings& settings) {
   if (settings.enable_software_rendering) {
@@ -266,6 +273,13 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
     if (api_level < kMinimumAndroidApiLevelForVulkan) {
       return kVulkanUnsupportedFallback;
     }
+    char product_model[PROP_VALUE_MAX];
+    __system_property_get("ro.product.model", product_model);
+    if (IsDeviceEmulator(product_model)) {
+      // Avoid using Vulkan on known emulators.
+      return kVulkanUnsupportedFallback;
+    }
+
     // Determine if Vulkan is supported by creating a Vulkan context and
     // checking if it is valid.
     impeller::ScopedValidationDisable disable_validation;

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -233,7 +233,7 @@ bool FlutterMain::Register(JNIEnv* env) {
 }
 
 // static
-bool IsDeviceEmulator(std::string_view product_model) {
+bool FlutterMain::IsDeviceEmulator(std::string_view product_model) {
   return std::string(product_model).find("gphone") != std::string::npos;
 }
 

--- a/engine/src/flutter/shell/platform/android/flutter_main.h
+++ b/engine/src/flutter/shell/platform/android/flutter_main.h
@@ -26,6 +26,8 @@ class FlutterMain {
   static AndroidRenderingAPI SelectedRenderingAPI(
       const flutter::Settings& settings);
 
+  static bool IsDeviceEmulator(std::string_view product_model);
+
  private:
   const flutter::Settings settings_;
   DartServiceIsolate::CallbackHandle vm_service_uri_callback_ = 0;

--- a/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
@@ -35,8 +35,8 @@ TEST(AndroidPlatformView, SoftwareRenderingNotSupportedWithImpeller) {
 }
 
 TEST(AndroidPlatformView, FallsBackToGLESonEmulator) {
-  char* emulator_product = "gphone_x64";
-  char* device_product = "smg1234";
+  std::string emulator_product = "gphone_x64";
+  std::string device_product = "smg1234";
 
   EXPECT_TRUE(IsDeviceEmulator(emulator_product));
   EXPECT_FALSE(IsDeviceEmulator(device_product));

--- a/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
@@ -34,5 +34,13 @@ TEST(AndroidPlatformView, SoftwareRenderingNotSupportedWithImpeller) {
   ASSERT_DEATH(FlutterMain::SelectedRenderingAPI(settings), "");
 }
 
+TEST(AndroidPlatformView, FallsBackToGLESonEmulator) {
+  char* emulator_product = "gphone_x64";
+  char* device_product = "smg1234";
+
+  EXPECT_TRUE(IsDeviceEmulator(emulator_product));
+  EXPECT_FALSE(IsDeviceEmulator(device_product));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
@@ -38,8 +38,8 @@ TEST(AndroidPlatformView, FallsBackToGLESonEmulator) {
   std::string emulator_product = "gphone_x64";
   std::string device_product = "smg1234";
 
-  EXPECT_TRUE(IsDeviceEmulator(emulator_product));
-  EXPECT_FALSE(IsDeviceEmulator(device_product));
+  EXPECT_TRUE(FlutterMain::IsDeviceEmulator(emulator_product));
+  EXPECT_FALSE(FlutterMain::IsDeviceEmulator(device_product));
 }
 
 }  // namespace testing


### PR DESCRIPTION
Forces known android emulators to use OpenGLES. This is a very conservative check that could be expanded over time if need be. For testing emulators can still use the debug flags.

Fixes https://github.com/flutter/flutter/issues/160442
Fixes https://github.com/flutter/flutter/issues/160439
Fixes https://github.com/flutter/flutter/issues/155973