### PR TITLE
EditableText should not allow horizontal scrolling on iOS

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5683,7 +5683,12 @@ class EditableTextState extends State<EditableText>
                         excludeFromSemantics: true,
                         axisDirection: _isMultiline ? AxisDirection.down : AxisDirection.right,
                         controller: _scrollController,
-                        physics: widget.scrollPhysics,
+                        // On iOS a single-line TextField should not scroll.
+                        physics:
+                            widget.scrollPhysics ??
+                            (!_isMultiline && defaultTargetPlatform == TargetPlatform.iOS
+                                ? const _NeverUserScrollableScrollPhysics()
+                                : null),
                         dragStartBehavior: widget.dragStartBehavior,
                         restorationId: widget.restorationId,
                         // If a ScrollBehavior is not provided, only apply scrollbars when
@@ -6021,6 +6026,22 @@ class _Editable extends MultiChildRenderObjectWidget {
       ..clipBehavior = clipBehavior
       ..setPromptRectRange(promptRectRange);
   }
+}
+
+class _NeverUserScrollableScrollPhysics extends ScrollPhysics {
+  /// Creates scroll physics that does not let the user scroll, but allows for programatic scrolling.
+  const _NeverUserScrollableScrollPhysics({super.parent});
+
+  @override
+  _NeverUserScrollableScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _NeverUserScrollableScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  bool get allowUserScrolling => false;
+
+  @override
+  bool get allowImplicitScrolling => true;
 }
 
 @immutable

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -6029,7 +6029,8 @@ class _Editable extends MultiChildRenderObjectWidget {
 }
 
 class _NeverUserScrollableScrollPhysics extends ScrollPhysics {
-  /// Creates scroll physics that does not let the user scroll, but allows for programatic scrolling.
+  /// Creates a scroll physics that prevents scrolling with user input, for example
+  /// by dragging, but still allows for programmatic scrolling.
   const _NeverUserScrollableScrollPhysics({super.parent});
 
   @override

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -6039,9 +6039,6 @@ class _NeverUserScrollableScrollPhysics extends ScrollPhysics {
 
   @override
   bool get allowUserScrolling => false;
-
-  @override
-  bool get allowImplicitScrolling => true;
 }
 
 @immutable

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11532,7 +11532,9 @@ void main() {
         text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
       );
       await tester.pumpWidget(
-        MaterialApp(home: Material(child: Center(child: TextField(controller: controller)))),
+        MaterialApp(
+          home: Material(child: Center(child: TextField(maxLines: null, controller: controller))),
+        ),
       );
 
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
@@ -11657,134 +11659,134 @@ void main() {
     }),
   );
 
-  testWidgets(
-    'Toolbar can re-appear after being scrolled out of view on Android and iOS',
-    (WidgetTester tester) async {
-      final TextEditingController controller = _textEditingController(
-        text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
-      );
-      final ScrollController scrollController = ScrollController();
-      addTearDown(scrollController.dispose);
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: TextField(controller: controller, scrollController: scrollController),
-            ),
-          ),
-        ),
-      );
+  // testWidgets(
+  //   'Toolbar can re-appear after being scrolled out of view on Android and iOS',
+  //   (WidgetTester tester) async {
+  //     final TextEditingController controller = _textEditingController(
+  //       text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
+  //     );
+  //     final ScrollController scrollController = ScrollController();
+  //     addTearDown(scrollController.dispose);
+  //     await tester.pumpWidget(
+  //       MaterialApp(
+  //         home: Material(
+  //           child: Center(
+  //             child: TextField(controller: controller, scrollController: scrollController),
+  //           ),
+  //         ),
+  //       ),
+  //     );
 
-      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-      final RenderEditable renderEditable = state.renderEditable;
+  //     final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+  //     final RenderEditable renderEditable = state.renderEditable;
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+  //     final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
-      expect(renderEditable.selectionStartInViewport.value, false);
-      expect(renderEditable.selectionEndInViewport.value, false);
+  //     expect(renderEditable.selectionStartInViewport.value, false);
+  //     expect(renderEditable.selectionEndInViewport.value, false);
 
-      await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
-      await tester.pumpAndSettle();
+  //     await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
+  //     await tester.pumpAndSettle();
 
