### PR TITLE
Update the `RangeSlider` widget to the 2024 Material Design appearance

### DIFF
--- a/dev/tools/gen_defaults/bin/gen_defaults.dart
+++ b/dev/tools/gen_defaults/bin/gen_defaults.dart
@@ -44,6 +44,7 @@ import 'package:gen_defaults/navigation_rail_template.dart';
 import 'package:gen_defaults/popup_menu_template.dart';
 import 'package:gen_defaults/progress_indicator_template.dart';
 import 'package:gen_defaults/radio_template.dart';
+import 'package:gen_defaults/range_slider_template.dart';
 import 'package:gen_defaults/search_bar_template.dart';
 import 'package:gen_defaults/search_view_template.dart';
 import 'package:gen_defaults/segmented_button_template.dart';
@@ -136,6 +137,7 @@ Future<void> main(List<String> args) async {
   PopupMenuTemplate('PopupMenu', '$materialLib/popup_menu.dart', tokens).updateFile();
   ProgressIndicatorTemplate('ProgressIndicator', '$materialLib/progress_indicator.dart', tokens).updateFile();
   RadioTemplate('Radio<T>', '$materialLib/radio.dart', tokens).updateFile();
+  RangeSliderTemplate('md.comp.slider', 'RangeSlider', '$materialLib/range_slider.dart', tokens).updateFile();
   SearchBarTemplate('SearchBar', '$materialLib/search_anchor.dart', tokens).updateFile();
   SearchViewTemplate('SearchView', '$materialLib/search_anchor.dart', tokens).updateFile();
   SegmentedButtonTemplate('md.comp.outlined-segmented-button', 'SegmentedButton', '$materialLib/segmented_button.dart', tokens).updateFile();

--- a/dev/tools/gen_defaults/lib/range_slider_template.dart
+++ b/dev/tools/gen_defaults/lib/range_slider_template.dart
@@ -1,0 +1,115 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'template.dart';
+
+class RangeSliderTemplate extends TokenTemplate {
+  const RangeSliderTemplate(
+    this.tokenGroup,
+    super.blockName,
+    super.fileName,
+    super.tokens, {
+    super.colorSchemePrefix = '_colors.',
+  });
+
+  final String tokenGroup;
+
+  @override
+  String generate() => '''
+class _${blockName}DefaultsM3 extends SliderThemeData {
+  _${blockName}DefaultsM3(this.context)
+    : super(trackHeight: ${getToken('$tokenGroup.active.track.height')});
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+
+  @override
+  Color? get activeTrackColor => ${componentColor('$tokenGroup.active.track')};
+
+  @override
+  Color? get inactiveTrackColor => ${componentColor('$tokenGroup.inactive.track')};
+
+  @override
+  Color? get disabledActiveTrackColor => ${componentColor('$tokenGroup.disabled.active.track')};
+
+  @override
+  Color? get disabledInactiveTrackColor => ${componentColor('$tokenGroup.disabled.inactive.track')};
+
+  @override
+  Color? get activeTickMarkColor => ${componentColor('$tokenGroup.active.stop-indicator.container')};
+
+  @override
+  Color? get inactiveTickMarkColor => ${componentColor('$tokenGroup.inactive.stop-indicator.container')};
+
+  @override
+  Color? get disabledActiveTickMarkColor => ${componentColor('$tokenGroup.disabled.active.stop-indicator.container')};
+
+  @override
+  Color? get disabledInactiveTickMarkColor => ${componentColor('$tokenGroup.disabled.inactive.stop-indicator.container')};
+
+  @override
+  Color? get thumbColor => ${componentColor('$tokenGroup.handle')};
+
+  @override
+  ui.Color? get overlappingShapeStrokeColor => _colors.surface;
+
+  @override
+  Color? get disabledThumbColor => ${componentColor('$tokenGroup.disabled.handle')};
+
+  @override
+  Color? get overlayColor => _colors.primary.withOpacity(0.12);
+
+  @override
+  TextStyle? get valueIndicatorTextStyle => ${textStyle('$tokenGroup.value-indicator.label.label-text')}!.copyWith(
+    color: ${componentColor('$tokenGroup.value-indicator.label.label-text')},
+  );
+
+  @override
+  Color? get valueIndicatorColor => ${componentColor('$tokenGroup.value-indicator.container')};
+
+  @override
+  RangeSliderTrackShape? get rangeTrackShape => const GappedRangeSliderTrackShape();
+
+  @override
+  RangeSliderTickMarkShape? get rangeTickMarkShape => const RoundRangeSliderTickMarkShape(tickMarkRadius: ${getToken("$tokenGroup.stop-indicator.size")} / 2);
+
+  @override
+  RangeSliderThumbShape? get rangeThumbShape => const HandleRangeSliderThumbShape();
+
+  @override
+  SliderComponentShape? get overlayShape => const RoundSliderOverlayShape();
+
+  @override
+  RangeSliderValueIndicatorShape? get rangeValueIndicatorShape => const RoundedRectRangeSliderValueIndicatorShape();
+
+  @override
+  ShowValueIndicator? get showValueIndicator => ShowValueIndicator.onlyForDiscrete;
+
+  @override
+  double? get minThumbSeparation => 0;
+
+  @override
+  MaterialStateProperty<Size?>? get thumbSize {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return const Size(${getToken("$tokenGroup.disabled.handle.width")}, ${getToken("$tokenGroup.handle.height")});
+      }
+      if (states.contains(MaterialState.hovered)) {
+        return const Size(${getToken("$tokenGroup.hover.handle.width")}, ${getToken("$tokenGroup.handle.height")});
+      }
+      if (states.contains(MaterialState.focused)) {
+        return const Size(${getToken("$tokenGroup.focus.handle.width")}, ${getToken("$tokenGroup.handle.height")});
+      }
+      if (states.contains(MaterialState.pressed)) {
+        return const Size(${getToken("$tokenGroup.pressed.handle.width")}, ${getToken("$tokenGroup.handle.height")});
+      }
+      return const Size(${getToken("$tokenGroup.handle.width")}, ${getToken("$tokenGroup.handle.height")});
+    });
+  }
+
+  @override
+  double? get trackGap => ${getToken("$tokenGroup.active.handle.padding")};
+}
+''';
+}

--- a/dev/tools/gen_defaults/lib/range_slider_template.dart
+++ b/dev/tools/gen_defaults/lib/range_slider_template.dart
@@ -52,7 +52,7 @@ class _${blockName}DefaultsM3 extends SliderThemeData {
   Color? get thumbColor => ${componentColor('$tokenGroup.handle')};
 
   @override
-  ui.Color? get overlappingShapeStrokeColor => _colors.surface;
+  Color? get overlappingShapeStrokeColor => _colors.surface;
 
   @override
   Color? get disabledThumbColor => ${componentColor('$tokenGroup.disabled.handle')};

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -23,6 +23,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart' show timeDilation;
 import 'package:flutter/widgets.dart';
 
+import 'color_scheme.dart';
 import 'constants.dart';
 import 'debug.dart';
 import 'material_state.dart';
@@ -167,6 +168,12 @@ class RangeSlider extends StatefulWidget {
     this.mouseCursor,
     this.semanticFormatterCallback,
     this.padding,
+    @Deprecated(
+      'Set this flag to false to opt into the 2024 range slider appearance. Defaults to true. '
+      'In the future, this flag will default to false. Use SliderThemeData to customize individual properties. '
+      'This feature was deprecated after v3.30.0-0.1.pre.',
+    )
+    this.year2023,
   }) : assert(min <= max),
        assert(values.start <= values.end),
        assert(values.start >= min && values.start <= max),
@@ -335,7 +342,10 @@ class RangeSlider extends StatefulWidget {
   /// The color of the track's inactive segments, i.e. the span of tracks
   /// between the min and the start thumb, and the end thumb and the max.
   ///
-  /// Defaults to [ColorScheme.primary] with 24% opacity.
+  /// If null, [SliderThemeData.inactiveTrackColor] of the ambient [SliderTheme]
+  /// is used. If [RangeSlider.year2023] is false and [ThemeData.useMaterial3] is true,
+  /// then [ColorScheme.secondaryContainer] is used. Otherwise, [ColorScheme.primary]
+  /// with an opacity of 0.24 is used.
   ///
   /// Using a [SliderTheme] gives more fine-grained control over the
   /// appearance of various components of the slider.
@@ -398,6 +408,20 @@ class RangeSlider extends StatefulWidget {
   /// is the height of the overlay shape, and the horizontal padding is the
   /// larger size between the width of the thumb shape and overlay shape.
   final EdgeInsetsGeometry? padding;
+
+  /// When true, the [RangeSlider] will use the 2023 Material Design 3 appearance.
+  /// Defaults to true.
+  ///
+  /// If this is set to false, the [RangeSlider] will use the latest Material Design 3
+  /// appearance, which was introduced in December 2023.
+  ///
+  /// If [ThemeData.useMaterial3] is false, then this property is ignored.
+  @Deprecated(
+    'Set this flag to false to opt into the 2024 range slider appearance. Defaults to true. '
+    'In the future, this flag will default to false. Use SliderThemeData to customize individual properties. '
+    'This feature was deprecated after v3.30.0-0.1.pre.',
+  )
+  final bool? year2023;
 
   // Touch width for the tap boundary of the slider thumbs.
   static const double _minTouchTargetWidth = kMinInteractiveDimension;
@@ -617,6 +641,11 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
 
     final ThemeData theme = Theme.of(context);
     SliderThemeData sliderTheme = SliderTheme.of(context);
+    final bool year2023 = widget.year2023 ?? sliderTheme.year2023 ?? true;
+    final SliderThemeData defaults =
+        theme.useMaterial3 && !year2023
+            ? _RangeSliderDefaultsM3(context)
+            : _RangeSliderDefaultsM2(context);
 
     // If the widget has active or inactive colors specified, then we plug them
     // in to the slider theme as best we can. If the developer wants more
@@ -624,16 +653,6 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     // colors come from the ThemeData.colorScheme. These colors, along with
     // the default shapes and text styles are aligned to the Material
     // Guidelines.
-
-    const double defaultTrackHeight = 4;
-    const RangeSliderTrackShape defaultTrackShape = RoundedRectRangeSliderTrackShape();
-    const RangeSliderTickMarkShape defaultTickMarkShape = RoundRangeSliderTickMarkShape();
-    const SliderComponentShape defaultOverlayShape = RoundSliderOverlayShape();
-    const RangeSliderThumbShape defaultThumbShape = RoundRangeSliderThumbShape();
-    const RangeSliderValueIndicatorShape defaultValueIndicatorShape =
-        RectangularRangeSliderValueIndicatorShape();
-    const ShowValueIndicator defaultShowValueIndicator = ShowValueIndicator.onlyForDiscrete;
-    const double defaultMinThumbSeparation = 8;
 
     final Set<MaterialState> states = <MaterialState>{
       if (!_enabled) MaterialState.disabled,
@@ -646,7 +665,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     // RectangularSliderValueIndicatorShape is used. In all other cases, the
     // value indicator is assumed to be the same as the active color.
     final RangeSliderValueIndicatorShape valueIndicatorShape =
-        sliderTheme.rangeValueIndicatorShape ?? defaultValueIndicatorShape;
+        sliderTheme.rangeValueIndicatorShape ?? defaults.rangeValueIndicatorShape!;
     final Color valueIndicatorColor;
     if (valueIndicatorShape is RectangularRangeSliderValueIndicatorShape) {
       valueIndicatorColor =
@@ -657,61 +676,53 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
           );
     } else {
       valueIndicatorColor =
-          widget.activeColor ?? sliderTheme.valueIndicatorColor ?? theme.colorScheme.primary;
+          widget.activeColor ?? sliderTheme.valueIndicatorColor ?? defaults.valueIndicatorColor!;
     }
 
     Color? effectiveOverlayColor() {
       return widget.overlayColor?.resolve(states) ??
           widget.activeColor?.withOpacity(0.12) ??
           MaterialStateProperty.resolveAs<Color?>(sliderTheme.overlayColor, states) ??
-          theme.colorScheme.primary.withOpacity(0.12);
+          defaults.overlayColor;
     }
 
     sliderTheme = sliderTheme.copyWith(
-      trackHeight: sliderTheme.trackHeight ?? defaultTrackHeight,
+      trackHeight: sliderTheme.trackHeight ?? defaults.trackHeight,
       activeTrackColor:
-          widget.activeColor ?? sliderTheme.activeTrackColor ?? theme.colorScheme.primary,
+          widget.activeColor ?? sliderTheme.activeTrackColor ?? defaults.activeTrackColor,
       inactiveTrackColor:
-          widget.inactiveColor ??
-          sliderTheme.inactiveTrackColor ??
-          theme.colorScheme.primary.withOpacity(0.24),
+          widget.inactiveColor ?? sliderTheme.inactiveTrackColor ?? defaults.inactiveTrackColor,
       disabledActiveTrackColor:
-          sliderTheme.disabledActiveTrackColor ?? theme.colorScheme.onSurface.withOpacity(0.32),
+          sliderTheme.disabledActiveTrackColor ?? defaults.disabledActiveTrackColor,
       disabledInactiveTrackColor:
-          sliderTheme.disabledInactiveTrackColor ?? theme.colorScheme.onSurface.withOpacity(0.12),
+          sliderTheme.disabledInactiveTrackColor ?? defaults.disabledInactiveTrackColor,
       activeTickMarkColor:
-          widget.inactiveColor ??
-          sliderTheme.activeTickMarkColor ??
-          theme.colorScheme.onPrimary.withOpacity(0.54),
+          widget.inactiveColor ?? sliderTheme.activeTickMarkColor ?? defaults.activeTickMarkColor,
       inactiveTickMarkColor:
-          widget.activeColor ??
-          sliderTheme.inactiveTickMarkColor ??
-          theme.colorScheme.primary.withOpacity(0.54),
+          widget.activeColor ?? sliderTheme.inactiveTickMarkColor ?? defaults.inactiveTickMarkColor,
       disabledActiveTickMarkColor:
-          sliderTheme.disabledActiveTickMarkColor ?? theme.colorScheme.onPrimary.withOpacity(0.12),
+          sliderTheme.disabledActiveTickMarkColor ?? defaults.disabledActiveTickMarkColor,
       disabledInactiveTickMarkColor:
-          sliderTheme.disabledInactiveTickMarkColor ??
-          theme.colorScheme.onSurface.withOpacity(0.12),
-      thumbColor: widget.activeColor ?? sliderTheme.thumbColor ?? theme.colorScheme.primary,
+          sliderTheme.disabledInactiveTickMarkColor ?? defaults.disabledInactiveTickMarkColor,
+      thumbColor: widget.activeColor ?? sliderTheme.thumbColor ?? defaults.thumbColor,
       overlappingShapeStrokeColor:
-          sliderTheme.overlappingShapeStrokeColor ?? theme.colorScheme.surface,
-      disabledThumbColor:
-          sliderTheme.disabledThumbColor ??
-          Color.alphaBlend(theme.colorScheme.onSurface.withOpacity(.38), theme.colorScheme.surface),
+          sliderTheme.overlappingShapeStrokeColor ?? defaults.overlappingShapeStrokeColor,
+      disabledThumbColor: sliderTheme.disabledThumbColor ?? defaults.disabledThumbColor,
       overlayColor: effectiveOverlayColor(),
       valueIndicatorColor: valueIndicatorColor,
-      rangeTrackShape: sliderTheme.rangeTrackShape ?? defaultTrackShape,
-      rangeTickMarkShape: sliderTheme.rangeTickMarkShape ?? defaultTickMarkShape,
-      rangeThumbShape: sliderTheme.rangeThumbShape ?? defaultThumbShape,
-      overlayShape: sliderTheme.overlayShape ?? defaultOverlayShape,
+      rangeTrackShape: sliderTheme.rangeTrackShape ?? defaults.rangeTrackShape,
+      rangeTickMarkShape: sliderTheme.rangeTickMarkShape ?? defaults.rangeTickMarkShape,
+      rangeThumbShape: sliderTheme.rangeThumbShape ?? defaults.rangeThumbShape,
+      overlayShape: sliderTheme.overlayShape ?? defaults.overlayShape,
       rangeValueIndicatorShape: valueIndicatorShape,
-      showValueIndicator: sliderTheme.showValueIndicator ?? defaultShowValueIndicator,
+      showValueIndicator: sliderTheme.showValueIndicator ?? defaults.showValueIndicator,
       valueIndicatorTextStyle:
-          sliderTheme.valueIndicatorTextStyle ??
-          theme.textTheme.bodyLarge!.copyWith(color: theme.colorScheme.onPrimary),
-      minThumbSeparation: sliderTheme.minThumbSeparation ?? defaultMinThumbSeparation,
+          sliderTheme.valueIndicatorTextStyle ?? defaults.valueIndicatorTextStyle,
+      minThumbSeparation: sliderTheme.minThumbSeparation ?? defaults.minThumbSeparation,
       thumbSelector: sliderTheme.thumbSelector ?? _defaultRangeThumbSelector,
       padding: widget.padding ?? sliderTheme.padding,
+      thumbSize: sliderTheme.thumbSize ?? defaults.thumbSize,
+      trackGap: sliderTheme.trackGap ?? defaults.trackGap,
     );
     final MouseCursor effectiveMouseCursor =
         widget.mouseCursor?.resolve(states) ??
@@ -1528,11 +1539,29 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       overlayEndRect = Rect.fromCircle(center: _endThumbCenter, radius: overlaySize.width / 2.0);
     }
 
+    // If [Slider.year2023] is false, the thumb uses handle thumb shape and gapped track shape.
+    // The handle width and track gap are adjusted when the thumb is pressed.
+    double? thumbWidth = _sliderTheme.thumbSize?.resolve(<MaterialState>{})?.width;
+    final double? thumbHeight = _sliderTheme.thumbSize?.resolve(<MaterialState>{})?.height;
+    double? trackGap = _sliderTheme.trackGap;
+    final double? pressedThumbWidth =
+        _sliderTheme.thumbSize?.resolve(<MaterialState>{MaterialState.pressed})?.width;
+    final double delta;
+    if (_active && thumbWidth != null && pressedThumbWidth != null && trackGap != null) {
+      delta = thumbWidth - pressedThumbWidth;
+      if (thumbWidth > 0.0) {
+        thumbWidth = pressedThumbWidth;
+      }
+      if (trackGap > 0.0) {
+        trackGap = trackGap - delta / 2;
+      }
+    }
+
     _sliderTheme.rangeTrackShape!.paint(
       context,
       offset,
       parentBox: this,
-      sliderTheme: _sliderTheme,
+      sliderTheme: _sliderTheme.copyWith(trackGap: trackGap),
       enableAnimation: _enableAnimation,
       textDirection: _textDirection,
       startThumbCenter: _startThumbCenter,
@@ -1656,7 +1685,12 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       isDiscrete: isDiscrete,
       isOnTop: false,
       textDirection: textDirection,
-      sliderTheme: _sliderTheme,
+      sliderTheme:
+          thumbWidth != null && thumbHeight != null
+              ? _sliderTheme.copyWith(
+                thumbSize: MaterialStatePropertyAll<Size?>(Size(thumbWidth, thumbHeight)),
+              )
+              : _sliderTheme,
       thumb: bottomThumb,
       isPressed: bottomThumb == Thumb.start ? startThumbSelected : endThumbSelected,
     );
@@ -1737,7 +1771,12 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       isOnTop:
           thumbDelta < sliderTheme.rangeThumbShape!.getPreferredSize(isEnabled, isDiscrete).width,
       textDirection: textDirection,
-      sliderTheme: _sliderTheme,
+      sliderTheme:
+          thumbWidth != null && thumbHeight != null
+              ? _sliderTheme.copyWith(
+                thumbSize: MaterialStatePropertyAll<Size?>(Size(thumbWidth, thumbHeight)),
+              )
+              : _sliderTheme,
       thumb: topThumb,
       isPressed: topThumb == Thumb.start ? startThumbSelected : endThumbSelected,
     );
@@ -1966,3 +2005,183 @@ class _RenderValueIndicator extends RenderBox with RelayoutWhenSystemFontsChange
     super.dispose();
   }
 }
