### PR TITLE
add assert message for BoxShape.circle and borderRadius check

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -325,7 +325,7 @@ abstract class BoxBorder extends ShapeBorder {
       case BoxShape.circle:
         assert(
           borderRadius == null,
-          'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
+          'A circle cannot have a border radius. Remove either the shape or the borderRadius argument.',
         );
         borderRect = RRect.fromRectAndRadius(
           Rect.fromCircle(center: rect.center, radius: rect.shortestSide / 2.0),
@@ -705,7 +705,7 @@ class Border extends BoxBorder {
             case BoxShape.circle:
               assert(
                 borderRadius == null,
-                'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
+                'A circle cannot have a border radius. Remove either the shape or the borderRadius argument.',
               );
               BoxBorder._paintUniformBorderWithCircle(canvas, rect, top);
             case BoxShape.rectangle:
@@ -1083,7 +1083,7 @@ class BorderDirectional extends BoxBorder {
             case BoxShape.circle:
               assert(
                 borderRadius == null,
-                'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
+                'A circle cannot have a border radius. Remove either the shape or the borderRadius argument.',
               );
               BoxBorder._paintUniformBorderWithCircle(canvas, rect, top);
             case BoxShape.rectangle:

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -323,7 +323,10 @@ abstract class BoxBorder extends ShapeBorder {
       case BoxShape.rectangle:
         borderRect = (borderRadius ?? BorderRadius.zero).resolve(textDirection).toRRect(rect);
       case BoxShape.circle:
-        assert(borderRadius == null, 'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.');
+        assert(
+          borderRadius == null,
+          'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
+        );
         borderRect = RRect.fromRectAndRadius(
           Rect.fromCircle(center: rect.center, radius: rect.shortestSide / 2.0),
           Radius.circular(rect.width),

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -323,10 +323,7 @@ abstract class BoxBorder extends ShapeBorder {
       case BoxShape.rectangle:
         borderRect = (borderRadius ?? BorderRadius.zero).resolve(textDirection).toRRect(rect);
       case BoxShape.circle:
-        assert(
-          borderRadius == null,
-          'A borderRadius cannot be given when shape is a BoxShape.circle.',
-        );
+        assert(borderRadius == null, 'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.');
         borderRect = RRect.fromRectAndRadius(
           Rect.fromCircle(center: rect.center, radius: rect.shortestSide / 2.0),
           Radius.circular(rect.width),
@@ -705,7 +702,7 @@ class Border extends BoxBorder {
             case BoxShape.circle:
               assert(
                 borderRadius == null,
-                'A borderRadius cannot be given when shape is a BoxShape.circle.',
+                'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
               );
               BoxBorder._paintUniformBorderWithCircle(canvas, rect, top);
             case BoxShape.rectangle:
@@ -1083,7 +1080,7 @@ class BorderDirectional extends BoxBorder {
             case BoxShape.circle:
               assert(
                 borderRadius == null,
-                'A borderRadius cannot be given when shape is a BoxShape.circle.',
+                'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
               );
               BoxBorder._paintUniformBorderWithCircle(canvas, rect, top);
             case BoxShape.rectangle:

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -133,6 +133,7 @@ class BoxDecoration extends Decoration {
   bool debugAssertIsValid() {
     assert(
       shape != BoxShape.circle || borderRadius == null,
+      'A borderRadius cannot be given when shape is a BoxShape.circle.',
     ); // Can't have a border radius if you're a circle.
     return super.debugAssertIsValid();
   }
@@ -428,7 +429,10 @@ class _BoxDecorationPainter extends BoxPainter {
   void _paintBox(Canvas canvas, Rect rect, Paint paint, TextDirection? textDirection) {
     switch (_decoration.shape) {
       case BoxShape.circle:
-        assert(_decoration.borderRadius == null);
+        assert(
+          _decoration.borderRadius == null,
+          'A borderRadius cannot be given when shape is a BoxShape.circle.',
+        );
         final Offset center = rect.center;
         final double radius = rect.shortestSide / 2.0;
         canvas.drawCircle(center, radius, paint);
@@ -537,7 +541,10 @@ class _BoxDecorationPainter extends BoxPainter {
     Path? clipPath;
     switch (_decoration.shape) {
       case BoxShape.circle:
-        assert(_decoration.borderRadius == null);
+        assert(
+          _decoration.borderRadius == null,
+          'A borderRadius cannot be given when shape is a BoxShape.circle.',
+        );
         final Offset center = rect.center;
         final double radius = rect.shortestSide / 2.0;
         final Rect square = Rect.fromCircle(center: center, radius: radius);

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -133,7 +133,7 @@ class BoxDecoration extends Decoration {
   bool debugAssertIsValid() {
     assert(
       shape != BoxShape.circle || borderRadius == null,
-      'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
+      'A circle cannot have a border radius. Remove either the shape or the borderRadius argument.',
     ); // Can't have a border radius if you're a circle.
     return super.debugAssertIsValid();
   }
@@ -431,7 +431,7 @@ class _BoxDecorationPainter extends BoxPainter {
       case BoxShape.circle:
         assert(
           _decoration.borderRadius == null,
-          'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
+          'A circle cannot have a border radius. Remove either the shape or the borderRadius argument.',
         );
         final Offset center = rect.center;
         final double radius = rect.shortestSide / 2.0;
@@ -543,7 +543,7 @@ class _BoxDecorationPainter extends BoxPainter {
       case BoxShape.circle:
         assert(
           _decoration.borderRadius == null,
-          'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
+          'A circle cannot have a border radius. Remove either the shape or the borderRadius argument.',
         );
         final Offset center = rect.center;
         final double radius = rect.shortestSide / 2.0;

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -133,7 +133,7 @@ class BoxDecoration extends Decoration {
   bool debugAssertIsValid() {
     assert(
       shape != BoxShape.circle || borderRadius == null,
-      'A borderRadius cannot be given when shape is a BoxShape.circle.',
+      'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
     ); // Can't have a border radius if you're a circle.
     return super.debugAssertIsValid();
   }
@@ -431,7 +431,7 @@ class _BoxDecorationPainter extends BoxPainter {
       case BoxShape.circle:
         assert(
           _decoration.borderRadius == null,
-          'A borderRadius cannot be given when shape is a BoxShape.circle.',
+          'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
         );
         final Offset center = rect.center;
         final double radius = rect.shortestSide / 2.0;
@@ -543,7 +543,7 @@ class _BoxDecorationPainter extends BoxPainter {
       case BoxShape.circle:
         assert(
           _decoration.borderRadius == null,
-          'A borderRadius cannot be given when shape is a BoxShape.circle.',
+          'borderRadius is not allowed when shape is BoxShape.circle. Remove either the shape or borderRadius argument.',
         );
         final Offset center = rect.center;
         final double radius = rect.shortestSide / 2.0;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR adds a assert message to  enforce null borderRadius when shape is BoxShape.circle.

Fixes #158207 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
