### PR TITLE
[macOS] Prepare TextInputPlugin for multi-view

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -91,7 +91,8 @@ constexpr char kTextPlainFormat[] = "text/plain";
  */
 @interface FlutterEngine () <FlutterBinaryMessenger,
                              FlutterMouseCursorPluginDelegate,
-                             FlutterKeyboardManagerDelegate>
+                             FlutterKeyboardManagerDelegate,
+                             FlutterTextInputPluginDelegate>
 
 /**
  * A mutable array that holds one bool value that determines if responses to platform messages are
@@ -478,6 +479,9 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, void* user_
 
   // Pointer to a keyboard manager.
   FlutterKeyboardManager* _keyboardManager;
+
+  // The text input plugin that handles text editing state for text fields.
+  FlutterTextInputPlugin* _textInputPlugin;
 }
 
 - (instancetype)initWithName:(NSString*)labelPrefix project:(FlutterDartProject*)project {
@@ -519,6 +523,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   _isResponseValid = [[NSMutableArray alloc] initWithCapacity:1];
   [_isResponseValid addObject:@YES];
   _keyboardManager = [[FlutterKeyboardManager alloc] initWithDelegate:self];
+  _textInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:self];
 
   _embedderAPI.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&_embedderAPI);

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -17,6 +17,7 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -216,6 +217,11 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
  * Returns keyboard manager for the engine.
  */
 @property(nonatomic, readonly) FlutterKeyboardManager* keyboardManager;
+
+/**
+ * Returns text input plugin for the engine.
+ */
+@property(nonatomic, readonly) FlutterTextInputPlugin* textInputPlugin;
 
 /**
  * Returns an array of screen objects representing all of the screens available on the system.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -224,7 +224,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
 
   // Unit test localization is unnecessary.
   // NOLINTNEXTLINE(clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker)
-  viewController.textInputPlugin.string = @"textfield";
+  engine.textInputPlugin.string = @"textfield";
   // Creates a NSWindow so that the native text field can become first responder.
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -12,8 +12,14 @@
 
 @class FlutterTextField;
 
+/**
+ * Delegate for FlutterTextInputPlugin. Implemented by FlutterEngine.
+ */
 @protocol FlutterTextInputPluginDelegate
 
+/**
+ * Returns the FlutterViewController for the given view identifier.
+ */
 - (FlutterViewController*)viewControllerForIdentifier:(FlutterViewIdentifier)viewIdentifier;
 
 @property(nonatomic, readonly) id<FlutterBinaryMessenger> binaryMessenger;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -12,6 +12,14 @@
 
 @class FlutterTextField;
 
+@protocol FlutterTextInputPluginDelegate
+
+- (FlutterViewController*)viewControllerForIdentifier:(FlutterViewIdentifier)viewIdentifier;
+
+@property(nonatomic, readonly) id<FlutterBinaryMessenger> binaryMessenger;
+
+@end
+
 /**
  * A plugin to handle text input.
  *
@@ -34,9 +42,15 @@
 @property(nonatomic, weak) FlutterTextField* client;
 
 /**
+ * Returns the view controller text input plugin is currently attached to,
+ * nil if not attached to any view controller.
+ */
+@property(nonatomic, readonly, weak) FlutterViewController* currentViewController;
+
+/**
  * Initializes a text input plugin that coordinates key event handling with |viewController|.
  */
-- (instancetype)initWithViewController:(FlutterViewController*)viewController;
+- (instancetype)initWithDelegate:(id<FlutterTextInputPluginDelegate>)delegate;
 
 /**
  * Whether this plugin is the first responder of this NSWindow.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -37,6 +37,7 @@ static NSString* const kPerformSelectors = @"TextInputClient.performSelectors";
 static NSString* const kMultilineInputType = @"TextInputType.multiline";
 
 #pragma mark - TextInputConfiguration field names
+static NSString* const kViewId = @"viewId";
 static NSString* const kSecureTextEntry = @"obscureText";
 static NSString* const kTextInputAction = @"inputAction";
 static NSString* const kEnableDeltaModel = @"enableDeltaModel";
@@ -202,78 +203,98 @@ static char markerKey;
 /**
  * Private properties of FlutterTextInputPlugin.
  */
