### PR TITLE
Add PlatformDispatcher.engineId

### DIFF
--- a/dev/integration_tests/android_engine_test/lib/engine_handle.dart
+++ b/dev/integration_tests/android_engine_test/lib/engine_handle.dart
@@ -1,0 +1,25 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:android_driver_extensions/extension.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_driver/driver_extension.dart';
+
+import 'src/allow_list_devices.dart';
+
+void main() {
+  ensureAndroidDevice();
+  enableFlutterDriverExtension(
+    handler: (String? command) async {
+      return json.encode(<String, Object?>{
+        'engineHandle': PlatformDispatcher.instance.engineHandle,
+      });
+    },
+    commands: <CommandExtension>[nativeDriverCommands],
+  );
+  runApp(const SizedBox());
+}

--- a/dev/integration_tests/android_engine_test/lib/engine_handle.dart
+++ b/dev/integration_tests/android_engine_test/lib/engine_handle.dart
@@ -16,7 +16,7 @@ void main() {
   enableFlutterDriverExtension(
     handler: (String? command) async {
       return json.encode(<String, Object?>{
-        'engineHandle': PlatformDispatcher.instance.engineHandle,
+        'engineId': PlatformDispatcher.instance.engineId,
       });
     },
     commands: <CommandExtension>[nativeDriverCommands],

--- a/dev/integration_tests/android_engine_test/lib/engine_handle.dart
+++ b/dev/integration_tests/android_engine_test/lib/engine_handle.dart
@@ -15,9 +15,7 @@ void main() {
   ensureAndroidDevice();
   enableFlutterDriverExtension(
     handler: (String? command) async {
-      return json.encode(<String, Object?>{
-        'engineId': PlatformDispatcher.instance.engineId,
-      });
+      return json.encode(<String, Object?>{'engineId': PlatformDispatcher.instance.engineId});
     },
     commands: <CommandExtension>[nativeDriverCommands],
   );

--- a/dev/integration_tests/android_engine_test/test_driver/engine_handle_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/engine_handle_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:android_driver_extensions/native_driver.dart';
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+late final FlutterDriver flutterDriver;
+late final NativeDriver nativeDriver;
+
+void main() async {
+  setUpAll(() async {
+    flutterDriver = await FlutterDriver.connect();
+    nativeDriver = await AndroidNativeDriver.connect(flutterDriver);
+  });
+
+  tearDownAll(() async {
+    await nativeDriver.close();
+    await flutterDriver.close();
+  });
+
+  test('verify that engineHandle is set and works', () async {
+    final Map<String, Object?> response =
+        json.decode(await flutterDriver.requestData('')) as Map<String, Object?>;
+    expect(response['engineHandle'], 1);
+  }, timeout: Timeout.none);
+}

--- a/dev/integration_tests/android_engine_test/test_driver/engine_handle_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/engine_handle_test.dart
@@ -23,15 +23,15 @@ void main() async {
   });
 
   // TODO(matanlurey): Convert to use package:integration_test
-  test('verify that engineHandle is set and works', () async {
+  test('verify that engineId is set and works', () async {
     final Map<String, Object?> response =
         json.decode(await flutterDriver.requestData('')) as Map<String, Object?>;
     expect(
-      response['engineHandle'],
+      response['engineId'],
       1,
-      // Valid engine handles start at 1 to make detecting uninitialized
+      // Valid engine ids start at 1 to make detecting uninitialized
       // values easier.
-      reason: 'engineHandle of first engine instance should be 1',
+      reason: 'engineId of first engine instance should be 1',
     );
   }, timeout: Timeout.none);
 }

--- a/dev/integration_tests/android_engine_test/test_driver/engine_handle_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/engine_handle_test.dart
@@ -22,9 +22,16 @@ void main() async {
     await flutterDriver.close();
   });
 
+  // TODO(matanlurey): Convert to use package:integration_test
   test('verify that engineHandle is set and works', () async {
     final Map<String, Object?> response =
         json.decode(await flutterDriver.requestData('')) as Map<String, Object?>;
-    expect(response['engineHandle'], 1);
+    expect(
+      response['engineHandle'],
+      1,
+      // Valid engine handles start at 1 to make detecting uninitialized
+      // values easier.
+      reason: 'engineHandle of first engine instance should be 1',
+    );
   }, timeout: Timeout.none);
 }

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -69,6 +69,11 @@ void _sendViewFocusEvent(int viewId, int viewFocusState, int viewFocusDirection)
 }
 
 @pragma('vm:entry-point')
+void _setEngineHandle(int engineHandle) {
+  PlatformDispatcher.instance._engineHandle = engineHandle;
+}
+
+@pragma('vm:entry-point')
 void _updateDisplays(
   List<int> ids,
   List<double> widths,

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -69,8 +69,8 @@ void _sendViewFocusEvent(int viewId, int viewFocusState, int viewFocusDirection)
 }
 
 @pragma('vm:entry-point')
-void _setEngineHandle(int engineHandle) {
-  PlatformDispatcher.instance._engineHandle = engineHandle;
+void _setEngineId(int engineId) {
+  PlatformDispatcher.instance._engineId = engineId;
 }
 
 @pragma('vm:entry-point')

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -305,11 +305,12 @@ class PlatformDispatcher {
     _invoke1<ViewFocusEvent>(onViewFocusChange, _onViewFocusChangeZone, event);
   }
 
-  /// Opaque engine handle for the engine running current isolate. Can be used
+  /// Opaque engine identifier for the engine running current isolate. Can be used
   /// in native code to retrieve the engine instance.
-  int? get engineHandle => _engineHandle;
+  /// The identifier is valid while the isolate is running.
+  int? get engineId => _engineId;
 
-  int? _engineHandle;
+  int? _engineId;
 
   // Called from the engine, via hooks.dart.
   //

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -305,6 +305,12 @@ class PlatformDispatcher {
     _invoke1<ViewFocusEvent>(onViewFocusChange, _onViewFocusChangeZone, event);
   }
 
+  /// Opaque engine handle for the engine running current isolate. Can be used
+  /// in native code to retrieve the engine instance.
+  int? get engineHandle => _engineHandle;
+
+  int? _engineHandle;
+
   // Called from the engine, via hooks.dart.
   //
   // Updates the available displays.

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -49,6 +49,9 @@ void PlatformConfiguration::DidCreateIsolate() {
   send_view_focus_event_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_sendViewFocusEvent")));
+  set_engine_handle_.Set(
+      tonic::DartState::Current(),
+      Dart_GetField(library, tonic::ToDart("_setEngineHandle")));
   update_window_metrics_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_updateWindowMetrics")));
@@ -165,6 +168,20 @@ bool PlatformConfiguration::SendFocusEvent(const ViewFocusEvent& event) {
                                         tonic::ToDart(event.state()),
                                         tonic::ToDart(event.direction()),
                                     }));
