### PR TITLE
Update multiple flutters benchmark test to latest gradle and agp and gradle defined dependencies 

### DIFF
--- a/dev/benchmarks/multiple_flutters/android/app/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/app/build.gradle
@@ -14,7 +14,7 @@ android {
     }
 
     namespace "dev.flutter.multipleflutters"
-    compileSdk 34
+    compileSdk 35
 
     // Flutter's CI installs the NDK at a non-standard path.
     // This non-standard structure is initially created by
@@ -26,18 +26,18 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     defaultConfig {
         applicationId "dev.flutter.multipleflutters"
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
 
@@ -56,12 +56,12 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
     testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     implementation project(':flutter')
 }

--- a/dev/benchmarks/multiple_flutters/android/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:8.1.0"
+        classpath 'com.android.tools.build:gradle:8.8.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Do not place your application dependencies here; they belong

--- a/dev/benchmarks/multiple_flutters/android/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/build.gradle
@@ -4,7 +4,7 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.7.10"
+    ext.kotlin_version = "2.1.0"
     repositories {
         google()
         mavenCentral()

--- a/dev/benchmarks/multiple_flutters/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/benchmarks/multiple_flutters/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 27 5:06 AM PST 2022
+#Mon Feb 24 15:28:21 EST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip


### PR DESCRIPTION
part of #149836

After this pr and https://github.com/flutter/flutter/pull/163849 are merged `find . -type f -name "build.gradle" | xargs grep -e "targetSdk" | tr -d '=' | tr -s ' ' | grep -v engine/src/flutter/third_party/ | grep -v 35 | grep -v flutter\.targetSdkVersion` will return no results. Marking everything migrated to 35. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
