### PR TITLE
Revert "Marks Mac_benchmark basic_material_app_macos__compile to be flaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3568,7 +3568,6 @@ targets:
       task_name: animated_complex_opacity_perf_macos__e2e_summary
 
   - name: Mac_benchmark basic_material_app_macos__compile
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/162364
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60


### PR DESCRIPTION
Reverts flutter/flutter#162365

The timeouts looked like infra issues, but it's no longer flaking.

Fixes https://github.com/flutter/flutter/issues/162364