### PR TITLE
Change the default optimization level to `-O2` for wasm in release mode.

### DIFF
--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -1151,11 +1151,13 @@ void main() {
               test(
                 'Dart2WasmTarget invokes dart2wasm with renderer=$renderer, -O$level, stripping=$strip, defines=$defines, modeMode=$buildMode sourceMaps=$sourceMaps',
                 () => testbed.run(() async {
-                  final int expectedLevel = level ?? switch (buildMode) {
-                    'debug' => 0,
-                    'profile' || 'release' => 2,
-                    _ => throw UnimplementedError(),
-                  };
+                  final int expectedLevel =
+                      level ??
+                      switch (buildMode) {
+                        'debug' => 0,
+                        'profile' || 'release' => 2,
+                        _ => throw UnimplementedError(),
+                      };
                   environment.defines[kBuildMode] = buildMode;
                   environment.defines[kDartDefines] = encodeDartDefines(defines);
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -1140,7 +1140,7 @@ void main() {
     WebRendererMode.canvaskit,
     WebRendererMode.skwasm,
   ]) {
-    for (int level = 1; level <= 4; level++) {
+    for (final int? level in <int?>[null, 0, 1, 2, 3, 4]) {
       for (final bool strip in <bool>[true, false]) {
         for (final List<String> defines in const <List<String>>[
           <String>[],
@@ -1151,6 +1151,11 @@ void main() {
               test(
                 'Dart2WasmTarget invokes dart2wasm with renderer=$renderer, -O$level, stripping=$strip, defines=$defines, modeMode=$buildMode sourceMaps=$sourceMaps',
                 () => testbed.run(() async {
+                  final int expectedLevel = level ?? switch (buildMode) {
+                    'debug' => 0,
+                    'profile' || 'release' => 2,
+                    _ => throw UnimplementedError(),
+                  };
                   environment.defines[kBuildMode] = buildMode;
                   environment.defines[kDartDefines] = encodeDartDefines(defines);
 
@@ -1182,7 +1187,7 @@ void main() {
                         ],
                         '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
                         '--extra-compiler-option=--depfile=${depFile.absolute.path}',
-                        '-O$level',
+                        '-O$expectedLevel',
                         if (strip && buildMode == 'release') '--strip-wasm' else '--no-strip-wasm',
                         if (!sourceMaps) '--no-source-maps',
                         if (buildMode == 'debug') '--extra-compiler-option=--enable-asserts',


### PR DESCRIPTION
As per the investigation in https://github.com/flutter/flutter/issues/162620, we determined that the soundness we gain from using `-O2` outweighs the perf benefits of `-O4`.