### PR TITLE
Revert "Marks Linux_pixel_7pro service_extensions_test to be flaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3251,7 +3251,6 @@ targets:
       task_name: routing_test
 
   - name: Linux_pixel_7pro service_extensions_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/157852
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
Reverts flutter/flutter#157853

Should have fixed https://github.com/flutter/flutter/issues/157852 but that was closed.