### PR TITLE
Fix incorrectly checking for invalid environment variables in the tool

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1497,12 +1497,6 @@ abstract class FlutterCommand extends Command<void> {
   // This adds the Dart defines used to access various Flutter version information at runtime.
   void _addFlutterVersionToDartDefines(FlutterVersion version, List<String> dartDefines) {
     for (final String dartDefine in flutterVersionDartDefines) {
-      if (globals.platform.environment[dartDefine] != null) {
-        throwToolExit(
-          '$dartDefine is used by the framework and cannot be set in the environment. '
-          'Use FlutterVersion to access it in Flutter code',
-        );
-      }
       if (dartDefines.any((String define) => define.startsWith(dartDefine))) {
         throwToolExit(
           '$dartDefine is used by the framework and cannot be '

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -1273,39 +1273,6 @@ flutter:
     group('Flutter version', () {
       for (final String dartDefine in FlutterCommand.flutterVersionDartDefines) {
         testUsingContext(
-          "tool exits when $dartDefine is already set in user's environment",
-          () async {
-            final CommandRunner<void> runner = createTestCommandRunner(
-              _TestRunCommandThatOnlyValidates(),
-            );
-
-            await expectLater(
-              runner.run(<String>['run', '--no-pub', '--no-hot']),
-              throwsToolExit(
-                message:
-                    '$dartDefine is used by the framework and cannot be set in the environment. '
-                    'Use FlutterVersion to access it in Flutter code',
-              ),
-            );
-          },
-          overrides: <Type, Generator>{
-            DeviceManager:
-                () => FakeDeviceManager()..attachedDevices = <Device>[FakeDevice('name', 'id')],
-            Platform:
-                () => FakePlatform(environment: <String, String>{dartDefine: 'I was already set'}),
-            Cache: () => Cache.test(processManager: FakeProcessManager.any()),
-            FileSystem: () {
-              return MemoryFileSystem.test()
-                ..file('lib/main.dart').createSync(recursive: true)
-                ..file('pubspec.yaml').createSync()
-                ..file('.packages').createSync();
-            },
-            ProcessManager: () => FakeProcessManager.any(),
-            FlutterVersion: () => FakeFlutterVersion(),
-          },
-        );
-
-        testUsingContext(
           'tool exits when $dartDefine is set in --dart-define or --dart-define-from-file',
           () async {
             final CommandRunner<void> runner = createTestCommandRunner(


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR removes a check that looks for the use of Flutter version related Dart define keys in the environment variables (not Dart defines) of the user of the Flutter tool. We don't need to check the environment variables, we only need to check the user defined Dart defines.

Here's how it currently works:

1. User builds a Flutter app via tool
2. tool checks environment variables for Flutter version related Dart define keys and throws if it finds and (_and_)
3. tool checks list of user defined Dart defines for Flutter version related Dart define keys and throws if it finds any

This PR removes the check in step 2, since step 3 is what we actually care about.

The `FLUTTER_GIT_URL` environment variable is set on forks and the Dart define is used to make that information available to applications at runtime. However, environment variables don't propagate to be Dart defines, thus the above mentioned check is not needed.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Fixes #164093

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
