### PR TITLE
[flutter_tool] Handle RPCErrorKind.kConnectionDisposed

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -431,6 +431,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
       }
     } on RPCError catch (err) {
       if (err.code == RPCErrorKind.kServiceDisappeared.code ||
+          err.code == RPCErrorKind.kConnectionDisposed.code ||
           err.message.contains('Service connection disposed')) {
         throwToolExit('Lost connection to device.');
       }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -870,6 +870,7 @@ class RunCommand extends RunCommandBase {
       }
     } on RPCError catch (error) {
       if (error.code == RPCErrorKind.kServiceDisappeared.code ||
+          error.code == RPCErrorKind.kConnectionDisposed.code ||
           error.message.contains('Service connection disposed')) {
         throwToolExit('Lost connection to device.');
       }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -507,6 +507,7 @@ class DevFS {
       _baseUri = Uri.parse(response.json!['uri'] as String);
     } on vm_service.RPCError catch (rpcException) {
       if (rpcException.code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
+          rpcException.code == vm_service.RPCErrorKind.kConnectionDisposed.code ||
           rpcException.message.contains('Service connection disposed')) {
         // This can happen if the device has been disconnected, so translate to
         // a DevFSException, which the caller will handle.

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -486,6 +486,7 @@ class FlutterVmService {
       return await service.getVM();
     } on vm_service.RPCError catch (err) {
       if (err.code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
+          err.code == vm_service.RPCErrorKind.kConnectionDisposed.code ||
           err.message.contains('Service connection disposed')) {
         globals.printTrace('VmService.getVm call failed: $err');
         return null;
@@ -507,6 +508,7 @@ class FlutterVmService {
       // Swallow the exception here and let the shutdown logic elsewhere deal
       // with cleaning up.
       if (e.code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
+          e.code == vm_service.RPCErrorKind.kConnectionDisposed.code ||
           e.message.contains('Service connection disposed')) {
         return null;
       }
@@ -792,6 +794,7 @@ class FlutterVmService {
       // disappears while handling a request, return null.
       if ((err.code == vm_service.RPCErrorKind.kMethodNotFound.code) ||
           (err.code == vm_service.RPCErrorKind.kServiceDisappeared.code) ||
+          (err.code == vm_service.RPCErrorKind.kConnectionDisposed.code) ||
           (err.message.contains('Service connection disposed'))) {
         return null;
       }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -1385,7 +1385,55 @@ void main() {
     );
 
     testUsingContext(
-      'Catches "Service connection disposed" error',
+      'Catches "Service connection disposed" error by code',
+      () async {
+        final FakeAndroidDevice device =
+            FakeAndroidDevice(id: '1')
+              ..portForwarder = const NoOpDevicePortForwarder()
+              ..onGetLogReader = () => NoOpDeviceLogReader('test');
+        final FakeHotRunner hotRunner = FakeHotRunner();
+        final FakeHotRunnerFactory hotRunnerFactory = FakeHotRunnerFactory()..hotRunner = hotRunner;
+        hotRunner.onAttach = (
+          Completer<DebugConnectionInfo>? connectionInfoCompleter,
+          Completer<void>? appStartedCompleter,
+          bool allowExistingDdsInstance,
+          bool enableDevTools,
+        ) async {
+          await null;
+          throw vm_service.RPCError(
+            'flutter._listViews',
+            vm_service.RPCErrorKind.kConnectionDisposed.code,
+            'dummy text not matched',
+          );
+        };
+
+        testDeviceManager.devices = <Device>[device];
+        testFileSystem.file('lib/main.dart').createSync();
+
+        final AttachCommand command = AttachCommand(
+          hotRunnerFactory: hotRunnerFactory,
+          stdio: stdio,
+          logger: logger,
+          terminal: terminal,
+          signals: signals,
+          platform: platform,
+          processInfo: processInfo,
+          fileSystem: testFileSystem,
+        );
+        await expectLater(
+          createTestCommandRunner(command).run(<String>['attach']),
+          throwsToolExit(message: 'Lost connection to device.'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        DeviceManager: () => testDeviceManager,
+      },
+    );
+
+    testUsingContext(
+      'Catches "Service connection disposed" error by text',
       () async {
         final FakeAndroidDevice device =
             FakeAndroidDevice(id: '1')

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1189,7 +1189,7 @@ void main() {
   });
 
   testUsingContext(
-    'Flutter run catches catches errors due to vm service disconnection and throws a tool exit',
+    'Flutter run catches catches errors due to vm service disconnection by text and throws a tool exit',
     () async {
       final FakeResidentRunner residentRunner = FakeResidentRunner();
       residentRunner.rpcError = RPCError(
@@ -1209,6 +1209,41 @@ void main() {
         'flutter._listViews',
         RPCErrorKind.kServerError.code,
         'Service connection disposed.',
+      );
+
+      await expectToolExitLater(
+        createTestCommandRunner(command).run(<String>['run', '--no-pub']),
+        contains('Lost connection to device.'),
+      );
+    },
+    overrides: <Type, Generator>{
+      Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    },
+  );
+
+  testUsingContext(
+    'Flutter run catches catches errors due to vm service disconnection by code and throws a tool exit',
+    () async {
+      final FakeResidentRunner residentRunner = FakeResidentRunner();
+      residentRunner.rpcError = RPCError(
+        'flutter._listViews',
+        RPCErrorKind.kServiceDisappeared.code,
+        '',
+      );
+      final TestRunCommandWithFakeResidentRunner command = TestRunCommandWithFakeResidentRunner();
+      command.fakeResidentRunner = residentRunner;
+
+      await expectToolExitLater(
+        createTestCommandRunner(command).run(<String>['run', '--no-pub']),
+        contains('Lost connection to device.'),
+      );
+
+      residentRunner.rpcError = RPCError(
+        'flutter._listViews',
+        RPCErrorKind.kConnectionDisposed.code,
+        'dummy text not matched.',
       );
 
       await expectToolExitLater(


### PR DESCRIPTION
There's currently a lot of code that handles RPC Errors that contain the text "Service connection disposed" because the error originally did not have a unique error code.

A new error code was added in https://dart-review.googlesource.com/c/sdk/+/381501 but it's not currently used because it won't be caught by existing code.

This change updates all places that check for this text, and now also handle the new error code in preperation for the code changing in future.

See https://github.com/flutter/flutter/issues/153471

cc @bkonyi 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
  Issue listed, but this change does not directly fix it, it just prepares for a related future change that will simplify handling these errors without string checks
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
