### PR TITLE
Check for tracked engine.version before overriding

### DIFF
--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -41,8 +41,6 @@ if (![string]::IsNullOrEmpty($env:FLUTTER_PREBUILT_ENGINE_VERSION)) {
 
 # Test for fusion repository
 if ([string]::IsNullOrEmpty($engineVersion) -and (Test-Path "$flutterRoot\DEPS" -PathType Leaf) -and (Test-Path "$flutterRoot\engine\src\.gn" -PathType Leaf)) {
-    # Calculate the engine hash from tracked git files.
-    $branch = (git -C "$flutterRoot" rev-parse --abbrev-ref HEAD)
     if ($null -eq $Env:LUCI_CONTEXT) {
         $ErrorActionPreference = "Continue"
         git -C "$flutterRoot" remote get-url upstream *> $null

--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -53,7 +53,9 @@ if ([string]::IsNullOrEmpty($engineVersion) -and (Test-Path "$flutterRoot\DEPS" 
     }
 }
 
-if (($branch -ne "stable" -and $branch -ne "beta")) {
+# If the engine.version is tracked by git; do not override it.
+$trackedEngine = (git -C "$flutterRoot" ls-files bin/internal/engine.version) | Out-String
+if ($trackedEngine.length -eq 0) {
     # Write the engine version out so downstream tools know what to look for.
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     [System.IO.File]::WriteAllText("$flutterRoot\bin\internal\engine.version", $engineVersion, $utf8NoBom)

--- a/bin/internal/update_engine_version.sh
+++ b/bin/internal/update_engine_version.sh
@@ -41,7 +41,6 @@ fi
 
 # Test for fusion repository and no environment variable override.
 if [ -z "$ENGINE_VERSION" ] && [ -f "$FLUTTER_ROOT/DEPS" ] && [ -f "$FLUTTER_ROOT/engine/src/.gn" ]; then
-  BRANCH=$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)
   # In a fusion repository; the engine.version comes from the git hashes.
   if [ -z "${LUCI_CONTEXT}" ]; then
     set +e

--- a/bin/internal/update_engine_version.sh
+++ b/bin/internal/update_engine_version.sh
@@ -33,6 +33,12 @@ fi
 
 FLUTTER_ROOT="$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")"
 
+# On stable, beta, and release tags, the engine.version is tracked by git - do not override it.
+TRACKED_ENGINE="$(git -C "$FLUTTER_ROOT" ls-files bin/internal/engine.version)"
+if [[ -n "$TRACKED_ENGINE" ]]; then
+  exit
+fi
+
 # Test for fusion repository and no environment variable override.
 if [ -z "$ENGINE_VERSION" ] && [ -f "$FLUTTER_ROOT/DEPS" ] && [ -f "$FLUTTER_ROOT/engine/src/.gn" ]; then
   BRANCH=$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)
@@ -54,14 +60,10 @@ if [ -z "$ENGINE_VERSION" ] && [ -f "$FLUTTER_ROOT/DEPS" ] && [ -f "$FLUTTER_ROO
   fi
 fi
 
-# If the engine.version is tracked by git; do not override it.
-TRACKED_ENGINE="$(git -C "$flutterRoot" ls-files bin/internal/engine.version)"
-if [[ -z "$TRACKED_ENGINE" ]]; then
-  # Write the engine version out so downstream tools know what to look for.
-  echo $ENGINE_VERSION > "$FLUTTER_ROOT/bin/internal/engine.version"
+# Write the engine version out so downstream tools know what to look for.
+echo $ENGINE_VERSION > "$FLUTTER_ROOT/bin/internal/engine.version"
 
-  # The realm on CI is passed in.
-  if [ -n "${FLUTTER_REALM}" ]; then
-    echo $FLUTTER_REALM > "$FLUTTER_ROOT/bin/internal/engine.realm"
-  fi
+# The realm on CI is passed in.
+if [ -n "${FLUTTER_REALM}" ]; then
+  echo $FLUTTER_REALM > "$FLUTTER_ROOT/bin/internal/engine.realm"
 fi

--- a/bin/internal/update_engine_version.sh
+++ b/bin/internal/update_engine_version.sh
@@ -54,7 +54,9 @@ if [ -z "$ENGINE_VERSION" ] && [ -f "$FLUTTER_ROOT/DEPS" ] && [ -f "$FLUTTER_ROO
   fi
 fi
 
-if [[ "$BRANCH" != "stable" && "$BRANCH" != "beta" ]]; then
+# If the engine.version is tracked by git; do not override it.
+TRACKED_ENGINE="$(git -C "$flutterRoot" ls-files bin/internal/engine.version)"
+if [[ -z "$TRACKED_ENGINE" ]]; then
   # Write the engine version out so downstream tools know what to look for.
   echo $ENGINE_VERSION > "$FLUTTER_ROOT/bin/internal/engine.version"
 


### PR DESCRIPTION
Checking out a flutter release tag (e.g. `3.29.0`) will see the checked in engine.version file overridden. Don't do that.

See: #163308
