### PR TITLE
[Impeller] don't use glFramebufferBlit for onscreen restore.

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1681,6 +1681,14 @@ std::shared_ptr<Texture> Canvas::FlipBackdrop(Point global_pass_position,
   return input_texture;
 }
 
+bool Canvas::SupportsBlitToOnscreen() const {
+  return renderer_.GetContext()
+             ->GetCapabilities()
+             ->SupportsTextureToTextureBlits() &&
+         renderer_.GetContext()->GetBackendType() !=
+             Context::BackendType::kOpenGLES;
+}
+
 bool Canvas::BlitToOnscreen(bool is_onscreen) {
   auto command_buffer = renderer_.GetContext()->CreateCommandBuffer();
   command_buffer->SetLabel("EntityPass Root Command Buffer");
@@ -1688,9 +1696,7 @@ bool Canvas::BlitToOnscreen(bool is_onscreen) {
                               .inline_pass_context->GetPassTarget()
                               .GetRenderTarget();
 
-  if (renderer_.GetContext()
-          ->GetCapabilities()
-          ->SupportsTextureToTextureBlits()) {
+  if (SupportsBlitToOnscreen()) {
     auto blit_pass = command_buffer->CreateBlitPass();
     blit_pass->AddCopy(offscreen_target.GetRenderTargetTexture(),
                        render_target_.GetRenderTargetTexture());

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -251,6 +251,16 @@ class Canvas {
   // Visible for testing.
   bool RequiresReadback() const { return requires_readback_; }
 
+  // Whether the current device has the capabilities to blit an offscreen
+  // texture into the onscreen.
+  //
+  // This requires the availibility of the blit framebuffer command, but is
+  // disabled for GLES. A simple glBlitFramebuffer does not support resolving
+  // different sample counts which may be present in GLES when using MSAA.
+  //
+  // Visible for testing.
+  bool SupportsBlitToOnscreen() const;
+
  private:
   ContentContext& renderer_;
   RenderTarget render_target_;

--- a/engine/src/flutter/impeller/display_list/canvas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/canvas_unittests.cc
@@ -15,6 +15,7 @@
 #include "impeller/display_list/canvas.h"
 #include "impeller/display_list/dl_vertices_geometry.h"
 #include "impeller/geometry/geometry_asserts.h"
+#include "impeller/playground/playground.h"
 #include "impeller/renderer/render_target.h"
 
 namespace impeller {
@@ -370,6 +371,18 @@ TEST_P(AiksTest, DrawVerticesWithEmptyTextureCoordinates) {
   };
 
   ASSERT_TRUE(Playground::OpenPlaygroundHere(callback));
+}
+
+TEST_P(AiksTest, SupportsBlitToOnscreen) {
+  ContentContext context(GetContext(), nullptr);
+  auto canvas = CreateTestCanvas(context, Rect::MakeLTRB(0, 0, 100, 100),
+                                 /*requires_readback=*/true);
+
+  if (GetBackend() == PlaygroundBackend::kOpenGLES) {
+    EXPECT_FALSE(canvas->SupportsBlitToOnscreen());
+  } else {
+    EXPECT_TRUE(canvas->SupportsBlitToOnscreen());
+  }
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -172,7 +172,7 @@ bool CapabilitiesGLES::SupportsTextureToTextureBlits() const {
 }
 
 bool CapabilitiesGLES::SupportsFramebufferFetch() const {
-  return supports_framebuffer_fetch_;
+  return false;  // supports_framebuffer_fetch_;
 }
 
 bool CapabilitiesGLES::SupportsCompute() const {

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -172,7 +172,7 @@ bool CapabilitiesGLES::SupportsTextureToTextureBlits() const {
 }
 
 bool CapabilitiesGLES::SupportsFramebufferFetch() const {
-  return false;  // supports_framebuffer_fetch_;
+  return supports_framebuffer_fetch_;
 }
 
 bool CapabilitiesGLES::SupportsCompute() const {


### PR DESCRIPTION
With the OpenGLES backend, we use the MSAA render to texture extension. This means that the offscreen textures are multisample and implicitly resolved when sampled from. This implicit resolve does not occur in the blit command used to restore to the onscreen, which can trigger a crash in the GLES driver.

In other backends, the onscreen is also multisample and the blit is OK.

Fixes https://github.com/flutter/flutter/issues/163304