### PR TITLE
Add a test to run on Galaxy S24

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -121,6 +121,17 @@ platform_properties:
       os: Linux
       device_type: "mokey"
 
+  linux_galaxy_s24:
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:35v1"},
+          {"dependency": "open_jdk", "version": "version:17"},
+          {"dependency": "curl", "version": "version:7.64.0"}
+        ]
+      os: Linux
+      device_type: "SM-S921U1"
+      
   mac:
     properties:
       contexts: >-
@@ -3064,6 +3075,17 @@ targets:
     properties:
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
+      task_name: new_gallery_impeller__transition_perf
+
+  # Samsung Galaxy S24, Impeller (Vulkan)
+  - name: Linux_galaxy_s24 new_gallery_impeller__transition_perf
+    recipe: devicelab/devicelab_drone
+    bringup: true
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux", "samsung", "s24"]
       task_name: new_gallery_impeller__transition_perf
 
   # Pixel 7 Pro, Impeller (OpenGL)

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -131,7 +131,7 @@ platform_properties:
         ]
       os: Linux
       device_type: "SM-S921U1"
-      
+
   mac:
     properties:
       contexts: >-


### PR DESCRIPTION
S24 is only hooked up in the try pool at the moment, so this will fail in the staging pool after landing, following which we can run the test in a second PR in presubmit by changing `presubmit` to `true`.

For https://github.com/flutter/flutter/issues/162639