### PR TITLE
[web] warm-up frame does not block schedule frame

### DIFF
--- a/engine/src/flutter/lib/web_ui/test/engine/frame_service_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/frame_service_test.dart
@@ -136,8 +136,13 @@ void testMain() {
         },
       );
 
-      // IMPORTANT: scheduled, but not yet rendering
-      expect(instance.isFrameScheduled, isTrue);
+      // Even though the warm-up frame is scheduled the value of
+      // isFrameScheduled remains false. This is because, for reasons to be yet
+      // addressed, the warm-up frame can be (and indeed is) interleaved with
+      // a normal scheduleFrame request. See the TODOs inside the
+      // scheduleWarmUpFrame code, and this discussion in particular:
+      // https://github.com/flutter/engine/pull/50570#discussion_r1496671676
+      expect(instance.isFrameScheduled, isFalse);
       expect(instance.isRenderingFrame, isFalse);
       await frameCompleter.future;
       expect(instance.isFrameScheduled, isFalse);


### PR DESCRIPTION
Fix the issue with the first frame not rendering, introduced in https://github.com/flutter/flutter/pull/162554.

Nobody filed an issue yet. I found it while testing something else.