### PR TITLE
Revert "Marks Mac_benchmark flutter_view_macos__start_up to be flaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3873,7 +3873,6 @@ targets:
       - dev/bots/**
 
   - name: Mac_benchmark flutter_view_macos__start_up
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/159540
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60


### PR DESCRIPTION
Reverts flutter/flutter#159541

This is no longer flaking.

Fixes https://github.com/flutter/flutter/issues/159540