### PR TITLE
[Impeller] In Paint::CreateContents, do not set a color source size if the size is empty

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -832,15 +832,15 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
   contents->SetAlpha(paint.color.alpha);
   contents->SetGeometry(vertices);
   contents->SetLazyTextureCoverage(src_coverage);
-  contents->SetLazyTexture(
-      [src_contents, src_coverage](const ContentContext& renderer) {
-        // Applying the src coverage as the coverage limit prevents the 1px
-        // coverage pad from adding a border that is picked up by developer
-        // specified UVs.
-        return src_contents
-            ->RenderToSnapshot(renderer, {}, Rect::Round(src_coverage))
-            ->texture;
-      });
+  contents->SetLazyTexture([src_contents,
+                            src_coverage](const ContentContext& renderer) {
+    // Applying the src coverage as the coverage limit prevents the 1px
+    // coverage pad from adding a border that is picked up by developer
+    // specified UVs.
+    auto snapshot =
+        src_contents->RenderToSnapshot(renderer, {}, Rect::Round(src_coverage));
+    return snapshot.has_value() ? snapshot->texture : nullptr;
+  });
   entity.SetContents(paint.WithFilters(std::move(contents)));
   AddRenderEntityToCurrentPass(entity);
 }

--- a/engine/src/flutter/impeller/display_list/canvas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/canvas_unittests.cc
@@ -13,6 +13,7 @@
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/display_list/aiks_unittests.h"
 #include "impeller/display_list/canvas.h"
+#include "impeller/display_list/dl_vertices_geometry.h"
 #include "impeller/geometry/geometry_asserts.h"
 #include "impeller/renderer/render_target.h"
 
@@ -276,6 +277,49 @@ TEST_P(AiksTest, BackdropCountDownWithNestedSaveLayers) {
 
   canvas->Restore();
   EXPECT_TRUE(canvas->RequiresReadback());
+}
+
+TEST_P(AiksTest, DrawVerticesLinearGradientWithEmptySize) {
+  RenderCallback callback = [&](RenderTarget& render_target) {
+    ContentContext context(GetContext(), nullptr);
+    Canvas canvas(context, render_target, true, false);
+
+    std::vector<flutter::DlPoint> vertex_coordinates = {
+        flutter::DlPoint(0, 0),
+        flutter::DlPoint(600, 0),
+        flutter::DlPoint(0, 600),
+    };
+    std::vector<flutter::DlPoint> texture_coordinates = {
+        flutter::DlPoint(0, 0),
+        flutter::DlPoint(500, 0),
+        flutter::DlPoint(0, 500),
+    };
+    std::vector<uint16_t> indices = {0, 1, 2};
+    flutter::DlVertices::Builder vertices_builder(
+        flutter::DlVertexMode::kTriangleStrip, vertex_coordinates.size(),
+        flutter::DlVertices::Builder::kHasTextureCoordinates, indices.size());
+    vertices_builder.store_vertices(vertex_coordinates.data());
+    vertices_builder.store_indices(indices.data());
+    vertices_builder.store_texture_coordinates(texture_coordinates.data());
+    auto vertices = vertices_builder.build();
+
+    std::vector<flutter::DlColor> colors = {flutter::DlColor::kBlue(),
+                                            flutter::DlColor::kRed()};
+    std::vector<Scalar> stops = {0.0, 1.0};
+    auto gradient = flutter::DlColorSource::MakeLinear(
+        {0, 0}, {0, 600}, 2, colors.data(), stops.data(),
+        flutter::DlTileMode::kClamp);
+
+    Paint paint;
+    paint.color_source = gradient.get();
+    canvas.DrawVertices(std::make_shared<DlVerticesGeometry>(vertices, context),
+                        BlendMode::kSourceOver, paint);
+
+    canvas.EndReplay();
+    return true;
+  };
+
+  Playground::OpenPlaygroundHere(callback);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/canvas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/canvas_unittests.cc
@@ -319,7 +319,7 @@ TEST_P(AiksTest, DrawVerticesLinearGradientWithEmptySize) {
     return true;
   };
 
-  Playground::OpenPlaygroundHere(callback);
+  ASSERT_TRUE(Playground::OpenPlaygroundHere(callback));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/paint.cc
+++ b/engine/src/flutter/impeller/display_list/paint.cc
@@ -65,7 +65,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
 
       std::array<Point, 2> bounds{start_point, end_point};
       auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-      if (intrinsic_size.has_value()) {
+      if (intrinsic_size.has_value() && !intrinsic_size->IsEmpty()) {
         contents->SetColorSourceSize(intrinsic_size->GetSize());
       }
       return contents;
@@ -95,7 +95,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
       auto radius_pt = Point(radius, radius);
       std::array<Point, 2> bounds{center + radius_pt, center - radius_pt};
       auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-      if (intrinsic_size.has_value()) {
+      if (intrinsic_size.has_value() && !intrinsic_size->IsEmpty()) {
         contents->SetColorSourceSize(intrinsic_size->GetSize());
       }
       return contents;
@@ -129,7 +129,7 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
       auto radius_pt = Point(radius, radius);
       std::array<Point, 2> bounds{center + radius_pt, center - radius_pt};
       auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-      if (intrinsic_size.has_value()) {
+      if (intrinsic_size.has_value() && !intrinsic_size->IsEmpty()) {
         contents->SetColorSourceSize(intrinsic_size->GetSize());
       }
       return contents;


### PR DESCRIPTION
The Canvas::DrawVertices lazy texture function will be unable to create a snapshot based on an empty color source size.

See https://github.com/flutter/flutter/issues/162969