### PR TITLE
Adds aria-controls support

### DIFF
--- a/engine/src/flutter/lib/ui/fixtures/ui_test.dart
+++ b/engine/src/flutter/lib/ui/fixtures/ui_test.dart
@@ -234,6 +234,7 @@ void sendSemanticsUpdate() {
     additionalActions: additionalActions,
     headingLevel: 0,
     linkUrl: '',
+    controlsNodes: null,
   );
   _semanticsUpdate(builder.build());
 }
@@ -287,6 +288,7 @@ void sendSemanticsUpdateWithRole() {
     headingLevel: 0,
     linkUrl: '',
     role: SemanticsRole.tab,
+    controlsNodes: null,
   );
   _semanticsUpdate(builder.build());
 }

--- a/engine/src/flutter/lib/ui/semantics.dart
+++ b/engine/src/flutter/lib/ui/semantics.dart
@@ -1129,6 +1129,7 @@ abstract class SemanticsUpdateBuilder {
     int headingLevel = 0,
     String linkUrl = '',
     SemanticsRole role = SemanticsRole.none,
+    required List<String>? controlsVisibilityOfNodes,
   });
 
   /// Update the custom semantics action associated with the given `id`.
@@ -1205,6 +1206,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
     int headingLevel = 0,
     String linkUrl = '',
     SemanticsRole role = SemanticsRole.none,
+    required List<String>? controlsVisibilityOfNodes,
   }) {
     assert(_matrix4IsValid(transform));
     assert(
@@ -1251,6 +1253,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
       headingLevel,
       linkUrl,
       role.index,
+      controlsVisibilityOfNodes,
     );
   }
 
@@ -1296,6 +1299,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
       Int32,
       Handle,
       Int32,
+      Handle,
     )
   >(symbol: 'SemanticsUpdateBuilder::updateNode')
   external void _updateNode(
@@ -1338,6 +1342,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
     int headingLevel,
     String linkUrl,
     int role,
+    List<String>? controlsVisibilityOfNodes,
   );
 
   @override

--- a/engine/src/flutter/lib/ui/semantics.dart
+++ b/engine/src/flutter/lib/ui/semantics.dart
@@ -1129,7 +1129,7 @@ abstract class SemanticsUpdateBuilder {
     int headingLevel = 0,
     String linkUrl = '',
     SemanticsRole role = SemanticsRole.none,
-    required List<String>? controlsVisibilityOfNodes,
+    required List<String>? controlsNodes,
   });
 
   /// Update the custom semantics action associated with the given `id`.
@@ -1206,7 +1206,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
     int headingLevel = 0,
     String linkUrl = '',
     SemanticsRole role = SemanticsRole.none,
-    required List<String>? controlsVisibilityOfNodes,
+    required List<String>? controlsNodes,
   }) {
     assert(_matrix4IsValid(transform));
     assert(
@@ -1253,7 +1253,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
       headingLevel,
       linkUrl,
       role.index,
-      controlsVisibilityOfNodes,
+      controlsNodes,
     );
   }
 
@@ -1342,7 +1342,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
     int headingLevel,
     String linkUrl,
     int role,
-    List<String>? controlsVisibilityOfNodes,
+    List<String>? controlsNodes,
   );
 
   @override

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
@@ -69,7 +69,8 @@ void SemanticsUpdateBuilder::updateNode(
     const tonic::Int32List& localContextActions,
     int headingLevel,
     std::string linkUrl,
-    int role) {
+    int role,
+    const std::vector<std::string> controlsVisibilityOfNodes) {
   FML_CHECK(scrollChildren == 0 ||
             (scrollChildren > 0 && childrenInHitTestOrder.data()))
       << "Semantics update contained scrollChildren but did not have "

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
@@ -70,7 +70,7 @@ void SemanticsUpdateBuilder::updateNode(
     int headingLevel,
     std::string linkUrl,
     int role,
-    const std::vector<std::string> controlsNodes) {
+    const std::vector<std::string>& controlsNodes) {
   FML_CHECK(scrollChildren == 0 ||
             (scrollChildren > 0 && childrenInHitTestOrder.data()))
       << "Semantics update contained scrollChildren but did not have "

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
@@ -70,7 +70,7 @@ void SemanticsUpdateBuilder::updateNode(
     int headingLevel,
     std::string linkUrl,
     int role,
-    const std::vector<std::string> controlsVisibilityOfNodes) {
+    const std::vector<std::string> controlsNodes) {
   FML_CHECK(scrollChildren == 0 ||
             (scrollChildren > 0 && childrenInHitTestOrder.data()))
       << "Semantics update contained scrollChildren but did not have "

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
@@ -68,7 +68,8 @@ class SemanticsUpdateBuilder
       const tonic::Int32List& customAccessibilityActions,
       int headingLevel,
       std::string linkUrl,
-      int role);
+      int role,
+      const std::vector<std::string> controlsVisibilityOfNodes);
 
   void updateCustomAction(int id,
                           std::string label,

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
@@ -69,7 +69,7 @@ class SemanticsUpdateBuilder
       int headingLevel,
       std::string linkUrl,
       int role,
-      const std::vector<std::string> controlsVisibilityOfNodes);
+      const std::vector<std::string> controlsNodes);
 
   void updateCustomAction(int id,
                           std::string label,

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
@@ -69,7 +69,7 @@ class SemanticsUpdateBuilder
       int headingLevel,
       std::string linkUrl,
       int role,
-      const std::vector<std::string> controlsNodes);
+      const std::vector<std::string>& controlsNodes);
 
   void updateCustomAction(int id,
                           std::string label,

--- a/engine/src/flutter/lib/web_ui/lib/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/semantics.dart
@@ -371,6 +371,7 @@ class SemanticsUpdateBuilder {
     int headingLevel = 0,
     String? linkUrl,
     SemanticsRole role = SemanticsRole.none,
+    required List<String>? controlsVisibilityOfNodes,
   }) {
     if (transform.length != 16) {
       throw ArgumentError('transform argument must have 16 entries.');
@@ -413,6 +414,7 @@ class SemanticsUpdateBuilder {
         headingLevel: headingLevel,
         linkUrl: linkUrl,
         role: role,
+        controlsVisibilityOfNodes: controlsVisibilityOfNodes,
       ),
     );
   }