+  return true;
+}
+
+bool PlatformConfiguration::SetEngineHandle(int64_t engine_handle) {
+  std::shared_ptr<tonic::DartState> dart_state =
+      set_engine_handle_.dart_state().lock();
+  if (!dart_state) {
+    return false;
+  }
+  tonic::DartState::Scope scope(dart_state);
+  tonic::CheckAndHandleError(tonic::DartInvoke(set_engine_handle_.Get(),
+                                               {
+                                                   tonic::ToDart(engine_handle),
+                                               }));
   return true;
 }
 

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -49,9 +49,8 @@ void PlatformConfiguration::DidCreateIsolate() {
   send_view_focus_event_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_sendViewFocusEvent")));
-  set_engine_handle_.Set(
-      tonic::DartState::Current(),
-      Dart_GetField(library, tonic::ToDart("_setEngineHandle")));
+  set_engine_id_.Set(tonic::DartState::Current(),
+                     Dart_GetField(library, tonic::ToDart("_setEngineId")));
   update_window_metrics_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_updateWindowMetrics")));
@@ -171,17 +170,17 @@ bool PlatformConfiguration::SendFocusEvent(const ViewFocusEvent& event) {
   return true;
 }
 
-bool PlatformConfiguration::SetEngineHandle(int64_t engine_handle) {
+bool PlatformConfiguration::SetEngineId(int64_t engine_id) {
   std::shared_ptr<tonic::DartState> dart_state =
-      set_engine_handle_.dart_state().lock();
+      set_engine_id_.dart_state().lock();
   if (!dart_state) {
     return false;
   }
   tonic::DartState::Scope scope(dart_state);
-  tonic::CheckAndHandleError(tonic::DartInvoke(set_engine_handle_.Get(),
-                                               {
-                                                   tonic::ToDart(engine_handle),
-                                               }));
+  tonic::CheckAndHandleError(
+      tonic::DartInvoke(set_engine_id_.Get(), {
+                                                  tonic::ToDart(engine_id),
+                                              }));
   return true;
 }
 

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -356,6 +356,14 @@ class PlatformConfiguration final {
   /// @return     Whether the focus event was sent.
   bool SendFocusEvent(const ViewFocusEvent& event);
 
+  /// @brief     Sets the opaque handle of the engine.
+  ///
+  ///            The handle can be passed from Dart to native code to retrieve
+  ///            the engine instance.
+  ///
+  /// @return    Whether the handle was set.
+  bool SetEngineHandle(int64_t engine_handle);
+
   //----------------------------------------------------------------------------
   /// @brief      Update the view metrics for the specified view.
   ///
@@ -548,6 +556,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue add_view_;
   tonic::DartPersistentValue remove_view_;
   tonic::DartPersistentValue send_view_focus_event_;
+  tonic::DartPersistentValue set_engine_handle_;
   tonic::DartPersistentValue update_window_metrics_;
   tonic::DartPersistentValue update_displays_;
   tonic::DartPersistentValue update_locales_;

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -356,13 +356,13 @@ class PlatformConfiguration final {
   /// @return     Whether the focus event was sent.
   bool SendFocusEvent(const ViewFocusEvent& event);
 
-  /// @brief     Sets the opaque handle of the engine.
+  /// @brief     Sets the opaque identifier of the engine.
   ///
-  ///            The handle can be passed from Dart to native code to retrieve
-  ///            the engine instance.
+  ///            The identifier can be passed from Dart to native code to
+  ///            retrieve the engine instance.
   ///
-  /// @return    Whether the handle was set.
-  bool SetEngineHandle(int64_t engine_handle);
+  /// @return    Whether the identifier was set.
+  bool SetEngineId(int64_t engine_id);
 
   //----------------------------------------------------------------------------
   /// @brief      Update the view metrics for the specified view.
@@ -556,7 +556,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue add_view_;
   tonic::DartPersistentValue remove_view_;
   tonic::DartPersistentValue send_view_focus_event_;
-  tonic::DartPersistentValue set_engine_handle_;
+  tonic::DartPersistentValue set_engine_id_;
   tonic::DartPersistentValue update_window_metrics_;
   tonic::DartPersistentValue update_displays_;
   tonic::DartPersistentValue update_locales_;

--- a/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
@@ -37,6 +37,8 @@ abstract class PlatformDispatcher {
 
   FlutterView? get implicitView;
 
+  int? get engineId;
+
   VoidCallback? get onMetricsChanged;
   set onMetricsChanged(VoidCallback? callback);
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -140,6 +140,8 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   EngineFlutterWindow? get implicitView => viewManager[kImplicitViewId] as EngineFlutterWindow?;
 
+  int? get engineId => null;
+
   /// A callback that is invoked whenever the platform's [devicePixelRatio],
   /// [physicalSize], [padding], [viewInsets], or [systemGestureInsets]
   /// values change, for example when the device is rotated or when the

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -140,6 +140,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   EngineFlutterWindow? get implicitView => viewManager[kImplicitViewId] as EngineFlutterWindow?;
 
+  @override
   int? get engineId => null;
 
   /// A callback that is invoked whenever the platform's [devicePixelRatio],

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -538,7 +538,7 @@ bool RuntimeController::LaunchRootIsolate(
     const std::vector<std::string>& dart_entrypoint_args,
     std::unique_ptr<IsolateConfiguration> isolate_configuration,
     std::shared_ptr<NativeAssetsManager> native_assets_manager,
-    std::optional<int64_t> engine_handle) {
+    std::optional<int64_t> engine_id) {
   if (root_isolate_.lock()) {
     FML_LOG(ERROR) << "Root isolate was already running.";
     return false;
@@ -587,9 +587,9 @@ bool RuntimeController::LaunchRootIsolate(
     if (!FlushRuntimeStateToIsolate()) {
       FML_DLOG(ERROR) << "Could not set up initial isolate state.";
     }
-    if (engine_handle) {
-      if (!platform_configuration->SetEngineHandle(*engine_handle)) {
-        FML_DLOG(ERROR) << "Could not set engine handle.";
+    if (engine_id) {
+      if (!platform_configuration->SetEngineId(*engine_id)) {
+        FML_DLOG(ERROR) << "Could not set engine identifier.";
       }
     }
   } else {

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -537,7 +537,8 @@ bool RuntimeController::LaunchRootIsolate(
     std::optional<std::string> dart_entrypoint_library,
     const std::vector<std::string>& dart_entrypoint_args,
     std::unique_ptr<IsolateConfiguration> isolate_configuration,
-    std::shared_ptr<NativeAssetsManager> native_assets_manager) {
+    std::shared_ptr<NativeAssetsManager> native_assets_manager,
+    std::optional<int64_t> engine_handle) {
   if (root_isolate_.lock()) {
     FML_LOG(ERROR) << "Root isolate was already running.";
     return false;
@@ -585,6 +586,11 @@ bool RuntimeController::LaunchRootIsolate(
     platform_configuration->DidCreateIsolate();
     if (!FlushRuntimeStateToIsolate()) {
       FML_DLOG(ERROR) << "Could not set up initial isolate state.";
+    }
+    if (engine_handle) {
+      if (!platform_configuration->SetEngineHandle(*engine_handle)) {
+        FML_DLOG(ERROR) << "Could not set engine handle.";
+      }
     }
   } else {
     FML_DCHECK(false) << "RuntimeController created without window binding.";

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -156,6 +156,8 @@ class RuntimeController : public PlatformConfigurationClient,
   /// @param[in]  dart_entrypoint_args     Arguments passed as a List<String>
   ///                                      to Dart's entrypoint function.
   /// @param[in]  isolate_configuration    The isolate configuration
+  /// @param[in]  engine_handle.           Engine handle to be passed to the
+  ///                                      platform dispatcher.
   ///
   /// @return     If the isolate could be launched and guided to the
   ///             `DartIsolate::Phase::Running` phase.
@@ -167,7 +169,8 @@ class RuntimeController : public PlatformConfigurationClient,
       std::optional<std::string> dart_entrypoint_library,
       const std::vector<std::string>& dart_entrypoint_args,
       std::unique_ptr<IsolateConfiguration> isolate_configuration,
-      std::shared_ptr<NativeAssetsManager> native_assets_manager);
+      std::shared_ptr<NativeAssetsManager> native_assets_manager,
+      std::optional<int64_t> engine_handle);
 
   //----------------------------------------------------------------------------
   /// @brief      Clone the runtime controller. Launching an isolate with a

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -156,7 +156,7 @@ class RuntimeController : public PlatformConfigurationClient,
   /// @param[in]  dart_entrypoint_args     Arguments passed as a List<String>
   ///                                      to Dart's entrypoint function.
   /// @param[in]  isolate_configuration    The isolate configuration
-  /// @param[in]  engine_handle.           Engine handle to be passed to the
+  /// @param[in]  engine_id.               Engine identifier to be passed to the
   ///                                      platform dispatcher.
   ///
   /// @return     If the isolate could be launched and guided to the
@@ -170,7 +170,7 @@ class RuntimeController : public PlatformConfigurationClient,
       const std::vector<std::string>& dart_entrypoint_args,
       std::unique_ptr<IsolateConfiguration> isolate_configuration,
       std::shared_ptr<NativeAssetsManager> native_assets_manager,
-      std::optional<int64_t> engine_handle);
+      std::optional<int64_t> engine_id);
 
   //----------------------------------------------------------------------------
   /// @brief      Clone the runtime controller. Launching an isolate with a

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -245,8 +245,9 @@ Engine::RunStatus Engine::Run(RunConfiguration configuration) {
           configuration.GetEntrypointLibrary(),      //
           configuration.GetEntrypointArgs(),         //
           configuration.TakeIsolateConfiguration(),  //
-          native_assets_manager_)                    //
-  ) {
+          native_assets_manager_,                    //
+          configuration.GetEngineHandle()))          //
+  {
     return RunStatus::Failure;
   }
 

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -246,7 +246,7 @@ Engine::RunStatus Engine::Run(RunConfiguration configuration) {
           configuration.GetEntrypointArgs(),         //
           configuration.TakeIsolateConfiguration(),  //
           native_assets_manager_,                    //
-          configuration.GetEngineHandle()))          //
+          configuration.GetEngineId()))              //
   {
     return RunStatus::Failure;
   }

--- a/engine/src/flutter/shell/common/fixtures/shell_test.dart
+++ b/engine/src/flutter/shell/common/fixtures/shell_test.dart
@@ -641,10 +641,10 @@ void testSendViewFocusEvent() {
   notifyNative();
 }
 
-@pragma('vm:external-name', 'ReportEngineHandle')
-external void _reportEngineHandle(int? handle);
+@pragma('vm:external-name', 'ReportEngineId')
+external void _reportEngineId(int? identifier);
 
 @pragma('vm:entry-point')
-void providesEngineHandle() {
-  _reportEngineHandle(PlatformDispatcher.instance.engineHandle);
+void providesEngineId() {
+  _reportEngineId(PlatformDispatcher.instance.engineId);
 }

--- a/engine/src/flutter/shell/common/fixtures/shell_test.dart
+++ b/engine/src/flutter/shell/common/fixtures/shell_test.dart
@@ -640,3 +640,11 @@ void testSendViewFocusEvent() {
   };
   notifyNative();
 }
+
+@pragma('vm:external-name', 'ReportEngineHandle')
+external void _reportEngineHandle(int? handle);
+
+@pragma('vm:entry-point')
+void providesEngineHandle() {
+  _reportEngineHandle(PlatformDispatcher.instance.engineHandle);
+}

--- a/engine/src/flutter/shell/common/run_configuration.cc
+++ b/engine/src/flutter/shell/common/run_configuration.cc
@@ -105,6 +105,15 @@ const std::vector<std::string>& RunConfiguration::GetEntrypointArgs() const {
   return entrypoint_args_;
 }
 
+void RunConfiguration::SetEngineHandle(int64_t engine_handle) {
+  engine_handle_ = engine_handle;
+}
+
+// Engine handle to be passed to the platform dispatcher.
+std::optional<int64_t> RunConfiguration::GetEngineHandle() const {
+  return engine_handle_;
+}
+
 std::unique_ptr<IsolateConfiguration>
 RunConfiguration::TakeIsolateConfiguration() {
   return std::move(isolate_configuration_);

--- a/engine/src/flutter/shell/common/run_configuration.cc
+++ b/engine/src/flutter/shell/common/run_configuration.cc
@@ -105,13 +105,13 @@ const std::vector<std::string>& RunConfiguration::GetEntrypointArgs() const {
   return entrypoint_args_;
 }
 
-void RunConfiguration::SetEngineHandle(int64_t engine_handle) {
-  engine_handle_ = engine_handle;
+void RunConfiguration::SetEngineId(int64_t engine_id) {
+  engine_id_ = engine_id;
 }
 
-// Engine handle to be passed to the platform dispatcher.
-std::optional<int64_t> RunConfiguration::GetEngineHandle() const {
-  return engine_handle_;
+// Engine identifier to be passed to the platform dispatcher.
+std::optional<int64_t> RunConfiguration::GetEngineId() const {
+  return engine_id_;
 }
 
 std::unique_ptr<IsolateConfiguration>

--- a/engine/src/flutter/shell/common/run_configuration.h
+++ b/engine/src/flutter/shell/common/run_configuration.h
@@ -194,12 +194,22 @@ class RunConfiguration {
   ///
   std::unique_ptr<IsolateConfiguration> TakeIsolateConfiguration();
 
+  //----------------------------------------------------------------------------
+  /// @brief      Sets the engine handle to be passed to the platform
+  ///             dispatcher.
+  void SetEngineHandle(int64_t engine_handle);
+
+  ///----------------------------------------------------------------------------
+  /// @return     Engine handle to be passed to the platform dispatcher.
+  std::optional<int64_t> GetEngineHandle() const;
+
  private:
   std::unique_ptr<IsolateConfiguration> isolate_configuration_;
   std::shared_ptr<AssetManager> asset_manager_;
   std::string entrypoint_ = "main";
   std::string entrypoint_library_ = "";
   std::vector<std::string> entrypoint_args_;
+  std::optional<int64_t> engine_handle_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RunConfiguration);
 };

--- a/engine/src/flutter/shell/common/run_configuration.h
+++ b/engine/src/flutter/shell/common/run_configuration.h
@@ -195,13 +195,13 @@ class RunConfiguration {
   std::unique_ptr<IsolateConfiguration> TakeIsolateConfiguration();
 
   //----------------------------------------------------------------------------
-  /// @brief      Sets the engine handle to be passed to the platform
+  /// @brief      Sets the engine identifier to be passed to the platform
   ///             dispatcher.
-  void SetEngineHandle(int64_t engine_handle);
+  void SetEngineId(int64_t engine_id);
 
   ///----------------------------------------------------------------------------
-  /// @return     Engine handle to be passed to the platform dispatcher.
-  std::optional<int64_t> GetEngineHandle() const;
+  /// @return     Engine identifier to be passed to the platform dispatcher.
+  std::optional<int64_t> GetEngineId() const;
 
  private:
   std::unique_ptr<IsolateConfiguration> isolate_configuration_;
@@ -209,7 +209,7 @@ class RunConfiguration {
   std::string entrypoint_ = "main";
   std::string entrypoint_library_ = "";
   std::vector<std::string> entrypoint_args_;
-  std::optional<int64_t> engine_handle_;
+  std::optional<int64_t> engine_id_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RunConfiguration);
 };

--- a/engine/src/flutter/shell/common/shell_test.h
+++ b/engine/src/flutter/shell/common/shell_test.h
@@ -71,6 +71,7 @@ class ShellTest : public FixtureTest {
     // Defaults to calling ShellTestPlatformView::Create with the provided
     // arguments.
     Shell::CreateCallback<PlatformView> platform_view_create_callback;
+    std::optional<int64_t> engine_handle;
   };
 
   ShellTest();

--- a/engine/src/flutter/shell/common/shell_test.h
+++ b/engine/src/flutter/shell/common/shell_test.h
@@ -71,7 +71,7 @@ class ShellTest : public FixtureTest {
     // Defaults to calling ShellTestPlatformView::Create with the provided
     // arguments.
     Shell::CreateCallback<PlatformView> platform_view_create_callback;
-    std::optional<int64_t> engine_handle;
+    std::optional<int64_t> engine_id;
   };
 
   ShellTest();

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -5006,7 +5006,7 @@ TEST_F(ShellTest, SendViewFocusEvent) {
   DestroyShell(std::move(shell), task_runners);
 }
 
-TEST_F(ShellTest, ProvidesEngineHandle) {
+TEST_F(ShellTest, ProvidesEngineId) {
   Settings settings = CreateSettingsForFixture();
   TaskRunners task_runners = GetTaskRunnersForFixture();
   fml::AutoResetWaitableEvent latch;
@@ -5014,7 +5014,7 @@ TEST_F(ShellTest, ProvidesEngineHandle) {
   int reported_handle = 0;
 
   AddNativeCallback(
-      "ReportEngineHandle", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+      "ReportEngineId", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
         Dart_Handle exception = nullptr;
         reported_handle =
             tonic::DartConverter<int64_t>::FromArguments(args, 0, exception);
@@ -5028,8 +5028,8 @@ TEST_F(ShellTest, ProvidesEngineHandle) {
   ASSERT_TRUE(shell->IsSetup());
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEngineHandle(99);
-  configuration.SetEntrypoint("providesEngineHandle");
+  configuration.SetEngineId(99);
+  configuration.SetEntrypoint("providesEngineId");
   RunEngine(shell.get(), std::move(configuration));
 
   latch.Wait();

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -5011,15 +5011,16 @@ TEST_F(ShellTest, ProvidesEngineId) {
   TaskRunners task_runners = GetTaskRunnersForFixture();
   fml::AutoResetWaitableEvent latch;
 
-  int reported_handle = 0;
+  std::optional<int> reported_handle = std::nullopt;
 
   AddNativeCallback(
       "ReportEngineId", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-        Dart_Handle exception = nullptr;
-        reported_handle =
-            tonic::DartConverter<int64_t>::FromArguments(args, 0, exception);
-        ASSERT_EQ(exception, nullptr);
-
+        Dart_Handle arg = Dart_GetNativeArgument(args, 0);
+        if (Dart_IsNull(arg)) {
+          reported_handle = std::nullopt;
+        } else {
+          reported_handle = tonic::DartConverter<int64_t>::FromDart(arg);
+        }
         latch.Signal();
       }));
   fml::AutoResetWaitableEvent check_latch;
@@ -5034,6 +5035,37 @@ TEST_F(ShellTest, ProvidesEngineId) {
 
   latch.Wait();
   ASSERT_EQ(reported_handle, 99);
+  DestroyShell(std::move(shell), task_runners);
+}
+
+TEST_F(ShellTest, ProvidesNullEngineId) {
+  Settings settings = CreateSettingsForFixture();
+  TaskRunners task_runners = GetTaskRunnersForFixture();
+  fml::AutoResetWaitableEvent latch;
+
+  std::optional<int> reported_handle = std::nullopt;
+
+  AddNativeCallback(
+      "ReportEngineId", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+        Dart_Handle arg = Dart_GetNativeArgument(args, 0);
+        if (Dart_IsNull(arg)) {
+          reported_handle = std::nullopt;
+        } else {
+          reported_handle = tonic::DartConverter<int64_t>::FromDart(arg);
+        }
+        latch.Signal();
+      }));
+  fml::AutoResetWaitableEvent check_latch;
+
+  std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
+  ASSERT_TRUE(shell->IsSetup());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("providesEngineId");
+  RunEngine(shell.get(), std::move(configuration));
+
+  latch.Wait();
+  ASSERT_EQ(reported_handle, std::nullopt);
   DestroyShell(std::move(shell), task_runners);
 }
 

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.cc
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.cc
@@ -223,7 +223,7 @@ std::unique_ptr<AndroidShellHolder> AndroidShellHolder::Spawn(
     const std::string& libraryUrl,
     const std::string& initial_route,
     const std::vector<std::string>& entrypoint_args,
-    int64_t engine_handle) const {
+    int64_t engine_id) const {
   FML_DCHECK(shell_ && shell_->IsSetup())
       << "A new Shell can only be spawned "
          "if the current Shell is properly constructed";
@@ -270,7 +270,7 @@ std::unique_ptr<AndroidShellHolder> AndroidShellHolder::Spawn(
     // Fail the whole thing.
     return nullptr;
   }
-  config->SetEngineHandle(engine_handle);
+  config->SetEngineId(engine_id);
 
   std::unique_ptr<flutter::Shell> shell =
       shell_->Spawn(std::move(config.value()), initial_route,
@@ -287,7 +287,7 @@ void AndroidShellHolder::Launch(
     const std::string& entrypoint,
     const std::string& libraryUrl,
     const std::vector<std::string>& entrypoint_args,
-    int64_t engine_handle) {
+    int64_t engine_id) {
   if (!IsValid()) {
     return;
   }
@@ -297,7 +297,7 @@ void AndroidShellHolder::Launch(
   if (!config) {
     return;
   }
-  config->SetEngineHandle(engine_handle);
+  config->SetEngineId(engine_id);
   UpdateDisplayMetrics();
   shell_->RunEngine(std::move(config.value()));
 }

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.cc
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.cc
@@ -222,7 +222,8 @@ std::unique_ptr<AndroidShellHolder> AndroidShellHolder::Spawn(
     const std::string& entrypoint,
     const std::string& libraryUrl,
     const std::string& initial_route,
-    const std::vector<std::string>& entrypoint_args) const {
+    const std::vector<std::string>& entrypoint_args,
+    int64_t engine_handle) const {
   FML_DCHECK(shell_ && shell_->IsSetup())
       << "A new Shell can only be spawned "
          "if the current Shell is properly constructed";
@@ -269,6 +270,7 @@ std::unique_ptr<AndroidShellHolder> AndroidShellHolder::Spawn(
     // Fail the whole thing.
     return nullptr;
   }
+  config->SetEngineHandle(engine_handle);
 
   std::unique_ptr<flutter::Shell> shell =
       shell_->Spawn(std::move(config.value()), initial_route,
@@ -284,7 +286,8 @@ void AndroidShellHolder::Launch(
     std::unique_ptr<APKAssetProvider> apk_asset_provider,
     const std::string& entrypoint,
     const std::string& libraryUrl,
-    const std::vector<std::string>& entrypoint_args) {
+    const std::vector<std::string>& entrypoint_args,
+    int64_t engine_handle) {
   if (!IsValid()) {
     return;
   }
@@ -294,6 +297,7 @@ void AndroidShellHolder::Launch(
   if (!config) {
     return;
   }
+  config->SetEngineHandle(engine_handle);
   UpdateDisplayMetrics();
   shell_->RunEngine(std::move(config.value()));
 }

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.h
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.h
@@ -79,12 +79,14 @@ class AndroidShellHolder {
       const std::string& entrypoint,
       const std::string& libraryUrl,
       const std::string& initial_route,
-      const std::vector<std::string>& entrypoint_args) const;
+      const std::vector<std::string>& entrypoint_args,
+      int64_t engine_handle) const;
 
   void Launch(std::unique_ptr<APKAssetProvider> apk_asset_provider,
               const std::string& entrypoint,
               const std::string& libraryUrl,
-              const std::vector<std::string>& entrypoint_args);
+              const std::vector<std::string>& entrypoint_args,
+              int64_t engine_handle);
 
   const flutter::Settings& GetSettings() const;
 

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.h
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.h
@@ -80,13 +80,13 @@ class AndroidShellHolder {
       const std::string& libraryUrl,
       const std::string& initial_route,
       const std::vector<std::string>& entrypoint_args,
-      int64_t engine_handle) const;
+      int64_t engine_id) const;
 
   void Launch(std::unique_ptr<APKAssetProvider> apk_asset_provider,
               const std::string& entrypoint,
               const std::string& libraryUrl,
               const std::vector<std::string>& entrypoint_args,
-              int64_t engine_handle);
+              int64_t engine_id);
 
   const flutter::Settings& GetSettings() const;
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -701,6 +701,11 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
     return pluginRegistry;
   }
 
+  /** Returns unique identifier for this engine. */
+  public long getEngineId() {
+    return engineId;
+  }
+
   /**
    * Returns engine for the given identifier or null if identifier is not valid. The handle can be
    * obtained through
@@ -710,6 +715,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
    * <p>Must be called on the UI thread.
    */
   @Nullable
+  @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
   public static FlutterEngine engineForId(long handle) {
     return idToEngine.get(handle);
   }

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -118,18 +118,18 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
   @NonNull private final Set<EngineLifecycleListener> engineLifecycleListeners = new HashSet<>();
 
   // Unique handle for this engine.
-  @NonNull private final long engineHandle;
+  @NonNull private final long engineId;
 
   @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-  public static void resetNextEngineHandle() {
-    nextEngineHandle = 1;
+  public static void resetNextEngineId() {
+    nextEngineId = 1;
   }
 
   // Handle to assign to the next engine created.
-  private static long nextEngineHandle = 1;
+  private static long nextEngineId = 1;
 
-  // Map of engine handles to engines.
-  private static final Map<Long, FlutterEngine> handleToEngine = new HashMap<>();
+  // Map of engine identifiers to engines.
+  private static final Map<Long, FlutterEngine> idToEngine = new HashMap<>();
 
   @NonNull
   private final EngineLifecycleListener engineLifecycleListener =
@@ -329,8 +329,8 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
       boolean waitForRestorationData,
       @Nullable FlutterEngineGroup group) {
 
-    this.engineHandle = nextEngineHandle++;
-    handleToEngine.put(engineHandle, this);
+    this.engineId = nextEngineId++;
+    idToEngine.put(engineId, this);
 
     AssetManager assetManager;
     try {
@@ -346,7 +346,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
     }
     this.flutterJNI = flutterJNI;
 
-    this.dartExecutor = new DartExecutor(flutterJNI, assetManager, engineHandle);
+    this.dartExecutor = new DartExecutor(flutterJNI, assetManager, engineId);
     this.dartExecutor.onAttachedToJNI();
 
     DeferredComponentManager deferredComponentManager =
@@ -472,7 +472,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
             dartEntrypoint.dartEntrypointLibrary,
             initialRoute,
             dartEntrypointArgs,
-            nextEngineHandle);
+            nextEngineId);
     return new FlutterEngine(
         context, // Context.
         null, // FlutterLoader. A null value passed here causes the constructor to get it from the
@@ -507,7 +507,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
       FlutterInjector.instance().deferredComponentManager().destroy();
       deferredComponentChannel.setDeferredComponentManager(null);
     }
-    handleToEngine.remove(engineHandle);
+    idToEngine.remove(engineId);
   }
 
   /**
@@ -702,16 +702,16 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
   }
 
   /**
-   * Returns engine for the given handle or null if handle is not valid. The handle can be obtained
-   * through
+   * Returns engine for the given identifier or null if identifier is not valid. The handle can be
+   * obtained through
    *
-   * <pre>PlatformDispatcher.instance.engineHandle</pre>
+   * <pre>PlatformDispatcher.instance.engineId</pre>
    *
    * <p>Must be called on the UI thread.
    */
   @Nullable
-  public static FlutterEngine engineForHandle(long handle) {
-    return handleToEngine.get(handle);
+  public static FlutterEngine engineForId(long handle) {
+    return idToEngine.get(handle);
   }
 
   /** Lifecycle callbacks for Flutter engine lifecycle events. */

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -44,8 +44,10 @@ import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.plugin.platform.PlatformViewsController2;
 import io.flutter.plugin.text.ProcessTextPlugin;
 import io.flutter.util.ViewUtils;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -114,6 +116,20 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
 
   // Engine Lifecycle.
   @NonNull private final Set<EngineLifecycleListener> engineLifecycleListeners = new HashSet<>();
+
+  // Unique handle for this engine.
+  @NonNull private final long engineHandle;
+
+  @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+  public static void resetNextEngineHandle() {
+    nextEngineHandle = 1;
+  }
+
+  // Handle to assign to the next engine created.
+  private static long nextEngineHandle = 1;
+
+  // Map of engine handles to engines.
+  private static final Map<Long, FlutterEngine> handleToEngine = new HashMap<>();
 
   @NonNull
   private final EngineLifecycleListener engineLifecycleListener =
@@ -312,6 +328,10 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
       boolean automaticallyRegisterPlugins,
       boolean waitForRestorationData,
       @Nullable FlutterEngineGroup group) {
+
+    this.engineHandle = nextEngineHandle++;
+    handleToEngine.put(engineHandle, this);
+
     AssetManager assetManager;
     try {
       assetManager = context.createPackageContext(context.getPackageName(), 0).getAssets();
@@ -326,7 +346,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
     }
     this.flutterJNI = flutterJNI;
 
-    this.dartExecutor = new DartExecutor(flutterJNI, assetManager);
+    this.dartExecutor = new DartExecutor(flutterJNI, assetManager, engineHandle);
     this.dartExecutor.onAttachedToJNI();
 
     DeferredComponentManager deferredComponentManager =
@@ -451,7 +471,8 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
             dartEntrypoint.dartEntrypointFunctionName,
             dartEntrypoint.dartEntrypointLibrary,
             initialRoute,
-            dartEntrypointArgs);
+            dartEntrypointArgs,
+            nextEngineHandle);
     return new FlutterEngine(
         context, // Context.
         null, // FlutterLoader. A null value passed here causes the constructor to get it from the
@@ -486,6 +507,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
       FlutterInjector.instance().deferredComponentManager().destroy();
       deferredComponentChannel.setDeferredComponentManager(null);
     }
+    handleToEngine.remove(engineHandle);
   }
 
   /**
@@ -677,6 +699,19 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
   @NonNull
   public ContentProviderControlSurface getContentProviderControlSurface() {
     return pluginRegistry;
+  }
+
+  /**
+   * Returns engine for the given handle or null if handle is not valid. The handle can be obtained
+   * through
+   *
+   * <pre>PlatformDispatcher.instance.engineHandle</pre>
+   *
+   * <p>Must be called on the UI thread.
+   */
+  @Nullable
+  public static FlutterEngine engineForHandle(long handle) {
+    return handleToEngine.get(handle);
   }
 
   /** Lifecycle callbacks for Flutter engine lifecycle events. */

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -460,7 +460,8 @@ public class FlutterJNI {
       @Nullable String entrypointFunctionName,
       @Nullable String pathToEntrypointFunction,
       @Nullable String initialRoute,
-      @Nullable List<String> entrypointArgs) {
+      @Nullable List<String> entrypointArgs,
+      long engineHandle) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
     FlutterJNI spawnedJNI =
@@ -469,7 +470,8 @@ public class FlutterJNI {
             entrypointFunctionName,
             pathToEntrypointFunction,
             initialRoute,
-            entrypointArgs);
+            entrypointArgs,
+            engineHandle);
     Preconditions.checkState(
         spawnedJNI.nativeShellHolderId != null && spawnedJNI.nativeShellHolderId != 0,
         "Failed to spawn new JNI connected shell from existing shell.");
@@ -482,7 +484,8 @@ public class FlutterJNI {
       @Nullable String entrypointFunctionName,
       @Nullable String pathToEntrypointFunction,
       @Nullable String initialRoute,
-      @Nullable List<String> entrypointArgs);
+      @Nullable List<String> entrypointArgs,
+      long engineHandle);
 
   /**
    * Detaches this {@code FlutterJNI} instance from Flutter's native engine, which precludes any
@@ -491,7 +494,7 @@ public class FlutterJNI {
    * <p>This method must not be invoked if {@code FlutterJNI} is not already attached to native.
    *
    * <p>Invoking this method will result in the release of all native-side resources that were set
-   * up during {@link #attachToNative()} or {@link #spawn(String, String, String, List)}, or
+   * up during {@link #attachToNative()} or {@link #spawn(String, String, String, List, long)}, or
    * accumulated thereafter.
    *
    * <p>It is permissible to re-attach this instance to native after detaching it from native.
@@ -1002,7 +1005,8 @@ public class FlutterJNI {
       @Nullable String entrypointFunctionName,
       @Nullable String pathToEntrypointFunction,
       @NonNull AssetManager assetManager,
-      @Nullable List<String> entrypointArgs) {
+      @Nullable List<String> entrypointArgs,
+      long engineHandle) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
     nativeRunBundleAndSnapshotFromLibrary(
@@ -1011,7 +1015,8 @@ public class FlutterJNI {
         entrypointFunctionName,
         pathToEntrypointFunction,
         assetManager,
-        entrypointArgs);
+        entrypointArgs,
+        engineHandle);
   }
 
   private native void nativeRunBundleAndSnapshotFromLibrary(
@@ -1020,7 +1025,8 @@ public class FlutterJNI {
       @Nullable String entrypointFunctionName,
       @Nullable String pathToEntrypointFunction,
       @NonNull AssetManager manager,
-      @Nullable List<String> entrypointArgs);
+      @Nullable List<String> entrypointArgs,
+      long engineHandle);
   // ------ End Dart Execution Support -------
 
   // --------- Start Platform Message Support ------

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -461,7 +461,7 @@ public class FlutterJNI {
       @Nullable String pathToEntrypointFunction,
       @Nullable String initialRoute,
       @Nullable List<String> entrypointArgs,
-      long engineHandle) {
+      long engineId) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
     FlutterJNI spawnedJNI =
@@ -471,7 +471,7 @@ public class FlutterJNI {
             pathToEntrypointFunction,
             initialRoute,
             entrypointArgs,
-            engineHandle);
+            engineId);
     Preconditions.checkState(
         spawnedJNI.nativeShellHolderId != null && spawnedJNI.nativeShellHolderId != 0,
         "Failed to spawn new JNI connected shell from existing shell.");
@@ -485,7 +485,7 @@ public class FlutterJNI {
       @Nullable String pathToEntrypointFunction,
       @Nullable String initialRoute,
       @Nullable List<String> entrypointArgs,
-      long engineHandle);
+      long engineId);
 
   /**
    * Detaches this {@code FlutterJNI} instance from Flutter's native engine, which precludes any
@@ -1006,7 +1006,7 @@ public class FlutterJNI {
       @Nullable String pathToEntrypointFunction,
       @NonNull AssetManager assetManager,
       @Nullable List<String> entrypointArgs,
-      long engineHandle) {
+      long engineId) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
     nativeRunBundleAndSnapshotFromLibrary(
@@ -1016,7 +1016,7 @@ public class FlutterJNI {
         pathToEntrypointFunction,
         assetManager,
         entrypointArgs,
-        engineHandle);
+        engineId);
   }
 
   private native void nativeRunBundleAndSnapshotFromLibrary(
@@ -1026,7 +1026,7 @@ public class FlutterJNI {
       @Nullable String pathToEntrypointFunction,
       @NonNull AssetManager manager,
       @Nullable List<String> entrypointArgs,
-      long engineHandle);
+      long engineId);
   // ------ End Dart Execution Support -------
 
   // --------- Start Platform Message Support ------

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -41,7 +41,7 @@ public class DartExecutor implements BinaryMessenger {
 
   @NonNull private final FlutterJNI flutterJNI;
   @NonNull private final AssetManager assetManager;
-  private final long engineHandle;
+  private final long engineId;
   @NonNull private final DartMessenger dartMessenger;
   @NonNull private final BinaryMessenger binaryMessenger;
   private boolean isApplicationRunning = false;
@@ -65,10 +65,10 @@ public class DartExecutor implements BinaryMessenger {
   }
 
   public DartExecutor(
-      @NonNull FlutterJNI flutterJNI, @NonNull AssetManager assetManager, long engineHandle) {
+      @NonNull FlutterJNI flutterJNI, @NonNull AssetManager assetManager, long engineId) {
     this.flutterJNI = flutterJNI;
     this.assetManager = assetManager;
-    this.engineHandle = engineHandle;
+    this.engineId = engineId;
     this.dartMessenger = new DartMessenger(flutterJNI);
     dartMessenger.setMessageHandler("flutter/isolate", isolateChannelMessageHandler);
     this.binaryMessenger = new DefaultBinaryMessenger(dartMessenger);
@@ -158,7 +158,7 @@ public class DartExecutor implements BinaryMessenger {
           dartEntrypoint.dartEntrypointLibrary,
           assetManager,
           dartEntrypointArgs,
-          engineHandle);
+          engineId);
 
       isApplicationRunning = true;
     }
@@ -185,7 +185,7 @@ public class DartExecutor implements BinaryMessenger {
           dartCallback.callbackHandle.callbackLibraryPath,
           dartCallback.androidAssetManager,
           null,
-          engineHandle);
+          engineId);
 
       isApplicationRunning = true;
     }

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -8,6 +8,7 @@ import android.content.res.AssetManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
@@ -40,6 +41,7 @@ public class DartExecutor implements BinaryMessenger {
 
   @NonNull private final FlutterJNI flutterJNI;
   @NonNull private final AssetManager assetManager;
+  private final long engineHandle;
   @NonNull private final DartMessenger dartMessenger;
   @NonNull private final BinaryMessenger binaryMessenger;
   private boolean isApplicationRunning = false;
@@ -57,9 +59,16 @@ public class DartExecutor implements BinaryMessenger {
         }
       };
 
+  @VisibleForTesting
   public DartExecutor(@NonNull FlutterJNI flutterJNI, @NonNull AssetManager assetManager) {
+    this(flutterJNI, assetManager, 0);
+  }
+
+  public DartExecutor(
+      @NonNull FlutterJNI flutterJNI, @NonNull AssetManager assetManager, long engineHandle) {
     this.flutterJNI = flutterJNI;
     this.assetManager = assetManager;
+    this.engineHandle = engineHandle;
     this.dartMessenger = new DartMessenger(flutterJNI);
     dartMessenger.setMessageHandler("flutter/isolate", isolateChannelMessageHandler);
     this.binaryMessenger = new DefaultBinaryMessenger(dartMessenger);
@@ -148,7 +157,8 @@ public class DartExecutor implements BinaryMessenger {
           dartEntrypoint.dartEntrypointFunctionName,
           dartEntrypoint.dartEntrypointLibrary,
           assetManager,
-          dartEntrypointArgs);
+          dartEntrypointArgs,
+          engineHandle);
 
       isApplicationRunning = true;
     }
@@ -174,7 +184,8 @@ public class DartExecutor implements BinaryMessenger {
           dartCallback.callbackHandle.callbackName,
           dartCallback.callbackHandle.callbackLibraryPath,
           dartCallback.androidAssetManager,
-          null);
+          null,
+          engineHandle);
 
       isApplicationRunning = true;
     }

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -196,7 +196,7 @@ static jobject SpawnJNI(JNIEnv* env,
                         jstring jLibraryUrl,
                         jstring jInitialRoute,
                         jobject jEntrypointArgs,
-                        jlong engineHandle) {
+                        jlong engineId) {
   jobject jni = env->NewObject(g_flutter_jni_class->obj(), g_jni_constructor);
   if (jni == nullptr) {
     FML_LOG(ERROR) << "Could not create a FlutterJNI instance";
@@ -214,7 +214,7 @@ static jobject SpawnJNI(JNIEnv* env,
 
   auto spawned_shell_holder =
       ANDROID_SHELL_HOLDER->Spawn(jni_facade, entrypoint, libraryUrl,
-                                  initial_route, entrypoint_args, engineHandle);
+                                  initial_route, entrypoint_args, engineId);
 
   if (spawned_shell_holder == nullptr || !spawned_shell_holder->IsValid()) {
     FML_LOG(ERROR) << "Could not spawn Shell";
@@ -282,7 +282,7 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
                                             jstring jLibraryUrl,
                                             jobject jAssetManager,
                                             jobject jEntrypointArgs,
-                                            jlong engineHandle) {
+                                            jlong engineId) {
   auto apk_asset_provider = std::make_unique<flutter::APKAssetProvider>(
       env,                                            // jni environment
       jAssetManager,                                  // asset manager
@@ -293,7 +293,7 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
   auto entrypoint_args = fml::jni::StringListToVector(env, jEntrypointArgs);
 
   ANDROID_SHELL_HOLDER->Launch(std::move(apk_asset_provider), entrypoint,
-                               libraryUrl, entrypoint_args, engineHandle);
+                               libraryUrl, entrypoint_args, engineId);
 }
 
 static jobject LookupCallbackInformation(JNIEnv* env,

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -195,7 +195,8 @@ static jobject SpawnJNI(JNIEnv* env,
                         jstring jEntrypoint,
                         jstring jLibraryUrl,
                         jstring jInitialRoute,
-                        jobject jEntrypointArgs) {
+                        jobject jEntrypointArgs,
+                        jlong engineHandle) {
   jobject jni = env->NewObject(g_flutter_jni_class->obj(), g_jni_constructor);
   if (jni == nullptr) {
     FML_LOG(ERROR) << "Could not create a FlutterJNI instance";
@@ -211,8 +212,9 @@ static jobject SpawnJNI(JNIEnv* env,
   auto initial_route = fml::jni::JavaStringToString(env, jInitialRoute);
   auto entrypoint_args = fml::jni::StringListToVector(env, jEntrypointArgs);
 
-  auto spawned_shell_holder = ANDROID_SHELL_HOLDER->Spawn(
-      jni_facade, entrypoint, libraryUrl, initial_route, entrypoint_args);
+  auto spawned_shell_holder =
+      ANDROID_SHELL_HOLDER->Spawn(jni_facade, entrypoint, libraryUrl,
+                                  initial_route, entrypoint_args, engineHandle);
 
   if (spawned_shell_holder == nullptr || !spawned_shell_holder->IsValid()) {
     FML_LOG(ERROR) << "Could not spawn Shell";
@@ -279,7 +281,8 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
                                             jstring jEntrypoint,
                                             jstring jLibraryUrl,
                                             jobject jAssetManager,
-                                            jobject jEntrypointArgs) {
+                                            jobject jEntrypointArgs,
+                                            jlong engineHandle) {
   auto apk_asset_provider = std::make_unique<flutter::APKAssetProvider>(
       env,                                            // jni environment
       jAssetManager,                                  // asset manager
@@ -290,7 +293,7 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
   auto entrypoint_args = fml::jni::StringListToVector(env, jEntrypointArgs);
 
   ANDROID_SHELL_HOLDER->Launch(std::move(apk_asset_provider), entrypoint,
-                               libraryUrl, entrypoint_args);
+                               libraryUrl, entrypoint_args, engineHandle);
 }
 
 static jobject LookupCallbackInformation(JNIEnv* env,
@@ -687,7 +690,7 @@ bool RegisterApi(JNIEnv* env) {
       {
           .name = "nativeSpawn",
           .signature = "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/"
-                       "String;Ljava/util/List;)Lio/flutter/"
+                       "String;Ljava/util/List;J)Lio/flutter/"
                        "embedding/engine/FlutterJNI;",
           .fnPtr = reinterpret_cast<void*>(&SpawnJNI),
       },
@@ -695,7 +698,7 @@ bool RegisterApi(JNIEnv* env) {
           .name = "nativeRunBundleAndSnapshotFromLibrary",
           .signature = "(JLjava/lang/String;Ljava/lang/String;"
                        "Ljava/lang/String;Landroid/content/res/"
-                       "AssetManager;Ljava/util/List;)V",
+                       "AssetManager;Ljava/util/List;J)V",
           .fnPtr = reinterpret_cast<void*>(&RunBundleAndSnapshotFromLibrary),
       },
       {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupComponentTest.java
@@ -59,7 +59,7 @@ public class FlutterEngineGroupComponentTest {
     when(mockFlutterJNI.isAttached()).thenAnswer(invocation -> jniAttached);
     doAnswer(invocation -> jniAttached = true).when(mockFlutterJNI).attachToNative();
     GeneratedPluginRegistrant.clearRegisteredEngines();
-    FlutterEngine.resetNextEngineHandle();
+    FlutterEngine.resetNextEngineId();
 
     when(mockFlutterLoader.findAppBundlePath()).thenReturn("some/path/to/flutter_assets");
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupComponentTest.java
@@ -59,6 +59,7 @@ public class FlutterEngineGroupComponentTest {
     when(mockFlutterJNI.isAttached()).thenAnswer(invocation -> jniAttached);
     doAnswer(invocation -> jniAttached = true).when(mockFlutterJNI).attachToNative();
     GeneratedPluginRegistrant.clearRegisteredEngines();
+    FlutterEngine.resetNextEngineHandle();
 
     when(mockFlutterLoader.findAppBundlePath()).thenReturn("some/path/to/flutter_assets");
 
@@ -190,7 +191,8 @@ public class FlutterEngineGroupComponentTest {
             eq("other entrypoint"),
             isNull(),
             any(AssetManager.class),
-            nullable(List.class));
+            nullable(List.class),
+            eq(1l));
   }
 
   @Test
@@ -213,14 +215,20 @@ public class FlutterEngineGroupComponentTest {
             nullable(String.class),
             nullable(String.class),
             nullable(String.class),
-            nullable(List.class));
+            nullable(List.class),
+            eq(2l));
 
     FlutterEngine secondEngine =
         engineGroupUnderTest.createAndRunEngine(ctx, mock(DartEntrypoint.class), "/bar");
 
     assertEquals(2, engineGroupUnderTest.activeEngines.size());
     verify(mockFlutterJNI, times(1))
-        .spawn(nullable(String.class), nullable(String.class), eq("/bar"), nullable(List.class));
+        .spawn(
+            nullable(String.class),
+            nullable(String.class),
+            eq("/bar"),
+            nullable(List.class),
+            eq(2l));
   }
 
   @Test
@@ -238,7 +246,8 @@ public class FlutterEngineGroupComponentTest {
             nullable(String.class),
             isNull(),
             any(AssetManager.class),
-            eq(firstDartEntrypointArgs));
+            eq(firstDartEntrypointArgs),
+            eq(1l));
 
     when(mockFlutterJNI.isAttached()).thenReturn(true);
     jniAttached = false;
@@ -251,7 +260,8 @@ public class FlutterEngineGroupComponentTest {
             nullable(String.class),
             nullable(String.class),
             nullable(String.class),
-            nullable(List.class));
+            nullable(List.class),
+            eq(2l));
     List<String> secondDartEntrypointArgs = new ArrayList<String>();
     FlutterEngine secondEngine =
         engineGroupUnderTest.createAndRunEngine(
@@ -265,7 +275,8 @@ public class FlutterEngineGroupComponentTest {
             nullable(String.class),
             nullable(String.class),
             nullable(String.class),
-            eq(secondDartEntrypointArgs));
+            eq(secondDartEntrypointArgs),
+            eq(2l));
   }
 
   @Test
@@ -309,7 +320,8 @@ public class FlutterEngineGroupComponentTest {
             nullable(String.class),
             isNull(),
             any(AssetManager.class),
-            nullable(List.class));
+            nullable(List.class),
+            eq(1l));
 
     when(mockFlutterJNI.isAttached()).thenReturn(true);
     jniAttached = false;
@@ -322,7 +334,8 @@ public class FlutterEngineGroupComponentTest {
             nullable(String.class),
             nullable(String.class),
             nullable(String.class),
-            nullable(List.class));
+            nullable(List.class),
+            eq(2l));
 
     PlatformViewsController controller = new PlatformViewsController();
     boolean waitForRestorationData = false;

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -79,6 +79,7 @@ public class FlutterEngineTest {
         .when(flutterJNI)
         .attachToNative();
     GeneratedPluginRegistrant.clearRegisteredEngines();
+    FlutterEngine.resetNextEngineHandle();
   }
 
   @After
@@ -128,6 +129,23 @@ public class FlutterEngineTest {
 
     verify(mockFlutterJNI, times(1))
         .dispatchPlatformMessage(eq("flutter/localization"), any(), anyInt(), anyInt());
+  }
+
+  @Test
+  public void itCanBeRetrievedByHandle() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    when(mockFlutterJNI.isAttached()).thenReturn(true);
+    FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+    when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(true);
+    FlutterEngine flutterEngine1 = new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJNI);
+    FlutterEngine flutterEngine2 = new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJNI);
+    assertEquals(flutterEngine1, FlutterEngine.engineForHandle(1));
+    assertEquals(flutterEngine2, FlutterEngine.engineForHandle(2));
+    flutterEngine1.destroy();
+    assertEquals(null, FlutterEngine.engineForHandle(1));
+    assertEquals(flutterEngine2, FlutterEngine.engineForHandle(2));
+    flutterEngine2.destroy();
+    assertEquals(null, FlutterEngine.engineForHandle(2));
   }
 
   // Helps show the root cause of MissingPluginException type errors like

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -79,7 +79,7 @@ public class FlutterEngineTest {
         .when(flutterJNI)
         .attachToNative();
     GeneratedPluginRegistrant.clearRegisteredEngines();
-    FlutterEngine.resetNextEngineHandle();
+    FlutterEngine.resetNextEngineId();
   }
 
   @After
@@ -139,13 +139,13 @@ public class FlutterEngineTest {
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(true);
     FlutterEngine flutterEngine1 = new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJNI);
     FlutterEngine flutterEngine2 = new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJNI);
-    assertEquals(flutterEngine1, FlutterEngine.engineForHandle(1));
-    assertEquals(flutterEngine2, FlutterEngine.engineForHandle(2));
+    assertEquals(flutterEngine1, FlutterEngine.engineForId(1));
+    assertEquals(flutterEngine2, FlutterEngine.engineForId(2));
     flutterEngine1.destroy();
-    assertEquals(null, FlutterEngine.engineForHandle(1));
-    assertEquals(flutterEngine2, FlutterEngine.engineForHandle(2));
+    assertEquals(null, FlutterEngine.engineForId(1));
+    assertEquals(flutterEngine2, FlutterEngine.engineForId(2));
     flutterEngine2.destroy();
-    assertEquals(null, FlutterEngine.engineForHandle(2));
+    assertEquals(null, FlutterEngine.engineForId(2));
   }
 
   // Helps show the root cause of MissingPluginException type errors like

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/DeferredComponentChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/DeferredComponentChannelTest.java
@@ -60,7 +60,7 @@ public class DeferredComponentChannelTest {
   public void deferredComponentChannel_installCompletesResults() {
     MethodChannel rawChannel = mock(MethodChannel.class);
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
-    DartExecutor dartExecutor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class));
+    DartExecutor dartExecutor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class), 0);
     TestDeferredComponentManager testDeferredComponentManager = new TestDeferredComponentManager();
     DeferredComponentChannel fakeDeferredComponentChannel =
         new DeferredComponentChannel(dartExecutor);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -164,6 +164,14 @@ FLUTTER_DARWIN_EXPORT
           restorationEnabled:(BOOL)restorationEnabled NS_DESIGNATED_INITIALIZER;
 
 /**
+ * Returns engine for the handle, nil if the handle is not valid.
+ * The handle can be obtained in Dart code through
+ * `PlatformDispatcher.instance.engineHandle`.
+ * This function must be called on the main thread.
+ */
++ (nullable FlutterEngine*)engineForHandle:(int64_t)handle;
+
+/**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that
  * contains `main()`), using `main()` as the entrypoint (the default for Flutter projects),
  * and using "/" (the default route) as the initial route.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -164,12 +164,12 @@ FLUTTER_DARWIN_EXPORT
           restorationEnabled:(BOOL)restorationEnabled NS_DESIGNATED_INITIALIZER;
 
 /**
- * Returns engine for the handle, nil if the handle is not valid.
- * The handle can be obtained in Dart code through
- * `PlatformDispatcher.instance.engineHandle`.
+ * Returns engine for the identifier, nil if the identifier is not valid.
+ * The identifier can be obtained in Dart code through
+ * `PlatformDispatcher.instance.engineId`.
  * This function must be called on the main thread.
  */
-+ (nullable FlutterEngine*)engineForHandle:(int64_t)handle;
++ (nullable FlutterEngine*)engineForId:(int64_t)identifier;
 
 /**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -172,7 +172,7 @@ FLUTTER_DARWIN_EXPORT
  *
  * This function must be called on the main thread.
  */
-+ (nullable FlutterEngine*)engineForId:(int64_t)identifier;
++ (nullable FlutterEngine*)engineForIdentifier:(int64_t)identifier;
 
 /**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -164,17 +164,6 @@ FLUTTER_DARWIN_EXPORT
           restorationEnabled:(BOOL)restorationEnabled NS_DESIGNATED_INITIALIZER;
 
 /**
- * Returns engine for the identifier. The identifier must be valid for an engine
- * that is currently running, otherwise the behavior is undefined.
- *
- * The identifier can be obtained in Dart code through
- * `PlatformDispatcher.instance.engineId`.
- *
- * This function must be called on the main thread.
- */
-+ (nullable FlutterEngine*)engineForIdentifier:(int64_t)identifier;
-
-/**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that
  * contains `main()`), using `main()` as the entrypoint (the default for Flutter projects),
  * and using "/" (the default route) as the initial route.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -164,9 +164,12 @@ FLUTTER_DARWIN_EXPORT
           restorationEnabled:(BOOL)restorationEnabled NS_DESIGNATED_INITIALIZER;
 
 /**
- * Returns engine for the identifier, nil if the identifier is not valid.
+ * Returns engine for the identifier. The identifier must be valid for an engine
+ * that is currently running, otherwise the behavior is undefined.
+ *
  * The identifier can be obtained in Dart code through
  * `PlatformDispatcher.instance.engineId`.
+ *
  * This function must be called on the main thread.
  */
 + (nullable FlutterEngine*)engineForId:(int64_t)identifier;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -246,7 +246,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   return self;
 }
 
-+ (FlutterEngine*)engineForId:(int64_t)identifier {
++ (FlutterEngine*)engineForIdentifier:(int64_t)identifier {
   NSAssert([[NSThread currentThread] isMainThread], @"Must be called on the main thread.");
   return (__bridge FlutterEngine*)reinterpret_cast<void*>(identifier);
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -158,6 +158,11 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   FlutterBinaryMessengerRelay* _binaryMessenger;
   FlutterTextureRegistryRelay* _textureRegistry;
   std::unique_ptr<flutter::ConnectionCollection> _connections;
+  int64_t _engineHandle;
+}
+
+- (int64_t)engineHandle {
+  return _engineHandle;
 }
 
 - (instancetype)init {
@@ -180,6 +185,9 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       allowHeadlessExecution:allowHeadlessExecution
           restorationEnabled:NO];
 }
+
+static int64_t nextHandle = 1;
+static NSMapTable* engineMap;
 
 - (instancetype)initWithName:(NSString*)labelPrefix
                      project:(FlutterDartProject*)project
@@ -238,7 +246,18 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                  name:NSCurrentLocaleDidChangeNotification
                object:nil];
 
+  _engineHandle = nextHandle++;
+  if (engineMap == nil) {
+    engineMap = [NSMapTable strongToWeakObjectsMapTable];
+  }
+  [engineMap setObject:self forKey:@(_engineHandle)];
+
   return self;
+}
+
++ (FlutterEngine*)engineForHandle:(int64_t)handle {
+  NSAssert([[NSThread currentThread] isMainThread], @"Must be called on the main thread.");
+  return [engineMap objectForKey:@(handle)];
 }
 
 - (void)setUpSceneLifecycleNotifications:(NSNotificationCenter*)center API_AVAILABLE(ios(13.0)) {
@@ -499,6 +518,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _profiler.reset();
   _threadHost.reset();
   _platformViewsController = nil;
+  [engineMap removeObjectForKey:@(_engineHandle)];
 }
 
 - (NSURL*)observatoryUrl {
@@ -704,9 +724,12 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
           libraryURI:(NSString*)libraryOrNil
       entrypointArgs:(NSArray<NSString*>*)entrypointArgs {
   // Launch the Dart application with the inferred run configuration.
-  self.shell.RunEngine([self.dartProject runConfigurationForEntrypoint:entrypoint
-                                                          libraryOrNil:libraryOrNil
-                                                        entrypointArgs:entrypointArgs]);
+  flutter::RunConfiguration configuration =
+      [self.dartProject runConfigurationForEntrypoint:entrypoint
+                                         libraryOrNil:libraryOrNil
+                                       entrypointArgs:entrypointArgs];
+  configuration.SetEngineHandle(_engineHandle);
+  self.shell.RunEngine(std::move(configuration));
 }
 
 - (void)setUpShell:(std::unique_ptr<flutter::Shell>)shell
@@ -1450,6 +1473,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
       [self.dartProject runConfigurationForEntrypoint:entrypoint
                                          libraryOrNil:libraryURI
                                        entrypointArgs:entrypointArgs];
+  configuration.SetEngineHandle(result->_engineHandle);
 
   fml::WeakPtr<flutter::PlatformView> platform_view = _shell->GetPlatformView();
   FML_DCHECK(platform_view);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -160,7 +160,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::unique_ptr<flutter::ConnectionCollection> _connections;
 }
 
