### PR TITLE
Add focus check to onTapUpOutside

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5378,10 +5378,6 @@ class EditableTextState extends State<EditableText>
   }
 
   void _onTapOutside(BuildContext context, PointerDownEvent event) {
-    if (!_hasFocus) {
-      return;
-    }
-
     _hadFocusOnTapDown = true;
 
     if (widget.onTapOutside != null) {
@@ -5396,7 +5392,7 @@ class EditableTextState extends State<EditableText>
       return;
     }
 
-    // Reset to false so that subsequent events doesn't trigger the callback erroneously.
+    // Reset to false so that subsequent events doesn't trigger the callback based on old information.
     _hadFocusOnTapDown = false;
 
     if (widget.onTapUpOutside != null) {
@@ -5572,7 +5568,8 @@ class EditableTextState extends State<EditableText>
           builder: (BuildContext context) {
             return TextFieldTapRegion(
               groupId: widget.groupId,
-              onTapOutside: (PointerDownEvent event) => _onTapOutside(context, event),
+              onTapOutside:
+                  _hasFocus ? (PointerDownEvent event) => _onTapOutside(context, event) : null,
               onTapUpOutside: (PointerUpEvent event) => _onTapUpOutside(context, event),
               debugLabel: kReleaseMode ? null : 'EditableText',
               child: MouseRegion(

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5541,8 +5541,10 @@ class EditableTextState extends State<EditableText>
                           (PointerDownEvent event) => _defaultOnTapOutside(context, event)
                       : null,
               onTapUpOutside:
-                  widget.onTapUpOutside ??
-                  (PointerUpEvent event) => _defaultOnTapUpOutside(context, event),
+                  _hasFocus
+                      ? widget.onTapUpOutside ??
+                          (PointerUpEvent event) => _defaultOnTapUpOutside(context, event)
+                      : null,
               debugLabel: kReleaseMode ? null : 'EditableText',
               child: MouseRegion(
                 cursor: widget.mouseCursor ?? SystemMouseCursors.text,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5384,7 +5384,6 @@ class EditableTextState extends State<EditableText>
 
     _hadFocusOnTapDown = true;
 
-
     if (widget.onTapOutside != null) {
       widget.onTapOutside!(event);
     } else {

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -737,39 +737,6 @@ void main() {
     expect(tapOutsideCount, 3);
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/134341.
-  testWidgets('onTapOutside is not called upon tap outside when field is not focused', (
-    WidgetTester tester,
-  ) async {
-    int tapOutsideCount = 0;
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Center(
-            child: Column(
-              children: <Widget>[
-                const Text('Outside'),
-                TextFormField(
-                  onTapOutside: (PointerEvent event) {
-                    tapOutsideCount += 1;
-                  },
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-    await tester.pump();
-
-    expect(tapOutsideCount, 0);
-    await tester.tap(find.byType(TextFormField));
-    await tester.tap(find.text('Outside'));
-    await tester.tap(find.text('Outside'));
-    await tester.tap(find.text('Outside'));
-    expect(tapOutsideCount, 0);
-  });
-
   // Regression test for https://github.com/flutter/flutter/issues/127597.
   testWidgets(
     'The second TextFormField is clicked, triggers the onTapOutside callback of the previous TextFormField',

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -16958,6 +16958,80 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
     skip: kIsWeb, // [intended]
   );
+
+  testWidgets('onTapUpOutside is called upon tap up outside', (WidgetTester tester) async {
+    int tapOutsideCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: Column(
+              children: <Widget>[
+                const Text('Outside'),
+                EditableText(
+                  autofocus: true,
+                  controller: controller,
+                  focusNode: focusNode,
+                  style: textStyle,
+                  cursorColor: Colors.blue,
+                  backgroundCursorColor: Colors.grey,
+                  onTapUpOutside: (PointerEvent event) {
+                    tapOutsideCount += 1;
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(); // Wait for autofocus to take effect.
+
+    expect(tapOutsideCount, 0);
+    await tester.tap(find.byType(EditableText));
+    await tester.tap(find.text('Outside'));
+    await tester.tap(find.text('Outside'));
+    await tester.tap(find.text('Outside'));
+    expect(tapOutsideCount, 3);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/162573
+  testWidgets('onTapUpOutside is not called upon tap up outside when field is not focused', (
+    WidgetTester tester,
+  ) async {
+    int tapOutsideCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: Column(
+              children: <Widget>[
+                const Text('Outside'),
+                EditableText(
+                  controller: controller,
+                  focusNode: focusNode,
+                  style: textStyle,
+                  cursorColor: Colors.blue,
+                  backgroundCursorColor: Colors.grey,
+                  onTapUpOutside: (PointerEvent event) {
+                    tapOutsideCount += 1;
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tapOutsideCount, 0);
+    await tester.tap(find.byType(EditableText));
+    await tester.tap(find.text('Outside'));
+    await tester.tap(find.text('Outside'));
+    await tester.tap(find.text('Outside'));
+    expect(tapOutsideCount, 0);
+  });
 }
 
 class UnsettableController extends TextEditingController {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -12016,6 +12016,13 @@ void main() {
   testWidgets('can change tap up outside behavior by overriding actions', (
     WidgetTester tester,
   ) async {
+    final CallbackAction<EditableTextTapOutsideIntent> noAction =
+        CallbackAction<EditableTextTapOutsideIntent>(
+          onInvoke: (EditableTextTapOutsideIntent intent) {
+            return null;
+          },
+        );
+
     bool myIntentWasCalled = false;
     final CallbackAction<EditableTextTapUpOutsideIntent> overrideAction =
         CallbackAction<EditableTextTapUpOutsideIntent>(
@@ -12031,13 +12038,18 @@ void main() {
           children: <Widget>[
             SizedBox(key: key, width: 200, height: 200),
             Actions(
-              actions: <Type, Action<Intent>>{EditableTextTapUpOutsideIntent: overrideAction},
+              actions: <Type, Action<Intent>>{
+                // The tap down has to be overridden so that the tap up will register.
+                EditableTextTapOutsideIntent: noAction,
+                EditableTextTapUpOutsideIntent: overrideAction,
+              },
               child: EditableText(
                 controller: controller,
                 focusNode: focusNode,
                 style: textStyle,
                 cursorColor: Colors.blue,
                 backgroundCursorColor: Colors.grey,
+                autofocus: true,
               ),
             ),
           ],

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -12031,9 +12031,7 @@ void main() {
           children: <Widget>[
             SizedBox(key: key, width: 200, height: 200),
             Actions(
-              actions: <Type, Action<Intent>>{
-                EditableTextTapUpOutsideIntent: overrideAction,
-              },
+              actions: <Type, Action<Intent>>{EditableTextTapUpOutsideIntent: overrideAction},
               child: EditableText(
                 controller: controller,
                 focusNode: focusNode,
@@ -17100,7 +17098,6 @@ void main() {
       ),
     );
     await tester.pump();
-
 
     expect(tapOutsideCount, 0);
     await tester.tap(find.text('Outside'));


### PR DESCRIPTION
Adds a focus check to `onTapUpOutside` of `EditableText`, so that it doesn't trigger if the `EditableText` doesn't have focus. 

`onTapOutside` already had this check, but it was missed when `onTapUpOutside` was added.

Fixes https://github.com/flutter/flutter/issues/162573


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
