### PR TITLE
Feat: Add mostly constructor for EdgeInsets

### DIFF
--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -311,6 +311,21 @@ class BorderRadius extends BorderRadiusGeometry {
     this.bottomRight = Radius.zero,
   });
 
+  /// Creates a border radius where only the specified corners are set while the
+  /// unspecified corners are set to [value].
+  const BorderRadius.mostly(
+    Radius value, {
+    Radius? topLeft,
+    Radius? topRight,
+    Radius? bottomLeft,
+    Radius? bottomRight,
+  }) : this.only(
+         topLeft: topLeft ?? value,
+         topRight: topRight ?? value,
+         bottomLeft: bottomLeft ?? value,
+         bottomRight: bottomRight ?? value,
+       );
+
   /// Returns a copy of this BorderRadius with the given fields replaced with
   /// the new values.
   BorderRadius copyWith({
@@ -541,6 +556,21 @@ class BorderRadiusDirectional extends BorderRadiusGeometry {
     this.bottomStart = Radius.zero,
     this.bottomEnd = Radius.zero,
   });
+
+  /// Creates a border radius where only the specified corners are set while the
+  /// unspecified corners are set to [value].
+  const BorderRadiusDirectional.mostly(
+    Radius value, {
+    Radius? topStart,
+    Radius? topEnd,
+    Radius? bottomStart,
+    Radius? bottomEnd,
+  }) : this.only(
+         topStart: topStart ?? value,
+         topEnd: topEnd ?? value,
+         bottomStart: bottomStart ?? value,
+         bottomEnd: bottomEnd ?? value,
+       );
 
   /// A border radius with all zero radii.
   ///

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -442,6 +442,19 @@ class Border extends BoxBorder {
       bottom = side,
       left = side;
 
+  /// Creates a border where specified sides are set while unspecified
+  /// sides are set to [side].
+  const Border.mostly(
+    BorderSide side, {
+    BorderSide? top,
+    BorderSide? bottom,
+    BorderSide? right,
+    BorderSide? left,
+  }) : top = top ?? side,
+       right = right ?? side,
+       bottom = bottom ?? side,
+       left = left ?? side;
+
   /// Creates a border with symmetrical vertical and horizontal sides.
   ///
   /// The `vertical` argument applies to the [left] and [right] sides, and the

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -374,6 +374,22 @@ class EdgeInsets extends EdgeInsetsGeometry {
   /// {@end-tool}
   const EdgeInsets.only({this.left = 0.0, this.top = 0.0, this.right = 0.0, this.bottom = 0.0});
 
+  /// Creates insets with offsets from the left, top, right, and bottom otherwise defaults to `value`.
+  ///
+  /// {@tool snippet}
+  ///
+  /// Left margin indent of 40 pixels and others 8 pixels:
+  ///
+  /// ```dart
+  /// const EdgeInsets.mostly(8.0, left: 40.0)
+  /// ```
+  /// {@end-tool}
+  const EdgeInsets.mostly(double value, {double? top, double? right, double? bottom, double? left})
+    : left = left ?? value,
+      top = top ?? value,
+      right = right ?? value,
+      bottom = bottom ?? value;
+
   /// Creates insets with symmetrical vertical and horizontal offsets.
   ///
   /// {@tool snippet}
@@ -693,6 +709,27 @@ class EdgeInsetsDirectional extends EdgeInsetsGeometry {
       top = value,
       end = value,
       bottom = value;
+
+  /// Creates insets with offsets from the left, top, right, and bottom otherwise defaults to `value`.
+  ///
+  /// {@tool snippet}
+  ///
+  /// Start margin indent of 40 pixels and others 8 pixels:
+  ///
+  /// ```dart
+  /// const EdgeInsetsDirectional.mostly(8.0, start: 40.0)
+  /// ```
+  /// {@end-tool}
+  const EdgeInsetsDirectional.mostly(
+    double value, {
+    double? start,
+    double? top,
+    double? end,
+    double? bottom,
+  }) : start = start ?? value,
+       top = top ?? value,
+       end = end ?? value,
+       bottom = bottom ?? value;
 
   /// An [EdgeInsetsDirectional] with zero offsets in each direction.
   ///

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -133,6 +133,23 @@ void main() {
     expect(BorderRadius.circular(15.0) ~/ 10.0, BorderRadius.circular(1.0));
 
     expect(BorderRadius.circular(15.0) % 10.0, BorderRadius.circular(5.0));
+
+    borderRadius = const BorderRadius.mostly(radius1, bottomRight: radius2);
+    expect(borderRadius, hasOneLineDescription);
+    expect(borderRadius.topLeft, radius1);
+    expect(borderRadius.topRight, radius1);
+    expect(borderRadius.bottomLeft, radius1);
+    expect(borderRadius.bottomRight, radius2);
+    expect(
+      borderRadius.toRRect(rect),
+      RRect.fromRectAndCorners(
+        rect,
+        topRight: radius1,
+        topLeft: radius1,
+        bottomLeft: radius1,
+        bottomRight: radius2,
+      ),
+    );
   });
 
   test('BorderRadius.lerp() invariants', () {
@@ -328,6 +345,34 @@ void main() {
     expect(BorderRadiusDirectional.circular(15.0) ~/ 10.0, BorderRadiusDirectional.circular(1.0));
 
     expect(BorderRadiusDirectional.circular(15.0) % 10.0, BorderRadiusDirectional.circular(5.0));
+
+    borderRadius = const BorderRadiusDirectional.mostly(radius1, bottomEnd: radius2);
+    expect(borderRadius, hasOneLineDescription);
+    expect(borderRadius.topStart, radius1);
+    expect(borderRadius.topEnd, radius1);
+    expect(borderRadius.bottomStart, radius1);
+    expect(borderRadius.bottomEnd, radius2);
+
+    expect(
+      borderRadius.resolve(TextDirection.ltr).toRRect(rect),
+      RRect.fromRectAndCorners(
+        rect,
+        topLeft: radius1,
+        topRight: radius1,
+        bottomLeft: radius1,
+        bottomRight: radius2,
+      ),
+    );
+    expect(
+      borderRadius.resolve(TextDirection.rtl).toRRect(rect),
+      RRect.fromRectAndCorners(
+        rect,
+        topLeft: radius1,
+        topRight: radius1,
+        bottomLeft: radius2,
+        bottomRight: radius1,
+      ),
+    );
   });
 
   test('BorderRadiusDirectional.lerp() invariants', () {

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -24,6 +24,16 @@ void main() {
     expect(border.bottom, same(side));
   });
 
+  test('Border.mostly constructor', () {
+    const BorderSide side = BorderSide();
+    const BorderSide leftSide = BorderSide(width: 2);
+    const Border border = Border.mostly(side, left: leftSide);
+    expect(border.left, same(leftSide));
+    expect(border.top, same(side));
+    expect(border.right, same(side));
+    expect(border.bottom, same(side));
+  });
+
   test('Border.symmetric constructor', () {
     const BorderSide side1 = BorderSide(color: Color(0xFFFFFFFF));
     const BorderSide side2 = BorderSide();

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -33,6 +33,11 @@ void main() {
     const EdgeInsets symmetric = EdgeInsets.symmetric(horizontal: 10, vertical: 20);
     expect(symmetric.resolve(TextDirection.ltr), equals(const EdgeInsets.fromLTRB(10, 20, 10, 20)));
     expect(symmetric.resolve(TextDirection.rtl), equals(const EdgeInsets.fromLTRB(10, 20, 10, 20)));
+
+    //mostly
+    const EdgeInsets mostly = EdgeInsets.mostly(8, left: 40);
+    expect(mostly.resolve(TextDirection.ltr), equals(const EdgeInsets.fromLTRB(40, 8, 8, 8)));
+    expect(mostly.resolve(TextDirection.rtl), equals(const EdgeInsets.fromLTRB(40, 8, 8, 8)));
   });
 
   test('EdgeInsetsDirectional constructors', () {
@@ -80,6 +85,11 @@ void main() {
     );
     expect(symmetric.resolve(TextDirection.ltr), equals(const EdgeInsets.fromLTRB(10, 20, 10, 20)));
     expect(symmetric.resolve(TextDirection.rtl), equals(const EdgeInsets.fromLTRB(10, 20, 10, 20)));
+
+    //mostly
+    const EdgeInsetsDirectional mostly = EdgeInsetsDirectional.mostly(8, top: 40);
+    expect(mostly.resolve(TextDirection.ltr), equals(const EdgeInsets.fromLTRB(8, 40, 8, 8)));
+    expect(mostly.resolve(TextDirection.rtl), equals(const EdgeInsets.fromLTRB(8, 40, 8, 8)));
   });
 
   test('EdgeInsets control test', () {


### PR DESCRIPTION
Feat: Add mostly constructor for EdgeInsets
fixes: #74981, #163465 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.