-- (int64_t)engineId {
+- (int64_t)engineIdentifier {
   // Conversion to intptr_t doesn't need bridged cast.
   return (int64_t)self;
 }
@@ -719,7 +719,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                          libraryOrNil:libraryOrNil
                                        entrypointArgs:entrypointArgs];
 
-  configuration.SetEngineId(self.engineId);
+  configuration.SetEngineId(self.engineIdentifier);
   self.shell.RunEngine(std::move(configuration));
 }
 
@@ -1465,7 +1465,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                                          libraryOrNil:libraryURI
                                        entrypointArgs:entrypointArgs];
 
-  configuration.SetEngineId(result.engineId);
+  configuration.SetEngineId(result.engineIdentifier);
 
   fml::WeakPtr<flutter::PlatformView> platform_view = _shell->GetPlatformView();
   FML_DCHECK(platform_view);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -158,11 +158,11 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   FlutterBinaryMessengerRelay* _binaryMessenger;
   FlutterTextureRegistryRelay* _textureRegistry;
   std::unique_ptr<flutter::ConnectionCollection> _connections;
-  int64_t _engineHandle;
+  int64_t _engineId;
 }
 
-- (int64_t)engineHandle {
-  return _engineHandle;
+- (int64_t)engineId {
+  return _engineId;
 }
 
 - (instancetype)init {
@@ -186,7 +186,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
           restorationEnabled:NO];
 }
 
