### PR TITLE
`flutter build aar` regenerates tooling between each build-mode step

### DIFF
--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -21,6 +21,11 @@ Future<void> main() async {
     }
     print('\nUsing JAVA_HOME=$javaHome');
 
+    // TODO(matanlurey): Remove after default.
+    // https://github.com/flutter/flutter/issues/160257
+    section('Opt-in to --explicit-package-dependencies');
+    await flutter('config', options: <String>['--explicit-package-dependencies']);
+
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_module_test.');
     final Directory projectDir = Directory(path.join(tempDir.path, 'hello'));
     try {

--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -19,6 +19,7 @@ abstract class AndroidBuilder {
     required FlutterProject project,
     required Set<AndroidBuildInfo> androidBuildInfo,
     required String target,
+    required Future<void> Function(FlutterProject, {required bool releaseMode}) generateTooling,
     String? outputDirectoryPath,
     required String buildNumber,
   });

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -191,6 +191,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
     required FlutterProject project,
     required Set<AndroidBuildInfo> androidBuildInfo,
     required String target,
+    required Future<void> Function(FlutterProject, {required bool releaseMode}) generateTooling,
     String? outputDirectoryPath,
     required String buildNumber,
   }) async {
@@ -208,6 +209,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
       _logger.printWarning(androidX86DeprecationWarning);
     }
     for (final AndroidBuildInfo androidBuildInfo in androidBuildInfo) {
+      await generateTooling(project, releaseMode: androidBuildInfo.buildInfo.isRelease);
       await buildGradleAar(
         project: project,
         androidBuildInfo: androidBuildInfo,

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -112,6 +112,15 @@ class BuildAarCommand extends BuildSubCommand {
   }
 
   @override
+  Future<void> regeneratePlatformSpecificTooling(
+    FlutterProject project, {
+    bool? releaseMode,
+  }) async {
+    // Intentionally left blank. We want to rebuild the tooling before every sub-build.
+    // See https://github.com/flutter/flutter/issues/162649.
+  }
+
+  @override
   Future<FlutterCommandResult> runCommand() async {
     if (_androidSdk == null) {
       exitWithNoSdkMessage();
@@ -153,6 +162,8 @@ class BuildAarCommand extends BuildSubCommand {
       project: project,
       target: targetFile.path,
       androidBuildInfo: androidBuildInfo,
+      // Intentionally use super.* in order to use the base implementation that is not NOP.
+      generateTooling: super.regeneratePlatformSpecificTooling,
       outputDirectoryPath: stringArg('output'),
       buildNumber: buildNumber,
     );

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -112,13 +112,7 @@ class BuildAarCommand extends BuildSubCommand {
   }
 
   @override
-  Future<void> regeneratePlatformSpecificTooling(
-    FlutterProject project, {
-    bool? releaseMode,
-  }) async {
-    // Intentionally left blank. We want to rebuild the tooling before every sub-build.
-    // See https://github.com/flutter/flutter/issues/162649.
-  }
+  bool get regeneratePlatformSpecificToolingDurifyVerify => false;
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -158,12 +152,12 @@ class BuildAarCommand extends BuildSubCommand {
     }
 
     displayNullSafetyMode(androidBuildInfo.first.buildInfo);
+
     await androidBuilder?.buildAar(
       project: project,
       target: targetFile.path,
       androidBuildInfo: androidBuildInfo,
-      // Intentionally use super.* in order to use the base implementation that is not NOP.
-      generateTooling: super.regeneratePlatformSpecificTooling,
+      generateTooling: regeneratePlatformSpecificToolingIfApplicable,
       outputDirectoryPath: stringArg('output'),
       buildNumber: buildNumber,
     );

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -20,6 +20,7 @@ class FakeAndroidBuilder implements AndroidBuilder {
     required FlutterProject project,
     required Set<AndroidBuildInfo> androidBuildInfo,
     required String target,
+    required Future<void> Function(FlutterProject, {required bool releaseMode}) generateTooling,
     String? outputDirectoryPath,
     required String buildNumber,
   }) async {}

--- a/packages/flutter_tools/test/src/fake_pub_deps.dart
+++ b/packages/flutter_tools/test/src/fake_pub_deps.dart
@@ -16,10 +16,15 @@ final class FakePubWithPrimedDeps implements Pub {
   /// dev-dependencies ([dependencies]) of any package to a set of any other
   /// packages. A resulting valid `dart pub deps --json` response is implicitly
   /// created.
+  ///
+  /// If [allowGet] is `true`, [Pub.get] can be invoked (all the parameters are
+  /// ignored and it is considered a success); otherwise an error is thrown to
+  /// reject an unexpected call.
   factory FakePubWithPrimedDeps({
     String rootPackageName = 'app_name',
     Set<String> devDependencies = const <String>{},
     Map<String, Set<String>> dependencies = const <String, Set<String>>{},
+    bool allowGet = false,
   }) {
     // Start the packages: [ ... ] list with the root package.
     final List<Object?> packages = <Object?>[
@@ -56,11 +61,34 @@ final class FakePubWithPrimedDeps implements Pub {
     return FakePubWithPrimedDeps._(<String, Object?>{
       'root': rootPackageName,
       'packages': packages,
-    });
+    }, allowGetToSucceed: allowGet);
   }
 
-  const FakePubWithPrimedDeps._(this._deps);
+  const FakePubWithPrimedDeps._(this._deps, {required bool allowGetToSucceed})
+    : _allowGetToSucceed = allowGetToSucceed;
   final Map<String, Object?> _deps;
+  final bool _allowGetToSucceed;
+
+  @override
+  Future<void> get({
+    required PubContext context,
+    required FlutterProject project,
+    bool upgrade = false,
+    bool offline = false,
+    String? flutterRootOverride,
+    bool checkUpToDate = false,
+    bool shouldSkipThirdPartyGenerator = true,
+    PubOutputMode outputMode = PubOutputMode.all,
+  }) async {
+    if (_allowGetToSucceed) {
+      return;
+    }
+    throw UnsupportedError(
+      'Instance did not expect <Pub>.get to be invoked. If this was intentional, '
+      'change the constructor of FakePubWithPrimeDeps to include the parameter '
+      'allowGet: true.',
+    );
+  }
 
   @override
   Future<Map<String, Object?>> deps(FlutterProject project) async => _deps;


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/162703.

I still need to do a similar change for `ios|macos`-`framework` in https://github.com/flutter/flutter/issues/162704.

I added two unit tests, as well as opted in an integration test to the flag (it will become the default in https://github.com/flutter/flutter/pull/160289).

/cc @reidbaker @gmackall.