### PR TITLE
[release] Update cherry-pick CHANGELOG requirements

### DIFF
--- a/docs/releases/Flutter-Cherrypick-Process.md
+++ b/docs/releases/Flutter-Cherrypick-Process.md
@@ -12,7 +12,7 @@ With branching and branch testability being supported for Flutter & Dart release
 2. Wait about 30 seconds.
 3. If automatic cherry pick succeeds (no merge conflict), a new pull requested will be created and you will receive an email. Edit the cherry-pick details in the PR description of the generated pull request, and a release engineer will follow up on the request.
 4. If automatic cherry pick fails, a comment will be left on the original PR. In this case you will need to follow instructions in the manual cherry-pick section below to manually create a cherry pick PR.
-5. Update CHANGELOG.md following our [best practices](Hotfix-Documentation-Best-Practices.md).
+5. [STABLE ONLY] Update CHANGELOG.md following our [best practices](Hotfix-Documentation-Best-Practices.md).
 
 If for some reason, an automated cherry-pick can not be applied, please follow the manual cherry-pick instructions.
 
@@ -29,7 +29,7 @@ If the automated cherry-pick process fails, you will have to create the cherry-p
   - Risk (What is the risk level of this cherry-pick?)
   - Test Coverage (Are you confident that your fix is well-tested by automated tests?)
   - Validation Steps (What are the steps to validate that this fix works?)
-4. Ensure that your cherry-pick PR updates CHANGELOG.md.
+4. [STABLE ONLY] Ensure that your cherry-pick PR updates CHANGELOG.md.
 
 ## Frequently asked questions
 


### PR DESCRIPTION
Clarify that updates to CHANGELOG.md need only be for cherry-picks to the stable channel.
