### PR TITLE
[CP][Impeller] disable Vulkan on known bad exynos SoCs. (#163236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ INTERNAL NOTE
 ### [3.29.0](https://github.com/flutter/flutter/releases/tag/3.29.0)
 Initial stable release.
 
+- [flutter/163236](https://github.com/flutter/flutter/pull/163236) Disable Vulkan on older Exynos SoC to work around Android HardwareBuffer import error.
+
 ## Flutter 3.27 Changes
 
 ### [3.27.2](https://github.com/flutter/flutter/releases/tag/3.27.2)

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -6,6 +6,7 @@
 
 #include <android/log.h>
 #include <sys/system_properties.h>
+#include <cstring>
 #include <optional>
 #include <string>
 #include <vector>
@@ -47,6 +48,23 @@ extern const intptr_t kPlatformStrongDillSize;
 namespace {
 
 fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_jni_class = nullptr;
+
+/// These are SoCs that crash when using AHB imports.
+static constexpr const char* kBLC[] = {
+    // Most Exynos Series SoC
+    "exynos7870",  //
+    "exynos7880",  //
+    "exynos7872",  //
+    "exynos7884",  //
+    "exynos7885",  //
+    "exynos8890",  //
+    "exynos8895",  //
+    "exynos7904",  //
+    "exynos9609",  //
+    "exynos9610",  //
+    "exynos9611",  //
+    "exynos9810"   //
+};
 
 }  // anonymous namespace
 
@@ -238,6 +256,18 @@ bool FlutterMain::IsDeviceEmulator(std::string_view product_model) {
 }
 
 // static
+bool FlutterMain::IsKnownBadSOC(std::string_view hardware) {
+  // TODO(jonahwilliams): if the list gets too long (> 16), convert
+  // to a hash map first.
+  for (const auto& board : kBLC) {
+    if (strcmp(board, hardware.data()) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// static
 AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
     const flutter::Settings& settings) {
   if (settings.enable_software_rendering) {
@@ -277,6 +307,12 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
     __system_property_get("ro.product.model", product_model);
     if (IsDeviceEmulator(product_model)) {
       // Avoid using Vulkan on known emulators.
+      return kVulkanUnsupportedFallback;
+    }
+
+    __system_property_get("ro.product.board", product_model);
+    if (IsKnownBadSOC(product_model)) {
+      // Avoid using Vulkan on known bad SoCs.
       return kVulkanUnsupportedFallback;
     }
 

--- a/engine/src/flutter/shell/platform/android/flutter_main.h
+++ b/engine/src/flutter/shell/platform/android/flutter_main.h
@@ -28,6 +28,8 @@ class FlutterMain {
 
   static bool IsDeviceEmulator(std::string_view product_model);
 
+  static bool IsKnownBadSOC(std::string_view hardware);
+
  private:
   const flutter::Settings settings_;
   DartServiceIsolate::CallbackHandle vm_service_uri_callback_ = 0;

--- a/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_unittests.cc
@@ -42,5 +42,13 @@ TEST(AndroidPlatformView, FallsBackToGLESonEmulator) {
   EXPECT_FALSE(FlutterMain::IsDeviceEmulator(device_product));
 }
 
+TEST(AndroidPlatformView, FallsBackToGLESonMostExynos) {
+  std::string exynos_board = "exynos7870";
+  std::string snap_board = "smg1234";
+
+  EXPECT_TRUE(FlutterMain::IsKnownBadSOC(exynos_board));
+  EXPECT_FALSE(FlutterMain::IsKnownBadSOC(snap_board));
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
The common theme in:
  * https://github.com/flutter/flutter/issues/160854
  * https://github.com/flutter/flutter/issues/160804
  * https://github.com/flutter/flutter/issues/158091
  
Is that the Samsung exynos chipset has problems with AHB imports. Unfortunately some of the reported bugs are hard crashes/. While I couldn't reproduce the crash itself, it does indicate to me that attempting to feature detect if AHB imports work is probably too risky (and potentially slow, as we'd have to do a read back).
 
While the Vulkan drivers otherwise work, the deivces in question are not able to reliably import AHBs which prevents platform views from working.
 
This may not fix all issues as there could be different SoC models that also have problems. I considered removing 29 support as well, but there are a large number of APi 29 devices that work fine.

