### PR TITLE
[Impeller] when binding to READ_FRAMEBUFFER, treat multisampled textures as single sampled.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/test/texture_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/texture_gles_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "GLES3/gl3.h"
 #include "flutter/impeller/playground/playground_test.h"
 #include "flutter/impeller/renderer/backend/gles/context_gles.h"
 #include "flutter/impeller/renderer/backend/gles/texture_gles.h"
@@ -63,6 +64,25 @@ TEST_P(TextureGLESTest, CanSetSyncFence) {
 
   sync_fence = TextureGLES::Cast(*texture).GetSyncFence();
   ASSERT_FALSE(sync_fence.has_value());
+}
+
+TEST_P(TextureGLESTest, Binds2DTexture) {
+  TextureDescriptor desc;
+  desc.storage_mode = StorageMode::kDevicePrivate;
+  desc.size = {100, 100};
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
+  desc.type = TextureType::kTexture2DMultisample;
+  desc.sample_count = SampleCount::kCount4;
+
+  auto texture = GetContext()->GetResourceAllocator()->CreateTexture(desc);
+
+  ASSERT_TRUE(texture);
+
+  EXPECT_EQ(
+      TextureGLES::Cast(*texture).ComputeTypeForBinding(GL_READ_FRAMEBUFFER),
+      TextureGLES::Type::kTexture);
+  EXPECT_EQ(TextureGLES::Cast(*texture).ComputeTypeForBinding(GL_FRAMEBUFFER),
+            TextureGLES::Type::kTextureMultisampled);
 }
 
 }  // namespace impeller::testing

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/texture_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/texture_gles_unittests.cc
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "GLES3/gl3.h"
 #include "flutter/impeller/playground/playground_test.h"
 #include "flutter/impeller/renderer/backend/gles/context_gles.h"
 #include "flutter/impeller/renderer/backend/gles/texture_gles.h"

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -597,13 +597,7 @@ bool TextureGLES::SetAsFramebufferAttachment(
   }
   const auto& gl = reactor_->GetProcTable();
 
-  Type type = type_;
-  // When binding to a GL_READ_FRAMEBUFFER, any multisampled
-  // textures must be bound as single sampled.
-  if (target == GL_READ_FRAMEBUFFER && type == Type::kTextureMultisampled) {
-    type = Type::kTexture;
-  }
-  switch (type) {
+  switch (ComputeTypeForBinding(target)) {
     case Type::kTexture:
       gl.FramebufferTexture2D(target,                             // target
                               ToAttachmentType(attachment_type),  // attachment

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -7,6 +7,7 @@
 #include <optional>
 #include <utility>
 
+#include "GLES3/gl3.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/trace_event.h"
@@ -588,7 +589,13 @@ bool TextureGLES::SetAsFramebufferAttachment(
   }
   const auto& gl = reactor_->GetProcTable();
 
-  switch (type_) {
+  Type type = type_;
+  // When binding to a GL_READ_FRAMEBUFFER, any multisampled
+  // textures must be bound as single sampled.
+  if (target == GL_READ_FRAMEBUFFER && type == Type::kTextureMultisampled) {
+    type = Type::kTexture;
+  }
+  switch (type) {
     case Type::kTexture:
       gl.FramebufferTexture2D(target,                             // target
                               ToAttachmentType(attachment_type),  // attachment

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -392,6 +392,15 @@ static std::optional<GLenum> ToRenderBufferFormat(PixelFormat format) {
   FML_UNREACHABLE();
 }
 
+TextureGLES::Type TextureGLES::ComputeTypeForBinding(GLenum target) const {
+  // When binding to a GL_READ_FRAMEBUFFER, any multisampled
+  // textures must be bound as single sampled.
+  if (target == GL_READ_FRAMEBUFFER && type_ == Type::kTextureMultisampled) {
+    return Type::kTexture;
+  }
+  return type_;
+}
+
 void TextureGLES::InitializeContentsIfNecessary() const {
   if (!IsValid() || slices_initialized_[0]) {
     return;

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -7,7 +7,6 @@
 #include <optional>
 #include <utility>
 
-#include "GLES3/gl3.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/trace_event.h"

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
@@ -144,6 +144,9 @@ class TextureGLES final : public Texture,
   // Visible for testing.
   std::optional<HandleGLES> GetSyncFence() const;
 
+  // visible for testing
+  Type ComputeTypeForBinding(GLenum target) const;
+
  private:
   std::shared_ptr<ReactorGLES> reactor_;
   const Type type_;


### PR DESCRIPTION
I noticed this causes crashes when doing readback, but only on some deivces. I suspect that this is the more correct binding choice, and other drivers are just more lenient.
