### PR TITLE
Fix M3 theme default decorationColor

### DIFF
--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -199,8 +199,8 @@ class Typography with Diagnosticable {
     final Color light =
         colorScheme.brightness == Brightness.light ? colorScheme.surface : colorScheme.onSurface;
     return base.copyWith(
-      black: base.black.apply(displayColor: dark, bodyColor: dark, decorationColor: dark),
-      white: base.white.apply(displayColor: light, bodyColor: light, decorationColor: light),
+      black: base.black.apply(displayColor: dark, bodyColor: dark),
+      white: base.white.apply(displayColor: light, bodyColor: light),
     );
   }
 

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -113,10 +113,7 @@ void main() {
       text.style,
       Typography.material2021().englishLike.bodyMedium!
           .merge(Typography.material2021().black.bodyMedium)
-          .copyWith(
-            color: theme.colorScheme.onSurface,
-            decorationColor: theme.colorScheme.onSurface,
-          ),
+          .copyWith(color: theme.colorScheme.onSurface),
     );
     expect(tester.getSize(find.byType(AppBar)).height, kToolbarHeight);
     expect(tester.getSize(find.byType(AppBar)).width, 800);
@@ -452,10 +449,7 @@ void main() {
       text.style,
       Typography.material2021().englishLike.bodyMedium!
           .merge(Typography.material2021().black.bodyMedium)
-          .copyWith(
-            color: darkTheme.colorScheme.onSurface,
-            decorationColor: darkTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: darkTheme.colorScheme.onSurface),
     );
   });
 

