### PR TITLE
[Windows] Enable merged platform and UI thread by default

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -299,11 +299,12 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
   custom_task_runners.thread_priority_setter =
       &WindowsPlatformThreadPrioritySetter;
 
-  if (project_->ui_thread_policy() ==
-      FlutterUIThreadPolicy::RunOnPlatformThread) {
-    FML_LOG(WARNING)
-        << "Running with merged platform and UI thread. Experimental.";
+  if (project_->ui_thread_policy() !=
+      FlutterUIThreadPolicy::RunOnSeparateThread) {
     custom_task_runners.ui_task_runner = &platform_task_runner;
+  } else {
+    FML_LOG(WARNING) << "Running with unmerged platform and UI thread. This "
+                        "will be removed in future.";
   }
 
   FlutterProjectArgs args = {};

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -303,7 +303,7 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
       FlutterUIThreadPolicy::RunOnSeparateThread) {
     custom_task_runners.ui_task_runner = &platform_task_runner;
   } else {
-    FML_LOG(WARNING) << "Running with unmerged platform and UI thread. This "
+    FML_LOG(WARNING) << "Running with unmerged platform and UI threads. This "
                         "will be removed in future.";
   }
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
@@ -131,19 +131,19 @@ TEST_F(WindowsTest, LaunchHeadlessEngine) {
   ASSERT_NE(engine, nullptr);
 
   std::string view_ids;
-  bool signalled = false;
+  bool signaled = false;
   context.AddNativeFunction(
       "SignalStringValue", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
         auto handle = Dart_GetNativeArgument(args, 0);
         ASSERT_FALSE(Dart_IsError(handle));
         view_ids = tonic::DartConverter<std::string>::FromDart(handle);
-        signalled = true;
+        signaled = true;
       }));
 
   ViewControllerPtr controller{builder.Run()};
   ASSERT_NE(controller, nullptr);
 
-  while (!signalled) {
+  while (!signaled) {
     PumpMessage();
   }
 
@@ -217,16 +217,16 @@ TEST_F(WindowsTest, VerifyNativeFunction) {
   WindowsConfigBuilder builder(context);
   builder.SetDartEntrypoint("verifyNativeFunction");
 
-  bool signalled = false;
+  bool signaled = false;
   auto native_entry =
-      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { signalled = true; });
+      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { signaled = true; });
   context.AddNativeFunction("Signal", native_entry);
 
   ViewControllerPtr controller{builder.Run()};
   ASSERT_NE(controller, nullptr);
 
   // Wait until signal has been called.
-  while (!signalled) {
+  while (!signaled) {
     PumpMessage();
   }
 }
@@ -239,11 +239,11 @@ TEST_F(WindowsTest, VerifyNativeFunctionWithParameters) {
   builder.SetDartEntrypoint("verifyNativeFunctionWithParameters");
 
   bool bool_value = false;
-  bool signalled = false;
+  bool signaled = false;
   auto native_entry = CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
     auto handle = Dart_GetNativeBooleanArgument(args, 0, &bool_value);
     ASSERT_FALSE(Dart_IsError(handle));
-    signalled = true;
+    signaled = true;
   });
   context.AddNativeFunction("SignalBoolValue", native_entry);
 
@@ -251,7 +251,7 @@ TEST_F(WindowsTest, VerifyNativeFunctionWithParameters) {
   ASSERT_NE(controller, nullptr);
 
   // Wait until signalBoolValue has been called.
-  while (!signalled) {
+  while (!signaled) {
     PumpMessage();
   }
   EXPECT_TRUE(bool_value);
@@ -264,12 +264,12 @@ TEST_F(WindowsTest, PlatformExecutable) {
   builder.SetDartEntrypoint("readPlatformExecutable");
 
   std::string executable_name;
-  bool signalled = false;
+  bool signaled = false;
   auto native_entry = CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
     auto handle = Dart_GetNativeArgument(args, 0);
     ASSERT_FALSE(Dart_IsError(handle));
     executable_name = tonic::DartConverter<std::string>::FromDart(handle);
-    signalled = true;
+    signaled = true;
   });
   context.AddNativeFunction("SignalStringValue", native_entry);
 
@@ -277,7 +277,7 @@ TEST_F(WindowsTest, PlatformExecutable) {
   ASSERT_NE(controller, nullptr);
 
   // Wait until signalStringValue has been called.
-  while (!signalled) {
+  while (!signaled) {
     PumpMessage();
   }
   EXPECT_EQ(executable_name, "flutter_windows_unittests.exe");

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_unittests.cc
@@ -131,20 +131,23 @@ TEST_F(WindowsTest, LaunchHeadlessEngine) {
   ASSERT_NE(engine, nullptr);
 
   std::string view_ids;
-  fml::AutoResetWaitableEvent latch;
+  bool signalled = false;
   context.AddNativeFunction(
       "SignalStringValue", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
         auto handle = Dart_GetNativeArgument(args, 0);
         ASSERT_FALSE(Dart_IsError(handle));
         view_ids = tonic::DartConverter<std::string>::FromDart(handle);
-        latch.Signal();
+        signalled = true;
       }));
 
   ViewControllerPtr controller{builder.Run()};
   ASSERT_NE(controller, nullptr);
 
+  while (!signalled) {
+    PumpMessage();
+  }
+
   // Verify a headless app has the implicit view.
-  latch.Wait();
   EXPECT_EQ(view_ids, "View IDs: [0]");
 }
 
@@ -214,16 +217,18 @@ TEST_F(WindowsTest, VerifyNativeFunction) {
   WindowsConfigBuilder builder(context);
   builder.SetDartEntrypoint("verifyNativeFunction");
 
-  fml::AutoResetWaitableEvent latch;
+  bool signalled = false;
   auto native_entry =
-      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { latch.Signal(); });
+      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { signalled = true; });
   context.AddNativeFunction("Signal", native_entry);
 
   ViewControllerPtr controller{builder.Run()};
   ASSERT_NE(controller, nullptr);
 
   // Wait until signal has been called.
