### PR TITLE
Run web benchmarks at -O2 to evaluate performance.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1557,7 +1557,7 @@ targets:
 
   - name: Linux web_benchmarks_canvaskit
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    # presubmit: false
     timeout: 60
     properties:
       dependencies: >-
@@ -1571,7 +1571,7 @@ targets:
 
   - name: Linux web_benchmarks_skwasm
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    # presubmit: false
     timeout: 60
     properties:
       dependencies: >-
@@ -1591,7 +1591,7 @@ targets:
 
   - name: Linux web_benchmarks_skwasm_st
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    # presubmit: false
     timeout: 60
     properties:
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1557,7 +1557,7 @@ targets:
 
   - name: Linux web_benchmarks_canvaskit
     recipe: devicelab/devicelab_drone
-    # presubmit: false
+    presubmit: false
     timeout: 60
     properties:
       dependencies: >-
@@ -1571,7 +1571,7 @@ targets:
 
   - name: Linux web_benchmarks_skwasm
     recipe: devicelab/devicelab_drone
-    # presubmit: false
+    presubmit: false
     timeout: 60
     properties:
       dependencies: >-
@@ -1591,7 +1591,7 @@ targets:
 
   - name: Linux web_benchmarks_skwasm_st
     recipe: devicelab/devicelab_drone
-    # presubmit: false
+    presubmit: false
     timeout: 60
     properties:
       dependencies: >-

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -38,7 +38,8 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       options: <String>[
         'web',
         '--no-tree-shake-icons', // local engine builds are frequently out of sync with the Dart Kernel version
-        if (benchmarkOptions.useWasm) ...<String>['-O4', '--wasm', '--no-strip-wasm'],
+        '-O2',
+        if (benchmarkOptions.useWasm) ...<String>['--wasm', '--no-strip-wasm'],
         '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
         '--profile',
         '--no-web-resources-cdn',


### PR DESCRIPTION
As per https://github.com/flutter/flutter/issues/162620, we are going to run the web benchmarks at `-O2` for a trial period to evaluate the performance difference, which will give us some data on whether we can consider changing to `-O2` by default.