### PR TITLE
Update the `RefreshProgressIndicator` widget to the 2024 Material Design appearance

### DIFF
--- a/dev/tools/gen_defaults/lib/progress_indicator_template.dart
+++ b/dev/tools/gen_defaults/lib/progress_indicator_template.dart
@@ -28,6 +28,9 @@ class _Circular${blockName}DefaultsM3 extends ProgressIndicatorThemeData {
   Color? get circularTrackColor => indeterminate ? null : ${componentColor('md.comp.progress-indicator.track')};
 
   @override
+  StrokeCap? get strokeCap => StrokeCap.round;
+
+  @override
   double get strokeWidth => ${getToken('md.comp.progress-indicator.track.thickness')};
 
   @override
@@ -44,6 +47,19 @@ class _Circular${blockName}DefaultsM3 extends ProgressIndicatorThemeData {
 
   @override
   EdgeInsetsGeometry? get circularTrackPadding => const EdgeInsets.all(4.0);
+}
+
+class _Refresh${blockName}DefaultsM3 extends _Circular${blockName}DefaultsM3 {
+  _Refresh${blockName}DefaultsM3(super.context, {required super.indeterminate});
+
+  @override
+  StrokeCap? get strokeCap => indeterminate ? StrokeCap.round : StrokeCap.butt;
+
+  @override
+  double? get strokeAlign => CircularProgressIndicator.strokeAlignCenter;
+
+  @override
+  Color? get refreshBackgroundColor => _colors.surfaceContainerHigh;
 }
 
 class _Linear${blockName}DefaultsM3 extends ProgressIndicatorThemeData {

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -1758,6 +1758,62 @@ void main() {
       ),
     );
   });
+
+  testWidgets('RefreshProgressIndicator defaults when year2023 is false', (
+    WidgetTester tester,
+  ) async {
+    final ThemeData theme = ThemeData();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const Center(child: RefreshProgressIndicator(year2023: false)),
+      ),
+    );
+    expect(
+      find.byType(RefreshProgressIndicator),
+      paints..arc(strokeCap: StrokeCap.round, color: theme.colorScheme.primary),
+    );
+    // Indeterminate RefreshProgressIndicator does not paint arrow head.
+    expect(
+      find.byType(RefreshProgressIndicator),
+      isNot(paints..path(color: theme.colorScheme.primary)),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const Center(child: RefreshProgressIndicator(year2023: false, value: 0.5)),
+      ),
+    );
+    expect(
+      find.byType(RefreshProgressIndicator),
+      paints
+        ..arc(strokeCap: StrokeCap.butt, color: theme.colorScheme.primary)
+        // Arrow head.
+        ..path(color: theme.colorScheme.primary),
+    );
+
+    final Material backgroundMaterial = tester.widget(
+      find.descendant(of: find.byType(RefreshProgressIndicator), matching: find.byType(Material)),
+    );
+    expect(backgroundMaterial.color, theme.colorScheme.surfaceContainerHigh);
+  });
+
+  testWidgets('RefreshProgressIndicator default arrow head when year2023 is false', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const Center(child: RefreshProgressIndicator(year2023: false, value: 0.5)),
+      ),
+    );
+
+    await expectLater(
+      find.byType(RefreshProgressIndicator),
+      matchesGoldenFile('refresh_progress_indicator.default_arrow_head.year2023_false.png'),
+    );
+  });
 }
 
 class _RefreshProgressIndicatorGolden extends StatefulWidget {


### PR DESCRIPTION
Fixes [RefreshIndicator is not displaying same as M3 specs](https://github.com/flutter/flutter/issues/163483)

### Description

This PR updates `RefreshProgressIndicator ` with `year2023` flag which can be used to opt into the 2024 `RangeSlider` design appearance.  The `RefreshProgressIndicator` specific tokens don't exit as this `RefreshProgressIndicator` isn't mentioned in M3 specs but based on the `CircularProgressIndicator` guidelines it exist and can be found in Jetpack Compose so I've matched the new arrow head and container background manually. This PR extends `CircularProgressIndicator` defaults for `RefreshProgressIndicator` as well. 

The updated `RefreshProgressIndicator` has:
1. New arrow head style.
2. Stroke roundness is updated based on drag value (when dragging it uses square stroke cap and rounded when released)

### Code Sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(progressIndicatorTheme: const ProgressIndicatorThemeData(year2023: false)),
      home: Scaffold(
        appBar: AppBar(
          title: const Text('Refresh Indicator Example'),
        ),
        body: RefreshIndicator(
          onRefresh: onRefresh,
          child: ListView.builder(
            itemCount: 30,
            itemBuilder: (BuildContext context, int index) {
              return ListTile(
                title: Text('Item $index'),
              );
            },
          ),
        ),
      ),
    );
  }

  Future<void> onRefresh() async {
    await Future<void>.delayed(const Duration(seconds: 2));
  }
}
```

</details>

### Preview

<img width="496" alt="Screenshot 2025-02-27 at 16 33 17" src="https://github.com/user-attachments/assets/ae8f9f6c-dd2e-42e5-bc8f-a3db2e44d672" />



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
