### PR TITLE
Mark platform_views_hcpp_scroll_perf__timeline_summary out of bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3224,7 +3224,6 @@ targets:
   - name: Linux_pixel_7pro platform_views_hcpp_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
platform_views_hcpp_scroll_perf__timeline_summary is happily passing

https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_pixel_7pro%20platform_views_hcpp_scroll_perf__timeline_summary/255/overview

Introduced in https://github.com/flutter/flutter/pull/163018.