### PR TITLE
Fix DropdownButtonFormField padding when ButtonTheme.alignedDropdown is true

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1526,7 +1526,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
 
     final EdgeInsetsGeometry padding =
-        ButtonTheme.of(context).alignedDropdown ? _kAlignedButtonPadding : _kUnalignedButtonPadding;
+        ButtonTheme.of(context).alignedDropdown && widget._inputDecoration == null
+            ? _kAlignedButtonPadding
+            : _kUnalignedButtonPadding;
 
     // If value is null (then _selectedIndex is null) then we
     // display the hint or nothing at all.

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -1253,4 +1253,45 @@ void main() {
 
     expect(find.text('**Required**'), findsOneWidget);
   });
+
+  testWidgets('ButtonTheme.alignedDropdown does not affect the field content position', (
+    WidgetTester tester,
+  ) async {
+    Widget buildFrame({required bool alignedDropdown, required TextDirection textDirection}) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: ButtonTheme(
+            alignedDropdown: alignedDropdown,
+            child: Material(
+              child: DropdownButtonFormField<String>(
+                value: menuItems.first,
+                items:
+                    menuItems.map((String value) {
+                      return DropdownMenuItem<String>(value: value, child: Text(value));
+                    }).toList(),
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final Finder findSelectedValue = find.text(menuItems.first).first;
+
+    await tester.pumpWidget(buildFrame(alignedDropdown: false, textDirection: TextDirection.ltr));
+    Rect contentRectForUnalignedDropdown = tester.getRect(findSelectedValue);
+
+    // When alignedDropdown is true, the content should be at the same position.
+    await tester.pumpWidget(buildFrame(alignedDropdown: true, textDirection: TextDirection.ltr));
+    expect(tester.getRect(findSelectedValue), contentRectForUnalignedDropdown);
+
+    await tester.pumpWidget(buildFrame(alignedDropdown: false, textDirection: TextDirection.rtl));
+    contentRectForUnalignedDropdown = tester.getRect(findSelectedValue);
+
+    // When alignedDropdown is true, the content should be at the same position.
+    await tester.pumpWidget(buildFrame(alignedDropdown: true, textDirection: TextDirection.rtl));
+    expect(tester.getRect(findSelectedValue), contentRectForUnalignedDropdown);
+  });
 }


### PR DESCRIPTION
## Description

This PR fixes `DropdownButtonFormField` content padding when `ButtonTheme.alignedDropdown` is true.

### Before:

An extra padding is added before the content when `alignedDropdown` is true:

![image](https://github.com/user-attachments/assets/429aa848-c56a-4e74-aca3-6c9eb9507578)


### After:

The content has the same position whether `alignedDropdown` is true or false:

![image](https://github.com/user-attachments/assets/2476194d-b582-4991-9285-d5c94af86f6a)


## Related Issue

Fixes https://github.com/flutter/flutter/issues/123783

## Tests

Adds 1 test.
