### PR TITLE
Fix window creation callback for multi-window

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -568,6 +568,8 @@ static FlEngine* fl_engine_new_full(FlDartProject* project,
   self->keyboard_manager = fl_keyboard_manager_new(self);
   self->mouse_cursor_handler =
       fl_mouse_cursor_handler_new(self->binary_messenger);
+  self->windowing_handler = fl_windowing_handler_new(self);
+
   fl_renderer_set_engine(self->renderer, self);
 
   return self;
@@ -707,7 +709,6 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   fl_settings_handler_start(self->settings_handler, settings);
 
   self->platform_handler = fl_platform_handler_new(self->binary_messenger);
-  self->windowing_handler = fl_windowing_handler_new(self);
 
   setup_keyboard(self);
 

--- a/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
@@ -957,6 +957,7 @@ TEST(FlEngineTest, ChildObjects) {
   EXPECT_NE(fl_engine_get_task_runner(engine), nullptr);
   EXPECT_NE(fl_engine_get_keyboard_manager(engine), nullptr);
   EXPECT_NE(fl_engine_get_mouse_cursor_handler(engine), nullptr);
+  EXPECT_NE(fl_engine_get_windowing_handler(engine), nullptr);
 }
 
 // NOLINTEND(clang-analyzer-core.StackAddressEscape)

--- a/engine/src/flutter/shell/platform/linux/fl_windowing_handler.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_windowing_handler.cc
@@ -61,8 +61,6 @@ static GtkWindow* fl_windowing_handler_create_window(
     FlWindowingHandler* handler,
     FlView* view) {
   GtkWidget* window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-
-  gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   return GTK_WINDOW(window);
@@ -86,6 +84,7 @@ static FlMethodResponse* create_regular(FlWindowingSize* size,
   }
 
   FlView* view = fl_view_new_for_engine(engine);
+  gtk_widget_show(GTK_WIDGET(view));
 
   GtkWindow* window;
   g_signal_emit(self, signals[SIGNAL_CREATE_WINDOW], 0, view, &window);


### PR DESCRIPTION
The windowing handler wasn't being created early enough and the view wasn't visibile by default.