-@interface FlutterTextInputPlugin ()
+@interface FlutterTextInputPlugin () {
+  /**
+   * A text input context, representing a connection to the Cocoa text input system.
+   */
+  NSTextInputContext* _textInputContext;
 
-/**
- * A text input context, representing a connection to the Cocoa text input system.
- */
-@property(nonatomic) NSTextInputContext* textInputContext;
+  /**
+   * The channel used to communicate with Flutter.
+   */
+  FlutterMethodChannel* _channel;
 
-/**
- * The channel used to communicate with Flutter.
- */
-@property(nonatomic) FlutterMethodChannel* channel;
+  /**
+   * The FlutterViewController to manage input for.
+   */
+  __weak FlutterViewController* _currentViewController;
 
-/**
- * The FlutterViewController to manage input for.
- */
-@property(nonatomic, weak) FlutterViewController* flutterViewController;
+  /**
+   * Used to obtain view controller on client creation
+   */
+  __weak id<FlutterTextInputPluginDelegate> _delegate;
 
-/**
- * Whether the text input is shown in the view.
- *
- * Defaults to TRUE on startup.
- */
-@property(nonatomic) BOOL shown;
+  /**
+   * Whether the text input is shown in the view.
+   *
+   * Defaults to TRUE on startup.
+   */
+  BOOL _shown;
 
-/**
- * The current state of the keyboard and pressed keys.
- */
-@property(nonatomic) uint64_t previouslyPressedFlags;
+  /**
+   * The current state of the keyboard and pressed keys.
+   */
+  uint64_t _previouslyPressedFlags;
 
-/**
- * The affinity for the current cursor position.
- */
-@property FlutterTextAffinity textAffinity;
+  /**
+   * The affinity for the current cursor position.
+   */
+  FlutterTextAffinity _textAffinity;
 
-/**
- * ID of the text input client.
- */
-@property(nonatomic, nonnull) NSNumber* clientID;
+  /**
+   * ID of the text input client.
+   */
+  NSNumber* _clientID;
 
-/**
- * Keyboard type of the client. See available options:
- * https://api.flutter.dev/flutter/services/TextInputType-class.html
- */
-@property(nonatomic, nonnull) NSString* inputType;
+  /**
+   * Keyboard type of the client. See available options:
+   * https://api.flutter.dev/flutter/services/TextInputType-class.html
+   */
+  NSString* _inputType;
 
-/**
- * An action requested by the user on the input client. See available options:
- * https://api.flutter.dev/flutter/services/TextInputAction-class.html
- */
-@property(nonatomic, nonnull) NSString* inputAction;
+  /**
+   * An action requested by the user on the input client. See available options:
+   * https://api.flutter.dev/flutter/services/TextInputAction-class.html
+   */
+  NSString* _inputAction;
 
-/**
- * Set to true if the last event fed to the input context produced a text editing command
- * or text output. It is reset to false at the beginning of every key event, and is only
- * used while processing this event.
- */
-@property(nonatomic) BOOL eventProducedOutput;
+  /**
+   * Set to true if the last event fed to the input context produced a text editing command
+   * or text output. It is reset to false at the beginning of every key event, and is only
+   * used while processing this event.
+   */
+  BOOL _eventProducedOutput;
 
-/**
- * Whether to enable the sending of text input updates from the engine to the
- * framework as TextEditingDeltas rather than as one TextEditingValue.
- * For more information on the delta model, see:
- * https://master-api.flutter.dev/flutter/services/TextInputConfiguration/enableDeltaModel.html
- */
-@property(nonatomic) BOOL enableDeltaModel;
+  /**
+   * Whether to enable the sending of text input updates from the engine to the
+   * framework as TextEditingDeltas rather than as one TextEditingValue.
+   * For more information on the delta model, see:
+   * https://master-api.flutter.dev/flutter/services/TextInputConfiguration/enableDeltaModel.html
+   */
+  BOOL _enableDeltaModel;
 
-/**
- * Used to gather multiple selectors performed in one run loop turn. These
- * will be all sent in one platform channel call so that the framework can process
- * them in single microtask.
- */
-@property(nonatomic) NSMutableArray* pendingSelectors;
+  /**
+   * Used to gather multiple selectors performed in one run loop turn. These
+   * will be all sent in one platform channel call so that the framework can process
+   * them in single microtask.
+   */
+  NSMutableArray* _pendingSelectors;
+
+  /**
+   * The currently active text input model.
+   */
+  std::unique_ptr<flutter::TextInputModel> _activeModel;
+
+  /**
+   * Transform for current the editable. Used to determine position of accent selection menu.
+   */
+  CATransform3D _editableTransform;
+
+  /**
+   * Current position of caret in local (editable) coordinates.
+   */
+  CGRect _caretRect;
+}
 
 /**
  * Handles a Flutter system message on the text input channel.
@@ -317,37 +338,23 @@ static char markerKey;
  * Allow overriding run loop mode for test.
  */
 @property(readwrite, nonatomic) NSString* customRunLoopMode;
+@property(nonatomic) NSTextInputContext* textInputContext;
 
 @end
 
 #pragma mark - FlutterTextInputPlugin
 