--- a/packages/flutter/test/material/snack_bar_theme_test.dart
+++ b/packages/flutter/test/material/snack_bar_theme_test.dart
@@ -139,7 +139,7 @@ void main() {
     WidgetTester tester,
   ) async {
     const String text = 'I am a snack bar.';
-    final ThemeData theme = ThemeData(useMaterial3: true);
+    final ThemeData theme = ThemeData();
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
@@ -174,11 +174,9 @@ void main() {
       content.text.style,
       Typography.material2021().englishLike.bodyMedium
           ?.merge(Typography.material2021().black.bodyMedium)
-          .copyWith(
-            color: theme.colorScheme.onInverseSurface,
-            decorationColor: theme.colorScheme.onSurface,
-          ),
+          .copyWith(color: theme.colorScheme.onInverseSurface),
     );
+
     expect(material.color, theme.colorScheme.inverseSurface);
     expect(material.elevation, 6.0);
     expect(material.shape, null);

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -556,7 +556,7 @@ void main() {
         expect(style.textBaseline, isNotNull);
         expect(style.height, isNotNull);
         expect(style.decoration, TextDecoration.none);
-        expect(style.decorationColor, isNotNull);
+        expect(style.decorationColor, null);
         expect(style.decorationStyle, null);
         expect(style.debugLabel, isNotNull);
         expect(style.locale, null);

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -300,10 +300,7 @@ void main() {
       hourText.text.style,
       Typography.material2021().englishLike.displayLarge!
           .merge(Typography.material2021().black.displayLarge)
-          .copyWith(
-            color: defaultTheme.colorScheme.onPrimaryContainer,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onPrimaryContainer),
     );
 
     final RenderParagraph minuteText = _textRenderParagraph(tester, '15');
@@ -311,10 +308,7 @@ void main() {
       minuteText.text.style,
       Typography.material2021().englishLike.displayLarge!
           .merge(Typography.material2021().black.displayLarge)
-          .copyWith(
-            color: defaultTheme.colorScheme.onSurface,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onSurface),
     );
 
     final RenderParagraph amText = _textRenderParagraph(tester, 'AM');
@@ -322,10 +316,7 @@ void main() {
       amText.text.style,
       Typography.material2021().englishLike.titleMedium!
           .merge(Typography.material2021().black.titleMedium)
-          .copyWith(
-            color: defaultTheme.colorScheme.onTertiaryContainer,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onTertiaryContainer),
     );
 
     final RenderParagraph pmText = _textRenderParagraph(tester, 'PM');
@@ -333,10 +324,7 @@ void main() {
       pmText.text.style,
       Typography.material2021().englishLike.titleMedium!
           .merge(Typography.material2021().black.titleMedium)
-          .copyWith(
-            color: defaultTheme.colorScheme.onSurfaceVariant,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onSurfaceVariant),
     );
 
     final RenderParagraph helperText = _textRenderParagraph(tester, 'Select time');
@@ -344,10 +332,7 @@ void main() {
       helperText.text.style,
       Typography.material2021().englishLike.bodyMedium!
           .merge(Typography.material2021().black.bodyMedium)
-          .copyWith(
-            color: defaultTheme.colorScheme.onSurface,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onSurface),
     );
 
     final CustomPaint dialPaint = tester.widget(findDialPaint);
@@ -359,10 +344,7 @@ void main() {
       primaryLabels.first.painter.text.style,
       Typography.material2021().englishLike.bodyLarge!
           .merge(Typography.material2021().black.bodyLarge)
-          .copyWith(
-            color: defaultTheme.colorScheme.onSurface,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onSurface),
     );
     // ignore: avoid_dynamic_calls
     final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
@@ -371,10 +353,7 @@ void main() {
       selectedLabels.first.painter.text.style,
       Typography.material2021().englishLike.bodyLarge!
           .merge(Typography.material2021().black.bodyLarge)
-          .copyWith(
-            color: defaultTheme.colorScheme.onPrimary,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onPrimary),
     );
 
     final Material hourMaterial = _textMaterial(tester, '7');
@@ -499,10 +478,7 @@ void main() {
       hourTextStyle,
       Typography.material2021().englishLike.displayMedium!
           .merge(Typography.material2021().black.displayMedium)
-          .copyWith(
-            color: defaultTheme.colorScheme.onSurface,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onSurface),
     );
 
     final TextStyle minuteTextStyle = _textField(tester, '15').style!;
@@ -510,10 +486,7 @@ void main() {
       minuteTextStyle,
       Typography.material2021().englishLike.displayMedium!
           .merge(Typography.material2021().black.displayMedium)
-          .copyWith(
-            color: defaultTheme.colorScheme.onSurface,
-            decorationColor: defaultTheme.colorScheme.onSurface,
-          ),
+          .copyWith(color: defaultTheme.colorScheme.onSurface),
     );
 
     final InputDecoration hourDecoration = _textField(tester, '7').decoration!;
@@ -697,7 +670,7 @@ void main() {
     WidgetTester tester,
   ) async {
     final TimePickerThemeData timePickerTheme = _timePickerTheme();
-    final ThemeData theme = ThemeData(timePickerTheme: timePickerTheme, useMaterial3: true);
+    final ThemeData theme = ThemeData(timePickerTheme: timePickerTheme);
     await tester.pumpWidget(_TimePickerLauncher(themeData: theme));
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle(const Duration(seconds: 1));
@@ -720,7 +693,7 @@ void main() {
       Typography.material2021().englishLike.bodyMedium!
           .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.hourMinuteTextStyle)
-          .copyWith(color: _selectedColor, decorationColor: const Color(0xff1d1b20)),
+          .copyWith(color: _selectedColor),
     );
 
     final RenderParagraph minuteText = _textRenderParagraph(tester, '15');
@@ -729,7 +702,7 @@ void main() {
       Typography.material2021().englishLike.bodyMedium!
           .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.hourMinuteTextStyle)
-          .copyWith(color: _unselectedColor, decorationColor: const Color(0xff1d1b20)),
+          .copyWith(color: _unselectedColor),
     );
 
     final RenderParagraph amText = _textRenderParagraph(tester, 'AM');
@@ -738,7 +711,7 @@ void main() {
       Typography.material2021().englishLike.bodyMedium!
           .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.hourMinuteTextStyle)
-          .copyWith(color: _selectedColor, decorationColor: const Color(0xff1d1b20)),
+          .copyWith(color: _selectedColor),
     );
 
     final RenderParagraph pmText = _textRenderParagraph(tester, 'PM');
