### PR TITLE
Enable `*_module_test_ios` tests that are skipped on presubmit.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3542,8 +3542,6 @@ targets:
   - name: Mac build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
     timeout: 60
-    # Flake rate of >3.5% in presubmit
-    presubmit: false # https://github.com/flutter/flutter/issues/150642
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4122,8 +4120,6 @@ targets:
   - name: Mac_arm64 module_test_ios
     recipe: devicelab/devicelab_drone
     timeout: 60
-    # Flake rate of >10% in presubmit
-    presubmit: false # https://github.com/flutter/flutter/issues/150642
     properties:
       dependencies: >-
         [


### PR DESCRIPTION
@vashworth fixed the underlying issue in https://github.com/flutter/flutter/issues/150642.

There doesn't seem to be anything specific to iOS/macOS that is regularly failing:
- https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_arm64%20module_test_ios
- https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.prod/Mac_arm64%20build_ios_framework_module_test
- https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.prod/Linux%20build_aar_module_test
- https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.prod/Mac%20build_ios_framework_module_test