### PR TITLE
Run new gallery transition perf benchmark on Galaxy S24

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3079,8 +3079,8 @@ targets:
   # Samsung Galaxy S24, Impeller (Vulkan)
   - name: Linux_galaxy_s24 new_gallery_impeller__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: true
-    presubmit: false
+    bringup: false
+    presubmit: true
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3079,8 +3079,7 @@ targets:
   # Samsung Galaxy S24, Impeller (Vulkan)
   - name: Linux_galaxy_s24 new_gallery_impeller__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: false
-    presubmit: true
+    presubmit: false
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
There are now many S24 devices in the prod pool.