### PR TITLE
[android] speculative fix for hcpp crashes.

### DIFF
--- a/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
@@ -15,6 +15,7 @@
 #include "flutter/shell/gpu/gpu_surface_vulkan_impeller.h"
 #include "flutter/vulkan/vulkan_native_surface_android.h"
 #include "impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h"
+#include "impeller/toolkit/android/surface_transaction.h"
 
 namespace flutter {
 
@@ -96,6 +97,9 @@ bool AndroidSurfaceVKImpeller::SetNativeWindow(
 
   impeller::CreateTransactionCB cb = [jni_facade]() {
     ASurfaceTransaction* tx = jni_facade->createTransaction();
+    if (tx == nullptr) {
+      return impeller::android::SurfaceTransaction();
+    }
     return impeller::android::SurfaceTransaction(tx);
   };
 


### PR DESCRIPTION
The crash indicates that FlutterJNI is returning a nullptr SurfaceControl.Transaction. That likely indicates that we're trying to rasterize a frame before the platform view controller is setup. Potentially a startup race?

At any rate, if the PVC is null that means there is no platform views - so it should be safe to create a tx on the fly. Interestingly I cannot repro this locally even on the same device.

```
[2025-02-11 21:50:37.462356] [STDOUT] stdout: [ +173 ms] *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
[2025-02-11 21:50:37.462539] [STDOUT] stdout: [        ] Build fingerprint: 'google/cheetah/cheetah:13/TQ3A.230901.001/10750268:user/release-keys'
[2025-02-11 21:50:37.462564] [STDOUT] stdout: [        ] Revision: 'MP1.0'
[2025-02-11 21:50:37.463914] [STDOUT] stdout: [   +1 ms] ABI: 'arm64'
[2025-02-11 21:50:37.463946] [STDOUT] stdout: [        ] Timestamp: 2025-02-11 21:57:42.183302140-0800
[2025-02-11 21:50:37.463959] [STDOUT] stdout: [        ] Process uptime: 3s
[2025-02-11 21:50:37.464054] [STDOUT] stdout: [        ] Cmdline: dev.benchmarks.platform_views_layout
[2025-02-11 21:50:37.464174] [STDOUT] stdout: [        ] pid: 15185, tid: 15246, name: 1.raster  >>> dev.benchmarks.platform_views_layout <<<
[2025-02-11 21:50:37.464354] [STDOUT] stdout: [        ] uid: 10250
[2025-02-11 21:50:37.464398] [STDOUT] stdout: [        ] tagged_addr_ctrl: 0000000000000001 (PR_TAGGED_ADDR_ENABLE)
[2025-02-11 21:50:37.464440] [STDOUT] stdout: [        ] signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000000000000
[2025-02-11 21:50:37.464602] [STDOUT] stdout: [        ] Cause: null pointer dereference
[2025-02-11 21:50:37.464651] [STDOUT] stdout: [        ]     x0  b400007b82ff2e70  x1  000000000000002d  x2  b400007c3309f370  x3  0000007abbcc6a23
[2025-02-11 21:50:37.464745] [STDOUT] stdout: [        ]     x4  0000007a30d286b0  x5  0000007a4f6dd47b  x6  0000000000000000  x7  61686b4b11ff3a78
[2025-02-11 21:50:37.464831] [STDOUT] stdout: [        ]     x8  0000000000000000  x9  1417c2bd490e1f78  x10 0000000000000010  x11 000000000000009c
[2025-02-11 21:50:37.464933] [STDOUT] stdout: [        ]     x12 0000000000000adb  x13 b400007ba2fe9510  x14 0000000000000e6b  x15 b400007ba2fe9510
[2025-02-11 21:50:37.465012] [STDOUT] stdout: [        ]     x16 0000000000000001  x17 0000000000000067  x18 0000007a2f996000  x19 b400007b82ff2e70
[2025-02-11 21:50:37.465082] [STDOUT] stdout: [        ]     x20 000000000000002d  x21 b400007ae3064b60  x22 b400007af30d0fa8  x23 0000000000000001
[2025-02-11 21:50:37.465155] [STDOUT] stdout: [        ]     x24 0000007a30d2a000  x25 b400007b73028fb0  x26 0000007a3a22da20  x27 000000003b9bf6c8
[2025-02-11 21:50:37.465235] [STDOUT] stdout: [        ]     x28 b400007af30d0fa8  x29 b400007ad3022cd0
[2025-02-11 21:50:37.465318] [STDOUT] stdout: [        ]     lr  0000007a3a8c7918  sp  0000007a30d28940  pc  0000000000000000  pst 0000000040001000
[2025-02-11 21:50:37.465401] [STDOUT] stdout: [        ] backtrace:
[2025-02-11 21:50:37.465491] [STDOUT] stdout: [        ]       #00 pc 0000000000000000  <unknown>
[2025-02-11 21:50:37.465596] [STDOUT] stdout: [        ]       #01 pc 000000000088b914  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (flutter::PlatformViewAndroidJNIImpl::createTransaction()+104) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.465688] [STDOUT] stdout: [        ]       #02 pc 000000000087f738  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (std::_fl::__function::__func<flutter::AndroidSurfaceVKImpeller::SetNativeWindow(fml::RefPtr<flutter::AndroidNativeWindow>, std::_fl::shared_ptr<flutter::PlatformViewAndroidJNI> const&)::$_0, std::_fl::allocator<flutter::AndroidSurfaceVKImpeller::SetNativeWindow(fml::RefPtr<flutter::AndroidNativeWindow>, std::_fl::shared_ptr<flutter::PlatformViewAndroidJNI> const&)::$_0>, impeller::android::SurfaceTransaction ()>::operator()()+16) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.465785] [STDOUT] stdout: [        ]       #03 pc 0000000000bdbf1c  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (std::_fl::__function::__func<impeller::AHBSwapchainImplVK::AcquireNextDrawable()::$_0, std::_fl::allocator<impeller::AHBSwapchainImplVK::AcquireNextDrawable()::$_0>, bool ()>::operator()()+1716) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.465874] [STDOUT] stdout: [        ]       #04 pc 0000000000b1d180  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (flutter::SurfaceFrame::Submit()+148) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.465989] [STDOUT] stdout: [        ]       #05 pc 0000000000beb2b4  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (flutter::Rasterizer::DrawToSurfacesUnsafe(flutter::FrameTimingsRecorder&, std::_fl::vector<std::_fl::unique_ptr<flutter::LayerTreeTask, std::_fl::default_delete<flutter::LayerTreeTask> >, std::_fl::allocator<std::_fl::unique_ptr<flutter::LayerTreeTask, std::_fl::default_delete<flutter::LayerTreeTask> > > >)+1284) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466400] [STDOUT] stdout: [        ]       #06 pc 0000000000beac58  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (flutter::Rasterizer::DrawToSurfaces(flutter::FrameTimingsRecorder&, std::_fl::vector<std::_fl::unique_ptr<flutter::LayerTreeTask, std::_fl::default_delete<flutter::LayerTreeTask> >, std::_fl::allocator<std::_fl::unique_ptr<flutter::LayerTreeTask, std::_fl::default_delete<flutter::LayerTreeTask> > > >)+112) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466444] [STDOUT] stdout: [        ]       #07 pc 0000000000bec144  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (std::_fl::__function::__func<flutter::Rasterizer::Draw(std::_fl::shared_ptr<flutter::Pipeline<flutter::FrameItem> > const&)::$_0, std::_fl::allocator<flutter::Rasterizer::Draw(std::_fl::shared_ptr<flutter::Pipeline<flutter::FrameItem> > const&)::$_0>, void (std::_fl::unique_ptr<flutter::FrameItem, std::_fl::default_delete<flutter::FrameItem> >)>::operator()(std::_fl::unique_ptr<flutter::FrameItem, std::_fl::default_delete<flutter::FrameItem> >&&)+192) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466468] [STDOUT] stdout: [        ]       #08 pc 0000000000bebc48  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (flutter::Rasterizer::Draw(std::_fl::shared_ptr<flutter::Pipeline<flutter::FrameItem> > const&)+360) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466521] [STDOUT] stdout: [        ]       #09 pc 0000000000bf9f7c  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (std::_fl::__function::__func<fml::internal::CopyableLambda<flutter::Shell::OnAnimatorDraw(std::_fl::shared_ptr<flutter::Pipeline<flutter::FrameItem> >)::$_0>, std::_fl::allocator<fml::internal::CopyableLambda<flutter::Shell::OnAnimatorDraw(std::_fl::shared_ptr<flutter::Pipeline<flutter::FrameItem> >)::$_0> >, void ()>::operator()()+84) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466543] [STDOUT] stdout: [        ]       #10 pc 00000000008a09ec  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (fml::MessageLoopImpl::RunExpiredTasksNow()+728) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466667] [STDOUT] stdout: [        ]       #11 pc 00000000008a4600  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (fml::MessageLoopAndroid::MessageLoopAndroid()::$_0::__invoke(int, int, void*)+84) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466746] [STDOUT] stdout: [        ]       #12 pc 0000000000011178  /system/lib64/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+808) (BuildId: 0b4a793fa8045c04066d988c68bac8bb)
[2025-02-11 21:50:37.466784] [STDOUT] stdout: [        ]       #13 pc 00000000000185e4  /system/lib64/libandroid.so (ALooper_pollOnce+100) (BuildId: 682dab490c18361d5d6527bcdd86cdfa)
[2025-02-11 21:50:37.466865] [STDOUT] stdout: [        ]       #14 pc 00000000008a470c  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (fml::MessageLoopAndroid::Run()+28) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466903] [STDOUT] stdout: [        ]       #15 pc 00000000008a283c  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (std::_fl::__function::__func<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0, std::_fl::allocator<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0>, void ()>::operator()()+116) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.466943] [STDOUT] stdout: [        ]       #16 pc 00000000008a2670  /data/app/~~u9nRjz4bI1GoKFecw6gtbg==/dev.benchmarks.platform_views_layout-RoPBoOldhc38L7sINb2Vgg==/lib/arm64/libflutter.so (fml::ThreadHandle::ThreadHandle(std::_fl::function<void ()>&&)::$_0::__invoke(void*)+8) (BuildId: 8fab16f9507483301ef418db2c91ed06689696b1)
[2025-02-11 21:50:37.467002] [STDOUT] stdout: [        ]       #17 pc 00000000000c226c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+204) (BuildId: dc4001c2ef2dfc23467040797a96840c)
[2025-02-11 21:50:37.467058] [STDOUT] stdout: [        ]       #18 pc 0000000000054a30  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: dc4001c2ef2dfc23467040797a96840c)
[2025-02-11 21:50:37.525275] [STDOUT] stdout: [  +57 ms] 00:00 [32m+0[0m[31m -1[0m: scrolling performance test (setUpAll) [1m[31m[E][0m[0m
```