-@implementation FlutterTextInputPlugin {
-  /**
-   * The currently active text input model.
-   */
-  std::unique_ptr<flutter::TextInputModel> _activeModel;
+@implementation FlutterTextInputPlugin
 
-  /**
-   * Transform for current the editable. Used to determine position of accent selection menu.
-   */
-  CATransform3D _editableTransform;
-
-  /**
-   * Current position of caret in local (editable) coordinates.
-   */
-  CGRect _caretRect;
-}
-
-- (instancetype)initWithViewController:(FlutterViewController*)viewController {
+- (instancetype)initWithDelegate:(id<FlutterTextInputPluginDelegate>)delegate {
   // The view needs an empty frame otherwise it is visible on dark background.
   // https://github.com/flutter/flutter/issues/118504
   self = [super initWithFrame:NSZeroRect];
   self.clipsToBounds = YES;
   if (self != nil) {
-    _flutterViewController = viewController;
+    _delegate = delegate;
     _channel = [FlutterMethodChannel methodChannelWithName:kTextInputChannel
-                                           binaryMessenger:viewController.engine.binaryMessenger
+                                           binaryMessenger:_delegate.binaryMessenger
                                                      codec:[FlutterJSONMethodCodec sharedInstance]];
     _shown = FALSE;
     // NSTextView does not support _weak reference, so this class has to
@@ -371,10 +378,10 @@ static char markerKey;
 }
 
 - (BOOL)isFirstResponder {
-  if (!self.flutterViewController.viewLoaded) {
+  if (!_currentViewController.viewLoaded) {
     return false;
   }
-  return [self.flutterViewController.view.window firstResponder] == self;
+  return [_currentViewController.view.window firstResponder] == self;
 }
 
 - (void)dealloc {
@@ -385,7 +392,7 @@ static char markerKey;
 
 - (void)resignAndRemoveFromSuperview {
   if (self.superview != nil) {
-    [self.window makeFirstResponder:_flutterViewController.flutterView];
+    [self.window makeFirstResponder:_currentViewController.flutterView];
     [self removeFromSuperview];
   }
 }
@@ -394,6 +401,7 @@ static char markerKey;
   BOOL handled = YES;
   NSString* method = call.method;
   if ([method isEqualToString:kSetClientMethod]) {
+    FML_DCHECK(_currentViewController == nil);
     if (!call.arguments[0] || !call.arguments[1]) {
       result([FlutterError
           errorWithCode:@"error"
@@ -410,20 +418,24 @@ static char markerKey;
       _enableDeltaModel = [config[kEnableDeltaModel] boolValue];
       NSDictionary* inputTypeInfo = config[kTextInputType];
       _inputType = inputTypeInfo[kTextInputTypeName];
-      self.textAffinity = kFlutterTextAffinityUpstream;
+      _textAffinity = kFlutterTextAffinityUpstream;
       self.automaticTextCompletionEnabled = EnableAutocomplete(config);
       if (@available(macOS 11.0, *)) {
         self.contentType = GetTextContentType(config);
       }
 
       _activeModel = std::make_unique<flutter::TextInputModel>();
+      NSNumber* viewId = config[kViewId];
+      _currentViewController = [_delegate viewControllerForIdentifier:viewId.longLongValue];
+      FML_DCHECK(_currentViewController != nil);
     }
   } else if ([method isEqualToString:kShowMethod]) {
+    FML_DCHECK(_currentViewController != nil);
     // Ensure the plugin is in hierarchy. Only do this with accessibility disabled.
     // When accessibility is enabled cocoa will reparent the plugin inside
     // FlutterTextField in [FlutterTextField startEditing].
     if (_client == nil) {
-      [_flutterViewController.view addSubview:self];
+      [_currentViewController.view addSubview:self];
     }
     [self.window makeFirstResponder:self];
     _shown = TRUE;
@@ -431,6 +443,7 @@ static char markerKey;
     [self resignAndRemoveFromSuperview];
     _shown = FALSE;
   } else if ([method isEqualToString:kClearClientMethod]) {
+    FML_DCHECK(_currentViewController != nil);
     [self resignAndRemoveFromSuperview];
     // If there's an active mark region, commit it, end composing, and clear the IME's mark text.
     if (_activeModel && _activeModel->composing()) {
@@ -444,13 +457,17 @@ static char markerKey;
     _enableDeltaModel = NO;
     _inputType = nil;
     _activeModel = nullptr;
+    _currentViewController = nil;
   } else if ([method isEqualToString:kSetEditingStateMethod]) {
+    FML_DCHECK(_currentViewController != nil);
     NSDictionary* state = call.arguments;
     [self setEditingState:state];
   } else if ([method isEqualToString:kSetEditableSizeAndTransform]) {
+    FML_DCHECK(_currentViewController != nil);
     NSDictionary* state = call.arguments;
     [self setEditableTransform:state[kTransformKey]];
   } else if ([method isEqualToString:kSetCaretRect]) {
+    FML_DCHECK(_currentViewController != nil);
     NSDictionary* rect = call.arguments;
     [self updateCaretRect:rect];
   } else {
@@ -545,7 +562,7 @@ static char markerKey;
   }
 
   NSDictionary* state = [self editingState];
-  [_channel invokeMethod:kUpdateEditStateResponseMethod arguments:@[ self.clientID, state ]];
+  [_channel invokeMethod:kUpdateEditStateResponseMethod arguments:@[ _clientID, state ]];
   [self updateTextAndSelection];
 }
 
@@ -574,8 +591,7 @@ static char markerKey;
     @"deltas" : @[ deltaToFramework ],
   };
 
-  [_channel invokeMethod:kUpdateEditStateWithDeltasResponseMethod
-               arguments:@[ self.clientID, deltas ]];
+  [_channel invokeMethod:kUpdateEditStateWithDeltasResponseMethod arguments:@[ _clientID, deltas ]];
   [self updateTextAndSelection];
 }
 
@@ -598,8 +614,8 @@ static char markerKey;
 }
 
 - (NSString*)textAffinityString {
-  return (self.textAffinity == kFlutterTextAffinityUpstream) ? kTextAffinityUpstream
-                                                             : kTextAffinityDownstream;
+  return (_textAffinity == kFlutterTextAffinityUpstream) ? kTextAffinityUpstream
+                                                         : kTextAffinityDownstream;
 }
 
 - (BOOL)handleKeyEvent:(NSEvent*)event {
@@ -637,15 +653,15 @@ static char markerKey;
 #pragma mark NSResponder
 
 - (void)keyDown:(NSEvent*)event {
-  [self.flutterViewController keyDown:event];
+  [_currentViewController keyDown:event];
 }
 
 - (void)keyUp:(NSEvent*)event {
-  [self.flutterViewController keyUp:event];
+  [_currentViewController keyUp:event];
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent*)event {
-  if ([_flutterViewController isDispatchingKeyEvent:event]) {
+  if ([_currentViewController isDispatchingKeyEvent:event]) {
     // When NSWindow is nextResponder, keyboard manager will send to it
     // unhandled events (through [NSWindow keyDown:]). If event has both
     // control and cmd modifiers set (i.e. cmd+control+space - emoji picker)
@@ -658,56 +674,56 @@ static char markerKey;
     return NO;
   }
   [event markAsKeyEquivalent];
-  [self.flutterViewController keyDown:event];
+  [_currentViewController keyDown:event];
   return YES;
 }
 
 - (void)flagsChanged:(NSEvent*)event {
-  [self.flutterViewController flagsChanged:event];
+  [_currentViewController flagsChanged:event];
 }
 
 - (void)mouseDown:(NSEvent*)event {
-  [self.flutterViewController mouseDown:event];
+  [_currentViewController mouseDown:event];
 }
 
 - (void)mouseUp:(NSEvent*)event {
-  [self.flutterViewController mouseUp:event];
+  [_currentViewController mouseUp:event];
 }
 
 - (void)mouseDragged:(NSEvent*)event {
-  [self.flutterViewController mouseDragged:event];
+  [_currentViewController mouseDragged:event];
 }
 
 - (void)rightMouseDown:(NSEvent*)event {
-  [self.flutterViewController rightMouseDown:event];
+  [_currentViewController rightMouseDown:event];
 }
 
 - (void)rightMouseUp:(NSEvent*)event {
-  [self.flutterViewController rightMouseUp:event];
+  [_currentViewController rightMouseUp:event];
 }
 
 - (void)rightMouseDragged:(NSEvent*)event {
-  [self.flutterViewController rightMouseDragged:event];
+  [_currentViewController rightMouseDragged:event];
 }
 
 - (void)otherMouseDown:(NSEvent*)event {
-  [self.flutterViewController otherMouseDown:event];
+  [_currentViewController otherMouseDown:event];
 }
 
 - (void)otherMouseUp:(NSEvent*)event {
-  [self.flutterViewController otherMouseUp:event];
+  [_currentViewController otherMouseUp:event];
 }
 
 - (void)otherMouseDragged:(NSEvent*)event {
-  [self.flutterViewController otherMouseDragged:event];
+  [_currentViewController otherMouseDragged:event];
 }
 
 - (void)mouseMoved:(NSEvent*)event {
-  [self.flutterViewController mouseMoved:event];
+  [_currentViewController mouseMoved:event];
 }
 
 - (void)scrollWheel:(NSEvent*)event {
-  [self.flutterViewController scrollWheel:event];
+  [_currentViewController scrollWheel:event];
 }
 
 - (NSTextInputContext*)inputContext {
@@ -777,7 +793,7 @@ static char markerKey;
     void (*func)(id, SEL, id) = reinterpret_cast<void (*)(id, SEL, id)>(imp);
     func(self, selector, nil);
   }
-  if (self.clientID == nil) {
+  if (_clientID == nil) {
     // The macOS may still call selector even if it is no longer a first responder.
     return;
   }
@@ -798,7 +814,7 @@ static char markerKey;
   if (_pendingSelectors.count == 1) {
     __weak NSMutableArray* selectors = _pendingSelectors;
     __weak FlutterMethodChannel* channel = _channel;
-    __weak NSNumber* clientID = self.clientID;
+    __weak NSNumber* clientID = _clientID;
 
     CFStringRef runLoopMode = self.customRunLoopMode != nil
                                   ? (__bridge CFStringRef)self.customRunLoopMode
@@ -821,11 +837,11 @@ static char markerKey;
     _activeModel->CommitComposing();
     _activeModel->EndComposing();
   }
-  if ([self.inputType isEqualToString:kMultilineInputType] &&
-      [self.inputAction isEqualToString:kInputActionNewline]) {
+  if ([_inputType isEqualToString:kMultilineInputType] &&
+      [_inputAction isEqualToString:kInputActionNewline]) {
     [self insertText:@"\n" replacementRange:self.selectedRange];
   }
-  [_channel invokeMethod:kPerformAction arguments:@[ self.clientID, self.inputAction ]];
+  [_channel invokeMethod:kPerformAction arguments:@[ _clientID, _inputAction ]];
 }
 
 - (void)setMarkedText:(id)string
@@ -957,7 +973,7 @@ static char markerKey;
     farthest.y = MAX(farthest.y, y);
   }
 
-  const NSView* fromView = self.flutterViewController.flutterView;
+  const NSView* fromView = _currentViewController.flutterView;
   const CGRect rectInWindow = [fromView
       convertRect:CGRectMake(origin.x, origin.y, farthest.x - origin.x, farthest.y - origin.y)
            toView:nil];
@@ -968,7 +984,7 @@ static char markerKey;
 - (NSRect)firstRectForCharacterRange:(NSRange)range actualRange:(NSRangePointer)actualRange {
   // This only determines position of caret instead of any arbitrary range, but it's enough
   // to properly position accent selection popup
-  return !self.flutterViewController.viewLoaded || CGRectEqualToRect(_caretRect, CGRectNull)
+  return !_currentViewController.viewLoaded || CGRectEqualToRect(_caretRect, CGRectNull)
              ? CGRectZero
              : [self screenRectFromFrameworkTransform:_caretRect];
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -14,6 +14,9 @@
 #import <OCMock/OCMock.h>
 #import "flutter/testing/testing.h"
 
+#include <cstdint>
+#include "flutter/common/constants.h"
+
 @interface FlutterTextField (Testing)
 - (void)setPlatformNode:(flutter::FlutterTextPlatformNode*)node;
 @end
@@ -54,6 +57,40 @@
 - (bool)testClearClientDuringComposing;
 @end
 
+@interface FlutterTextInputPluginTestDelegate : NSObject <FlutterTextInputPluginDelegate> {
+  id<FlutterBinaryMessenger> _binaryMessenger;
+  FlutterViewController* _viewController;
+}
+
+@end
+
+@implementation FlutterTextInputPluginTestDelegate
+
+static const FlutterViewIdentifier kViewId = 1;
+
+@synthesize binaryMessenger = _binaryMessenger;
+
+- (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)messenger
+                         viewController:(FlutterViewController*)viewController {
+  self = [super init];
+  if (self) {
+    _binaryMessenger = messenger;
+    _viewController = viewController;
+  }
+  return self;
+}
+
+- (nullable FlutterViewController*)viewControllerForIdentifier:
+    (FlutterViewIdentifier)viewIdentifier {
+  if (viewIdentifier == kViewId) {
+    return _viewController;
+  } else {
+    return nil;
+  }
+}
+
+@end
+
 @implementation FlutterInputPluginTestObjc
 
 - (bool)testEmptyCompositionRange {
@@ -67,10 +104,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
   };
@@ -115,10 +156,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
   };
@@ -181,10 +226,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
   };
@@ -247,10 +296,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
   };
@@ -306,11 +359,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
   };
@@ -358,11 +415,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
   };
@@ -386,11 +447,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
     @"autofill" : @{
@@ -424,11 +489,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
     @"autofill" : @{
@@ -457,11 +526,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
     @"obscureText" : @YES,
@@ -490,11 +563,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
     @"autofill" : @{
@@ -528,11 +605,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
     @"fields" : @[
@@ -576,11 +657,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
     @"autofill" : @{
@@ -614,11 +699,15 @@
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Set input client 1.
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"inputType" : @{@"name" : @"inputName"},
     @"autofill" : @{
@@ -669,8 +758,19 @@
       [windowMock convertRectToScreen:NSMakeRect(28, 10, 2, 19)])
       .andReturn(NSMakeRect(38, 20, 2, 19));
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:controllerMock];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:controllerMock];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
+  };
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                             arguments:@[ @(1), setClientConfig ]]
+                    result:^(id){
+                    }];
 
   FlutterMethodCall* call = [FlutterMethodCall
       methodCallWithMethodName:@"TextInput.setEditableSizeAndTransform"
@@ -729,8 +829,19 @@
       [viewMock window])
       .andReturn(windowMock);
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:controllerMock];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:controllerMock];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
+  };
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                             arguments:@[ @(1), setClientConfig ]]
+                    result:^(id){
+                    }];
 
   FlutterMethodCall* call = [FlutterMethodCall
       methodCallWithMethodName:@"TextInput.setEditableSizeAndTransform"
@@ -791,8 +902,19 @@
       [windowMock convertRectToScreen:NSMakeRect(-18, 6, 3, 3)])
       .andReturn(NSMakeRect(-18, 6, 3, 3));
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:controllerMock];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:controllerMock];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
+  };
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                             arguments:@[ @(1), setClientConfig ]]
+                    result:^(id){
+                    }];
 
   FlutterMethodCall* call = [FlutterMethodCall
       methodCallWithMethodName:@"TextInput.setEditableSizeAndTransform"
@@ -847,10 +969,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -896,10 +1022,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -1011,10 +1141,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -1246,10 +1380,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -1306,6 +1444,7 @@
 }
 
 - (bool)testPerformKeyEquivalent {
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   __block NSEvent* eventBeingDispatchedByKeyboardManager = nil;
   FlutterViewController* viewControllerMock = OCMClassMock([FlutterViewController class]);
   OCMStub([viewControllerMock isDispatchingKeyEvent:[OCMArg any]])
@@ -1327,8 +1466,19 @@
                                    isARepeat:NO
                                      keyCode:0x50];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewControllerMock];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewControllerMock];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