-static int64_t nextHandle = 1;
+static int64_t nextEngineId = 1;
 static NSMapTable* engineMap;
 
 - (instancetype)initWithName:(NSString*)labelPrefix
@@ -246,18 +246,18 @@ static NSMapTable* engineMap;
                  name:NSCurrentLocaleDidChangeNotification
                object:nil];
 
-  _engineHandle = nextHandle++;
+  _engineId = nextEngineId++;
   if (engineMap == nil) {
     engineMap = [NSMapTable strongToWeakObjectsMapTable];
   }
-  [engineMap setObject:self forKey:@(_engineHandle)];
+  [engineMap setObject:self forKey:@(_engineId)];
 
   return self;
 }
 
-+ (FlutterEngine*)engineForHandle:(int64_t)handle {
++ (FlutterEngine*)engineForId:(int64_t)identifier {
   NSAssert([[NSThread currentThread] isMainThread], @"Must be called on the main thread.");
-  return [engineMap objectForKey:@(handle)];
+  return [engineMap objectForKey:@(identifier)];
 }
 
 - (void)setUpSceneLifecycleNotifications:(NSNotificationCenter*)center API_AVAILABLE(ios(13.0)) {
@@ -518,7 +518,7 @@ static NSMapTable* engineMap;
   _profiler.reset();
   _threadHost.reset();
   _platformViewsController = nil;
-  [engineMap removeObjectForKey:@(_engineHandle)];
+  [engineMap removeObjectForKey:@(_engineId)];
 }
 
 - (NSURL*)observatoryUrl {
@@ -728,7 +728,7 @@ static NSMapTable* engineMap;
       [self.dartProject runConfigurationForEntrypoint:entrypoint
                                          libraryOrNil:libraryOrNil
                                        entrypointArgs:entrypointArgs];
-  configuration.SetEngineHandle(_engineHandle);
+  configuration.SetEngineId(_engineId);
   self.shell.RunEngine(std::move(configuration));
 }
 
@@ -1473,7 +1473,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
       [self.dartProject runConfigurationForEntrypoint:entrypoint
                                          libraryOrNil:libraryURI
                                        entrypointArgs:entrypointArgs];
-  configuration.SetEngineHandle(result->_engineHandle);
+  configuration.SetEngineId(result->_engineId);
 
   fml::WeakPtr<flutter::PlatformView> platform_view = _shell->GetPlatformView();
   FML_DCHECK(platform_view);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -161,8 +161,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 }
 
 - (int64_t)engineIdentifier {
-  // Conversion to intptr_t doesn't need bridged cast.
-  return (int64_t)self;
+  return reinterpret_cast<int64_t>((__bridge void*)self);
 }
 
 - (instancetype)init {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -273,25 +273,25 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotNil(spawn);
 }
 
