### PR TITLE
Convert manual writes of `package_config.json` to more structured output.

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -29,6 +29,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_pub_deps.dart';
 import '../../src/fakes.dart';
+import '../../src/package_config.dart';
 import '../../src/test_build_system.dart';
 import '../../src/test_flutter_command_runner.dart';
 
@@ -87,7 +88,7 @@ void main() {
   // Sets up the minimal mock project files necessary to look like a Flutter project.
   void createCoreMockProjectFiles() {
     fileSystem.file('pubspec.yaml').createSync();
-    fileSystem.directory('.dart_tool').childFile('package_config.json').createSync(recursive: true);
+    writePackageConfig(fileSystem.currentDirectory);
     fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
   }
 
@@ -258,10 +259,7 @@ void main() {
         osUtils: FakeOperatingSystemUtils(),
       );
       fileSystem.file('pubspec.yaml').createSync();
-      fileSystem
-          .directory('.dart_tool')
-          .childFile('package_config.json')
-          .createSync(recursive: true);
+      writePackageConfig(fileSystem.currentDirectory);
       fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
 
       final bool supported =

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -80,6 +80,7 @@ void main() {
 
   setUpAll(() {
     Cache.disableLocking();
+    Cache.flutterRoot = '';
   });
 
   setUp(() {
@@ -112,9 +113,13 @@ void main() {
         .file(fileSystem.path.join('ios', 'Runner.xcodeproj', 'project.pbxproj'))
         .createSync();
     writePackageConfig(
-      fileSystem.directory('${Cache.flutterRoot!}/packages/flutter_tools'),
+      fileSystem.directory('${Cache.flutterRoot!}packages/flutter_tools'),
       packages: <Package>[
-        Package('flutter_template_images', Uri(path: '/flutter_template_images')),
+        Package(
+          'flutter_template_images',
+          fileSystem.directory('flutter_template_images').absolute.uri,
+          packageUriRoot: Uri(path: 'lib/'),
+        ),
       ],
     );
     createCoreMockProjectFiles();

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -23,6 +23,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/package_config.dart';
 import '../../src/test_build_system.dart';
 import '../../src/test_flutter_command_runner.dart';
 
@@ -60,7 +61,7 @@ void main() {
   // Creates the mock files necessary to look like a Flutter project.
   void setUpMockCoreProjectFiles() {
     fileSystem.file('pubspec.yaml').createSync();
-    fileSystem.directory('.dart_tool').childFile('package_config.json').createSync(recursive: true);
+    writePackageConfig(fileSystem.currentDirectory);
     fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
   }
 
@@ -685,10 +686,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "fizz_bar")
 ''');
       fileSystem.file('pubspec.yaml').createSync();
-      fileSystem
-          .directory('.dart_tool')
-          .childFile('package_config.json')
-          .createSync(recursive: true);
+      writePackageConfig(fileSystem.currentDirectory);
       final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(
         fileSystem.currentDirectory,
       );

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -16,10 +16,12 @@ import 'package:flutter_tools/src/commands/build_web.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/web/compile.dart';
+import 'package:package_config/package_config.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/package_config.dart';
 import '../../src/test_build_system.dart';
 import '../../src/test_flutter_command_runner.dart';
 
@@ -39,7 +41,7 @@ void main() {
     fileSystem.file('pubspec.yaml')
       ..createSync()
       ..writeAsStringSync('name: foo\n');
-    fileSystem.directory('.dart_tool').childFile('package_config.json').createSync(recursive: true);
+    writePackageConfig(fileSystem.currentDirectory);
     fileSystem.file(fileSystem.path.join('web', 'index.html')).createSync(recursive: true);
     fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
     logger = BufferLogger.test();
@@ -501,27 +503,10 @@ void setupFileSystemForEndToEndTest(FileSystem fileSystem) {
   }
 
   // Project files.
-  fileSystem.directory('.dart_tool').childFile('package_config.json')
-    ..createSync(recursive: true)
-    ..writeAsStringSync('''
-{
-  "packages": [
-    {
-      "name": "foo",
-      "rootUri": "../",
-      "packageUri": "lib/",
-      "languageVersion": "3.2"
-    },
-    {
-      "name": "fizz",
-      "rootUri": "../bar",
-      "packageUri": "lib/",
-      "languageVersion": "3.2"
-    }
-  ],
-  "configVersion": 2
-}
-''');
+  writePackageConfig(
+    fileSystem.currentDirectory,
+    packages: <Package>[Package('foo', Uri(path: '../')), Package('fizz', Uri(path: '../bar'))],
+  );
   fileSystem.file('pubspec.yaml').writeAsStringSync('''
 name: foo
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -505,7 +505,10 @@ void setupFileSystemForEndToEndTest(FileSystem fileSystem) {
   // Project files.
   writePackageConfig(
     fileSystem.currentDirectory,
-    packages: <Package>[Package('foo', Uri(path: '../')), Package('fizz', Uri(path: '../bar'))],
+    packages: <Package>[
+      Package('foo', fileSystem.currentDirectory.uri, packageUriRoot: Uri(path: 'lib/')),
+      Package('fizz', fileSystem.directory('bar').absolute.uri, packageUriRoot: Uri(path: 'lib/')),
+    ],
   );
   fileSystem.file('pubspec.yaml').writeAsStringSync('''
 name: foo

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -19,6 +19,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/package_config.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 const String flutterRoot = r'C:\flutter';
@@ -62,7 +63,7 @@ void main() {
   // Creates the mock files necessary to look like a Flutter project.
   void setUpMockCoreProjectFiles() {
     fileSystem.file('pubspec.yaml').createSync();
-    fileSystem.directory('.dart_tool').childFile('package_config.json').createSync(recursive: true);
+    writePackageConfig(fileSystem.currentDirectory);
     fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -77,12 +77,7 @@ void main() {
 
           expect(projectUnderTest.flutterPluginsFile, isNot(exists));
           expect(projectUnderTest.flutterPluginsDependenciesFile, isNot(exists));
-          expect(
-            projectUnderTest.directory
-                .childDirectory('.dart_tool')
-                .childFile('package_config.json'),
-            isNot(exists),
-          );
+          expect(projectUnderTest.packageConfig, isNot(exists));
 
           expect(xcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
             CleanWorkspaceCall('/ios/Runner.xcworkspace', 'Runner', false),

--- a/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
@@ -149,7 +149,9 @@ void main() {
           templateImagesDirectory.createSync(recursive: true);
           writePackageConfig(
             globals.fs.directory(globals.fs.path.join('flutter', 'packages', 'flutter_tools')),
-            packages: <Package>[Package('flutter_template_images', templateImagesDirectory.uri)],
+            packages: <Package>[
+              Package('flutter_template_images', templateImagesDirectory.absolute.uri),
+            ],
           );
           flutterManifest.writeAsStringSync('{"files":[]}');
         },

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -35,6 +35,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_devices.dart';
 import '../../src/fakes.dart';
+import '../../src/package_config.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -203,14 +204,7 @@ void main() {
         fs = MemoryFileSystem.test();
 
         fs.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: flutter_app');
-        fs.currentDirectory.childDirectory('.dart_tool').childFile('package_config.json')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
-{
-  "packages": [],
-  "configVersion": 2
-}
-''');
+        writePackageConfig(fs.currentDirectory);
         final Directory libDir = fs.currentDirectory.childDirectory('lib');
         libDir.createSync();
         final File mainFile = libDir.childFile('main.dart');

--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -14,6 +14,7 @@ import 'package:test/fake.dart';
 import 'package:yaml/yaml.dart';
 
 import '../../src/context.dart';
+import '../../src/package_config.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 // An example pubspec.yaml from flutter, not necessary for it to be up to date.
@@ -405,9 +406,7 @@ packages:
 sdks:
   dart: ">=2.14.0 <3.0.0"
 ''');
-    fileSystem.currentDirectory.childDirectory('.dart_tool').childFile('package_config.json')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('{"configVersion":2,"packages":[]}');
+    writePackageConfig(fileSystem.currentDirectory);
   }
 
   @override

--- a/packages/flutter_tools/test/src/package_config.dart
+++ b/packages/flutter_tools/test/src/package_config.dart
@@ -30,9 +30,13 @@ void writePackageConfig(FileSystemEntity entity, {Iterable<Package> packages = c
 /// ```dart
 /// writePackageConfig(project.packageConfig);
 /// ```
+/// ... that always worrks, even if the file did not previously exist.
 void writePackageConfigForProject(
   FlutterProject project, {
   Iterable<Package> packages = const <Package>[],
 }) {
-  writePackageConfig(project.packageConfig, packages: packages);
+  writePackageConfig(
+    project.directory.childDirectory('.dart_tool').childFile('package_config.json'),
+    packages: packages,
+  );
 }

--- a/packages/flutter_tools/test/src/package_config.dart
+++ b/packages/flutter_tools/test/src/package_config.dart
@@ -20,7 +20,7 @@ void writePackageConfig(FileSystemEntity entity, {Iterable<Package> packages = c
       const JsonEncoder jsonEncoder = JsonEncoder.withIndent('  ');
       entity
         ..createSync(recursive: true)
-        ..writeAsStringSync(jsonEncoder.convert(PackageConfig(packages)));
+        ..writeAsStringSync(jsonEncoder.convert(PackageConfig.toJson(PackageConfig(packages))));
   }
 }
 

--- a/packages/flutter_tools/test/src/package_config.dart
+++ b/packages/flutter_tools/test/src/package_config.dart
@@ -1,0 +1,38 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:package_config/package_config.dart';
+
+/// Writes a `.dart_tool/package_config.json` that includes [packages].
+///
+/// - If [entity] is a [File], it is written to assuming it _is_ `package_config.json`.
+/// - If [entity] is a [Directory], `.dart_tool/package_config.json` is written relative to that directory.
+void writePackageConfig(FileSystemEntity entity, {Iterable<Package> packages = const <Package>[]}) {
+  switch (entity) {
+    case Directory():
+      writePackageConfigForProject(FlutterProject.fromDirectoryTest(entity), packages: packages);
+    case File():
+      const JsonEncoder jsonEncoder = JsonEncoder.withIndent('  ');
+      entity
+        ..createSync(recursive: true)
+        ..writeAsStringSync(jsonEncoder.convert(PackageConfig(packages)));
+  }
+}
+
+/// Writes a `.dart_tool/package_config.json` that includes [packages].
+///
+/// This is a convenience function for:
+/// ```dart
+/// writePackageConfig(project.packageConfig);
+/// ```
+void writePackageConfigForProject(
+  FlutterProject project, {
+  Iterable<Package> packages = const <Package>[],
+}) {
+  writePackageConfig(project.packageConfig, packages: packages);
+}


### PR DESCRIPTION
I ran into how painful this is in https://github.com/flutter/flutter/issues/163774.

Instead of having all of this bespoke code to _pretend_ to write a `package_config.json`, let's use the existing structured code and writers. This is not conclusive - I'd want to send 1-2 more follow-up PRs converting the rest of `packages/flutter_tools/test`.

/cc @sigurdm 