### PR TITLE
Update .ci.yaml to support Fuchsia cherrypick branches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -14,7 +14,6 @@
 enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
-  - fuchsia_f\d+[a-z]*
 
 platform_properties:
   staging_build_linux:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -14,6 +14,7 @@
 enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
+  - fuchsia_f\d+[a-z]*
 
 platform_properties:
   staging_build_linux:

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -8,7 +8,6 @@
 enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
-  - fuchsia_r\d+[a-z]*
 
 platform_properties:
   linux:

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -8,6 +8,7 @@
 enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
+  - fuchsia_f\d+[a-z]*
 
 platform_properties:
   linux:


### PR DESCRIPTION
Fuchsia cherry-pick branches were previously created in flutter/engine, and now need to be supported in flutter/flutter: https://github.com/flutter/engine/blob/main/.ci.yaml#L11

Branch naming was changed from `fuchsia_rNN` to `fuchsia_fNN` (see https://chat.google.com/room/AAAAT9RJL9Q/AnUIORFRVOM)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

