### PR TITLE
Increase timeout for Linux flutter_packaging_test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -684,6 +684,7 @@ targets:
     presubmit: false
     enabled_branches:
       - master
+    timeout: 60 # TODO(https://github.com/flutter/flutter/issues/162654)
     properties:
       task_name: flutter_packaging
       tags: >


### PR DESCRIPTION
This test increased in time and is timing out. While we search for the cause, we need to increase the timeout
