### PR TITLE
[CP][Impeller] Disable Vulkan on Emulators. (#162454)

### DIFF
--- a/engine/src/flutter/shell/platform/android/flutter_main.h
+++ b/engine/src/flutter/shell/platform/android/flutter_main.h
@@ -26,6 +26,8 @@ class FlutterMain {
   static AndroidRenderingAPI SelectedRenderingAPI(
       const flutter::Settings& settings);
 
+  static bool IsDeviceEmulator(std::string_view product_model);
+
  private:
   const flutter::Settings settings_;
   DartServiceIsolate::CallbackHandle vm_service_uri_callback_ = 0;

--- a/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
@@ -34,5 +34,13 @@ TEST(AndroidPlatformView, SoftwareRenderingNotSupportedWithImpeller) {
   ASSERT_DEATH(FlutterMain::SelectedRenderingAPI(settings), "");
 }
 
+TEST(AndroidPlatformView, FallsBackToGLESonEmulator) {
+  std::string emulator_product = "gphone_x64";
+  std::string device_product = "smg1234";
+
+  EXPECT_TRUE(FlutterMain::IsDeviceEmulator(emulator_product));
+  EXPECT_FALSE(FlutterMain::IsDeviceEmulator(device_product));
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Forces known android emulators to use OpenGLES. This is a very conservative check that could be expanded over time if need be. For testing emulators can still use the debug flags.

Fixes https://github.com/flutter/flutter/issues/160442
Fixes https://github.com/flutter/flutter/issues/160439
Fixes https://github.com/flutter/flutter/issues/155973

