### PR TITLE
Increase customer test timeout to 60 minutes

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -585,6 +585,8 @@ targets:
       shard: customer_testing
       tags: >
         ["framework", "hostonly", "shard", "linux"]
+      # TODO(flutter/flutter#164140): Reduce timeout once customer
+      # tests are sharded.
       test_timeout_secs: "3600" # Allows 60 minutes (up from 30 default)
 
   - name: Linux docs_publish

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -585,7 +585,7 @@ targets:
       shard: customer_testing
       tags: >
         ["framework", "hostonly", "shard", "linux"]
-      test_timeout_secs: "2700" # Allows 45 minutes (up from 30 default)
+      test_timeout_secs: "3600" # Allows 60 minutes (up from 30 default)
 
   - name: Linux docs_publish
     recipe: flutter/docs


### PR DESCRIPTION
Customer test timeouts are a frequent source of tree closures.

This change should be reverted once https://github.com/flutter/flutter/issues/164140 is completed.