### PR TITLE
[iOS] increase backdrop cached task limit.

### DIFF
--- a/engine/src/flutter/impeller/renderer/context.h
+++ b/engine/src/flutter/impeller/renderer/context.h
@@ -57,7 +57,7 @@ class Context {
   /// This number was arbitrarily chosen. The idea is that this is a somewhat
   /// rare situation where tasks happen to get executed in that tiny amount of
   /// time while an app is being backgrounded but still executing.
-  static constexpr int32_t kMaxTasksAwaitingGPU = 10;
+  static constexpr int32_t kMaxTasksAwaitingGPU = 64;
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys an Impeller context.


### PR DESCRIPTION
Partial workaround for https://github.com/flutter/flutter/issues/161142 . Since this was an arbitrary number anyway we can increase it a bit.