### PR TITLE
[ui] Fix ImageFilter.shader equality to consider uniform values.

### DIFF
--- a/engine/src/flutter/lib/ui/dart_ui.cc
+++ b/engine/src/flutter/lib/ui/dart_ui.cc
@@ -205,6 +205,7 @@ typedef CanvasPath Path;
   V(ImageFilter, initComposeFilter)              \
   V(ImageFilter, initShader)                     \
   V(ImageFilter, initMatrix)                     \
+  V(ImageFilter, equals)                         \
   V(ImageShader, dispose)                        \
   V(ImageShader, initWithImage)                  \
   V(ImmutableBuffer, dispose)                    \

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4466,10 +4466,14 @@ class _FragmentShaderImageFilter implements ImageFilter {
 
   @override
   bool operator ==(Object other) {
-    if (other.runtimeType != runtimeType) {
-      return false;
-    }
-    return other is _FragmentShaderImageFilter && other.shader == shader;
+    // This object always returns false for equality, because it wraps
+    // a mutable object (The fragment shader). The expectation is that this
+    // object can be mutated to update the shader result. However, the framework
+    // equality checks ImageFilter objects to determine if the filter has
+    // actually changed. Because the object was mutated, even a deep equality
+    // check would pass. Thus, we work around these problems by always
+    // returning false.
+    return false;
   }
 
   @override

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4466,15 +4466,16 @@ class _FragmentShaderImageFilter implements ImageFilter {
 
   @override
   bool operator ==(Object other) {
-    // This object always returns false for equality, because it wraps
-    // a mutable object (The fragment shader). The expectation is that this
-    // object can be mutated to update the shader result. However, the framework
-    // equality checks ImageFilter objects to determine if the filter has
-    // actually changed. Because the object was mutated, even a deep equality
-    // check would pass. Thus, we work around these problems by always
-    // returning false.
-    return false;
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is _FragmentShaderImageFilter &&
+        other.shader == shader &&
+        _equals(nativeFilter, other.nativeFilter);
   }
+
+  @Native<Bool Function(Handle, Handle)>(symbol: 'ImageFilter::equal')
+  external static bool _equals(_ImageFilter a, _ImageFilter b);
 
   @override
   int get hashCode => shader.hashCode;

--- a/engine/src/flutter/lib/ui/painting/image_filter.cc
+++ b/engine/src/flutter/lib/ui/painting/image_filter.cc
@@ -125,4 +125,8 @@ void ImageFilter::initShader(ReusableFragmentShader* shader) {
   filter_ = shader->as_image_filter();
 }
 
+bool ImageFilter::equals(ImageFilter* a, ImageFilter* b) {
+  return a->filter_ == b->filter_;
+}
+
 }  // namespace flutter

--- a/engine/src/flutter/lib/ui/painting/image_filter.h
+++ b/engine/src/flutter/lib/ui/painting/image_filter.h
@@ -36,6 +36,7 @@ class ImageFilter : public RefCountedDartWrappable<ImageFilter> {
   void initColorFilter(ColorFilter* colorFilter);
   void initComposeFilter(ImageFilter* outer, ImageFilter* inner);
   void initShader(ReusableFragmentShader* shader);
+  bool equals(ImageFilter* a, ImageFilter* b);
 
   const std::shared_ptr<DlImageFilter> filter(DlTileMode mode) const;
 

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -415,6 +415,26 @@ void main() async {
     expect(color, const Color(0xFF00FF00));
   });
 
+  // For an explaination of the problem see https://github.com/flutter/flutter/issues/163302 .
+  test('ImageFilter.shader equality checks always fail', () async {
+    if (!impellerEnabled) {
+      print('Skipped for Skia');
+      return;
+    }
+    final FragmentProgram program = await FragmentProgram.fromAsset('filter_shader.frag.iplr');
+    final FragmentShader shader = program.fragmentShader();
+
+    // The same shader is not equal to itself.
+    expect(shader, isNot(shader));
+    expect(identical(shader, shader), true);
+
+    final FragmentShader shader_2 = program.fragmentShader();
+
+    // The different shader is not equal or identical.
+    expect(shader, isNot(shader_2));
+    expect(identical(shader, shader_2), false);
+  });
+
   if (impellerEnabled) {
     print('Skipped for Impeller - https://github.com/flutter/flutter/issues/122823');
     return;

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -416,23 +416,31 @@ void main() async {
   });
 
   // For an explaination of the problem see https://github.com/flutter/flutter/issues/163302 .
-  test('ImageFilter.shader equality checks always fail', () async {
+  test('ImageFilter.shader equality checks consider uniform values', () async {
     if (!impellerEnabled) {
       print('Skipped for Skia');
       return;
     }
     final FragmentProgram program = await FragmentProgram.fromAsset('filter_shader.frag.iplr');
     final FragmentShader shader = program.fragmentShader();
+    final ImageFilter filter = ImageFilter.shader(shader);
 
-    // The same shader is not equal to itself.
-    expect(shader, isNot(shader));
-    expect(identical(shader, shader), true);
+    // The same shader is equal to itself.
+    expect(filter, filter);
+    expect(identical(filter, filter), true);
 
-    final FragmentShader shader_2 = program.fragmentShader();
+    final ImageFilter filter_2 = ImageFilter.shader(shader);
 
-    // The different shader is not equal or identical.
-    expect(shader, isNot(shader_2));
-    expect(identical(shader, shader_2), false);
+    // The different shader is equal as long as uniforms are identical.
+    expect(filter, filter_2);
+    expect(identical(filter, filter_2), false);
+
+    // Not equal if uniforms change.
+    shader.setFloat(0, 1);
+    final ImageFilter filter_3 = ImageFilter.shader(shader);
+
+    expect(filter, isNot(filter_3));
+    expect(identical(filter, filter_3), false);
   });
 
   if (impellerEnabled) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/163302

Framework widgets check for ImageFIlter.== to determine whether to mark themselves dirty. The filter obejct needs to delegate its equality to the underlying native filter so that uniform values are considered.