@@ -747,7 +720,7 @@ void main() {
       Typography.material2021().englishLike.bodyMedium!
           .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.hourMinuteTextStyle)
-          .copyWith(color: _unselectedColor, decorationColor: const Color(0xff1d1b20)),
+          .copyWith(color: _unselectedColor),
     );
 
     final RenderParagraph helperText = _textRenderParagraph(tester, 'Select time');
@@ -756,10 +729,7 @@ void main() {
       Typography.material2021().englishLike.bodyMedium!
           .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.helpTextStyle)
-          .copyWith(
-            color: theme.colorScheme.onSurface,
-            decorationColor: theme.colorScheme.onSurface,
-          ),
+          .copyWith(color: theme.colorScheme.onSurface),
     );
 
     final CustomPaint dialPaint = tester.widget(findDialPaint);
@@ -771,7 +741,7 @@ void main() {
       primaryLabels.first.painter.text.style,
       Typography.material2021().englishLike.bodyLarge!
           .merge(Typography.material2021().black.bodyLarge)
-          .copyWith(color: _unselectedColor, decorationColor: theme.colorScheme.onSurface),
+          .copyWith(color: _unselectedColor),
     );
     // ignore: avoid_dynamic_calls
     final List<dynamic> selectedLabels = dialPainter.selectedLabels as List<dynamic>;
@@ -780,7 +750,7 @@ void main() {
       selectedLabels.first.painter.text.style,
       Typography.material2021().englishLike.bodyLarge!
           .merge(Typography.material2021().black.bodyLarge)
-          .copyWith(color: _selectedColor, decorationColor: theme.colorScheme.onSurface),
+          .copyWith(color: _selectedColor),
     );
 
     final Material hourMaterial = _textMaterial(tester, '7');


### PR DESCRIPTION
## Description

This PR removes the enforcement for `TextStyle.decorationColor` on M3 text themes.

In https://github.com/flutter/flutter/pull/116125, `TextStyle.decorationColor` (for M3 text themes), was enforced to the same value as `TextStyle.color`. This was overzealous because when not set `TextStyle.decorationColor` is rendered using the color set to `TextStyle.color` and it introduced a side effect which is requiring users to explicitly set `TextStyle.decorationColor` when they change `TextStyle.color` otherwhise the decoration is rendered using the theme default instead of the text color. This was not the case for M2 and it is reasonable that users expect the decoration color to be the same as the text color if they don't explicitly set this decoration color.

### Before:

In M3, the default decoration color is not the text color:

![image](https://github.com/user-attachments/assets/81bb97cc-bade-4da7-b075-4a1bc020a73e)



### After:

The decoration color defaults to the text color (as it did on M2):

![image](https://github.com/user-attachments/assets/d4d73519-4d89-4365-bd55-3b36deba9dbb)



<details><summary>Code sample used for screenshots</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(const DecorationColorExampleApp());

class DecorationColorExampleApp extends StatelessWidget {
  const DecorationColorExampleApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: Scaffold(
        body: Center(
          child: Text(
            'Flutter',
            style: TextStyle(
              fontSize: 80,
              fontWeight: FontWeight.w800,
              color: Colors.blue,
              decoration: TextDecoration.underline,
              // Setting decorationColor can mitigate the issue
              // decorationColor: Colors.blue,
            ),
          ),
        ),
      ),
    );
  }
}

``` 
</details> 

## Related Issue
Fixes [TextDecoration doesn't inherit text color in Material3](https://github.com/flutter/flutter/issues/129553)

## Tests

Updates several tests.
(Most of those changes remove decorationColor checks that were added in https://github.com/flutter/flutter/pull/128300 to make the tests pass on M3).