### PR TITLE
Fix `Linux docs_publish` running at head

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -579,7 +579,7 @@ targets:
       os: "Linux"
     enabled_branches:
       # Don't run this on release branches
-      - master      
+      - master
     properties:
       cores: "32"
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -578,7 +578,10 @@ targets:
     dimensions:
       os: "Linux"
     enabled_branches:
-      # Don't run this on release branches
+      # Produces docs for main-api.flutter.dev
+      # stable and beta are managed by the targets:
+      #   - Linux docs_deploy_beta
+      #   - Linux docs_deploy_stable
       - master
     properties:
       cores: "32"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -577,6 +577,9 @@ targets:
     timeout: 60
     dimensions:
       os: "Linux"
+    enabled_branches:
+      # Don't run this on release branches
+      - master      
     properties:
       cores: "32"
       dependencies: >-
@@ -591,7 +594,6 @@ targets:
       validation_name: Docs
       firebase_project: main-docs-flutter-prod
       release_ref: refs/heads/master
-      release_build: "true"
     drone_dimensions:
       - os=Linux
 


### PR DESCRIPTION
This target was using `release_build: true` as a way to skip release branches. This flag is used to signal engine artifacts are built - they need to be skipped:
- in release branches because artifacts are produced through other paths.
- in postsubmits of monorepo since the engine artifacts are produced in the merge queue.

This target was the only one in the framework defining it this way. It should have been using  `enabled_branches`.

tested: locally, using CiYaml directly with a copy of flutter's ci.yaml:

```dart
  final YamlMap configYaml = loadYaml(await File(args.command!['file']).readAsString()) as YamlMap;
  final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
  final masterYaml = CiYamlSet(
    yamls: {
      CiType.any: schedulerConfig,
    },
    slug: RepositorySlug.full('flutter/flutter'),
    branch: 'master',
    validate: false,
    isFusion: false,
  );
  final masterNames = {...masterYaml.postsubmitTargets().map((t) => t.value.name)};
  final releaseYaml = CiYamlSet(
    yamls: {
      CiType.any: schedulerConfig,
    },
    slug: RepositorySlug.full('flutter/flutter'),
    branch: 'flutter-3.27-candidate.0',
    validate: false,
    isFusion: false,
  );
  final releaseNames = {...releaseYaml.postsubmitTargets().map((t) => t.value.name)};

  print("********************************");
  print(releaseNames.contains('Linux docs_publish'));  // false
  print(masterNames.contains('Linux docs_publish')); // true - generate docs in postsubmit
  print("********************************");
```


Fixes #162552