### PR TITLE
Update API doc for scroll_configuration's dragDevices

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -112,10 +112,11 @@ class ScrollBehavior {
 
   /// The device kinds that the scrollable will accept drag gestures from.
   ///
-  /// By default only [PointerDeviceKind.touch], [PointerDeviceKind.stylus], and
-  /// [PointerDeviceKind.invertedStylus] are configured to create drag gestures.
-  /// Enabling this for [PointerDeviceKind.mouse] will make it difficult or
-  /// impossible to select text in scrollable containers and is not recommended.
+  /// By default only [PointerDeviceKind.touch], [PointerDeviceKind.stylus],
+  /// [PointerDeviceKind.invertedStylus] and [PointerDeviceKind.trackpad] are
+  /// configured to create drag gestures. Enabling this for
+  /// [PointerDeviceKind.mouse] will make it difficult or impossible to select
+  /// text in scrollable containers and is not recommended.
   Set<PointerDeviceKind> get dragDevices => _kTouchLikeDeviceTypes;
 
   /// {@macro flutter.gestures.monodrag.DragGestureRecognizer.multitouchDragStrategy}


### PR DESCRIPTION
The track pad has been added [here](https://github.com/flutter/flutter/blob/401ab831ee56bb31b8beceb0a08bc3293f1a9788/packages/flutter/lib/src/widgets/scroll_configuration.dart#L33), but the api doc was not updated. 

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

None

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