+
+class _RangeSliderDefaultsM2 extends SliderThemeData {
+  _RangeSliderDefaultsM2(this.context) : super(trackHeight: 4);
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+  late final SliderThemeData sliderTheme = SliderTheme.of(context);
+
+  @override
+  Color? get activeTrackColor => _colors.primary;
+
+  @override
+  Color? get inactiveTrackColor => _colors.primary.withOpacity(0.24);
+
+  @override
+  Color? get disabledActiveTrackColor => _colors.onSurface.withOpacity(0.32);
+
+  @override
+  Color? get disabledInactiveTrackColor => _colors.onSurface.withOpacity(0.12);
+
+  @override
+  Color? get activeTickMarkColor => _colors.onPrimary.withOpacity(0.54);
+
+  @override
+  Color? get inactiveTickMarkColor => _colors.primary.withOpacity(0.54);
+
+  @override
+  Color? get disabledActiveTickMarkColor => _colors.onPrimary.withOpacity(0.12);
+
+  @override
+  Color? get disabledInactiveTickMarkColor => _colors.onSurface.withOpacity(0.12);
+
+  @override
+  Color? get thumbColor => _colors.primary;
+
+  @override
+  ui.Color? get overlappingShapeStrokeColor => _colors.surface;
+
+  @override
+  Color? get disabledThumbColor =>
+      Color.alphaBlend(_colors.onSurface.withOpacity(.38), _colors.surface);
+
+  @override
+  Color? get overlayColor => _colors.primary.withOpacity(0.12);
+
+  @override
+  TextStyle? get valueIndicatorTextStyle =>
+      Theme.of(context).textTheme.bodyLarge!.copyWith(color: _colors.onPrimary);
+
+  @override
+  Color? get valueIndicatorColor => _colors.primary;
+
+  @override
+  RangeSliderTrackShape? get rangeTrackShape => const RoundedRectRangeSliderTrackShape();
+
+  @override
+  RangeSliderTickMarkShape? get rangeTickMarkShape => const RoundRangeSliderTickMarkShape();
+
+  @override
+  RangeSliderThumbShape? get rangeThumbShape => const RoundRangeSliderThumbShape();
+
+  @override
+  SliderComponentShape? get overlayShape => const RoundSliderOverlayShape();
+
+  @override
+  RangeSliderValueIndicatorShape? get rangeValueIndicatorShape =>
+      const RectangularRangeSliderValueIndicatorShape();
+
+  @override
+  ShowValueIndicator? get showValueIndicator => ShowValueIndicator.onlyForDiscrete;
+
+  @override
+  double? get minThumbSeparation => 8;
+}
+
+// BEGIN GENERATED TOKEN PROPERTIES - RangeSlider
+
+// Do not edit by hand. The code between the "BEGIN GENERATED" and
+// "END GENERATED" comments are generated from data in the Material
+// Design token database by the script:
+//   dev/tools/gen_defaults/bin/gen_defaults.dart.
+
+// dart format off
+class _RangeSliderDefaultsM3 extends SliderThemeData {
+  _RangeSliderDefaultsM3(this.context)
+    : super(trackHeight: 16.0);
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+
+  @override
+  Color? get activeTrackColor => _colors.primary;
+
+  @override
+  Color? get inactiveTrackColor => _colors.secondaryContainer;
+
+  @override
+  Color? get disabledActiveTrackColor => _colors.onSurface.withOpacity(0.38);
+
+  @override
+  Color? get disabledInactiveTrackColor => _colors.onSurface.withOpacity(0.12);
+
+  @override
+  Color? get activeTickMarkColor => _colors.onPrimary.withOpacity(1.0);
+
+  @override
+  Color? get inactiveTickMarkColor => _colors.onSecondaryContainer.withOpacity(1.0);
+
+  @override
+  Color? get disabledActiveTickMarkColor => _colors.onInverseSurface;
+
+  @override
+  Color? get disabledInactiveTickMarkColor => _colors.onSurface;
+
+  @override
+  Color? get thumbColor => _colors.primary;
+
+  @override
+  ui.Color? get overlappingShapeStrokeColor => _colors.surface;
+
+  @override
+  Color? get disabledThumbColor => _colors.onSurface.withOpacity(0.38);
+
+  @override
+  Color? get overlayColor => _colors.primary.withOpacity(0.12);
+
+  @override
+  TextStyle? get valueIndicatorTextStyle => Theme.of(context).textTheme.labelLarge!.copyWith(
+    color: _colors.onInverseSurface,
+  );
+
+  @override
+  Color? get valueIndicatorColor => _colors.inverseSurface;
+
+  @override
+  RangeSliderTrackShape? get rangeTrackShape => const GappedRangeSliderTrackShape();
+
+  @override
+  RangeSliderTickMarkShape? get rangeTickMarkShape => const RoundRangeSliderTickMarkShape(tickMarkRadius: 4.0 / 2);
+
+  @override
+  RangeSliderThumbShape? get rangeThumbShape => const HandleRangeSliderThumbShape();
+
+  @override
+  SliderComponentShape? get overlayShape => const RoundSliderOverlayShape();
+
+  @override
+  RangeSliderValueIndicatorShape? get rangeValueIndicatorShape => const RoundedRectRangeSliderValueIndicatorShape();
+
+  @override
+  ShowValueIndicator? get showValueIndicator => ShowValueIndicator.onlyForDiscrete;
+
+  @override
+  double? get minThumbSeparation => 0;
+
+  @override
+  MaterialStateProperty<Size?>? get thumbSize {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return const Size(4.0, 44.0);
+      }
+      if (states.contains(MaterialState.hovered)) {
+        return const Size(4.0, 44.0);
+      }
+      if (states.contains(MaterialState.focused)) {
+        return const Size(2.0, 44.0);
+      }
+      if (states.contains(MaterialState.pressed)) {
+        return const Size(2.0, 44.0);
+      }
+      return const Size(4.0, 44.0);
+    });
+  }
+
+  @override
+  double? get trackGap => 6.0;
+}
+// dart format on
+
+// END GENERATED TOKEN PROPERTIES - RangeSlider

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1539,8 +1539,8 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       overlayEndRect = Rect.fromCircle(center: _endThumbCenter, radius: overlaySize.width / 2.0);
     }
 