+  };
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                             arguments:@[ @(1), setClientConfig ]]
+                    result:^(id){
+                    }];
 
   OCMExpect([viewControllerMock keyDown:event]);
 
@@ -1379,12 +1529,16 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   plugin.textInputContext = textInputContext;
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -1456,10 +1610,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -1533,10 +1691,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputType" : @{@"name" : @"TextInputType.multiline"},
     @"inputAction" : @"TextInputAction.newline",
   };
@@ -1597,10 +1759,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputType" : @{@"name" : @"TextInputType.multiline"},
     @"inputAction" : @"TextInputAction.send",
   };
@@ -1693,10 +1859,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -1752,10 +1922,14 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -1813,8 +1987,11 @@
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   // Can't run CFRunLoop in default mode because it causes crashes from scheduled
   // sources from other tests.
@@ -1969,10 +2146,14 @@ TEST(FlutterTextInputPluginTest, TestAttributedSubstringOutOfRange) {
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
     @"inputAction" : @"action",
     @"enableDeltaModel" : @"true",
     @"inputType" : @{@"name" : @"inputName"},
@@ -2034,11 +2215,12 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
 
     FlutterTextFieldMock* mockTextField =
         [[FlutterTextFieldMock alloc] initWithPlatformNode:&text_platform_node
-                                               fieldEditor:viewController.textInputPlugin];
+                                               fieldEditor:engine.textInputPlugin];
     [viewController.view addSubview:mockTextField];
     [mockTextField startEditing];
 
     NSDictionary* setClientConfig = @{
+      @"viewId" : @(flutter::kFlutterImplicitViewId),
       @"inputAction" : @"action",
       @"inputType" : @{@"name" : @"inputName"},
     };
