### PR TITLE
engine: report mouse backward and forward buttons on linux

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -153,9 +153,7 @@ static gboolean get_mouse_button(GdkEvent* event, int64_t* button) {
       *button = kFlutterPointerButtonMouseForward;
       return TRUE;
     default:
-      *button = 1 << event_button;
-      // return FALSE;
-      return TRUE;
+      return FALSE;
   }
 }
 

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -146,8 +146,16 @@ static gboolean get_mouse_button(GdkEvent* event, int64_t* button) {
     case 3:
       *button = kFlutterPointerButtonMouseSecondary;
       return TRUE;
+    case 8:
+      *button = kFlutterPointerButtonMouseBack;
+      return TRUE;
+    case 9:
+      *button = kFlutterPointerButtonMouseForward;
+      return TRUE;
     default:
-      return FALSE;
+      *button = 1 << event_button;
+      // return FALSE;
+      return TRUE;
   }
 }
 

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -63,11 +63,17 @@ struct _FlView {
   // Accessible tree from Flutter, exposed as an AtkPlug.
   FlViewAccessible* view_accessible;
 
-  // Signal subscripton for cursor changes.
+  // Signal subscription for cursor changes.
   guint cursor_changed_cb_id;
 
   GCancellable* cancellable;
 };
+
+// 8 corresponds to mouse back button on both x11 and wayland
+static constexpr guint kMouseButtonBack = 8;
+
+// 9 corresponds to mouse forward button on both x11 and wayland
+static constexpr guint kMouseButtonForward = 9;
 
 enum { SIGNAL_FIRST_FRAME, LAST_SIGNAL };
 
@@ -146,10 +152,10 @@ static gboolean get_mouse_button(GdkEvent* event, int64_t* button) {
     case 3:
       *button = kFlutterPointerButtonMouseSecondary;
       return TRUE;
-    case 8:
+    case kMouseButtonBack:
       *button = kFlutterPointerButtonMouseBack;
       return TRUE;
-    case 9:
+    case kMouseButtonForward:
       *button = kFlutterPointerButtonMouseForward;
       return TRUE;
     default:


### PR DESCRIPTION
This patch allows a mouse's back and forward buttons to be reported on Linux.
I tested/verified this on x11 using a sample flutter project that employs a custom `RawGestureDetector` to act upon the detected mouse event's buttons (back and forward).

This relates to #152128 and its parent issue #115641. Clearly, more discussion needs to be had about other mouse buttons before #152128 can be fully resolved.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