-    // If [Slider.year2023] is false, the thumb uses handle thumb shape and gapped track shape.
-    // The handle width and track gap are adjusted when the thumb is pressed.
+    // If [RangeSlider.year2023] is false, the thumbs uses handle thumb shape and gapped track shape.
+    // The handle width and track gaps are adjusted when the thumb is pressed.
     double? thumbWidth = _sliderTheme.thumbSize?.resolve(<MaterialState>{})?.width;
     final double? thumbHeight = _sliderTheme.thumbSize?.resolve(<MaterialState>{})?.height;
     double? trackGap = _sliderTheme.trackGap;
@@ -1549,9 +1549,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     final double delta;
     if (_active && thumbWidth != null && pressedThumbWidth != null && trackGap != null) {
       delta = thumbWidth - pressedThumbWidth;
-      if (thumbWidth > 0.0) {
-        thumbWidth = pressedThumbWidth;
-      }
+      thumbWidth = pressedThumbWidth;
       if (trackGap > 0.0) {
         trackGap = trackGap - delta / 2;
       }
@@ -2123,7 +2121,7 @@ class _RangeSliderDefaultsM3 extends SliderThemeData {
   Color? get thumbColor => _colors.primary;
 
   @override
-  ui.Color? get overlappingShapeStrokeColor => _colors.surface;
+  Color? get overlappingShapeStrokeColor => _colors.surface;
 
   @override
   Color? get disabledThumbColor => _colors.onSurface.withOpacity(0.38);

--- a/packages/flutter/lib/src/material/range_slider_parts.dart
+++ b/packages/flutter/lib/src/material/range_slider_parts.dart
@@ -743,6 +743,11 @@ class RoundRangeSliderTickMarkShape extends RangeSliderTickMarkShape {
     assert(sliderTheme.activeTickMarkColor != null);
     assert(sliderTheme.inactiveTickMarkColor != null);
 
+    final bool hasGap = sliderTheme.trackGap != null && sliderTheme.trackGap! > 0;
+    final bool underThumb = startThumbCenter.dx == center.dx || endThumbCenter.dx == center.dx;
+    if (hasGap && underThumb) {
+      return;
+    }
     final bool isBetweenThumbs = switch (textDirection) {
       TextDirection.ltr => startThumbCenter.dx < center.dx && center.dx < endThumbCenter.dx,
       TextDirection.rtl => endThumbCenter.dx < center.dx && center.dx < startThumbCenter.dx,
@@ -983,5 +988,665 @@ void _debugDrawShadow(Canvas canvas, Path path, double elevation) {
         ..style = PaintingStyle.stroke
         ..strokeWidth = elevation * 2.0,
     );
+  }
+}
+
+// The gapped shape of a [RangeSlider]'s track.
+///
+/// The [GappedRangeSliderTrackShape] consists of active and inactive
+/// tracks. The active track uses the [SliderThemeData.activeTrackColor] and the
+/// inactive tracks uses the [SliderThemeData.inactiveTrackColor].
+///
+/// The track shape uses circular corner radius for the edge corners and a corner radius
+/// of 2 pixels for the inside corners.
+///
+/// Between the active and inactive tracks there are gaps of size [SliderThemeData.trackGap].
+/// If the [SliderThemeData.thumbShape] is [HandleRangeSliderThumbShape] and the thumb is pressed,
+/// the thumb's width is reduced; as a result, the track gaps size in [GappedRangeSliderTrackShape]
+/// is also reduced.
+///
+/// If [SliderThemeData.trackGap] is null, then the track gaps size defaults to 6 pixels.
+///
+/// If [ThemeData.useMaterial3] is true and [RangeSlider.year2023] is false, then the [RangeSlider]
+/// will use [GappedRangeSliderTrackShape] as the default track shape.
+///
+/// See also:
+///
+///  * [RangeSlider], which includes a track defined by this shape.
+///  * [SliderTheme], which can be used to configure the track shape of all
+///    range sliders in a widget subtree.
+class GappedRangeSliderTrackShape extends RangeSliderTrackShape with BaseRangeSliderTrackShape {
+  /// Create a range slider track that draws 3 rounded rectangles with rounded outer edges.
+  const GappedRangeSliderTrackShape();
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset offset, {
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    required Animation<double> enableAnimation,
+    required Offset startThumbCenter,
+    required Offset endThumbCenter,
+    bool isEnabled = false,
+    bool isDiscrete = false,
+    required TextDirection textDirection,
+    double additionalActiveTrackHeight = 2,
+  }) {
+    assert(sliderTheme.disabledActiveTrackColor != null);
+    assert(sliderTheme.disabledInactiveTrackColor != null);
+    assert(sliderTheme.activeTrackColor != null);
+    assert(sliderTheme.inactiveTrackColor != null);
+    assert(sliderTheme.rangeThumbShape != null);
+
+    if (sliderTheme.trackHeight == null || sliderTheme.trackHeight! <= 0) {
+      return;
+    }
+
+    final ColorTween activeTrackColorTween = ColorTween(
+      begin: sliderTheme.disabledActiveTrackColor,
+      end: sliderTheme.activeTrackColor,
+    );
+    final ColorTween inactiveTrackColorTween = ColorTween(
+      begin: sliderTheme.disabledInactiveTrackColor,
+      end: sliderTheme.inactiveTrackColor,
+    );
+
+    final Paint activePaint = Paint()..color = activeTrackColorTween.evaluate(enableAnimation)!;
+    final Paint inactivePaint = Paint()..color = inactiveTrackColorTween.evaluate(enableAnimation)!;
+
+    final Rect trackRect = getPreferredRect(
+      parentBox: parentBox,
+      offset: offset,
+      sliderTheme: sliderTheme,
+      isEnabled: isEnabled,
+      isDiscrete: isDiscrete,
+    );
+
+    final Radius trackCornerRadius = Radius.circular(trackRect.shortestSide / 2);
+    const Radius trackInsideCornerRadius = Radius.circular(2.0);
+
+    final (Offset leftThumbOffset, Offset rightThumbOffset) = switch (textDirection) {
+      TextDirection.ltr => (startThumbCenter, endThumbCenter),
+      TextDirection.rtl => (endThumbCenter, startThumbCenter),
+    };
+
+    final Size thumbSize = sliderTheme.rangeThumbShape!.getPreferredSize(isEnabled, isDiscrete);
+    final double thumbRadius = thumbSize.width / 2;
+    assert(thumbRadius > 0);
+    final double trackGap = sliderTheme.trackGap!;
+
+    final RRect trackRRect = RRect.fromRectAndCorners(
+      trackRect,
+      topLeft: trackCornerRadius,
+      bottomLeft: trackCornerRadius,
+      topRight: trackCornerRadius,
+      bottomRight: trackCornerRadius,
+    );
+
+    final RRect leftRRect = RRect.fromLTRBAndCorners(
+      trackRect.left,
+      trackRect.top,
+      leftThumbOffset.dx - trackGap,
+      trackRect.bottom,
+      topLeft: trackCornerRadius,
+      bottomLeft: trackCornerRadius,
+      topRight: trackInsideCornerRadius,
+      bottomRight: trackInsideCornerRadius,
+    );
+
+    final RRect rightRRect = RRect.fromLTRBAndCorners(
+      rightThumbOffset.dx + trackGap,
+      trackRect.top,
+      trackRect.right,
+      trackRect.bottom,
+      topLeft: trackInsideCornerRadius,
+      bottomLeft: trackInsideCornerRadius,
+      topRight: trackCornerRadius,
+      bottomRight: trackCornerRadius,
+    );
+
+    context.canvas
+      ..save()
+      ..clipRRect(trackRRect);
+    final bool drawLeftTrack =
+        startThumbCenter.dx > (leftRRect.left + (sliderTheme.trackHeight! / 2));
+    final bool drawRightTrack =
+        endThumbCenter.dx < (rightRRect.right - (sliderTheme.trackHeight! / 2));
+
+    if (drawLeftTrack) {
+      context.canvas.drawRRect(leftRRect, inactivePaint);
+    }
+    if (drawRightTrack) {
+      context.canvas.drawRRect(rightRRect, inactivePaint);
+    }
+
+    if (leftThumbOffset.dx + trackGap < rightThumbOffset.dx - trackGap) {
+      context.canvas.drawRRect(
+        RRect.fromLTRBR(
+          leftThumbOffset.dx + trackGap,
+          trackRect.top,
+          rightThumbOffset.dx - trackGap,
+          trackRect.bottom,
+          trackInsideCornerRadius,
+        ),
+        activePaint,
+      );
+    }
+
+    context.canvas.restore();
+
+    const double stopIndicatorRadius = 2.0;
+    final double stopIndicatorTrailingSpace = sliderTheme.trackHeight! / 2;
+    final Offset startStopIndicatorOffset = Offset(
+      trackRect.centerLeft.dx + stopIndicatorTrailingSpace,
+      trackRect.center.dy,
+    );
+    final Offset endStopIndicatorOffset = Offset(
+      trackRect.centerRight.dx - stopIndicatorTrailingSpace,
+      trackRect.center.dy,
+    );
+
+    final bool showStartStopIndicator = startThumbCenter.dx > startStopIndicatorOffset.dx;
+    if (showStartStopIndicator && !isDiscrete) {
+      final Rect stopIndicatorRect = Rect.fromCircle(
+        center: startStopIndicatorOffset,
+        radius: stopIndicatorRadius,
+      );
+      context.canvas.drawCircle(stopIndicatorRect.center, stopIndicatorRadius, activePaint);
+    }
+
+    final bool showEndStopIndicator = endThumbCenter.dx < endStopIndicatorOffset.dx;
+    if (showEndStopIndicator && !isDiscrete) {
+      final Rect stopIndicatorRect = Rect.fromCircle(
+        center: endStopIndicatorOffset,
+        radius: stopIndicatorRadius,
+      );
+      context.canvas.drawCircle(stopIndicatorRect.center, stopIndicatorRadius, activePaint);
+    }
+  }
+
+  @override
+  bool get isRounded => true;
+}
+
+/// The bar shape of [RangeSlider]'s thumbs.
+///
+/// When the range slider is enabled, the [ColorScheme.primary] color is used for the
+/// thumb. When the slider is disabled, the [ColorScheme.onSurface] color with an
+/// opacity of 0.38 is used for the thumb.
+///
+/// The thumb bar shape width is reduced when the thumb is pressed.
+///
+/// If [SliderThemeData.thumbSize] is null, then the thumb size is 4 pixels for the width
+/// and 44 pixels for the height.
+///
+/// If [ThemeData.useMaterial3] is true and [RangeSlider.year2023] is false, then the [RangeSlider]
+/// will use [HandleRangeSliderThumbShape] as the default track shape.
+///
+/// See also:
+///
+///  * [RangeSlider], which includes thumbs defined by this shape.
+///  * [SliderTheme], which can be used to configure the thumbs shape of all
+///    range sliders in a widget subtree.
+class HandleRangeSliderThumbShape extends RangeSliderThumbShape {
+  /// Create a range slider thumb that draws a bar.
+  const HandleRangeSliderThumbShape();
+
+  @override
+  Size getPreferredSize(bool isEnabled, bool isDiscrete) {
+    return const Size(4.0, 44.0);
+  }
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    required Animation<double> activationAnimation,
+    required Animation<double> enableAnimation,
+    bool isDiscrete = false,
+    bool isEnabled = false,
+    bool? isOnTop,
+    required SliderThemeData sliderTheme,
+    TextDirection? textDirection,
+    Thumb? thumb,
+    bool? isPressed,
+  }) {
+    assert(sliderTheme.showValueIndicator != null);
+    assert(sliderTheme.overlappingShapeStrokeColor != null);
+    assert(sliderTheme.disabledThumbColor != null);
+    assert(sliderTheme.thumbColor != null);
+    assert(sliderTheme.thumbSize != null);
+
+    final ColorTween colorTween = ColorTween(
+      begin: sliderTheme.disabledThumbColor,
+      end: sliderTheme.thumbColor,
+    );
+    final Color color = colorTween.evaluate(enableAnimation)!;
+    final Canvas canvas = context.canvas;
+
+    final Size thumbSize =
+        sliderTheme.thumbSize!.resolve(<WidgetState>{})!; // This is resolved in the paint method.
+    final RRect rrect = RRect.fromRectAndRadius(
+      Rect.fromCenter(center: center, width: thumbSize.width, height: thumbSize.height),
+      Radius.circular(thumbSize.shortestSide / 2),
+    );
+
+    canvas.drawRRect(rrect, Paint()..color = color);
+  }
+}
+
+/// The rounded rectangle shape of a [RangeSlider]'s value indicators.
+///
+/// If the [SliderThemeData.valueIndicatorColor] is null, then the shape uses the [ColorScheme.inverseSurface]
+/// color to draw the value indicator.
+///
+/// If the [SliderThemeData.valueIndicatorTextStyle] is null, then the indicator label text style
+/// defaults to [TextTheme.labelMedium] with the color set to [ColorScheme.onInverseSurface]. If the
+/// [ThemeData.useMaterial3] is set to false, then the indicator label text style defaults to
+/// [TextTheme.bodyLarge] with the color set to [ColorScheme.onInverseSurface].
+///
+/// If the [SliderThemeData.valueIndicatorStrokeColor] is provided, then the value indicator is drawn with a
+/// stroke border with the color provided.
+///
+/// If [ThemeData.useMaterial3] is true and [RangeSlider.year2023] is false, then the [RangeSlider]
+/// will use [RoundedRectRangeSliderValueIndicatorShape] as the default value indicators shape.
+///
+/// See also:
+///
+///  * [RangeSlider], which includes value indicators defined by this shape.
+///  * [SliderTheme], which can be used to configure the range slider value indicators
+///    of all range sliders in a widget subtree.
+class RoundedRectRangeSliderValueIndicatorShape extends RangeSliderValueIndicatorShape {
+  /// Create range slider value indicators that resembles a rounded rectangle.
+  const RoundedRectRangeSliderValueIndicatorShape();
+
+  static const _RoundedRectSliderValueIndicatorPathPainter _pathPainter =
+      _RoundedRectSliderValueIndicatorPathPainter();
+
+  @override
+  Size getPreferredSize(
+    bool isEnabled,
+    bool isDiscrete, {
+    TextPainter? labelPainter,
+    double? textScaleFactor,
+  }) {
+    assert(labelPainter != null);
+    assert(textScaleFactor != null && textScaleFactor >= 0);
+    return _pathPainter.getPreferredSize(labelPainter!, textScaleFactor!);
+  }
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    required Animation<double> activationAnimation,
+    required Animation<double> enableAnimation,
+    bool? isDiscrete,
+    bool? isOnTop,
+    required TextPainter labelPainter,
+    double? textScaleFactor,
+    Size? sizeWithOverflow,
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    TextDirection? textDirection,
+    double? value,
+    Thumb? thumb,
+  }) {
+    assert(textScaleFactor != null);
+    assert(sizeWithOverflow != null);
+    assert(sliderTheme.valueIndicatorColor != null);
+
+    final Canvas canvas = context.canvas;
+    final double scale = activationAnimation.value;
+    _pathPainter.paint(
+      parentBox: parentBox,
+      canvas: canvas,
+      center: center,
+      scale: scale,
+      labelPainter: labelPainter,
+      textScaleFactor: textScaleFactor!,
+      sizeWithOverflow: sizeWithOverflow!,
+      backgroundPaintColor: sliderTheme.valueIndicatorColor!,
+      strokePaintColor:
+          isOnTop!
+              ? sliderTheme.overlappingShapeStrokeColor
+              : sliderTheme.valueIndicatorStrokeColor,
+    );
+  }
+}
+
+/// The shape of a Material 3 [RangeSlider]'s value indicators.
+///
+/// If the [SliderThemeData.valueIndicatorColor] is null, then the shape uses the [ColorScheme.primary]
+/// color to draw the value indicator.
+///
+/// If the [SliderThemeData.valueIndicatorTextStyle] is null, then the indicator label text style
+/// defaults to [TextTheme.labelMedium] with the color set to [ColorScheme.onPrimary]. If the
+/// [ThemeData.useMaterial3] is set to false, then the indicator label text style defaults to
+/// [TextTheme.bodyLarge] with the color set to [ColorScheme.onInverseSurface].
+///
+/// If the [SliderThemeData.valueIndicatorStrokeColor] is provided, then the value indicator is drawn with a
+/// stroke border with the color provided.
+///
+/// See also:
+///
+///  * [RangeSlider], which includes value indicators defined by this shape.
+///  * [SliderTheme], which can be used to configure the range slider value indicators
+///    of all range sliders in a widget subtree.
+class DropRangeSliderValueIndicatorShape extends RangeSliderValueIndicatorShape {
+  /// Create a range slider value indicator that resembles a drop shape.
+  const DropRangeSliderValueIndicatorShape();
+
+  static const _DropSliderValueIndicatorPathPainter _pathPainter =
+      _DropSliderValueIndicatorPathPainter();
+
+  @override
+  Size getPreferredSize(
+    bool isEnabled,
+    bool isDiscrete, {
+    TextPainter? labelPainter,
+    double? textScaleFactor,
+  }) {
+    assert(labelPainter != null);
+    assert(textScaleFactor != null && textScaleFactor >= 0);
+    return _pathPainter.getPreferredSize(labelPainter!, textScaleFactor!);
+  }
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    required Animation<double> activationAnimation,
+    required Animation<double> enableAnimation,
+    bool? isDiscrete,
+    bool? isOnTop,
+    required TextPainter labelPainter,
+    double? textScaleFactor,
+    Size? sizeWithOverflow,
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    TextDirection? textDirection,
+    double? value,
+    Thumb? thumb,
+  }) {
+    final Canvas canvas = context.canvas;
+    final double scale = activationAnimation.value;
+    _pathPainter.paint(
+      parentBox: parentBox,
+      canvas: canvas,
+      center: center,
+      scale: scale,
+      labelPainter: labelPainter,
+      textScaleFactor: textScaleFactor!,
+      sizeWithOverflow: sizeWithOverflow!,
+      backgroundPaintColor: sliderTheme.valueIndicatorColor!,
+      strokePaintColor:
+          isOnTop!
+              ? sliderTheme.overlappingShapeStrokeColor
+              : sliderTheme.valueIndicatorStrokeColor,
+    );
+  }
+}
+
+class _RoundedRectSliderValueIndicatorPathPainter {
+  const _RoundedRectSliderValueIndicatorPathPainter();
+
+  static const double _labelPadding = 10.0;
+  static const double _preferredHeight = 32.0;
+  static const double _minLabelWidth = 16.0;
+  static const double _rectYOffset = 10.0;
+  static const double _bottomTipYOffset = 16.0;
+  static const double _preferredHalfHeight = _preferredHeight / 2;
+
+  Size getPreferredSize(TextPainter labelPainter, double textScaleFactor) {
+    final double width =
+        math.max(_minLabelWidth, labelPainter.width) + (_labelPadding * 2) * textScaleFactor;
+    return Size(width, _preferredHeight * textScaleFactor);
+  }
+
+  double getHorizontalShift({
+    required RenderBox parentBox,
+    required Offset center,
+    required TextPainter labelPainter,
+    required double textScaleFactor,
+    required Size sizeWithOverflow,
+    required double scale,
+  }) {
+    assert(!sizeWithOverflow.isEmpty);
+
+    const double edgePadding = 8.0;
+    final double rectangleWidth = _upperRectangleWidth(labelPainter, scale);
+
+    /// Value indicator draws on the Overlay and by using the global Offset
+    /// we are making sure we use the bounds of the Overlay instead of the Slider.
+    final Offset globalCenter = parentBox.localToGlobal(center);
+
+    // The rectangle must be shifted towards the center so that it minimizes the
+    // chance of it rendering outside the bounds of the render box. If the shift
+    // is negative, then the lobe is shifted from right to left, and if it is
+    // positive, then the lobe is shifted from left to right.
+    final double overflowLeft = math.max(0, rectangleWidth / 2 - globalCenter.dx + edgePadding);
+    final double overflowRight = math.max(
+      0,
+      rectangleWidth / 2 - (sizeWithOverflow.width - globalCenter.dx - edgePadding),
+    );
+
+    if (rectangleWidth < sizeWithOverflow.width) {
+      return overflowLeft - overflowRight;
+    } else if (overflowLeft - overflowRight > 0) {
+      return overflowLeft - (edgePadding * textScaleFactor);
+    } else {
+      return -overflowRight + (edgePadding * textScaleFactor);
+    }
+  }
+
+  double _upperRectangleWidth(TextPainter labelPainter, double scale) {
+    final double unscaledWidth = math.max(_minLabelWidth, labelPainter.width) + (_labelPadding * 2);
+    return unscaledWidth * scale;
+  }
+
+  void paint({
+    required RenderBox parentBox,
+    required Canvas canvas,
+    required Offset center,
+    required double scale,
+    required TextPainter labelPainter,
+    required double textScaleFactor,
+    required Size sizeWithOverflow,
+    required Color backgroundPaintColor,
+    Color? strokePaintColor,
+  }) {
+    if (scale == 0.0) {
+      // Zero scale essentially means "do not draw anything", so it's safe to just return.
+      return;
+    }
+    assert(!sizeWithOverflow.isEmpty);
+
+    final double rectangleWidth = _upperRectangleWidth(labelPainter, scale);
+    final double horizontalShift = getHorizontalShift(
+      parentBox: parentBox,
+      center: center,
+      labelPainter: labelPainter,
+      textScaleFactor: textScaleFactor,
+      sizeWithOverflow: sizeWithOverflow,
+      scale: scale,
+    );
+
+    final Rect upperRect = Rect.fromLTWH(
+      -rectangleWidth / 2 + horizontalShift,
+      -_rectYOffset - _preferredHeight,
+      rectangleWidth,
+      _preferredHeight,
+    );
+
+    final Paint fillPaint = Paint()..color = backgroundPaintColor;
+
+    canvas.save();
+    // Prepare the canvas for the base of the tooltip, which is relative to the
+    // center of the thumb.
+    canvas.translate(center.dx, center.dy - _bottomTipYOffset);
+    canvas.scale(scale, scale);
+
+    final RRect rrect = RRect.fromRectAndRadius(upperRect, Radius.circular(upperRect.height / 2));
+    if (strokePaintColor != null) {
+      final Paint strokePaint =
+          Paint()
+            ..color = strokePaintColor
+            ..strokeWidth = 1.0
+            ..style = PaintingStyle.stroke;
+      canvas.drawRRect(rrect, strokePaint);
+    }
+
+    canvas.drawRRect(rrect, fillPaint);
+
+    // The label text is centered within the value indicator.
+    final double bottomTipToUpperRectTranslateY = -_preferredHalfHeight / 2 - upperRect.height;
+    canvas.translate(0, bottomTipToUpperRectTranslateY);
+    final Offset boxCenter = Offset(horizontalShift, upperRect.height / 2.3);
+    final Offset halfLabelPainterOffset = Offset(labelPainter.width / 2, labelPainter.height / 2);
+    final Offset labelOffset = boxCenter - halfLabelPainterOffset;
+    labelPainter.paint(canvas, labelOffset);
+    canvas.restore();
+  }
+}
+
+class _DropSliderValueIndicatorPathPainter {
+  const _DropSliderValueIndicatorPathPainter();
+
+  static const double _triangleHeight = 10.0;
+  static const double _labelPadding = 8.0;
+  static const double _preferredHeight = 32.0;
+  static const double _minLabelWidth = 20.0;
+  static const double _minRectHeight = 28.0;
+  static const double _rectYOffset = 6.0;
+  static const double _bottomTipYOffset = 16.0;
+  static const double _preferredHalfHeight = _preferredHeight / 2;
+  static const double _upperRectRadius = 4;
+
+  Size getPreferredSize(TextPainter labelPainter, double textScaleFactor) {
+    final double width =
+        math.max(_minLabelWidth, labelPainter.width) + _labelPadding * 2 * textScaleFactor;
+    return Size(width, _preferredHeight * textScaleFactor);
+  }
+
+  double getHorizontalShift({
+    required RenderBox parentBox,
+    required Offset center,
+    required TextPainter labelPainter,
+    required double textScaleFactor,
+    required Size sizeWithOverflow,
+    required double scale,
+  }) {
+    assert(!sizeWithOverflow.isEmpty);
+
+    const double edgePadding = 8.0;
+    final double rectangleWidth = _upperRectangleWidth(labelPainter, scale);
+
+    /// Value indicator draws on the Overlay and by using the global Offset
+    /// we are making sure we use the bounds of the Overlay instead of the Slider.
+    final Offset globalCenter = parentBox.localToGlobal(center);
+
+    // The rectangle must be shifted towards the center so that it minimizes the
+    // chance of it rendering outside the bounds of the render box. If the shift
+    // is negative, then the lobe is shifted from right to left, and if it is
+    // positive, then the lobe is shifted from left to right.
+    final double overflowLeft = math.max(0, rectangleWidth / 2 - globalCenter.dx + edgePadding);
+    final double overflowRight = math.max(
+      0,
+      rectangleWidth / 2 - (sizeWithOverflow.width - globalCenter.dx - edgePadding),
+    );
+
+    if (rectangleWidth < sizeWithOverflow.width) {
+      return overflowLeft - overflowRight;
+    } else if (overflowLeft - overflowRight > 0) {
+      return overflowLeft - (edgePadding * textScaleFactor);
+    } else {
+      return -overflowRight + (edgePadding * textScaleFactor);
+    }
+  }
+
+  double _upperRectangleWidth(TextPainter labelPainter, double scale) {
+    final double unscaledWidth = math.max(_minLabelWidth, labelPainter.width) + _labelPadding;
+    return unscaledWidth * scale;
+  }
+
+  BorderRadius _adjustBorderRadius(Rect rect) {
+    const double rectness = 0.0;
+    return BorderRadius.lerp(
+      BorderRadius.circular(_upperRectRadius),
+      BorderRadius.all(Radius.circular(rect.shortestSide / 2.0)),
+      1.0 - rectness,
+    )!;
+  }
+
+  void paint({
+    required RenderBox parentBox,
+    required Canvas canvas,
+    required Offset center,
+    required double scale,
+    required TextPainter labelPainter,
+    required double textScaleFactor,
+    required Size sizeWithOverflow,
+    required Color backgroundPaintColor,
+    Color? strokePaintColor,
+  }) {
+    if (scale == 0.0) {
+      // Zero scale essentially means "do not draw anything", so it's safe to just return.
+      return;
+    }
+    assert(!sizeWithOverflow.isEmpty);
+    final double rectangleWidth = _upperRectangleWidth(labelPainter, scale);
+    final double horizontalShift = getHorizontalShift(
+      parentBox: parentBox,
+      center: center,
+      labelPainter: labelPainter,
+      textScaleFactor: textScaleFactor,
+      sizeWithOverflow: sizeWithOverflow,
+      scale: scale,
+    );
+    final Rect upperRect = Rect.fromLTWH(
+      -rectangleWidth / 2 + horizontalShift,
+      -_rectYOffset - _minRectHeight,
+      rectangleWidth,
+      _minRectHeight,
+    );
+
+    final Paint fillPaint = Paint()..color = backgroundPaintColor;
+
+    canvas.save();
+    canvas.translate(center.dx, center.dy - _bottomTipYOffset);
+    canvas.scale(scale, scale);
+
+    final BorderRadius adjustedBorderRadius = _adjustBorderRadius(upperRect);
+    final RRect borderRect = adjustedBorderRadius
+        .resolve(labelPainter.textDirection)
+        .toRRect(upperRect);
+    final Path trianglePath =
+        Path()
+          ..lineTo(-_triangleHeight, -_triangleHeight)
+          ..lineTo(_triangleHeight, -_triangleHeight)
+          ..close();
+    trianglePath.addRRect(borderRect);
+
+    if (strokePaintColor != null) {
+      final Paint strokePaint =
+          Paint()
+            ..color = strokePaintColor
+            ..strokeWidth = 1.0
+            ..style = PaintingStyle.stroke;
+      canvas.drawPath(trianglePath, strokePaint);
+    }
+
+    canvas.drawPath(trianglePath, fillPaint);
+
+    // The label text is centered within the value indicator.
+    final double bottomTipToUpperRectTranslateY = -_preferredHalfHeight / 2 - upperRect.height;
+    canvas.translate(0, bottomTipToUpperRectTranslateY);
+    final Offset boxCenter = Offset(horizontalShift, upperRect.height / 1.75);
+    final Offset halfLabelPainterOffset = Offset(labelPainter.width / 2, labelPainter.height / 2);
+    final Offset labelOffset = boxCenter - halfLabelPainterOffset;
+    labelPainter.paint(canvas, labelOffset);
+    canvas.restore();
   }
 }

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -630,12 +630,12 @@ class SliderThemeData with Diagnosticable {
   /// Defaults to 6.0 pixels of gap between the active and inactive tracks.
   final double? trackGap;
 
-  /// Overrides the default value of [Slider.year2023].
+  /// Overrides the default value of [Slider.year2023] and [RangeSlider.year2023].
   ///
-  /// When true, the [Slider] will use the 2023 Material Design 3 appearance.
+  /// When true, the [Slider] and [RangeSlider] will use the 2023 Material Design 3 appearance.
   /// Defaults to true.
   ///
-  /// If this is set to false, the [Slider] will use the latest Material Design 3
+  /// If this is set to false, the [Slider] and [RangeSlider] will use the latest Material Design 3
   /// appearance, which was introduced in December 2023.
   ///
   /// If [ThemeData.useMaterial3] is false, then this property is ignored.

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -3136,4 +3136,311 @@ void main() {
         ..circle(x: 800.0 - sliderPadding, y: 300.0, color: theme.colorScheme.primary),
     );
   });
