### PR TITLE
Enable `linux_android_emulator_tests` on presubmit.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -57,7 +57,6 @@ targets:
     timeout: 180
 
   - name: Linux linux_android_emulator_tests
-    bringup: true
     enabled_branches:
       - master
     recipe: engine_v2/engine_v2


### PR DESCRIPTION
Finalizes https://github.com/flutter/flutter/issues/163742.

It passed the last ~10 builds on postsubmit.