### PR TITLE
Roll .ci.yaml changes into the LUCI configuration only when the master branch is updated

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -561,6 +561,9 @@ targets:
     recipe: infra/ci_yaml
     presubmit: false
     timeout: 30
+    enabled_branches:
+      # Don't run this on release branches
+      - master
     properties:
       tags: >
         ["framework", "hostonly", "shard", "linux"]


### PR DESCRIPTION
The .ci.yaml on a release branch may be missing builders that are active on the latest master version of .ci.yaml.  If a configuration based on the release branch is pushed to LUCI, then CI will fail to schedule those builders when run for a master branch PR.