### PR TITLE
[CP] Roll .ci.yaml changes into the LUCI configuration only when the master branch is updated

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -545,6 +545,9 @@ targets:
     recipe: infra/ci_yaml
     presubmit: false
     timeout: 30
+    enabled_branches:
+      # Don't run this on release branches
+      - master
     properties:
       tags: >
         ["framework", "hostonly", "shard", "linux"]


### PR DESCRIPTION
This is a cherry pick of an infrastructure fix.  The "ci_yaml flutter roller" job updates the LUCI builder configuration to match the contents of ci.yaml.  It should only run on the master branch because the older version of ci.yaml in a release branch may not contain newer builders that are needed by master branch PRs.

See https://github.com/flutter/flutter/pull/163897