### PR TITLE
[windows] Implement merged UI and platform thread

### DIFF
--- a/engine/src/flutter/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -19,6 +19,8 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
   c_engine_properties.dart_entrypoint = project.dart_entrypoint().c_str();
   c_engine_properties.gpu_preference =
       static_cast<FlutterDesktopGpuPreference>(project.gpu_preference());
+  c_engine_properties.merged_platform_ui_thread =
+      project.merged_platform_ui_thread();
 
   const std::vector<std::string>& entrypoint_args =
       project.dart_entrypoint_arguments();

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -125,7 +125,7 @@ class DartProject {
   std::vector<std::string> dart_entrypoint_arguments_;
   // The preference for GPU to be used by flutter engine.
   GpuPreference gpu_preference_ = GpuPreference::NoPreference;
-  // Whether the UI isolate should be running on the platform thread.
+  // Whether the UI isolate should run on the platform thread.
   bool merged_platform_ui_thread_ = false;
 };
 

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -90,13 +90,17 @@ class DartProject {
   // Defaults to NoPreference.
   GpuPreference gpu_preference() const { return gpu_preference_; }
 
-  // Sets whether the UI isolate should be running on the platform thread.
+  // Sets whether the UI isolate should run on the platform thread.
+  // In a future release, this setting will become a no-op when
+  // Flutter Windows requires merged platform and UI threads.
   void set_merged_platform_ui_thread(bool merged_platform_ui_thread) {
     merged_platform_ui_thread_ = merged_platform_ui_thread;
   }
 
-  // Returns whether the UI isolate should be running on the platform thread.
-  // Defaults to false.
+  // Returns whether the UI isolate should run on the platform thread.
+  // Defaults to false. In a future release, this setting will default
+  // to true.
+  /// this setting will become a no-op when the Skia backend is fully removed.
   bool merged_platform_ui_thread() const { return merged_platform_ui_thread_; }
 
  private:

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -90,6 +90,15 @@ class DartProject {
   // Defaults to NoPreference.
   GpuPreference gpu_preference() const { return gpu_preference_; }
 
+  // Sets whether the UI isolate should be running on the platform thread.
+  void set_merged_platform_ui_thread(bool merged_platform_ui_thread) {
+    merged_platform_ui_thread_ = merged_platform_ui_thread;
+  }
+
+  // Returns whether the UI isolate should be running on the platform thread.
+  // Defaults to false.
+  bool merged_platform_ui_thread() const { return merged_platform_ui_thread_; }
+
  private:
   // Accessors for internals are private, so that they can be changed if more
   // flexible options for project structures are needed later without it
@@ -116,6 +125,8 @@ class DartProject {
   std::vector<std::string> dart_entrypoint_arguments_;
   // The preference for GPU to be used by flutter engine.
   GpuPreference gpu_preference_ = GpuPreference::NoPreference;
+  // Whether the UI isolate should be running on the platform thread.
+  bool merged_platform_ui_thread_ = false;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -100,7 +100,6 @@ class DartProject {
   // Returns whether the UI isolate should run on the platform thread.
   // Defaults to false. In a future release, this setting will default
   // to true.
-  /// this setting will become a no-op when the Skia backend is fully removed.
   bool merged_platform_ui_thread() const { return merged_platform_ui_thread_; }
 
  private:

--- a/engine/src/flutter/shell/platform/windows/flutter_project_bundle.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_project_bundle.cc
@@ -32,6 +32,8 @@ FlutterProjectBundle::FlutterProjectBundle(
   gpu_preference_ =
       static_cast<FlutterGpuPreference>(properties.gpu_preference);
 
+  merged_platform_ui_thread_ = properties.merged_platform_ui_thread;
+
   // Resolve any relative paths.
   if (assets_path_.is_relative() || icu_path_.is_relative() ||
       (!aot_library_path_.empty() && aot_library_path_.is_relative())) {

--- a/engine/src/flutter/shell/platform/windows/flutter_project_bundle.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_project_bundle.h
@@ -67,6 +67,9 @@ class FlutterProjectBundle {
   // Returns the app's GPU preference.
   FlutterGpuPreference gpu_preference() const { return gpu_preference_; }
 
+  // Whether the UI isolate should be running on the platform thread.
+  bool merged_platform_ui_thread() const { return merged_platform_ui_thread_; }
+
  private:
   std::filesystem::path assets_path_;
   std::filesystem::path icu_path_;
@@ -85,6 +88,9 @@ class FlutterProjectBundle {
 
   // App's GPU preference.
   FlutterGpuPreference gpu_preference_;
+
+  // Whether the UI isolate should be running on the platform thread.
+  bool merged_platform_ui_thread_;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -294,6 +294,12 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
   custom_task_runners.thread_priority_setter =
       &WindowsPlatformThreadPrioritySetter;
 
+  if (project_->merged_platform_ui_thread()) {
+    FML_LOG(WARNING)
+        << "Running with merged platform and UI thread. Experimenal.";
+    custom_task_runners.ui_task_runner = &platform_task_runner;
+  }
+
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);
   args.shutdown_dart_vm_when_done = true;

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -296,7 +296,7 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
 
   if (project_->merged_platform_ui_thread()) {
     FML_LOG(WARNING)
-        << "Running with merged platform and UI thread. Experimenal.";
+        << "Running with merged platform and UI thread. Experimental.";
     custom_task_runners.ui_task_runner = &platform_task_runner;
   }
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
@@ -191,7 +191,7 @@ void FlutterWindowsView::ForceRedraw() {
   }
 }
 
-// Called on platform thread.
+// Called on the platform thread.
 bool FlutterWindowsView::OnWindowSizeChanged(size_t width, size_t height) {
   if (!engine_->egl_manager()) {
     SendWindowMetrics(width, height, binding_handler_->GetDpiScale());

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
@@ -18,7 +18,7 @@
 namespace flutter {
 
 namespace {
-// The maximum duration to block the platform thread for while waiting
+// The maximum duration to block the Windows event loop while waiting
 // for a window resize operation to complete.
 constexpr std::chrono::milliseconds kWindowResizeTimeout{100};
 
@@ -233,7 +233,7 @@ bool FlutterWindowsView::OnWindowSizeChanged(size_t width, size_t height) {
       break;
     }
     lock.unlock();
-    engine_->task_runner()->PollOnce();
+    engine_->task_runner()->PollOnce(kWindowResizeTimeout);
   }
   return true;
 }

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
@@ -673,11 +673,9 @@ void FlutterWindowsView::OnFramePresented() {
       return;
     case ResizeState::kFrameGenerated: {
       // A frame was generated for a pending resize.
+      resize_status_ = ResizeState::kDone;
       // Unblock the platform thread.
-      engine_->task_runner()->PostTask([this] {
-        std::unique_lock<std::mutex> lock(resize_mutex_);
-        resize_status_ = ResizeState::kDone;
-      });
+      engine_->task_runner()->PostTask([this] {});
 
       lock.unlock();
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
@@ -429,10 +429,8 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // Currently configured WindowBindingHandler for view.
   std::unique_ptr<WindowBindingHandler> binding_handler_;
 
-  // Resize events are synchronized using this mutex and the corresponding
-  // condition variable.
+  // Protects resize_status_, resize_target_width_ and resize_target_height_.
   std::mutex resize_mutex_;
-  std::condition_variable resize_cv_;
 
   // Indicates the state of a window resize event. Platform thread will be
   // blocked while this is not done. Guarded by resize_mutex_.

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -81,7 +81,7 @@ typedef struct {
   // GPU choice preference
   FlutterDesktopGpuPreference gpu_preference;
 
-  // Whether the UI isolate should be running on the platform thread.
+  // Whether the UI isolate should run on the platform thread.
   bool merged_platform_ui_thread;
 } FlutterDesktopEngineProperties;
 

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -80,6 +80,9 @@ typedef struct {
 
   // GPU choice preference
   FlutterDesktopGpuPreference gpu_preference;
+
+  // Whether the UI isolate should be running on the platform thread.
+  bool merged_platform_ui_thread;
 } FlutterDesktopEngineProperties;
 
 // ========== View Controller ==========

--- a/engine/src/flutter/shell/platform/windows/task_runner.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner.cc
@@ -92,8 +92,8 @@ void TaskRunner::PostTask(TaskClosure closure) {
   EnqueueTask(std::move(task));
 }
 
-void TaskRunner::PollOnce() {
-  task_runner_window_->PollOnce();
+void TaskRunner::PollOnce(std::chrono::milliseconds timeout) {
+  task_runner_window_->PollOnce(timeout);
 }
 
 void TaskRunner::EnqueueTask(Task task) {

--- a/engine/src/flutter/shell/platform/windows/task_runner.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner.cc
@@ -92,6 +92,10 @@ void TaskRunner::PostTask(TaskClosure closure) {
   EnqueueTask(std::move(task));
 }
 
+void TaskRunner::PollOnce() {
+  task_runner_window_->PollOnce();
+}
+
 void TaskRunner::EnqueueTask(Task task) {
   static std::atomic_uint64_t sGlobalTaskOrder(0);
 

--- a/engine/src/flutter/shell/platform/windows/task_runner.h
+++ b/engine/src/flutter/shell/platform/windows/task_runner.h
@@ -46,6 +46,10 @@ class TaskRunner : public TaskRunnerWindow::Delegate {
   // Post a task to the event loop.
   void PostTask(TaskClosure task);
 
+  // Polls the event loop once. This will only process tasks scheduled through
+  // the task runner. It will not process messages sent to other windows.
+  void PollOnce();
+
   // Post a task to the event loop or run it immediately if this is being called
   // from the runner's thread.
   void RunNowOrPostTask(TaskClosure task) {

--- a/engine/src/flutter/shell/platform/windows/task_runner.h
+++ b/engine/src/flutter/shell/platform/windows/task_runner.h
@@ -48,7 +48,7 @@ class TaskRunner : public TaskRunnerWindow::Delegate {
 
   // Polls the event loop once. This will only process tasks scheduled through
   // the task runner. It will not process messages sent to other windows.
-  void PollOnce();
+  void PollOnce(std::chrono::milliseconds timeout);
 
   // Post a task to the event loop or run it immediately if this is being called
   // from the runner's thread.

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -74,9 +74,9 @@ void TaskRunnerWindow::RemoveDelegate(Delegate* delegate) {
   }
 }
 
-void TaskRunnerWindow::PollOnce() {
+void TaskRunnerWindow::PollOnce(std::chrono::milliseconds timeout) {
   MSG msg;
-  ::SetTimer(window_handle_, kPollTimeoutTimerId, 100, nullptr);
+  ::SetTimer(window_handle_, kPollTimeoutTimerId, timeout.count(), nullptr);
   if (GetMessage(&msg, window_handle_, 0, 0)) {
     TranslateMessage(&msg);
     DispatchMessage(&msg);
@@ -135,6 +135,8 @@ TaskRunnerWindow::HandleMessage(UINT const message,
         return 0;
       }
       FML_DCHECK(wparam == kTimerId);
+      ProcessTasks();
+      return 0;
     case WM_NULL:
       ProcessTasks();
       return 0;

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -13,7 +13,7 @@ namespace flutter {
 static const uintptr_t kTimerId = 0;
 
 // Timer used for PollOnce timeout.
-static const UINT_PTR kPollTimeoutTimerId = 1;
+static const uintptr_t kPollTimeoutTimerId = 1;
 
 TaskRunnerWindow::TaskRunnerWindow() {
   WNDCLASS window_class = RegisterWindowClass();

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -10,6 +10,11 @@
 
 namespace flutter {
 
+static const uintptr_t kTimerId = 0;
+
+// Timer used for PollOnce timeout.
+static const UINT_PTR kPollTimeoutTimerId = 1;
+
 TaskRunnerWindow::TaskRunnerWindow() {
   WNDCLASS window_class = RegisterWindowClass();
   window_handle_ =
@@ -69,6 +74,16 @@ void TaskRunnerWindow::RemoveDelegate(Delegate* delegate) {
   }
 }
 
+void TaskRunnerWindow::PollOnce() {
+  MSG msg;
+  ::SetTimer(window_handle_, kPollTimeoutTimerId, 100, nullptr);
+  if (GetMessage(&msg, window_handle_, 0, 0)) {
+    TranslateMessage(&msg);
+    DispatchMessage(&msg);
+  }
+  ::KillTimer(window_handle_, kPollTimeoutTimerId);
+}
+
 void TaskRunnerWindow::ProcessTasks() {
   auto next = std::chrono::nanoseconds::max();
   auto delegates_copy(delegates_);
@@ -84,10 +99,10 @@ void TaskRunnerWindow::ProcessTasks() {
 
 void TaskRunnerWindow::SetTimer(std::chrono::nanoseconds when) {
   if (when == std::chrono::nanoseconds::max()) {
-    KillTimer(window_handle_, 0);
+    KillTimer(window_handle_, kTimerId);
   } else {
     auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(when);
-    ::SetTimer(window_handle_, 0, millis.count() + 1, nullptr);
+    ::SetTimer(window_handle_, kTimerId, millis.count() + 1, nullptr);
   }
 }
 
@@ -115,6 +130,11 @@ TaskRunnerWindow::HandleMessage(UINT const message,
                                 LPARAM const lparam) noexcept {
   switch (message) {
     case WM_TIMER:
+      if (wparam == kPollTimeoutTimerId) {
+        // Ignore PollOnce timeout timer.
+        return 0;
+      }
+      FML_DCHECK(wparam == kTimerId);
     case WM_NULL:
       ProcessTasks();
       return 0;

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.h
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.h
@@ -36,7 +36,7 @@ class TaskRunnerWindow {
   void AddDelegate(Delegate* delegate);
   void RemoveDelegate(Delegate* delegate);
 
-  void PollOnce();
+  void PollOnce(std::chrono::milliseconds timeout);
 
   ~TaskRunnerWindow();
 

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.h
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.h
@@ -36,6 +36,8 @@ class TaskRunnerWindow {
   void AddDelegate(Delegate* delegate);
   void RemoveDelegate(Delegate* delegate);
 
+  void PollOnce();
+
   ~TaskRunnerWindow();
 
  private:


### PR DESCRIPTION
Original issue: https://github.com/flutter/flutter/issues/150525

Thread merging is currently disabled by default. 
It is controlled from the application through `DartProject`:
```cpp
flutter::DartProject project(L"data");
// Enables running UI isolate on platform thread
project.set_merged_platform_ui_thread(true);
```
Required changes to windows embedder: 
- Resize synchronization no longer blocks on condition variable, instead it polls the Flutter run loop (ignoring other windows messages) until the frame is available. This way resize synchronization works with both thread merging enabled and disabled. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
