### PR TITLE
Re-land #162644: Remove `--verbose` from devicelab task executions.

### DIFF
--- a/dev/devicelab/bin/tasks/android_obfuscate_test.dart
+++ b/dev/devicelab/bin/tasks/android_obfuscate_test.dart
@@ -22,7 +22,6 @@ Future<void> main() async {
               '--target-platform=android-arm',
               '--obfuscate',
               '--split-debug-info=foo/',
-              '--verbose',
             ],
           );
         });
@@ -67,7 +66,6 @@ Future<void> main() async {
               '--split-debug-info=foo/',
               '--no-debug',
               '--no-profile',
-              '--verbose',
             ],
           );
         });

--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -93,7 +93,7 @@ Future<void> main() async {
       section('Build release AAR');
 
       await inDirectory(projectDir, () async {
-        await flutter('build', options: <String>['aar', '--verbose']);
+        await flutter('build', options: <String>['aar']);
       });
 
       final String repoPath = path.join(projectDir.path, 'build', 'host', 'outputs', 'repo');

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -85,7 +85,6 @@ Future<void> _testBuildIosFramework(Directory projectDir, {bool isModule = false
       'build',
       options: <String>[
         'ios-framework',
-        '--verbose',
         '--output=$outputDirectoryName',
         '--obfuscate',
         '--split-debug-info=symbols',
@@ -470,7 +469,6 @@ Future<void> _testBuildMacOSFramework(Directory projectDir) async {
       'build',
       options: <String>[
         'macos-framework',
-        '--verbose',
         '--output=$outputDirectoryName',
         '--obfuscate',
         '--split-debug-info=symbols',

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -44,7 +44,7 @@ class NewGalleryChromeRunTest {
 
         await flutter('build', options: <String>['web', '-v', '--release', '--no-pub']);
 
-        final List<String> options = <String>['-d', 'chrome', '--verbose', '--resident'];
+        final List<String> options = <String>['-d', 'chrome', '--resident'];
         final Process process = await startFlutter('run', options: options);
 
         final Completer<void> stdoutDone = Completer<void>();

--- a/dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart
@@ -81,10 +81,7 @@ Future<void> main() async {
         section('Build app bundle using the flutter tool - flavor: flavor_underscore');
 
         int exitCode = await inDirectory(project.rootPath, () {
-          return flutter(
-            'build',
-            options: <String>['appbundle', '--flavor=flavor_underscore', '--verbose'],
-          );
+          return flutter('build', options: <String>['appbundle', '--flavor=flavor_underscore']);
         });
 
         if (exitCode != 0) {
@@ -114,10 +111,7 @@ Future<void> main() async {
         section('Build app bundle using the flutter tool - flavor: production');
 
         exitCode = await inDirectory(project.rootPath, () {
-          return flutter(
-            'build',
-            options: <String>['appbundle', '--flavor=production', '--verbose'],
-          );
+          return flutter('build', options: <String>['appbundle', '--flavor=production']);
         });
 
         if (exitCode != 0) {

--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -16,7 +16,7 @@ Future<void> main() async {
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleDebug without explicit target platform');
         await inDirectory(pluginProject.exampleAndroidPath, () {
-          return flutter('build', options: <String>['apk', '--debug', '--verbose']);
+          return flutter('build', options: <String>['apk', '--debug']);
         });
 
         Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
@@ -42,7 +42,7 @@ Future<void> main() async {
         section('APK content for task assembleRelease without explicit target platform');
 
         await inDirectory(pluginProject.exampleAndroidPath, () {
-          return flutter('build', options: <String>['apk', '--release', '--verbose']);
+          return flutter('build', options: <String>['apk', '--release']);
         });
 
         apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
@@ -67,12 +67,7 @@ Future<void> main() async {
         await inDirectory(pluginProject.exampleAndroidPath, () {
           return flutter(
             'build',
-            options: <String>[
-              'apk',
-              '--release',
-              '--verbose',
-              '--target-platform=android-arm,android-arm64',
-            ],
+            options: <String>['apk', '--release', '--target-platform=android-arm,android-arm64'],
           );
         });
 
@@ -100,7 +95,6 @@ Future<void> main() async {
             options: <String>[
               'apk',
               '--release',
-              '--verbose',
               '--split-per-abi',
               '--target-platform=android-arm,android-arm64',
             ],
@@ -136,7 +130,7 @@ Future<void> main() async {
         section('gradlew assembleRelease');
 
         await inDirectory(project.rootPath, () {
-          return flutter('build', options: <String>['apk', '--release', '--verbose']);
+          return flutter('build', options: <String>['apk', '--release']);
         });
 
         // When the platform-target isn't specified, we generate the snapshots

--- a/dev/devicelab/bin/tasks/hello_world__memory.dart
+++ b/dev/devicelab/bin/tasks/hello_world__memory.dart
@@ -21,7 +21,7 @@ class HelloWorldMemoryTest extends MemoryTest {
     print('launching $project$test on device...');
     await flutter(
       'run',
-      options: <String>['--verbose', '--release', '--no-resident', '-d', device!.deviceId, test],
+      options: <String>['--release', '--no-resident', '-d', device!.deviceId, test],
     );
     await Future<void>.delayed(const Duration(milliseconds: 1500));
     await recordStart();

--- a/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
@@ -35,7 +35,7 @@ Future<void> main() async {
       await inDirectory(projectDir, () async {
         final String buildOutput = await evalFlutter(
           'build',
-          options: <String>['ios', '--no-codesign', '--release'],
+          options: <String>['ios', '--no-codesign', '--release', '--verbose'],
         );
         if (!buildOutput.contains('-destination generic/platform=watchOS')) {
           print(buildOutput);

--- a/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
@@ -35,7 +35,7 @@ Future<void> main() async {
       await inDirectory(projectDir, () async {
         final String buildOutput = await evalFlutter(
           'build',
-          options: <String>['ios', '--no-codesign', '--release', '--verbose'],
+          options: <String>['ios', '--no-codesign', '--release'],
         );
         if (!buildOutput.contains('-destination generic/platform=watchOS')) {
           print(buildOutput);

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -85,7 +85,7 @@ dependencies:
       section('Build ephemeral host app in release mode without CocoaPods');
 
       await inDirectory(projectDir, () async {
-        await flutter('build', options: <String>['ios', '--no-codesign', '--verbose']);
+        await flutter('build', options: <String>['ios', '--no-codesign']);
       });
 
       // Check the tool is no longer copying to the legacy xcframework location.
@@ -606,7 +606,7 @@ end
       );
 
       if (!xcodebuildOutput.contains(
-            'flutter --verbose --local-engine-src-path=bogus assemble',
+            RegExp('flutter.*--local-engine-src-path=bogus assemble'),
           ) || // Verbose output
           !xcodebuildOutput.contains(
             'Unable to detect a Flutter engine build directory in bogus',

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -280,7 +280,7 @@ public class DummyPluginAClass {
         section('Build plugin A example iOS app');
 
         await inDirectory(exampleApp, () async {
-          await evalFlutter('build', options: <String>['ios', '--no-codesign', '--verbose']);
+          await evalFlutter('build', options: <String>['ios', '--no-codesign']);
         });
 
         final Directory appBundle = Directory(

--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -37,13 +37,7 @@ Future<void> main() async {
           'integration_test.podspec',
         );
 
-        await exec('pod', <String>[
-          'lib',
-          'lint',
-          iosintegrationTestPodspec,
-          '--use-libraries',
-          '--verbose',
-        ]);
+        await exec('pod', <String>['lib', 'lint', iosintegrationTestPodspec, '--use-libraries']);
 
         final String macosintegrationTestPodspec = path.join(
           integrationTestPackage,
@@ -51,7 +45,7 @@ Future<void> main() async {
           'macos',
           'integration_test_macos.podspec',
         );
-        await _tryMacOSLint(macosintegrationTestPodspec, <String>['--verbose']);
+        await _tryMacOSLint(macosintegrationTestPodspec, <String>[]);
       });
 
       section('Create Objective-C plugin');
@@ -76,13 +70,7 @@ Future<void> main() async {
       final String objcPluginPath = path.join(tempDir.path, objcPluginName);
       final String objcPodspecPath = path.join(objcPluginPath, 'ios', '$objcPluginName.podspec');
       await inDirectory(tempDir, () async {
-        await exec('pod', <String>[
-          'lib',
-          'lint',
-          objcPodspecPath,
-          '--allow-warnings',
-          '--verbose',
-        ]);
+        await exec('pod', <String>['lib', 'lint', objcPodspecPath, '--allow-warnings']);
       });
 
       section('Lint Objective-C iOS podspec plugin as library');
@@ -94,7 +82,6 @@ Future<void> main() async {
           objcPodspecPath,
           '--allow-warnings',
           '--use-libraries',
-          '--verbose',
         ]);
       });
 
@@ -120,13 +107,7 @@ Future<void> main() async {
       final String swiftPluginPath = path.join(tempDir.path, swiftPluginName);
       final String swiftPodspecPath = path.join(swiftPluginPath, 'ios', '$swiftPluginName.podspec');
       await inDirectory(tempDir, () async {
-        await exec('pod', <String>[
-          'lib',
-          'lint',
-          swiftPodspecPath,
-          '--allow-warnings',
-          '--verbose',
-        ]);
+        await exec('pod', <String>['lib', 'lint', swiftPodspecPath, '--allow-warnings']);
       });
 
       section('Lint Swift iOS podspec plugin as library');
@@ -138,7 +119,6 @@ Future<void> main() async {
           swiftPodspecPath,
           '--allow-warnings',
           '--use-libraries',
-          '--verbose',
         ]);
       });
 
@@ -150,17 +130,13 @@ Future<void> main() async {
         '$swiftPluginName.podspec',
       );
       await inDirectory(tempDir, () async {
-        await _tryMacOSLint(macOSPodspecPath, <String>['--allow-warnings', '--verbose']);
+        await _tryMacOSLint(macOSPodspecPath, <String>['--allow-warnings']);
       });
 
       section('Lint Swift macOS podspec plugin as library');
 
       await inDirectory(tempDir, () async {
-        await _tryMacOSLint(macOSPodspecPath, <String>[
-          '--allow-warnings',
-          '--use-libraries',
-          '--verbose',
-        ]);
+        await _tryMacOSLint(macOSPodspecPath, <String>['--allow-warnings', '--use-libraries']);
       });
 
       section('Create Objective-C application');

--- a/dev/devicelab/bin/tasks/route_test_ios.dart
+++ b/dev/devicelab/bin/tasks/route_test_ios.dart
@@ -20,14 +20,7 @@ void main() {
     await inDirectory(appDir, () async {
       return flutter(
         'drive',
-        options: <String>[
-          '--verbose',
-          '-d',
-          device.deviceId,
-          '--route',
-          '/smuggle-it',
-          'lib/route.dart',
-        ],
+        options: <String>['-d', device.deviceId, '--route', '/smuggle-it', 'lib/route.dart'],
       );
     });
     return TaskResult.success(null);

--- a/dev/devicelab/bin/tasks/routing_test.dart
+++ b/dev/devicelab/bin/tasks/routing_test.dart
@@ -23,14 +23,7 @@ void main() {
     await inDirectory(appDir, () async {
       return flutter(
         'drive',
-        options: <String>[
-          '--verbose',
-          '-d',
-          device.deviceId,
-          '--route',
-          '/smuggle-it',
-          'lib/route.dart',
-        ],
+        options: <String>['-d', device.deviceId, '--route', '/smuggle-it', 'lib/route.dart'],
       );
     });
     section('TEST WHETHER `flutter run --route` WORKS');
@@ -42,7 +35,6 @@ void main() {
         'run',
         // --fast-start does not support routes.
         options: <String>[
-          '--verbose',
           '--disable-service-auth-codes',
           '--no-fast-start',
           '--no-publish-port',

--- a/dev/devicelab/bin/tasks/service_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/service_extensions_test.dart
@@ -28,7 +28,6 @@ void main() {
       final Process run = await startFlutter(
         'run',
         options: <String>[
-          '--verbose',
           '--no-fast-start',
           '--no-publish-port',
           '--disable-service-auth-codes',


### PR DESCRIPTION
Re-lands https://github.com/flutter/flutter/pull/162644.

Reverts 7569fbfce500f3859902984144855cb249de24ed, with the change to `ios_app_with_extensions_test.dart` omitted, which is intentional (`--verbose` is load-bearing and used to check for a particular message).