### PR TITLE
[Embedder] Detect and ignore stale task runner tasks

### DIFF
--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -3228,7 +3228,7 @@ FlutterEngineResult FlutterEngineRunTask(FLUTTER_API_SYMBOL(FlutterEngine)
   }
 
   if (!flutter::EmbedderThreadHost::RunnerIsValid(
-          reinterpret_cast<int64_t>(task->runner))) {
+          reinterpret_cast<intptr_t>(task->runner))) {
     // This task came too late, the embedder has already been destroyed.
     // This is not an error, just ignore the task.
     return kSuccess;

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -2566,6 +2566,7 @@ FlutterEngineResult FlutterEngineDeinitialize(FLUTTER_API_SYMBOL(FlutterEngine)
   auto embedder_engine = reinterpret_cast<flutter::EmbedderEngine*>(engine);
   embedder_engine->NotifyDestroyed();
   embedder_engine->CollectShell();
+  embedder_engine->CollectThreadHost();
   return kSuccess;
 }
 
@@ -3224,6 +3225,13 @@ FlutterEngineResult FlutterEngineRunTask(FLUTTER_API_SYMBOL(FlutterEngine)
                                          const FlutterTask* task) {
   if (engine == nullptr) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments, "Invalid engine handle.");
+  }
+
+  if (!flutter::EmbedderThreadHost::RunnerIsValid(
+          reinterpret_cast<int64_t>(task->runner))) {
+    // This task came too late, the embedder has already been destroyed.
+    // This is not an error, just ignore the task.
+    return kSuccess;
   }
 
   return reinterpret_cast<flutter::EmbedderEngine*>(engine)->RunTask(task)

