### PR TITLE
[Embedder] Implement merged platform and UI thread

### DIFF
--- a/engine/src/flutter/fml/message_loop_task_queues.cc
+++ b/engine/src/flutter/fml/message_loop_task_queues.cc
@@ -17,6 +17,7 @@
 namespace fml {
 
 const size_t TaskQueueId::kUnmerged = ULONG_MAX;
+const size_t TaskQueueId::kInvalid = ULONG_MAX - 1;
 
 namespace {
 

--- a/engine/src/flutter/fml/task_queue_id.h
+++ b/engine/src/flutter/fml/task_queue_id.h
@@ -18,12 +18,18 @@ class TaskQueueId {
   /// runner.
   static const size_t kUnmerged;
 
+  /// This constant indicates an invalid task queue. Used in embedder
+  /// supplied task runners not associated with a task queue.
+  static const size_t kInvalid;
+
   /// Intializes a task queue with the given value as it's ID.
   explicit TaskQueueId(size_t value) : value_(value) {}
 
   operator size_t() const {  // NOLINT(google-explicit-constructor)
     return value_;
   }
+
+  bool is_valid() const { return value_ != kInvalid; }
 
  private:
   size_t value_ = kUnmerged;

--- a/engine/src/flutter/fml/task_runner.h
+++ b/engine/src/flutter/fml/task_runner.h
@@ -55,6 +55,9 @@ class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner>,
 
   /// Returns the unique identifier associated with the TaskRunner.
   /// \see fml::MessageLoopTaskQueues
+  ///
+  /// Will be TaskQueueId::kInvalid for embedder supplied task runners
+  /// that are not associated with a task queue.
   virtual TaskQueueId GetTaskQueueId();
 
   /// Executes the \p task directly if the TaskRunner \p runner is the

--- a/engine/src/flutter/runtime/dart_isolate.cc
+++ b/engine/src/flutter/runtime/dart_isolate.cc
@@ -510,7 +510,13 @@ bool DartIsolate::Initialize(Dart_Isolate dart_isolate) {
     SetMessageHandlingTaskRunner(GetTaskRunners().GetPlatformTaskRunner(),
                                  true);
   } else {
-    SetMessageHandlingTaskRunner(GetTaskRunners().GetUITaskRunner(), false);
+    // When running with custom UI task runner post directly to runner (there is
+    // no task queue).
+    bool post_directly_to_runner =
+        GetTaskRunners().GetUITaskRunner() &&
+        !GetTaskRunners().GetUITaskRunner()->GetTaskQueueId().is_valid();
+    SetMessageHandlingTaskRunner(GetTaskRunners().GetUITaskRunner(),
+                                 post_directly_to_runner);
   }
 
   if (tonic::CheckAndHandleError(

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -655,6 +655,12 @@ class RuntimeController : public PlatformConfigurationClient,
     return root_isolate_;
   }
 
+  void FlushMicrotaskQueue() {
+    if (auto isolate = root_isolate_.lock()) {
+      isolate->FlushMicrotasksNow();
+    }
+  }
+
   std::shared_ptr<PlatformIsolateManager> GetPlatformIsolateManager() override {
     return platform_isolate_manager_;
   }

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -627,4 +627,8 @@ void Engine::ShutdownPlatformIsolates() {
   runtime_controller_->ShutdownPlatformIsolates();
 }
 
+void Engine::FlushMicrotaskQueue() {
+  runtime_controller_->FlushMicrotaskQueue();
+}
+
 }  // namespace flutter

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -978,6 +978,11 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   ///
   void ShutdownPlatformIsolates();
 
+  //--------------------------------------------------------------------------
+  /// @brief      Flushes the microtask queue of root isolate.
+  ///
+  void FlushMicrotaskQueue();
+
  private:
   // |RuntimeDelegate|
   std::string DefaultRouteName() override;

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -979,7 +979,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   void ShutdownPlatformIsolates();
 
   //--------------------------------------------------------------------------
-  /// @brief      Flushes the microtask queue of root isolate.
+  /// @brief      Flushes the microtask queue of the root isolate.
   ///
   void FlushMicrotaskQueue();
 

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -634,6 +634,13 @@ void Shell::NotifyLowMemoryWarning() const {
   // to purge them.
 }
 
+void Shell::FlushMicrotaskQueue() const {
+  if (!weak_engine_) {
+    return;
+  }
+  weak_engine_->FlushMicrotaskQueue();
+}
+
 void Shell::RunEngine(RunConfiguration run_configuration) {
   RunEngine(std::move(run_configuration), nullptr);
 }

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -635,10 +635,9 @@ void Shell::NotifyLowMemoryWarning() const {
 }
 
 void Shell::FlushMicrotaskQueue() const {
-  if (!weak_engine_) {
-    return;
+  if (engine_) {
+    engine_->FlushMicrotaskQueue();
   }
-  weak_engine_->FlushMicrotaskQueue();
 }
 
 void Shell::RunEngine(RunConfiguration run_configuration) {

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -290,6 +290,13 @@ class Shell final : public PlatformView::Delegate,
   void NotifyLowMemoryWarning() const;
 
   //----------------------------------------------------------------------------
+  /// @brief      Used by embedders to flush the microtask queue. Required
+  ///             when running with merged platform and UI threads, in which
+  ///             case the embedder is responsible for flushing the microtask
+  ///             queue.
+  void FlushMicrotaskQueue() const;
+
+  //----------------------------------------------------------------------------
   /// @brief      Used by embedders to check if all shell subcomponents are
   ///             initialized. It is the embedder's responsibility to make this
   ///             call before accessing any other shell method. A shell that is

--- a/engine/src/flutter/shell/common/vsync_waiter.cc
+++ b/engine/src/flutter/shell/common/vsync_waiter.cc
@@ -154,12 +154,16 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
 void VsyncWaiter::PauseDartEventLoopTasks() {
   auto ui_task_queue_id = task_runners_.GetUITaskRunner()->GetTaskQueueId();
   auto task_queues = fml::MessageLoopTaskQueues::GetInstance();
-  task_queues->PauseSecondarySource(ui_task_queue_id);
+  if (ui_task_queue_id.is_valid()) {
+    task_queues->PauseSecondarySource(ui_task_queue_id);
+  }
 }
 
 void VsyncWaiter::ResumeDartEventLoopTasks(fml::TaskQueueId ui_task_queue_id) {
   auto task_queues = fml::MessageLoopTaskQueues::GetInstance();
-  task_queues->ResumeSecondarySource(ui_task_queue_id);
+  if (ui_task_queue_id.is_valid()) {
+    task_queues->ResumeSecondarySource(ui_task_queue_id);
+  }
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -2087,12 +2087,6 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
     settings.application_kernel_asset = kApplicationKernelSnapshotFileName;
   }
 
-  settings.task_observer_add = [](intptr_t key, const fml::closure& callback) {
-    fml::MessageLoop::GetCurrent().AddTaskObserver(key, callback);
-  };
-  settings.task_observer_remove = [](intptr_t key) {
-    fml::MessageLoop::GetCurrent().RemoveTaskObserver(key);
-  };
   if (SAFE_ACCESS(args, root_isolate_create_callback, nullptr) != nullptr) {
     VoidCallback callback =
         SAFE_ACCESS(args, root_isolate_create_callback, nullptr);
@@ -2354,6 +2348,21 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
     return LOG_EMBEDDER_ERROR(kInternalInconsistency,
                               "Task runner configuration was invalid.");
   }
+
+  // Embedder supplied UI task runner runner does not have a message loop.
+  bool has_ui_thread_message_loop =
+      task_runners.GetUITaskRunner()->GetTaskQueueId().is_valid();
+  settings.task_observer_add = [has_ui_thread_message_loop](
+                                   intptr_t key, const fml::closure& callback) {
+    if (has_ui_thread_message_loop) {
+      fml::MessageLoop::GetCurrent().AddTaskObserver(key, callback);
+    }
+  };
+  settings.task_observer_remove = [has_ui_thread_message_loop](intptr_t key) {
+    if (has_ui_thread_message_loop) {
+      fml::MessageLoop::GetCurrent().RemoveTaskObserver(key);
+    }
+  };
 
   auto run_configuration =
       flutter::RunConfiguration::InferFromSettings(settings);

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -2352,6 +2352,9 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
   // Embedder supplied UI task runner runner does not have a message loop.
   bool has_ui_thread_message_loop =
       task_runners.GetUITaskRunner()->GetTaskQueueId().is_valid();
+  // Message loop observers are used to flush the microtask queue.
+  // If there is no message loop the queue is flushed from
+  // EmbedderEngine::RunTask.
   settings.task_observer_add = [has_ui_thread_message_loop](
                                    intptr_t key, const fml::closure& callback) {
     if (has_ui_thread_message_loop) {

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -1703,6 +1703,10 @@ typedef struct {
   /// Specify a callback that is used to set the thread priority for embedder
   /// task runners.
   void (*thread_priority_setter)(FlutterThreadPriority);
+  /// Specify the task runner for the thread on which the UI tasks will be run.
+  /// This may be same as platform_task_runner, in which case the Flutter engine
+  /// will run the UI isolate on platform thread.
+  const FlutterTaskRunnerDescription* ui_task_runner;
 } FlutterCustomTaskRunners;
 
 typedef struct {

--- a/engine/src/flutter/shell/platform/embedder/embedder_engine.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_engine.cc
@@ -246,8 +246,8 @@ bool EmbedderEngine::RunTask(const FlutterTask* task) {
   auto result = thread_host_->PostTask(reinterpret_cast<int64_t>(task->runner),
                                        task->task);
   // Normally the microtask queue is flushed through MessageLoopTaskQueues
-  // observer, but when running with application specified UI task runner,
-  // which is not associated with a task queue so the microtask queue needs to
+  // observer. When running with application specified UI task runner
+  // which is not associated with a task queue, the microtask queue needs to
   // be flushed manually after running the task.
   if (result && task_runners_.GetUITaskRunner() &&
       task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread() &&

--- a/engine/src/flutter/shell/platform/embedder/embedder_engine.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_engine.cc
@@ -249,7 +249,7 @@ bool EmbedderEngine::RunTask(const FlutterTask* task) {
   // observer. When running with application specified UI task runner
   // which is not associated with a task queue, the microtask queue needs to
   // be flushed manually after running the task.
-  if (result && task_runners_.GetUITaskRunner() &&
+  if (result && shell_ && task_runners_.GetUITaskRunner() &&
       task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread() &&
       !task_runners_.GetUITaskRunner()->GetTaskQueueId().is_valid()) {
     shell_->FlushMicrotaskQueue();

--- a/engine/src/flutter/shell/platform/embedder/embedder_engine.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_engine.cc
@@ -245,10 +245,11 @@ bool EmbedderEngine::RunTask(const FlutterTask* task) {
   }
   auto result = thread_host_->PostTask(reinterpret_cast<int64_t>(task->runner),
                                        task->task);
-  // Normally the microtask queue is flushed through MessageLoopTaskQueues
-  // observer. When running with application specified UI task runner
-  // which is not associated with a task queue, the microtask queue needs to
-  // be flushed manually after running the task.
+  // If the UI and platform threads are separate, the microtask queue is
+  // flushed through MessageLoopTaskQueues observer.
+  // If the UI and platform threads are merged, the UI task runner has no
+  // associated task queue, and microtasks need to be flushed manually
+  // after running the task.
   if (result && shell_ && task_runners_.GetUITaskRunner() &&
       task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread() &&
       !task_runners_.GetUITaskRunner()->GetTaskQueueId().is_valid()) {

--- a/engine/src/flutter/shell/platform/embedder/embedder_task_runner.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_task_runner.cc
@@ -14,8 +14,7 @@ EmbedderTaskRunner::EmbedderTaskRunner(DispatchTable table,
     : TaskRunner(nullptr /* loop implemenation*/),
       embedder_identifier_(embedder_identifier),
       dispatch_table_(std::move(table)),
-      placeholder_id_(
-          fml::MessageLoopTaskQueues::GetInstance()->CreateTaskQueue()) {
+      placeholder_id_(fml::TaskQueueId(fml::TaskQueueId::kInvalid)) {
   FML_DCHECK(dispatch_table_.post_task_callback);
   FML_DCHECK(dispatch_table_.runs_task_on_current_thread_callback);
   FML_DCHECK(dispatch_table_.destruction_callback);

--- a/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
@@ -63,12 +63,19 @@ void invokePlatformTaskRunner() {
 }
 
 @pragma('vm:entry-point')
-void mergedPlatformUIThreadRuns() {
+void canSpecifyCustomUITaskRunner() {
   signalNativeTest();
+  PlatformDispatcher.instance.sendPlatformMessage('OhHi', null, null);
 }
 
 @pragma('vm:entry-point')
-void mergedPlatformUIThreadFlushesMicrotasks() {
+void mergedPlatformUIThread() {
+  signalNativeTest();
+  PlatformDispatcher.instance.sendPlatformMessage('OhHi', null, null);
+}
+
+@pragma('vm:entry-point')
+void uiTaskRunnerFlushesMicrotasks() {
   // Microtasks are always flushed at the beginning of the frame, hence the delay.
   Future.delayed(const Duration(milliseconds: 50), () {
     Future.microtask(() {

--- a/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
@@ -63,6 +63,21 @@ void invokePlatformTaskRunner() {
 }
 
 @pragma('vm:entry-point')
+void mergedPlatformUIThreadRuns() {
+  signalNativeTest();
+}
+
+@pragma('vm:entry-point')
+void mergedPlatformUIThreadFlushesMicrotasks() {
+  // Microtasks are always flushed at the beginning of the frame, hence the delay.
+  Future.delayed(const Duration(milliseconds: 50), () {
+    Future.microtask(() {
+      signalNativeTest();
+    });
+  });
+}
+
+@pragma('vm:entry-point')
 void invokePlatformThreadIsolate() {
   signalNativeTest();
   runOnPlatformThread(ffiSignalNativeTest);

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -163,6 +163,15 @@ void EmbedderConfigBuilder::SetPlatformTaskRunner(
   project_args_.custom_task_runners = &custom_task_runners_;
 }
 
+void EmbedderConfigBuilder::SetUITaskRunner(
+    const FlutterTaskRunnerDescription* runner) {
+  if (runner == nullptr) {
+    return;
+  }
+  custom_task_runners_.ui_task_runner = runner;
+  project_args_.custom_task_runners = &custom_task_runners_;
+}
+
 void EmbedderConfigBuilder::SetupVsyncCallback() {
   project_args_.vsync_callback = [](void* user_data, intptr_t baton) {
     auto context = reinterpret_cast<EmbedderTestContext*>(user_data);

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.h
@@ -74,6 +74,8 @@ class EmbedderConfigBuilder {
 
   void SetPlatformTaskRunner(const FlutterTaskRunnerDescription* runner);
 
+  void SetUITaskRunner(const FlutterTaskRunnerDescription* runner);
+
   void SetRenderTaskRunner(const FlutterTaskRunnerDescription* runner);
 
   void SetPlatformMessageCallback(

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
@@ -205,18 +205,21 @@ std::atomic_size_t EmbedderTestTaskRunner::sEmbedderTaskRunnerIdentifiers = {};
 TEST_F(EmbedderTest, CanSpecifyCustomUITaskRunner) {
   auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   auto ui_task_runner = CreateNewThread("test_ui_thread");
-  auto platform_task_runner = CreateNewThread("test_ui_thread");
+  auto platform_task_runner = CreateNewThread("test_platform_thread");
+  static std::mutex engine_mutex;
   UniqueEngine engine;
 
   EmbedderTestTaskRunner test_ui_task_runner(
       ui_task_runner, [&](FlutterTask task) {
+        std::scoped_lock lock(engine_mutex);
         if (!engine.is_valid()) {
           return;
         }
         FlutterEngineRunTask(engine.get(), &task);
       });
   EmbedderTestTaskRunner test_platform_task_runner(
-      ui_task_runner, [&](FlutterTask task) {
+      platform_task_runner, [&](FlutterTask task) {
+        std::scoped_lock lock(engine_mutex);
         if (!engine.is_valid()) {
           return;
         }
@@ -233,28 +236,35 @@ TEST_F(EmbedderTest, CanSpecifyCustomUITaskRunner) {
         signal_latch_ui.Signal();
       }));
 
-  ui_task_runner->PostTask([&]() {
+  platform_task_runner->PostTask([&]() {
     EmbedderConfigBuilder builder(context);
-    const auto task_runner_description =
+    const auto ui_task_runner_description =
         test_ui_task_runner.GetFlutterTaskRunnerDescription();
+    const auto platform_task_runner_description =
+        test_platform_task_runner.GetFlutterTaskRunnerDescription();
     builder.SetSurface(SkISize::Make(1, 1));
-    builder.SetUITaskRunner(&task_runner_description);
+    builder.SetUITaskRunner(&ui_task_runner_description);
+    builder.SetPlatformTaskRunner(&platform_task_runner_description);
     builder.SetDartEntrypoint("canSpecifyCustomUITaskRunner");
     builder.SetPlatformMessageCallback(
         [&](const FlutterPlatformMessage* message) {
           ASSERT_TRUE(platform_task_runner->RunsTasksOnCurrentThread());
           signal_latch_platform.Signal();
         });
-    engine = builder.LaunchEngine();
+    {
+      std::scoped_lock lock(engine_mutex);
+      engine = builder.InitializeEngine();
+    }
+    ASSERT_EQ(FlutterEngineRunInitialized(engine.get()), kSuccess);
     ASSERT_TRUE(engine.is_valid());
   });
   signal_latch_ui.Wait();
   signal_latch_platform.Wait();
 
   fml::AutoResetWaitableEvent kill_latch;
-  ui_task_runner->PostTask([&] {
+  platform_task_runner->PostTask([&] {
     engine.reset();
-    ui_task_runner->PostTask([&kill_latch] { kill_latch.Signal(); });
+    platform_task_runner->PostTask([&kill_latch] { kill_latch.Signal(); });
   });
   kill_latch.Wait();
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/152337

Introduces `ui_task_runner` field on `FlutterCustomTaskRunners`. This lets the embedder to specify task runner for UI isolate tasks, allowing for merging platform and UI threads.

With custom UI task runner there is no `MessageLoop` anymore for the UI thread,  so the message loop task observer can no longer be used to flush microtask queue. Instead the microtask queue is flushed at the end of each `FlutterEngineRunTask` invocation if needed. This is handled internally by the embedder.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
