### PR TITLE
Move `integration_test.FlutterDeviceScreenshotTest` to the framework slow shard

### DIFF
--- a/dev/bots/suite_runners/run_framework_tests.dart
+++ b/dev/bots/suite_runners/run_framework_tests.dart
@@ -247,6 +247,36 @@ Future<void> frameworkTestsRunner() async {
     await runFixTests('integration_test');
     await runFixTests('flutter_driver');
     await runPrivateTests();
+
+    // Run java unit tests for integration_test
+    //
+    // Generate Gradle wrapper if it doesn't exist.
+    Process.runSync(
+      flutter,
+      <String>['build', 'apk', '--config-only'],
+      workingDirectory: path.join(
+        flutterRoot,
+        'packages',
+        'integration_test',
+        'example',
+        'android',
+      ),
+    );
+    await runCommand(
+      path.join(flutterRoot, 'packages', 'integration_test', 'example', 'android', 'gradlew$bat'),
+      <String>[
+        ':integration_test:testDebugUnitTest',
+        '--tests',
+        'dev.flutter.plugins.integration_test.FlutterDeviceScreenshotTest',
+      ],
+      workingDirectory: path.join(
+        flutterRoot,
+        'packages',
+        'integration_test',
+        'example',
+        'android',
+      ),
+    );
   }
 
   Future<void> runMisc() async {
@@ -288,35 +318,6 @@ Future<void> frameworkTestsRunner() async {
         // Web-specific tests depend on Chromium, so they run as part of the web_long_running_tests shard.
         '--exclude-tags=web',
       ],
-    );
-    // Run java unit tests for integration_test
-    //
-    // Generate Gradle wrapper if it doesn't exist.
-    Process.runSync(
-      flutter,
-      <String>['build', 'apk', '--config-only'],
-      workingDirectory: path.join(
-        flutterRoot,
-        'packages',
-        'integration_test',
-        'example',
-        'android',
-      ),
-    );
-    await runCommand(
-      path.join(flutterRoot, 'packages', 'integration_test', 'example', 'android', 'gradlew$bat'),
-      <String>[
-        ':integration_test:testDebugUnitTest',
-        '--tests',
-        'dev.flutter.plugins.integration_test.FlutterDeviceScreenshotTest',
-      ],
-      workingDirectory: path.join(
-        flutterRoot,
-        'packages',
-        'integration_test',
-        'example',
-        'android',
-      ),
     );
     await runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_goldens'));
     await runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_localizations'));


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/164177.

[Every](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8721680858175088673/+/u/run_test.dart_for_framework_tests_shard_and_subshard_misc/stdout) [recent](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8721678607671718689/+/u/run_test.dart_for_framework_tests_shard_and_subshard_misc/stdout) [failure](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8721668796723786737/+/u/run_test.dart_for_framework_tests_shard_and_subshard_misc/stdout) is `integration_test.FlutterDeviceScreenshotTest`, which is run using Gradle, and often takes 5m+. This test is already [close to hitting its threshold of 30m consistently](https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.prod/Windows%20framework_tests_misc):

![Image](https://github.com/user-attachments/assets/e05fa1af-c431-4960-b08b-c3ceebc75f85)

I am proposing moving this test to `Linux framework_tests_slow`, it does not have a lot of value to run on every platform, and is indeed, slow.