-- (void)testEngineHandle {
-  int64_t handle1;
-  int64_t handle2;
+- (void)testEngineId {
+  int64_t id1;
+  int64_t id2;
   @autoreleasepool {
     FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
     [engine run];
-    handle1 = engine.engineHandle;
-    XCTAssertTrue(handle1 != 0);
+    id1 = engine.engineId;
+    XCTAssertTrue(id1 != 0);
     FlutterEngine* spawn = [engine spawnWithEntrypoint:nil
                                             libraryURI:nil
                                           initialRoute:nil
                                         entrypointArgs:nil];
-    handle2 = spawn.engineHandle;
-    XCTAssertEqual(handle2, handle1 + 1);
-    XCTAssertEqual([FlutterEngine engineForHandle:handle1], engine);
-    XCTAssertEqual([FlutterEngine engineForHandle:handle2], spawn);
+    id2 = spawn.engineId;
+    XCTAssertEqual(id2, id1 + 1);
+    XCTAssertEqual([FlutterEngine engineForId:id1], engine);
+    XCTAssertEqual([FlutterEngine engineForId:id2], spawn);
   }
-  XCTAssertNil([FlutterEngine engineForHandle:handle1]);
-  XCTAssertNil([FlutterEngine engineForHandle:handle2]);
+  XCTAssertNil([FlutterEngine engineForId:id1]);
+  XCTAssertNil([FlutterEngine engineForId:id2]);
 }
 
 - (void)testSetHandlerAfterRun {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -273,6 +273,27 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotNil(spawn);
 }
 
+- (void)testEngineHandle {
+  int64_t handle1;
+  int64_t handle2;
+  @autoreleasepool {
+    FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
+    [engine run];
+    handle1 = engine.engineHandle;
+    XCTAssertTrue(handle1 != 0);
+    FlutterEngine* spawn = [engine spawnWithEntrypoint:nil
+                                            libraryURI:nil
+                                          initialRoute:nil
+                                        entrypointArgs:nil];
+    handle2 = spawn.engineHandle;
+    XCTAssertEqual(handle2, handle1 + 1);
+    XCTAssertEqual([FlutterEngine engineForHandle:handle1], engine);
+    XCTAssertEqual([FlutterEngine engineForHandle:handle2], spawn);
+  }
+  XCTAssertNil([FlutterEngine engineForHandle:handle1]);
+  XCTAssertNil([FlutterEngine engineForHandle:handle2]);
+}
+
 - (void)testSetHandlerAfterRun {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
   XCTestExpectation* gotMessage = [self expectationWithDescription:@"gotMessage"];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -274,24 +274,17 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testEngineId {
-  int64_t id1;
-  int64_t id2;
-  @autoreleasepool {
-    FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
-    [engine run];
-    id1 = engine.engineId;
-    XCTAssertTrue(id1 != 0);
-    FlutterEngine* spawn = [engine spawnWithEntrypoint:nil
-                                            libraryURI:nil
-                                          initialRoute:nil
-                                        entrypointArgs:nil];
-    id2 = spawn.engineId;
-    XCTAssertEqual(id2, id1 + 1);
-    XCTAssertEqual([FlutterEngine engineForId:id1], engine);
-    XCTAssertEqual([FlutterEngine engineForId:id2], spawn);
-  }
-  XCTAssertNil([FlutterEngine engineForId:id1]);
-  XCTAssertNil([FlutterEngine engineForId:id2]);
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
+  [engine run];
+  int64_t id1 = engine.engineId;
+  XCTAssertTrue(id1 != 0);
+  FlutterEngine* spawn = [engine spawnWithEntrypoint:nil
+                                          libraryURI:nil
+                                        initialRoute:nil
+                                      entrypointArgs:nil];
+  int64_t id2 = spawn.engineId;
+  XCTAssertEqual([FlutterEngine engineForId:id1], engine);
+  XCTAssertEqual([FlutterEngine engineForId:id2], spawn);
 }
 
 - (void)testSetHandlerAfterRun {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -283,8 +283,8 @@ FLUTTER_ASSERT_ARC
                                         initialRoute:nil
                                       entrypointArgs:nil];
   int64_t id2 = spawn.engineId;
-  XCTAssertEqual([FlutterEngine engineForId:id1], engine);
-  XCTAssertEqual([FlutterEngine engineForId:id2], spawn);
+  XCTAssertEqual([FlutterEngine engineForIdentifier:id1], engine);
+  XCTAssertEqual([FlutterEngine engineForIdentifier:id2], spawn);
 }
 
 - (void)testSetHandlerAfterRun {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -276,13 +276,13 @@ FLUTTER_ASSERT_ARC
 - (void)testEngineId {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
   [engine run];
-  int64_t id1 = engine.engineId;
+  int64_t id1 = engine.engineIdentifier;
   XCTAssertTrue(id1 != 0);
   FlutterEngine* spawn = [engine spawnWithEntrypoint:nil
                                           libraryURI:nil
                                         initialRoute:nil
                                       entrypointArgs:nil];
-  int64_t id2 = spawn.engineId;
+  int64_t id2 = spawn.engineIdentifier;
   XCTAssertEqual([FlutterEngine engineForIdentifier:id1], engine);
   XCTAssertEqual([FlutterEngine engineForIdentifier:id2], spawn);
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns the engine handle. Used in FlutterEngineTest.
  */
-- (int64_t)engineHandle;
+- (int64_t)engineId;
 
 @end
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -87,6 +87,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) FlutterDartProject* project;
 
+/**
+ * Returns the engine handle. Used in FlutterEngineTest.
+ */
+- (int64_t)engineHandle;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -92,6 +92,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (int64_t)engineId;
 
+/**
+ * Returns engine for the identifier. The identifier must be valid for an engine
+ * that is currently running, otherwise the behavior is undefined.
+ *
+ * The identifier can be obtained in Dart code through
+ * `PlatformDispatcher.instance.engineId`.
+ *
+ * This function must be called on the main thread.
+ */
++ (nullable FlutterEngine*)engineForIdentifier:(int64_t)identifier;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns the engine handle. Used in FlutterEngineTest.
  */
-- (int64_t)engineId;
+- (int64_t)engineIdentifier;
 
 /**
  * Returns engine for the identifier. The identifier must be valid for an engine

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
@@ -107,7 +107,7 @@ FLUTTER_DARWIN_EXPORT
  *
  * This function must be called on the main thread.
  */
-+ (nullable FlutterEngine*)engineForId:(int64_t)identifier;
++ (nullable FlutterEngine*)engineForIdentifier:(int64_t)identifier;
 
 @end
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
@@ -99,9 +99,12 @@ FLUTTER_DARWIN_EXPORT
 - (void)shutDownEngine;
 
 /**
- * Returns engine for the identifier, nil if the identifier is not valid.
+ * Returns engine for the identifier. The identifier must be valid for an engine
+ * that is currently running, otherwise the behavior is undefined.
+ *
  * The identifier can be obtained in Dart code through
  * `PlatformDispatcher.instance.engineId`.
+ *
  * This function must be called on the main thread.
  */
 + (nullable FlutterEngine*)engineForId:(int64_t)identifier;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
@@ -98,17 +98,6 @@ FLUTTER_DARWIN_EXPORT
  */
 - (void)shutDownEngine;
 
-/**
- * Returns engine for the identifier. The identifier must be valid for an engine
- * that is currently running, otherwise the behavior is undefined.
- *
- * The identifier can be obtained in Dart code through
- * `PlatformDispatcher.instance.engineId`.
- *
- * This function must be called on the main thread.
- */
-+ (nullable FlutterEngine*)engineForIdentifier:(int64_t)identifier;
-
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_HEADERS_FLUTTERENGINE_H_

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
@@ -99,12 +99,12 @@ FLUTTER_DARWIN_EXPORT
 - (void)shutDownEngine;
 
 /**
- * Returns engine for the handle, nil if the handle is not valid.
- * The handle can be obtained in Dart code through
- * `PlatformDispatcher.instance.engineHandle`.
+ * Returns engine for the identifier, nil if the identifier is not valid.
+ * The identifier can be obtained in Dart code through
+ * `PlatformDispatcher.instance.engineId`.
  * This function must be called on the main thread.
  */
-+ (nullable FlutterEngine*)engineForHandle:(int64_t)handle;
++ (nullable FlutterEngine*)engineForId:(int64_t)identifier;
 
 @end
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
@@ -98,6 +98,14 @@ FLUTTER_DARWIN_EXPORT
  */
 - (void)shutDownEngine;
 
+/**
+ * Returns engine for the handle, nil if the handle is not valid.
+ * The handle can be obtained in Dart code through
+ * `PlatformDispatcher.instance.engineHandle`.
+ * This function must be called on the main thread.
+ */
++ (nullable FlutterEngine*)engineForHandle:(int64_t)handle;
+
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_HEADERS_FLUTTERENGINE_H_

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -641,7 +641,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
     }
     std::cout << message << std::endl;
   };