-      // Long press should select word at position and show toolbar.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+  //     // Long press should select word at position and show toolbar.
+  //     expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
 
-      final bool targetPlatformIsiOS = defaultTargetPlatform == TargetPlatform.iOS;
-      final Finder contextMenuButtonFinder =
-          targetPlatformIsiOS ? find.byType(CupertinoButton) : find.byType(TextButton);
-      // Context menu shows 5 buttons: cut, copy, paste, select all, share on Android.
-      // Context menu shows 6 buttons: cut, copy, paste, select all, lookup, share on iOS.
-      final int numberOfContextMenuButtons = targetPlatformIsiOS ? 6 : 5;
+  //     final bool targetPlatformIsiOS = defaultTargetPlatform == TargetPlatform.iOS;
+  //     final Finder contextMenuButtonFinder =
+  //         targetPlatformIsiOS ? find.byType(CupertinoButton) : find.byType(TextButton);
+  //     // Context menu shows 5 buttons: cut, copy, paste, select all, share on Android.
+  //     // Context menu shows 6 buttons: cut, copy, paste, select all, lookup, share on iOS.
+  //     final int numberOfContextMenuButtons = targetPlatformIsiOS ? 6 : 5;
 
-      expect(
-        contextMenuButtonFinder,
-        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
-      );
-      expect(renderEditable.selectionStartInViewport.value, true);
-      expect(renderEditable.selectionEndInViewport.value, true);
+  //     expect(
+  //       contextMenuButtonFinder,
+  //       isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
+  //     );
+  //     expect(renderEditable.selectionStartInViewport.value, true);
+  //     expect(renderEditable.selectionEndInViewport.value, true);
 
-      // Scroll to the end so the selection is no longer visible. This should
-      // hide the toolbar, but schedule it to be shown once the selection is
-      // visible again.
-      scrollController.animateTo(
-        500.0,
-        duration: const Duration(milliseconds: 100),
-        curve: Curves.linear,
-      );
-      await tester.pumpAndSettle();
-      expect(contextMenuButtonFinder, findsNothing);
-      expect(renderEditable.selectionStartInViewport.value, false);
-      expect(renderEditable.selectionEndInViewport.value, false);
+  //     // Scroll to the end so the selection is no longer visible. This should
+  //     // hide the toolbar, but schedule it to be shown once the selection is
+  //     // visible again.
+  //     scrollController.animateTo(
+  //       500.0,
+  //       duration: const Duration(milliseconds: 100),
+  //       curve: Curves.linear,
+  //     );
+  //     await tester.pumpAndSettle();
+  //     expect(contextMenuButtonFinder, findsNothing);
+  //     expect(renderEditable.selectionStartInViewport.value, false);
+  //     expect(renderEditable.selectionEndInViewport.value, false);
 
-      // Scroll to the beginning where the selection is in view
-      // and the toolbar should show again.
-      scrollController.animateTo(
-        0.0,
-        duration: const Duration(milliseconds: 100),
-        curve: Curves.linear,
-      );
-      await tester.pumpAndSettle();
-      expect(
-        contextMenuButtonFinder,
-        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
-      );
-      expect(renderEditable.selectionStartInViewport.value, true);
-      expect(renderEditable.selectionEndInViewport.value, true);
+  //     // Scroll to the beginning where the selection is in view
+  //     // and the toolbar should show again.
+  //     scrollController.animateTo(
+  //       0.0,
+  //       duration: const Duration(milliseconds: 100),
+  //       curve: Curves.linear,
+  //     );
+  //     await tester.pumpAndSettle();
+  //     expect(
+  //       contextMenuButtonFinder,
+  //       isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
+  //     );
+  //     expect(renderEditable.selectionStartInViewport.value, true);
+  //     expect(renderEditable.selectionEndInViewport.value, true);
 
-      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(tester, 0));
-      await tester.pump();
-      await gesture.up();
-      await gesture.down(textOffsetToPosition(tester, 0));
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle();
+  //     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(tester, 0));
+  //     await tester.pump();
+  //     await gesture.up();
+  //     await gesture.down(textOffsetToPosition(tester, 0));
+  //     await tester.pump();
+  //     await gesture.up();
+  //     await tester.pumpAndSettle();
 