-  latch.Wait();
+  while (!signalled) {
+    PumpMessage();
+  }
 }
 
 // Verify that native functions that pass parameters can be registered and
@@ -234,11 +239,11 @@ TEST_F(WindowsTest, VerifyNativeFunctionWithParameters) {
   builder.SetDartEntrypoint("verifyNativeFunctionWithParameters");
 
   bool bool_value = false;
-  fml::AutoResetWaitableEvent latch;
+  bool signalled = false;
   auto native_entry = CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
     auto handle = Dart_GetNativeBooleanArgument(args, 0, &bool_value);
     ASSERT_FALSE(Dart_IsError(handle));
-    latch.Signal();
+    signalled = true;
   });
   context.AddNativeFunction("SignalBoolValue", native_entry);
 
@@ -246,7 +251,9 @@ TEST_F(WindowsTest, VerifyNativeFunctionWithParameters) {
   ASSERT_NE(controller, nullptr);
 
   // Wait until signalBoolValue has been called.
-  latch.Wait();
+  while (!signalled) {
+    PumpMessage();
+  }
   EXPECT_TRUE(bool_value);
 }
 
@@ -257,12 +264,12 @@ TEST_F(WindowsTest, PlatformExecutable) {
   builder.SetDartEntrypoint("readPlatformExecutable");
 
   std::string executable_name;
-  fml::AutoResetWaitableEvent latch;
+  bool signalled = false;
   auto native_entry = CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
     auto handle = Dart_GetNativeArgument(args, 0);
     ASSERT_FALSE(Dart_IsError(handle));
     executable_name = tonic::DartConverter<std::string>::FromDart(handle);
-    latch.Signal();
+    signalled = true;
   });
   context.AddNativeFunction("SignalStringValue", native_entry);
 
@@ -270,7 +277,9 @@ TEST_F(WindowsTest, PlatformExecutable) {
   ASSERT_NE(controller, nullptr);
 
   // Wait until signalStringValue has been called.
-  latch.Wait();
+  while (!signalled) {
+    PumpMessage();
+  }
   EXPECT_EQ(executable_name, "flutter_windows_unittests.exe");
 }
 
@@ -282,10 +291,10 @@ TEST_F(WindowsTest, VerifyNativeFunctionWithReturn) {
   builder.SetDartEntrypoint("verifyNativeFunctionWithReturn");
 
   bool bool_value_to_return = true;
-  fml::CountDownLatch latch(2);
+  int count = 2;
   auto bool_return_entry = CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
     Dart_SetBooleanReturnValue(args, bool_value_to_return);
-    latch.CountDown();
+    --count;
   });
   context.AddNativeFunction("SignalBoolReturn", bool_return_entry);
 
@@ -293,7 +302,7 @@ TEST_F(WindowsTest, VerifyNativeFunctionWithReturn) {
   auto bool_pass_entry = CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
     auto handle = Dart_GetNativeBooleanArgument(args, 0, &bool_value_passed);
     ASSERT_FALSE(Dart_IsError(handle));
-    latch.CountDown();
+    --count;
   });
   context.AddNativeFunction("SignalBoolValue", bool_pass_entry);
 
@@ -301,7 +310,9 @@ TEST_F(WindowsTest, VerifyNativeFunctionWithReturn) {
   ASSERT_NE(controller, nullptr);
 
   // Wait until signalBoolReturn and signalBoolValue have been called.
-  latch.Wait();
+  while (count > 0) {
+    PumpMessage();
+  }
   EXPECT_TRUE(bool_value_passed);
 }
 
@@ -614,10 +625,10 @@ TEST_F(WindowsTest, AddRemoveView) {
   WindowsConfigBuilder builder(context);
   builder.SetDartEntrypoint("onMetricsChangedSignalViewIds");
 
-  fml::AutoResetWaitableEvent ready_latch;
+  bool ready = false;
   context.AddNativeFunction(
-      "Signal", CREATE_NATIVE_ENTRY(
-                    [&](Dart_NativeArguments args) { ready_latch.Signal(); }));
+      "Signal",
+      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { ready = true; }));
 
   context.AddNativeFunction(
       "SignalStringValue", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
@@ -632,7 +643,9 @@ TEST_F(WindowsTest, AddRemoveView) {
   ViewControllerPtr first_controller{builder.Run()};
   ASSERT_NE(first_controller, nullptr);
 
-  ready_latch.Wait();
+  while (!ready) {
+    PumpMessage();
+  }
 
   // Create a second view.
   FlutterDesktopEngineRef engine =


### PR DESCRIPTION
This enables running UI isolate on platform thread by default. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
