### PR TITLE
[Android] Make PVC1 and PVC2 share a platform view registry.

### DIFF
--- a/dev/integration_tests/android_engine_test/android/app/src/main/kotlin/com/example/native_driver_test/MainActivity.kt
+++ b/dev/integration_tests/android_engine_test/android/app/src/main/kotlin/com/example/native_driver_test/MainActivity.kt
@@ -32,17 +32,6 @@ class MainActivity : FlutterActivity() {
                 add(NativeDriverSupportPlugin())
             }
 
-        // TODO(jonahwilliams): make platform view controllers share platform view registry.
-        flutterEngine
-            .platformViewsController2
-            .registry
-            .apply {
-                registerViewFactory("blue_orange_gradient_platform_view", BlueOrangeGradientPlatformViewFactory())
-                registerViewFactory("blue_orange_gradient_surface_view_platform_view", BlueOrangeGradientSurfaceViewPlatformViewFactory())
-                registerViewFactory("changing_color_button_platform_view", ChangingColorButtonPlatformViewFactory())
-                registerViewFactory("box_platform_view", BoxPlatformViewFactory())
-            }
-
         flutterEngine
             .platformViewsController
             .registry

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -40,7 +40,6 @@ import io.flutter.embedding.engine.systemchannels.SpellCheckChannel;
 import io.flutter.embedding.engine.systemchannels.SystemChannel;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.plugin.localization.LocalizationPlugin;
-import io.flutter.plugin.platform.PlatformViewRegistryImpl;
 import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.plugin.platform.PlatformViewsController2;
 import io.flutter.plugin.text.ProcessTextPlugin;
@@ -365,8 +364,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
     }
 
     PlatformViewsController2 platformViewsController2 = new PlatformViewsController2();
-    platformViewsController2.setRegistry(
-        (PlatformViewRegistryImpl) platformViewsController.getRegistry());
+    platformViewsController2.setRegistry(platformViewsController.getRegistry());
 
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
     flutterJNI.setPlatformViewsController(platformViewsController);

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -364,9 +364,9 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
       flutterLoader.ensureInitializationComplete(context, dartVmArgs);
     }
 
-    PlatformViewsController2 platformViewsController2 =
-        new PlatformViewsController2(
-            (PlatformViewRegistryImpl) platformViewsController.getRegistry());
+    PlatformViewsController2 platformViewsController2 = new PlatformViewsController2();
+    platformViewsController2.setRegistry(
+        (PlatformViewRegistryImpl) platformViewsController.getRegistry());
 
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
     flutterJNI.setPlatformViewsController(platformViewsController);

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -40,6 +40,7 @@ import io.flutter.embedding.engine.systemchannels.SpellCheckChannel;
 import io.flutter.embedding.engine.systemchannels.SystemChannel;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.plugin.localization.LocalizationPlugin;
+import io.flutter.plugin.platform.PlatformViewRegistryImpl;
 import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.plugin.platform.PlatformViewsController2;
 import io.flutter.plugin.text.ProcessTextPlugin;
@@ -363,7 +364,9 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
       flutterLoader.ensureInitializationComplete(context, dartVmArgs);
     }
 
-    PlatformViewsController2 platformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2 platformViewsController2 =
+        new PlatformViewsController2(
+            (PlatformViewRegistryImpl) platformViewsController.getRegistry());
 
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
     flutterJNI.setPlatformViewsController(platformViewsController);

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistryImpl.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistryImpl.java
@@ -7,7 +7,7 @@ package io.flutter.plugin.platform;
 import java.util.HashMap;
 import java.util.Map;
 
