### PR TITLE
Invalidate `pod install` output if `.flutter-plugins-dependencies` content changes.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -244,7 +244,15 @@ bool _writeFlutterPluginsList(
   final String? oldPluginsFileStringContent = _readFileContent(pluginsFile);
   bool pluginsChanged = true;
   if (oldPluginsFileStringContent != null) {
-    pluginsChanged = oldPluginsFileStringContent.contains(pluginsMap.toString());
+    Object? decodedJson;
+    try {
+      decodedJson = jsonDecode(oldPluginsFileStringContent);
+      if (decodedJson is Map<String, Object?>) {
+        final String jsonOfNewPluginsMap = jsonEncode(pluginsMap);
+        final String jsonOfOldPluginsMap = jsonEncode(decodedJson[_kFlutterPluginsPluginListKey]);
+        pluginsChanged = jsonOfNewPluginsMap != jsonOfOldPluginsMap;
+      }
+    } on FormatException catch (_) {}
   }
   final String pluginFileContent = json.encode(result);
   pluginsFile.writeAsStringSync(pluginFileContent, flush: true);


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/162399.
Closes https://github.com/flutter/flutter/issues/163272.

`refreshPluginsList` is commonly called in iOS/macOS apps, more times than you expect (and load bearing); https://github.com/flutter/flutter/issues/157391.

With `--explicit-package-dependencies`, we no longer write (or compare) the output of `.flutter-plugins`. The iOS/macOS workflows required `pod install` output to be invalidated when plugins when change, but the logic that was being used to see if plugins changed _only_ worked for the `.flutter-plugins` file format.

In the original code:

```txt
# oldPluginsFileStringContent
{"info":"This is a generated file; do not edit or check into version control.","plugins":{"ios":[{"name":"integration_test","path":"/Users/matanl/Developer/flutter/packages/integration_test/","native_build":true,"dependencies":[],"dev_dependency":false},{"name":"ios_objc_cocoapods_plugin","path":"/var/folders/qw/qw_3qd1x4kz5w975jhdq4k58007b7h/T/swift_package_manager_enabled.XrEWXS/ios_objc_cocoapods_plugin/","native_build":true,"dependencies":[],"dev_dependency":false}],"android":[{"name":"integration_test","path":"/Users/matanl/Developer/flutter/packages/integration_test/","native_build":true,"dependencies":[],"dev_dependency":false}],"macos":[],"linux":[],"windows":[],"web":[]},"dependencyGraph":[{"name":"integration_test","dependencies":[]},{"name":"ios_objc_cocoapods_plugin","dependencies":[]}],"date_created":"2025-02-13 17:01:11.023097","version":"3.30.0-1.0.pre.163","swift_package_manager_enabled":{"ios":true,"macos":false}}

# pluginsMap
{ios: [{name: integration_test, path: /Users/matanl/Developer/flutter/packages/integration_test/, native_build: true, dependencies: [], dev_dependency: false}, {name: ios_objc_cocoapods_plugin, path: /var/folders/qw/qw_3qd1x4kz5w975jhdq4k58007b7h/T/swift_package_manager_enabled.XrEWXS/ios_objc_cocoapods_plugin/, native_build: true, dependencies: [], dev_dependency: false}], android: [{name: integration_test, path: /Users/matanl/Developer/flutter/packages/integration_test/, native_build: true, dependencies: [], dev_dependency: false}], macos: [], linux: [], windows: [], web: []}
```

As you can see, `pluginsChanged = oldPluginsFileStringContent.contains(pluginsMap.toString());` was _always_ `false`, but we never knew because we'd always just fall back to using the `.flutter-plugins` content comparison (which always worked). 

I added a test as well.

This also appears to fix https://github.com/flutter/flutter/issues/162399.

/cc @jmagman @jonahwilliams 