### PR TITLE
fix(doctor): add an alternative path for the Dart plugin

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -76,7 +76,7 @@ class AndroidStudioValidator extends DoctorValidator {
       );
       plugins.validatePackage(
         messages,
-        <String>['Dart'],
+        <String>['Dart', 'dart'],
         'Dart',
         IntelliJPlugins.kIntellijDartPluginUrl,
       );

--- a/packages/flutter_tools/lib/src/intellij/intellij_validator.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij_validator.dart
@@ -109,7 +109,7 @@ abstract class IntelliJValidator extends DoctorValidator {
       );
       plugins.validatePackage(
         messages,
-        <String>['Dart'],
+        <String>['Dart', 'dart'],
         'Dart',
         IntelliJPlugins.kIntellijDartPluginUrl,
       );


### PR DESCRIPTION
It seems like with some recent plugin/IDE version, the path for the Dart plugin has changed from `<base path>/Dart` to `<base path>/dart`, causing `flutter doctor` to incorrectly assume that the plugin is not installed.

Add `dart` as an alternative to the existing `Dart` package name.

Fixes #163214.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
