### PR TITLE
Fix flutter doctor usage of eglinfo in failure cases.

### DIFF
--- a/packages/flutter_tools/lib/src/linux/linux_doctor.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_doctor.dart
@@ -43,6 +43,8 @@ class _DriverInformation {
       result = await _processManager.run(<String>['eglinfo'], stdoutEncoding: utf8);
     } on ArgumentError {
       // ignore error.
+    } on ProcessException {
+      return false;
     }
     // result.exitCode is ignored, as this is non-zero if some platforms are not avaiable.
     // The output information is still parsable in all cases.

--- a/packages/flutter_tools/lib/src/linux/linux_doctor.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_doctor.dart
@@ -44,7 +44,9 @@ class _DriverInformation {
     } on ArgumentError {
       // ignore error.
     }
-    if (result == null || result.exitCode != 0) {
+    // result.exitCode is ignored, as this is non-zero if some platforms are not avaiable.
+    // The output information is still parsable in all cases.
+    if (result == null) {
       return false;
     }
 

--- a/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
@@ -160,7 +160,11 @@ Configurations:
 
 // A command that will failure when running 'eglinfo'.
 FakeCommand _eglinfoMissingCommand() {
-  return const FakeCommand(command: <String>['eglinfo'], exitCode: 1);
+  return FakeCommand(
+    command: <String>['eglinfo'],
+    exitCode: 1,
+    exception: ProcessException('eglinfo', <String>[]),
+  );
 }
 
 // Commands that give some failures for the GTK library pkg-config queries.

--- a/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
@@ -160,7 +160,7 @@ Configurations:
 
 // A command that will failure when running 'eglinfo'.
 FakeCommand _eglinfoMissingCommand() {
-  return FakeCommand(
+  return const FakeCommand(
     command: <String>['eglinfo'],
     exitCode: 1,
     exception: ProcessException('eglinfo', <String>[]),


### PR DESCRIPTION
Ignore return value from eglinfo - it doesn't indicate failure. Discovered when using an X11 system where Wayland is not available. It returns 1 in this case, but the output is still valid. Confirmed by looking at the eglinfo source - we should parse the output regardless of what it returns.

Catch exception correctly when eglinfo is not installed.

Fixes for https://github.com/flutter/flutter/pull/163980