-class PlatformViewRegistryImpl implements PlatformViewRegistry {
+public class PlatformViewRegistryImpl implements PlatformViewRegistry {
 
   PlatformViewRegistryImpl() {
     viewFactories = new HashMap<>();

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistryImpl.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistryImpl.java
@@ -7,7 +7,7 @@ package io.flutter.plugin.platform;
 import java.util.HashMap;
 import java.util.Map;
 
-public class PlatformViewRegistryImpl implements PlatformViewRegistry {
+class PlatformViewRegistryImpl implements PlatformViewRegistry {
 
   PlatformViewRegistryImpl() {
     viewFactories = new HashMap<>();

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -64,8 +64,8 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   private final ArrayList<SurfaceControl.Transaction> activeTransactions;
   private Surface overlayerSurface = null;
 
-  public PlatformViewsController2() {
-    registry = new PlatformViewRegistryImpl();
+  public PlatformViewsController2(@NonNull PlatformViewRegistryImpl registry) {
+    this.registry = registry;
     accessibilityEventsDelegate = new AccessibilityEventsDelegate();
     platformViews = new SparseArray<>();
     platformViewParent = new SparseArray<>();

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -46,7 +46,7 @@ import java.util.List;
 public class PlatformViewsController2 implements PlatformViewsAccessibilityDelegate {
   private static final String TAG = "PlatformViewsController2";
 
-  private final PlatformViewRegistryImpl registry;
+  private PlatformViewRegistryImpl registry;
   private AndroidTouchProcessor androidTouchProcessor;
   private Context context;
   private FlutterView flutterView;
@@ -64,14 +64,17 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   private final ArrayList<SurfaceControl.Transaction> activeTransactions;
   private Surface overlayerSurface = null;
 
-  public PlatformViewsController2(@NonNull PlatformViewRegistryImpl registry) {
-    this.registry = registry;
+  public PlatformViewsController2() {
     accessibilityEventsDelegate = new AccessibilityEventsDelegate();
     platformViews = new SparseArray<>();
     platformViewParent = new SparseArray<>();
     pendingTransactions = new ArrayList<>();
     activeTransactions = new ArrayList<>();
     motionEventTracker = MotionEventTracker.getInstance();
+  }
+
+  public void setRegistry(@NonNull PlatformViewRegistryImpl registry) {
+    this.registry = registry;
   }
 
   @Override

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -73,8 +73,8 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     motionEventTracker = MotionEventTracker.getInstance();
   }
 
-  public void setRegistry(@NonNull PlatformViewRegistryImpl registry) {
-    this.registry = registry;
+  public void setRegistry(@NonNull PlatformViewRegistry registry) {
+    this.registry = (PlatformViewRegistryImpl) registry;
   }
 
   @Override

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -95,7 +95,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void itRemovesPlatformViewBeforeDiposeIsCalled() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
     FlutterJNI jni = new FlutterJNI();
     attach(jni, PlatformViewsController2);
     // Get the platform view registry.
@@ -127,7 +128,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void itNotifiesPlatformViewsOfEngineAttachmentAndDetachment() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
     FlutterJNI jni = new FlutterJNI();
     attach(jni, PlatformViewsController2);
     // Get the platform view registry.
@@ -165,7 +167,8 @@ public class PlatformViewsController2Test {
   @Test
   public void itUsesActionEventTypeFromFrameworkEventAsActionChanged() {
     MotionEventTracker motionEventTracker = MotionEventTracker.getInstance();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     MotionEvent original =
         MotionEvent.obtain(
@@ -257,7 +260,8 @@ public class PlatformViewsController2Test {
 
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void getPlatformViewById() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -285,7 +289,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createPlatformViewMessage_initializesAndroidView() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -307,7 +312,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createPlatformViewMessage_setsAndroidViewLayoutDirection() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -331,7 +337,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createPlatformViewMessage_throwsIfViewIsNull() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -355,7 +362,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createHybridPlatformViewMessage_throwsIfViewIsNull() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -379,7 +387,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void setPlatformViewDirection_throwIfPlatformViewNotFound() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -413,7 +422,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void disposeAndroidView() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -454,7 +464,8 @@ public class PlatformViewsController2Test {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void disposeNullAndroidView() {
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -96,7 +96,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void itRemovesPlatformViewBeforeDiposeIsCalled() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
     FlutterJNI jni = new FlutterJNI();
     attach(jni, PlatformViewsController2);
     // Get the platform view registry.
@@ -129,7 +130,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void itNotifiesPlatformViewsOfEngineAttachmentAndDetachment() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
     FlutterJNI jni = new FlutterJNI();
     attach(jni, PlatformViewsController2);
     // Get the platform view registry.
@@ -168,7 +170,8 @@ public class PlatformViewsController2Test {
   public void itUsesActionEventTypeFromFrameworkEventAsActionChanged() {
     MotionEventTracker motionEventTracker = MotionEventTracker.getInstance();
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     MotionEvent original =
         MotionEvent.obtain(
@@ -261,7 +264,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void getPlatformViewById() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -290,7 +294,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createPlatformViewMessage_initializesAndroidView() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -313,7 +318,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createPlatformViewMessage_setsAndroidViewLayoutDirection() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -338,7 +344,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createPlatformViewMessage_throwsIfViewIsNull() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -363,7 +370,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createHybridPlatformViewMessage_throwsIfViewIsNull() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -388,7 +396,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void setPlatformViewDirection_throwIfPlatformViewNotFound() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -423,7 +432,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void disposeAndroidView() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));
@@ -465,7 +475,8 @@ public class PlatformViewsController2Test {
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void disposeNullAndroidView() {
     PlatformViewRegistryImpl registryImpl = new PlatformViewRegistryImpl();
-    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2(registryImpl);
+    PlatformViewsController2 PlatformViewsController2 = new PlatformViewsController2();
+    PlatformViewsController2.setRegistry(registryImpl);
 
     int platformViewId = 0;
     assertNull(PlatformViewsController2.getPlatformViewById(platformViewId));

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1664,7 +1664,8 @@ public class PlatformViewsControllerTest {
 
     platformViewsController.attach(context, registry, executor);
 
-    PlatformViewsController2 secondController = new PlatformViewsController2();
+    PlatformViewsController2 secondController =
+        new PlatformViewsController2(platformViewsController.getRegistry());
 
     final FlutterEngine engine = mock(FlutterEngine.class);
     when(engine.getRenderer()).thenReturn(new FlutterRenderer(jni));

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1664,8 +1664,8 @@ public class PlatformViewsControllerTest {
 
     platformViewsController.attach(context, registry, executor);
 
-    PlatformViewsController2 secondController =
-        new PlatformViewsController2(new PlatformViewRegistryImpl());
+    PlatformViewsController2 secondController = new PlatformViewsController2();
+    secondController.setRegistry(new PlatformViewRegistryImpl());
 
     final FlutterEngine engine = mock(FlutterEngine.class);
     when(engine.getRenderer()).thenReturn(new FlutterRenderer(jni));

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1665,7 +1665,7 @@ public class PlatformViewsControllerTest {
     platformViewsController.attach(context, registry, executor);
 
     PlatformViewsController2 secondController =
-        new PlatformViewsController2(platformViewsController.getRegistry());
+        new PlatformViewsController2(new PlatformViewRegistryImpl());
 
     final FlutterEngine engine = mock(FlutterEngine.class);
     when(engine.getRenderer()).thenReturn(new FlutterRenderer(jni));


### PR DESCRIPTION
This avoids the insanity of having to register everything twice. Since the object is shared a registration on pvc1 will automatically apply to pvc2.
