### PR TITLE
Add remaining dart fixes for Color deprecations when importing painting.dart

### DIFF
--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -274,15 +274,15 @@ class Color {
   double get opacity => alpha / 0xFF;
 
   /// The red channel of this color in an 8 bit value.
-  @Deprecated('Use .r.')
+  @Deprecated('Use (*.r * 255.0).round() & 0xff')
   int get red => (0x00ff0000 & value) >> 16;
 
   /// The green channel of this color in an 8 bit value.
-  @Deprecated('Use .g.')
+  @Deprecated('Use (*.g * 255.0).round() & 0xff')
   int get green => (0x0000ff00 & value) >> 8;
 
   /// The blue channel of this color in an 8 bit value.
-  @Deprecated('Use .b.')
+  @Deprecated('Use (*.b * 255.0).round() & 0xff')
   int get blue => (0x000000ff & value) >> 0;
 
   /// Returns a new color with the provided components updated.

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -270,7 +270,7 @@ class Color {
   ///
   /// A value of 0.0 means this color is fully transparent. A value of 1.0 means
   /// this color is fully opaque.
-  @Deprecated('Use .a.')
+  @Deprecated('Use (*.a * 255.0).round() & 0xff')
   double get opacity => alpha / 0xFF;
 
   /// The red channel of this color in an 8 bit value.

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -263,14 +263,14 @@ class Color {
   ///
   /// A value of 0 means this color is fully transparent. A value of 255 means
   /// this color is fully opaque.
-  @Deprecated('Use .a.')
+  @Deprecated('Use (*.a * 255.0).round() & 0xff')
   int get alpha => (0xff000000 & value) >> 24;
 
   /// The alpha channel of this color as a double.
   ///
   /// A value of 0.0 means this color is fully transparent. A value of 1.0 means
   /// this color is fully opaque.
-  @Deprecated('Use (*.a * 255.0).round() & 0xff')
+  @Deprecated('Use .a.')
   double get opacity => alpha / 0xFF;
 
   /// The red channel of this color in an 8 bit value.

--- a/packages/flutter/lib/fix_data/fix_painting.yaml
+++ b/packages/flutter/lib/fix_data/fix_painting.yaml
@@ -127,6 +127,56 @@ transforms:
       - kind: 'rename'
         newName: 'a'
 
+  - title: "Rename from 'alpha' to 'a'"
+    date: 2024-09-10
+    element:
+      uris: [ 'painting.dart' ]
+      method: 'alpha'
+      inClass: 'Color'
+    changes:
+      - kind: 'rename'
+        newName: 'a'
+
+  - title: "Rename from 'red' to 'r'"
+    date: 2024-09-10
+    element:
+      uris: [ 'painting.dart' ]
+      method: 'red'
+      inClass: 'Color'
+    changes:
+      - kind: 'rename'
+        newName: 'r'
+
+  - title: "Rename from 'green' to 'g'"
+    date: 2024-09-10
+    element:
+      uris: [ 'painting.dart' ]
+      method: 'green'
+      inClass: 'Color'
+    changes:
+      - kind: 'rename'
+        newName: 'g'
+
+  - title: "Rename from 'blue' to 'b'"
+    date: 2024-09-10
+    element:
+      uris: [ 'painting.dart' ]
+      method: 'blue'
+      inClass: 'Color'
+    changes:
+      - kind: 'rename'
+        newName: 'b'
+
+  - title: "Replace 'value' with 'toARGB32()'"
+    date: 2025-02-03
+    element:
+      uris: [ 'painting.dart' ]
+      method: 'value'
+      inClass: 'Color'
+    changes:
+      - kind: 'rename'
+        newName: 'toARGB32()'
+
   - title: "Rename 'withOpacity'"
     date: 2024-09-10
     element:

--- a/packages/flutter/lib/fix_data/fix_painting.yaml
+++ b/packages/flutter/lib/fix_data/fix_painting.yaml
@@ -137,7 +137,7 @@ transforms:
       - kind: 'rename'
         newName: 'a'
 
-  - title: "Rename from 'red' to 'r'"
+  - title: "Replace 'red' with 'r'"
     date: 2024-09-10
     element:
       uris: [ 'painting.dart' ]
@@ -145,9 +145,9 @@ transforms:
       inClass: 'Color'
     changes:
       - kind: 'rename'
-        newName: 'r'
+        newName: 'r * 255.0).round() & 0xff'
 
-  - title: "Rename from 'green' to 'g'"
+  - title: "Replace 'green' with 'g'"
     date: 2024-09-10
     element:
       uris: [ 'painting.dart' ]
@@ -155,9 +155,9 @@ transforms:
       inClass: 'Color'
     changes:
       - kind: 'rename'
-        newName: 'g'
+        newName: 'g * 255.0).round() & 0xff'
 
-  - title: "Rename from 'blue' to 'b'"
+  - title: "Replace 'blue' with 'b'"
     date: 2024-09-10
     element:
       uris: [ 'painting.dart' ]
@@ -165,7 +165,7 @@ transforms:
       inClass: 'Color'
     changes:
       - kind: 'rename'
-        newName: 'b'
+        newName: 'b * 255.0).round() & 0xff'
 
   - title: "Replace 'value' with 'toARGB32()'"
     date: 2025-02-03

--- a/packages/flutter/lib/fix_data/fix_painting.yaml
+++ b/packages/flutter/lib/fix_data/fix_painting.yaml
@@ -127,16 +127,6 @@ transforms:
       - kind: 'rename'
         newName: 'a'
 
-  - title: "Rename from 'alpha' to 'a'"
-    date: 2024-09-10
-    element:
-      uris: [ 'painting.dart' ]
-      method: 'alpha'
-      inClass: 'Color'
-    changes:
-      - kind: 'rename'
-        newName: 'a'
-
   - title: "Replace 'value' with 'toARGB32()'"
     date: 2025-02-03
     element:

--- a/packages/flutter/lib/fix_data/fix_painting.yaml
+++ b/packages/flutter/lib/fix_data/fix_painting.yaml
@@ -137,36 +137,6 @@ transforms:
       - kind: 'rename'
         newName: 'a'
 
-  - title: "Replace 'red' with 'r'"
-    date: 2024-09-10
-    element:
-      uris: [ 'painting.dart' ]
-      method: 'red'
-      inClass: 'Color'
-    changes:
-      - kind: 'rename'
-        newName: 'r * 255.0).round() & 0xff'
-
-  - title: "Replace 'green' with 'g'"
-    date: 2024-09-10
-    element:
-      uris: [ 'painting.dart' ]
-      method: 'green'
-      inClass: 'Color'
-    changes:
-      - kind: 'rename'
-        newName: 'g * 255.0).round() & 0xff'
-
-  - title: "Replace 'blue' with 'b'"
-    date: 2024-09-10
-    element:
-      uris: [ 'painting.dart' ]
-      method: 'blue'
-      inClass: 'Color'
-    changes:
-      - kind: 'rename'
-        newName: 'b * 255.0).round() & 0xff'
-
   - title: "Replace 'value' with 'toARGB32()'"
     date: 2025-02-03
     element:
@@ -174,8 +144,11 @@ transforms:
       method: 'value'
       inClass: 'Color'
     changes:
-      - kind: 'rename'
-        newName: 'toARGB32()'
+      - kind: 'replacedBy'
+        newElement:
+          uris: [ 'painting.dart' ]
+          method: 'toARGB32'
+          inClass: 'Color'
 
   - title: "Rename 'withOpacity'"
     date: 2024-09-10

--- a/packages/flutter/test_fixes/painting/painting.dart
+++ b/packages/flutter/test_fixes/painting/painting.dart
@@ -22,5 +22,10 @@ void main() {
 
   Color color = Color.from(alpha: 1, red: 0, green: 1, blue: 0);
   print(color.opacity);
+  print(color.value);
+  print(color.alpha);
+  print(color.red);
+  print(color.blue);
+  print(color.green);
   color = color.withOpacity(0.55);
 }

--- a/packages/flutter/test_fixes/painting/painting.dart
+++ b/packages/flutter/test_fixes/painting/painting.dart
@@ -24,8 +24,5 @@ void main() {
   print(color.opacity);
   print(color.value);
   print(color.alpha);
-  print(color.red);
-  print(color.blue);
-  print(color.green);
   color = color.withOpacity(0.55);
 }

--- a/packages/flutter/test_fixes/painting/painting.dart
+++ b/packages/flutter/test_fixes/painting/painting.dart
@@ -23,6 +23,5 @@ void main() {
   Color color = Color.from(alpha: 1, red: 0, green: 1, blue: 0);
   print(color.opacity);
   print(color.value);
-  print(color.alpha);
   color = color.withOpacity(0.55);
 }

--- a/packages/flutter/test_fixes/painting/painting.dart.expect
+++ b/packages/flutter/test_fixes/painting/painting.dart.expect
@@ -21,5 +21,10 @@ void main() {
 
   Color color = Color.from(alpha: 1, red: 0, green: 1, blue: 0);
   print(color.a);
+  print(color.toARGB32());
+  print(color.a);
+  print(color.r);
+  print(color.b);
+  print(color.g);
   color = color.withValues(alpha: 0.55);
 }

--- a/packages/flutter/test_fixes/painting/painting.dart.expect
+++ b/packages/flutter/test_fixes/painting/painting.dart.expect
@@ -23,8 +23,8 @@ void main() {
   print(color.a);
   print(color.toARGB32());
   print(color.a);
-  print(color.r);
-  print(color.b);
-  print(color.g);
+  print(color.r * 255.0).round() & 0xff);
+  print(color.b * 255.0).round() & 0xff);
+  print(color.g * 255.0).round() & 0xff);
   color = color.withValues(alpha: 0.55);
 }

