### PR TITLE
Fix and test an edge case in `findPackageConfigFile`.

### DIFF
--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -38,6 +38,8 @@ File? findPackageConfigFile(Directory dir) {
     // parentDir exists if the candidateDir exists, then we can just check that
     // the candidate dir exists (if it doesn't, then identicalSync would throw
     // which is probably not what findPackageConfigFile is intende to do).
+    //
+    // See https://github.com/flutter/flutter/issues/163901.
     if (candidateDir.existsSync() && fileSystem.identicalSync(parentDir.path, candidateDir.path)) {
       return null;
     }

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -34,13 +34,7 @@ File? findPackageConfigFile(Directory dir) {
       return candidatePackageConfigFile;
     }
     final Directory parentDir = candidateDir.parent;
-    // identicalSync requires that both paths exist; if we assume that the
-    // parentDir exists if the candidateDir exists, then we can just check that
-    // the candidate dir exists (if it doesn't, then identicalSync would throw
-    // which is probably not what findPackageConfigFile is intende to do).
-    //
-    // See https://github.com/flutter/flutter/issues/163901.
-    if (candidateDir.existsSync() && fileSystem.identicalSync(parentDir.path, candidateDir.path)) {
+    if (fileSystem.path.equals(parentDir.path, candidateDir.path)) {
       return null;
     }
     candidateDir = parentDir;

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -34,7 +34,11 @@ File? findPackageConfigFile(Directory dir) {
       return candidatePackageConfigFile;
     }
     final Directory parentDir = candidateDir.parent;
-    if (fileSystem.identicalSync(parentDir.path, candidateDir.path)) {
+    // identicalSync requires that both paths exist; if we assume that the
+    // parentDir exists if the candidateDir exists, then we can just check that
+    // the candidate dir exists (if it doesn't, then identicalSync would throw
+    // which is probably not what findPackageConfigFile is intende to do).
+    if (candidateDir.existsSync() && fileSystem.identicalSync(parentDir.path, candidateDir.path)) {
       return null;
     }
     candidateDir = parentDir;

--- a/packages/flutter_tools/test/general.shard/dart/package_map_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/package_map_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/dart/package_map.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  group('findPackageConfigFile', () {
+    late FileSystem fileSystem;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem.test();
+    });
+
+    test('should find an immediate .dart_tool/package_config.json', () {
+      fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+      expect(findPackageConfigFile(fileSystem.currentDirectory), isNotNull);
+    });
+
+    test('should find a parent .dart_tool/package_config.json', () {
+      fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+      fileSystem.currentDirectory.childDirectory('child').createSync(recursive: true);
+      expect(findPackageConfigFile(fileSystem.currentDirectory.childDirectory('child')), isNotNull);
+    });
+
+    test('should not find a .dart_tool/package_config.json in an existing directory', () {
+      fileSystem.currentDirectory.childDirectory('child').createSync(recursive: true);
+      expect(findPackageConfigFile(fileSystem.currentDirectory.childDirectory('child')), isNull);
+    });
+
+    // Regression test: https://github.com/flutter/flutter/issues/163901.
+    test('should not find a .dart_tool/package_config.json in a missing directory', () {
+      expect(findPackageConfigFile(fileSystem.currentDirectory.childDirectory('missing')), isNull);
+    });
+
+    // Regression test: https://github.com/flutter/flutter/issues/163901.
+    test('should find a .dart_tool/package_config.json in a parent of a missing directory', () {
+      fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+      expect(
+        findPackageConfigFile(fileSystem.currentDirectory.childDirectory('missing')),
+        isNotNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/163901.

I'm not aware of a case where this causes user crashes, but it could, and seems easy to fix/test.