### PR TITLE
Opt-out of `--explicit-package-dependencies` for `flutter_gen_test`.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/flutter_gen_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_gen_test.dart
@@ -8,16 +8,50 @@ library;
 import 'dart:convert';
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/features.dart';
 
 import '../src/common.dart';
 import 'test_data/basic_project.dart';
 import 'test_driver.dart';
 import 'test_utils.dart';
 
+// TODO(matanlurey): Remove this test; https://github.com/flutter/flutter/issues/102983.
+//
+// This is a legacy test that verifies that the old (package:flutter_gen) synthetic package
+// works end-to-end. It's sister test, which verifies the supported in-package source
+// generation, is flutter_tools/test/integration.shard/gen_l10n_test.dart, which tests the
+// same workflow.
 void main() {
   late Directory tempDir;
   final BasicProjectWithFlutterGen project = BasicProjectWithFlutterGen();
   late FlutterRunTestDriver flutter;
+
+  setUpAll(() async {
+    // Disable the --explicit-package-dependencies flag *if* it is on by default.
+    if (!explicitPackageDependencies.master.enabledByDefault) {
+      return;
+    }
+    final ProcessResult result = processManager.runSync(<String>[
+      flutterBin,
+      'config',
+      '--no-explicit-package-dependencies',
+    ]);
+    expect(result, const ProcessResultMatcher());
+  });
+
+  tearDownAll(() async {
+    // Enable the --explicit-package-dependencies flag *if* it is on by default.
+    if (!explicitPackageDependencies.master.enabledByDefault) {
+      return;
+    }
+    final ProcessResult result = processManager.runSync(<String>[
+      flutterBin,
+      'config',
+      '--explicit-package-dependencies',
+    ]);
+    expect(result, const ProcessResultMatcher());
+  });
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('run_test.');


### PR DESCRIPTION
Unblocks https://github.com/flutter/flutter/pull/160289.