### PR TITLE
Remove unsound artifacts, remove `*Sound` qualifier.

### DIFF
--- a/engine/src/flutter/web_sdk/BUILD.gn
+++ b/engine/src/flutter/web_sdk/BUILD.gn
@@ -214,6 +214,7 @@ template("_compile_platform") {
     inputs = [ "sdk_rewriter.dart" ] + web_ui_sources
 
     outputs = [ invoker.output_dill ]
+    args = []
 
     if (invoker.summary_only) {
       args += [ "--summary-only" ]

--- a/engine/src/flutter/web_sdk/BUILD.gn
+++ b/engine/src/flutter/web_sdk/BUILD.gn
@@ -323,7 +323,7 @@ template("_compile_ddc_module") {
       dart_sdk_js_path + ".map",
     ]
 
-    args += [
+    args = [
       "--compile-sdk",
       "dart:core",
 

--- a/engine/src/flutter/web_sdk/BUILD.gn
+++ b/engine/src/flutter/web_sdk/BUILD.gn
@@ -204,8 +204,6 @@ template("_kernel_worker") {
 }
 
 template("_compile_platform") {
-  assert(defined(invoker.sound_null_safety),
-         "sound_null_safety must be defined for $target_name")
   assert(defined(invoker.kernel_target),
          "kernel_target must be defined for $target_name")
   assert(defined(invoker.summary_only),
@@ -216,12 +214,6 @@ template("_compile_platform") {
     inputs = [ "sdk_rewriter.dart" ] + web_ui_sources
 
     outputs = [ invoker.output_dill ]
-
-    if (invoker.sound_null_safety) {
-      args = [ "--sound-null-safety" ]
-    } else {
-      args = [ "--no-sound-null-safety" ]
-    }
 
     if (invoker.summary_only) {
       args += [ "--summary-only" ]
@@ -280,41 +272,20 @@ template("_compile_platform") {
   }
 }
 
-# Compile the unsound DDC SDK's summary.
-_compile_platform("flutter_dartdevc_kernel_sdk_outline_unsound") {
-  sound_null_safety = false
+_compile_platform("flutter_dartdevc_kernel_sdk_outline") {
   kernel_target = "ddc"
   summary_only = true
   output_dill = "$root_out_dir/flutter_web_sdk/kernel/ddc_outline.dill"
 }
 
-# Compile the sound DDC SDK's summary.
-_compile_platform("flutter_dartdevc_kernel_sdk_outline_sound") {
-  sound_null_safety = true
-  kernel_target = "ddc"
-  summary_only = true
-  output_dill = "$root_out_dir/flutter_web_sdk/kernel/ddc_outline_sound.dill"
-}
-
-_compile_platform("flutter_dart2js_kernel_sdk_full_unsound") {
-  sound_null_safety = false
-  kernel_target = "dart2js"
-  summary_only = false
-  output_dill =
-      "$root_out_dir/flutter_web_sdk/kernel/dart2js_platform_unsound.dill"
-  null_environment = true
-}
-
-_compile_platform("flutter_dart2js_kernel_sdk_full_sound") {
-  sound_null_safety = true
+_compile_platform("flutter_dart2js_kernel_sdk_full") {
   kernel_target = "dart2js"
   summary_only = false
   output_dill = "$root_out_dir/flutter_web_sdk/kernel/dart2js_platform.dill"
   null_environment = true
 }
 
-_compile_platform("flutter_dart2wasm_kernel_sdk_full_sound") {
-  sound_null_safety = true
+_compile_platform("flutter_dart2wasm_kernel_sdk_full") {
   kernel_target = "dart2wasm"
   summary_only = false
   output_dill = "$root_out_dir/flutter_web_sdk/kernel/dart2wasm_platform.dill"
@@ -323,22 +294,14 @@ _compile_platform("flutter_dart2wasm_kernel_sdk_full_sound") {
 
 group("flutter_platform_dills") {
   public_deps = [
-    ":flutter_dart2js_kernel_sdk_full_sound",
-    ":flutter_dart2js_kernel_sdk_full_unsound",
-    ":flutter_dart2wasm_kernel_sdk_full_sound",
-    ":flutter_dartdevc_kernel_sdk_outline_sound",
-    ":flutter_dartdevc_kernel_sdk_outline_unsound",
-
-    # TODO(jacksongardner): remove these once they are no longer used by the flutter tool
-    # https://github.com/flutter/flutter/issues/113303
-    ":flutter_dartdevc_kernel_sdk_outline_sound",
-    ":flutter_dartdevc_kernel_sdk_outline_unsound",
+    ":flutter_dart2js_kernel_sdk_full",
+    ":flutter_dart2wasm_kernel_sdk_full",
+    ":flutter_dartdevc_kernel_sdk_outline",
+    ":flutter_dartdevc_kernel_sdk_outline",
   ]
 }
 
 template("_compile_ddc_module") {
-  assert(defined(invoker.sound_null_safety),
-         "sound_null_safety must be defined for $target_name")
   assert(defined(invoker.sdk_path_prefix),
          "sdk_path_prefix must be defined for $target_name")
   assert(defined(invoker.module_format),
@@ -351,9 +314,6 @@ template("_compile_ddc_module") {
     packages = dart_sdk_package_config
 
     name_suffix = "-canvaskit"
-    if (invoker.sound_null_safety) {
-      name_suffix += "-sound"
-    }
 
     dart_sdk_js_path = "$root_out_dir/flutter_web_sdk/kernel/${invoker.sdk_path_prefix}${name_suffix}/dart_sdk.js"
 
@@ -361,12 +321,6 @@ template("_compile_ddc_module") {
       dart_sdk_js_path,
       dart_sdk_js_path + ".map",
     ]
-
-    if (invoker.sound_null_safety) {
-      args = [ "--sound-null-safety" ]
-    } else {
-      args = [ "--no-sound-null-safety" ]
-    }
 
     args += [
       "--compile-sdk",
@@ -415,8 +369,6 @@ template("_compile_ddc_module") {
 }
 
 template("_compile_ddc_modules") {
-  assert(defined(invoker.sound_null_safety),
-         "sound_null_safety must be defined for $target_name")
   forward_variables_from(invoker, "*")
 
   # We compile multiple times instead of passing multiple modules to a single
@@ -428,31 +380,22 @@ template("_compile_ddc_modules") {
     canary = false
   }
 
-  # No support for unsound null safety with the DDC library bundle format.
-  if (sound_null_safety) {
-    _compile_ddc_module("${target_name}_ddcLibraryBundle") {
-      sdk_path_prefix = "ddcLibraryBundle"
-      module_format = "ddc"
-      canary = true
-    }
+  _compile_ddc_module("${target_name}_ddcLibraryBundle") {
+    sdk_path_prefix = "ddcLibraryBundle"
+    module_format = "ddc"
+    canary = true
   }
 }
 
-# Compiles the unsound canvaskit only renderer.
+# Compiles the canvaskit only renderer.
 _compile_ddc_modules("flutter_dartdevc_canvaskit_kernel_sdk") {
-  sound_null_safety = false
-}
-
-# Compiles the sound canvaskit only renderer.
-_compile_ddc_modules("flutter_dartdevc_canvaskit_kernel_sdk_sound") {
-  sound_null_safety = true
 }
 
 group("flutter_ddc_modules") {
   public_deps = [
     ":flutter_dartdevc_canvaskit_kernel_sdk_amd",
-    ":flutter_dartdevc_canvaskit_kernel_sdk_sound_amd",
-    ":flutter_dartdevc_canvaskit_kernel_sdk_sound_ddcLibraryBundle",
+    ":flutter_dartdevc_canvaskit_kernel_sdk_amd",
+    ":flutter_dartdevc_canvaskit_kernel_sdk_ddcLibraryBundle",
   ]
 }
 
@@ -477,18 +420,14 @@ if (!is_fuchsia) {
 
     # flutter_ddc_modules
     sources = get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk_amd")
-    sources +=
-        get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk_sound_amd")
+    sources += get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk_amd")
     sources += get_target_outputs(
-            ":flutter_dartdevc_canvaskit_kernel_sdk_sound_ddcLibraryBundle")
+            ":flutter_dartdevc_canvaskit_kernel_sdk_ddcLibraryBundle")
 
     # flutter_platform_dills
-    sources +=
-        get_target_outputs(":flutter_dartdevc_kernel_sdk_outline_unsound")
-    sources += get_target_outputs(":flutter_dartdevc_kernel_sdk_outline_sound")
-    sources += get_target_outputs(":flutter_dart2js_kernel_sdk_full_unsound")
-    sources += get_target_outputs(":flutter_dart2js_kernel_sdk_full_sound")
-    sources += get_target_outputs(":flutter_dart2wasm_kernel_sdk_full_sound")
+    sources += get_target_outputs(":flutter_dartdevc_kernel_sdk_outline")
+    sources += get_target_outputs(":flutter_dart2js_kernel_sdk_full")
+    sources += get_target_outputs(":flutter_dart2wasm_kernel_sdk_full")
     if (is_wasm) {
       sources += [
         "$root_out_dir/flutter_web_sdk/canvaskit/canvaskit.js",

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -111,8 +111,7 @@ enum HostArtifact {
   webPrecompiledAmdCanvaskitAndHtmlSdkSourcemaps,
 
   /// The precompiled SDKs and sourcemaps for web debug builds with the DDC
-  /// library bundle module system. Only SDKs built with sound null-safety are
-  /// provided here.
+  /// library bundle module system.
   webPrecompiledDdcLibraryBundleSdk,
   webPrecompiledDdcLibraryBundleSdkSourcemaps,
   webPrecompiledDdcLibraryBundleCanvaskitSdk,
@@ -465,7 +464,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-sound',
+          'amd',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -474,7 +473,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-sound',
+          'amd-canvaskit',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -483,7 +482,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-html-sound',
+          'amd-canvaskit-html',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -492,7 +491,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-sound',
+          'ddcLibraryBundle',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -501,7 +500,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-canvaskit-sound',
+          'ddcLibraryBundle-canvaskit',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -510,7 +509,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-canvaskit-html-sound',
+          'ddcLibraryBundle-canvaskit-html',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1168,7 +1167,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-sound',
+          'amd',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1177,7 +1176,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-sound',
+          'amd-canvaskit',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1186,7 +1185,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-html-sound',
+          'amd-canvaskit-html',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1195,7 +1194,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-sound',
+          'ddcLibraryBundle',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1204,7 +1203,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-canvaskit-sound',
+          'ddcLibraryBundle-canvaskit',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1213,7 +1212,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-canvaskit-html-sound',
+          'ddcLibraryBundle-canvaskit-html',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1575,7 +1574,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-sound',
+          'amd',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1584,7 +1583,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-sound',
+          'amd-canvaskit',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1593,7 +1592,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-html-sound',
+          'amd-canvaskit-html',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1602,7 +1601,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-sound',
+          'ddcLibraryBundle',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1611,7 +1610,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-canvaskit-sound',
+          'ddcLibraryBundle-canvaskit',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1620,7 +1619,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'ddcLibraryBundle-canvaskit-html-sound',
+          'ddcLibraryBundle-canvaskit-html',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -89,19 +89,17 @@ enum HostArtifact {
   /// Folder that contains platform dill files for the web sdk.
   webPlatformKernelFolder,
 
-  // TODO(matanlurey): Remove the non-Sound variants, and rename the Sound variants, https://github.com/flutter/flutter/issues/162846.
+  // **NOTE**: All of the precompiled SDKs, summaries, and source maps are
+  // strictly with sound null-safety, there is no longer support for unsound
+  // null-safety within the Flutter tool or SDK.
+  //
+  // See https://github.com/flutter/flutter/issues/162846.
 
   /// The summary dill for the dartdevc target.
   webPlatformDDCKernelDill,
 
-  /// The summary dill with null safety enabled for the dartdevc target.g
-  webPlatformDDCSoundKernelDill,
-
-  /// The summary dill for the dartdevc target.
+  /// The summary dill for the dart2js target.
   webPlatformDart2JSKernelDill,
-
-  /// The summary dill with null safety enabled for the dartdevc target.
-  webPlatformDart2JSSoundKernelDill,
 
   /// The precompiled SDKs and sourcemaps for web debug builds with the AMD module system.
   // TODO(markzipan): delete these when DDC's AMD module system is deprecated, https://github.com/flutter/flutter/issues/142060.
@@ -111,22 +109,16 @@ enum HostArtifact {
   webPrecompiledAmdCanvaskitSdkSourcemaps,
   webPrecompiledAmdCanvaskitAndHtmlSdk,
   webPrecompiledAmdCanvaskitAndHtmlSdkSourcemaps,
-  webPrecompiledAmdSoundSdk,
-  webPrecompiledAmdSoundSdkSourcemaps,
-  webPrecompiledAmdCanvaskitSoundSdk,
-  webPrecompiledAmdCanvaskitSoundSdkSourcemaps,
-  webPrecompiledAmdCanvaskitAndHtmlSoundSdk,
-  webPrecompiledAmdCanvaskitAndHtmlSoundSdkSourcemaps,
 
   /// The precompiled SDKs and sourcemaps for web debug builds with the DDC
   /// library bundle module system. Only SDKs built with sound null-safety are
   /// provided here.
-  webPrecompiledDdcLibraryBundleSoundSdk,
-  webPrecompiledDdcLibraryBundleSoundSdkSourcemaps,
-  webPrecompiledDdcLibraryBundleCanvaskitSoundSdk,
-  webPrecompiledDdcLibraryBundleCanvaskitSoundSdkSourcemaps,
-  webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdk,
-  webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdkSourcemaps,
+  webPrecompiledDdcLibraryBundleSdk,
+  webPrecompiledDdcLibraryBundleSdkSourcemaps,
+  webPrecompiledDdcLibraryBundleCanvaskitSdk,
+  webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps,
+  webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdk,
+  webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdkSourcemaps,
 
   iosDeploy,
   idevicesyslog,
@@ -267,34 +259,24 @@ String _hostArtifactToFileName(HostArtifact artifact, Platform platform) {
     case HostArtifact.webPlatformKernelFolder:
       return 'kernel';
     case HostArtifact.webPlatformDDCKernelDill:
-      return 'ddc_outline.dill';
-    case HostArtifact.webPlatformDDCSoundKernelDill:
       return 'ddc_outline_sound.dill';
     case HostArtifact.webPlatformDart2JSKernelDill:
-      return 'dart2js_platform_unsound.dill';
-    case HostArtifact.webPlatformDart2JSSoundKernelDill:
       return 'dart2js_platform.dill';
     case HostArtifact.flutterWebLibrariesJson:
       return 'libraries.json';
     case HostArtifact.webPrecompiledAmdSdk:
     case HostArtifact.webPrecompiledAmdCanvaskitSdk:
     case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSdk:
-    case HostArtifact.webPrecompiledAmdSoundSdk:
-    case HostArtifact.webPrecompiledAmdCanvaskitSoundSdk:
-    case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdk:
-    case HostArtifact.webPrecompiledDdcLibraryBundleSoundSdk:
-    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk:
-    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdk:
+    case HostArtifact.webPrecompiledDdcLibraryBundleSdk:
+    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
+    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdk:
       return 'dart_sdk.js';
     case HostArtifact.webPrecompiledAmdSdkSourcemaps:
     case HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps:
     case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSdkSourcemaps:
-    case HostArtifact.webPrecompiledAmdSoundSdkSourcemaps:
-    case HostArtifact.webPrecompiledAmdCanvaskitSoundSdkSourcemaps:
-    case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdkSourcemaps:
-    case HostArtifact.webPrecompiledDdcLibraryBundleSoundSdkSourcemaps:
-    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdkSourcemaps:
-    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdkSourcemaps:
+    case HostArtifact.webPrecompiledDdcLibraryBundleSdkSourcemaps:
+    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
+    case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdkSourcemaps:
       return 'dart_sdk.js.map';
     case HostArtifact.impellerc:
       return 'impellerc$exe';
@@ -471,9 +453,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel');
         return _fileSystem.file(path);
       case HostArtifact.webPlatformDDCKernelDill:
-      case HostArtifact.webPlatformDDCSoundKernelDill:
       case HostArtifact.webPlatformDart2JSKernelDill:
-      case HostArtifact.webPlatformDart2JSSoundKernelDill:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -485,7 +465,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd',
+          'amd-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -494,7 +474,7 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit',
+          'amd-canvaskit-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -503,39 +483,12 @@ class CachedArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-html',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdSoundSdk:
-      case HostArtifact.webPrecompiledAmdSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-sound',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdCanvaskitSoundSdk:
-      case HostArtifact.webPrecompiledAmdCanvaskitSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-canvaskit-sound',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdk:
-      case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
           'amd-canvaskit-html-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -543,8 +496,8 @@ class CachedArtifacts implements Artifacts {
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -552,8 +505,8 @@ class CachedArtifacts implements Artifacts {
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -1203,9 +1156,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel');
         return _fileSystem.file(path);
       case HostArtifact.webPlatformDDCKernelDill:
-      case HostArtifact.webPlatformDDCSoundKernelDill:
       case HostArtifact.webPlatformDart2JSKernelDill:
-      case HostArtifact.webPlatformDart2JSSoundKernelDill:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -1217,7 +1168,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd',
+          'amd-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1226,7 +1177,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit',
+          'amd-canvaskit-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1235,39 +1186,12 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-html',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdSoundSdk:
-      case HostArtifact.webPrecompiledAmdSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-sound',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdCanvaskitSoundSdk:
-      case HostArtifact.webPrecompiledAmdCanvaskitSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-canvaskit-sound',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdk:
-      case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
           'amd-canvaskit-html-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -1275,8 +1199,8 @@ class CachedLocalEngineArtifacts implements Artifacts {
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -1284,8 +1208,8 @@ class CachedLocalEngineArtifacts implements Artifacts {
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -1639,9 +1563,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel');
         return _fileSystem.file(path);
       case HostArtifact.webPlatformDDCKernelDill:
-      case HostArtifact.webPlatformDDCSoundKernelDill:
       case HostArtifact.webPlatformDart2JSKernelDill:
-      case HostArtifact.webPlatformDart2JSSoundKernelDill:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -1653,7 +1575,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd',
+          'amd-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1662,7 +1584,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit',
+          'amd-canvaskit-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
@@ -1671,39 +1593,12 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
-          'amd-canvaskit-html',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdSoundSdk:
-      case HostArtifact.webPrecompiledAmdSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-sound',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdCanvaskitSoundSdk:
-      case HostArtifact.webPrecompiledAmdCanvaskitSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
-          'amd-canvaskit-sound',
-          _hostArtifactToFileName(artifact, _platform),
-        );
-        return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdk:
-      case HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdkSourcemaps:
-        final String path = _fileSystem.path.join(
-          _getFlutterWebSdkPath(),
-          'kernel',
           'amd-canvaskit-html-sound',
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -1711,8 +1606,8 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',
@@ -1720,8 +1615,8 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
           _hostArtifactToFileName(artifact, _platform),
         );
         return _fileSystem.file(path);
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdk:
-      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdkSourcemaps:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdk:
+      case HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdkSourcemaps:
         final String path = _fileSystem.path.join(
           _getFlutterWebSdkPath(),
           'kernel',

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -258,7 +258,7 @@ String _hostArtifactToFileName(HostArtifact artifact, Platform platform) {
     case HostArtifact.webPlatformKernelFolder:
       return 'kernel';
     case HostArtifact.webPlatformDDCKernelDill:
-      return 'ddc_outline_sound.dill';
+      return 'ddc_outline.dill';
     case HostArtifact.webPlatformDart2JSKernelDill:
       return 'dart2js_platform.dill';
     case HostArtifact.flutterWebLibrariesJson:

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -124,15 +124,10 @@ class FlutterDevice {
       final List<String> extraFrontEndOptions = List<String>.of(buildInfo.extraFrontEndOptions);
       switch (buildInfo.nullSafetyMode) {
         case NullSafetyMode.unsound:
-          platformDillName = 'ddc_outline.dill';
-          if (!extraFrontEndOptions.contains('--no-sound-null-safety')) {
-            extraFrontEndOptions.add('--no-sound-null-safety');
-          }
+          // TODO(matanlurey): Should be unreachable, remove as part of https://github.com/flutter/flutter/issues/162846.
+          throw UnsupportedError('Unsound null safety mode is not supported');
         case NullSafetyMode.sound:
-          platformDillName = 'ddc_outline_sound.dill';
-          if (!extraFrontEndOptions.contains('--sound-null-safety')) {
-            extraFrontEndOptions.add('--sound-null-safety');
-          }
+          platformDillName = 'ddc_outline.dill';
         case NullSafetyMode.autodetect:
           throw StateError(
             'Expected buildInfo.nullSafetyMode to be one of unsound or sound, '

--- a/packages/flutter_tools/lib/src/test/web_test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/web_test_compiler.dart
@@ -126,16 +126,11 @@ class WebTestCompiler {
     final List<String> extraFrontEndOptions = List<String>.of(buildInfo.extraFrontEndOptions);
     switch (buildInfo.nullSafetyMode) {
       case NullSafetyMode.unsound || NullSafetyMode.autodetect:
-        platformDillName = 'ddc_outline.dill';
-        if (!extraFrontEndOptions.contains('--no-sound-null-safety')) {
-          extraFrontEndOptions.add('--no-sound-null-safety');
-        }
+        // TODO(matanlurey): Should be unreachable, remove as part of https://github.com/flutter/flutter/issues/162846.
+        throw UnsupportedError('Unsound null safety mode is not supported');
       case NullSafetyMode.sound:
         languageVersion = currentLanguageVersion(_fileSystem, Cache.flutterRoot!);
-        platformDillName = 'ddc_outline_sound.dill';
-        if (!extraFrontEndOptions.contains('--sound-null-safety')) {
-          extraFrontEndOptions.add('--sound-null-safety');
-        }
+        platformDillName = 'ddc_outline.dill';
     }
 
     final String platformDillPath = _fileSystem.path.join(

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -266,8 +266,7 @@ const Map<WebRendererMode, HostArtifact> kAmdDartSdkJsMapArtifactMap =
     };
 
 /// The correct precompiled artifact to use for each build and render mode for
-/// DDC with DDC library bundle module format. Only artifacts with sound
-/// null-safety are provided.
+/// DDC with DDC library bundle module format.
 const Map<WebRendererMode, HostArtifact> kDdcLibraryBundleDartSdkJsArtifactMap =
     <WebRendererMode, HostArtifact>{
       WebRendererMode.auto: HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdk,
@@ -276,8 +275,7 @@ const Map<WebRendererMode, HostArtifact> kDdcLibraryBundleDartSdkJsArtifactMap =
     };
 
 /// The correct source map artifact to use for each build and render mode for
-/// DDC with DDC library bundle module format. Only artifacts with sound
-/// null-safety are provided.
+/// DDC with DDC library bundle module format.
 const Map<WebRendererMode, HostArtifact> kDdcLibraryBundleDartSdkJsMapArtifactMap =
     <WebRendererMode, HostArtifact>{
       WebRendererMode.auto:

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -251,18 +251,18 @@ enum WebRendererMode {
 /// The correct precompiled artifact to use for each build and render mode for DDC with AMD modules.
 // TODO(markzipan): delete this when DDC's AMD module system is deprecated, https://github.com/flutter/flutter/issues/142060.
 const Map<WebRendererMode, HostArtifact> kAmdDartSdkJsArtifactMap = <WebRendererMode, HostArtifact>{
-  WebRendererMode.auto: HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdk,
-  WebRendererMode.canvaskit: HostArtifact.webPrecompiledAmdCanvaskitSoundSdk,
-  WebRendererMode.html: HostArtifact.webPrecompiledAmdSoundSdk,
+  WebRendererMode.auto: HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSdk,
+  WebRendererMode.canvaskit: HostArtifact.webPrecompiledAmdCanvaskitSdk,
+  WebRendererMode.html: HostArtifact.webPrecompiledAmdSdk,
 };
 
 /// The correct source map artifact to use for each build and render mode for DDC with AMD modules.
 // TODO(markzipan): delete this when DDC's AMD module system is deprecated, https://github.com/flutter/flutter/issues/142060.
 const Map<WebRendererMode, HostArtifact> kAmdDartSdkJsMapArtifactMap =
     <WebRendererMode, HostArtifact>{
-      WebRendererMode.auto: HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdkSourcemaps,
-      WebRendererMode.canvaskit: HostArtifact.webPrecompiledAmdCanvaskitSoundSdkSourcemaps,
-      WebRendererMode.html: HostArtifact.webPrecompiledAmdSoundSdkSourcemaps,
+      WebRendererMode.auto: HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSdkSourcemaps,
+      WebRendererMode.canvaskit: HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps,
+      WebRendererMode.html: HostArtifact.webPrecompiledAmdSdkSourcemaps,
     };
 
 /// The correct precompiled artifact to use for each build and render mode for
@@ -270,9 +270,9 @@ const Map<WebRendererMode, HostArtifact> kAmdDartSdkJsMapArtifactMap =
 /// null-safety are provided.
 const Map<WebRendererMode, HostArtifact> kDdcLibraryBundleDartSdkJsArtifactMap =
     <WebRendererMode, HostArtifact>{
-      WebRendererMode.auto: HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdk,
-      WebRendererMode.canvaskit: HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk,
-      WebRendererMode.html: HostArtifact.webPrecompiledDdcLibraryBundleSoundSdk,
+      WebRendererMode.auto: HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdk,
+      WebRendererMode.canvaskit: HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk,
+      WebRendererMode.html: HostArtifact.webPrecompiledDdcLibraryBundleSdk,
     };
 
 /// The correct source map artifact to use for each build and render mode for
@@ -281,10 +281,9 @@ const Map<WebRendererMode, HostArtifact> kDdcLibraryBundleDartSdkJsArtifactMap =
 const Map<WebRendererMode, HostArtifact> kDdcLibraryBundleDartSdkJsMapArtifactMap =
     <WebRendererMode, HostArtifact>{
       WebRendererMode.auto:
-          HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdkSourcemaps,
-      WebRendererMode.canvaskit:
-          HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdkSourcemaps,
-      WebRendererMode.html: HostArtifact.webPrecompiledDdcLibraryBundleSoundSdkSourcemaps,
+          HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdkSourcemaps,
+      WebRendererMode.canvaskit: HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps,
+      WebRendererMode.html: HostArtifact.webPrecompiledDdcLibraryBundleSdkSourcemaps,
     };
 
 String _buildEventAnalyticsSettings({required List<WebCompilerConfig> configs}) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/flutter_web_platform_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/flutter_web_platform_test.dart
@@ -53,15 +53,12 @@ void main() {
     tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_web_platform_test.');
 
     for (final HostArtifact artifact in <HostArtifact>[
-      HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSoundSdk,
       HostArtifact.webPrecompiledAmdCanvaskitAndHtmlSdk,
-      HostArtifact.webPrecompiledAmdCanvaskitSoundSdk,
       HostArtifact.webPrecompiledAmdCanvaskitSdk,
-      HostArtifact.webPrecompiledAmdSoundSdk,
       HostArtifact.webPrecompiledAmdSdk,
-      HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSoundSdk,
-      HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk,
-      HostArtifact.webPrecompiledDdcLibraryBundleSoundSdk,
+      HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitAndHtmlSdk,
+      HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk,
+      HostArtifact.webPrecompiledDdcLibraryBundleSdk,
     ]) {
       final File artifactFile = artifacts.getHostArtifact(artifact) as File;
       artifactFile.createSync();
@@ -109,7 +106,7 @@ void main() {
         shelf.Request('GET', Uri.parse('http://localhost/dart_sdk.js')),
       );
       final String contents = await response.readAsString();
-      expect(contents, HostArtifact.webPrecompiledAmdCanvaskitSoundSdk.name);
+      expect(contents, HostArtifact.webPrecompiledAmdCanvaskitSdk.name);
       await webPlatform.close();
     },
     overrides: <Type, Generator>{
@@ -161,7 +158,7 @@ void main() {
         shelf.Request('GET', Uri.parse('http://localhost/dart_sdk.js')),
       );
       final String contents = await response.readAsString();
-      expect(contents, HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk.name);
+      expect(contents, HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk.name);
       await webPlatform.close();
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -238,19 +238,19 @@ void main() {
     testWithoutContext('Precompiled web AMD module system artifact paths are correct', () {
       expect(
         artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdSdk).path,
-        'root/bin/cache/flutter_web_sdk/kernel/amd-sound/dart_sdk.js',
+        'root/bin/cache/flutter_web_sdk/kernel/amd/dart_sdk.js',
       );
       expect(
         artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdSdkSourcemaps).path,
-        'root/bin/cache/flutter_web_sdk/kernel/amd-sound/dart_sdk.js.map',
+        'root/bin/cache/flutter_web_sdk/kernel/amd/dart_sdk.js.map',
       );
       expect(
         artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdk).path,
-        'root/bin/cache/flutter_web_sdk/kernel/amd-canvaskit-sound/dart_sdk.js',
+        'root/bin/cache/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js',
       );
       expect(
         artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps).path,
-        'root/bin/cache/flutter_web_sdk/kernel/amd-canvaskit-sound/dart_sdk.js.map',
+        'root/bin/cache/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js.map',
       );
     });
 
@@ -259,21 +259,21 @@ void main() {
       () {
         expect(
           artifacts.getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSdk).path,
-          'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-sound/dart_sdk.js',
+          'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle/dart_sdk.js',
         );
         expect(
           artifacts.getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSdkSourcemaps).path,
-          'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-sound/dart_sdk.js.map',
+          'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle/dart_sdk.js.map',
         );
         expect(
           artifacts.getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk).path,
-          'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-canvaskit-sound/dart_sdk.js',
+          'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-canvaskit/dart_sdk.js',
         );
         expect(
           artifacts
               .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps)
               .path,
-          'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-canvaskit-sound/dart_sdk.js.map',
+          'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-canvaskit/dart_sdk.js.map',
         );
       },
     );

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -238,34 +238,18 @@ void main() {
     testWithoutContext('Precompiled web AMD module system artifact paths are correct', () {
       expect(
         artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdSdk).path,
-        'root/bin/cache/flutter_web_sdk/kernel/amd/dart_sdk.js',
-      );
-      expect(
-        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdSdkSourcemaps).path,
-        'root/bin/cache/flutter_web_sdk/kernel/amd/dart_sdk.js.map',
-      );
-      expect(
-        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdk).path,
-        'root/bin/cache/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js',
-      );
-      expect(
-        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps).path,
-        'root/bin/cache/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js.map',
-      );
-      expect(
-        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdSoundSdk).path,
         'root/bin/cache/flutter_web_sdk/kernel/amd-sound/dart_sdk.js',
       );
       expect(
-        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdSoundSdkSourcemaps).path,
+        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdSdkSourcemaps).path,
         'root/bin/cache/flutter_web_sdk/kernel/amd-sound/dart_sdk.js.map',
       );
       expect(
-        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSoundSdk).path,
+        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdk).path,
         'root/bin/cache/flutter_web_sdk/kernel/amd-canvaskit-sound/dart_sdk.js',
       );
       expect(
-        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSoundSdkSourcemaps).path,
+        artifacts.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps).path,
         'root/bin/cache/flutter_web_sdk/kernel/amd-canvaskit-sound/dart_sdk.js.map',
       );
     });
@@ -274,26 +258,20 @@ void main() {
       'Precompiled web DDC library bundle module system artifact paths are correct',
       () {
         expect(
-          artifacts.getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSoundSdk).path,
+          artifacts.getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSdk).path,
           'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-sound/dart_sdk.js',
         );
         expect(
-          artifacts
-              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSoundSdkSourcemaps)
-              .path,
+          artifacts.getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSdkSourcemaps).path,
           'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-sound/dart_sdk.js.map',
         );
         expect(
-          artifacts
-              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk)
-              .path,
+          artifacts.getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk).path,
           'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-canvaskit-sound/dart_sdk.js',
         );
         expect(
           artifacts
-              .getHostArtifact(
-                HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdkSourcemaps,
-              )
+              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps)
               .path,
           'root/bin/cache/flutter_web_sdk/kernel/ddcLibraryBundle-canvaskit-sound/dart_sdk.js.map',
         );

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1785,7 +1785,6 @@ flutter:
                   BuildMode.debug,
                   '',
                   treeShakeIcons: false,
-                  nullSafetyMode: NullSafetyMode.unsound,
                   packageConfigPath: '.dart_tool/package_config.json',
                 ),
                 target: null,
@@ -1795,7 +1794,7 @@ flutter:
 
       expect(
         residentCompiler!.initializeFromDill,
-        globals.fs.path.join(getBuildDirectory(), 'fbbe6a61fb7a1de317d381f8df4814e5.cache.dill'),
+        globals.fs.path.join(getBuildDirectory(), 'cache.dill'),
       );
       expect(
         residentCompiler.librariesSpec,
@@ -1844,7 +1843,7 @@ flutter:
 
       expect(
         residentCompiler!.initializeFromDill,
-        globals.fs.path.join(getBuildDirectory(), '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'),
+        globals.fs.path.join(getBuildDirectory(), 'cache.dill'),
       );
       expect(
         residentCompiler.librariesSpec,
@@ -1860,7 +1859,7 @@ flutter:
       );
       expect(
         residentCompiler.platformDill,
-        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill',
+        'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill',
       );
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/test/web_test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/web_test_compiler_test.dart
@@ -34,7 +34,7 @@ void main() {
       platform: platform,
     );
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      FakeCommand(
+      const FakeCommand(
         command: <Pattern>[
           'Artifact.engineDartAotRuntime.TargetPlatform.web_javascript',
           'Artifact.frontendServerSnapshotForEngineDartSdk.TargetPlatform.web_javascript',
@@ -59,11 +59,10 @@ void main() {
           '--filesystem-scheme',
           'org-dartlang-app',
           '--initialize-from-dill',
-          RegExp(r'^build\/(?:[a-z0-9]{32})\.cache\.dill$'),
+          'build/cache.dill',
           '--platform',
-          'file:///HostArtifact.webPlatformKernelFolder/ddc_outline_sound.dill',
+          'file:///HostArtifact.webPlatformKernelFolder/ddc_outline.dill',
           '--verbosity=error',
-          '--sound-null-safety',
         ],
         stdout: 'result abc\nline0\nline1\nabc\nabc build/out 0',
       ),

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_ddc_modules_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_ddc_modules_test.dart
@@ -823,22 +823,18 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync('GENERATED');
       final String webPrecompiledSdk =
-          globals.artifacts!
-              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSoundSdk)
-              .path;
+          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSdk).path;
       final String webPrecompiledSdkSourcemaps =
           globals.artifacts!
-              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSoundSdkSourcemaps)
+              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleSdkSourcemaps)
               .path;
       final String webPrecompiledCanvaskitSdk =
           globals.artifacts!
-              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdk)
+              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdk)
               .path;
       final String webPrecompiledCanvaskitSdkSourcemaps =
           globals.artifacts!
-              .getHostArtifact(
-                HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSoundSdkSourcemaps,
-              )
+              .getHostArtifact(HostArtifact.webPrecompiledDdcLibraryBundleCanvaskitSdkSourcemaps)
               .path;
       globals.fs.file(webPrecompiledSdk)
         ..createSync(recursive: true)

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -941,17 +941,9 @@ void main() {
       final Uri uri = await webDevFS.create();
       webDevFS.webAssetServer.entrypointCacheDirectory = globals.fs.currentDirectory;
       final String webPrecompiledSdk =
-          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdSoundSdk).path;
+          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdSdk).path;
       final String webPrecompiledSdkSourcemaps =
-          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdSoundSdkSourcemaps).path;
-      final String webPrecompiledCanvaskitSdk =
-          globals.artifacts!
-              .getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps)
-              .path;
-      final String webPrecompiledCanvaskitSdkSourcemaps =
-          globals.artifacts!
-              .getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps)
-              .path;
+          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdSdkSourcemaps).path;
       globals.fs.currentDirectory.childDirectory('lib').childFile('web_entrypoint.dart')
         ..createSync(recursive: true)
         ..writeAsStringSync('GENERATED');
@@ -961,12 +953,6 @@ void main() {
       globals.fs.file(webPrecompiledSdkSourcemaps)
         ..createSync(recursive: true)
         ..writeAsStringSync('THERE');
-      globals.fs.file(webPrecompiledCanvaskitSdk)
-        ..createSync(recursive: true)
-        ..writeAsStringSync('OL');
-      globals.fs.file(webPrecompiledCanvaskitSdkSourcemaps)
-        ..createSync(recursive: true)
-        ..writeAsStringSync('CHUM');
 
       await webDevFS.update(
         mainUri: globals.fs.file(globals.fs.path.join('lib', 'main.dart')).uri,
@@ -1065,14 +1051,14 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync('GENERATED');
       final String webPrecompiledSdk =
-          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdSoundSdk).path;
+          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdSdk).path;
       final String webPrecompiledSdkSourcemaps =
-          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdSoundSdkSourcemaps).path;
+          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdSdkSourcemaps).path;
       final String webPrecompiledCanvaskitSdk =
-          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSoundSdk).path;
+          globals.artifacts!.getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdk).path;
       final String webPrecompiledCanvaskitSdkSourcemaps =
           globals.artifacts!
-              .getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSoundSdkSourcemaps)
+              .getHostArtifact(HostArtifact.webPrecompiledAmdCanvaskitSdkSourcemaps)
               .path;
       final String flutterJs = globals.fs.path.join(
         globals.artifacts!.getHostArtifact(HostArtifact.flutterJsDirectory).path,


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/162846.

Removes all of the unsound host artifacts, and then uses their name for the sound artifacts.

That is, for something like `webPlatformDDCKernelDill`, this PR:

- Changes the web GN builders to only emit the sound SDK, without the `-sound` suffixes
- Deletes `webPlatformDDCKernelDill` and all usages of it (implicitly unsound, and unused).
- Renames `webPlatformDDCKernelSoundDill` to `webPlatformDDCKernelDill`.

No user impact expected, as there was no way to use the unsound artifacts from the Flutter tool.

