### PR TITLE
[flutter_tools] remove SkSL target for iOS builds.

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -123,6 +123,7 @@ class ShaderCompiler {
         ];
 
       case TargetPlatform.ios:
+        return <String>['--runtime-stage-metal'];
       case TargetPlatform.darwin:
         return <String>['--sksl', '--runtime-stage-metal'];
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -314,7 +314,6 @@ void main() {
         const FakeCommand(
           command: <String>[
             'HostArtifact.impellerc',
-            '--sksl',
             '--runtime-stage-metal',
             '--iplr',
             '--sl=/App.framework/flutter_assets/shader.glsl',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -86,7 +86,6 @@ void main() {
         FakeCommand(
           command: <String>[
             impellerc,
-            '--sksl',
             '--runtime-stage-metal',
             '--iplr',
             '--sl=$outputPath',


### PR DESCRIPTION
Skia is no longer supported on iOS targets, so runtime shaders don't need to bundle SkSL.

Fixes https://github.com/flutter/flutter/issues/138919