@@ -2047,7 +2229,7 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
                                           arguments:@[ @(1), setClientConfig ]];
     FlutterResult result = ^(id result) {
     };
-    [viewController.textInputPlugin handleMethodCall:methodCall result:result];
+    [engine.textInputPlugin handleMethodCall:methodCall result:result];
 
     NSDictionary* arguments = @{
       @"text" : @"new text",
@@ -2058,7 +2240,7 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
     };
     methodCall = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
                                                    arguments:arguments];
-    [viewController.textInputPlugin handleMethodCall:methodCall result:result];
+    [engine.textInputPlugin handleMethodCall:methodCall result:result];
     EXPECT_EQ([mockTextField.lastUpdatedString isEqualToString:@"new text"], YES);
     EXPECT_EQ(NSEqualRanges(mockTextField.lastUpdatedSelection, NSMakeRange(1, 1)), YES);
 
@@ -2118,24 +2300,33 @@ TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
                                                      defer:NO];
   window.contentView = viewController.view;
 
-  ASSERT_EQ(viewController.textInputPlugin.superview, nil);
-  ASSERT_FALSE(window.firstResponder == viewController.textInputPlugin);
+  ASSERT_EQ(engine.textInputPlugin.superview, nil);
+  ASSERT_FALSE(window.firstResponder == engine.textInputPlugin);
 
