### PR TITLE
Increase the timeout for Mac web_tool_tests to 45 minutes

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4574,6 +4574,7 @@ targets:
       subshard: "1_1"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700" # Allows 45 minutes (up from 30 default)
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
This job seems to be timing out often when it is scheduled on a slower x64 machine.