### PR TITLE
Lower minimum java file count to 1.

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -866,7 +866,7 @@ Future<void> verifyNoMissingLicense(String workingDirectory, {bool checkMinimums
   await _verifyNoMissingLicenseForExtension(
     workingDirectory,
     'java',
-    overrideMinimumMatches ?? 39,
+    overrideMinimumMatches ?? 1,
     _generateLicense('// '),
   );
   await _verifyNoMissingLicenseForExtension(


### PR DESCRIPTION
We removed enough java files that we're failing a "minimum number of java check".
