### PR TITLE
Fix doc reference typos

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4,10 +4,10 @@
 
 /// @docImport 'dart:ui';
 ///
-/// @docImport 'package:flutter/rendering.dart';
 /// @docImport 'package:flutter/widgets.dart';
 ///
 /// @docImport 'box.dart';
+/// @docImport 'paragraph.dart';
 /// @docImport 'proxy_box.dart';
 /// @docImport 'view.dart';
 /// @docImport 'viewport.dart';

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4,6 +4,7 @@
 
 /// @docImport 'dart:ui';
 ///
+/// @docImport 'package:flutter/rendering.dart';
 /// @docImport 'package:flutter/widgets.dart';
 ///
 /// @docImport 'box.dart';
@@ -4551,7 +4552,7 @@ final class _SemanticsParentData {
   /// [_RenderObjectSemantics.contributesToSemanticsTree] should forms a node
   ///
   /// This is imposed by parent render objects that set
-  /// [SemanticsConfiguration.explicitChildNode] to true.
+  /// [SemanticsConfiguration.explicitChildNodes] to true.
   final bool explicitChildNodes;
 
   /// Tags for immediate render object semantics that

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -78,7 +78,7 @@ mixin SemanticsBinding on BindingBase {
   final ObserverList<ValueSetter<ui.SemanticsActionEvent>> _semanticsActionListeners =
       ObserverList<ValueSetter<ui.SemanticsActionEvent>>();
 
-  /// Adds a listener that is called for every [SemanticsActionEvent] received.
+  /// Adds a listener that is called for every [ui.SemanticsActionEvent] received.
   ///
   /// The listeners are called before [performSemanticsAction] is invoked.
   ///

--- a/packages/flutter/lib/src/widgets/widget_preview.dart
+++ b/packages/flutter/lib/src/widgets/widget_preview.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'media_query.dart';
+library;
+
 import 'framework.dart';
 
 /// Annotation used to mark functions that return a widget preview.


### PR DESCRIPTION
I updated https://github.com/flutter/flutter/pull/160921 and found these. Sadly, the lint is not quite ready to be enabled yet.

Work towards https://github.com/flutter/flutter/issues/150800.