+
+  testWidgets('Default RangeSlider when year2023 is false', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    final ColorScheme colorScheme = theme.colorScheme;
+    final Color activeTrackColor = colorScheme.primary;
+    final Color inactiveTrackColor = colorScheme.secondaryContainer;
+    final Color disabledActiveTrackColor = colorScheme.onSurface.withOpacity(0.38);
+    final Color disabledInactiveTrackColor = colorScheme.onSurface.withOpacity(0.12);
+    final Color activeTickMarkColor = colorScheme.onPrimary;
+    final Color inactiveTickMarkColor = colorScheme.onSecondaryContainer;
+    final Color disabledActiveTickMarkColor = colorScheme.onInverseSurface;
+    final Color disabledInactiveTickMarkColor = colorScheme.onSurface;
+    final Color thumbColor = colorScheme.primary;
+    final Color disabledThumbColor = colorScheme.onSurface.withOpacity(0.38);
+    final Color valueIndicatorColor = colorScheme.inverseSurface;
+    RangeValues values = const RangeValues(25.0, 75.0);
+    Widget buildApp({int? divisions, bool enabled = true}) {
+      final ValueChanged<RangeValues>? onChanged =
+          !enabled
+              ? null
+              : (RangeValues newValues) {
+                values = newValues;
+              };
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: Theme(
+              data: theme,
+              child: RangeSlider(
+                year2023: false,
+                values: values,
+                max: 100,
+                labels: RangeLabels(values.start.round().toString(), values.end.round().toString()),
+                divisions: divisions,
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+
+    final MaterialInkController material = Material.of(tester.element(find.byType(RangeSlider)));
+
+    // Test default track shape.
+    const Radius trackOuterCornerRadius = Radius.circular(8.0);
+    const Radius trackInnerCornerRadius = Radius.circular(2.0);
+    expect(
+      material,
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            24.0,
+            292.0,
+            206.0,
+            308.0,
+            topLeft: trackOuterCornerRadius,
+            topRight: trackInnerCornerRadius,
+            bottomRight: trackInnerCornerRadius,
+            bottomLeft: trackOuterCornerRadius,
+          ),
+          color: inactiveTrackColor,
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            594.0,
+            292.0,
+            776.0,
+            308.0,
+            topLeft: trackInnerCornerRadius,
+            topRight: trackOuterCornerRadius,
+            bottomRight: trackOuterCornerRadius,
+            bottomLeft: trackInnerCornerRadius,
+          ),
+          color: inactiveTrackColor,
+        )
+        // Active track.
+        ..rrect(
+          rrect: RRect.fromLTRBR(218.0, 292.0, 582.0, 308.0, trackInnerCornerRadius),
+          color: activeTrackColor,
+        ),
+    );
+
+    // Test default colors for enabled slider.
+    expect(
+      material,
+      paints
+        ..circle()
+        ..circle()
+        ..rrect(color: thumbColor)
+        ..rrect(color: thumbColor),
+    );
+    expect(
+      material,
+      isNot(
+        paints
+          ..circle()
+          ..circle()
+          ..rrect(color: disabledThumbColor)
+          ..rrect(color: disabledThumbColor),
+      ),
+    );
+    expect(material, isNot(paints..rrect(color: disabledActiveTrackColor)));
+    expect(material, isNot(paints..rrect(color: disabledInactiveTrackColor)));
+
+    // Test defaults colors for discrete slider.
+    await tester.pumpWidget(buildApp(divisions: 4));
+    expect(
+      material,
+      paints
+        ..rrect(color: inactiveTrackColor)
+        ..rrect(color: inactiveTrackColor)
+        ..rrect(color: activeTrackColor)
+        ..circle(color: inactiveTickMarkColor)
+        ..circle(color: activeTickMarkColor)
+        ..circle(color: inactiveTickMarkColor),
+    );
+    expect(material, isNot(paints..rrect(color: disabledThumbColor)));
+    expect(material, isNot(paints..rrect(color: disabledActiveTrackColor)));
+    expect(material, isNot(paints..rrect(color: disabledInactiveTrackColor)));
+
+    // Test defaults colors for disabled slider.
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(
+      material,
+      paints
+        ..rrect(color: disabledInactiveTrackColor)
+        ..rrect(color: disabledInactiveTrackColor)
+        ..rrect(color: disabledActiveTrackColor)
+        ..rrect(color: disabledThumbColor)
+        ..rrect(color: disabledThumbColor),
+    );
+    expect(
+      material,
+      isNot(
+        paints
+          ..rrect(color: thumbColor)
+          ..rrect(color: thumbColor),
+      ),
+    );
+    expect(material, isNot(paints..rrect(color: activeTrackColor)));
+    expect(material, isNot(paints..rrect(color: inactiveTrackColor)));
+
+    // Test defaults colors for disabled discrete slider.
+    await tester.pumpWidget(buildApp(divisions: 4, enabled: false));
+    expect(
+      material,
+      paints
+        ..rrect(color: disabledInactiveTrackColor)
+        ..rrect(color: disabledInactiveTrackColor)
+        ..rrect(color: disabledActiveTrackColor)
+        ..circle(color: disabledInactiveTickMarkColor)
+        ..circle(color: disabledActiveTickMarkColor)
+        ..circle(color: disabledInactiveTickMarkColor)
+        ..rrect(color: disabledThumbColor)
+        ..rrect(color: disabledThumbColor),
+    );
+    expect(
+      material,
+      isNot(
+        paints
+          ..rrect(color: thumbColor)
+          ..rrect(color: thumbColor),
+      ),
+    );
+    expect(material, isNot(paints..rrect(color: activeTrackColor)));
+    expect(material, isNot(paints..rrect(color: inactiveTrackColor)));
+
+    await tester.pumpWidget(buildApp(divisions: 4));
+    await tester.pumpAndSettle();
+
+    final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider));
+    final TestGesture gesture = await tester.startGesture(topLeft);
+    // Wait for value indicator animation to finish.
+    await tester.pumpAndSettle();
+
+    final RenderBox valueIndicatorBox = tester.renderObject(find.byType(Overlay));
+    expect(
+      valueIndicatorBox,
+      paints
+        ..scale()
+        ..rrect(color: valueIndicatorColor),
+    );
+    await gesture.up();
+  });
+
+  testWidgets('RangeSlider value indicator text when year2023 is false', (
+    WidgetTester tester,
+  ) async {
+    const RangeValues values = RangeValues(25.0, 75.0);
+    final List<InlineSpan> log = <InlineSpan>[];
+    final LoggingRangeSliderValueIndicatorShape loggingValueIndicatorShape =
+        LoggingRangeSliderValueIndicatorShape(log);
+    final ThemeData theme = ThemeData(
+      sliderTheme: SliderThemeData(rangeValueIndicatorShape: loggingValueIndicatorShape),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: RangeSlider(
+              year2023: false,
+              values: values,
+              max: 100,
+              labels: RangeLabels(values.start.round().toString(), values.end.round().toString()),
+              divisions: 4,
+              onChanged: (RangeValues value) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider));
+    final TestGesture gesture = await tester.startGesture(topLeft);
+    await tester.pumpAndSettle();
+
+    expect(log.last.toPlainText(), '25');
+    expect(log.last.style!.fontSize, 14.0);
+    expect(log.last.style!.color, theme.colorScheme.onInverseSurface);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('RangeSlider supports DropRangeSliderValueIndicatorShape', (
+    WidgetTester tester,
+  ) async {
+    const RangeValues values = RangeValues(25.0, 75.0);
+    const Color valueIndicatorColor = Color(0XFFFF0000);
+    final ThemeData theme = ThemeData(
+      sliderTheme: const SliderThemeData(
+        rangeValueIndicatorShape: DropRangeSliderValueIndicatorShape(),
+        valueIndicatorColor: valueIndicatorColor,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: RangeSlider(
+              year2023: false,
+              values: values,
+              max: 100,
+              labels: RangeLabels(values.start.round().toString(), values.end.round().toString()),
+              divisions: 4,
+              onChanged: (RangeValues value) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider));
+    final TestGesture gesture = await tester.startGesture(topLeft);
+    await tester.pumpAndSettle();
+
+    final RenderBox valueIndicatorBox = tester.renderObject(find.byType(Overlay));
+    expect(valueIndicatorBox, paints..path(color: valueIndicatorColor));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+}
+
+// A value indicator shape to log labelPainter text.
+class LoggingRangeSliderValueIndicatorShape extends RangeSliderValueIndicatorShape {
+  LoggingRangeSliderValueIndicatorShape(this.logLabel);
+
+  final List<InlineSpan> logLabel;
+
+  @override
+  Size getPreferredSize(
+    bool isEnabled,
+    bool isDiscrete, {
+    required TextPainter labelPainter,
+    required double textScaleFactor,
+  }) {
+    return const Size(10.0, 10.0);
+  }
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    required Animation<double> activationAnimation,
+    required Animation<double> enableAnimation,
+    bool? isDiscrete,
+    bool? isOnTop,
+    required TextPainter labelPainter,
+    double? textScaleFactor,
+    Size? sizeWithOverflow,
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    TextDirection? textDirection,
+    double? value,
+    Thumb? thumb,
+  }) {
+    logLabel.add(labelPainter.text!);
+  }
 }

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -2926,7 +2926,7 @@ void main() {
     );
   });
 
