### PR TITLE
[Linux] Merge UI And Platform thread

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_dart_project.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_dart_project.cc
@@ -13,6 +13,8 @@ struct _FlDartProject {
   gchar* assets_path;
   gchar* icu_data_path;
   gchar** dart_entrypoint_args;
+
+  FlUIThreadPolicy ui_thread_policy;
 };
 
 G_DEFINE_TYPE(FlDartProject, fl_dart_project, G_TYPE_OBJECT)
@@ -113,4 +115,18 @@ G_MODULE_EXPORT void fl_dart_project_set_dart_entrypoint_arguments(
   g_return_if_fail(FL_IS_DART_PROJECT(self));
   g_clear_pointer(&self->dart_entrypoint_args, g_strfreev);
   self->dart_entrypoint_args = g_strdupv(argv);
+}
+
+G_MODULE_EXPORT
+void fl_dart_project_set_ui_thread_policy(FlDartProject* project,
+                                          FlUIThreadPolicy policy) {
+  g_return_if_fail(FL_IS_DART_PROJECT(project));
+  project->ui_thread_policy = policy;
+}
+
+G_MODULE_EXPORT
+FlUIThreadPolicy fl_dart_project_get_ui_thread_policy(FlDartProject* project) {
+  g_return_val_if_fail(FL_IS_DART_PROJECT(project),
+                       FL_UI_THREAD_POLICY_DEFAULT);
+  return project->ui_thread_policy;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -637,6 +637,11 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   custom_task_runners.struct_size = sizeof(FlutterCustomTaskRunners);
   custom_task_runners.platform_task_runner = &platform_task_runner;
 
+  if (fl_dart_project_get_ui_thread_policy(self->project) ==
+      FL_UI_THREAD_POLICY_RUN_ON_PLATFORM_THREAD) {
+    custom_task_runners.ui_task_runner = &platform_task_runner;
+  }
+
   g_autoptr(GPtrArray) command_line_args =
       g_ptr_array_new_with_free_func(g_free);
   g_ptr_array_insert(command_line_args, 0, g_strdup("flutter"));

--- a/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -156,7 +156,7 @@ void fl_dart_project_set_ui_thread_policy(FlDartProject* project,
  * fl_dart_project_get_ui_thread_policy:
  * @project: an #FlDartProject.
  *
- * Returns the thread policy used for running the UI isolate.
+ * Returns: the thread policy used for running the UI isolate.
  */
 FlUIThreadPolicy fl_dart_project_get_ui_thread_policy(FlDartProject* project);
 

--- a/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -128,6 +128,38 @@ void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project,
  */
 gchar** fl_dart_project_get_dart_entrypoint_arguments(FlDartProject* project);
 
+/**
+ * FlUIThreadPolicy:
+ * Configures the thread policy for running the UI isolate.
+ * @FL_UI_THREAD_POLICY_DEFAULT: Defaut value. Currently will run the UI isolate
+ * on separate thread, later will change to run on platform thread.
+ * @FL_UI_THREAD_POLICY_RUN_ON_PLATFORM_THREAD: Run the UI isolate on the
+ * platform thread.
+ * @FL_UI_THREAD_POLICY_RUN_ON_SEPARATE_THREAD: Run the UI isolate on a separate
+ * thread.
+ */
+typedef enum {
+  FL_UI_THREAD_POLICY_DEFAULT,
+  FL_UI_THREAD_POLICY_RUN_ON_PLATFORM_THREAD,
+  FL_UI_THREAD_POLICY_RUN_ON_SEPARATE_THREAD,
+} FlUIThreadPolicy;
+
+/**
+ * fl_dart_project_set_ui_thread_policy:
+ * @project: an #FlDartProject.
+ * @policy: the thread policy to use for running the UI isolate.
+ */
+void fl_dart_project_set_ui_thread_policy(FlDartProject* project,
+                                          FlUIThreadPolicy policy);
+
+/**
+ * fl_dart_project_get_ui_thread_policy:
+ * @project: an #FlDartProject.
+ *
+ * Returns the thread policy used for running the UI isolate.
+ */
+FlUIThreadPolicy fl_dart_project_get_ui_thread_policy(FlDartProject* project);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_PUBLIC_FLUTTER_LINUX_FL_DART_PROJECT_H_


### PR DESCRIPTION
Disabled by default, to enable use `fl_dart_project_get_ui_thread_policy`:
```cpp
  g_autoptr(FlDartProject) project = fl_dart_project_new();
  fl_dart_project_set_ui_thread_policy(project, FL_UI_THREAD_POLICY_RUN_ON_PLATFORM_THREAD);
```

With this PR, the UI isolate now runs on platform thread, which allows for synchronous calls to Gtk, as well as synchronous calls from Gtk to Flutter. For example something like this is now possible:

```dart
typedef GtkWindow = Pointer<Void>;

void setWindowPosition() {
  final library = DynamicLibrary.executable();
  // Hypothetical function to get pointer to GtkWindow
  final getMainWindow = library
      .lookupFunction<GtkWindow Function(), GtkWindow Function()>(
        'get_main_window',
      );
  final gtkWindowResize = library.lookupFunction<
    Void Function(GtkWindow, Int32, Int32),
    void Function(GtkWindow, int, int)
  >('gtk_window_resize');
  final window = getMainWindow();
  gtkWindowResize(window, 200, 200);
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x]  I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
