### PR TITLE
Move `AndroidRenderingApi` from `common` to `shell/platform/android`

### DIFF
--- a/engine/src/flutter/common/settings.h
+++ b/engine/src/flutter/common/settings.h
@@ -7,7 +7,6 @@
 
 #include <fcntl.h>
 
-#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -21,14 +20,6 @@
 #include "flutter/fml/unique_fd.h"
 
 namespace flutter {
-
-// The combination of targeted graphics API and Impeller support.
-enum class AndroidRenderingAPI {
-  kSoftware,
-  kImpellerOpenGLES,
-  kImpellerVulkan,
-  kSkiaOpenGLES
-};
 
 class FrameTiming {
  public:
@@ -239,10 +230,6 @@ struct Settings {
 
   // Log a warning during shell initialization if Impeller is not enabled.
   bool warn_on_impeller_opt_out = false;
-
-  // The selected Android rendering API.
-  AndroidRenderingAPI android_rendering_api =
-      AndroidRenderingAPI::kSkiaOpenGLES;
 
   // Requests a specific rendering backend.
   std::optional<std::string> requested_rendering_backend;

--- a/engine/src/flutter/shell/platform/android/android_context_vk_impeller.h
+++ b/engine/src/flutter/shell/platform/android/android_context_vk_impeller.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_CONTEXT_VK_IMPELLER_H_
 #define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_CONTEXT_VK_IMPELLER_H_
 
-#include "flutter/fml/concurrent_message_loop.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/native_library.h"
 #include "flutter/shell/platform/android/context/android_context.h"

--- a/engine/src/flutter/shell/platform/android/android_rendering_selector.h
+++ b/engine/src/flutter/shell/platform/android/android_rendering_selector.h
@@ -15,6 +15,6 @@ enum class AndroidRenderingAPI {
   kSkiaOpenGLES
 };
 
-} // namespace flutter
+}  // namespace flutter
 
 #endif  // FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_RENDERING_SELECTOR_H_

--- a/engine/src/flutter/shell/platform/android/android_rendering_selector.h
+++ b/engine/src/flutter/shell/platform/android/android_rendering_selector.h
@@ -1,0 +1,20 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_RENDERING_SELECTOR_H_
+#define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_RENDERING_SELECTOR_H_
+
+namespace flutter {
+
+// The combination of targeted graphics API and Impeller support.
+enum class AndroidRenderingAPI {
+  kSoftware,
+  kImpellerOpenGLES,
+  kImpellerVulkan,
+  kSkiaOpenGLES
+};
+
+} // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_RENDERING_SELECTOR_H_

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.cc
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.cc
@@ -23,8 +23,8 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/platform/android/android_display.h"
 #include "flutter/shell/platform/android/android_image_generator.h"
-#include "flutter/shell/platform/android/android_shell_holder.h"
 #include "flutter/shell/platform/android/android_rendering_selector.h"
+#include "flutter/shell/platform/android/android_shell_holder.h"
 #include "flutter/shell/platform/android/context/android_context.h"
 #include "flutter/shell/platform/android/platform_view_android.h"
 

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.cc
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.cc
@@ -4,8 +4,6 @@
 
 #define FML_USED_ON_EMBEDDER
 
-#include "flutter/shell/platform/android/android_shell_holder.h"
-
 #include <pthread.h>
 #include <sys/resource.h>
 #include <sys/time.h>
@@ -25,6 +23,8 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/platform/android/android_display.h"
 #include "flutter/shell/platform/android/android_image_generator.h"
+#include "flutter/shell/platform/android/android_shell_holder.h"
+#include "flutter/shell/platform/android/android_rendering_selector.h"
 #include "flutter/shell/platform/android/context/android_context.h"
 #include "flutter/shell/platform/android/platform_view_android.h"
 
@@ -81,8 +81,11 @@ static PlatformData GetDefaultPlatformData() {
 
 AndroidShellHolder::AndroidShellHolder(
     const flutter::Settings& settings,
-    std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
-    : settings_(settings), jni_facade_(jni_facade) {
+    std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
+    AndroidRenderingAPI android_rendering_api)
+    : settings_(settings),
+      jni_facade_(jni_facade),
+      android_rendering_api_(android_rendering_api) {
   static size_t thread_host_count = 1;
   auto thread_label = std::to_string(thread_host_count++);
 

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.h
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.h
@@ -38,7 +38,8 @@ namespace flutter {
 class AndroidShellHolder {
  public:
   AndroidShellHolder(const flutter::Settings& settings,
-                     std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
+                     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
+                     AndroidRenderingAPI android_rendering_api);
 
   ~AndroidShellHolder();
 
@@ -115,7 +116,7 @@ class AndroidShellHolder {
   bool is_valid_ = false;
   uint64_t next_pointer_flow_id_ = 0;
   std::unique_ptr<APKAssetProvider> apk_asset_provider_;
-  AndroidRenderingAPI android_rendering_api_;
+  const AndroidRenderingAPI android_rendering_api_;
 
   //----------------------------------------------------------------------------
   /// @brief      Constructor with its components injected.

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.h
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.h
@@ -7,17 +7,13 @@
 
 #include <memory>
 
-#include "flutter/assets/asset_manager.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/unique_fd.h"
-#include "flutter/lib/ui/window/viewport_metrics.h"
-#include "flutter/runtime/platform_data.h"
 #include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/thread_host.h"
+#include "flutter/shell/platform/android/android_rendering_selector.h"
 #include "flutter/shell/platform/android/apk_asset_provider.h"
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
-#include "flutter/shell/platform/android/platform_message_handler_android.h"
 #include "flutter/shell/platform/android/platform_view_android.h"
 
 namespace flutter {
@@ -119,6 +115,7 @@ class AndroidShellHolder {
   bool is_valid_ = false;
   uint64_t next_pointer_flow_id_ = 0;
   std::unique_ptr<APKAssetProvider> apk_asset_provider_;
+  AndroidRenderingAPI android_rendering_api_;
 
   //----------------------------------------------------------------------------
   /// @brief      Constructor with its components injected.
@@ -136,7 +133,8 @@ class AndroidShellHolder {
                      const std::shared_ptr<ThreadHost>& thread_host,
                      std::unique_ptr<Shell> shell,
                      std::unique_ptr<APKAssetProvider> apk_asset_provider,
-                     const fml::WeakPtr<PlatformViewAndroid>& platform_view);
+                     const fml::WeakPtr<PlatformViewAndroid>& platform_view,
+                     AndroidRenderingAPI rendering_api);
   static void ThreadDestructCallback(void* value);
   std::optional<RunConfiguration> BuildRunConfiguration(
       const std::string& entrypoint,

--- a/engine/src/flutter/shell/platform/android/android_shell_holder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder_unittests.cc
@@ -145,7 +145,8 @@ TEST(AndroidShellHolder, Create) {
   Settings settings;
   settings.enable_software_rendering = false;
   auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
-  auto holder = std::make_unique<AndroidShellHolder>(settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
+  auto holder = std::make_unique<AndroidShellHolder>(
+      settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
   EXPECT_NE(holder.get(), nullptr);
   EXPECT_TRUE(holder->IsValid());
   EXPECT_NE(holder->GetPlatformView().get(), nullptr);
@@ -158,7 +159,8 @@ TEST(AndroidShellHolder, HandlePlatformMessage) {
   Settings settings;
   settings.enable_software_rendering = false;
   auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
-  auto holder = std::make_unique<AndroidShellHolder>(settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
+  auto holder = std::make_unique<AndroidShellHolder>(
+      settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
   EXPECT_NE(holder.get(), nullptr);
   EXPECT_TRUE(holder->IsValid());
   EXPECT_NE(holder->GetPlatformView().get(), nullptr);
@@ -186,7 +188,8 @@ TEST(AndroidShellHolder, HandlePlatformMessage) {
 TEST(AndroidShellHolder, CreateWithMergedPlatformAndUIThread) {
   Settings settings;
   auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
-  auto holder = std::make_unique<AndroidShellHolder>(settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
+  auto holder = std::make_unique<AndroidShellHolder>(
+      settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(
       nullptr, /*is_fake_window=*/true);
   holder->GetPlatformView()->NotifyCreated(window);
@@ -200,7 +203,8 @@ TEST(AndroidShellHolder, CreateWithUnMergedPlatformAndUIThread) {
   Settings settings;
   settings.merged_platform_ui_thread = false;
   auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
-  auto holder = std::make_unique<AndroidShellHolder>(settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
+  auto holder = std::make_unique<AndroidShellHolder>(
+      settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(
       nullptr, /*is_fake_window=*/true);
   holder->GetPlatformView()->NotifyCreated(window);

--- a/engine/src/flutter/shell/platform/android/android_shell_holder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder_unittests.cc
@@ -145,7 +145,7 @@ TEST(AndroidShellHolder, Create) {
   Settings settings;
   settings.enable_software_rendering = false;
   auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
-  auto holder = std::make_unique<AndroidShellHolder>(settings, jni);
+  auto holder = std::make_unique<AndroidShellHolder>(settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
   EXPECT_NE(holder.get(), nullptr);
   EXPECT_TRUE(holder->IsValid());
   EXPECT_NE(holder->GetPlatformView().get(), nullptr);
@@ -158,7 +158,7 @@ TEST(AndroidShellHolder, HandlePlatformMessage) {
   Settings settings;
   settings.enable_software_rendering = false;
   auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
-  auto holder = std::make_unique<AndroidShellHolder>(settings, jni);
+  auto holder = std::make_unique<AndroidShellHolder>(settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
   EXPECT_NE(holder.get(), nullptr);
   EXPECT_TRUE(holder->IsValid());
   EXPECT_NE(holder->GetPlatformView().get(), nullptr);
@@ -186,7 +186,7 @@ TEST(AndroidShellHolder, HandlePlatformMessage) {
 TEST(AndroidShellHolder, CreateWithMergedPlatformAndUIThread) {
   Settings settings;
   auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
-  auto holder = std::make_unique<AndroidShellHolder>(settings, jni);
+  auto holder = std::make_unique<AndroidShellHolder>(settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(
       nullptr, /*is_fake_window=*/true);
   holder->GetPlatformView()->NotifyCreated(window);
@@ -200,7 +200,7 @@ TEST(AndroidShellHolder, CreateWithUnMergedPlatformAndUIThread) {
   Settings settings;
   settings.merged_platform_ui_thread = false;
   auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
-  auto holder = std::make_unique<AndroidShellHolder>(settings, jni);
+  auto holder = std::make_unique<AndroidShellHolder>(settings, jni, AndroidRenderingAPI::kImpellerOpenGLES);
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(
       nullptr, /*is_fake_window=*/true);
   holder->GetPlatformView()->NotifyCreated(window);

--- a/engine/src/flutter/shell/platform/android/context/android_context.h
+++ b/engine/src/flutter/shell/platform/android/context/android_context.h
@@ -5,10 +5,9 @@
 #ifndef FLUTTER_SHELL_PLATFORM_ANDROID_CONTEXT_ANDROID_CONTEXT_H_
 #define FLUTTER_SHELL_PLATFORM_ANDROID_CONTEXT_ANDROID_CONTEXT_H_
 
-#include "common/settings.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/task_runner.h"
 #include "flutter/impeller/renderer/context.h"
+#include "flutter/shell/platform/android/android_rendering_selector.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 
 namespace flutter {

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "shell/platform/android/android_rendering_selector.h"
 #define FML_USED_ON_EMBEDDER
 
 #include <android/log.h>
@@ -15,22 +16,17 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/logging.h"
-#include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop.h"
-#include "flutter/fml/native_library.h"
-#include "flutter/fml/paths.h"
 #include "flutter/fml/platform/android/jni_util.h"
 #include "flutter/fml/platform/android/paths_android.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
 #include "flutter/runtime/dart_vm.h"
-#include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/android/android_context_vk_impeller.h"
 #include "flutter/shell/platform/android/context/android_context.h"
 #include "flutter/shell/platform/android/flutter_main.h"
 #include "impeller/base/validation.h"
 #include "impeller/toolkit/android/proc_table.h"
-#include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "txt/platform.h"
 
 namespace flutter {
@@ -116,8 +112,7 @@ void FlutterMain::Init(JNIEnv* env,
     }
   }
 
-  settings.android_rendering_api = SelectedRenderingAPI(settings);
-  switch (settings.android_rendering_api) {
+  switch (SelectedRenderingAPI(settings)) {
     case AndroidRenderingAPI::kSoftware:
     case AndroidRenderingAPI::kSkiaOpenGLES:
       settings.enable_impeller = false;

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -64,8 +64,9 @@ static constexpr const char* kBLC[] = {
 
 }  // anonymous namespace
 
-FlutterMain::FlutterMain(const flutter::Settings& settings)
-    : settings_(settings) {}
+FlutterMain::FlutterMain(const flutter::Settings& settings,
+                         flutter::AndroidRenderingAPI android_rendering_api)
+    : settings_(settings), android_rendering_api_(android_rendering_api) {}
 
 FlutterMain::~FlutterMain() = default;
 
@@ -116,8 +117,8 @@ void FlutterMain::Init(JNIEnv* env,
     }
   }
 
-  selected_rendering_api_ = SelectedRenderingAPI(settings);
-  switch (selected_rendering_api_ ) {
+  AndroidRenderingAPI android_rendering_api = SelectedRenderingAPI(settings);
+  switch (android_rendering_api) {
     case AndroidRenderingAPI::kSoftware:
     case AndroidRenderingAPI::kSkiaOpenGLES:
       settings.enable_impeller = false;
@@ -187,8 +188,7 @@ void FlutterMain::Init(JNIEnv* env,
 
   // Not thread safe. Will be removed when FlutterMain is refactored to no
   // longer be a singleton.
-  g_flutter_main.reset(new FlutterMain(settings));
-
+  g_flutter_main.reset(new FlutterMain(settings, android_rendering_api));
   g_flutter_main->SetupDartVMServiceUriCallback(env);
 }
 

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -81,6 +81,10 @@ const flutter::Settings& FlutterMain::GetSettings() const {
   return settings_;
 }
 
+flutter::AndroidRenderingAPI FlutterMain::GetAndroidRenderingAPI() {
+  return android_rendering_api_;
+}
+
 void FlutterMain::Init(JNIEnv* env,
                        jclass clazz,
                        jobject context,

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -116,7 +116,8 @@ void FlutterMain::Init(JNIEnv* env,
     }
   }
 
-  switch (SelectedRenderingAPI(settings)) {
+  selected_rendering_api_ = SelectedRenderingAPI(settings);
+  switch (selected_rendering_api_ ) {
     case AndroidRenderingAPI::kSoftware:
     case AndroidRenderingAPI::kSkiaOpenGLES:
       settings.enable_impeller = false;

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "shell/platform/android/android_rendering_selector.h"
 #define FML_USED_ON_EMBEDDER
 
 #include <android/log.h>
@@ -23,6 +22,7 @@
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/android/android_context_vk_impeller.h"
+#include "flutter/shell/platform/android/android_rendering_selector.h"
 #include "flutter/shell/platform/android/context/android_context.h"
 #include "flutter/shell/platform/android/flutter_main.h"
 #include "impeller/base/validation.h"

--- a/engine/src/flutter/shell/platform/android/flutter_main.h
+++ b/engine/src/flutter/shell/platform/android/flutter_main.h
@@ -10,6 +10,7 @@
 #include "flutter/common/settings.h"
 #include "flutter/fml/macros.h"
 #include "flutter/runtime/dart_service_isolate.h"
+#include "flutter/shell/platform/android/android_rendering_selector.h"
 
 namespace flutter {
 

--- a/engine/src/flutter/shell/platform/android/flutter_main.h
+++ b/engine/src/flutter/shell/platform/android/flutter_main.h
@@ -34,10 +34,11 @@ class FlutterMain {
 
  private:
   const flutter::Settings settings_;
-  flutter::AndroidRenderingAPI android_rendering_api_;
+  const flutter::AndroidRenderingAPI android_rendering_api_;
   DartServiceIsolate::CallbackHandle vm_service_uri_callback_ = 0;
 
-  explicit FlutterMain(const flutter::Settings& settings);
+  explicit FlutterMain(const flutter::Settings& settings,
+                       flutter::AndroidRenderingAPI android_rendering_api);
 
   static void Init(JNIEnv* env,
                    jclass clazz,

--- a/engine/src/flutter/shell/platform/android/flutter_main.h
+++ b/engine/src/flutter/shell/platform/android/flutter_main.h
@@ -23,6 +23,7 @@ class FlutterMain {
   static FlutterMain& Get();
 
   const flutter::Settings& GetSettings() const;
+  flutter::AndroidRenderingAPI GetAndroidRenderingAPI();
 
   static AndroidRenderingAPI SelectedRenderingAPI(
       const flutter::Settings& settings);
@@ -33,6 +34,7 @@ class FlutterMain {
 
  private:
   const flutter::Settings settings_;
+  flutter::AndroidRenderingAPI android_rendering_api_;
   DartServiceIsolate::CallbackHandle vm_service_uri_callback_ = 0;
 
   explicit FlutterMain(const flutter::Settings& settings);

--- a/engine/src/flutter/shell/platform/android/jni/platform_view_android_jni.h
+++ b/engine/src/flutter/shell/platform/android/jni/platform_view_android_jni.h
@@ -7,13 +7,11 @@
 
 #include <utility>
 
-#include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
 
 #include "flutter/flow/embedded_views.h"
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/shell/platform/android/surface/android_native_window.h"
-#include "third_party/skia/include/core/SkMatrix.h"
 
 #if FML_OS_ANDROID
 #include "flutter/fml/platform/android/scoped_java_ref.h"

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -80,7 +80,6 @@ std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
 }
 
 static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
-    bool use_software_rendering,
     const flutter::TaskRunners& task_runners,
     AndroidRenderingAPI android_rendering_api,
     bool enable_opengl_gpu_tracing,
@@ -113,7 +112,6 @@ PlatformViewAndroid::PlatformViewAndroid(
           task_runners,
           jni_facade,
           CreateAndroidContext(
-              rendering_api == AndroidRenderingAPI::kSoftware,
               task_runners,
               rendering_api,
               delegate.OnPlatformViewGetSettings().enable_opengl_gpu_tracing,

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -16,6 +16,7 @@
 #include "flutter/shell/platform/android/android_context_gl_impeller.h"
 #include "flutter/shell/platform/android/android_context_gl_skia.h"
 #include "flutter/shell/platform/android/android_context_vk_impeller.h"
+#include "flutter/shell/platform/android/android_rendering_selector.h"
 #include "flutter/shell/platform/android/android_surface_gl_impeller.h"
 #include "flutter/shell/platform/android/android_surface_gl_skia.h"
 #include "flutter/shell/platform/android/android_surface_software.h"
@@ -106,15 +107,15 @@ PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,
     const flutter::TaskRunners& task_runners,
     const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade,
-    bool use_software_rendering)
+    AndroidRenderingAPI rendering_api)
     : PlatformViewAndroid(
           delegate,
           task_runners,
           jni_facade,
           CreateAndroidContext(
-              use_software_rendering,
+              rendering_api == AndroidRenderingAPI::kSoftware,
               task_runners,
-              delegate.OnPlatformViewGetSettings().android_rendering_api,
+              rendering_api,
               delegate.OnPlatformViewGetSettings().enable_opengl_gpu_tracing,
               CreateContextSettings(delegate.OnPlatformViewGetSettings()))) {}
 

--- a/engine/src/flutter/shell/platform/android/platform_view_android.h
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.h
@@ -7,11 +7,9 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <android/hardware_buffer_jni.h>
-#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/shell/common/platform_view.h"
@@ -46,7 +44,7 @@ class PlatformViewAndroid final : public PlatformView {
   PlatformViewAndroid(PlatformView::Delegate& delegate,
                       const flutter::TaskRunners& task_runners,
                       const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade,
-                      bool use_software_rendering);
+                      AndroidRenderingAPI rendering_api);
 
   //----------------------------------------------------------------------------
   /// @brief      Creates a new PlatformViewAndroid but using an existing

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -20,16 +20,13 @@
 #include "flutter/fml/platform/android/jni_util.h"
 #include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
+#include "flutter/impeller/toolkit/android/proc_table.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
-#include "flutter/runtime/dart_service_isolate.h"
-#include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/platform/android/android_shell_holder.h"
 #include "flutter/shell/platform/android/apk_asset_provider.h"
 #include "flutter/shell/platform/android/flutter_main.h"
-#include "flutter/shell/platform/android/image_external_texture_gl.h"
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
 #include "flutter/shell/platform/android/platform_view_android.h"
-#include "impeller/toolkit/android/proc_table.h"
 
 #define ANDROID_SHELL_HOLDER \
   (reinterpret_cast<AndroidShellHolder*>(shell_holder))

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -166,7 +166,8 @@ static jlong AttachJNI(JNIEnv* env, jclass clazz, jobject flutterJNI) {
   std::shared_ptr<PlatformViewAndroidJNI> jni_facade =
       std::make_shared<PlatformViewAndroidJNIImpl>(java_object);
   auto shell_holder = std::make_unique<AndroidShellHolder>(
-      FlutterMain::Get().GetSettings(), jni_facade);
+      FlutterMain::Get().GetSettings(), jni_facade,
+      FlutterMain::Get().GetAndroidRenderingAPI());
   if (shell_holder->IsValid()) {
     return reinterpret_cast<jlong>(shell_holder.release());
   } else {


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/163792.

Major changes:

- `enum class AndroidRenderingAPI` physically moves to `shell/platform/android`
- Store in `FlutterMain` (as a result of `::init`), instead of in `Settings`