### PR TITLE
Add a data driven fix for InputDecoration.maintainHintHeight

### DIFF
--- a/packages/flutter/lib/fix_data/fix_material/fix_input_decoration.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_input_decoration.yaml
@@ -18,6 +18,41 @@
 # * Fixes in this file are for InputDecoration and InputDecorationTheme from the Material library. *
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/161235.
+  - title: "Migrate to 'maintainHintSize'"
+    date: 2025-01-24
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'InputDecoration'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'maintainHintHeight'
+        newName: 'maintainHintSize'
+
+  # Changes made in https://github.com/flutter/flutter/pull/161235.
+  - title: "Migrate to 'maintainHintSize'"
+    date: 2025-01-24
+    element:
+      uris: [ 'material.dart' ]
+      constructor: 'collapsed'
+      inClass: 'InputDecoration'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'maintainHintHeight'
+        newName: 'maintainHintSize'
+
+  # Changes made in https://github.com/flutter/flutter/pull/161235.
+  - title: "Migrate to 'maintainHintSize'"
+    date: 2025-01-24
+    element:
+      uris: [ 'material.dart' ]
+      field: 'maintainHintHeight'
+      inClass: 'InputDecoration'
+    changes:
+      - kind: 'rename'
+        newName: 'maintainHintSize'
+
   # Changes made in https://github.com/flutter/flutter/pull/152486.
   - title: "Remove invalid parameter"
     date: 2024-07-27

--- a/packages/flutter/test_fixes/material/input_decorator.dart
+++ b/packages/flutter/test_fixes/material/input_decorator.dart
@@ -35,4 +35,12 @@ void main() {
     floatingLabelAlignment: FloatingLabelAlignment.center,
     floatingLabelBehavior: FloatingLabelBehavior.always,
   );
+
+  // Changes made in https://github.com/flutter/flutter/pull/161235.
+  const InputDecoration decoration = InputDecoration(maintainHintHeight: false);
+  decoration.maintainHintHeight;
+
+  const InputDecoration decoration = InputDecoration.collapsed(
+    maintainHintHeight: false,
+  );
 }

--- a/packages/flutter/test_fixes/material/input_decorator.dart.expect
+++ b/packages/flutter/test_fixes/material/input_decorator.dart.expect
@@ -33,4 +33,12 @@ void main() {
   const InputDecoration decoration = InputDecoration.collapsed(
     hintText: 'Hint',
   );
+
+  // Changes made in https://github.com/flutter/flutter/pull/161235.
+  const InputDecoration decoration = InputDecoration(maintainHintSize: false);
+  decoration.maintainHintSize;
+
+  const InputDecoration decoration = InputDecoration.collapsed(
+    maintainHintSize: false,
+  );
 }


### PR DESCRIPTION
## Description

This PR adds a dart fix to migrate from InputDecoration.maintainHintHeight to InputDecoration.maintainHintSize.

## Related PR

Follow up to https://github.com/flutter/flutter/pull/161235

## Tests

Adds 1 test.