### PR TITLE
[Android] fix hcpp gestures.

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -888,12 +888,6 @@ abstract class AndroidViewController extends PlatformViewController {
   /// call's future has completed.
   bool get requiresViewComposition => false;
 
-  /// True if the experimental hybrid composition controller is enabled.
-  ///
-  /// This value may change during [create], but will not change after that
-  /// call's future has completed.
-  bool get useNewHybridComposition => false;
-
   /// Sends an Android [MotionEvent](https://developer.android.com/reference/android/view/MotionEvent)
   /// to the view.
   ///
@@ -1180,9 +1174,6 @@ class HybridAndroidViewController extends AndroidViewController {
   }
 
   @override
-  bool get useNewHybridComposition => true;
-
-  @override
   int? get textureId {
     return _internals.textureId;
   }
@@ -1205,6 +1196,11 @@ class HybridAndroidViewController extends AndroidViewController {
   @override
   Future<void> setOffset(Offset off) {
     return _internals.setOffset(off, viewId: viewId, viewState: _state);
+  }
+
+  @override
+  Future<void> sendMotionEvent(AndroidMotionEvent event) async {
+    await SystemChannels.platform_views.invokeMethod<dynamic>('touch', event._asList(viewId));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -1473,14 +1473,6 @@ class _AndroidViewSurfaceState extends State<AndroidViewSurface> {
   @override
   Widget build(BuildContext context) {
     if (widget.controller.requiresViewComposition) {
-      if (widget.controller.useNewHybridComposition) {
-        // TODO(jonahwilliams): make it actually work.
-        return _PlatformLayerBasedAndroidViewSurface(
-          controller: widget.controller,
-          hitTestBehavior: widget.hitTestBehavior,
-          gestureRecognizers: widget.gestureRecognizers,
-        );
-      }
       return _PlatformLayerBasedAndroidViewSurface(
         controller: widget.controller,
         hitTestBehavior: widget.hitTestBehavior,

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -49,7 +49,6 @@ class FakeAndroidViewController implements AndroidViewController {
     this.viewId, {
     this.requiresSize = false,
     this.requiresViewComposition = false,
-    this.useNewHybridComposition = false,
   });
 
   bool disposed = false;
@@ -148,9 +147,6 @@ class FakeAndroidViewController implements AndroidViewController {
 
   @override
   bool requiresViewComposition;
-
-  @override
-  bool useNewHybridComposition;
 }
 
 class FakeAndroidPlatformViewsController {


### PR DESCRIPTION
We only need to conditionally send motion events to the platform_view_2 channel. This can be done with an override in the controller, the existing surface classes don't need to be touched.
