### PR TITLE
[android] correct API availibility checks for hcpp.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
@@ -59,7 +59,8 @@ std::shared_ptr<SwapchainVK> SwapchainVK::Create(
 
   // Use AHB Swapchains if they are opted in.
   if (ContextVK::Cast(*context).GetShouldEnableSurfaceControlSwapchain() &&
-      AHBSwapchainVK::IsAvailableOnPlatform()) {
+      AHBSwapchainVK::IsAvailableOnPlatform() &&
+      android_get_device_api_level() >= 34) {
     FML_LOG(WARNING) << "Using Android SurfaceControl Swapchain.";
     auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
         context,             //

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -136,13 +136,13 @@ PlatformViewAndroid::PlatformViewAndroid(
         delegate.OnPlatformViewGetSettings().enable_impeller  //
     );
     android_surface_ = surface_factory_->CreateSurface();
-    // TODO(jonahwilliams): we need to expose the runtime check for the
-    // correct extensions and allowlist for this to work correctly.
     android_use_new_platform_view_ =
         android_context->RenderingApi() ==
             AndroidRenderingAPI::kImpellerVulkan &&
         (android_get_device_api_level() >= kMinAPILevelHCPP) &&
-        delegate.OnPlatformViewGetSettings().enable_surface_control;
+        delegate.OnPlatformViewGetSettings().enable_surface_control &&
+        impeller::ContextVK::Cast(*android_context->GetImpellerContext())
+            .GetShouldEnableSurfaceControlSwapchain();
     FML_CHECK(android_surface_ && android_surface_->IsValid())
         << "Could not create an OpenGL, Vulkan or Software surface to set "
            "up "


### PR DESCRIPTION
This fixes the HCPP crashes in devicelab by correctly disabling HCPP for devices that are < API level 34. Unfortunately this means we can't benchmark on CI until we update the devices.