### PR TITLE
No, but really increase the timeout to 60 minutes

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -689,6 +689,7 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "linux"]
+      test_timeout_secs: "3600" # TODO(https://github.com/flutter/flutter/issues/162654)
     runIf:
       - .ci.yaml
       - engine/**


### PR DESCRIPTION
`timeout` does work for the overall build timeout.
`properties["test_timeout_secs"]` does the individual steps  timeout.

They should both be set.