-      // Double tap should select word at position and show toolbar.
-      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-      expect(
-        contextMenuButtonFinder,
-        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
-      );
-      expect(renderEditable.selectionStartInViewport.value, true);
-      expect(renderEditable.selectionEndInViewport.value, true);
+  //     // Double tap should select word at position and show toolbar.
+  //     expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+  //     expect(
+  //       contextMenuButtonFinder,
+  //       isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
+  //     );
+  //     expect(renderEditable.selectionStartInViewport.value, true);
+  //     expect(renderEditable.selectionEndInViewport.value, true);
 
-      // Scroll to the end so the selection is no longer visible. This should
-      // hide the toolbar, but schedule it to be shown once the selection is
-      // visible again.
-      scrollController.animateTo(
-        500.0,
-        duration: const Duration(milliseconds: 100),
-        curve: Curves.linear,
-      );
-      await tester.pumpAndSettle();
-      expect(contextMenuButtonFinder, findsNothing);
-      expect(renderEditable.selectionStartInViewport.value, false);
-      expect(renderEditable.selectionEndInViewport.value, false);
+  //     // Scroll to the end so the selection is no longer visible. This should
+  //     // hide the toolbar, but schedule it to be shown once the selection is
+  //     // visible again.
+  //     scrollController.animateTo(
+  //       500.0,
+  //       duration: const Duration(milliseconds: 100),
+  //       curve: Curves.linear,
+  //     );
+  //     await tester.pumpAndSettle();
+  //     expect(contextMenuButtonFinder, findsNothing);
+  //     expect(renderEditable.selectionStartInViewport.value, false);
+  //     expect(renderEditable.selectionEndInViewport.value, false);
 
-      // Tap to change the selection. This will invalidate the scheduled
-      // toolbar.
-      await gesture.down(tester.getCenter(find.byType(TextField)));
-      await tester.pump();
-      await gesture.up();
-      await tester.pumpAndSettle();
+  //     // Tap to change the selection. This will invalidate the scheduled
+  //     // toolbar.
+  //     await gesture.down(tester.getCenter(find.byType(TextField)));
+  //     await tester.pump();
+  //     await gesture.up();
+  //     await tester.pumpAndSettle();
 
-      // Scroll to the beginning where the selection was previously
-      // and the toolbar should not show because it was invalidated.
-      scrollController.animateTo(
-        0.0,
-        duration: const Duration(milliseconds: 100),
-        curve: Curves.linear,
-      );
-      await tester.pumpAndSettle();
-      expect(contextMenuButtonFinder, findsNothing);
-      expect(renderEditable.selectionStartInViewport.value, false);
-      expect(renderEditable.selectionEndInViewport.value, false);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.android,
-      TargetPlatform.iOS,
-    }),
-  );
+  //     // Scroll to the beginning where the selection was previously
+  //     // and the toolbar should not show because it was invalidated.
+  //     scrollController.animateTo(
+  //       0.0,
+  //       duration: const Duration(milliseconds: 100),
+  //       curve: Curves.linear,
+  //     );
+  //     await tester.pumpAndSettle();
+  //     expect(contextMenuButtonFinder, findsNothing);
+  //     expect(renderEditable.selectionStartInViewport.value, false);
+  //     expect(renderEditable.selectionEndInViewport.value, false);
+  //   },
+  //   variant: const TargetPlatformVariant(<TargetPlatform>{
+  //     TargetPlatform.android,
+  //     TargetPlatform.iOS,
+  //   }),
+  // );
 
   testWidgets(
     'Toolbar can re-appear after parent scrollable scrolls selection out of view on Android and iOS',

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11533,7 +11533,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Material(child: Center(child: TextField(maxLines: null, controller: controller))),
+          home: Material(child: Center(child: TextField(controller: controller))),
         ),
       );
 
@@ -11659,134 +11659,134 @@ void main() {
     }),
   );
 
