### PR TITLE
[WIP] willHandlePopInterally now considers PopScopes

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1919,6 +1919,22 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   // declared with any supertype of T.
   final Set<PopEntry<Object?>> _popEntries = <PopEntry<Object?>>{};
 
+  @override
+  bool get willHandlePopInternally {
+    // TODO(justinmc): Need a clear distinction between willHandlePopInt and popDisposition. Currently, popDisposition uses willhandlePopInternally in LocalHistoryRoute.
+    // stackoverflow
+    //return super.willHandlePopInternally || popDisposition == RoutePopDisposition.doNotPop;
+    if (super.willHandlePopInternally) {
+      return true;
+    }
+    for (final PopEntry<Object?> popEntry in _popEntries) {
+      if (!popEntry.canPopNotifier.value) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /// Returns [RoutePopDisposition.doNotPop] if any of callbacks added with
   /// [addScopedWillPopCallback] returns either false or null. If they all
   /// return true, the base [Route.willPop]'s result will be returned. The


### PR DESCRIPTION
Currently, go_router doesn't handle PopScopes correctly when using nested navigation (ShellRoute in go_router).

Option 1: Add a NanvigatorPopHandler to ShellRoute.
Option 2: Automatically add a NavigatorPopHandler to all nested Navigators (https://github.com/flutter/flutter/pull/152330).
Option 3: (This PR) Make willHandlePopInternally consider PopScopes.

I was under the impression that willHandlePopInternally should not consider PopScope because it did not consider WillPopScope. @chunhtai has argued that the reason it didn't consider WillPopScope is that WillPopScope determines if it can pop at the time of the pop, but now that PopScope determines this ahead of time, it should be considered by willHandlePopInternally. See https://github.com/flutter/packages/pull/8162#issuecomment-2657752385.

I think this makes sense to me, but I want to see:

 * Does everything still work if we make the change? Tests pass?
 * Do we have clear definitions of willHandlePopInternally and popDisposition that all make sense?
 * Does this change actually fix the bug with go_router ShellRoute?

<details>

<summary>Repro code</summary>

```dart
// Copyright 2014 The Flutter Authors. All rights reserved.
// Use of this source code is governed by a BSD-style license that can be
// found in the LICENSE file.

import 'package:flutter/material.dart';

/// Flutter code sample for [Scrollbar].

void main() {
  runApp(const ScrollbarExampleApp());
}

final GlobalKey<NavigatorState> nav = GlobalKey<NavigatorState>();

class ScrollbarExampleApp extends StatelessWidget {
  const ScrollbarExampleApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      navigatorKey: nav,
      home: PopScope(
        canPop: false,
        child: Scaffold(
          appBar: AppBar(title: const Text('Scrollbar Sample')),
          body: Center(
            child: ElevatedButton(
              onPressed: () {
                print(
                  'navigator can Pop should be true! but got ${nav.currentState!.canPop()}',
                );
              },
              child: Text('canPop?'),
            ),
          ),
        ),
      ),
    );
  }
}
```

Code taken from https://github.com/flutter/packages/pull/8162#issuecomment-2672965102.

</details>