--- a/engine/src/flutter/shell/platform/embedder/embedder_engine.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_engine.cc
@@ -284,7 +284,7 @@ bool EmbedderEngine::RunTask(const FlutterTask* task) {
   if (task == nullptr) {
     return false;
   }
-  auto result = thread_host_->PostTask(reinterpret_cast<int64_t>(task->runner),
+  auto result = thread_host_->PostTask(reinterpret_cast<intptr_t>(task->runner),
                                        task->task);
   // If the UI and platform threads are separate, the microtask queue is
   // flushed through MessageLoopTaskQueues observer.

--- a/engine/src/flutter/shell/platform/embedder/embedder_engine.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_engine.h
@@ -38,6 +38,8 @@ class EmbedderEngine {
 
   bool CollectShell();
 
+  void CollectThreadHost();
+
   const TaskRunners& GetTaskRunners() const;
 
   bool NotifyCreated();
@@ -88,7 +90,7 @@ class EmbedderEngine {
   Shell& GetShell();
 
  private:
-  const std::unique_ptr<EmbedderThreadHost> thread_host_;
+  std::unique_ptr<EmbedderThreadHost> thread_host_;
   TaskRunners task_runners_;
   RunConfiguration run_configuration_;
   std::unique_ptr<ShellArgs> shell_args_;

--- a/engine/src/flutter/shell/platform/embedder/embedder_task_runner.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_task_runner.cc
@@ -9,12 +9,15 @@
 
 namespace flutter {
 
+std::atomic_int64_t EmbedderTaskRunner::next_unique_id_ = 0;
+
 EmbedderTaskRunner::EmbedderTaskRunner(DispatchTable table,
                                        size_t embedder_identifier)
     : TaskRunner(nullptr /* loop implemenation*/),
       embedder_identifier_(embedder_identifier),
       dispatch_table_(std::move(table)),
-      placeholder_id_(fml::TaskQueueId(fml::TaskQueueId::kInvalid)) {
+      placeholder_id_(fml::TaskQueueId(fml::TaskQueueId::kInvalid)),
+      unique_id_(next_unique_id_++) {
   FML_DCHECK(dispatch_table_.post_task_callback);
   FML_DCHECK(dispatch_table_.runs_task_on_current_thread_callback);
   FML_DCHECK(dispatch_table_.destruction_callback);

--- a/engine/src/flutter/shell/platform/embedder/embedder_task_runner.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_task_runner.cc
@@ -9,7 +9,7 @@
 
 namespace flutter {
 
-std::atomic_int64_t EmbedderTaskRunner::next_unique_id_ = 0;
+std::atomic_intptr_t EmbedderTaskRunner::next_unique_id_ = 0;
 
 EmbedderTaskRunner::EmbedderTaskRunner(DispatchTable table,
                                        size_t embedder_identifier)

--- a/engine/src/flutter/shell/platform/embedder/embedder_task_runner.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_task_runner.h
@@ -75,6 +75,8 @@ class EmbedderTaskRunner final : public fml::TaskRunner {
 
   bool PostTask(uint64_t baton);
 
+  uint64_t unique_id() const { return unique_id_; }
+
  private:
   const size_t embedder_identifier_;
   DispatchTable dispatch_table_;
@@ -82,6 +84,9 @@ class EmbedderTaskRunner final : public fml::TaskRunner {
   uint64_t last_baton_ = 0;
   std::unordered_map<uint64_t, fml::closure> pending_tasks_;
   fml::TaskQueueId placeholder_id_;
+  int64_t unique_id_;
+
+  static std::atomic_int64_t next_unique_id_;
 
   // |fml::TaskRunner|
   void PostTask(const fml::closure& task) override;

--- a/engine/src/flutter/shell/platform/embedder/embedder_task_runner.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_task_runner.h
@@ -75,7 +75,7 @@ class EmbedderTaskRunner final : public fml::TaskRunner {
 
   bool PostTask(uint64_t baton);
 
-  uint64_t unique_id() const { return unique_id_; }
+  intptr_t unique_id() const { return unique_id_; }
 
  private:
   const size_t embedder_identifier_;
@@ -84,9 +84,9 @@ class EmbedderTaskRunner final : public fml::TaskRunner {
   uint64_t last_baton_ = 0;
   std::unordered_map<uint64_t, fml::closure> pending_tasks_;
   fml::TaskQueueId placeholder_id_;
-  int64_t unique_id_;
+  intptr_t unique_id_;
 
-  static std::atomic_int64_t next_unique_id_;
+  static std::atomic_intptr_t next_unique_id_;
 
   // |fml::TaskRunner|
   void PostTask(const fml::closure& task) override;

--- a/engine/src/flutter/shell/platform/embedder/embedder_thread_host.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_thread_host.cc
@@ -13,7 +13,7 @@
 
 namespace flutter {
 
-std::set<int64_t> EmbedderThreadHost::active_runners_;
+std::set<intptr_t> EmbedderThreadHost::active_runners_;
 std::mutex EmbedderThreadHost::active_runners_mutex_;
 
 //------------------------------------------------------------------------------
@@ -325,7 +325,7 @@ void EmbedderThreadHost::InvalidateActiveRunners() {
   }
 }
 
-bool EmbedderThreadHost::RunnerIsValid(int64_t runner) {
+bool EmbedderThreadHost::RunnerIsValid(intptr_t runner) {
   std::lock_guard guard(active_runners_mutex_);
   return active_runners_.find(runner) != active_runners_.end();
 }
@@ -338,7 +338,7 @@ const flutter::TaskRunners& EmbedderThreadHost::GetTaskRunners() const {
   return runners_;
 }
 
-bool EmbedderThreadHost::PostTask(int64_t runner, uint64_t task) const {
+bool EmbedderThreadHost::PostTask(intptr_t runner, uint64_t task) const {
   auto found = runners_map_.find(runner);
   if (found == runners_map_.end()) {
     return false;

--- a/engine/src/flutter/shell/platform/embedder/embedder_thread_host.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_thread_host.h
@@ -38,10 +38,17 @@ class EmbedderThreadHost {
 
   bool PostTask(int64_t runner, uint64_t task) const;
 
+  static bool RunnerIsValid(int64_t runner);
+
+  void InvalidateActiveRunners();
+
  private:
   ThreadHost host_;
   flutter::TaskRunners runners_;
   std::map<int64_t, fml::RefPtr<EmbedderTaskRunner>> runners_map_;
+
+  static std::set<int64_t> active_runners_;
+  static std::mutex active_runners_mutex_;
 
   static std::unique_ptr<EmbedderThreadHost> CreateEmbedderManagedThreadHost(
       const FlutterCustomTaskRunners* custom_task_runners,

--- a/engine/src/flutter/shell/platform/embedder/embedder_thread_host.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_thread_host.h
@@ -36,18 +36,18 @@ class EmbedderThreadHost {
 
   const flutter::TaskRunners& GetTaskRunners() const;
 
-  bool PostTask(int64_t runner, uint64_t task) const;
+  bool PostTask(intptr_t runner, uint64_t task) const;
 
-  static bool RunnerIsValid(int64_t runner);
+  static bool RunnerIsValid(intptr_t runner);
 
   void InvalidateActiveRunners();
 
  private:
   ThreadHost host_;
   flutter::TaskRunners runners_;
-  std::map<int64_t, fml::RefPtr<EmbedderTaskRunner>> runners_map_;
+  std::map<intptr_t, fml::RefPtr<EmbedderTaskRunner>> runners_map_;
 
-  static std::set<int64_t> active_runners_;
+  static std::set<intptr_t> active_runners_;
   static std::mutex active_runners_mutex_;
 
   static std::unique_ptr<EmbedderThreadHost> CreateEmbedderManagedThreadHost(

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
@@ -279,7 +279,7 @@ TEST_F(EmbedderTest, IgnoresStaleTasks) {
 
   EmbedderTestTaskRunner test_ui_task_runner(
       ui_task_runner, [&](FlutterTask task) {
-        // The test for engine.is_valid() is intentionally absent here.
+        // The check for engine.is_valid() is intentionally absent here.
         // FlutterEngineRunTask must be able to detect and ignore stale tasks
         // without crashing even if the engine pointer is not null.
         // Because the engine is destroyed on platform thread,

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
@@ -269,6 +269,73 @@ TEST_F(EmbedderTest, CanSpecifyCustomUITaskRunner) {
   kill_latch.Wait();
 }
 
+TEST_F(EmbedderTest, IgnoresStaleTasks) {
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+  auto ui_task_runner = CreateNewThread("test_ui_thread");
+  auto platform_task_runner = CreateNewThread("test_platform_thread");
+  static std::mutex engine_mutex;
+  UniqueEngine engine;
+  FlutterEngine engine_ptr;
+
+  EmbedderTestTaskRunner test_ui_task_runner(
+      ui_task_runner, [&](FlutterTask task) {
+        // We intentionally do not test for engine.is_valid() here.
+        // FlutterEngineRunTask must be able to detect and ignore stale tasks
+        // without crashing even if the engine pointer is not null.
+        // Because the engine is destroyed on platform thread,
+        // relying on solely engine.is_valid() in UI thread is not safe.
+        FlutterEngineRunTask(engine_ptr, &task);
+      });
+  EmbedderTestTaskRunner test_platform_task_runner(
+      platform_task_runner, [&](FlutterTask task) {
+        std::scoped_lock lock(engine_mutex);
+        if (!engine.is_valid()) {
+          return;
+        }
+        FlutterEngineRunTask(engine.get(), &task);
+      });
+
+  fml::AutoResetWaitableEvent init_latch;
+
+  platform_task_runner->PostTask([&]() {
+    EmbedderConfigBuilder builder(context);
+    const auto ui_task_runner_description =
+        test_ui_task_runner.GetFlutterTaskRunnerDescription();
+    const auto platform_task_runner_description =
+        test_platform_task_runner.GetFlutterTaskRunnerDescription();
+    builder.SetUITaskRunner(&ui_task_runner_description);
+    builder.SetPlatformTaskRunner(&platform_task_runner_description);
+    {
+      std::scoped_lock lock(engine_mutex);
+      engine = builder.InitializeEngine();
+    }
+    init_latch.Signal();
+  });
+
+  init_latch.Wait();
+  engine_ptr = engine.get();
+
+  auto flutter_engine = reinterpret_cast<EmbedderEngine*>(engine.get());
+
+  // Schedule task on UI thread that will likely run after the engine has shut
+  // down.
+  flutter_engine->GetTaskRunners().GetUITaskRunner()->PostDelayedTask(
+      []() {}, fml::TimeDelta::FromMilliseconds(50));
+
+  fml::AutoResetWaitableEvent kill_latch;
+  platform_task_runner->PostTask([&] {
+    engine.reset();
+    platform_task_runner->PostTask([&kill_latch] { kill_latch.Signal(); });
+  });
+  kill_latch.Wait();
+
+  // Ensure that the schedule task indeed runs.
+  kill_latch.Reset();
+  ui_task_runner->PostDelayedTask([&]() { kill_latch.Signal(); },
+                                  fml::TimeDelta::FromMilliseconds(50));
+  kill_latch.Wait();
+}
+
 TEST_F(EmbedderTest, MergedPlatformUIThread) {
   auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   auto task_runner = CreateNewThread("test_thread");

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
@@ -279,11 +279,11 @@ TEST_F(EmbedderTest, IgnoresStaleTasks) {
 
   EmbedderTestTaskRunner test_ui_task_runner(
       ui_task_runner, [&](FlutterTask task) {
-        // We intentionally do not test for engine.is_valid() here.
+        // The test for engine.is_valid() is intentionally absent here.
         // FlutterEngineRunTask must be able to detect and ignore stale tasks
         // without crashing even if the engine pointer is not null.
         // Because the engine is destroyed on platform thread,
-        // relying on solely engine.is_valid() in UI thread is not safe.
+        // relying solely on engine.is_valid() in UI thread is not safe.
         FlutterEngineRunTask(engine_ptr, &task);
       });
   EmbedderTestTaskRunner test_platform_task_runner(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/163104

The core issue is that `EmbedderTaskRunner` can schedule things in advance, but there is no checking if the task is stale when executing it. It is possible that `FlutterEngineRunTask` will attempt to run the task on engine that is non null but already being deallocated.

This in  not a problem for raster and platform task runners, because raster task runner shouldn't have any scheduled tasks after shutdown and platform task runner executes the shutdown process, so the pointer is always either valid or null, but it is an issue for custom `ui_task_runner`, because it may be calling `FlutterEngineRunTask` with engine pointer that is not yet null but already shutting down.

The proposed solution is to assign a unique identifier for each `EmbedderTaskRunner`, use this identifier as the `runner` field inside `FlutterTask` instead of casting the address of the runner, and verify that this identifier is valid inside `FlutterEngineRunTask` before calling anything on the engine.

Special care needs to be done to not invalidate the unique identifier while `ui_task_runner` is running a task as it may lead to raciness. See `EmbedderEngine::CollectThreadHost()`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