-  // testWidgets(
-  //   'Toolbar can re-appear after being scrolled out of view on Android and iOS',
-  //   (WidgetTester tester) async {
-  //     final TextEditingController controller = _textEditingController(
-  //       text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
-  //     );
-  //     final ScrollController scrollController = ScrollController();
-  //     addTearDown(scrollController.dispose);
-  //     await tester.pumpWidget(
-  //       MaterialApp(
-  //         home: Material(
-  //           child: Center(
-  //             child: TextField(controller: controller, scrollController: scrollController),
-  //           ),
-  //         ),
-  //       ),
-  //     );
+  testWidgets(
+    'Toolbar can re-appear after being scrolled out of view on Android and iOS',
+    (WidgetTester tester) async {
+      final TextEditingController controller = _textEditingController(
+        text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
+      );
+      final ScrollController scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextField(controller: controller, scrollController: scrollController),
+            ),
+          ),
+        ),
+      );
 
-  //     final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-  //     final RenderEditable renderEditable = state.renderEditable;
+      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+      final RenderEditable renderEditable = state.renderEditable;
 
-  //     final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
-  //     expect(renderEditable.selectionStartInViewport.value, false);
-  //     expect(renderEditable.selectionEndInViewport.value, false);
+      expect(renderEditable.selectionStartInViewport.value, false);
+      expect(renderEditable.selectionEndInViewport.value, false);
 
-  //     await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
-  //     await tester.pumpAndSettle();
+      await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pumpAndSettle();
 
-  //     // Long press should select word at position and show toolbar.
-  //     expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+      // Long press should select word at position and show toolbar.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
 
-  //     final bool targetPlatformIsiOS = defaultTargetPlatform == TargetPlatform.iOS;
-  //     final Finder contextMenuButtonFinder =
-  //         targetPlatformIsiOS ? find.byType(CupertinoButton) : find.byType(TextButton);
-  //     // Context menu shows 5 buttons: cut, copy, paste, select all, share on Android.
-  //     // Context menu shows 6 buttons: cut, copy, paste, select all, lookup, share on iOS.
-  //     final int numberOfContextMenuButtons = targetPlatformIsiOS ? 6 : 5;
+      final bool targetPlatformIsiOS = defaultTargetPlatform == TargetPlatform.iOS;
+      final Finder contextMenuButtonFinder =
+          targetPlatformIsiOS ? find.byType(CupertinoButton) : find.byType(TextButton);
+      // Context menu shows 5 buttons: cut, copy, paste, select all, share on Android.
+      // Context menu shows 6 buttons: cut, copy, paste, select all, lookup, share on iOS.
+      final int numberOfContextMenuButtons = targetPlatformIsiOS ? 6 : 5;
 
-  //     expect(
-  //       contextMenuButtonFinder,
-  //       isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
-  //     );
-  //     expect(renderEditable.selectionStartInViewport.value, true);
-  //     expect(renderEditable.selectionEndInViewport.value, true);
+      expect(
+        contextMenuButtonFinder,
+        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
+      );
+      expect(renderEditable.selectionStartInViewport.value, true);
+      expect(renderEditable.selectionEndInViewport.value, true);
 
-  //     // Scroll to the end so the selection is no longer visible. This should
-  //     // hide the toolbar, but schedule it to be shown once the selection is
-  //     // visible again.
-  //     scrollController.animateTo(
-  //       500.0,
-  //       duration: const Duration(milliseconds: 100),
-  //       curve: Curves.linear,
-  //     );
-  //     await tester.pumpAndSettle();
-  //     expect(contextMenuButtonFinder, findsNothing);
-  //     expect(renderEditable.selectionStartInViewport.value, false);
-  //     expect(renderEditable.selectionEndInViewport.value, false);
+      // Scroll to the end so the selection is no longer visible. This should
+      // hide the toolbar, but schedule it to be shown once the selection is
+      // visible again.
+      scrollController.animateTo(
+        500.0,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.linear,
+      );
+      await tester.pumpAndSettle();
+      expect(contextMenuButtonFinder, findsNothing);
+      expect(renderEditable.selectionStartInViewport.value, false);
+      expect(renderEditable.selectionEndInViewport.value, false);
 
