### PR TITLE
[Impeller] gate GLES3 on presence of GL_OES_EGL_image_external_essl3 extension.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -26,6 +26,10 @@ static const constexpr char* kMultisampledRenderToTextureExt =
 static const constexpr char* kMultisampledRenderToTexture2Ext =
     "GL_EXT_multisampled_render_to_texture2";
 
+// https://registry.khronos.org/OpenGL/extensions/OES/OES_EGL_image_external_essl3.txt
+static const constexpr char* kOESImageExternalGLES3 =
+    "GL_OES_EGL_image_external_essl3";
+
 CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   {
     GLint value = 0;
@@ -136,6 +140,9 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   }
   is_es_ = desc->IsES();
   is_angle_ = desc->IsANGLE();
+  is_android_es3_safe_ = desc->IsES() &&
+                         desc->GetGlVersion().IsAtLeast(Version{3, 0, 0}) &&
+                         desc->HasExtension(kOESImageExternalGLES3);
 }
 
 bool CapabilitiesGLES::IsES() const {
@@ -153,6 +160,10 @@ size_t CapabilitiesGLES::GetMaxTextureUnits(ShaderStage stage) const {
       return 0u;
   }
   FML_UNREACHABLE();
+}
+
+bool CapabilitiesGLES::IsES3AndroidSafe() const {
+  return is_android_es3_safe_;
 }
 
 bool CapabilitiesGLES::SupportsOffscreenMSAA() const {

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -77,6 +77,11 @@ class CapabilitiesGLES final
 
   bool IsANGLE() const;
 
+  /// @brief Whether the GLES version is at least 3.0 and the
+  ///        GL_OES_EGL_image_external_essl3 used for external texture interop
+  ///        is supported.
+  bool IsES3AndroidSafe() const;
+
   /// @brief Whether this is an ES GL variant or (if false) desktop GL.
   bool IsES() const;
 
@@ -138,6 +143,7 @@ class CapabilitiesGLES final
   bool supports_implicit_msaa_ = false;
   bool is_angle_ = false;
   bool is_es_ = false;
+  bool is_android_es3_safe_ = false;
   PixelFormat default_glyph_atlas_format_ = PixelFormat::kUnknown;
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/capabilities_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/capabilities_unittests.cc
@@ -72,5 +72,16 @@ TEST(CapabilitiesGLES, SupportsMSAA) {
   EXPECT_FALSE(capabilities->SupportsOffscreenMSAA());
 }
 
+TEST(CapabilitiesGLES, IsES3AndroidSafe) {
+  auto const extensions = std::vector<const char*>{
+      "GL_OES_EGL_image_external_essl3",
+  };
+  // defaults to ES 3.0
+  auto mock_gles = MockGLES::Init(extensions);
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+
+  EXPECT_TRUE(capabilities->IsES3AndroidSafe());
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/shell/platform/android/android_context_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_gl_impeller.cc
@@ -57,8 +57,7 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
     FML_LOG(ERROR) << "Could not create OpenGL proc table.";
     return nullptr;
   }
-  bool is_gles3 = proc_table->GetDescription()->GetGlVersion().IsAtLeast(
-      impeller::Version{3, 0, 0});
+  bool is_gles3 = proc_table->GetCapabilities()->IsES3AndroidSafe();
 
   std::vector<std::shared_ptr<fml::Mapping>> gles2_shader_mappings = {
       std::make_shared<fml::NonOwnedMapping>(


### PR DESCRIPTION
GLES 3.0 capable devices may not have the extension for external texture support. We don't want to support all different combinations of GLES version + shaders, so just fall back to ES 2.