### PR TITLE
[Impeller] Call glDebugMessageControlKHR only if the KHR_debug extension is available

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
@@ -374,7 +374,7 @@ bool ReactorGLES::FlushOps() {
 
 void ReactorGLES::SetupDebugGroups() {
   // Setup of a default active debug group: Filter everything in.
-  if (proc_table_->DebugMessageControlKHR.IsAvailable()) {
+  if (can_set_debug_labels_) {
     proc_table_->DebugMessageControlKHR(GL_DONT_CARE,  // source
                                         GL_DONT_CARE,  // type
                                         GL_DONT_CARE,  // severity


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/163269