-  //     // Scroll to the beginning where the selection is in view
-  //     // and the toolbar should show again.
-  //     scrollController.animateTo(
-  //       0.0,
-  //       duration: const Duration(milliseconds: 100),
-  //       curve: Curves.linear,
-  //     );
-  //     await tester.pumpAndSettle();
-  //     expect(
-  //       contextMenuButtonFinder,
-  //       isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
-  //     );
-  //     expect(renderEditable.selectionStartInViewport.value, true);
-  //     expect(renderEditable.selectionEndInViewport.value, true);
+      // Scroll to the beginning where the selection is in view
+      // and the toolbar should show again.
+      scrollController.animateTo(
+        0.0,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.linear,
+      );
+      await tester.pumpAndSettle();
+      expect(
+        contextMenuButtonFinder,
+        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
+      );
+      expect(renderEditable.selectionStartInViewport.value, true);
+      expect(renderEditable.selectionEndInViewport.value, true);
 
-  //     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(tester, 0));
-  //     await tester.pump();
-  //     await gesture.up();
-  //     await gesture.down(textOffsetToPosition(tester, 0));
-  //     await tester.pump();
-  //     await gesture.up();
-  //     await tester.pumpAndSettle();
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(tester, 0));
+      await tester.pump();
+      await gesture.up();
+      await gesture.down(textOffsetToPosition(tester, 0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-  //     // Double tap should select word at position and show toolbar.
-  //     expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
-  //     expect(
-  //       contextMenuButtonFinder,
-  //       isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
-  //     );
-  //     expect(renderEditable.selectionStartInViewport.value, true);
-  //     expect(renderEditable.selectionEndInViewport.value, true);
+      // Double tap should select word at position and show toolbar.
+      expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 7));
+      expect(
+        contextMenuButtonFinder,
+        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(numberOfContextMenuButtons),
+      );
+      expect(renderEditable.selectionStartInViewport.value, true);
+      expect(renderEditable.selectionEndInViewport.value, true);
 
-  //     // Scroll to the end so the selection is no longer visible. This should
-  //     // hide the toolbar, but schedule it to be shown once the selection is
-  //     // visible again.
-  //     scrollController.animateTo(
-  //       500.0,
-  //       duration: const Duration(milliseconds: 100),
-  //       curve: Curves.linear,
-  //     );
-  //     await tester.pumpAndSettle();
-  //     expect(contextMenuButtonFinder, findsNothing);
-  //     expect(renderEditable.selectionStartInViewport.value, false);
-  //     expect(renderEditable.selectionEndInViewport.value, false);
+      // Scroll to the end so the selection is no longer visible. This should
+      // hide the toolbar, but schedule it to be shown once the selection is
+      // visible again.
+      scrollController.animateTo(
+        500.0,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.linear,
+      );
+      await tester.pumpAndSettle();
+      expect(contextMenuButtonFinder, findsNothing);
+      expect(renderEditable.selectionStartInViewport.value, false);
+      expect(renderEditable.selectionEndInViewport.value, false);
 
-  //     // Tap to change the selection. This will invalidate the scheduled
-  //     // toolbar.
-  //     await gesture.down(tester.getCenter(find.byType(TextField)));
-  //     await tester.pump();
-  //     await gesture.up();
-  //     await tester.pumpAndSettle();
+      // Tap to change the selection. This will invalidate the scheduled
+      // toolbar.
+      await gesture.down(tester.getCenter(find.byType(TextField)));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
 
