### PR TITLE
Increase timeout for Windows build_android_host_app_with_module_aar

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5899,6 +5899,7 @@ targets:
       tags: >
         ["devicelab", "hostonly", "windows"]
       task_name: build_android_host_app_with_module_aar
+      test_timeout_secs: "2700" # Allows 45 minutes (up from 30 default)
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
Windows is taking just longer than 30 minutes to finish this task. 45 minutes will keep us informed if it gets much longer without causing lots of CI flakes. Mac and Linux versions of these tasks are finishing well under 30 minutes so their timeouts are being left at the default.