### PR TITLE
Wait until all scripts are loaded in the page before running main for the DDC library bundle format

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -1087,6 +1087,10 @@ class WebDevFS implements DevFS {
               generateLoadingIndicator: enableDwds,
             ),
       );
+      const String onLoadEndBootstrap = 'on_load_end_bootstrap.js';
+      if (ddcModuleSystem) {
+        webAssetServer.writeFile(onLoadEndBootstrap, generateDDCLibraryBundleOnLoadEndBootstrap());
+      }
       webAssetServer.writeFile(
         'main_module.bootstrap.js',
         ddcModuleSystem
@@ -1094,6 +1098,7 @@ class WebDevFS implements DevFS {
               entrypoint: entrypoint,
               nullAssertions: nullAssertions,
               nativeNullAssertions: nativeNullAssertions,
+              onLoadEndBootstrap: onLoadEndBootstrap,
             )
             : generateMainModule(
               entrypoint: entrypoint,

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -547,8 +547,8 @@ String generateDDCLibraryBundleMainModule({
     dwdsCalledMain = true;
     runMainWhenBoth();
   }
-  // Should be called by the bootstrap script set up within `loadConfig` once
-  // all the scripts have been loaded.
+  // Should be called by $onLoadEndBootstrap once all the scripts have been
+  // loaded.
   window.$_onLoadEndCallback = function() {
     dartSrcsLoaded = true;
     runMainWhenBoth();

--- a/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
@@ -273,6 +273,7 @@ void main() {
         entrypoint: 'main.js',
         nullAssertions: false,
         nativeNullAssertions: false,
+        onLoadEndBootstrap: 'on_load_end_bootstrap.js',
       );
       // bootstrap main module has correct defined module.
       expect(result, contains('let appName = "org-dartlang-app:/main.js";'));
@@ -284,6 +285,7 @@ void main() {
         entrypoint: 'main.js',
         nullAssertions: true,
         nativeNullAssertions: true,
+        onLoadEndBootstrap: 'on_load_end_bootstrap.js',
       );
 
       expect(result, contains('nonNullAsserts: true'));
@@ -295,6 +297,7 @@ void main() {
         entrypoint: 'main.js',
         nullAssertions: false,
         nativeNullAssertions: false,
+        onLoadEndBootstrap: 'on_load_end_bootstrap.js',
       );
 
       expect(result, contains('nonNullAsserts: false'));

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_test_common.dart
@@ -12,11 +12,7 @@ import '../test_driver.dart';
 import '../test_utils.dart';
 import 'hot_reload_project.dart';
 
-void testAll({
-  bool chrome = false,
-  List<String> additionalCommandArgs = const <String>[],
-  Object? skip = false,
-}) {
+void testAll({bool chrome = false, List<String> additionalCommandArgs = const <String>[]}) {
   group('chrome: $chrome'
       '${additionalCommandArgs.isEmpty ? '' : ' with args: $additionalCommandArgs'}', () {
     late Directory tempDir;
@@ -235,7 +231,7 @@ void testAll({
       // isolates, so this test will wait forever.
       skip: chrome,
     );
-  }, skip: skip);
+  });
 }
 
 bool _isHotReloadCompletionEvent(Map<String, Object?>? event) {

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset_test_common.dart
@@ -11,11 +11,7 @@ import '../test_driver.dart';
 import '../test_utils.dart';
 import 'hot_reload_with_asset.dart';
 
-void testAll({
-  bool chrome = false,
-  List<String> additionalCommandArgs = const <String>[],
-  Object? skip = false,
-}) {
+void testAll({bool chrome = false, List<String> additionalCommandArgs = const <String>[]}) {
   group('chrome: $chrome'
       '${additionalCommandArgs.isEmpty ? '' : ' with args: $additionalCommandArgs'}', () {
     late Directory tempDir;
@@ -86,5 +82,5 @@ void testAll({
       await flutter.hotRestart();
       await onSecondLoad.future;
     });
-  }, skip: skip);
+  });
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_hot_reload_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_hot_reload_test_common.dart
@@ -13,11 +13,7 @@ import '../test_utils.dart';
 
 // This test verifies that we can hot reload a stateless widget into a
 // stateful one and back.
-void testAll({
-  bool chrome = false,
-  List<String> additionalCommandArgs = const <String>[],
-  Object? skip = false,
-}) {
+void testAll({bool chrome = false, List<String> additionalCommandArgs = const <String>[]}) {
   group('chrome: $chrome'
       '${additionalCommandArgs.isEmpty ? '' : ' with args: $additionalCommandArgs'}', () {
     late Directory tempDir;
@@ -60,5 +56,5 @@ void testAll({
       expect(logs, contains('STATEFUL'));
       await subscription.cancel();
     });
-  }, skip: skip);
+  });
 }

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_errors_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_errors_test.dart
@@ -5,8 +5,6 @@
 @Tags(<String>['flutter-test-driver'])
 library;
 
-import 'dart:io';
-
 import '../integration.shard/test_data/hot_reload_errors_common.dart';
 import '../src/common.dart';
 
@@ -19,7 +17,5 @@ void main() {
     // TODO(srujzs): Remove this custom message once we have the delta inspector emitting the same
     // string as the VM.
     constClassFieldRemovalErrorMessage: 'Const class cannot remove fields',
-    // https://github.com/flutter/flutter/issues/162567
-    skip: Platform.isWindows,
   );
 }

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -14,7 +14,5 @@ void main() {
     additionalCommandArgs: <String>[
       '--extra-front-end-options=--dartdevc-canary,--dartdevc-module-format=ddc',
     ],
-    // https://github.com/flutter/flutter/issues/162567
-    skip: true,
   );
 }

--- a/packages/flutter_tools/test/web.shard/hot_reload_with_asset_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_with_asset_web_test.dart
@@ -14,7 +14,5 @@ void main() {
     additionalCommandArgs: <String>[
       '--extra-front-end-options=--dartdevc-canary,--dartdevc-module-format=ddc',
     ],
-    // https://github.com/flutter/flutter/issues/162567
-    skip: true,
   );
 }

--- a/packages/flutter_tools/test/web.shard/stateless_stateful_hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/stateless_stateful_hot_reload_web_test.dart
@@ -14,7 +14,5 @@ void main() {
     additionalCommandArgs: <String>[
       '--extra-front-end-options=--dartdevc-canary,--dartdevc-module-format=ddc',
     ],
-    // https://github.com/flutter/flutter/issues/162567
-    skip: true,
   );
 }


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/162567

- Uses the `bootstrapScript` field in `loadConfig` to run a script after all scripts have loaded.
- This script just calls a callback that is set up beforehand and calls main.
- Modifies the callback that calls `dartDevEmbedder.runMain` to wait until both DWDS called main and all scripts have loaded.
- Unskips hot reload tests now that the race condition should no longer exist.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
