### PR TITLE
Update code comments for navigation_bar.dart

### DIFF
--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -385,13 +385,12 @@ class NavigationDestination extends StatelessWidget {
   /// The text label that appears below the icon of this
   /// [NavigationDestination].
   ///
-  /// The accompanying [Text] widget will use
-  /// [NavigationBarThemeData.labelTextStyle]. If this is null, the default
-  /// text style would depend on [ThemeData.useMaterial3]:
-  /// - If `false`, it defaults to [TextTheme.labelSmall] with [ColorScheme.onSurface].
-  /// - If `true`, it defaults to [TextTheme.labelMedium], using:
-  ///   - [ColorScheme.onSurface] when selected.
-  ///   - [ColorScheme.onSurfaceVariant] when not selected.
+  /// The accompanying [Text] widget will use [NavigationBarThemeData.labelTextStyle].
+  /// If this is null, the default text style will use [TextTheme.labelSmall] with
+  /// [ColorScheme.onSurface] when the destination is selected and
+  /// [ColorScheme.onSurfaceVariant] when the destination is unselected. If
+  /// [ThemeData.useMaterial3] is false, then the default text style will use
+  /// [TextTheme.labelSmall] with [ColorScheme.onSurface].
   final String label;
 
   /// The text to display in the tooltip for this [NavigationDestination], when

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -386,8 +386,12 @@ class NavigationDestination extends StatelessWidget {
   /// [NavigationDestination].
   ///
   /// The accompanying [Text] widget will use
-  /// [NavigationBarThemeData.labelTextStyle]. If this are null, the default
-  /// text style would use [TextTheme.labelSmall] with [ColorScheme.onSurface].
+  /// [NavigationBarThemeData.labelTextStyle]. If this is null, the default
+  /// text style would depend on [ThemeData.useMaterial3]:
+  /// - If `false`, it defaults to [TextTheme.labelSmall] with [ColorScheme.onSurface].
+  /// - If `true`, it defaults to [TextTheme.labelMedium], using:
+  ///   - [ColorScheme.onSurface] when selected.
+  ///   - [ColorScheme.onSurfaceVariant] when not selected.
   final String label;
 
   /// The text to display in the tooltip for this [NavigationDestination], when

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -386,7 +386,7 @@ class NavigationDestination extends StatelessWidget {
   /// [NavigationDestination].
   ///
   /// The accompanying [Text] widget will use [NavigationBarThemeData.labelTextStyle].
-  /// If this is null, the default text style will use [TextTheme.labelSmall] with
+  /// If this is null, the default text style will use [TextTheme.labelMedium] with
   /// [ColorScheme.onSurface] when the destination is selected and
   /// [ColorScheme.onSurfaceVariant] when the destination is unselected. If
   /// [ThemeData.useMaterial3] is false, then the default text style will use


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/162592

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

### Comments error:
```
class NavigationDestination extends StatelessWidget {
...

  /// The text label that appears below the icon of this
  /// [NavigationDestination].
  ///
  /// The accompanying [Text] widget will use
  /// [NavigationBarThemeData.labelTextStyle]. If this are null, the default
  /// text style would use [TextTheme.labelSmall] with [ColorScheme.onSurface].
  final String label;

...
}
```

`If this are null, the default text style would use [TextTheme.labelSmall]` is wrong. Actually, This is right in material2, but wrong in material3. I have dived into `_NavigationBarDefaultsM3`, I found this:
```
class _NavigationBarDefaultsM3 extends NavigationBarThemeData {
...

@override
  MaterialStateProperty<TextStyle?>? get labelTextStyle {
    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
    final TextStyle style = _textTheme.labelMedium!;
      return style.apply(
        color: states.contains(MaterialState.disabled)
          ? _colors.onSurfaceVariant.withOpacity(0.38)
          : states.contains(MaterialState.selected)
            ? _colors.onSurface
            : _colors.onSurfaceVariant
      );
    });
  }

...
}
```
**The default text style would use [TextTheme.labelMedium] in Material3.**


### Changes

Just clarify the doc comments above.[test-exempt]


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
