### PR TITLE
Remove android 34 redundant emulator tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -58,7 +58,9 @@ platform_properties:
       cores: "8"
       device_type: none
       kvm: "1"
-  linux_android_emu_34:
+  # linux_android_emu_unstable is intended to be how flutter-android proves the stability
+  # of new combinations of dependencies.
+  linux_android_emu_unstable:
     properties:
       contexts: >-
         [
@@ -67,8 +69,8 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:35v1"},
-          {"dependency": "android_virtual_device", "version": "android_34_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8733065022087935185"},
+          {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8723189955818532721"},
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       os: Ubuntu
@@ -417,14 +419,6 @@ targets:
         ["framework","hostonly","linux"]
       task_name: android_views
       presubmit_max_attempts: "2"
-    timeout: 60
-
-  - name: Linux_android_emu_34 android views
-    recipe: devicelab/devicelab_drone
-    properties:
-      tags: >
-        ["framework","hostonly","linux"]
-      task_name: android_views
     timeout: 60
 
   - name: Linux build_aar_module_test
@@ -2177,7 +2171,7 @@ targets:
       task_name: android_defines_test
       presubmit_max_attempts: "2"
 
-  - name: Linux_android_emu_34 android_defines_test
+  - name: Linux_android_emu_unstable android_defines_test
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2596,21 +2590,6 @@ targets:
         ["devicelab", "linux"]
       task_name: external_textures_integration_test
       presubmit_max_attempts: "2"
-
-  - name: Linux_android_emu_34 external_textures_integration_test
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    # Functionally the same as "presubmit: false", except that we will run on
-    # presubmit during engine rolls. This test is the *only* automated e2e
-    # test for external textures for the engine, it should never break.
-    runIf:
-      - engine/**
-      - DEPS
-      - .ci.yaml
-    properties:
-      tags: >
-        ["devicelab", "linux"]
-      task_name: external_textures_integration_test
 
   # linux mokey benchmark
   - name: Linux_mokey fading_child_animation_perf__timeline_summary

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2174,6 +2174,7 @@ targets:
   - name: Linux_android_emu_unstable android_defines_test
     recipe: devicelab/devicelab_drone
     timeout: 60
+    bringup: true
     properties:
       tags: >
         ["devicelab", "linux"]


### PR DESCRIPTION
b/371020223

linux_android_emu and linux_android_emu_34 ran 2 different sets of dependencies because the adoption of 35 was unstable. The reasons why wound up being incompatible/bad versions of the build tool dependencies like the graphics engine chosen was unstable on 35. This was fixed with dependency changes. 

Introduce an unstable linux android emulator configuration that can be used to prove a dependency set as stable.  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

