### PR TITLE
[fuchsia] include more tests in the fuchsia builders

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/BUILD.gn
@@ -889,23 +889,95 @@ if (enable_unittests) {
     binary = "dart_utils_unittests"
   }
 
+  fuchsia_test_archive("assets_unittests") {
+    deps = [ "//flutter/assets:assets_unittests" ]
+    gen_cml_file = true
+    binary = "assets_unittests"
+  }
+
+  fuchsia_test_archive("client_wrapper_unittests") {
+    deps = [
+      "//flutter/shell/platform/common/client_wrapper:client_wrapper_unittests",
+    ]
+    gen_cml_file = true
+    binary = "client_wrapper_unittests"
+  }
+
+  fuchsia_test_archive("common_cpp_core_unittests") {
+    deps = [ "//flutter/shell/platform/common:common_cpp_core_unittests" ]
+    gen_cml_file = true
+    binary = "common_cpp_core_unittests"
+  }
+
+  fuchsia_test_archive("common_cpp_unittests") {
+    deps = [ "//flutter/shell/platform/common:common_cpp_unittests" ]
+    gen_cml_file = true
+    binary = "common_cpp_unittests"
+  }
+
+  fuchsia_test_archive("dart_plugin_registrant_unittests") {
+    deps = [ "//flutter/runtime:dart_plugin_registrant_unittests" ]
+    gen_cml_file = true
+    binary = "dart_plugin_registrant_unittests"
+  }
+
+  fuchsia_test_archive("no_dart_plugin_registrant_unittests") {
+    deps = [ "//flutter/runtime:no_dart_plugin_registrant_unittests" ]
+    gen_cml_file = true
+    binary = "no_dart_plugin_registrant_unittests"
+  }
+
+  fuchsia_test_archive("embedder_a11y_unittests") {
+    deps = [ "//flutter/shell/platform/embedder:embedder_a11y_unittests" ]
+    gen_cml_file = true
+    binary = "embedder_a11y_unittests"
+  }
+
+  fuchsia_test_archive("embedder_proctable_unittests") {
+    deps = [ "//flutter/shell/platform/embedder:embedder_proctable_unittests" ]
+    gen_cml_file = true
+    binary = "embedder_proctable_unittests"
+  }
+
+  fuchsia_test_archive("testing_unittests") {
+    deps = [ "//flutter/testing:testing_unittests" ]
+    gen_cml_file = true
+    binary = "testing_unittests"
+  }
+
+  fuchsia_test_archive("tonic_unittests") {
+    deps = [ "//flutter/third_party/tonic/tests:tonic_unittests" ]
+    gen_cml_file = true
+    binary = "tonic_unittests"
+  }
+
   # When adding a new dep here, please also ensure the dep is added to
   # testing/fuchsia/test_suites.yaml.
   group("tests") {
     testonly = true
 
     deps = [
+      ":assets_unittests",
+      ":client_wrapper_unittests",
+      ":common_cpp_core_unittests",
+      ":common_cpp_unittests",
+      ":dart_plugin_registrant_unittests",
       ":dart_utils_tests",
       ":display_list_render_tests",
       ":display_list_tests",
+      ":embedder_a11y_unittests",
+      ":embedder_proctable_unittests",
       ":embedder_tests",
       ":flow_tests",
       ":flutter_runner_tests",
       ":flutter_runner_tzdata_missing_tests",
       ":flutter_runner_tzdata_tests",
       ":fml_tests",
+      ":no_dart_plugin_registrant_unittests",
       ":runtime_tests",
       ":shell_tests",
+      ":testing_unittests",
+      ":tonic_unittests",
       ":txt_tests",
       ":ui_tests",
       "tests/integration",

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -14,9 +14,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/common_cpp_unittests#meta/common_cpp_unittests.cm
   package: common_cpp_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart_plugin_registrant_unittests#meta/dart_plugin_registrant_unittests.cm
-  packages:
-    - flutter_aot_product_runner-0.far
-    - dart_plugin_registrant_unittests-0.far
+  package: dart_plugin_registrant_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart-aot-runner-integration-test#meta/dart-aot-runner-integration-test.cm
   packages:
     - oot_dart_aot_runner-0.far
@@ -46,9 +44,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/display_list_tests#meta/display_list_tests.cm
   package: display_list_tests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_a11y_unittests#meta/embedder_a11y_unittests.cm
-  packages:
-    - flutter_aot_product_runner-0.far
-    - embedder_a11y_unittests-0.far
+  package: embedder_a11y_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_proctable_unittests#meta/embedder_proctable_unittests.cm
   package: embedder_proctable_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_tests#meta/embedder_tests.cm
@@ -77,9 +73,7 @@
     - oot_flutter_jit_runner-0.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/mouse-input-view/mouse-input-view.far
 - test_command: test run fuchsia-pkg://fuchsia.com/no_dart_plugin_registrant_unittests#meta/no_dart_plugin_registrant_unittests.cm
-  packages:
-    - flutter_aot_product_runner-0.far
-    - no_dart_plugin_registrant_unittests-0.far
+  package: no_dart_plugin_registrant_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/runtime_tests#meta/runtime_tests.cm
   package: runtime_tests-0.far
   disabled: on debug_arm64 because of the slowness
@@ -96,9 +90,7 @@
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/text-input-view/text-input-view.far
   variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/tonic_unittests#meta/tonic_unittests.cm
-  packages:
-    - flutter_aot_product_runner-0.far
-    - tonic_unittests-0.far
+  package: tonic_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
   package: txt_tests-0.far
   variant: debug

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -15,7 +15,7 @@
   package: common_cpp_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart_plugin_registrant_unittests#meta/dart_plugin_registrant_unittests.cm
   packages:
-    - oot_flutter_aot_runner-0.far
+    - flutter_aot_product_runner-0.far
     - dart_plugin_registrant_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart-aot-runner-integration-test#meta/dart-aot-runner-integration-test.cm
   packages:

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -95,17 +95,17 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/tonic_unittests#meta/tonic_unittests.cm
   disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: tonic_unittests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
-  package: txt_tests-0.far
-  variant: debug
-- test_command: test run fuchsia-pkg://fuchsia.com/ui_tests#meta/ui_tests.cm
-  package: ui_tests-0.far
-  disabled: on debug_arm64 because of the slowness
-  variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/touch-input-test#meta/touch-input-test.cm
   packages:
     - touch-input-test-0.far
     - oot_flutter_jit_runner-0.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/touch-input-view/touch-input-view.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/embedding-flutter-view/embedding-flutter-view.far
+  variant: debug_x64
+- test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
+  package: txt_tests-0.far
+  variant: debug
+- test_command: test run fuchsia-pkg://fuchsia.com/ui_tests#meta/ui_tests.cm
+  package: ui_tests-0.far
+  disabled: on debug_arm64 because of the slowness
   variant: debug_x64

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -14,6 +14,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/common_cpp_unittests#meta/common_cpp_unittests.cm
   package: common_cpp_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart_plugin_registrant_unittests#meta/dart_plugin_registrant_unittests.cm
+  disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: dart_plugin_registrant_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart-aot-runner-integration-test#meta/dart-aot-runner-integration-test.cm
   packages:
@@ -44,6 +45,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/display_list_tests#meta/display_list_tests.cm
   package: display_list_tests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_a11y_unittests#meta/embedder_a11y_unittests.cm
+  disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: embedder_a11y_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_proctable_unittests#meta/embedder_proctable_unittests.cm
   package: embedder_proctable_unittests-0.far
@@ -73,6 +75,7 @@
     - oot_flutter_jit_runner-0.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/mouse-input-view/mouse-input-view.far
 - test_command: test run fuchsia-pkg://fuchsia.com/no_dart_plugin_registrant_unittests#meta/no_dart_plugin_registrant_unittests.cm
+  disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: no_dart_plugin_registrant_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/runtime_tests#meta/runtime_tests.cm
   package: runtime_tests-0.far
@@ -90,6 +93,7 @@
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/text-input-view/text-input-view.far
   variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/tonic_unittests#meta/tonic_unittests.cm
+  disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: tonic_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
   package: txt_tests-0.far

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -5,7 +5,7 @@
 
 # Please keep the list alphabetical order.
 
-- test_command: test run fuchsia-pkg://fuchsia.com/assets_unittests#meta/assets_untitests.cm
+- test_command: test run fuchsia-pkg://fuchsia.com/assets_unittests#meta/assets_unittests.cm
   package: assets_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/client_wrapper_unittests#meta/client_wrapper_unittests.cm
   package: client_wrapper_unittests-0.far

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -16,6 +16,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/dart_plugin_registrant_unittests#meta/dart_plugin_registrant_unittests.cm
   disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: dart_plugin_registrant_unittests-0.far
+  variant: disabled
 - test_command: test run fuchsia-pkg://fuchsia.com/dart-aot-runner-integration-test#meta/dart-aot-runner-integration-test.cm
   packages:
     - oot_dart_aot_runner-0.far
@@ -47,6 +48,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_a11y_unittests#meta/embedder_a11y_unittests.cm
   disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: embedder_a11y_unittests-0.far
+  variant: disabled
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_proctable_unittests#meta/embedder_proctable_unittests.cm
   package: embedder_proctable_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_tests#meta/embedder_tests.cm
@@ -77,6 +79,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/no_dart_plugin_registrant_unittests#meta/no_dart_plugin_registrant_unittests.cm
   disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: no_dart_plugin_registrant_unittests-0.far
+  variant: disabled
 - test_command: test run fuchsia-pkg://fuchsia.com/runtime_tests#meta/runtime_tests.cm
   package: runtime_tests-0.far
   disabled: on debug_arm64 because of the slowness
@@ -95,6 +98,7 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/tonic_unittests#meta/tonic_unittests.cm
   disabled: Error while initializing the Dart VM, Precompiled runtime requires a precompiled snapshot
   package: tonic_unittests-0.far
+  variant: disabled
 - test_command: test run fuchsia-pkg://fuchsia.com/touch-input-test#meta/touch-input-test.cm
   packages:
     - touch-input-test-0.far

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -1,43 +1,29 @@
 # This configuration file specifies several test suites with their package and
-# test command for femu_test.py.
+# test command for engine/src/flutter/testing/fuchsia/run_tests.py
+# The list is inherited from the engine/src/flutter/testing/run_tests.py, and
+# need consistent maintenance.
 
-- test_command: test run fuchsia-pkg://fuchsia.com/dart_runner_tests#meta/dart_runner_tests.cm
-  package: dart_runner_tests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/flutter_runner_tests#meta/flutter_runner_tests.cm
-  package: flutter_runner_tests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/flutter_runner_tzdata_tests#meta/flutter_runner_tzdata_tests.cm
-  package: flutter_runner_tzdata_tests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/flutter_runner_tzdata_missing_tests#meta/flutter_runner_tzdata_missing_tests.cm
-  package: flutter_runner_tzdata_missing_tests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/fml_tests#meta/fml_tests.cm
-  package: fml_tests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/display_list_tests#meta/display_list_tests.cm
-  package: display_list_tests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/display_list_render_tests#meta/display_list_render_tests.cm
-  package: display_list_render_tests-0.far
-  disabled: on arm64 because of the slowness
-  variant: x64
-- test_command: test run fuchsia-pkg://fuchsia.com/flow_tests#meta/flow_tests.cm
-  package: flow_tests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/runtime_tests#meta/runtime_tests.cm
-  package: runtime_tests-0.far
-  disabled: on debug_arm64 because of the slowness
-  variant: debug_x64
-- test_command: test run fuchsia-pkg://fuchsia.com/shell_tests#meta/shell_tests.cm
-  package: shell_tests-0.far
-  variant: debug_x64
-- test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
-  package: txt_tests-0.far
-  variant: debug
-- test_command: test run fuchsia-pkg://fuchsia.com/ui_tests#meta/ui_tests.cm
-  package: ui_tests-0.far
-  disabled: on debug_arm64 because of the slowness
-  variant: debug_x64
-- test_command: test run fuchsia-pkg://fuchsia.com/embedder_tests#meta/embedder_tests.cm
-  package: embedder_tests-0.far
-  variant: debug_x64
-- test_command: test run fuchsia-pkg://fuchsia.com/dart_utils_tests#meta/dart_utils_tests.cm
-  package: dart_utils_tests-0.far
+# Please keep the list alphabetical order.
+
+- test_command: test run fuchsia-pkg://fuchsia.com/assets_unittests#meta/assets_untitests.cm
+  package: assets_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/client_wrapper_unittests#meta/client_wrapper_unittests.cm
+  package: client_wrapper_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/common_cpp_core_unittests#meta/common_cpp_core_unittests.cm
+  package: common_cpp_core_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/common_cpp_unittests#meta/common_cpp_unittests.cm
+  package: common_cpp_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/dart_plugin_registrant_unittests#meta/dart_plugin_registrant_unittests.cm
+  package: dart_plugin_registrant_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/dart-aot-runner-integration-test#meta/dart-aot-runner-integration-test.cm
+  packages:
+    - oot_dart_aot_runner-0.far
+    - dart-aot-runner-integration-test-0.far
+    - gen/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_echo_server/dart_aot_echo_server/dart_aot_echo_server.far
+  emulator_arch:
+    - 'x64'
+    - 'arm64'
+  variant: profile
 - test_command: test run fuchsia-pkg://fuchsia.com/dart-jit-runner-integration-test#meta/dart-jit-runner-integration-test.cm
   packages:
     - oot_dart_jit_runner-0.far
@@ -47,16 +33,25 @@
     - 'x64'
     - 'arm64'
   variant: debug
-- test_command: test run fuchsia-pkg://fuchsia.com/dart-aot-runner-integration-test#meta/dart-aot-runner-integration-test.cm
-  run_with_dart_aot: 'true'
-  packages:
-    - oot_dart_aot_runner-0.far
-    - dart-aot-runner-integration-test-0.far
-    - gen/flutter/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_echo_server/dart_aot_echo_server/dart_aot_echo_server.far
-  emulator_arch:
-    - 'x64'
-    - 'arm64'
-  variant: profile
+- test_command: test run fuchsia-pkg://fuchsia.com/dart_utils_tests#meta/dart_utils_tests.cm
+  package: dart_utils_tests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/embedder_tests#meta/embedder_tests.cm
+  package: embedder_tests-0.far
+  variant: debug_x64
+- test_command: test run fuchsia-pkg://fuchsia.com/dart_runner_tests#meta/dart_runner_tests.cm
+  package: dart_runner_tests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/display_list_render_tests#meta/display_list_render_tests.cm
+  package: display_list_render_tests-0.far
+  disabled: on arm64 because of the slowness
+  variant: x64
+- test_command: test run fuchsia-pkg://fuchsia.com/display_list_tests#meta/display_list_tests.cm
+  package: display_list_tests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/embedder_a11y_unittests#meta/embedder_a11y_unittests.cm
+  package: embedder_a11y_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/embedder_proctable_unittests#meta/embedder_proctable_unittests.cm
+  package: embedder_proctable_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/flow_tests#meta/flow_tests.cm
+  package: flow_tests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/flutter-embedder-test#meta/flutter-embedder-test.cm
   packages:
     - flutter-embedder-test-0.far
@@ -64,21 +59,49 @@
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/child-view/child-view/child-view.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/parent-view/parent-view.far
   variant: debug_x64
+- test_command: test run fuchsia-pkg://fuchsia.com/flutter_runner_tests#meta/flutter_runner_tests.cm
+  package: flutter_runner_tests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/flutter_runner_tzdata_tests#meta/flutter_runner_tzdata_tests.cm
+  package: flutter_runner_tzdata_tests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/flutter_runner_tzdata_missing_tests#meta/flutter_runner_tzdata_missing_tests.cm
+  package: flutter_runner_tzdata_missing_tests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/fml_tests#meta/fml_tests.cm
+  package: fml_tests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/mouse-input-test#meta/mouse-input-test.cm
+  packages:
+    - mouse-input-test-0.far
+    - oot_flutter_jit_runner-0.far
+    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/mouse-input-view/mouse-input-view.far
+- test_command: test run fuchsia-pkg://fuchsia.com/no_dart_plugin_registrant_unittests#meta/no_dart_plugin_registrant_unittests.cm
+  package: no_dart_plugin_registrant_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/runtime_tests#meta/runtime_tests.cm
+  package: runtime_tests-0.far
+  disabled: on debug_arm64 because of the slowness
+  variant: debug_x64
+- test_command: test run fuchsia-pkg://fuchsia.com/shell_tests#meta/shell_tests.cm
+  package: shell_tests-0.far
+  variant: debug_x64
+- test_command: test run fuchsia-pkg://fuchsia.com/testing_unittests#meta/testing_unittests.cm
+  package: testing_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/text-input-test#meta/text-input-test.cm
+  packages:
+    - text-input-test-0.far
+    - oot_flutter_jit_runner-0.far
+    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/text-input-view/text-input-view.far
+  variant: debug_x64
+- test_command: test run fuchsia-pkg://fuchsia.com/tonic_unittests#meta/tonic_unittests.cm
+  package: tonic_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
+  package: txt_tests-0.far
+  variant: debug
+- test_command: test run fuchsia-pkg://fuchsia.com/ui_tests#meta/ui_tests.cm
+  package: ui_tests-0.far
+  disabled: on debug_arm64 because of the slowness
+  variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/touch-input-test#meta/touch-input-test.cm
   packages:
     - touch-input-test-0.far
     - oot_flutter_jit_runner-0.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/touch-input-view/touch-input-view.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/embedding-flutter-view/embedding-flutter-view.far
-  variant: debug_x64
-- test_command: test run fuchsia-pkg://fuchsia.com/mouse-input-test#meta/mouse-input-test.cm
-  packages:
-    - mouse-input-test-0.far
-    - oot_flutter_jit_runner-0.far
-    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/mouse-input-view/mouse-input-view.far
-- test_command: test run fuchsia-pkg://fuchsia.com/text-input-test#meta/text-input-test.cm
-  packages:
-    - text-input-test-0.far
-    - oot_flutter_jit_runner-0.far
-    - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/text-input-view/text-input-view.far
   variant: debug_x64

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -14,7 +14,9 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/common_cpp_unittests#meta/common_cpp_unittests.cm
   package: common_cpp_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart_plugin_registrant_unittests#meta/dart_plugin_registrant_unittests.cm
-  package: dart_plugin_registrant_unittests-0.far
+  packages:
+    - oot_flutter_aot_runner-0.far
+    - dart_plugin_registrant_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/dart-aot-runner-integration-test#meta/dart-aot-runner-integration-test.cm
   packages:
     - oot_dart_aot_runner-0.far
@@ -35,9 +37,6 @@
   variant: debug
 - test_command: test run fuchsia-pkg://fuchsia.com/dart_utils_tests#meta/dart_utils_tests.cm
   package: dart_utils_tests-0.far
-- test_command: test run fuchsia-pkg://fuchsia.com/embedder_tests#meta/embedder_tests.cm
-  package: embedder_tests-0.far
-  variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/dart_runner_tests#meta/dart_runner_tests.cm
   package: dart_runner_tests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/display_list_render_tests#meta/display_list_render_tests.cm
@@ -47,9 +46,14 @@
 - test_command: test run fuchsia-pkg://fuchsia.com/display_list_tests#meta/display_list_tests.cm
   package: display_list_tests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_a11y_unittests#meta/embedder_a11y_unittests.cm
-  package: embedder_a11y_unittests-0.far
+  packages:
+    - flutter_aot_product_runner-0.far
+    - embedder_a11y_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/embedder_proctable_unittests#meta/embedder_proctable_unittests.cm
   package: embedder_proctable_unittests-0.far
+- test_command: test run fuchsia-pkg://fuchsia.com/embedder_tests#meta/embedder_tests.cm
+  package: embedder_tests-0.far
+  variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/flow_tests#meta/flow_tests.cm
   package: flow_tests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/flutter-embedder-test#meta/flutter-embedder-test.cm
@@ -73,7 +77,9 @@
     - oot_flutter_jit_runner-0.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/mouse-input-view/mouse-input-view.far
 - test_command: test run fuchsia-pkg://fuchsia.com/no_dart_plugin_registrant_unittests#meta/no_dart_plugin_registrant_unittests.cm
-  package: no_dart_plugin_registrant_unittests-0.far
+  packages:
+    - flutter_aot_product_runner-0.far
+    - no_dart_plugin_registrant_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/runtime_tests#meta/runtime_tests.cm
   package: runtime_tests-0.far
   disabled: on debug_arm64 because of the slowness
@@ -90,7 +96,9 @@
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/text-input-view/text-input-view.far
   variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/tonic_unittests#meta/tonic_unittests.cm
-  package: tonic_unittests-0.far
+  packages:
+    - flutter_aot_product_runner-0.far
+    - tonic_unittests-0.far
 - test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
   package: txt_tests-0.far
   variant: debug


### PR DESCRIPTION
This change includes 6 more test suites, and another 4 disabled test suites.

http://b/394632376

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