--- a/engine/src/flutter/lib/web_ui/lib/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/semantics.dart
@@ -371,7 +371,7 @@ class SemanticsUpdateBuilder {
     int headingLevel = 0,
     String? linkUrl,
     SemanticsRole role = SemanticsRole.none,
-    required List<String>? controlsVisibilityOfNodes,
+    required List<String>? controlsNodes,
   }) {
     if (transform.length != 16) {
       throw ArgumentError('transform argument must have 16 entries.');
@@ -414,7 +414,7 @@ class SemanticsUpdateBuilder {
         headingLevel: headingLevel,
         linkUrl: linkUrl,
         role: role,
-        controlsVisibilityOfNodes: controlsVisibilityOfNodes,
+        controlsNodes: controlsNodes,
       ),
     );
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -38,46 +38,6 @@ import 'tabs.dart';
 import 'tappable.dart';
 import 'text_field.dart';
 
-bool unorderedListEqual<T>(List<T>? a, List<T>? b) {
-  if (a == b) {
-    return true;
-  }
-  if ((a == null) != (b == null)) {
-    return false;
-  }
-  // They most both be non-null now.
-  if (a!.length != b!.length) {
-    return false;
-  }
-
-  if (a.length == 1) {
-    return a.first == b.first;
-  }
-
-  if (a.length == 2) {
-    return a.first == b.first && a.last == b.last || a.last == b.first && b.first == a.last;
-  }
-
-  // Complex cases.
-  final Map<T, int> wordCounts = <T, int>{};
-  for (final T word in a) {
-    int count = wordCounts[word] ?? 0;
-    wordCounts[word] = count + 1;
-  }
-
-  for (final T otherWord in b) {
-    int? count = wordCounts[otherWord];
-    if (count == null || count == 0) {
-      return false;
-    }
-    if (count == 1) {
-      wordCounts.remove(otherWord);
-    }
-    wordCounts[otherWord] = count - 1;
-  }
-  return wordCounts.isEmpty;
-}
-
 class EngineAccessibilityFeatures implements ui.AccessibilityFeatures {
   const EngineAccessibilityFeatures(this._index);
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -699,7 +699,7 @@ abstract class SemanticRole {
           if (semanticNodeId == null) {
             continue;
           }
-          elementIds.add('flt-semantic-node-${semanticNodeId}');
+          elementIds.add('flt-semantic-node-$semanticNodeId');
         }
         if (elementIds.isNotEmpty) {
           setAttribute('aria-controls', elementIds.join(' '));

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -55,20 +55,19 @@ bool unorderedListEqual<T>(List<T>? a, List<T>? b) {
   }
 
   if (a.length == 2) {
-    return a.first == b.first && a.last == b.last ||
-      a.last == b.first && b.first == a.last;
+    return a.first == b.first && a.last == b.last || a.last == b.first && b.first == a.last;
   }
 
   // Complex cases.
-  final Map<String, int> wordCounts = <String, int>{};
-  for (final String word in a) {
+  final Map<T, int> wordCounts = <T, int>{};
+  for (final T word in a) {
     int count = wordCounts[word] ?? 0;
     wordCounts[word] = count + 1;
   }
 
-  for (final String otherWord in b) {
+  for (final T otherWord in b) {
     int? count = wordCounts[otherWord];
-    if (count == null || count = 0) {
+    if (count == null || count == 0) {
       return false;
     }
     if (count == 1) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -69,7 +69,7 @@ class EngineAccessibilityFeatures implements ui.AccessibilityFeatures {
 
   @override
   String toString() {
-    final List<String> features = <String>[];
+    final features = <String>[];
     if (accessibleNavigation) {
       features.add('accessibleNavigation');
     }
@@ -693,7 +693,7 @@ abstract class SemanticRole {
   void _updateControls() {
     if (semanticsObject.hasControlsNodes) {
       semanticsObject.owner.addOneTimePostUpdateCallback(() {
-        final List<String> elementIds = <String>[];
+        final elementIds = <String>[];
         for (final String identifier in semanticsObject.controlsNodes!) {
           final int? semanticNodeId = semanticsObject.owner.identifiersToIds[identifier];
           if (semanticNodeId == null) {
@@ -1691,7 +1691,7 @@ class SemanticsObject {
 
     // Always render in traversal order, because the accessibility traversal
     // is determined by the DOM order of elements.
-    final List<SemanticsObject> childrenInRenderOrder = <SemanticsObject>[];
+    final childrenInRenderOrder = <SemanticsObject>[];
     for (int i = 0; i < childCount; i++) {
       childrenInRenderOrder.add(owner._semanticsTree[childrenInTraversalOrder[i]]!);
     }
@@ -1725,7 +1725,7 @@ class SemanticsObject {
     }
 
     // At this point it is guaranteed to have had a non-empty previous child list.
-    final List<SemanticsObject> previousChildrenInRenderOrder = _currentChildrenInRenderOrder!;
+    final previousChildrenInRenderOrder = _currentChildrenInRenderOrder!;
     final int previousCount = previousChildrenInRenderOrder.length;
 
     // Both non-empty case.
@@ -1746,7 +1746,7 @@ class SemanticsObject {
 
     // Indices into the old child list pointing at children that also exist in
     // the new child list.
-    final List<int> intersectionIndicesOld = <int>[];
+    final intersectionIndicesOld = <int>[];
 
     int newIndex = 0;
 
@@ -1780,7 +1780,7 @@ class SemanticsObject {
     // The longest sub-sequence in the old list maximizes the number of children
     // that do not need to be moved.
     final List<int?> longestSequence = longestIncreasingSubsequence(intersectionIndicesOld);
-    final List<int> stationaryIds = <int>[];
+    final stationaryIds = <int>[];
     for (int i = 0; i < longestSequence.length; i += 1) {
       stationaryIds.add(
         previousChildrenInRenderOrder[intersectionIndicesOld[longestSequence[i]!]].id,
@@ -2908,8 +2908,8 @@ AFTER: $description
 /// Complexity: n*log(n)
 List<int> longestIncreasingSubsequence(List<int> list) {
   final int len = list.length;
-  final List<int> predecessors = <int>[];
-  final List<int> mins = <int>[0];
+  final predecessors = <int>[];
+  final mins = <int>[0];
   int longest = 0;
   for (int i = 0; i < len; i++) {
     // Binary search for the largest positive `j ≤ longest`
@@ -2942,7 +2942,7 @@ List<int> longestIncreasingSubsequence(List<int> list) {
     }
   }
   // Reconstruct the longest subsequence
-  final List<int> seq = List<int>.filled(longest, 0);
+  final seq = List<int>.filled(longest, 0);
   int k = mins[longest];
   for (int i = longest - 1; i >= 0; i--) {
     seq[i] = k;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/util.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/util.dart
@@ -551,6 +551,52 @@ bool listEquals<T>(List<T>? a, List<T>? b) {
   return true;
 }
 
+/// Determines if lists [a] and [b] are deep equivalent, regardless of their
+/// order.
+///
+/// Returns true if the lists are both null, or if they are both non-null, have
+/// the same length, and contain the same elements regardless of their order.
+/// Returns false otherwise.
+bool unorderedListEqual<T>(List<T>? a, List<T>? b) {
+  if (a == b) {
+    return true;
+  }
+  if ((a == null) != (b == null)) {
+    return false;
+  }
+  // They most both be non-null now.
+  if (a!.length != b!.length) {
+    return false;
+  }
+
+  if (a.length == 1) {
+    return a.first == b.first;
+  }
+
+  if (a.length == 2) {
+    return a.first == b.first && a.last == b.last || a.last == b.first && b.first == a.last;
+  }
+
+  // Complex cases.
+  final Map<T, int> wordCounts = <T, int>{};
+  for (final T word in a) {
+    int count = wordCounts[word] ?? 0;
+    wordCounts[word] = count + 1;
+  }
+
+  for (final T otherWord in b) {
+    int? count = wordCounts[otherWord];
+    if (count == null || count == 0) {
+      return false;
+    }
+    if (count == 1) {
+      wordCounts.remove(otherWord);
+    }
+    wordCounts[otherWord] = count - 1;
+  }
+  return wordCounts.isEmpty;
+}
+
 // HTML only supports a single radius, but Flutter ImageFilter supports separate
 // horizontal and vertical radii. The best approximation we can provide is to
 // average the two radii together for a single compromise value.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/util.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/util.dart
@@ -561,10 +561,14 @@ bool unorderedListEqual<T>(List<T>? a, List<T>? b) {
   if (a == b) {
     return true;
   }
+  if ((a?.isEmpty ?? true) && (b?.isEmpty ?? true)) {
+    return true;
+  }
+
   if ((a == null) != (b == null)) {
     return false;
   }
-  // They most both be non-null now.
+  // They most both be non-null now, and at least one of them is not empty.
   if (a!.length != b!.length) {
     return false;
   }
@@ -574,7 +578,7 @@ bool unorderedListEqual<T>(List<T>? a, List<T>? b) {
   }
 
   if (a.length == 2) {
-    return a.first == b.first && a.last == b.last || a.last == b.first && b.first == a.last;
+    return (a.first == b.first && a.last == b.last) || (a.last == b.first && a.first == b.last);
   }
 
   // Complex cases.
@@ -591,8 +595,9 @@ bool unorderedListEqual<T>(List<T>? a, List<T>? b) {
     }
     if (count == 1) {
       wordCounts.remove(otherWord);
+    } else {
+      wordCounts[otherWord] = count - 1;
     }
-    wordCounts[otherWord] = count - 1;
   }
   return wordCounts.isEmpty;
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/util.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/util.dart
@@ -584,12 +584,12 @@ bool unorderedListEqual<T>(List<T>? a, List<T>? b) {
   // Complex cases.
   final Map<T, int> wordCounts = <T, int>{};
   for (final T word in a) {
-    int count = wordCounts[word] ?? 0;
+    final int count = wordCounts[word] ?? 0;
     wordCounts[word] = count + 1;
   }
 
   for (final T otherWord in b) {
-    int? count = wordCounts[otherWord];
+    final int? count = wordCounts[otherWord];
     if (count == null || count == 0) {
       return false;
     }

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -4042,7 +4042,7 @@ void _testTables() {
 }
 
 void _testControlsNodes() {
-  test('nodes with table role', () {
+  test('can have multiple controlled nodes', () {
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
       ..semanticsEnabled = true;
@@ -4088,6 +4088,65 @@ void _testControlsNodes() {
     tester.apply();
 
     object = tester.getSemanticsObject(0);
+    expect(object.element.getAttribute('aria-controls'), 'flt-semantic-node-1 flt-semantic-node-2');
+
+    tester.updateNode(
+      id: 0,
+      controlsNodes: <String>['a', 'b', 'c'],
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      children: <SemanticsNodeUpdate>[
+        tester.updateNode(id: 1, identifier: 'a'),
+        tester.updateNode(id: 2, identifier: 'b'),
+        tester.updateNode(id: 3, identifier: 'c'),
+        tester.updateNode(id: 4, identifier: 'd'),
+      ],
+    );
+    tester.apply();
+
+    object = tester.getSemanticsObject(0);
+    expect(
+      object.element.getAttribute('aria-controls'),
+      'flt-semantic-node-1 flt-semantic-node-2 flt-semantic-node-3',
+    );
+
+    tester.updateNode(
+      id: 0,
+      controlsNodes: <String>['a', 'b', 'd'],
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      children: <SemanticsNodeUpdate>[
+        tester.updateNode(id: 1, identifier: 'a'),
+        tester.updateNode(id: 2, identifier: 'b'),
+        tester.updateNode(id: 3, identifier: 'c'),
+        tester.updateNode(id: 4, identifier: 'd'),
+      ],
+    );
+    tester.apply();
+
+    object = tester.getSemanticsObject(0);
+    expect(
+      object.element.getAttribute('aria-controls'),
+      'flt-semantic-node-1 flt-semantic-node-2 flt-semantic-node-4',
+    );
+  });
+
+  test('can control multiple nodes with same identifier', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final SemanticsTester tester = SemanticsTester(owner());
+    tester.updateNode(
+      id: 0,
+      controlsNodes: <String>['a'],
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      children: <SemanticsNodeUpdate>[
+        tester.updateNode(id: 1, identifier: 'a'),
+        tester.updateNode(id: 2, identifier: 'a'),
+      ],
+    );
+    tester.apply();
+
+    SemanticsObject object = tester.getSemanticsObject(0);
     expect(object.element.getAttribute('aria-controls'), 'flt-semantic-node-1 flt-semantic-node-2');
   });
 

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -129,6 +129,9 @@ void runSemanticsTests() {
   group('table', () {
     _testTables();
   });
+  group('controlsNodes', () {
+    _testControlsNodes();
+  });
 }
 
 void _testSemanticRole() {
@@ -4038,6 +4041,59 @@ void _testTables() {
   semantics().semanticsEnabled = false;
 }
 
+void _testControlsNodes() {
+  test('nodes with table role', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final SemanticsTester tester = SemanticsTester(owner());
+    tester.updateNode(
+      id: 0,
+      controlsNodes: <String>['a'],
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      children: <SemanticsNodeUpdate>[
+        tester.updateNode(id: 1, identifier: 'a'),
+        tester.updateNode(id: 2, identifier: 'b'),
+      ],
+    );
+    tester.apply();
+
+    SemanticsObject object = tester.getSemanticsObject(0);
+    expect(object.element.getAttribute('aria-controls'), 'flt-semantic-node-1');
+
+    tester.updateNode(
+      id: 0,
+      controlsNodes: <String>['b'],
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      children: <SemanticsNodeUpdate>[
+        tester.updateNode(id: 1, identifier: 'a'),
+        tester.updateNode(id: 2, identifier: 'b'),
+      ],
+    );
+    tester.apply();
+
+    object = tester.getSemanticsObject(0);
+    expect(object.element.getAttribute('aria-controls'), 'flt-semantic-node-2');
+
+    tester.updateNode(
+      id: 0,
+      controlsNodes: <String>['a', 'b'],
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      children: <SemanticsNodeUpdate>[
+        tester.updateNode(id: 1, identifier: 'a'),
+        tester.updateNode(id: 2, identifier: 'b'),
+      ],
+    );
+    tester.apply();
+
+    object = tester.getSemanticsObject(0);
+    expect(object.element.getAttribute('aria-controls'), 'flt-semantic-node-1 flt-semantic-node-2');
+  });
+
+  semantics().semanticsEnabled = false;
+}
+
 /// A facade in front of [ui.SemanticsUpdateBuilder.updateNode] that
 /// supplies default values for semantics attributes.
 void updateNode(
@@ -4077,6 +4133,7 @@ void updateNode(
   Int32List? additionalActions,
   int headingLevel = 0,
   String? linkUrl,
+  List<String>? controlsNodes,
 }) {
   transform ??= Float64List.fromList(Matrix4.identity().storage);
   childrenInTraversalOrder ??= Int32List(0);
@@ -4118,6 +4175,7 @@ void updateNode(
     additionalActions: additionalActions,
     headingLevel: headingLevel,
     linkUrl: linkUrl,
+    controlsNodes: controlsNodes,
   );
 }
 

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -4129,27 +4129,6 @@ void _testControlsNodes() {
     );
   });
 
-  test('can control multiple nodes with same identifier', () {
-    semantics()
-      ..debugOverrideTimestampFunction(() => _testTime)
-      ..semanticsEnabled = true;
-
-    final SemanticsTester tester = SemanticsTester(owner());
-    tester.updateNode(
-      id: 0,
-      controlsNodes: <String>['a'],
-      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
-      children: <SemanticsNodeUpdate>[
-        tester.updateNode(id: 1, identifier: 'a'),
-        tester.updateNode(id: 2, identifier: 'a'),
-      ],
-    );
-    tester.apply();
-
-    SemanticsObject object = tester.getSemanticsObject(0);
-    expect(object.element.getAttribute('aria-controls'), 'flt-semantic-node-1 flt-semantic-node-2');
-  });
-
   semantics().semanticsEnabled = false;
 }
 

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -118,6 +118,7 @@ class SemanticsTester {
     int? headingLevel,
     String? linkUrl,
     ui.SemanticsRole? role,
+    List<String>? controlsNodes,
   }) {
     // Flags
     if (hasCheckedState ?? false) {
@@ -333,6 +334,7 @@ class SemanticsTester {
       headingLevel: headingLevel ?? 0,
       linkUrl: linkUrl,
       role: role ?? ui.SemanticsRole.none,
+      controlsNodes: controlsNodes,
     );
     _nodeUpdates.add(update);
     return update;

--- a/engine/src/flutter/lib/web_ui/test/engine/util_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/util_test.dart
@@ -154,4 +154,22 @@ void testMain() {
       expect('$exception', contains('operation failed'));
     }
   });
+
+  test('unordered list equality', () {
+    expect(unorderedListEqual<int>(null, null), isTrue);
+    expect(unorderedListEqual<int>(<int>[], null), isTrue);
+    expect(unorderedListEqual<int>(<int>[], <int>[]), isTrue);
+    expect(unorderedListEqual<int>(<int>[1], <int>[1]), isTrue);
+    expect(unorderedListEqual<int>(<int>[1, 2], <int>[1, 2]), isTrue);
+    expect(unorderedListEqual<int>(<int>[2, 1], <int>[1, 2]), isTrue);
+    expect(unorderedListEqual<int>(<int>[2, 1, 3], <int>[3, 1, 2]), isTrue);
+
+    expect(unorderedListEqual<int>(<int>[1], null), isFalse);
+    expect(unorderedListEqual<int>(<int>[1], <int>[2]), isFalse);
+    expect(unorderedListEqual<int>(<int>[1, 2], <int>[2, 2]), isFalse);
+    expect(unorderedListEqual<int>(<int>[1, 2], <int>[2, 3]), isFalse);
+    expect(unorderedListEqual<int>(<int>[1, 2], <int>[3, 4]), isFalse);
+    expect(unorderedListEqual<int>(<int>[2, 1, 3], <int>[3, 1, 1]), isFalse);
+    expect(unorderedListEqual<int>(<int>[1, 1, 2], <int>[3, 1, 1]), isFalse);
+  });
 }

--- a/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
@@ -198,6 +198,7 @@ Future<void> a11y_main() async {
           tooltip: 'tooltip',
           textDirection: TextDirection.ltr,
           additionalActions: Int32List(0),
+          controlsNodes: null,
         )
         ..updateNode(
           id: 84,
@@ -233,6 +234,7 @@ Future<void> a11y_main() async {
           additionalActions: Int32List(0),
           childrenInHitTestOrder: Int32List(0),
           childrenInTraversalOrder: Int32List(0),
+          controlsNodes: null,
         )
         ..updateNode(
           id: 96,
@@ -268,6 +270,7 @@ Future<void> a11y_main() async {
           tooltip: 'tooltip',
           textDirection: TextDirection.ltr,
           additionalActions: Int32List(0),
+          controlsNodes: null,
         )
         ..updateNode(
           id: 128,
@@ -303,6 +306,7 @@ Future<void> a11y_main() async {
           textDirection: TextDirection.ltr,
           childrenInHitTestOrder: Int32List(0),
           childrenInTraversalOrder: Int32List(0),
+          controlsNodes: null,
         )
         ..updateCustomAction(id: 21, label: 'Archive', hint: 'archive message');
 
@@ -390,6 +394,7 @@ Future<void> a11y_string_attributes() async {
         tooltip: 'tooltip',
         textDirection: TextDirection.ltr,
         additionalActions: Int32List(0),
+        controlsNodes: null,
       );
 
   PlatformDispatcher.instance.views.first.updateSemantics(builder.build());

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/locale_initialization.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/locale_initialization.dart
@@ -75,7 +75,7 @@ class LocaleInitialization extends Scenario {
           childrenInTraversalOrder: Int32List(0),
           childrenInHitTestOrder: Int32List(0),
           additionalActions: Int32List(0),
-          controlsVisibilityOfNodes: null,
+          controlsNodes: null,
         );
 
     final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/locale_initialization.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/locale_initialization.dart
@@ -75,6 +75,7 @@ class LocaleInitialization extends Scenario {
           childrenInTraversalOrder: Int32List(0),
           childrenInHitTestOrder: Int32List(0),
           additionalActions: Int32List(0),
+          controlsVisibilityOfNodes: null,
         );
 
     final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/locale_initialization.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/locale_initialization.dart
@@ -136,6 +136,7 @@ class LocaleInitialization extends Scenario {
           childrenInTraversalOrder: Int32List(0),
           childrenInHitTestOrder: Int32List(0),
           additionalActions: Int32List(0),
+          controlsNodes: null,
         );
 
     final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4540,6 +4540,10 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     if (properties.role != null) {
       config.role = _properties.role!;
     }
+    if (_properties.controlsVisibilityOfNodes != null) {
+      config.controlsVisibilityOfNodes = _properties.controlsVisibilityOfNodes;
+    }
+
     // Registering _perform* as action handlers instead of the user provided
     // ones to ensure that changing a user provided handler from a non-null to
     // another non-null value doesn't require a semantics update.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4540,8 +4540,8 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     if (properties.role != null) {
       config.role = _properties.role!;
     }
-    if (_properties.controlsVisibilityOfNodes != null) {
-      config.controlsVisibilityOfNodes = _properties.controlsVisibilityOfNodes;
+    if (_properties.controlsNodes != null) {
+      config.controlsNodes = _properties.controlsNodes;
     }
 
     // Registering _perform* as action handlers instead of the user provided

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -595,7 +595,7 @@ class SemanticsData with Diagnosticable {
     required this.headingLevel,
     required this.linkUrl,
     required this.role,
-    required this.controlsVisibilityOfNodes,
+    required this.controlsNodes,
     this.tags,
     this.transform,
     this.customSemanticsActionIds,
@@ -856,8 +856,10 @@ class SemanticsData with Diagnosticable {
   /// {@macro flutter.semantics.SemanticsNode.role}
   final SemanticsRole role;
 
-  /// {@macro flutter.semantics.SemanticsNode.controlsVisibilityOfNodes}
-  final Set<String>? controlsVisibilityOfNodes;
+  /// {@macro flutter.semantics.SemanticsNode.controlsNodes}
+  ///
+  /// {@macro flutter.semantics.SemanticsProperties.controlsNodes}
+  final Set<String>? controlsNodes;
 
   /// Whether [flags] contains the given flag.
   bool hasFlag(SemanticsFlag flag) => (flags & flag.index) != 0;
@@ -916,10 +918,8 @@ class SemanticsData with Diagnosticable {
     properties.add(DoubleProperty('scrollExtentMax', scrollExtentMax, defaultValue: null));
     properties.add(IntProperty('headingLevel', headingLevel, defaultValue: 0));
     properties.add(DiagnosticsProperty<Uri>('linkUrl', linkUrl, defaultValue: null));
-    if (controlsVisibilityOfNodes != null) {
-      properties.add(
-        IterableProperty<String>('controls', controlsVisibilityOfNodes, ifEmpty: null),
-      );
+    if (controlsNodes != null) {
+      properties.add(IterableProperty<String>('controls', controlsNodes, ifEmpty: null));
     }
   }
 
@@ -954,7 +954,7 @@ class SemanticsData with Diagnosticable {
         other.linkUrl == linkUrl &&
         other.role == role &&
         _sortedListsEqual(other.customSemanticsActionIds, customSemanticsActionIds) &&
-        setEquals<String>(controlsVisibilityOfNodes, other.controlsVisibilityOfNodes);
+        setEquals<String>(controlsNodes, other.controlsNodes);
   }
 
   @override
@@ -988,7 +988,7 @@ class SemanticsData with Diagnosticable {
       linkUrl,
       customSemanticsActionIds == null ? null : Object.hashAll(customSemanticsActionIds!),
       role,
-      controlsVisibilityOfNodes == null ? null : Object.hashAll(controlsVisibilityOfNodes!),
+      controlsNodes == null ? null : Object.hashAll(controlsNodes!),
     ),
   );
 
@@ -1157,7 +1157,7 @@ class SemanticsProperties extends DiagnosticableTree {
     this.onDismiss,
     this.customSemanticsActions,
     this.role,
-    this.controlsVisibilityOfNodes,
+    this.controlsNodes,
   }) : assert(
          label == null || attributedLabel == null,
          'Only one of label or attributedLabel should be provided',
@@ -1959,16 +1959,16 @@ class SemanticsProperties extends DiagnosticableTree {
   /// {@endtemplate}
   final SemanticsRole? role;
 
-  /// A set of [SemanticsNode.identifier]s' visibilities that this subtree
-  /// controls
+  /// The [SemanticsNode.identifier]s of widgets controlled by this subtree.
   ///
-  /// If a widget is controlling the visibility of the other widget, for example,
-  /// [Tab]s controls children visibilities of [TabBarView] or [ExpansionTile]
-  /// controls visibility of its expanded content. One must assign a
-  /// [SemanticsNode.identifier] to the hidden content and also provide a
-  /// set of identifiers include the hidden content's identifier to this
-  /// property.
-  final Set<String>? controlsVisibilityOfNodes;
+  /// {@template flutter.semantics.SemanticsProperties.controlsNodes}
+  /// If a widget is controlling the visibility or content of another widget,
+  /// for example, [Tab]s control child visibilities of [TabBarView] or
+  /// [ExpansionTile] controls visibility of its expanded content, one must
+  /// assign a [SemanticsNode.identifier] to the content and also provide a set
+  /// of identifiers including the content's identifier to this property.
+  /// {@endtemplate}
+  final Set<String>? controlsNodes;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -2927,19 +2927,13 @@ class SemanticsNode with DiagnosticableTreeMixin {
   SemanticsRole get role => _role;
   SemanticsRole _role = _kEmptyConfig.role;
 
-  /// {@template flutter.semantics.SemanticsNode.controlsVisibilityOfNodes}
-  /// A set of [SemanticsNode.identifier]s' visibilities that this node
-  /// controls
-  ///
-  /// If a widget is controlling the visibility of the other widget, for example,
-  /// [Tab]s controls children visibilities of [TabBarView] or [ExpansionTile]
-  /// controls visibility of its expanded content. One must assign a
-  /// [SemanticsNode.identifier] to the hidden content and also provide a
-  /// set of identifiers include the hidden content's identifier to this
-  /// property.
+  /// {@template flutter.semantics.SemanticsNode.controlsNodes}
+  /// The [SemanticsNode.identifier]s of widgets controlled by this node.
   /// {@endtemplate}
-  Set<String>? get controlsVisibilityOfNodes => _controlsVisibilityOfNodes;
-  Set<String>? _controlsVisibilityOfNodes = _kEmptyConfig.controlsVisibilityOfNodes;
+  ///
+  /// {@macro flutter.semantics.SemanticsProperties.controlsNodes}
+  Set<String>? get controlsNodes => _controlsNodes;
+  Set<String>? _controlsNodes = _kEmptyConfig.controlsNodes;
 
   bool _canPerformAction(SemanticsAction action) => _actions.containsKey(action);
 
@@ -3007,7 +3001,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     _headingLevel = config._headingLevel;
     _linkUrl = config._linkUrl;
     _role = config._role;
-    _controlsVisibilityOfNodes = config._controlsVisibilityOfNodes;
+    _controlsNodes = config._controlsNodes;
     _replaceChildren(childrenInInversePaintOrder ?? const <SemanticsNode>[]);
 
     if (mergeAllDescendantsIntoThisNodeValueChanged) {
@@ -3057,7 +3051,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     double thickness = _thickness;
     Uri? linkUrl = _linkUrl;
     SemanticsRole role = _role;
-    Set<String>? controlsVisibilityOfNodes = _controlsVisibilityOfNodes;
+    Set<String>? controlsNodes = _controlsNodes;
     final Set<int> customSemanticsActionIds = <int>{};
     for (final CustomSemanticsAction action in _customSemanticsActions.keys) {
       customSemanticsActionIds.add(CustomSemanticsAction.getIdentifier(action));
@@ -3157,10 +3151,10 @@ class SemanticsNode with DiagnosticableTreeMixin {
 
         thickness = math.max(thickness, node._thickness + node._elevation);
 
-        if (controlsVisibilityOfNodes == null) {
-          controlsVisibilityOfNodes = node._controlsVisibilityOfNodes;
-        } else if (node._controlsVisibilityOfNodes != null) {
-          controlsVisibilityOfNodes!.addAll(node._controlsVisibilityOfNodes!);
+        if (controlsNodes == null) {
+          controlsNodes = node._controlsNodes;
+        } else if (node._controlsNodes != null) {
+          controlsNodes = <String>{...controlsNodes!, ...node._controlsNodes!};
         }
 
         return true;
@@ -3196,7 +3190,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       headingLevel: headingLevel,
       linkUrl: linkUrl,
       role: role,
-      controlsVisibilityOfNodes: controlsVisibilityOfNodes,
+      controlsNodes: controlsNodes,
     );
   }
 
@@ -3282,7 +3276,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       headingLevel: data.headingLevel,
       linkUrl: data.linkUrl?.toString() ?? '',
       role: data.role,
-      controlsVisibilityOfNodes: data.controlsVisibilityOfNodes?.toList(),
+      controlsNodes: data.controlsNodes?.toList(),
     );
     _dirty = false;
   }
@@ -5426,12 +5420,12 @@ class SemanticsConfiguration {
     _hasBeenAnnotated = true;
   }
 
-  /// A set of [SemanticsNode.identifier]s' visibilities that this node controls
-  Set<String>? get controlsVisibilityOfNodes => _controlsVisibilityOfNodes;
-  Set<String>? _controlsVisibilityOfNodes;
-  set controlsVisibilityOfNodes(Set<String>? value) {
+  /// The [SemanticsNode.identifier]s of widgets controlled by this node.
+  Set<String>? get controlsNodes => _controlsNodes;
+  Set<String>? _controlsNodes;
+  set controlsNodes(Set<String>? value) {
     assert(value != null);
-    _controlsVisibilityOfNodes = value;
+    _controlsNodes = value;
     _hasBeenAnnotated = true;
   }
 
@@ -5599,10 +5593,10 @@ class SemanticsConfiguration {
 
     _thickness = math.max(_thickness, child._thickness + child._elevation);
 
-    if (_controlsVisibilityOfNodes == null) {
-      _controlsVisibilityOfNodes = child._controlsVisibilityOfNodes;
-    } else if (child._controlsVisibilityOfNodes != null) {
-      _controlsVisibilityOfNodes!.addAll(child._controlsVisibilityOfNodes!);
+    if (_controlsNodes == null) {
+      _controlsNodes = child._controlsNodes;
+    } else if (child._controlsNodes != null) {
+      _controlsNodes!.addAll(child._controlsNodes!);
     }
 
     _hasBeenAnnotated = hasBeenAnnotated || child.hasBeenAnnotated;
@@ -5647,7 +5641,7 @@ class SemanticsConfiguration {
       .._headingLevel = _headingLevel
       .._linkUrl = _linkUrl
       .._role = _role
-      .._controlsVisibilityOfNodes = _controlsVisibilityOfNodes;
+      .._controlsNodes = _controlsNodes;
   }
 }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -595,6 +595,7 @@ class SemanticsData with Diagnosticable {
     required this.headingLevel,
     required this.linkUrl,
     required this.role,
+    required this.controlsVisibilityOfNodes,
     this.tags,
     this.transform,
     this.customSemanticsActionIds,
@@ -855,6 +856,9 @@ class SemanticsData with Diagnosticable {
   /// {@macro flutter.semantics.SemanticsNode.role}
   final SemanticsRole role;
 
+  /// {@macro flutter.semantics.SemanticsNode.controlsVisibilityOfNodes}
+  final Set<String>? controlsVisibilityOfNodes;
+
   /// Whether [flags] contains the given flag.
   bool hasFlag(SemanticsFlag flag) => (flags & flag.index) != 0;
 
@@ -912,6 +916,11 @@ class SemanticsData with Diagnosticable {
     properties.add(DoubleProperty('scrollExtentMax', scrollExtentMax, defaultValue: null));
     properties.add(IntProperty('headingLevel', headingLevel, defaultValue: 0));
     properties.add(DiagnosticsProperty<Uri>('linkUrl', linkUrl, defaultValue: null));
+    if (controlsVisibilityOfNodes != null) {
+      properties.add(
+        IterableProperty<String>('controls', controlsVisibilityOfNodes, ifEmpty: null),
+      );
+    }
   }
 
   @override
@@ -944,7 +953,8 @@ class SemanticsData with Diagnosticable {
         other.headingLevel == headingLevel &&
         other.linkUrl == linkUrl &&
         other.role == role &&
-        _sortedListsEqual(other.customSemanticsActionIds, customSemanticsActionIds);
+        _sortedListsEqual(other.customSemanticsActionIds, customSemanticsActionIds) &&
+        setEquals<String>(controlsVisibilityOfNodes, other.controlsVisibilityOfNodes);
   }
 
   @override
@@ -978,6 +988,7 @@ class SemanticsData with Diagnosticable {
       linkUrl,
       customSemanticsActionIds == null ? null : Object.hashAll(customSemanticsActionIds!),
       role,
+      controlsVisibilityOfNodes == null ? null : Object.hashAll(controlsVisibilityOfNodes!),
     ),
   );
 
@@ -1146,6 +1157,7 @@ class SemanticsProperties extends DiagnosticableTree {
     this.onDismiss,
     this.customSemanticsActions,
     this.role,
+    this.controlsVisibilityOfNodes,
   }) : assert(
          label == null || attributedLabel == null,
          'Only one of label or attributedLabel should be provided',
@@ -1946,6 +1958,17 @@ class SemanticsProperties extends DiagnosticableTree {
   /// For a list of available roles, see [SemanticsRole].
   /// {@endtemplate}
   final SemanticsRole? role;
+
+  /// A set of [SemanticsNode.identifier]s' visibilities that this subtree
+  /// controls
+  ///
+  /// If a widget is controlling the visibility of the other widget, for example,
+  /// [Tab]s controls children visibilities of [TabBarView] or [ExpansionTile]
+  /// controls visibility of its expanded content. One must assign a
+  /// [SemanticsNode.identifier] to the hidden content and also provide a
+  /// set of identifiers include the hidden content's identifier to this
+  /// property.
+  final Set<String>? controlsVisibilityOfNodes;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -2904,6 +2927,20 @@ class SemanticsNode with DiagnosticableTreeMixin {
   SemanticsRole get role => _role;
   SemanticsRole _role = _kEmptyConfig.role;
 
+  /// {@template flutter.semantics.SemanticsNode.controlsVisibilityOfNodes}
+  /// A set of [SemanticsNode.identifier]s' visibilities that this node
+  /// controls
+  ///
+  /// If a widget is controlling the visibility of the other widget, for example,
+  /// [Tab]s controls children visibilities of [TabBarView] or [ExpansionTile]
+  /// controls visibility of its expanded content. One must assign a
+  /// [SemanticsNode.identifier] to the hidden content and also provide a
+  /// set of identifiers include the hidden content's identifier to this
+  /// property.
+  /// {@endtemplate}
+  Set<String>? get controlsVisibilityOfNodes => _controlsVisibilityOfNodes;
+  Set<String>? _controlsVisibilityOfNodes = _kEmptyConfig.controlsVisibilityOfNodes;
+
   bool _canPerformAction(SemanticsAction action) => _actions.containsKey(action);
 
   static final SemanticsConfiguration _kEmptyConfig = SemanticsConfiguration();
@@ -2970,6 +3007,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     _headingLevel = config._headingLevel;
     _linkUrl = config._linkUrl;
     _role = config._role;
+    _controlsVisibilityOfNodes = config._controlsVisibilityOfNodes;
     _replaceChildren(childrenInInversePaintOrder ?? const <SemanticsNode>[]);
 
     if (mergeAllDescendantsIntoThisNodeValueChanged) {
@@ -3019,6 +3057,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     double thickness = _thickness;
     Uri? linkUrl = _linkUrl;
     SemanticsRole role = _role;
+    Set<String>? controlsVisibilityOfNodes = _controlsVisibilityOfNodes;
     final Set<int> customSemanticsActionIds = <int>{};
     for (final CustomSemanticsAction action in _customSemanticsActions.keys) {
       customSemanticsActionIds.add(CustomSemanticsAction.getIdentifier(action));
@@ -3118,6 +3157,12 @@ class SemanticsNode with DiagnosticableTreeMixin {
 
         thickness = math.max(thickness, node._thickness + node._elevation);
 
+        if (controlsVisibilityOfNodes == null) {
+          controlsVisibilityOfNodes = node._controlsVisibilityOfNodes;
+        } else if (node._controlsVisibilityOfNodes != null) {
+          controlsVisibilityOfNodes!.addAll(node._controlsVisibilityOfNodes!);
+        }
+
         return true;
       });
     }
@@ -3151,6 +3196,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       headingLevel: headingLevel,
       linkUrl: linkUrl,
       role: role,
+      controlsVisibilityOfNodes: controlsVisibilityOfNodes,
     );
   }
 
@@ -3236,6 +3282,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       headingLevel: data.headingLevel,
       linkUrl: data.linkUrl?.toString() ?? '',
       role: data.role,
+      controlsVisibilityOfNodes: data.controlsVisibilityOfNodes?.toList(),
     );
     _dirty = false;
   }
@@ -5379,6 +5426,15 @@ class SemanticsConfiguration {
     _hasBeenAnnotated = true;
   }
 
+  /// A set of [SemanticsNode.identifier]s' visibilities that this node controls
+  Set<String>? get controlsVisibilityOfNodes => _controlsVisibilityOfNodes;
+  Set<String>? _controlsVisibilityOfNodes;
+  set controlsVisibilityOfNodes(Set<String>? value) {
+    assert(value != null);
+    _controlsVisibilityOfNodes = value;
+    _hasBeenAnnotated = true;
+  }
+
   // TAGS
 
   /// The set of tags that this configuration wants to add to all child
@@ -5543,6 +5599,12 @@ class SemanticsConfiguration {
 
     _thickness = math.max(_thickness, child._thickness + child._elevation);
 
+    if (_controlsVisibilityOfNodes == null) {
+      _controlsVisibilityOfNodes = child._controlsVisibilityOfNodes;
+    } else if (child._controlsVisibilityOfNodes != null) {
+      _controlsVisibilityOfNodes!.addAll(child._controlsVisibilityOfNodes!);
+    }
+
     _hasBeenAnnotated = hasBeenAnnotated || child.hasBeenAnnotated;
   }
 
@@ -5584,7 +5646,8 @@ class SemanticsConfiguration {
       ..isBlockingUserActions = isBlockingUserActions
       .._headingLevel = _headingLevel
       .._linkUrl = _linkUrl
-      .._role = _role;
+      .._role = _role
+      .._controlsVisibilityOfNodes = _controlsVisibilityOfNodes;
   }
 }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5596,7 +5596,7 @@ class SemanticsConfiguration {
     if (_controlsNodes == null) {
       _controlsNodes = child._controlsNodes;
     } else if (child._controlsNodes != null) {
-      _controlsNodes!.addAll(child._controlsNodes!);
+      _controlsNodes = <String>{..._controlsNodes!, ...child._controlsNodes!};
     }
 
     _hasBeenAnnotated = hasBeenAnnotated || child.hasBeenAnnotated;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7382,7 +7382,7 @@ class Semantics extends SingleChildRenderObjectWidget {
     VoidCallback? onFocus,
     Map<CustomSemanticsAction, VoidCallback>? customSemanticsActions,
     ui.SemanticsRole? role,
-    Set<String>? controlsVisibilityOfNodes,
+    Set<String>? controlsNodes,
   }) : this.fromProperties(
          key: key,
          child: child,
@@ -7458,7 +7458,7 @@ class Semantics extends SingleChildRenderObjectWidget {
                    ? SemanticsHintOverrides(onTapHint: onTapHint, onLongPressHint: onLongPressHint)
                    : null,
            role: role,
-           controlsVisibilityOfNodes: controlsVisibilityOfNodes,
+           controlsNodes: controlsNodes,
          ),
        );
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7382,6 +7382,7 @@ class Semantics extends SingleChildRenderObjectWidget {
     VoidCallback? onFocus,
     Map<CustomSemanticsAction, VoidCallback>? customSemanticsActions,
     ui.SemanticsRole? role,
+    Set<String>? controlsVisibilityOfNodes,
   }) : this.fromProperties(
          key: key,
          child: child,
@@ -7457,6 +7458,7 @@ class Semantics extends SingleChildRenderObjectWidget {
                    ? SemanticsHintOverrides(onTapHint: onTapHint, onLongPressHint: onLongPressHint)
                    : null,
            role: role,
+           controlsVisibilityOfNodes: controlsVisibilityOfNodes,
          ),
        );
 

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -229,6 +229,7 @@ class SemanticsUpdateBuilderSpy extends Fake implements ui.SemanticsUpdateBuilde
     int headingLevel = 0,
     String? linkUrl,
     ui.SemanticsRole role = ui.SemanticsRole.none,
+    required List<String>? controlsNodes,
   }) {
     // Makes sure we don't send the same id twice.
     assert(!observations.containsKey(id));

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -380,6 +380,25 @@ void main() {
       expect(attributedHint.attributes[0].range, const TextRange(start: 1, end: 2));
     });
 
+    testWidgets('Semantics can set controls visibility of nodes', (WidgetTester tester) async {
+      final UniqueKey key = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Semantics(
+              key: key,
+              controlsVisibilityOfNodes: const <String>{'abc'},
+              child: const Placeholder(),
+            ),
+          ),
+        ),
+      );
+      final SemanticsNode node = tester.getSemantics(find.byKey(key));
+      final SemanticsData data = node.getSemanticsData();
+      expect(data.controlsVisibilityOfNodes!.length, 1);
+      expect(data.controlsVisibilityOfNodes!.first, 'abc');
+    });
+
     testWidgets('Semantics can merge attributed strings', (WidgetTester tester) async {
       final UniqueKey key = UniqueKey();
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -399,6 +399,28 @@ void main() {
       expect(data.controlsNodes!.first, 'abc');
     });
 
+    testWidgets('Semantics can set controls visibility of nodes', (WidgetTester tester) async {
+      final UniqueKey key = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Semantics(
+              key: key,
+              controlsNodes: const <String>{'abc', 'ghi'},
+              child: Semantics(
+                controlsNodes: const <String>{'abc', 'def'},
+                child: const Placeholder(),
+              ),
+            ),
+          ),
+        ),
+      );
+      final SemanticsNode node = tester.getSemantics(find.byKey(key));
+      final SemanticsData data = node.getSemanticsData();
+      expect(data.controlsNodes!.length, 3);
+      expect(data.controlsNodes, <String>{'abc', 'ghi', 'def'});
+    });
+
     testWidgets('Semantics can merge attributed strings', (WidgetTester tester) async {
       final UniqueKey key = UniqueKey();
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -387,7 +387,7 @@ void main() {
           home: Scaffold(
             body: Semantics(
               key: key,
-              controlsVisibilityOfNodes: const <String>{'abc'},
+              controlsNodes: const <String>{'abc'},
               child: const Placeholder(),
             ),
           ),
@@ -395,8 +395,8 @@ void main() {
       );
       final SemanticsNode node = tester.getSemantics(find.byKey(key));
       final SemanticsData data = node.getSemanticsData();
-      expect(data.controlsVisibilityOfNodes!.length, 1);
-      expect(data.controlsVisibilityOfNodes!.first, 'abc');
+      expect(data.controlsNodes!.length, 1);
+      expect(data.controlsNodes!.first, 'abc');
     });
 
     testWidgets('Semantics can merge attributed strings', (WidgetTester tester) async {

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -730,6 +730,7 @@ void main() {
         headingLevel: 0,
         linkUrl: Uri(path: 'l'),
         role: ui.SemanticsRole.none,
+        controlsNodes: null,
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1029,6 +1030,7 @@ void main() {
         headingLevel: 0,
         linkUrl: Uri(path: 'l'),
         role: ui.SemanticsRole.none,
+        controlsNodes: null,
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1125,6 +1127,7 @@ void main() {
         headingLevel: 0,
         linkUrl: null,
         role: ui.SemanticsRole.none,
+        controlsNodes: null,
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1228,6 +1231,7 @@ void main() {
         headingLevel: 0,
         linkUrl: null,
         role: ui.SemanticsRole.none,
+        controlsNodes: null,
       );
       final _FakeSemanticsNode emptyNode = _FakeSemanticsNode(emptyData);
 
@@ -1259,6 +1263,7 @@ void main() {
         headingLevel: 0,
         linkUrl: Uri(path: 'l'),
         role: ui.SemanticsRole.none,
+        controlsNodes: null,
       );
       final _FakeSemanticsNode fullNode = _FakeSemanticsNode(fullData);
 
@@ -1346,6 +1351,7 @@ void main() {
         headingLevel: 0,
         linkUrl: null,
         role: ui.SemanticsRole.none,
+        controlsNodes: null,
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

adding a new property in semantics properties called controlsVisibilityOfNodes, where developer can assign SemanticsProperties.identifier of other nodes to indicates which nodes' visibilities this node controls

fixes https://github.com/flutter/flutter/issues/162125

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
