### PR TITLE
remove last usages of min/compile/target SdkVersion, align sourceCompatibility across repo and update android version documentation

### DIFF
--- a/dev/integration_tests/deferred_components_test/android/component1/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/component1/build.gradle
@@ -23,8 +23,8 @@ if (flutterVersionName == null) {
 apply plugin: "com.android.dynamic-feature"
 
 android {
-    namespace "io.flutter.integration.deferred_components_test.component1"
-    compileSdk 35
+    namespace = "io.flutter.integration.deferred_components_test.component1"
+    compileSdk = 35
 
     // Flutter's CI installs the NDK at a non-standard path.
     // This non-standard structure is initially created by
@@ -43,15 +43,15 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 35
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk = 21
+        targetSdk = 35
+        versionCode = flutterVersionCode.toInteger()
+        versionName = flutterVersionName
     }
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.application'
 
 android {
     namespace = "io.flutter.addtoapp"
-    compileSdk 35
+    compileSdk = 35
 
     // Flutter's CI installs the NDK at a non-standard path.
     // This non-standard structure is initially created by
@@ -23,11 +23,11 @@ android {
     }
 
     defaultConfig {
-        applicationId "io.flutter.addtoapp"
-        minSdkVersion 21
-        targetSdkVersion 35
-        versionCode 1
-        versionName "1.0"
+        applicationId = "io.flutter.addtoapp"
+        minSdk = 21
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
     }
     // Test build types.
     buildTypes {

--- a/docs/contributing/Android-API-And-Related-Versions.md
+++ b/docs/contributing/Android-API-And-Related-Versions.md
@@ -107,7 +107,7 @@ Gradle versions are the least likley to break across minor version updates.
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 ```
 
-### kotlin
+### Kotlin
 
 Changing kotlin versions is most likley to have an issue with another dependency and not the code under test.
 
@@ -119,4 +119,47 @@ Changing kotlin versions is most likley to have an issue with another dependency
 ext.kotlin_version = "1.7.10"
 ...
 classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+```
+
+### compileOptions and kotlinOptions
+
+- sourceCompatibility must use JavaVersion.*
+- targetCompatibility must use JavaVersion.*
+- kotlinOptions jvmTarget should match the versions used by compileOptions or there should be a comment explaining why.
+- jvmTarget should use JavaVersion.<SOMEVERSION>.toString() or there should be a comment explaining why.
+
+```
+// Ok
+compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_11.toString()
+}
+```
+
+```
+// Not ok
+compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlinOptions {
+    jvmTarget = "17"
+}
+```
+
+```
+// Not ok
+compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_17.toString()
+}
 ```


### PR DESCRIPTION
Related to #149836
- Remove last usages of minSdkVersion/compileSdkVersion/targetSdkVersion in favor of minSdk/compileSdk/targetSdk. That do not also use `flutter.minSdkVersion` etc. (that will happen in another pass) 
- Update the files that used "SdkVersion" to use equals for setting new values. [Not yet landed documentation change](https://github.com/flutter/flutter/pull/164195/files#diff-ee6ec18be8d752e2696c8ccc8bec2f202dfc29a43b3b4f9d8041aa6bc3e852a1)
- align sourceCompatibility and targetCompatibility across repo to use JavaVersion.* and update android version documentation. 

This pr updates `kotlinOptions jvmTarget` documentation but does not fix all existing usages. 

This pr is expected to cause no behavioral changes. 
This pr makes logical sense after https://github.com/flutter/flutter/pull/164195 but can be landed in any order. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
