### PR TITLE
[iOS] always post new task during gesture dispatch.

### DIFF
--- a/engine/src/flutter/shell/common/fixtures/shell_test.dart
+++ b/engine/src/flutter/shell/common/fixtures/shell_test.dart
@@ -625,3 +625,10 @@ void testPointerActions() {
     });
   };
 }
+
+@pragma('vm:entry-point')
+void testDispatchEvents() {
+  PlatformDispatcher.instance.onPointerDataPacket = (PointerDataPacket pointer) {
+    notifyNative();
+  };
+}

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1095,8 +1095,8 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   TRACE_FLOW_BEGIN("flutter", "PointerEvent", next_pointer_flow_id_);
   FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
-  fml::TaskRunner::RunNowAndFlushMessages(
-      task_runners_.GetUITaskRunner(),
+
+  task_runners_.GetUITaskRunner()->PostTask(
       fml::MakeCopyable([engine = weak_engine_, packet = std::move(packet),
                          flow_id = next_pointer_flow_id_]() mutable {
         if (engine) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/163429

If we synchronously call into dart ui when dispatching pointer events, then we only end up scheduling about ~half as many frames as we should. Nothing is blocked, no task starvation, et cetera. It should always be safe to post pointer events as a new task instead.