--- a/packages/flutter/test_fixes/painting/painting.dart.expect
+++ b/packages/flutter/test_fixes/painting/painting.dart.expect
@@ -23,8 +23,5 @@ void main() {
   print(color.a);
   print(color.toARGB32());
   print(color.a);
-  print(color.r * 255.0).round() & 0xff);
-  print(color.b * 255.0).round() & 0xff);
-  print(color.g * 255.0).round() & 0xff);
   color = color.withValues(alpha: 0.55);
 }

--- a/packages/flutter/test_fixes/painting/painting.dart.expect
+++ b/packages/flutter/test_fixes/painting/painting.dart.expect
@@ -22,6 +22,5 @@ void main() {
   Color color = Color.from(alpha: 1, red: 0, green: 1, blue: 0);
   print(color.a);
   print(color.toARGB32());
-  print(color.a);
   color = color.withValues(alpha: 0.55);
 }


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/160617

Noticed the `opacity` and `withOpacity` deprecations were supported by dart fix, but not the others. Adding them here.

But strange too given `dart:ui` does not support dart fix (https://github.com/dart-lang/sdk/issues/59764)..

---

We think since `painting.dart` exports `dart:ui`, this is somewhat of a workaround.

If a user has this atop their file:

```dart
import 'package:flutter/painting.dart'; // 👍  dart fix will work here
```
 If instead

```dart
import 'dart:ui'; // ❌  dart fix will not work here
```

Will continue to follow up on dart fix support for `dart:X` libraries, for now hopefully this will help!

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