-  testWidgets('Can customize track gap when year2023 is false', (WidgetTester tester) async {
+  testWidgets('Can customize Slider track gap when year2023 is false', (WidgetTester tester) async {
     Widget buildSlider({double? trackGap}) {
       return MaterialApp(
         theme: ThemeData(sliderTheme: SliderThemeData(trackGap: trackGap)),
@@ -3008,7 +3008,104 @@ void main() {
     );
   });
 
-  testWidgets('Can customize thumb size when year2023 is false', (WidgetTester tester) async {
+  testWidgets('Can customize RangeSlider track gap when year2023 is false', (
+    WidgetTester tester,
+  ) async {
+    Widget buildRangeSlider({double? trackGap}) {
+      return MaterialApp(
+        theme: ThemeData(sliderTheme: SliderThemeData(trackGap: trackGap)),
+        home: Material(
+          child: Center(
+            child: RangeSlider(
+              year2023: false,
+              values: const RangeValues(25, 75),
+              max: 100,
+              onChanged: (RangeValues value) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildRangeSlider(trackGap: 0));
+
+    final MaterialInkController material = Material.of(tester.element(find.byType(RangeSlider)));
+
+    // Test default track shape.
+    const Radius trackOuterCornerRadius = Radius.circular(8.0);
+    const Radius trackInnerCornerRadius = Radius.circular(2.0);
+    expect(
+      material,
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            24.0,
+            292.0,
+            212.0,
+            308.0,
+            topLeft: trackOuterCornerRadius,
+            topRight: trackInnerCornerRadius,
+            bottomRight: trackInnerCornerRadius,
+            bottomLeft: trackOuterCornerRadius,
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            588.0,
+            292.0,
+            776.0,
+            308.0,
+            topLeft: trackInnerCornerRadius,
+            topRight: trackOuterCornerRadius,
+            bottomRight: trackOuterCornerRadius,
+            bottomLeft: trackInnerCornerRadius,
+          ),
+        )
+        // Inactive track.
+        ..rrect(rrect: RRect.fromLTRBR(212.0, 292.0, 588.0, 308.0, trackInnerCornerRadius)),
+    );
+
+    await tester.pumpWidget(buildRangeSlider(trackGap: 10));
+    await tester.pumpAndSettle();
+    expect(
+      material,
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            24.0,
+            292.0,
+            202.0,
+            308.0,
+            topLeft: trackOuterCornerRadius,
+            topRight: trackInnerCornerRadius,
+            bottomRight: trackInnerCornerRadius,
+            bottomLeft: trackOuterCornerRadius,
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            598.0,
+            292.0,
+            776.0,
+            308.0,
+            topLeft: trackInnerCornerRadius,
+            topRight: trackOuterCornerRadius,
+            bottomRight: trackOuterCornerRadius,
+            bottomLeft: trackInnerCornerRadius,
+          ),
+        )
+        // Inactive track.
+        ..rrect(rrect: RRect.fromLTRBR(222.0, 292.0, 578.0, 308.0, trackInnerCornerRadius)),
+    );
+  });
+
+  testWidgets('Can customize Slider thumb size when year2023 is false', (
+    WidgetTester tester,
+  ) async {
     Widget buildSlider({WidgetStateProperty<Size?>? thumbSize}) {
       return MaterialApp(
         theme: ThemeData(sliderTheme: SliderThemeData(thumbSize: thumbSize)),
@@ -3062,6 +3159,72 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('Can customize RangeSlider thumbs size when year2023 is false', (
+    WidgetTester tester,
+  ) async {
+    Widget buildRangeSlider({WidgetStateProperty<Size?>? thumbSize}) {
+      return MaterialApp(
+        theme: ThemeData(sliderTheme: SliderThemeData(thumbSize: thumbSize)),
+        home: Material(
+          child: Center(
+            child: RangeSlider(
+              year2023: false,
+              values: const RangeValues(25, 75),
+              max: 100,
+              onChanged: (RangeValues value) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(
+      buildRangeSlider(thumbSize: const WidgetStatePropertyAll<Size>(Size(20, 20))),
+    );
+
+    final MaterialInkController material = Material.of(tester.element(find.byType(RangeSlider)));
+    expect(
+      material,
+      paints
+        ..circle()
+        ..rrect(rrect: RRect.fromLTRBR(202.0, 290.0, 222.0, 310.0, const Radius.circular(10.0)))
+        ..rrect(rrect: RRect.fromLTRBR(578.0, 290.0, 598.0, 310.0, const Radius.circular(10.0))),
+    );
+
+    await tester.pumpWidget(
+      buildRangeSlider(
+        thumbSize: const WidgetStateProperty<Size?>.fromMap(<WidgetStatesConstraint, Size>{
+          WidgetState.pressed: Size(20, 20),
+          WidgetState.any: Size(10, 10),
+        }),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      material,
+      paints
+        ..circle()
+        ..rrect(rrect: RRect.fromLTRBR(207.0, 295.0, 217.0, 305.0, const Radius.circular(5.0)))
+        ..rrect(rrect: RRect.fromLTRBR(583.0, 295.0, 593.0, 305.0, const Radius.circular(5.0))),
+    );
+
+    final Offset topRight = tester.getTopRight(find.byType(RangeSlider));
+    final TestGesture gesture = await tester.startGesture(topRight);
+    await tester.pumpAndSettle();
+
+    expect(
+      material,
+      paints
+        ..circle()
+        ..rrect(rrect: RRect.fromLTRBR(207.0, 295.0, 217.0, 305.0, const Radius.circular(5.0)))
+        ..rrect(rrect: RRect.fromLTRBR(583.0, 295.0, 593.0, 305.0, const Radius.circular(5.0))),
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('Opt into 2024 Slider appearance with SliderThemeData.year2023', (
     WidgetTester tester,
   ) async {
@@ -3081,7 +3244,7 @@ void main() {
 
     // Test default track shape.
     const Radius trackOuterCornerRadius = Radius.circular(8.0);
-    const Radius trackInnerCornderRadius = Radius.circular(2.0);
+    const Radius trackInnerCornerRadius = Radius.circular(2.0);
     expect(
       material,
       paints
@@ -3093,8 +3256,8 @@ void main() {
             356.4,
             308.0,
             topLeft: trackOuterCornerRadius,
-            topRight: trackInnerCornderRadius,
-            bottomRight: trackInnerCornderRadius,
+            topRight: trackInnerCornerRadius,
+            bottomRight: trackInnerCornerRadius,
             bottomLeft: trackOuterCornerRadius,
           ),
           color: activeTrackColor,
@@ -3106,10 +3269,10 @@ void main() {
             292.0,
             776.0,
             308.0,
-            topLeft: trackInnerCornderRadius,
+            topLeft: trackInnerCornerRadius,
             topRight: trackOuterCornerRadius,
             bottomRight: trackOuterCornerRadius,
-            bottomLeft: trackInnerCornderRadius,
+            bottomLeft: trackInnerCornerRadius,
           ),
           color: inactiveTrackColor,
         ),


### PR DESCRIPTION
Fixes [Update `RangeSlider` for Material 3 redesign](https://github.com/flutter/flutter/issues/162505)

### Description

This PR updates `RangeSlider` with `year2023` flag which can be used to opt into the 2024 `RangeSlider design appearance. 

### Code Sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const RangeSliderExampleApp());

class RangeSliderExampleApp extends StatelessWidget {
  const RangeSliderExampleApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(
        sliderTheme: const SliderThemeData(
          showValueIndicator: ShowValueIndicator.always,
        ),
      ),
      home: Scaffold(
        appBar: AppBar(title: const Text('RangeSlider Sample')),
        body: const RangeSliderExample(),
      ),
    );
  }
}

class RangeSliderExample extends StatefulWidget {
  const RangeSliderExample({super.key});

  @override
  State<RangeSliderExample> createState() => _RangeSliderExampleState();
}

class _RangeSliderExampleState extends State<RangeSliderExample> {
  RangeValues _currentRange1Values = const RangeValues(20.0, 60.0);
  RangeValues _currentRange2Values = const RangeValues(30.0, 80.0);

  @override
  Widget build(BuildContext context) {
    return Column(
      spacing: 20.0,
      mainAxisAlignment: MainAxisAlignment.center,
      children: <Widget>[
        RangeSlider(
          year2023: false,
          values: _currentRange1Values,
          max: 100,
          onChanged: (RangeValues values) {
            setState(() {
              _currentRange1Values = values;
            });
          },
        ),
        RangeSlider(
          year2023: false,
          values: _currentRange2Values,
          max: 100,
          divisions: 10,
          labels: RangeLabels(
            _currentRange2Values.start.round().toString(),
            _currentRange2Values.end.round().toString(),
          ),
          onChanged: (RangeValues values) {
            setState(() {
              _currentRange2Values = values;
            });
          },
        ),
      ],
    );
  }
}
```

</details>

| Preview 1 | Preview 2 |
| --------------- | --------------- |
| <img src="https://github.com/user-attachments/assets/e14a1b04-4e32-4b37-b2f5-2d2001f53114"/>  | <img src="https://github.com/user-attachments/assets/aad36529-d576-4ec7-b2e5-49c9387456be"/>  |


# Custom track gap and thumb size 

<img width="343" alt="Screenshot 2025-02-20 at 15 26 09" src="https://github.com/user-attachments/assets/06c09679-1df8-4380-b3e6-c4add8f0cc42" />
<img width="338" alt="Screenshot 2025-02-20 at 15 27 19" src="https://github.com/user-attachments/assets/6226c515-f96b-412a-b59e-cafd2fba0515" />

                

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