-  flutterArguments.engine_id = (int64_t)self;  // Conversion to intptr_t doesn't need bridged cast.
+  flutterArguments.engine_id = (int64_t)self;  // Conversion to intptr_t doesn't need bridged
 
   static size_t sTaskRunnerIdentifiers = 0;
   const FlutterTaskRunnerDescription cocoa_task_runner_description = {
@@ -1160,7 +1160,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   _engine = nullptr;
 }
 
-+ (FlutterEngine*)engineForId:(int64_t)identifier {
++ (FlutterEngine*)engineForIdentifier:(int64_t)identifier {
   NSAssert([[NSThread currentThread] isMainThread], @"Must be called on the main thread.");
   return (__bridge FlutterEngine*)reinterpret_cast<void*>(identifier);
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -474,8 +474,8 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, void* user_
   // pair cursor change with a view.
   __weak FlutterView* _lastViewWithPointerEvent;
 
-  // Unique handle for current engine.
-  int64_t _engineHandle;
+  // Unique identifier for current engine.
+  int64_t _engineId;
 }
 
 - (instancetype)initWithName:(NSString*)labelPrefix project:(FlutterDartProject*)project {
@@ -497,7 +497,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 }
 
-static int64_t nextHandle = 1;
+static int64_t nextEngineId = 1;
 static NSMapTable* engineMap;
 
 - (instancetype)initWithName:(NSString*)labelPrefix
@@ -555,11 +555,11 @@ static NSMapTable* engineMap;
   }
 
   _vsyncWaiters = [NSMapTable strongToStrongObjectsMapTable];
-  _engineHandle = nextHandle++;
+  _engineId = nextEngineId++;
   if (engineMap == nil) {
     engineMap = [NSMapTable strongToWeakObjectsMapTable];
   }
-  [engineMap setObject:self forKey:@(_engineHandle)];
+  [engineMap setObject:self forKey:@(_engineId)];
 
   return self;
 }
@@ -652,7 +652,7 @@ static NSMapTable* engineMap;
     }
     std::cout << message << std::endl;
   };
-  flutterArguments.engine_handle = _engineHandle;
+  flutterArguments.engine_id = _engineId;
 
   static size_t sTaskRunnerIdentifiers = 0;
   const FlutterTaskRunnerDescription cocoa_task_runner_description = {
@@ -1170,12 +1170,12 @@ static NSMapTable* engineMap;
   }
   _engine = nullptr;
 
-  [engineMap removeObjectForKey:@(_engineHandle)];
+  [engineMap removeObjectForKey:@(_engineId)];
 }
 
-+ (FlutterEngine*)engineForHandle:(int64_t)handle {
++ (FlutterEngine*)engineForId:(int64_t)identifier {
   NSAssert([[NSThread currentThread] isMainThread], @"Must be called on the main thread.");
-  return [engineMap objectForKey:@(handle)];
+  return [engineMap objectForKey:@(identifier)];
 }
 
 - (void)setUpPlatformViewChannel {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -641,7 +641,8 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
     }
     std::cout << message << std::endl;
   };
-  flutterArguments.engine_id = (int64_t)self;  // Conversion to intptr_t doesn't need bridged
+
+  flutterArguments.engine_id = reinterpret_cast<int64_t>((__bridge void*)self);
 
   static size_t sTaskRunnerIdentifiers = 0;
   const FlutterTaskRunnerDescription cocoa_task_runner_description = {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -863,30 +863,30 @@ TEST_F(FlutterEngineTest, ResponseFromBackgroundThread) {
   }
 }
 
-TEST_F(FlutterEngineTest, CanGetEngineForHandle) {
+TEST_F(FlutterEngineTest, CanGetEngineForId) {
   FlutterEngine* engine = GetFlutterEngine();
 
   fml::AutoResetWaitableEvent latch;
-  std::optional<int64_t> engineHandle;
-  AddNativeCallback("NotifyEngineHandle", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+  std::optional<int64_t> engineId;
+  AddNativeCallback("NotifyEngineId", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
                       const auto argument = Dart_GetNativeArgument(args, 0);
                       if (!Dart_IsNull(argument)) {
-                        const auto handle = tonic::DartConverter<int64_t>::FromDart(argument);
-                        engineHandle = handle;
+                        const auto id = tonic::DartConverter<int64_t>::FromDart(argument);
+                        engineId = id;
                       }
                       latch.Signal();
                     }));
 
-  EXPECT_TRUE([engine runWithEntrypoint:@"testEngineHandle"]);
+  EXPECT_TRUE([engine runWithEntrypoint:@"testEngineId"]);
   latch.Wait();
 
-  EXPECT_TRUE(engineHandle.has_value());
-  if (!engineHandle.has_value()) {
+  EXPECT_TRUE(engineId.has_value());
+  if (!engineId.has_value()) {
     return;
   }
-  EXPECT_EQ(engine, [FlutterEngine engineForHandle:*engineHandle]);
+  EXPECT_EQ(engine, [FlutterEngine engineForId:*engineId]);
   ShutDownEngine();
-  EXPECT_EQ(nil, [FlutterEngine engineForHandle:*engineHandle]);
+  EXPECT_EQ(nil, [FlutterEngine engineForId:*engineId]);
 }
 
 TEST_F(FlutterEngineTest, ThreadSynchronizerNotBlockingRasterThreadAfterShutdown) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -884,7 +884,7 @@ TEST_F(FlutterEngineTest, CanGetEngineForId) {
   if (!engineId.has_value()) {
     return;
   }
-  EXPECT_EQ(engine, [FlutterEngine engineForId:*engineId]);
+  EXPECT_EQ(engine, [FlutterEngine engineForIdentifier:*engineId]);
   ShutDownEngine();
 }
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -886,7 +886,6 @@ TEST_F(FlutterEngineTest, CanGetEngineForId) {
   }
   EXPECT_EQ(engine, [FlutterEngine engineForId:*engineId]);
   ShutDownEngine();
-  EXPECT_EQ(nil, [FlutterEngine engineForId:*engineId]);
 }
 
 TEST_F(FlutterEngineTest, ThreadSynchronizerNotBlockingRasterThreadAfterShutdown) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -222,6 +222,17 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
  * Returns an array of screen objects representing all of the screens available on the system.
  */
 - (NSArray<NSScreen*>*)screens;
