### PR TITLE
Add integration test for Gradle-initiated android builds with flavors

### DIFF
--- a/dev/integration_tests/flavors/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
+++ b/dev/integration_tests/flavors/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
@@ -4,24 +4,6 @@
 
 package com.yourcompany.flavors;
 
-import android.os.Bundle;
-
-import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.embedding.engine.FlutterEngine;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugins.GeneratedPluginRegistrant;
 
-public class MainActivity extends FlutterActivity {
-  @Override
-  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    GeneratedPluginRegistrant.registerWith(flutterEngine);
-    new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), "flavor")
-        .setMethodCallHandler(
-            (call, result) -> {
-                result.success(BuildConfig.FLAVOR);
-        }
-    );
-  }
-}
+public class MainActivity extends FlutterActivity {}

--- a/dev/integration_tests/flavors/lib/main.dart
+++ b/dev/integration_tests/flavors/lib/main.dart
@@ -23,26 +23,11 @@ class Flavor extends StatefulWidget {
 }
 
 class _FlavorState extends State<Flavor> {
-  String? _flavor;
-
-  @override
-  void initState() {
-    super.initState();
-    const MethodChannel('flavor').invokeMethod<String>('getFlavor').then((String? flavor) {
-      setState(() {
-        _flavor = flavor;
-      });
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Directionality(
+    return const Directionality(
       textDirection: TextDirection.ltr,
-      child:
-          _flavor == null
-              ? const Text('Awaiting flavor...')
-              : Text(_flavor!, key: const ValueKey<String>('flavor')),
+      child: Text(appFlavor ?? 'null', key: ValueKey<String>('flavor')),
     );
   }
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This request is a subset of #157871 and follows up #162907.

#162907 actually fixed behaviour of building with native tooling not only for iOS/macOS, but also for Android builds too: now on master, if you start build with `gradle` instead of `flutter build ...` – you also get the correct behaviour and `appFlavor` won't be null in runtime. Tests in this PR will check exactly this behavior. 

Another diff is the change in the method of obtaining flavor at runtime inside test project. Before this change, method channels were used for this, after – `appFlavor` constant. Both methods do more or less the same thing right now, but they may diverge in future, so I guess this is the right way to check correctness here. Also, this change was requested and approved by Andrew in https://github.com/flutter/flutter/pull/157871#discussion_r1931153339

issue for checklist: #155951 

New test was tested here: https://ci.chromium.org/ui/p/flutter/builders/try/Linux_pixel_7pro%20flavors_test/63/overview


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
