### PR TITLE
[engine] keeps AiksContext initialized.

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/content_context.cc
+++ b/engine/src/flutter/impeller/entity/contents/content_context.cc
@@ -283,19 +283,6 @@ ContentContext::ContentContext(
     desc.format = PixelFormat::kR8G8B8A8UNormInt;
     desc.size = ISize{1, 1};
     empty_texture_ = GetContext()->GetResourceAllocator()->CreateTexture(desc);
-    auto data = Color::BlackTransparent().ToR8G8B8A8();
-    auto cmd_buffer = GetContext()->CreateCommandBuffer();
-    auto blit_pass = cmd_buffer->CreateBlitPass();
-    auto& host_buffer = GetTransientsBuffer();
-    auto buffer_view = host_buffer.Emplace(data);
-    blit_pass->AddCopy(buffer_view, empty_texture_);
-
-    if (!blit_pass->EncodeCommands() || !GetContext()
-                                             ->GetCommandQueue()
-                                             ->Submit({std::move(cmd_buffer)})
-                                             .ok()) {
-      VALIDATION_LOG << "Failed to create empty texture.";
-    }
   }
 
   auto options = ContentContextOptions{

--- a/engine/src/flutter/impeller/entity/contents/content_context.cc
+++ b/engine/src/flutter/impeller/entity/contents/content_context.cc
@@ -283,6 +283,20 @@ ContentContext::ContentContext(
     desc.format = PixelFormat::kR8G8B8A8UNormInt;
     desc.size = ISize{1, 1};
     empty_texture_ = GetContext()->GetResourceAllocator()->CreateTexture(desc);
+
+    auto data = Color::BlackTransparent().ToR8G8B8A8();
+    auto cmd_buffer = GetContext()->CreateCommandBuffer();
+    auto blit_pass = cmd_buffer->CreateBlitPass();
+    auto& host_buffer = GetTransientsBuffer();
+    auto buffer_view = host_buffer.Emplace(data);
+    blit_pass->AddCopy(buffer_view, empty_texture_);
+
+    if (!blit_pass->EncodeCommands() || !GetContext()
+                                             ->GetCommandQueue()
+                                             ->Submit({std::move(cmd_buffer)})
+                                             .ok()) {
+      VALIDATION_LOG << "Failed to create empty texture.";
+    }
   }
 
   auto options = ContentContextOptions{

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -415,17 +415,14 @@ TypographerContextSkia::CollectNewGlyphs(
   std::vector<FontGlyphPair> new_glyphs;
   std::vector<Rect> glyph_sizes;
   size_t generation_id = atlas->GetAtlasGeneration();
-  intptr_t atlas_id = reinterpret_cast<intptr_t>(atlas.get());
   for (const auto& frame : text_frames) {
-    auto [frame_generation_id, frame_atlas_id] =
-        frame->GetAtlasGenerationAndID();
     if (atlas->IsValid() && frame->IsFrameComplete() &&
-        frame_generation_id == generation_id && frame_atlas_id == atlas_id &&
+        frame->GetAtlasGeneration() == generation_id &&
         !frame->GetFrameBounds(0).is_placeholder) {
       continue;
     }
     frame->ClearFrameBounds();
-    frame->SetAtlasGeneration(generation_id, atlas_id);
+    frame->SetAtlasGeneration(generation_id);
 
     for (const auto& run : frame->GetRuns()) {
       auto metrics = run.GetFont().GetMetrics();

--- a/engine/src/flutter/impeller/typographer/text_frame.cc
+++ b/engine/src/flutter/impeller/typographer/text_frame.cc
@@ -146,13 +146,12 @@ const FrameBounds& TextFrame::GetFrameBounds(size_t index) const {
   return bound_values_[index];
 }
 
-std::pair<size_t, intptr_t> TextFrame::GetAtlasGenerationAndID() const {
-  return std::make_pair(generation_, atlas_id_);
+size_t TextFrame::GetAtlasGeneration() const {
+  return generation_;
 }
 
-void TextFrame::SetAtlasGeneration(size_t value, intptr_t atlas_id) {
+void TextFrame::SetAtlasGeneration(size_t value) {
   generation_ = value;
-  atlas_id_ = atlas_id;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/typographer/text_frame.h
+++ b/engine/src/flutter/impeller/typographer/text_frame.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_IMPELLER_TYPOGRAPHER_TEXT_FRAME_H_
 #define FLUTTER_IMPELLER_TYPOGRAPHER_TEXT_FRAME_H_
 
-#include <cstdint>
 #include "impeller/typographer/glyph_atlas.h"
 #include "impeller/typographer/text_run.h"
 
@@ -89,7 +88,7 @@ class TextFrame {
   // with. As long as the frame generation matches the atlas generation,
   // the contents are guaranteed to be populated and do not need to be
   // processed.
-  std::pair<size_t, intptr_t> GetAtlasGenerationAndID() const;
+  size_t GetAtlasGeneration() const;
 
   TextFrame& operator=(TextFrame&& other) = default;
 
@@ -111,7 +110,7 @@ class TextFrame {
 
   void ClearFrameBounds();
 
-  void SetAtlasGeneration(size_t value, intptr_t atlas_id);
+  void SetAtlasGeneration(size_t value);
 
   std::vector<TextRun> runs_;
   Rect bounds_;
@@ -122,7 +121,6 @@ class TextFrame {
   std::vector<FrameBounds> bound_values_;
   Scalar scale_ = 0;
   size_t generation_ = 0;
-  intptr_t atlas_id_ = 0;
   Point offset_;
   std::optional<GlyphProperties> properties_;
   Matrix transform_;

--- a/engine/src/flutter/impeller/typographer/typographer_unittests.cc
+++ b/engine/src/flutter/impeller/typographer/typographer_unittests.cc
@@ -585,9 +585,9 @@ TEST_P(TypographerTest, TextFrameAtlasGenerationTracksState) {
   EXPECT_TRUE(frame->GetFrameBounds(0).is_placeholder);
   if (GetBackend() == PlaygroundBackend::kOpenGLES) {
     // OpenGLES must always increase the atlas backend if the texture grows.
-    EXPECT_EQ(frame->GetAtlasGenerationAndID().first, 1u);
+    EXPECT_EQ(frame->GetAtlasGeneration(), 1u);
   } else {
-    EXPECT_EQ(frame->GetAtlasGenerationAndID().first, 0u);
+    EXPECT_EQ(frame->GetAtlasGeneration(), 0u);
   }
 
   atlas = CreateGlyphAtlas(*GetContext(), context.get(), *host_buffer,
@@ -598,9 +598,9 @@ TEST_P(TypographerTest, TextFrameAtlasGenerationTracksState) {
   EXPECT_TRUE(frame->IsFrameComplete());
   EXPECT_FALSE(frame->GetFrameBounds(0).is_placeholder);
   if (GetBackend() == PlaygroundBackend::kOpenGLES) {
-    EXPECT_EQ(frame->GetAtlasGenerationAndID().first, 1u);
+    EXPECT_EQ(frame->GetAtlasGeneration(), 1u);
   } else {
-    EXPECT_EQ(frame->GetAtlasGenerationAndID().first, 0u);
+    EXPECT_EQ(frame->GetAtlasGeneration(), 0u);
   }
 
   // Force increase the generation.
@@ -609,7 +609,7 @@ TEST_P(TypographerTest, TextFrameAtlasGenerationTracksState) {
                            GlyphAtlas::Type::kAlphaBitmap, /*scale=*/1.0f,
                            atlas_context, frame);
 
-  EXPECT_EQ(frame->GetAtlasGenerationAndID().first, 2u);
+  EXPECT_EQ(frame->GetAtlasGeneration(), 2u);
 }
 
 TEST_P(TypographerTest, InvalidAtlasForcesRepopulation) {
@@ -637,9 +637,9 @@ TEST_P(TypographerTest, InvalidAtlasForcesRepopulation) {
   EXPECT_TRUE(frame->GetFrameBounds(0).is_placeholder);
   if (GetBackend() == PlaygroundBackend::kOpenGLES) {
     // OpenGLES must always increase the atlas backend if the texture grows.
-    EXPECT_EQ(frame->GetAtlasGenerationAndID().first, 1u);
+    EXPECT_EQ(frame->GetAtlasGeneration(), 1u);
   } else {
-    EXPECT_EQ(frame->GetAtlasGenerationAndID().first, 0u);
+    EXPECT_EQ(frame->GetAtlasGeneration(), 0u);
   }
 
   auto second_context = TypographerContextSkia::Make();

--- a/engine/src/flutter/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_gl_impeller.cc
@@ -15,6 +15,7 @@ namespace flutter {
 GPUSurfaceGLImpeller::GPUSurfaceGLImpeller(
     GPUSurfaceGLDelegate* delegate,
     std::shared_ptr<impeller::Context> context,
+    std::shared_ptr<impeller::AiksContext> aiks_context,
     bool render_to_surface)
     : weak_factory_(this) {
   if (delegate == nullptr) {
@@ -24,9 +25,6 @@ GPUSurfaceGLImpeller::GPUSurfaceGLImpeller(
   if (!context || !context->IsValid()) {
     return;
   }
-
-  auto aiks_context = std::make_shared<impeller::AiksContext>(
-      context, impeller::TypographerContextSkia::Make());
 
   if (!aiks_context->IsValid()) {
     return;

--- a/engine/src/flutter/shell/gpu/gpu_surface_gl_impeller.h
+++ b/engine/src/flutter/shell/gpu/gpu_surface_gl_impeller.h
@@ -17,9 +17,11 @@ namespace flutter {
 
 class GPUSurfaceGLImpeller final : public Surface {
  public:
-  explicit GPUSurfaceGLImpeller(GPUSurfaceGLDelegate* delegate,
-                                std::shared_ptr<impeller::Context> context,
-                                bool render_to_surface);
+  explicit GPUSurfaceGLImpeller(
+      GPUSurfaceGLDelegate* delegate,
+      std::shared_ptr<impeller::Context> context,
+      std::shared_ptr<impeller::AiksContext> aiks_context,
+      bool render_to_surface);
 
   // |Surface|
   ~GPUSurfaceGLImpeller() override;

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -18,7 +18,6 @@
 #include "impeller/renderer/backend/vulkan/swapchain/surface_vk.h"
 #include "impeller/renderer/render_target.h"
 #include "impeller/renderer/surface.h"
-#include "impeller/typographer/backends/skia/typographer_context_skia.h"
 
 namespace flutter {
 
@@ -48,15 +47,10 @@ class WrappedTextureSourceVK : public impeller::TextureSourceVK {
 
 GPUSurfaceVulkanImpeller::GPUSurfaceVulkanImpeller(
     GPUSurfaceVulkanDelegate* delegate,
-    std::shared_ptr<impeller::Context> context)
+    std::shared_ptr<impeller::Context> context,
+    std::shared_ptr<impeller::AiksContext> aiks_context)
     : delegate_(delegate) {
   if (!context || !context->IsValid()) {
-    return;
-  }
-
-  auto aiks_context = std::make_shared<impeller::AiksContext>(
-      context, impeller::TypographerContextSkia::Make());
-  if (!aiks_context->IsValid()) {
     return;
   }
 

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
@@ -18,8 +18,10 @@ namespace flutter {
 
 class GPUSurfaceVulkanImpeller final : public Surface {
  public:
-  explicit GPUSurfaceVulkanImpeller(GPUSurfaceVulkanDelegate* delegate,
-                                    std::shared_ptr<impeller::Context> context);
+  explicit GPUSurfaceVulkanImpeller(
+      GPUSurfaceVulkanDelegate* delegate,
+      std::shared_ptr<impeller::Context> context,
+      std::shared_ptr<impeller::AiksContext> aiks_context);
 
   // |Surface|
   ~GPUSurfaceVulkanImpeller() override;

--- a/engine/src/flutter/shell/platform/android/android_context_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_gl_impeller.cc
@@ -13,6 +13,7 @@
 #include "impeller/entity/gles/framebuffer_blend_shaders_gles.h"
 #include "impeller/entity/gles3/entity_shaders_gles.h"
 #include "impeller/entity/gles3/framebuffer_blend_shaders_gles.h"
+#include "impeller/typographer/backends/skia/typographer_context_skia.h"
 
 namespace flutter {
 
@@ -198,7 +199,15 @@ AndroidContextGLImpeller::AndroidContextGLImpeller(
   offscreen_config_ = std::move(offscreen_config);
   onscreen_context_ = std::move(onscreen_context);
   offscreen_context_ = std::move(offscreen_context);
-  SetImpellerContext(impeller_context);
+
+  auto aiks_context = std::make_shared<impeller::AiksContext>(
+      impeller_context, impeller::TypographerContextSkia::Make());
+  if (!aiks_context->IsValid()) {
+    FML_DLOG(ERROR) << "Could not create valid Impeller Context.";
+    return;
+  }
+
+  SetImpellerContext(aiks_context);
 
   is_valid_ = true;
 }

--- a/engine/src/flutter/shell/platform/android/android_context_gl_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_gl_unittests.cc
@@ -34,73 +34,6 @@ TaskRunners MakeTaskRunners(const std::string& thread_label,
 }
 }  // namespace
 
-class TestImpellerContext : public impeller::Context {
- public:
-  TestImpellerContext() {}
-
-  ~TestImpellerContext() {}
-
-  impeller::Context::BackendType GetBackendType() const override {
-    return impeller::Context::BackendType::kOpenGLES;
-  }
-
-  std::string DescribeGpuModel() const override { return ""; }
-
-  bool IsValid() const override { return true; }
-
-  const std::shared_ptr<const impeller::Capabilities>& GetCapabilities()
-      const override {
-    FML_UNREACHABLE();
-  }
-
-  bool UpdateOffscreenLayerPixelFormat(impeller::PixelFormat format) override {
-    FML_UNREACHABLE();
-  }
-
-  std::shared_ptr<impeller::Allocator> GetResourceAllocator() const override {
-    FML_UNREACHABLE();
-  }
-
-  std::shared_ptr<impeller::ShaderLibrary> GetShaderLibrary() const override {
-    FML_UNREACHABLE();
-  }
-
-  std::shared_ptr<impeller::SamplerLibrary> GetSamplerLibrary() const override {
-    FML_UNREACHABLE();
-  }
-
-  std::shared_ptr<impeller::PipelineLibrary> GetPipelineLibrary()
-      const override {
-    FML_UNREACHABLE();
-  }
-
-  std::shared_ptr<impeller::CommandBuffer> CreateCommandBuffer()
-      const override {
-    FML_UNREACHABLE();
-  }
-
-  std::shared_ptr<impeller::CommandQueue> GetCommandQueue() const override {
-    FML_UNREACHABLE();
-  }
-
-  void Shutdown() override { did_shutdown = true; }
-
-  impeller::RuntimeStageBackend GetRuntimeStageBackend() const override {
-    return impeller::RuntimeStageBackend::kVulkan;
-  }
-
-  bool did_shutdown = false;
-};
-
-class TestAndroidContext : public AndroidContext {
- public:
-  TestAndroidContext(const std::shared_ptr<impeller::Context>& impeller_context,
-                     AndroidRenderingAPI rendering_api)
-      : AndroidContext(rendering_api) {
-    SetImpellerContext(impeller_context);
-  }
-};
-
 TEST(AndroidContextGl, Create) {
   GrMockOptions main_context_options;
   sk_sp<GrDirectContext> main_context =
@@ -119,17 +52,6 @@ TEST(AndroidContextGl, Create) {
   EXPECT_NE(context.get(), nullptr);
   context.reset();
   EXPECT_TRUE(main_context->abandoned());
-}
-
-TEST(AndroidContextGl, CreateImpeller) {
-  auto impeller_context = std::make_shared<TestImpellerContext>();
-  auto android_context = std::make_unique<TestAndroidContext>(
-      impeller_context, AndroidRenderingAPI::kImpellerOpenGLES);
-  EXPECT_FALSE(impeller_context->did_shutdown);
-
-  android_context.reset();
-
-  EXPECT_TRUE(impeller_context->did_shutdown);
 }
 
 TEST(AndroidContextGl, CreateSingleThread) {

--- a/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
@@ -10,6 +10,7 @@
 #include "flutter/impeller/entity/vk/framebuffer_blend_shaders_vk.h"
 #include "flutter/impeller/entity/vk/modern_shaders_vk.h"
 #include "flutter/impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/typographer/backends/skia/typographer_context_skia.h"
 #include "shell/platform/android/context/android_context.h"
 
 namespace flutter {
@@ -74,7 +75,15 @@ AndroidContextVKImpeller::AndroidContextVKImpeller(
     : AndroidContext(AndroidRenderingAPI::kImpellerVulkan),
       vulkan_dylib_(fml::NativeLibrary::Create("libvulkan.so")) {
   auto impeller_context = CreateImpellerContext(vulkan_dylib_, settings);
-  SetImpellerContext(impeller_context);
+
+  auto aiks_context = std::make_shared<impeller::AiksContext>(
+      impeller_context, impeller::TypographerContextSkia::Make());
+  if (!aiks_context->IsValid()) {
+    FML_DLOG(ERROR) << "Could not create valid Impeller Context.";
+    return;
+  }
+
+  SetImpellerContext(aiks_context);
   is_valid_ = !!impeller_context;
 }
 

--- a/engine/src/flutter/shell/platform/android/android_surface_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_gl_impeller.cc
@@ -36,9 +36,10 @@ bool AndroidSurfaceGLImpeller::IsValid() const {
 std::unique_ptr<Surface> AndroidSurfaceGLImpeller::CreateGPUSurface(
     GrDirectContext* gr_context) {
   auto surface = std::make_unique<GPUSurfaceGLImpeller>(
-      this,                                    // delegate
-      android_context_->GetImpellerContext(),  // context
-      true                                     // render to surface
+      this,                                                  // delegate
+      android_context_->GetImpellerContext()->GetContext(),  // context
+      android_context_->GetImpellerContext(),                // aiks context
+      true  // render to surface
   );
   if (!surface->IsValid()) {
     return nullptr;
@@ -96,16 +97,17 @@ std::unique_ptr<Surface> AndroidSurfaceGLImpeller::CreateSnapshotSurface() {
     return nullptr;
   }
   return std::make_unique<GPUSurfaceGLImpeller>(
-      this,                                    // delegate
-      android_context_->GetImpellerContext(),  // context
-      true                                     // render to surface
+      this,                                                  // delegate
+      android_context_->GetImpellerContext()->GetContext(),  // context
+      android_context_->GetImpellerContext(),                // context
+      true  // render to surface
   );
 }
 
 // |AndroidSurface|
 std::shared_ptr<impeller::Context>
 AndroidSurfaceGLImpeller::GetImpellerContext() {
-  return android_context_->GetImpellerContext();
+  return android_context_->GetImpellerContext()->GetContext();
 }
 
 // |GPUSurfaceGLDelegate|

--- a/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
@@ -23,11 +23,12 @@ AndroidSurfaceVKImpeller::AndroidSurfaceVKImpeller(
     const std::shared_ptr<AndroidContextVKImpeller>& android_context) {
   is_valid_ = android_context->IsValid();
 
-  auto& context_vk =
-      impeller::ContextVK::Cast(*android_context->GetImpellerContext());
+  auto& context_vk = impeller::ContextVK::Cast(
+      *android_context->GetImpellerContext()->GetContext());
   surface_context_vk_ = context_vk.CreateSurfaceContext();
-  eager_gpu_surface_ =
-      std::make_unique<GPUSurfaceVulkanImpeller>(nullptr, surface_context_vk_);
+  aiks_context_ = android_context->GetImpellerContext();
+  eager_gpu_surface_ = std::make_unique<GPUSurfaceVulkanImpeller>(
+      nullptr, surface_context_vk_, aiks_context_);
 }
 
 AndroidSurfaceVKImpeller::~AndroidSurfaceVKImpeller() = default;
@@ -59,7 +60,8 @@ std::unique_ptr<Surface> AndroidSurfaceVKImpeller::CreateGPUSurface(
   }
 
   std::unique_ptr<GPUSurfaceVulkanImpeller> gpu_surface =
-      std::make_unique<GPUSurfaceVulkanImpeller>(nullptr, surface_context_vk_);
+      std::make_unique<GPUSurfaceVulkanImpeller>(nullptr, surface_context_vk_,
+                                                 aiks_context_);
 
   if (!gpu_surface->IsValid()) {
     return nullptr;

--- a/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.h
+++ b/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.h
@@ -11,6 +11,7 @@
 #include "flutter/shell/platform/android/android_context_vk_impeller.h"
 #include "flutter/shell/platform/android/surface/android_native_window.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
+#include "impeller/display_list/aiks_context.h"
 #include "shell/gpu/gpu_surface_vulkan_impeller.h"
 
 namespace flutter {
@@ -51,6 +52,7 @@ class AndroidSurfaceVKImpeller : public AndroidSurface {
 
  private:
   std::shared_ptr<impeller::SurfaceContextVK> surface_context_vk_;
+  std::shared_ptr<impeller::AiksContext> aiks_context_;
   fml::RefPtr<AndroidNativeWindow> native_window_;
   // The first GPU Surface is initialized as soon as the
   // AndroidSurfaceVulkanImpeller is created. This ensures that the pipelines

--- a/engine/src/flutter/shell/platform/android/context/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/context/BUILD.gn
@@ -16,6 +16,7 @@ source_set("context") {
   deps = [
     "//flutter/common",
     "//flutter/fml",
+    "//flutter/impeller/display_list:display_list",
     "//flutter/impeller/renderer",
     "//flutter/skia",
   ]

--- a/engine/src/flutter/shell/platform/android/context/android_context.cc
+++ b/engine/src/flutter/shell/platform/android/context/android_context.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/android/context/android_context.h"
+#include "impeller/display_list/aiks_context.h"
 
 namespace flutter {
 
@@ -14,7 +15,7 @@ AndroidContext::~AndroidContext() {
     main_context_->releaseResourcesAndAbandonContext();
   }
   if (impeller_context_) {
-    impeller_context_->Shutdown();
+    impeller_context_->GetContext()->Shutdown();
   }
 };
 
@@ -35,12 +36,13 @@ sk_sp<GrDirectContext> AndroidContext::GetMainSkiaContext() const {
   return main_context_;
 }
 
-std::shared_ptr<impeller::Context> AndroidContext::GetImpellerContext() const {
+std::shared_ptr<impeller::AiksContext> AndroidContext::GetImpellerContext()
+    const {
   return impeller_context_;
 }
 
 void AndroidContext::SetImpellerContext(
-    const std::shared_ptr<impeller::Context>& context) {
+    const std::shared_ptr<impeller::AiksContext>& context) {
   impeller_context_ = context;
 }
 

--- a/engine/src/flutter/shell/platform/android/context/android_context.h
+++ b/engine/src/flutter/shell/platform/android/context/android_context.h
@@ -7,8 +7,7 @@
 
 #include "common/settings.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/task_runner.h"
-#include "flutter/impeller/renderer/context.h"
+#include "impeller/display_list/aiks_context.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 
 namespace flutter {
@@ -62,12 +61,13 @@ class AndroidContext {
   /// @brief      Accessor for the Impeller context associated with
   ///             AndroidSurfaces and the raster thread.
   ///
-  std::shared_ptr<impeller::Context> GetImpellerContext() const;
+  std::shared_ptr<impeller::AiksContext> GetImpellerContext() const;
 
  protected:
   /// Intended to be called from a subclass constructor after setup work for the
   /// context has completed.
-  void SetImpellerContext(const std::shared_ptr<impeller::Context>& context);
+  void SetImpellerContext(
+      const std::shared_ptr<impeller::AiksContext>& context);
 
  private:
   const AndroidRenderingAPI rendering_api_;
@@ -75,7 +75,7 @@ class AndroidContext {
   // This is the Skia context used for on-screen rendering.
   sk_sp<GrDirectContext> main_context_;
 
-  std::shared_ptr<impeller::Context> impeller_context_;
+  std::shared_ptr<impeller::AiksContext> impeller_context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidContext);
 };

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -141,7 +141,8 @@ PlatformViewAndroid::PlatformViewAndroid(
             AndroidRenderingAPI::kImpellerVulkan &&
         (android_get_device_api_level() >= kMinAPILevelHCPP) &&
         delegate.OnPlatformViewGetSettings().enable_surface_control &&
-        impeller::ContextVK::Cast(*android_context->GetImpellerContext())
+        impeller::ContextVK::Cast(
+            *android_context->GetImpellerContext()->GetContext())
             .GetShouldEnableSurfaceControlSwapchain();
     FML_CHECK(android_surface_ && android_surface_->IsValid())
         << "Could not create an OpenGL, Vulkan or Software surface to set "
@@ -300,10 +301,10 @@ void PlatformViewAndroid::RegisterExternalTexture(
       // Impeller GLES.
       RegisterTexture(std::make_shared<SurfaceTextureExternalTextureGLImpeller>(
           std::static_pointer_cast<impeller::ContextGLES>(
-              android_context_->GetImpellerContext()),  //
-          texture_id,                                   //
-          surface_texture,                              //
-          jni_facade_                                   //
+              android_context_->GetImpellerContext()->GetContext()),  //
+          texture_id,                                                 //
+          surface_texture,                                            //
+          jni_facade_                                                 //
           ));
       break;
     case AndroidRenderingAPI::kSkiaOpenGLES:
@@ -325,10 +326,10 @@ void PlatformViewAndroid::RegisterExternalTexture(
              "android-surface-plugins";
       RegisterTexture(std::make_shared<SurfaceTextureExternalTextureVKImpeller>(
           std::static_pointer_cast<impeller::ContextVK>(
-              android_context_->GetImpellerContext()),  //
-          texture_id,                                   //
-          surface_texture,                              //
-          jni_facade_                                   //
+              android_context_->GetImpellerContext()->GetContext()),  //
+          texture_id,                                                 //
+          surface_texture,                                            //
+          jni_facade_                                                 //
           ));
   }
 }
@@ -341,7 +342,7 @@ void PlatformViewAndroid::RegisterImageTexture(
       // Impeller GLES.
       RegisterTexture(std::make_shared<ImageExternalTextureGLImpeller>(
           std::static_pointer_cast<impeller::ContextGLES>(
-              android_context_->GetImpellerContext()),
+              android_context_->GetImpellerContext()->GetContext()),
           texture_id, image_texture_entry, jni_facade_));
       break;
     case AndroidRenderingAPI::kSkiaOpenGLES:
@@ -353,7 +354,7 @@ void PlatformViewAndroid::RegisterImageTexture(
     case AndroidRenderingAPI::kImpellerVulkan:
       RegisterTexture(std::make_shared<ImageExternalTextureVKImpeller>(
           std::static_pointer_cast<impeller::ContextVK>(
-              android_context_->GetImpellerContext()),
+              android_context_->GetImpellerContext()->GetContext()),
           texture_id, image_texture_entry, jni_facade_));
       break;
     case AndroidRenderingAPI::kSoftware:

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.cc
@@ -11,6 +11,7 @@
 #include "impeller/entity/gles/modern_shaders_gles.h"
 #include "impeller/renderer/backend/gles/context_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
+#include "impeller/typographer/backends/skia/typographer_context_skia.h"
 
 namespace flutter {
 
@@ -92,6 +93,14 @@ EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
     FML_LOG(ERROR) << "Could not add reactor worker.";
     return;
   }
+
+  auto aiks_context = std::make_shared<impeller::AiksContext>(
+      impeller_context_, impeller::TypographerContextSkia::Make());
+  if (!aiks_context->IsValid()) {
+    FML_DLOG(ERROR) << "Could not create valid Impeller Context.";
+    return;
+  }
+  aiks_context_ = aiks_context;
 
   gl_dispatch_table_.gl_clear_current_callback();
   FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (OpenGL).";
@@ -178,6 +187,7 @@ std::unique_ptr<Surface> EmbedderSurfaceGLImpeller::CreateGPUSurface() {
   return std::make_unique<GPUSurfaceGLImpeller>(
       this,                     // GPU surface GL delegate
       impeller_context_,        // Impeller context
+      aiks_context_,            // aiks context
       !external_view_embedder_  // render to surface
   );
 }

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.cc
@@ -94,6 +94,10 @@ EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
     return;
   }
 
+  // Ensure that the GL context is current before creating the GPU surface.
+  // GPUSurfaceGLImpeller initialization will set up shader pipelines, and the
+  // current thread needs to be able to execute reactor operations.
+  GLContextMakeCurrent();
   auto aiks_context = std::make_shared<impeller::AiksContext>(
       impeller_context_, impeller::TypographerContextSkia::Make());
   if (!aiks_context->IsValid()) {
@@ -179,11 +183,6 @@ EmbedderSurfaceGLImpeller::GLContextFramebufferInfo() const {
 
 // |EmbedderSurface|
 std::unique_ptr<Surface> EmbedderSurfaceGLImpeller::CreateGPUSurface() {
-  // Ensure that the GL context is current before creating the GPU surface.
-  // GPUSurfaceGLImpeller initialization will set up shader pipelines, and the
-  // current thread needs to be able to execute reactor operations.
-  GLContextMakeCurrent();
-
   return std::make_unique<GPUSurfaceGLImpeller>(
       this,                     // GPU surface GL delegate
       impeller_context_,        // Impeller context

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_gl_impeller.h
@@ -10,6 +10,7 @@
 #include "flutter/shell/platform/embedder/embedder_external_view_embedder.h"
 #include "flutter/shell/platform/embedder/embedder_surface.h"
 #include "flutter/shell/platform/embedder/embedder_surface_gl_skia.h"
+#include "impeller/display_list/aiks_context.h"
 
 namespace impeller {
 class ContextGLES;
@@ -34,6 +35,7 @@ class EmbedderSurfaceGLImpeller final : public EmbedderSurface,
   EmbedderSurfaceGLSkia::GLDispatchTable gl_dispatch_table_;
   bool fbo_reset_after_present_;
   std::shared_ptr<impeller::ContextGLES> impeller_context_;
+  std::shared_ptr<impeller::AiksContext> aiks_context_;
   std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;
   std::shared_ptr<ReactorWorker> worker_;
 

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_vulkan_impeller.cc
@@ -11,6 +11,7 @@
 #include "flutter/impeller/entity/vk/modern_shaders_vk.h"
 #include "flutter/shell/gpu/gpu_surface_vulkan.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/typographer/backends/skia/typographer_context_skia.h"
 #include "include/gpu/ganesh/GrDirectContext.h"
 #include "shell/gpu/gpu_surface_vulkan_impeller.h"
 
@@ -76,6 +77,14 @@ EmbedderSurfaceVulkanImpeller::EmbedderSurfaceVulkanImpeller(
     return;
   }
 
+  auto aiks_context = std::make_shared<impeller::AiksContext>(
+      context_, impeller::TypographerContextSkia::Make());
+  if (!aiks_context->IsValid()) {
+    FML_DLOG(ERROR) << "Could not create valid Impeller Context.";
+    return;
+  }
+  aiks_context_ = aiks_context;
+
   FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (Vulkan).";
 
   valid_ = true;
@@ -112,7 +121,8 @@ bool EmbedderSurfaceVulkanImpeller::IsValid() const {
 
 // |EmbedderSurface|
 std::unique_ptr<Surface> EmbedderSurfaceVulkanImpeller::CreateGPUSurface() {
-  return std::make_unique<GPUSurfaceVulkanImpeller>(this, context_);
+  return std::make_unique<GPUSurfaceVulkanImpeller>(this, context_,
+                                                    aiks_context_);
 }
 
 // |EmbedderSurface|

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_vulkan_impeller.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_vulkan_impeller.h
@@ -12,6 +12,7 @@
 #include "flutter/shell/platform/embedder/embedder_external_view_embedder.h"
 #include "flutter/shell/platform/embedder/embedder_surface.h"
 #include "flutter/vulkan/procs/vulkan_proc_table.h"
+#include "impeller/display_list/aiks_context.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 
 namespace flutter {
@@ -61,6 +62,7 @@ class EmbedderSurfaceVulkanImpeller final : public EmbedderSurface,
   VulkanDispatchTable vulkan_dispatch_table_;
   std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;
   std::shared_ptr<impeller::ContextVK> context_;
+  std::shared_ptr<impeller::AiksContext> aiks_context_;
 
   // |EmbedderSurface|
   bool IsValid() const override;


### PR DESCRIPTION
Right now the engine tears down the aiks context (but not the content_context or gpu context) when backgrounded. This results in us clearing out a bunch of caches that could be kept alive (AFAIK).