### PR TITLE
Revert "Marks Windows_mokey native_assets_android to be flaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6695,7 +6695,6 @@ targets:
 
   # windows mokey test
   - name: Windows_mokey native_assets_android
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/156063
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
Reverts flutter/flutter#156064

Should have marked https://github.com/flutter/flutter/issues/156063 fixed but it was already closed.