### PR TITLE
Add `.flutter-plugins-dependencies` to `FlutterBuildSystem`; update logic, add tests.

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -639,15 +639,20 @@ class FlutterBuildSystem extends BuildSystem {
     // We also remove files under .dart_tool, since these are intermediaries
     // and don't need to be tracked by external systems.
     {
+      bool isUnconditionalFile(String path) {
+        return switch (_fileSystem.path.basename(path)) {
+          '.flutter-plugins' || '.flutter-plugins-dependencies' => true,
+          _ when _fileSystem.path.extension(path) == '.xcconfig' => true,
+          _ when _fileSystem.path.split(path).contains('.dart_tool') => true,
+          _ => false,
+        };
+      }
+
       buildInstance.inputFiles.removeWhere((String path, File file) {
-        return path.contains('.flutter-plugins') ||
-            path.contains('xcconfig') ||
-            path.contains('.dart_tool');
+        return isUnconditionalFile(path);
       });
       buildInstance.outputFiles.removeWhere((String path, File file) {
-        return path.contains('.flutter-plugins') ||
-            path.contains('xcconfig') ||
-            path.contains('.dart_tool');
+        return isUnconditionalFile(path);
       });
     }
     trackSharedBuildDirectory(environment, _fileSystem, buildInstance.outputFiles);


### PR DESCRIPTION
I happened to run into this while chasing other bugs, and noticed `.flutter-plugins-dependencies` is omitted.

I am guessing this is probably quite stale, but something something [Chesterton's fence](https://en.wiktionary.org/wiki/Chesterton%27s_fence), and added tests.