### PR TITLE
Enable `goldenFileComparator` fix for on-device integration tests.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -246,6 +246,11 @@ void main() {
     autoUpdateGoldenFiles = $updateGoldens;
 ''');
   }
+  if (integrationTest) {
+    buffer.write('''
+    VmServiceProxyGoldenFileComparator.useIfRunningOnDevice();
+''');
+  }
   if (testConfigFile != null) {
     buffer.write('''
     return () => test_config.testExecutable(_testMain);

--- a/packages/integration_test/example/integration_test/matches_golden_test.dart
+++ b/packages/integration_test/example/integration_test/matches_golden_test.dart
@@ -24,9 +24,6 @@ import 'package:integration_test_example/main.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  // TODO(matanlurey): Make this automatic as part of the bootstrap.
-  VmServiceProxyGoldenFileComparator.useIfRunningOnDevice();
-
   testWidgets('can use matchesGoldenFile with integration_test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     app.main();

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -23,6 +23,7 @@ import 'common.dart';
 import 'src/callback.dart' as driver_actions;
 import 'src/channel.dart';
 import 'src/extension.dart';
+import 'src/vm_service_golden_client.dart';
 
 export 'src/vm_service_golden_client.dart';
 
@@ -154,6 +155,8 @@ https://docs.flutter.dev/testing/integration-tests
   ///
   ///  * [WidgetsFlutterBinding.ensureInitialized], the equivalent in the widgets framework.
   static IntegrationTestWidgetsFlutterBinding ensureInitialized() {
+    // Change the golden-file comparator if required by the platform.
+    VmServiceProxyGoldenFileComparator.useIfRunningOnDevice();
     if (_instance == null) {
       IntegrationTestWidgetsFlutterBinding();
     }

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -23,7 +23,6 @@ import 'common.dart';
 import 'src/callback.dart' as driver_actions;
 import 'src/channel.dart';
 import 'src/extension.dart';
-import 'src/vm_service_golden_client.dart';
 
 export 'src/vm_service_golden_client.dart';
 
@@ -155,8 +154,6 @@ https://docs.flutter.dev/testing/integration-tests
   ///
   ///  * [WidgetsFlutterBinding.ensureInitialized], the equivalent in the widgets framework.
   static IntegrationTestWidgetsFlutterBinding ensureInitialized() {
-    // Change the golden-file comparator if required by the platform.
-    VmServiceProxyGoldenFileComparator.useIfRunningOnDevice();
     if (_instance == null) {
       IntegrationTestWidgetsFlutterBinding();
     }

--- a/packages/integration_test/lib/src/vm_service_golden_client.dart
+++ b/packages/integration_test/lib/src/vm_service_golden_client.dart
@@ -12,7 +12,6 @@ import 'dart:io' as io;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 
 /// Compares image pixels against a golden image file on the host system.
 ///
@@ -65,7 +64,6 @@ import 'package:meta/meta.dart';
 /// See also:
 ///
 ///   * [matchesGoldenFile], the function that invokes the comparator.
-@experimental
 final class VmServiceProxyGoldenFileComparator extends GoldenFileComparator {
   VmServiceProxyGoldenFileComparator._() : _postEvent = dev.postEvent {
     dev.registerExtension(_kServiceName, (_, Map<String, String> parameters) {


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/143299.
Closes https://github.com/flutter/flutter/issues/160043.

A website update is work-in-progress here to add more context for users: <https://github.com/flutter/website/pull/11716>.