### PR TITLE
[canvaskit] Revert back to `createImageBitmap` for rasterization

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -149,18 +149,19 @@ class Surface extends DisplayCanvas {
 
     if (browserSupportsCreateImageBitmap) {
       JSObject bitmapSource;
-      DomImageBitmap bitmap;
       if (useOffscreenCanvas) {
-        bitmap = _offscreenCanvas!.transferToImageBitmap();
+        bitmapSource = _offscreenCanvas! as JSObject;
       } else {
         bitmapSource = _canvasElement! as JSObject;
-        bitmap = await createImageBitmap(bitmapSource, (
-          x: 0,
-          y: _pixelHeight - bitmapSize.height,
-          width: bitmapSize.width,
-          height: bitmapSize.height,
-        ));
       }
+      // TODO(harryterkelsen): Switch to using `transferToImageBitmap` once
+      // Chrome issues with it have been resolved, https://github.com/flutter/flutter/issues/163775.
+      final DomImageBitmap bitmap = await createImageBitmap(bitmapSource, (
+        x: 0,
+        y: _pixelHeight - bitmapSize.height,
+        width: bitmapSize.width,
+        height: bitmapSize.height,
+      ));
       canvas.render(bitmap);
     } else {
       // If the browser doesn't support `createImageBitmap` (e.g. Safari 14)

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/surface_test.dart
@@ -12,6 +12,10 @@ import 'package:ui/ui.dart' as ui;
 
 import 'common.dart';
 
+/// Remove this and unskip the test it is blocking once
+/// https://github.com/flutter/flutter/issues/163775 is resolved.
+const bool isIssue163775Resolved = false;
+
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
@@ -320,7 +324,8 @@ void testMain() {
       final CkPicture picture = recorder.endRecording();
       await surface.rasterizeToCanvas(const BitmapSize(10, 10), renderCanvas, <CkPicture>[picture]);
       expect(transferToImageBitmapCalls, 1);
-    }, skip: !Surface.offscreenCanvasSupported);
+      // Skip this until the issues with `transferToImageBitmap` are resolved
+    }, skip: !isIssue163775Resolved);
 
     test('throws error if CanvasKit.MakeGrContext returns null', () async {
       final Object originalMakeGrContext = js_util.getProperty(canvasKit, 'MakeGrContext');


### PR DESCRIPTION
Reverts back to using `createImageBitmap` since after switching to `transferToImageBitmap` we received error reports.

See https://github.com/flutter/flutter/issues/163775 for more context.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
