### PR TITLE
Shorten method signature to make invokations fit one line.

### DIFF
--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -379,9 +379,7 @@ class ReverseAnimation extends Animation<double>
 class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<double> {
   /// Creates a curved animation.
   CurvedAnimation({required this.parent, required this.curve, this.reverseCurve}) {
-    assert(
-      debugMaybeDispatchObjectCreated('package:flutter/animation.dart', 'CurvedAnimation', this),
-    );
+    assert(debugMaybeDispatchCreated('animation', 'CurvedAnimation', this));
     _updateCurveDirection(parent.status);
     parent.addStatusListener(_updateCurveDirection);
   }
@@ -428,7 +426,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
 
   /// Cleans up any listeners added by this CurvedAnimation.
   void dispose() {
-    assert(debugMaybeDispatchObjectDisposed(this));
+    assert(debugMaybeDispatchDisposed(this));
     isDisposed = true;
     parent.removeStatusListener(_updateCurveDirection);
   }

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -143,10 +143,10 @@ String? connectedVmServiceUri;
 /// Should be called only from within an assert.
 ///
 /// Returns true to make it easier to be wrapped into `assert`.
-bool debugMaybeDispatchObjectCreated(String library, String className, Object object) {
+bool debugMaybeDispatchCreated(String flutterLibrary, String className, Object object) {
   if (kFlutterMemoryAllocationsEnabled) {
     FlutterMemoryAllocations.instance.dispatchObjectCreated(
-      library: library,
+      library: 'package:flutter/$flutterLibrary.dart',
       className: className,
       object: object,
     );
@@ -159,7 +159,7 @@ bool debugMaybeDispatchObjectCreated(String library, String className, Object ob
 /// Should be called only from within an assert.
 ///
 /// Returns true to make it easier to be wrapped into `assert`.
-bool debugMaybeDispatchObjectDisposed(Object object) {
+bool debugMaybeDispatchDisposed(Object object) {
   if (kFlutterMemoryAllocationsEnabled) {
     FlutterMemoryAllocations.instance.dispatchObjectDisposed(object: object);
   }

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -134,15 +134,16 @@ String? activeDevToolsServerAddress;
 /// The uri for the connected vm service protocol.
 String? connectedVmServiceUri;
 
-/// If memory allocation tracking is enabled, dispatch object creation.
+/// If memory allocation tracking is enabled, dispatch Flutter object creation.
 ///
 /// This method is not member of FlutterMemoryAllocations, because
 /// [FlutterMemoryAllocations] should not increase size of the Flutter application
 /// if memory allocations are disabled.
 ///
-/// [flutterLibrary] is the name of the Flutter library where the object is declared.
+/// The [flutterLibrary] argument is the name of the Flutter library where
+/// the object is declared. For example, 'widgets' for widgets.dart.
 ///
-/// Should be called only from within an assert.
+/// Should be called only from within an assert and only inside Flutter Framework.
 ///
 /// Returns true to make it easier to be wrapped into `assert`.
 bool debugMaybeDispatchCreated(String flutterLibrary, String className, Object object) {

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -140,6 +140,8 @@ String? connectedVmServiceUri;
 /// [FlutterMemoryAllocations] should not increase size of the Flutter application
 /// if memory allocations are disabled.
 ///
+/// [flutterLibrary] is the name of the Flutter library where the object is declared.
+///
 /// Should be called only from within an assert.
 ///
 /// Returns true to make it easier to be wrapped into `assert`.

--- a/packages/flutter/test/foundation/debug_test.dart
+++ b/packages/flutter/test/foundation/debug_test.dart
@@ -66,8 +66,8 @@ void main() {
       FlutterMemoryAllocations.instance.removeListener(listener);
     });
 
-    test('debugMaybeDispatchObjectCreated', () async {
-      debugMaybeDispatchObjectCreated('library', 'class', object);
+    test('debugMaybeDispatchCreated', () async {
+      debugMaybeDispatchCreated('library', 'class', object);
 
       if (kFlutterMemoryAllocationsEnabled) {
         final ObjectEvent? theEvent = dispatchedEvent;
@@ -77,15 +77,15 @@ void main() {
         }
 
         expect(theEvent.object, object);
-        expect(theEvent.library, 'library');
+        expect(theEvent.library, 'package:flutter/library.dart');
         expect(theEvent.className, 'class');
       } else {
         expect(dispatchedEvent, isNull);
       }
     });
 
-    test('debugMaybeDispatchObjectDisposed', () async {
-      debugMaybeDispatchObjectDisposed(object);
+    test('debugMaybeDispatchDisposed', () async {
+      debugMaybeDispatchDisposed(object);
 
       if (kFlutterMemoryAllocationsEnabled) {
         final ObjectEvent? theEvent = dispatchedEvent;


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/137435.