### PR TITLE
animate cupertino time picker label

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -2492,11 +2492,87 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
           },
           child: _buildHourPicker(additionalPadding, selectionOverlay),
         ),
-        _buildLabel(
-          localizations.timerPickerHourLabel(lastSelectedHour ?? selectedHour!) ?? '',
-          additionalPadding,
-        ),
+        _buildHourLabel(additionalPadding),
       ],
+    );
+  }
+
+  Widget _buildHourLabel(EdgeInsetsDirectional pickerPadding) {
+    final String oneHourLabel = localizations.timerPickerHourLabel(1) ?? '';
+    final String currentLabel =
+        localizations.timerPickerHourLabel(lastSelectedHour ?? selectedHour!) ?? '';
+    final List<String> parts = currentLabel.split(oneHourLabel);
+    final bool containsOneHourLabel = parts.length > 1;
+    final String prefix = parts.first;
+    final String suffix = parts.last;
+
+    final EdgeInsetsDirectional padding = EdgeInsetsDirectional.only(
+      start: numberLabelWidth + _kTimerPickerLabelPadSize + pickerPadding.start,
+    );
+
+    return IgnorePointer(
+      child: Padding(
+        padding: padding.resolve(textDirection),
+        child: Align(
+          alignment: AlignmentDirectional.centerStart.resolve(textDirection),
+          child: SizedBox(
+            height: numberLabelHeight,
+            child: Baseline(
+              baseline: numberLabelBaseline,
+              baselineType: TextBaseline.alphabetic,
+              child:
+                  containsOneHourLabel
+                      ? Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          Text.rich(
+                            maxLines: 1,
+                            softWrap: false,
+                            TextSpan(
+                              text: prefix,
+                              style: const TextStyle(
+                                fontSize: _kTimerPickerLabelFontSize,
+                                fontWeight: FontWeight.w600,
+                              ),
+                              children: <TextSpan>[
+                                TextSpan(
+                                  text: oneHourLabel,
+                                  style: const TextStyle(
+                                    fontSize: _kTimerPickerLabelFontSize,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 200),
+                            child: Text(
+                              suffix,
+                              key: ValueKey<String?>(suffix),
+                              style: const TextStyle(
+                                fontSize: _kTimerPickerLabelFontSize,
+                                fontWeight: FontWeight.w600,
+                              ),
+                              maxLines: 1,
+                              softWrap: false,
+                            ),
+                          ),
+                        ],
+                      )
+                      : Text(
+                        currentLabel,
+                        style: const TextStyle(
+                          fontSize: _kTimerPickerLabelFontSize,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 1,
+                        softWrap: false,
+                      ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
- Remove variables that store the last selected hour, minute, and second, as the use of these variables doesn't allow animation
- Remove NotificationListener that wraps hour, minute and second pickers as they are not needed anymore
- Add AnimatedSwitcher to animate the label when the picker changes

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/5e71c271-7442-437c-8d35-094d45221418"> | <video src="https://github.com/user-attachments/assets/2b22790d-08fd-4c0c-8938-38e231143504"> |

ref #27515

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
