### PR TITLE
Exclude build.gradle.kts files from automatic lockfile generation in display rotation 

### DIFF
--- a/dev/tools/bin/config/lockfile_exclusion.yaml
+++ b/dev/tools/bin/config/lockfile_exclusion.yaml
@@ -5,6 +5,9 @@
 # hello_world uses a Kotlin Gradle settings file (settings.gradle.kts). We don't have a template
 # Kotlin Gradle settings file (only a groovy one), so we currently can't generate it.
 - examples/hello_world/android
+# Also uses kts files.
+- dev/integration_tests/display_cutout_rotation/android
+- dev/integration_tests/display_cutout_rotation/android/app
 
 # The following files must also be manually updated at the moment, because they don't use a
 # lib/main.dart (but they don't need exclusion, as we already skip that case).

--- a/dev/tools/bin/config/lockfile_exclusion.yaml
+++ b/dev/tools/bin/config/lockfile_exclusion.yaml
@@ -7,7 +7,6 @@
 - examples/hello_world/android
 # Also uses kts files.
 - dev/integration_tests/display_cutout_rotation/android
-- dev/integration_tests/display_cutout_rotation/android/app
 
 # The following files must also be manually updated at the moment, because they don't use a
 # lib/main.dart (but they don't need exclusion, as we already skip that case).


### PR DESCRIPTION
Fixes #162614 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