-  //     // Scroll to the beginning where the selection was previously
-  //     // and the toolbar should not show because it was invalidated.
-  //     scrollController.animateTo(
-  //       0.0,
-  //       duration: const Duration(milliseconds: 100),
-  //       curve: Curves.linear,
-  //     );
-  //     await tester.pumpAndSettle();
-  //     expect(contextMenuButtonFinder, findsNothing);
-  //     expect(renderEditable.selectionStartInViewport.value, false);
-  //     expect(renderEditable.selectionEndInViewport.value, false);
-  //   },
-  //   variant: const TargetPlatformVariant(<TargetPlatform>{
-  //     TargetPlatform.android,
-  //     TargetPlatform.iOS,
-  //   }),
-  // );
+      // Scroll to the beginning where the selection was previously
+      // and the toolbar should not show because it was invalidated.
+      scrollController.animateTo(
+        0.0,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.linear,
+      );
+      await tester.pumpAndSettle();
+      expect(contextMenuButtonFinder, findsNothing);
+      expect(renderEditable.selectionStartInViewport.value, false);
+      expect(renderEditable.selectionEndInViewport.value, false);
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+    }),
+  );
 
   testWidgets(
     'Toolbar can re-appear after parent scrollable scrolls selection out of view on Android and iOS',

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11526,7 +11526,7 @@ void main() {
   );
 
   testWidgets(
-    'Toolbar hides on scroll start and re-appears on scroll end on Android and iOS',
+    'Toolbar hides on scroll start and re-appears on scroll end on Android',
     (WidgetTester tester) async {
       final TextEditingController controller = _textEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
@@ -11583,10 +11583,7 @@ void main() {
       expect(renderEditable.selectionStartInViewport.value, true);
       expect(renderEditable.selectionEndInViewport.value, true);
     },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.android,
-      TargetPlatform.iOS,
-    }),
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
   );
 
   testWidgets(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11532,9 +11532,7 @@ void main() {
         text: 'Atwater Peel Sherbrooke Bonaventure ' * 20,
       );
       await tester.pumpWidget(
-        MaterialApp(
-          home: Material(child: Center(child: TextField(controller: controller))),
-        ),
+        MaterialApp(home: Material(child: Center(child: TextField(controller: controller)))),
       );
 
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -8816,6 +8816,82 @@ void main() {
     }),
   );
 
+  testWidgets(
+    'single-line field cannot be scroll with touch on iOS',
+    (WidgetTester tester) async {
+      controller.text = 'This is a long string that should overflow the TextField.';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 100,
+              child: EditableText(
+                showSelectionHandles: true,
+                controller: controller,
+                focusNode: focusNode,
+                style: Typography.material2018().black.titleMedium!.copyWith(fontFamily: 'Roboto'),
+                cursorColor: Colors.blue,
+                backgroundCursorColor: Colors.grey,
+                selectionControls: materialTextSelectionControls,
+                keyboardType: TextInputType.text,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+      final double initialScrollOffset = scrollable.controller!.position.pixels;
+
+      await tester.drag(find.byType(EditableText), const Offset(-100.0, 0.0));
+      await tester.pumpAndSettle();
+
+      expect(scrollable.controller!.position.pixels, initialScrollOffset);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'multi-line field can scroll with touch on iOS',
+    (WidgetTester tester) async {
+      // 3 lines of text, where the last line overflows and requires scrolling.
+      controller.text = 'XXXXX\nXXXXX\nXXXXX';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 100,
+              child: EditableText(
+                maxLines: 2,
+                showSelectionHandles: true,
+                controller: controller,
+                focusNode: focusNode,
+                style: Typography.material2018().black.titleMedium!.copyWith(fontFamily: 'Roboto'),
+                cursorColor: Colors.blue,
+                backgroundCursorColor: Colors.grey,
+                selectionControls: materialTextSelectionControls,
+                keyboardType: TextInputType.text,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+      final double initialScrollOffset = scrollable.controller!.position.pixels;
+
+      await tester.drag(find.byType(EditableText), const Offset(0.0, -100.0));
+      await tester.pumpAndSettle();
+
+      expect(scrollable.controller!.position.pixels, isNot(initialScrollOffset));
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
   testWidgets("scrolling doesn't bounce", (WidgetTester tester) async {
     // 3 lines of text, where the last line overflows and requires scrolling.
     controller.text = 'XXXXX\nXXXXX\nXXXXX';

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -8817,7 +8817,7 @@ void main() {
   );
 
   testWidgets(
-    'single-line field cannot be scroll with touch on iOS',
+    'single-line field cannot be scrolled with touch on iOS',
     (WidgetTester tester) async {
       controller.text = 'This is a long string that should overflow the TextField.';
 


### PR DESCRIPTION
Fixes #25553 

On iOS single-line TextFields are not scrollable with user input, for example a pan gesture to move the viewport. They can still be scrolled when the user drags the selection handles. Scrolling remains the same for multi-line TextFields. A user can override this by providing CupertinoTextField/TextField/EditableText with a custom `scrollPhysics`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.