### PR TITLE
[CP][Beta] Unblock drag gestures in CupertinoSheetRoute content

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -669,12 +669,10 @@ class _CupertinoDownGestureDetectorState<T> extends State<_CupertinoDownGestureD
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      fit: StackFit.passthrough,
-      children: <Widget>[
-        widget.child,
-        Listener(onPointerDown: _handlePointerDown, behavior: HitTestBehavior.translucent),
-      ],
+    return Listener(
+      onPointerDown: _handlePointerDown,
+      behavior: HitTestBehavior.translucent,
+      child: widget.child,
     );
   }
 }

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -895,7 +895,7 @@ void main() {
 
       await gesture.down(const Offset(100, 100));
 
-      // Need 2 events to form a valid drag
+      // Need 2 events to form a valid drag.
       await tester.pump(const Duration(milliseconds: 100));
       await gesture.moveTo(const Offset(100, 80), timeStamp: const Duration(milliseconds: 100));
       await tester.pump(const Duration(milliseconds: 200));
@@ -907,6 +907,9 @@ void main() {
 
       // Final position should be higher.
       expect(endPosition, lessThan(startPosition));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -844,5 +844,69 @@ void main() {
 
       expect(find.text('Page 1'), findsOneWidget);
     });
+
+    testWidgets('Sheet should not block nested scroll', (WidgetTester tester) async {
+      final GlobalKey homeKey = GlobalKey();
+
+      Widget sheetScaffoldContent(BuildContext context) {
+        return ListView(
+          children: const <Widget>[
+            Text('Top of Scroll'),
+            SizedBox(width: double.infinity, height: 100),
+            Text('Middle of Scroll'),
+            SizedBox(width: double.infinity, height: 100),
+          ],
+        );
+      }
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoPageScaffold(
+            key: homeKey,
+            child: Center(
+              child: Column(
+                children: <Widget>[
+                  const Text('Page 1'),
+                  CupertinoButton(
+                    onPressed: () {
+                      showCupertinoSheet<void>(
+                        context: homeKey.currentContext!,
+                        pageBuilder: (BuildContext context) {
+                          return CupertinoPageScaffold(child: sheetScaffoldContent(context));
+                        },
+                      );
+                    },
+                    child: const Text('Push Page 2'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Push Page 2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Top of Scroll'), findsOneWidget);
+      final double startPosition = tester.getTopLeft(find.text('Middle of Scroll')).dy;
+
+      final TestGesture gesture = await tester.createGesture();
+
+      await gesture.down(const Offset(100, 100));
+
+      // Need 2 events to form a valid drag
+      await tester.pump(const Duration(milliseconds: 100));
+      await gesture.moveTo(const Offset(100, 80), timeStamp: const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 200));
+      await gesture.moveTo(const Offset(100, 50), timeStamp: const Duration(milliseconds: 200));
+
+      await tester.pumpAndSettle();
+
+      final double endPosition = tester.getTopLeft(find.text('Middle of Scroll')).dy;
+
+      // Final position should be higher.
+      expect(endPosition, lessThan(startPosition));
+    });
   });
 }


### PR DESCRIPTION
CupertinoSheetRoute is a new widget added in 3.29 as a part of #157568. #161696 fixes #161623, which was an issue where you could not put scrollable content in the sheet, which is expected behavior. CupertinoSheetRoute has been a highly requested widget so is expected to get a lot of use.

Impacted users: anyone using the CupertinoSheetRoute with scrollable content, which should be a common use case.

Impact description: not being able to scroll within the sheet would create a very bad first impression and leave the sheet unusable for a lot of apps.

Workaround: None.

Risk: This is a brand new widget, so none. 
Test Coverage (Are you confident that your fix is well-tested by automated tests?): Yes, the fix has regression tests.
Validation Steps (What are the steps to validate that this fix works?): Create a CupertinoSheetRoute with scrollable content that expands past the size of the sheet. #161623 has a code sample.