-  [viewController.textInputPlugin
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(flutter::kFlutterImplicitViewId),
+  };
+  [engine.textInputPlugin
+      handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                         arguments:@[ @(1), setClientConfig ]]
+                result:^(id){
+                }];
+
+  [engine.textInputPlugin
       handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.show" arguments:@[]]
                 result:^(id){
                 }];
 
-  ASSERT_EQ(viewController.textInputPlugin.superview, viewController.view);
-  ASSERT_TRUE(window.firstResponder == viewController.textInputPlugin);
+  ASSERT_EQ(engine.textInputPlugin.superview, viewController.view);
+  ASSERT_TRUE(window.firstResponder == engine.textInputPlugin);
 
-  [viewController.textInputPlugin
+  [engine.textInputPlugin
       handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.hide" arguments:@[]]
                 result:^(id){
                 }];
 
-  ASSERT_EQ(viewController.textInputPlugin.superview, nil);
-  ASSERT_FALSE(window.firstResponder == viewController.textInputPlugin);
+  ASSERT_EQ(engine.textInputPlugin.superview, nil);
+  ASSERT_FALSE(window.firstResponder == engine.textInputPlugin);
 }
 
 TEST(FlutterTextInputPluginTest, FirstResponderIsCorrect) {
@@ -2155,16 +2346,25 @@ TEST(FlutterTextInputPluginTest, FirstResponderIsCorrect) {
 
   [window makeFirstResponder:viewController.flutterView];
 
-  [viewController.textInputPlugin
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(flutter::kFlutterImplicitViewId),
+  };
+  [engine.textInputPlugin
+      handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                         arguments:@[ @(1), setClientConfig ]]
+                result:^(id){
+                }];
+
+  [engine.textInputPlugin
       handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.show" arguments:@[]]
                 result:^(id){
                 }];
 
-  ASSERT_TRUE(window.firstResponder == viewController.textInputPlugin);
+  ASSERT_TRUE(window.firstResponder == engine.textInputPlugin);
 
   ASSERT_FALSE(viewController.flutterView.acceptsFirstResponder);
 
-  [viewController.textInputPlugin
+  [engine.textInputPlugin
       handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.hide" arguments:@[]]
                 result:^(id){
                 }];
@@ -2184,8 +2384,11 @@ TEST(FlutterTextInputPluginTest, HasZeroSizeAndClipsToBounds) {
                                                                                 nibName:@""
                                                                                  bundle:nil];
 
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
 
   ASSERT_TRUE(NSIsEmptyRect(plugin.frame));
   ASSERT_TRUE(plugin.clipsToBounds);

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.mm
@@ -164,7 +164,7 @@ FlutterTextPlatformNode::FlutterTextPlatformNode(FlutterPlatformNodeDelegate* de
   view_controller_ = view_controller;
   appkit_text_field_ =
       [[FlutterTextField alloc] initWithPlatformNode:this
-                                         fieldEditor:view_controller.textInputPlugin];
+                                         fieldEditor:view_controller.engine.textInputPlugin];
   appkit_text_field_.bezeled = NO;
   appkit_text_field_.drawsBackground = NO;
   appkit_text_field_.bordered = NO;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -309,7 +309,7 @@ struct MouseState {
 // Returns the text input plugin associated with this view controller.
 // This method only returns non nil instance if the text input plugin has active
 // client with viewId matching this controller's view identifier.
-- (FlutterTextInputPlugin*)textInputPlugin {
+- (FlutterTextInputPlugin*)activeTextInputPlugin {
   if (_engine.textInputPlugin.currentViewController == self) {
     return _engine.textInputPlugin;
   } else {
@@ -554,7 +554,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
                                      NSResponder* firstResponder = [[event window] firstResponder];
                                      if (weakSelf.viewLoaded && weakSelf.flutterView &&
                                          (firstResponder == weakSelf.flutterView ||
-                                          firstResponder == weakSelf.textInputPlugin) &&
+                                          firstResponder == weakSelf.activeTextInputPlugin) &&
                                          ([event modifierFlags] & NSEventModifierFlagCommand) &&
                                          ([event type] == NSEventTypeKeyUp)) {
                                        [weakSelf keyUp:event];
@@ -782,12 +782,12 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
 }
 
 - (void)onAccessibilityStatusChanged:(BOOL)enabled {
-  if (!enabled && self.viewLoaded && [self.textInputPlugin isFirstResponder]) {
+  if (!enabled && self.viewLoaded && [self.activeTextInputPlugin isFirstResponder]) {
     // Normally TextInputPlugin, when editing, is child of FlutterViewWrapper.
     // When accessibility is enabled the TextInputPlugin gets added as an indirect
     // child to FlutterTextField. When disabling the plugin needs to be reparented
     // back.
-    [self.view addSubview:self.textInputPlugin];
+    [self.view addSubview:self.activeTextInputPlugin];
   }
 }
 
@@ -828,7 +828,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
   // Only allow FlutterView to become first responder if TextInputPlugin is
   // not active. Otherwise a mouse event inside FlutterView would cause the
   // TextInputPlugin to lose first responder status.
-  return !self.textInputPlugin.isFirstResponder;
+  return !self.activeTextInputPlugin.isFirstResponder;
 }
 
 #pragma mark - FlutterPluginRegistry
@@ -844,7 +844,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
 #pragma mark - FlutterKeyboardViewDelegate
 
 - (BOOL)onTextInputKeyEvent:(nonnull NSEvent*)event {
-  return [self.textInputPlugin handleKeyEvent:event];
+  return [self.activeTextInputPlugin handleKeyEvent:event];
 }
 
 #pragma mark - NSResponder

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -306,6 +306,17 @@ struct MouseState {
 
 @dynamic accessibilityBridge;
 
+// Returns the text input plugin associated with this view controller.
+// This method only returns non nil instance if the text input plugin has active
+// client with viewId matching this controller's view identifier.
+- (FlutterTextInputPlugin*)textInputPlugin {
+  if (_engine.textInputPlugin.currentViewController == self) {
+    return _engine.textInputPlugin;
+  } else {
+    return nil;
+  }
+}
+
 /**
  * Performs initialization that's common between the different init paths.
  */
@@ -326,7 +337,6 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
             @"the FlutterEngine is mocked. Please subclass these classes instead.",
             controller.engine, controller.viewIdentifier);
   controller->_mouseTrackingMode = kFlutterMouseTrackingModeInKeyWindow;
-  controller->_textInputPlugin = [[FlutterTextInputPlugin alloc] initWithViewController:controller];
   [controller notifySemanticsEnabledChanged];
 }
 
@@ -772,12 +782,12 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
 }
 
 - (void)onAccessibilityStatusChanged:(BOOL)enabled {
-  if (!enabled && self.viewLoaded && [_textInputPlugin isFirstResponder]) {
+  if (!enabled && self.viewLoaded && [self.textInputPlugin isFirstResponder]) {
     // Normally TextInputPlugin, when editing, is child of FlutterViewWrapper.
-    // When accessiblity is enabled the TextInputPlugin gets added as an indirect
+    // When accessibility is enabled the TextInputPlugin gets added as an indirect
     // child to FlutterTextField. When disabling the plugin needs to be reparented
     // back.
-    [self.view addSubview:_textInputPlugin];
+    [self.view addSubview:self.textInputPlugin];
   }
 }
 
@@ -818,7 +828,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
   // Only allow FlutterView to become first responder if TextInputPlugin is
   // not active. Otherwise a mouse event inside FlutterView would cause the
   // TextInputPlugin to lose first responder status.
-  return !_textInputPlugin.isFirstResponder;
+  return !self.textInputPlugin.isFirstResponder;
 }
 
 #pragma mark - FlutterPluginRegistry
@@ -834,7 +844,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
 #pragma mark - FlutterKeyboardViewDelegate
 
 - (BOOL)onTextInputKeyEvent:(nonnull NSEvent*)event {
-  return [_textInputPlugin handleKeyEvent:event];
+  return [self.textInputPlugin handleKeyEvent:event];
 }
 
 #pragma mark - NSResponder

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -8,6 +8,7 @@
 
 #import <OCMock/OCMock.h>
 
+#include "flutter/common/constants.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
@@ -224,15 +225,27 @@ TEST_F(FlutterViewControllerTest, ReparentsPluginWhenAccessibilityDisabled) {
   window.contentView = viewController.view;
   NSView* dummyView = [[NSView alloc] initWithFrame:CGRectZero];
   [viewController.view addSubview:dummyView];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(flutter::kFlutterImplicitViewId),
+  };
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                        arguments:@[ @(1), setClientConfig ]];
+  FlutterResult result = ^(id result) {
+  };
+  [engine.textInputPlugin handleMethodCall:methodCall result:result];
+
   // Attaches FlutterTextInputPlugin to the view;
-  [dummyView addSubview:viewController.textInputPlugin];
+  [dummyView addSubview:engine.textInputPlugin];
   // Makes sure the textInputPlugin can be the first responder.
-  EXPECT_TRUE([window makeFirstResponder:viewController.textInputPlugin]);
-  EXPECT_EQ([window firstResponder], viewController.textInputPlugin);
-  EXPECT_FALSE(viewController.textInputPlugin.superview == viewController.view);
+
+  EXPECT_TRUE([window makeFirstResponder:engine.textInputPlugin]);
+  EXPECT_EQ([window firstResponder], engine.textInputPlugin);
+  EXPECT_FALSE(engine.textInputPlugin.superview == viewController.view);
   [viewController onAccessibilityStatusChanged:NO];
   // FlutterView becomes child of view controller
-  EXPECT_TRUE(viewController.textInputPlugin.superview == viewController.view);
+  EXPECT_TRUE(viewController.engine.textInputPlugin.superview == viewController.view);
 }
 
 TEST_F(FlutterViewControllerTest, CanSetMouseTrackingModeBeforeViewLoaded) {
@@ -464,11 +477,24 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
                                                      defer:NO];
   window.contentView = viewController.view;
 
-  [viewController.view addSubview:viewController.textInputPlugin];
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(flutter::kFlutterImplicitViewId),
+  };
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                        arguments:@[ @(1), setClientConfig ]];
+  FlutterResult result = ^(id result) {
+  };
+  [viewController.engine.textInputPlugin handleMethodCall:methodCall result:result];
+
+  [viewController.engine.textInputPlugin
+      handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.show" arguments:@[]]
+                result:^(id){
+                }];
 
   // Make the textInputPlugin first responder. This should still result in
   // view controller reporting the key event.
-  [window makeFirstResponder:viewController.textInputPlugin];
+  [window makeFirstResponder:viewController.engine.textInputPlugin];
 
   [viewController.view performKeyEquivalent:event];
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -18,11 +18,6 @@
 // The FlutterView for this view controller.
 @property(nonatomic, readonly, nullable) FlutterView* flutterView;
 
-/**
- * The text input plugin that handles text editing state for text fields.
- */
-@property(nonatomic, readonly, nonnull) FlutterTextInputPlugin* textInputPlugin;
-
 @property(nonatomic, readonly) std::weak_ptr<flutter::AccessibilityBridgeMac> accessibilityBridge;
 
 /**


### PR DESCRIPTION
Notable changes:
- `FlutterTextInputPlugin` is now owned by `FlutterEngine`.
- `FlutterTextInputPlugin` is only associated with a `FlutterViewController` while having active IME connection.
- Changed private state of `TextInputPlugin` from properties to ivars. There is no need for these to be properties, and the state was accessed both as ivars and properties which seemed inconsistent.
- Updated test to reflect the changes

I've also tested everything including voice-over to make sure accessibility didn't regress.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
