### PR TITLE
[Impeller] Ensure that texture coordinate coverage and gradient color source sizes used by DrawVertices are nonempty

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -817,10 +817,14 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
   } else {
     auto cvg = vertices->GetCoverage(Matrix{});
     FML_CHECK(cvg.has_value());
-    src_coverage =
-        // Covered by FML_CHECK.
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        vertices->GetTextureCoordinateCoverage().value_or(cvg.value());
+    auto texture_coverage = vertices->GetTextureCoordinateCoverage();
+    if (texture_coverage.has_value()) {
+      src_coverage =
+          Rect::MakeOriginSize(texture_coverage->GetOrigin(),
+                               texture_coverage->GetSize().Max({1, 1}));
+    } else {
+      src_coverage = cvg.value();
+    }
   }
   src_contents = src_paint.CreateContents();
 

--- a/engine/src/flutter/impeller/display_list/paint.cc
+++ b/engine/src/flutter/impeller/display_list/paint.cc
@@ -65,8 +65,8 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
 
       std::array<Point, 2> bounds{start_point, end_point};
       auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-      if (intrinsic_size.has_value() && !intrinsic_size->IsEmpty()) {
-        contents->SetColorSourceSize(intrinsic_size->GetSize());
+      if (intrinsic_size.has_value()) {
+        contents->SetColorSourceSize(intrinsic_size->GetSize().Max({1, 1}));
       }
       return contents;
     }
@@ -95,8 +95,8 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
       auto radius_pt = Point(radius, radius);
       std::array<Point, 2> bounds{center + radius_pt, center - radius_pt};
       auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-      if (intrinsic_size.has_value() && !intrinsic_size->IsEmpty()) {
-        contents->SetColorSourceSize(intrinsic_size->GetSize());
+      if (intrinsic_size.has_value()) {
+        contents->SetColorSourceSize(intrinsic_size->GetSize().Max({1, 1}));
       }
       return contents;
     }
@@ -129,8 +129,8 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
       auto radius_pt = Point(radius, radius);
       std::array<Point, 2> bounds{center + radius_pt, center - radius_pt};
       auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-      if (intrinsic_size.has_value() && !intrinsic_size->IsEmpty()) {
-        contents->SetColorSourceSize(intrinsic_size->GetSize());
+      if (intrinsic_size.has_value()) {
+        contents->SetColorSourceSize(intrinsic_size->GetSize().Max({1, 1}));
       }
       return contents;
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/162969