+
+/**
+ * Returns engine for the identifier. The identifier must be valid for an engine
+ * that is currently running, otherwise the behavior is undefined.
+ *
+ * The identifier can be obtained in Dart code through
+ * `PlatformDispatcher.instance.engineId`.
+ *
+ * This function must be called on the main thread.
+ */
++ (nullable FlutterEngine*)engineForIdentifier:(int64_t)identifier;
 @end
 
 @interface FlutterEngine (Tests)

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -86,10 +86,10 @@ void sendFooMessage() {
   PlatformDispatcher.instance.sendPlatformMessage('foo', null, (ByteData? result) {});
 }
 
-@pragma('vm:external-name', 'NotifyEngineHandle')
-external void notifyEngineHandle(int? engineHandle);
+@pragma('vm:external-name', 'NotifyEngineId')
+external void notifyEngineId(int? engineId);
 
 @pragma('vm:entry-point')
-void testEngineHandle() {
-  notifyEngineHandle(PlatformDispatcher.instance.engineHandle);
+void testEngineId() {
+  notifyEngineId(PlatformDispatcher.instance.engineId);
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -85,3 +85,11 @@ void backgroundTest() {
 void sendFooMessage() {
   PlatformDispatcher.instance.sendPlatformMessage('foo', null, (ByteData? result) {});
 }
+
+@pragma('vm:external-name', 'NotifyEngineHandle')
+external void notifyEngineHandle(int? engineHandle);
+
+@pragma('vm:entry-point')
+void testEngineHandle() {
+  notifyEngineHandle(PlatformDispatcher.instance.engineHandle);
+}

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -2416,8 +2416,8 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         "Could not infer the Flutter project to run from given arguments.");
   }
 
-  if (args->engine_handle != 0) {
-    run_configuration.SetEngineHandle(args->engine_handle);
+  if (args->engine_id != 0) {
+    run_configuration.SetEngineId(args->engine_id);
   }
 
   // Create the engine but don't launch the shell or run the root isolate.

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -2410,8 +2410,8 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
     run_configuration.SetEntrypointArgs(std::move(arguments));
   }
 
-  if (args->engine_id != 0) {
-    run_configuration.SetEngineId(SAFE_ACCESS(args, engine_id, 0));
+  if (SAFE_ACCESS(args, engine_id, 0) != 0) {
+    run_configuration.SetEngineId(args->engine_id);
   }
 
   if (!run_configuration.IsValid()) {

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -2410,14 +2410,14 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
     run_configuration.SetEntrypointArgs(std::move(arguments));
   }
 
+  if (args->engine_id != 0) {
+    run_configuration.SetEngineId(SAFE_ACCESS(args, engine_id, 0));
+  }
+
   if (!run_configuration.IsValid()) {
     return LOG_EMBEDDER_ERROR(
         kInvalidArguments,
         "Could not infer the Flutter project to run from given arguments.");
-  }
-
-  if (args->engine_id != 0) {
-    run_configuration.SetEngineId(args->engine_id);
   }
 
   // Create the engine but don't launch the shell or run the root isolate.

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -2416,6 +2416,10 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         "Could not infer the Flutter project to run from given arguments.");
   }
 
