### PR TITLE
feat(FixedExtentScrollController): Add parent class properties to the constructor.

### DIFF
--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -219,7 +219,13 @@ class FixedExtentScrollController extends ScrollController {
   /// Creates a scroll controller for scrollables whose items have the same size.
   ///
   /// [initialItem] defaults to zero.
-  FixedExtentScrollController({this.initialItem = 0, super.keepScrollOffset, super.debugLabel, super.onAttach, super.onDetach});
+  FixedExtentScrollController({
+    this.initialItem = 0,
+    super.keepScrollOffset,
+    super.debugLabel,
+    super.onAttach,
+    super.onDetach,
+  });
 
   /// The page to show when first creating the scroll view.
   ///

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -219,7 +219,7 @@ class FixedExtentScrollController extends ScrollController {
   /// Creates a scroll controller for scrollables whose items have the same size.
   ///
   /// [initialItem] defaults to zero.
-  FixedExtentScrollController({this.initialItem = 0, super.onAttach, super.onDetach});
+  FixedExtentScrollController({this.initialItem = 0, super.keepScrollOffset, super.debugLabel, super.onAttach, super.onDetach});
 
   /// The page to show when first creating the scroll view.
   ///
@@ -294,6 +294,8 @@ class FixedExtentScrollController extends ScrollController {
       context: context,
       initialItem: initialItem,
       oldPosition: oldPosition,
+      keepScrollOffset: keepScrollOffset,
+      debugLabel: debugLabel,
     );
   }
 }
@@ -369,6 +371,8 @@ class _FixedExtentScrollPosition extends ScrollPositionWithSingleContext
     required super.context,
     required int initialItem,
     super.oldPosition,
+    super.keepScrollOffset,
+    super.debugLabel,
   }) : assert(
          context is _FixedExtentScrollableState,
          'FixedExtentScrollController can only be used with ListWheelScrollViews',

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -117,6 +117,66 @@ void main() {
       expect(detach, 1);
     });
 
+    testWidgets('FixedExtentScrollController keepScrollOffset', (WidgetTester tester) async {
+      final PageStorageBucket bucket = PageStorageBucket();
+
+      Widget buildFrame(ScrollController controller) {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: PageStorage(
+            bucket: bucket,
+            child: KeyedSubtree(
+              key: const PageStorageKey<String>('ListWheelScrollView'),
+              child: ListWheelScrollView(
+                key: UniqueKey(),
+                itemExtent: 100.0,
+                controller: controller,
+                children:
+                    List<Widget>.generate(100, (int index) {
+                      return SizedBox(height: 100.0, width: 400.0, child: Text('Item $index'));
+                    }).toList(),
+              ),
+            ),
+          ),
+        );
+      }
+
+      FixedExtentScrollController controller = FixedExtentScrollController(initialItem: 2);
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(buildFrame(controller));
+      expect(controller.selectedItem, 2);
+      expect(
+        tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 2')),
+        offsetMoreOrLessEquals(const Offset(200.0, 250.0)),
+      );
+
+      controller.jumpToItem(20);
+      await tester.pump();
+      expect(controller.selectedItem, 20);
+      expect(
+        tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 20')),
+        offsetMoreOrLessEquals(const Offset(200.0, 250.0)),
+      );
+
+      controller = FixedExtentScrollController(initialItem: 25);
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(buildFrame(controller));
+      expect(controller.selectedItem, 20);
+      expect(
+        tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 20')),
+        offsetMoreOrLessEquals(const Offset(200.0, 250.0)),
+      );
+
+      controller = FixedExtentScrollController(keepScrollOffset: false, initialItem: 10);
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(buildFrame(controller));
+      expect(controller.selectedItem, 10);
+      expect(
+        tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 10')),
+        offsetMoreOrLessEquals(const Offset(200.0, 250.0)),
+      );
+    });
+
     testWidgets('ListWheelScrollView needs positive magnification', (WidgetTester tester) async {
       expect(() {
         ListWheelScrollView(

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -117,6 +117,7 @@ void main() {
       expect(detach, 1);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/162972
     testWidgets('FixedExtentScrollController keepScrollOffset', (WidgetTester tester) async {
       final PageStorageBucket bucket = PageStorageBucket();
 
@@ -175,6 +176,15 @@ void main() {
         tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 10')),
         offsetMoreOrLessEquals(const Offset(200.0, 250.0)),
       );
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/162972
+    test('FixedExtentScrollController debugLabel', () {
+      final FixedExtentScrollController controller = FixedExtentScrollController(
+        debugLabel: 'MyCustomWidget',
+      );
+      expect(controller.debugLabel, 'MyCustomWidget');
+      expect(controller.toString(), contains('MyCustomWidget'));
     });
 
     testWidgets('ListWheelScrollView needs positive magnification', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -146,6 +146,7 @@ void main() {
       addTearDown(controller.dispose);
       await tester.pumpWidget(buildFrame(controller));
       expect(controller.selectedItem, 2);
+      expect(controller.offset, 200.0);
       expect(
         tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 2')),
         offsetMoreOrLessEquals(const Offset(200.0, 250.0)),
@@ -154,6 +155,7 @@ void main() {
       controller.jumpToItem(20);
       await tester.pump();
       expect(controller.selectedItem, 20);
+      expect(controller.offset, 2000.0);
       expect(
         tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 20')),
         offsetMoreOrLessEquals(const Offset(200.0, 250.0)),
@@ -163,6 +165,7 @@ void main() {
       addTearDown(controller.dispose);
       await tester.pumpWidget(buildFrame(controller));
       expect(controller.selectedItem, 20);
+      expect(controller.offset, 2000.0);
       expect(
         tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 20')),
         offsetMoreOrLessEquals(const Offset(200.0, 250.0)),
@@ -172,6 +175,7 @@ void main() {
       addTearDown(controller.dispose);
       await tester.pumpWidget(buildFrame(controller));
       expect(controller.selectedItem, 10);
+      expect(controller.offset, 1000.0);
       expect(
         tester.getTopLeft(find.widgetWithText(SizedBox, 'Item 10')),
         offsetMoreOrLessEquals(const Offset(200.0, 250.0)),


### PR DESCRIPTION
This request is to add configurable parameters keepScrollOffset and debugLabel to FixedExtentScrollController.

- Fixes  https://github.com/flutter/flutter/issues/162972

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.