### PR TITLE
Bump `Linux mac_clang_tidy" to 120m timeout

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -355,6 +355,7 @@ targets:
 
   - name: Linux mac_clang_tidy
     recipe: engine_v2/engine_v2
+    timeout: 120    
     properties:
       config_name: mac_clang_tidy
     runIf:


### PR DESCRIPTION
Matches `Linux linux_clang_tidy`