### PR TITLE
Fix DropdownButtonFormField icon not vertically centered

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1565,6 +1565,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
 
     const Icon defaultIcon = Icon(Icons.arrow_drop_down);
+    final Widget effectiveSuffixIcon = IconTheme(
+      data: IconThemeData(color: _iconColor, size: widget.iconSize),
+      child: widget.icon ?? widget._inputDecoration?.suffixIcon ?? defaultIcon,
+    );
 
     Widget result = DefaultTextStyle(
       style: _enabled ? _textStyle! : _textStyle!.copyWith(color: Theme.of(context).disabledColor),
@@ -1577,10 +1581,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               if (widget.isExpanded) Expanded(child: innerItemsWidget) else innerItemsWidget,
-              IconTheme(
-                data: IconThemeData(color: _iconColor, size: widget.iconSize),
-                child: widget.icon ?? defaultIcon,
-              ),
+              if (widget._inputDecoration == null) effectiveSuffixIcon,
             ],
           ),
         ),
@@ -1623,7 +1624,12 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     // visible only for filled dropdown button, see:
     // https://m2.material.io/components/menus#dropdown-menu
     if (widget._inputDecoration != null) {
-      InputDecoration effectiveDecoration = widget._inputDecoration!;
+      InputDecoration effectiveDecoration = widget._inputDecoration!.copyWith(
+        // Override the suffix icon constraints to allow the
+        // icon alignment to match the regular dropdown button.
+        suffixIconConstraints: const BoxConstraints(minWidth: 40.0),
+        suffixIcon: effectiveSuffixIcon,
+      );
       if (_hasPrimaryFocus) {
         final Color? focusColor = widget.focusColor ?? effectiveDecoration.focusColor;
         // For compatibility, override the fill color when focusColor is set.

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1624,11 +1624,26 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     // visible only for filled dropdown button, see:
     // https://m2.material.io/components/menus#dropdown-menu
     if (widget._inputDecoration != null) {
+      final bool filled =
+          widget._inputDecoration?.filled ?? Theme.of(context).inputDecorationTheme.filled;
+      final bool oulined =
+          widget._inputDecoration?.border?.isOutline ??
+          Theme.of(context).inputDecorationTheme.border?.isOutline ??
+          false;
+
+      final double suffixIconEndMargin = (filled || oulined) ? 12.0 : 0.0;
       InputDecoration effectiveDecoration = widget._inputDecoration!.copyWith(
         // Override the suffix icon constraints to allow the
         // icon alignment to match the regular dropdown button.
-        suffixIconConstraints: const BoxConstraints(minWidth: 40.0),
-        suffixIcon: effectiveSuffixIcon,
+        suffixIconConstraints: BoxConstraints(
+          minWidth: widget.iconSize + suffixIconEndMargin,
+          minHeight: widget.iconSize,
+        ),
+        // suffixIconGap: 0.0,
+        suffixIcon: Padding(
+          padding: EdgeInsetsGeometry.directional(end: suffixIconEndMargin),
+          child: effectiveSuffixIcon,
+        ),
       );
       if (_hasPrimaryFocus) {
         final Color? focusColor = widget.focusColor ?? effectiveDecoration.focusColor;

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -1459,7 +1459,7 @@ void main() {
                   <String>['One', 'Two'].map<DropdownMenuItem<String>>((String value) {
                     return DropdownMenuItem<String>(value: value, child: Text(value));
                   }).toList(),
-              onChanged: (_) {},
+              onChanged: (String? value) {},
             ),
           ),
         ),

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -805,7 +805,7 @@ void main() {
 
     // test for size
     final RenderBox icon = tester.renderObject(find.byKey(iconKey));
-    expect(icon.size, const Size(40.0, 30.0));
+    expect(icon.size, const Size(30.0, 30.0));
 
     // test for enabled color
     final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -805,7 +805,7 @@ void main() {
 
     // test for size
     final RenderBox icon = tester.renderObject(find.byKey(iconKey));
-    expect(icon.size, const Size(30.0, 30.0));
+    expect(icon.size, const Size(40.0, 30.0));
 
     // test for enabled color
     final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
@@ -1442,5 +1442,30 @@ void main() {
 
     // The dropdown should still be open, i.e., there should be one widget with 'second' text.
     expect(find.text('second'), findsOneWidget);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/157074.
+  testWidgets('DropdownButtonFormField icon is aligned with label text', (
+    WidgetTester tester,
+  ) async {
+    const String labelText = 'Label Text';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: DropdownButtonFormField<String>(
+              decoration: const InputDecoration(labelText: labelText),
+              items:
+                  <String>['One', 'Two'].map<DropdownMenuItem<String>>((String value) {
+                    return DropdownMenuItem<String>(value: value, child: Text(value));
+                  }).toList(),
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getCenter(find.text(labelText)).dy, tester.getCenter(find.byType(Icon).last).dy);
   });
 }


### PR DESCRIPTION
## Description

This PR fixes `DropdownButtonFormField` suffix icon vertical alignment when `DropdownButtonFormField.inputDecoration` is provided without a hint text.

### Before:

The dropdown icon is misaligned vertically:

![image](https://github.com/user-attachments/assets/b79b35ae-c333-4cb4-91f7-5c9ce8edd975)


### After:

The dropdown icon is aligned vertically:

![image](https://github.com/user-attachments/assets/b5704453-66a3-4cb2-97ff-bef556bff377)


## Related Issue

Fixes [DropdownButtonFormField arrow icon is misaligned vertically](https://github.com/flutter/flutter/issues/157074) 

## Tests

Adds 1 test.
