### PR TITLE
Revert web_benchmarks back to default optimization level (`-O4`)

### DIFF
--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -38,7 +38,6 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       options: <String>[
         'web',
         '--no-tree-shake-icons', // local engine builds are frequently out of sync with the Dart Kernel version
-        '-O2',
         if (benchmarkOptions.useWasm) ...<String>['--wasm', '--no-strip-wasm'],
         '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
         '--profile',


### PR DESCRIPTION
As per https://github.com/flutter/flutter/issues/162620.

We got the data we were looking for with the experiment. Return the benchmarks to the default optimization level.