### PR TITLE
Hot Restart should dispose all previous Platform Views (macOS)

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -1124,6 +1124,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   while ((nextViewController = [viewControllerEnumerator nextObject])) {
     [nextViewController onPreEngineRestart];
   }
+  [_platformViewController reset];
 }
 
 - (void)onVSync:(uintptr_t)baton {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
@@ -58,6 +58,11 @@
  */
 - (void)disposePlatformViews;
 
+/**
+ * Removes all platform views.
+ */
+- (void)reset;
+
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWCONTROLLER_H_

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
@@ -170,4 +170,11 @@
   _platformViewsToDispose.clear();
 }
 
+- (void)reset {
+  for (const auto& pair : _platformViews) {
+    _platformViewsToDispose.insert(pair.first);
+  }
+  [self disposePlatformViews];
+}
+
 @end

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
@@ -148,13 +148,6 @@ TEST(FlutterPlatformViewController, TestReset) {
 
   [platformViewController registerViewFactory:factory withId:@"MockPlatformView"];
 
-  FlutterMethodCall* methodCallOnCreate =
-      [FlutterMethodCall methodCallWithMethodName:@"create"
-                                        arguments:@{
-                                          @"id" : @3,
-                                          @"viewType" : @"MockPlatformView"
-                                        }];
-
   __block bool created = false;
   FlutterResult resultOnCreate = ^(id result) {
     // If a platform view is successfully created, the result is nil.
@@ -165,20 +158,41 @@ TEST(FlutterPlatformViewController, TestReset) {
     }
   };
 
-  [platformViewController handleMethodCall:methodCallOnCreate result:resultOnCreate];
+  // Create 2 views.
+  FlutterMethodCall* methodCallOnCreate0 =
+      [FlutterMethodCall methodCallWithMethodName:@"create"
+                                        arguments:@{
+                                          @"id" : @0,
+                                          @"viewType" : @"MockPlatformView"
+                                        }];
 
+  [platformViewController handleMethodCall:methodCallOnCreate0 result:resultOnCreate];
   EXPECT_TRUE(created);
 
-  // Creating with the same id should fail.
-  [platformViewController handleMethodCall:methodCallOnCreate result:resultOnCreate];
+  FlutterMethodCall* methodCallOnCreate1 =
+      [FlutterMethodCall methodCallWithMethodName:@"create"
+                                        arguments:@{
+                                          @"id" : @1,
+                                          @"viewType" : @"MockPlatformView"
+                                        }];
+  [platformViewController handleMethodCall:methodCallOnCreate1 result:resultOnCreate];
+  EXPECT_TRUE(created);
 
-  EXPECT_FALSE(created);
+  TestFlutterPlatformView* view = nil;
 
-  // After a reset, creating with the same id should succeed.
+  // Before the reset, the views exist.
+  view = (TestFlutterPlatformView*)[platformViewController platformViewWithID:0];
+  EXPECT_TRUE(view != nil);
+  view = (TestFlutterPlatformView*)[platformViewController platformViewWithID:1];
+  EXPECT_TRUE(view != nil);
+
+  // After a reset, the views should no longer exist.
   [platformViewController reset];
-  [platformViewController handleMethodCall:methodCallOnCreate result:resultOnCreate];
 
-  EXPECT_TRUE(created);
+  view = (TestFlutterPlatformView*)[platformViewController platformViewWithID:0];
+  EXPECT_TRUE(view == nil);
+  view = (TestFlutterPlatformView*)[platformViewController platformViewWithID:1];
+  EXPECT_TRUE(view == nil);
 }
 
 TEST(FlutterPlatformViewController, TestDisposeOnMissingViewId) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
@@ -141,6 +141,46 @@ TEST(FlutterPlatformViewController, TestCreateAndDispose) {
   EXPECT_TRUE(disposed);
 }
 
+TEST(FlutterPlatformViewController, TestReset) {
+  // Use id so we can access handleMethodCall method.
+  id platformViewController = [[FlutterPlatformViewController alloc] init];
+  TestFlutterPlatformViewFactory* factory = [TestFlutterPlatformViewFactory alloc];
+
+  [platformViewController registerViewFactory:factory withId:@"MockPlatformView"];
+
+  FlutterMethodCall* methodCallOnCreate =
+      [FlutterMethodCall methodCallWithMethodName:@"create"
+                                        arguments:@{
+                                          @"id" : @3,
+                                          @"viewType" : @"MockPlatformView"
+                                        }];
+
+  __block bool created = false;
+  FlutterResult resultOnCreate = ^(id result) {
+    // If a platform view is successfully created, the result is nil.
+    if (result == nil) {
+      created = true;
+    } else {
+      created = false;
+    }
+  };
+
+  [platformViewController handleMethodCall:methodCallOnCreate result:resultOnCreate];
+
+  EXPECT_TRUE(created);
+
+  // Creating with the same id should fail.
+  [platformViewController handleMethodCall:methodCallOnCreate result:resultOnCreate];
+
+  EXPECT_FALSE(created);
+
+  // After a reset, creating with the same id should succeed.
+  [platformViewController reset];
+  [platformViewController handleMethodCall:methodCallOnCreate result:resultOnCreate];
+
+  EXPECT_TRUE(created);
+}
+
 TEST(FlutterPlatformViewController, TestDisposeOnMissingViewId) {
   // Use id so we can access handleMethodCall method.
   id platformViewController = [[FlutterPlatformViewController alloc] init];


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

When using Platform Views on macOS, performing a Hot Restart throws an exception with message "trying to create an already created view". This is because the old Platform Views are not cleaned up. So, here we dispose of the old Platform Views as part of the Hot Restart process.

Fixes issue: https://github.com/flutter/flutter/issues/110381

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
