### PR TITLE
[Impeller] disable Vulkan on known bad exynos SoCs.

### DIFF
--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <cstring>
 #define FML_USED_ON_EMBEDDER
 
 #include <android/log.h>
 #include <sys/system_properties.h>
+#include <cstring>
 #include <optional>
 #include <string>
 #include <vector>

--- a/engine/src/flutter/shell/platform/android/flutter_main.h
+++ b/engine/src/flutter/shell/platform/android/flutter_main.h
@@ -28,6 +28,8 @@ class FlutterMain {
 
   static bool IsDeviceEmulator(std::string_view product_model);
 
+  static bool IsKnownBadSOC(std::string_view hardware);
+
  private:
   const flutter::Settings settings_;
   DartServiceIsolate::CallbackHandle vm_service_uri_callback_ = 0;

--- a/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
@@ -42,5 +42,13 @@ TEST(AndroidPlatformView, FallsBackToGLESonEmulator) {
   EXPECT_FALSE(FlutterMain::IsDeviceEmulator(device_product));
 }
 
+TEST(AndroidPlatformView, FallsBackToGLESonMostExynos) {
+  std::string exynos_board = "exynos7870";
+  std::string snap_board = "smg1234";
+
+  EXPECT_TRUE(FlutterMain::IsKnownBadSOC(exynos_board));
+  EXPECT_FALSE(FlutterMain::IsKnownBadSOC(snap_board));
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
The common theme in:
  * https://github.com/flutter/flutter/issues/160854
  * https://github.com/flutter/flutter/issues/160804
  * https://github.com/flutter/flutter/issues/158091
  
 Is that the Samsung exynos chipset has problems with AHB imports. Unfortunately some of the reported bugs are hard crashes/. While I couldn't reproduce the crash itself, it does indicate to me that attempting to feature detect if AHB imports work is probably too risky (and potentially slow, as we'd have to do a read back).
 
 While the Vulkan drivers otherwise work, the deivces in question are not able to reliably import AHBs which prevents platform views from working.
 
 This may not fix all issues as there could be different SoC models that also have problems. I considered removing 29 support as well, but there are a large number of APi 29 devices that work fine.