+  if (args->engine_handle != 0) {
+    run_configuration.SetEngineHandle(args->engine_handle);
+  }
+
   // Create the engine but don't launch the shell or run the root isolate.
   auto embedder_engine = std::make_unique<flutter::EmbedderEngine>(
       std::move(thread_host),               //

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -2631,6 +2631,11 @@ typedef struct {
   /// the native view. The callback is invoked from a task posted to the
   /// platform thread.
   FlutterViewFocusChangeRequestCallback view_focus_change_request_callback;
+
+  /// Opaque handle provided by the engine. Accessible in Dart code through
+  /// `PlatformDispatcher.instance.engineHandle`. Can be used in native code to
+  /// retrieve the engine instance that is running the Dart code.
+  int64_t engine_handle;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -2632,10 +2632,10 @@ typedef struct {
   /// platform thread.
   FlutterViewFocusChangeRequestCallback view_focus_change_request_callback;
 
-  /// Opaque handle provided by the engine. Accessible in Dart code through
-  /// `PlatformDispatcher.instance.engineHandle`. Can be used in native code to
+  /// Opaque identifier provided by the engine. Accessible in Dart code through
+  /// `PlatformDispatcher.instance.engineId`. Can be used in native code to
   /// retrieve the engine instance that is running the Dart code.
-  int64_t engine_handle;
+  int64_t engine_id;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -35,6 +35,9 @@ static constexpr size_t kPlatformTaskRunnerIdentifier = 1;
 static constexpr int32_t kMousePointerDeviceId = 0;
 static constexpr int32_t kPointerPanZoomDeviceId = 1;
 
+static int64_t next_handle = 1;
+static GHashTable* engine_map;
+
 struct _FlEngine {
   GObject parent_instance;
 
@@ -97,6 +100,9 @@ struct _FlEngine {
   FlEnginePlatformMessageHandler platform_message_handler;
   gpointer platform_message_handler_data;
   GDestroyNotify platform_message_handler_destroy_notify;
+
+  // Unique handle for this engine.
+  gint64 engine_handle;
 };
 
 G_DEFINE_QUARK(fl_engine_error_quark, fl_engine_error)
@@ -463,6 +469,8 @@ static void fl_engine_set_property(GObject* object,
 static void fl_engine_dispose(GObject* object) {
   FlEngine* self = FL_ENGINE(object);
 
+  g_hash_table_remove(engine_map, GINT_TO_POINTER(self->engine_handle));
+
   if (self->engine != nullptr) {
     self->embedder_api.Shutdown(self->engine);
     self->engine = nullptr;
@@ -545,6 +553,13 @@ static FlEngine* fl_engine_new_full(FlDartProject* project,
   g_return_val_if_fail(FL_IS_RENDERER(renderer), nullptr);
 
   FlEngine* self = FL_ENGINE(g_object_new(fl_engine_get_type(), nullptr));
+  self->engine_handle = next_handle++;
+  if (engine_map == nullptr) {
+    engine_map =
+        g_hash_table_new_full(g_direct_hash, g_direct_equal, nullptr, nullptr);
+  }
+  g_hash_table_insert(engine_map, GINT_TO_POINTER(self->engine_handle), self);
+
   self->project = FL_DART_PROJECT(g_object_ref(project));
   self->renderer = FL_RENDERER(g_object_ref(renderer));
   if (binary_messenger != nullptr) {
@@ -561,6 +576,11 @@ static FlEngine* fl_engine_new_full(FlDartProject* project,
   fl_renderer_set_engine(self->renderer, self);
 
   return self;
+}
+
+FlEngine* fl_engine_for_handle(int64_t handle) {
+  void* engine = g_hash_table_lookup(engine_map, GINT_TO_POINTER(handle));
+  return engine ? FL_ENGINE(engine) : nullptr;
 }
 
 FlEngine* fl_engine_new_with_renderer(FlDartProject* project,
@@ -651,6 +671,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
       dart_entrypoint_args != nullptr ? g_strv_length(dart_entrypoint_args) : 0;
   args.dart_entrypoint_argv =
       reinterpret_cast<const char* const*>(dart_entrypoint_args);
+  args.engine_handle = self->engine_handle;
 
   FlutterCompositor compositor = {};
   compositor.struct_size = sizeof(FlutterCompositor);

--- a/engine/src/flutter/shell/platform/linux/fl_engine_private.h
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_private.h
@@ -588,6 +588,20 @@ FlTextInputHandler* fl_engine_get_text_input_handler(FlEngine* engine);
  */
 FlMouseCursorHandler* fl_engine_get_mouse_cursor_handler(FlEngine* engine);
 
+/**
+ * fl_engine_for_id:
+ * @handle: an engine identifier obtained through
+ * PlatformDispatcher.instance.engineId.
+ *
+ * Returns Flutter engine associated with the identifier. The identifier
+ * must be valid and for a running engine otherwise the behavior is
+ * undefined.
+ * Must be called from the main thread.
+ *
+ * Returns: a #FlEngine or NULL.
+ */
+FlEngine* fl_engine_for_id(int64_t handle);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_ENGINE_PRIVATE_H_

--- a/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
@@ -416,6 +416,33 @@ TEST(FlEngineTest, DartEntrypointArgs) {
   EXPECT_TRUE(called);
 }
 
+TEST(FlEngineTest, EngineHandle) {
+  int64_t engine_handle;
+  {
+    g_autoptr(FlDartProject) project = fl_dart_project_new();
+    g_autoptr(FlEngine) engine = fl_engine_new(project);
+
+    fl_engine_get_embedder_api(engine)->Initialize = MOCK_ENGINE_PROC(
+        Initialize,
+        ([&engine_handle](size_t version, const FlutterRendererConfig* config,
+                          const FlutterProjectArgs* args, void* user_data,
+                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+          engine_handle = args->engine_handle;
+          return kSuccess;
+        }));
+    fl_engine_get_embedder_api(engine)->RunInitialized = MOCK_ENGINE_PROC(
+        RunInitialized, ([](auto engine) { return kSuccess; }));
+
+    g_autoptr(GError) error = nullptr;
+    EXPECT_TRUE(fl_engine_start(engine, &error));
+    EXPECT_EQ(error, nullptr);
+    EXPECT_TRUE(engine_handle != 0);
+
+    EXPECT_EQ(fl_engine_for_handle(engine_handle), engine);
+  }
+  EXPECT_EQ(fl_engine_for_handle(engine_handle), nullptr);
+}
+
 TEST(FlEngineTest, Locales) {
   g_autofree gchar* initial_language = g_strdup(g_getenv("LANGUAGE"));
   g_setenv("LANGUAGE", "de:en_US", TRUE);

--- a/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
@@ -416,18 +416,18 @@ TEST(FlEngineTest, DartEntrypointArgs) {
   EXPECT_TRUE(called);
 }
 
-TEST(FlEngineTest, EngineHandle) {
-  int64_t engine_handle;
+TEST(FlEngineTest, EngineId) {
+  int64_t engine_id;
   {
     g_autoptr(FlDartProject) project = fl_dart_project_new();
     g_autoptr(FlEngine) engine = fl_engine_new(project);
 
     fl_engine_get_embedder_api(engine)->Initialize = MOCK_ENGINE_PROC(
         Initialize,
-        ([&engine_handle](size_t version, const FlutterRendererConfig* config,
-                          const FlutterProjectArgs* args, void* user_data,
-                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
-          engine_handle = args->engine_handle;
+        ([&engine_id](size_t version, const FlutterRendererConfig* config,
+                      const FlutterProjectArgs* args, void* user_data,
+                      FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+          engine_id = args->engine_id;
           return kSuccess;
         }));
     fl_engine_get_embedder_api(engine)->RunInitialized = MOCK_ENGINE_PROC(
@@ -436,11 +436,11 @@ TEST(FlEngineTest, EngineHandle) {
     g_autoptr(GError) error = nullptr;
     EXPECT_TRUE(fl_engine_start(engine, &error));
     EXPECT_EQ(error, nullptr);
-    EXPECT_TRUE(engine_handle != 0);
+    EXPECT_TRUE(engine_id != 0);
 
-    EXPECT_EQ(fl_engine_for_handle(engine_handle), engine);
+    EXPECT_EQ(fl_engine_for_id(engine_id), engine);
   }
-  EXPECT_EQ(fl_engine_for_handle(engine_handle), nullptr);
+  EXPECT_EQ(fl_engine_for_id(engine_id), nullptr);
 }
 
 TEST(FlEngineTest, Locales) {

--- a/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_engine.h
+++ b/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_engine.h
@@ -48,16 +48,16 @@ FlEngine* fl_engine_new(FlDartProject* project);
 FlEngine* fl_engine_new_headless(FlDartProject* project);
 
 /**
- * fl_engine_for_handle:
- * @handle: an engine handle obtained through
- * PlatformDispatcher.instance.engineHandle.
+ * fl_engine_for_id:
+ * @handle: an engine identifier obtained through
+ * PlatformDispatcher.instance.engineId.
  *
- * Returns Flutter engine associated with the handle or NULL if not found.
+ * Returns Flutter engine associated with the identifier or NULL if not found.
  * Must be called from the main thread.
  *
  * Returns: a #FlEngine or NULL.
  */
-FlEngine* fl_engine_for_handle(int64_t handle);
+FlEngine* fl_engine_for_id(int64_t handle);
 
 /**
  * fl_engine_get_binary_messenger:

--- a/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_engine.h
+++ b/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_engine.h
@@ -48,6 +48,18 @@ FlEngine* fl_engine_new(FlDartProject* project);
 FlEngine* fl_engine_new_headless(FlDartProject* project);
 
 /**
+ * fl_engine_for_handle:
+ * @handle: an engine handle obtained through
+ * PlatformDispatcher.instance.engineHandle.
+ *
+ * Returns Flutter engine associated with the handle or NULL if not found.
+ * Must be called from the main thread.
+ *
+ * Returns: a #FlEngine or NULL.
+ */
+FlEngine* fl_engine_for_handle(int64_t handle);
+
+/**
  * fl_engine_get_binary_messenger:
  * @engine: an #FlEngine.
  *

--- a/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_engine.h
+++ b/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_engine.h
@@ -52,7 +52,9 @@ FlEngine* fl_engine_new_headless(FlDartProject* project);
  * @handle: an engine identifier obtained through
  * PlatformDispatcher.instance.engineId.
  *
- * Returns Flutter engine associated with the identifier or NULL if not found.
+ * Returns Flutter engine associated with the identifier. The identifier
+ * must be valid and for a running engine otherwise the behavior is
+ * undefined.
  * Must be called from the main thread.
  *
  * Returns: a #FlEngine or NULL.

--- a/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_engine.h
+++ b/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_engine.h
@@ -48,20 +48,6 @@ FlEngine* fl_engine_new(FlDartProject* project);
 FlEngine* fl_engine_new_headless(FlDartProject* project);
 
 /**
- * fl_engine_for_id:
- * @handle: an engine identifier obtained through
- * PlatformDispatcher.instance.engineId.
- *
- * Returns Flutter engine associated with the identifier. The identifier
- * must be valid and for a running engine otherwise the behavior is
- * undefined.
- * Must be called from the main thread.
- *
- * Returns: a #FlEngine or NULL.
- */
-FlEngine* fl_engine_for_id(int64_t handle);
-
-/**
  * fl_engine_get_binary_messenger:
  * @engine: an #FlEngine.
  *

--- a/engine/src/flutter/shell/platform/windows/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/windows/fixtures/main.dart
@@ -397,10 +397,10 @@ void mergedUIThread() {
   signal();
 }
 
-@pragma('vm:external-name', 'NotifyEngineHandle')
-external void notifyEngineHandle(int? handle);
+@pragma('vm:external-name', 'NotifyEngineId')
+external void notifyEngineId(int? handle);
 
 @pragma('vm:entry-point')
-void testEngineHandle() {
-  notifyEngineHandle(ui.PlatformDispatcher.instance.engineHandle);
+void testEngineId() {
+  notifyEngineId(ui.PlatformDispatcher.instance.engineId);
 }

--- a/engine/src/flutter/shell/platform/windows/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/windows/fixtures/main.dart
@@ -396,3 +396,11 @@ void onMetricsChangedSignalViewIds() {
 void mergedUIThread() {
   signal();
 }
+
+@pragma('vm:external-name', 'NotifyEngineHandle')
+external void notifyEngineHandle(int? handle);
+
+@pragma('vm:entry-point')
+void testEngineHandle() {
+  notifyEngineHandle(ui.PlatformDispatcher.instance.engineHandle);
+}

--- a/engine/src/flutter/shell/platform/windows/flutter_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows.cc
@@ -197,10 +197,10 @@ bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine_ref) {
   return result;
 }
 
-FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForHandle(
-    int64_t engine_handle) {
+FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForId(
+    int64_t engine_id) {
   return HandleForEngine(
-      flutter::FlutterWindowsEngine::GetEngineForHandle(engine_handle));
+      flutter::FlutterWindowsEngine::GetEngineForId(engine_id));
 }
 
 bool FlutterDesktopEngineRun(FlutterDesktopEngineRef engine,

--- a/engine/src/flutter/shell/platform/windows/flutter_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows.cc
@@ -197,6 +197,12 @@ bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine_ref) {
   return result;
 }
 
+FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForHandle(
+    int64_t engine_handle) {
+  return HandleForEngine(
+      flutter::FlutterWindowsEngine::GetEngineForHandle(engine_handle));
+}
+
 bool FlutterDesktopEngineRun(FlutterDesktopEngineRef engine,
                              const char* entry_point) {
   std::string_view entry_point_view{""};

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -146,9 +146,8 @@ FlutterLocale CovertToFlutterLocale(const LanguageInfo& info) {
 
 }  // namespace
 
-int64_t FlutterWindowsEngine::next_engine_handle_ = 1;
-std::map<int64_t, FlutterWindowsEngine*>
-    FlutterWindowsEngine::handle_to_engine_;
+int64_t FlutterWindowsEngine::next_engine_id_ = 1;
+std::map<int64_t, FlutterWindowsEngine*> FlutterWindowsEngine::id_to_engine_;
 
 FlutterWindowsEngine::FlutterWindowsEngine(
     const FlutterProjectBundle& project,
@@ -161,8 +160,8 @@ FlutterWindowsEngine::FlutterWindowsEngine(
     windows_proc_table_ = std::make_shared<WindowsProcTable>();
   }
 
-  engine_handle_ = next_engine_handle_++;
-  handle_to_engine_[engine_handle_] = this;
+  engine_id_ = next_engine_id_++;
+  id_to_engine_[engine_id_] = this;
 
   gl_ = egl::ProcTable::Create();
 
@@ -238,13 +237,12 @@ FlutterWindowsEngine::FlutterWindowsEngine(
 FlutterWindowsEngine::~FlutterWindowsEngine() {
   messenger_->SetEngine(nullptr);
   Stop();
-  handle_to_engine_.erase(engine_handle_);
+  id_to_engine_.erase(engine_id_);
 }
 
-FlutterWindowsEngine* FlutterWindowsEngine::GetEngineForHandle(
-    int64_t engine_handle) {
-  auto it = handle_to_engine_.find(engine_handle);
-  if (it == handle_to_engine_.end()) {
+FlutterWindowsEngine* FlutterWindowsEngine::GetEngineForId(int64_t engine_id) {
+  auto it = id_to_engine_.find(engine_id);
+  if (it == id_to_engine_.end()) {
     return nullptr;
   }
   return it->second;
@@ -326,7 +324,7 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
   args.icu_data_path = icu_path_string.c_str();
   args.command_line_argc = static_cast<int>(argv.size());
   args.command_line_argv = argv.empty() ? nullptr : argv.data();
-  args.engine_handle = engine_handle_;
+  args.engine_id = engine_id_;
 
   // Fail if conflicting non-default entrypoints are specified in the method
   // argument and the project.

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -96,8 +96,9 @@ class FlutterWindowsEngine {
 
   virtual ~FlutterWindowsEngine();
 
-  // Returns the engine associated with the given identifier, or nullptr if the
-  // identifier is not valid.
+  // Returns the engine associated with the given identifier.
+  // The engine_id must be valid and for a running engine, otherwise
+  // the behavior is undefined.
   // Must be called on the platform thread.
   static FlutterWindowsEngine* GetEngineForId(int64_t engine_id);
 
@@ -369,12 +370,6 @@ class FlutterWindowsEngine {
 
   // The ID that the next view will have.
   FlutterViewId next_view_id_ = kImplicitViewId;
-
-  // Unique handle for the engine.
-  int64_t engine_id_;
-
-  static int64_t next_engine_id_;
-  static std::map<int64_t, FlutterWindowsEngine*> id_to_engine_;
 
   // The views displaying the content running in this engine, if any.
   //

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -96,6 +96,11 @@ class FlutterWindowsEngine {
 
   virtual ~FlutterWindowsEngine();
 
+  // Returns the engine associated with the given handle, or nullptr if the
+  // handle is not valid.
+  // Must be called on the platform thread.
+  static FlutterWindowsEngine* GetEngineForHandle(int64_t engine_handle);
+
   // Starts running the entrypoint function specifed in the project bundle. If
   // unspecified, defaults to main().
   //
@@ -364,6 +369,12 @@ class FlutterWindowsEngine {
 
   // The ID that the next view will have.
   FlutterViewId next_view_id_ = kImplicitViewId;
+
+  // Unique handle for the engine.
+  int64_t engine_handle_;
+
+  static int64_t next_engine_handle_;
+  static std::map<int64_t, FlutterWindowsEngine*> handle_to_engine_;
 
   // The views displaying the content running in this engine, if any.
   //

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -96,10 +96,10 @@ class FlutterWindowsEngine {
 
   virtual ~FlutterWindowsEngine();
 
-  // Returns the engine associated with the given handle, or nullptr if the
-  // handle is not valid.
+  // Returns the engine associated with the given identifier, or nullptr if the
+  // identifier is not valid.
   // Must be called on the platform thread.
-  static FlutterWindowsEngine* GetEngineForHandle(int64_t engine_handle);
+  static FlutterWindowsEngine* GetEngineForId(int64_t engine_id);
 
   // Starts running the entrypoint function specifed in the project bundle. If
   // unspecified, defaults to main().
@@ -371,10 +371,10 @@ class FlutterWindowsEngine {
   FlutterViewId next_view_id_ = kImplicitViewId;
 
   // Unique handle for the engine.
-  int64_t engine_handle_;
+  int64_t engine_id_;
 
-  static int64_t next_engine_handle_;
-  static std::map<int64_t, FlutterWindowsEngine*> handle_to_engine_;
+  static int64_t next_engine_id_;
+  static std::map<int64_t, FlutterWindowsEngine*> id_to_engine_;
 
   // The views displaying the content running in this engine, if any.
   //

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_internal.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_internal.h
@@ -65,6 +65,15 @@ FLUTTER_EXPORT void FlutterDesktopEngineRegisterPlatformViewType(
     const char* view_type_name,
     FlutterPlatformViewTypeEntry view_type);
 
+// Returns the engine associated with the given identifier. Engine identifier
+// must be valid and for a running engine, otherwise the behavior is undefined.
+//
+// Identifier can be obtained from PlatformDispatcher.instance.engineId.
+//
+// This method must be called from the platform thread.
+FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForId(
+    int64_t engine_id);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
@@ -679,8 +679,6 @@ TEST_F(WindowsTest, EngineId) {
   }
   auto engine = FlutterDesktopViewControllerGetEngine(first_controller.get());
   EXPECT_EQ(engine, FlutterDesktopEngineForId(*engineId));
-  first_controller.reset();
-  EXPECT_EQ(nullptr, FlutterDesktopEngineForId(*engineId));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
@@ -652,19 +652,19 @@ TEST_F(WindowsTest, AddRemoveView) {
   }
 }
 
-TEST_F(WindowsTest, EngineHandle) {
+TEST_F(WindowsTest, EngineId) {
   auto& context = GetContext();
   WindowsConfigBuilder builder(context);
-  builder.SetDartEntrypoint("testEngineHandle");
+  builder.SetDartEntrypoint("testEngineId");
 
   fml::AutoResetWaitableEvent latch;
-  std::optional<int64_t> engineHandle;
+  std::optional<int64_t> engineId;
   context.AddNativeFunction(
-      "NotifyEngineHandle", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+      "NotifyEngineId", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
         const auto argument = Dart_GetNativeArgument(args, 0);
         if (!Dart_IsNull(argument)) {
           const auto handle = tonic::DartConverter<int64_t>::FromDart(argument);
-          engineHandle = handle;
+          engineId = handle;
         }
         latch.Signal();
       }));
@@ -673,14 +673,14 @@ TEST_F(WindowsTest, EngineHandle) {
   ASSERT_NE(first_controller, nullptr);
 
   latch.Wait();
-  EXPECT_TRUE(engineHandle.has_value());
-  if (!engineHandle.has_value()) {
+  EXPECT_TRUE(engineId.has_value());
+  if (!engineId.has_value()) {
     return;
   }
   auto engine = FlutterDesktopViewControllerGetEngine(first_controller.get());
-  EXPECT_EQ(engine, FlutterDesktopEngineForHandle(*engineHandle));
+  EXPECT_EQ(engine, FlutterDesktopEngineForId(*engineId));
   first_controller.reset();
-  EXPECT_EQ(nullptr, FlutterDesktopEngineForHandle(*engineHandle));
+  EXPECT_EQ(nullptr, FlutterDesktopEngineForId(*engineId));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -173,10 +173,12 @@ FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineCreate(
 // |engine| is no longer valid after this call.
 FLUTTER_EXPORT bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine);
 
-// Returns the engine associated with the given identifier, or nullptr if no
-// such engine exists. Identifier can be obtained from
-// PlatformDispatcher.instance.engineId. This must be called from the platform
-// thread.
+// Returns the engine associated with the given identifier. Engine identifier
+// must be valid and for a running engine, otherwise the behavior is undefined.
+//
+// Identifier can be obtained from PlatformDispatcher.instance.engineId.
+//
+// This method must be called from the platform thread.
 FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForId(
     int64_t engine_id);
 

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -173,15 +173,6 @@ FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineCreate(
 // |engine| is no longer valid after this call.
 FLUTTER_EXPORT bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine);
 
-// Returns the engine associated with the given identifier. Engine identifier
-// must be valid and for a running engine, otherwise the behavior is undefined.
-//
-// Identifier can be obtained from PlatformDispatcher.instance.engineId.
-//
-// This method must be called from the platform thread.
-FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForId(
-    int64_t engine_id);
-
 // Starts running the given engine instance.
 //
 // The entry_point parameter is deprecated but preserved for

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -173,6 +173,13 @@ FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineCreate(
 // |engine| is no longer valid after this call.
 FLUTTER_EXPORT bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine);
 
+// Returns the engine associated with the given handle, or nullptr if no such
+// engine exists.
+// Handle can be obtained from PlatformDispatcher.instance.engineHandle.
+// This must be called from the platform thread.
+FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForHandle(
+    int64_t engine_handle);
+
 // Starts running the given engine instance.
 //
 // The entry_point parameter is deprecated but preserved for

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -173,12 +173,12 @@ FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineCreate(
 // |engine| is no longer valid after this call.
 FLUTTER_EXPORT bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine);
 
-// Returns the engine associated with the given handle, or nullptr if no such
-// engine exists.
-// Handle can be obtained from PlatformDispatcher.instance.engineHandle.
-// This must be called from the platform thread.
-FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForHandle(
-    int64_t engine_handle);
+// Returns the engine associated with the given identifier, or nullptr if no
+// such engine exists. Identifier can be obtained from
+// PlatformDispatcher.instance.engineId. This must be called from the platform
+// thread.
+FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineForId(
+    int64_t engine_id);
 
 // Starts running the given engine instance.
 //


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/163430.

This PR adds `engineId` field to `PlatformDispatcher`. When provided by the engine, this can be used to retrieve the engine instance from native code.

Dart code:
```dart
final identifier = PlatformDispatcher.instance.engineId!;
```

macOS, iOS: 
```objc
FlutterEngine *engine = [FlutterEngine engineForIdentifier: identifier];
```

Android:
```java
FlutterEngine engine = FlutterEngine.engineForId(identifier);
```

Linux
```cpp
FlEngine *engine = fl_engine_for_id(identifier);
```

Windows
```cpp
FlutterDesktopEngineRef engine = FlutterDesktopEngineForId(identifier);
```

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
