### PR TITLE
[Web] fix Image fit when using ImgElementPlatformView

### DIFF
--- a/packages/flutter/lib/src/web.dart
+++ b/packages/flutter/lib/src/web.dart
@@ -148,5 +148,3 @@ extension type XMLHttpRequest._(JSObject _) implements XMLHttpRequestEventTarget
 }
 
 extension type XMLHttpRequestEventTarget._(JSObject _) implements EventTarget, JSObject {}
-
-enum CSSObjectFit { fill, contain, cover, fitWidth, fitHeight, none, scaleDown }

--- a/packages/flutter/lib/src/web.dart
+++ b/packages/flutter/lib/src/web.dart
@@ -42,6 +42,10 @@ extension type CSSStyleDeclaration._(JSObject _) implements JSObject {
   external String get height;
   external set width(String value);
   external String get width;
+  @JS('object-fit')
+  external set objectFit(String value);
+  @JS('object-fit')
+  external String get objectFit;
 }
 
 extension type CSSStyleSheet._(JSObject _) implements JSObject {
@@ -144,3 +148,5 @@ extension type XMLHttpRequest._(JSObject _) implements XMLHttpRequestEventTarget
 }
 
 extension type XMLHttpRequestEventTarget._(JSObject _) implements EventTarget, JSObject {}
+
+enum CSSObjectFit { fill, contain, cover, fitWidth, fitHeight, none, scaleDown }

--- a/packages/flutter/lib/src/widgets/_web_image_web.dart
+++ b/packages/flutter/lib/src/widgets/_web_image_web.dart
@@ -21,7 +21,7 @@ import 'platform_view.dart';
 /// Displays an `<img>` element with `src` set to [src].
 class ImgElementPlatformView extends StatelessWidget {
   /// Creates a platform view backed with an `<img>` element.
-  ImgElementPlatformView(this.src, {super.key}) {
+  ImgElementPlatformView(this.src, {this.fit, super.key}) {
     if (!_registered) {
       _register();
     }
@@ -39,12 +39,21 @@ class ImgElementPlatformView extends StatelessWidget {
       // without fetching it over the network again.
       final web.HTMLImageElement img = web.document.createElement('img') as web.HTMLImageElement;
       img.src = paramsMap['src']! as String;
+      img.style.width = '100%';
+      img.style.height = '100%';
+      final String? fit = paramsMap['fit'] as String?;
+      if (fit != null) {
+        img.style.objectFit = fit;
+      }
       return img;
     });
   }
 
   /// The `src` URL for the `<img>` tag.
   final String? src;
+
+  /// The `object-fit` CSS property for the `<img>` tag.
+  final web.CSSObjectFit? fit;
 
   @override
   Widget build(BuildContext context) {
@@ -53,7 +62,7 @@ class ImgElementPlatformView extends StatelessWidget {
     }
     return HtmlElementView(
       viewType: _viewType,
-      creationParams: <String, String?>{'src': src},
+      creationParams: <String, String?>{'src': src, 'fit': fit?.name},
       hitTestBehavior: PlatformViewHitTestBehavior.transparent,
     );
   }
@@ -72,7 +81,7 @@ class RawWebImage extends SingleChildRenderObjectWidget {
     this.fit,
     this.alignment = Alignment.center,
     this.matchTextDirection = false,
-  }) : super(child: ImgElementPlatformView(image.htmlImage.src));
+  }) : super(child: ImgElementPlatformView(image.htmlImage.src, fit: fit?.cssObjectFit));
 
   /// The underlying HTML element to be displayed.
   final WebImageInfo image;
@@ -369,5 +378,22 @@ class RenderWebImage extends RenderShiftedBox {
     properties.add(
       DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null),
     );
+  }
+}
+
+extension on BoxFit {
+  web.CSSObjectFit get cssObjectFit {
+    switch (this) {
+      case BoxFit.contain:
+      case BoxFit.cover:
+      case BoxFit.fitWidth:
+      case BoxFit.fitHeight:
+      case BoxFit.scaleDown:
+        return web.CSSObjectFit.cover;
+      case BoxFit.fill:
+        return web.CSSObjectFit.fill;
+      case BoxFit.none:
+        return web.CSSObjectFit.none;
+    }
   }
 }

--- a/packages/flutter/lib/src/widgets/_web_image_web.dart
+++ b/packages/flutter/lib/src/widgets/_web_image_web.dart
@@ -18,6 +18,10 @@ import 'basic.dart';
 import 'framework.dart';
 import 'platform_view.dart';
 
+/// Function signature for `ui_web.platformViewRegistry.registerViewFactory`.
+@visibleForTesting
+typedef RegisterViewFactory = void Function(String, Object Function(int viewId), {bool isVisible});
+
 /// Displays an `<img>` element with `src` set to [src].
 class ImgElementPlatformView extends StatelessWidget {
   /// Creates a platform view backed with an `<img>` element.
@@ -30,10 +34,18 @@ class ImgElementPlatformView extends StatelessWidget {
   static const String _viewType = 'Flutter__ImgElementImage__';
   static bool _registered = false;
 
+  /// Override this to provide a custom implementation of [ui_web.platformViewRegistry.registerViewFactory].
+  ///
+  /// This should only be used for testing.
+  @visibleForTesting
+  static RegisterViewFactory? debugOverrideRegisterViewFactory;
+  static RegisterViewFactory get _registerViewFactory =>
+      debugOverrideRegisterViewFactory ?? ui_web.platformViewRegistry.registerViewFactory;
+
   static void _register() {
     assert(!_registered);
     _registered = true;
-    ui_web.platformViewRegistry.registerViewFactory(_viewType, (int viewId, {Object? params}) {
+    _registerViewFactory(_viewType, (int viewId, {Object? params}) {
       final Map<Object?, Object?> paramsMap = params! as Map<Object?, Object?>;
       // Create a new <img> element. The browser is able to display the image
       // without fetching it over the network again.

--- a/packages/flutter/test/painting/_network_image_test_web.dart
+++ b/packages/flutter/test/painting/_network_image_test_web.dart
@@ -40,6 +40,12 @@ void runTests() {
       // without fetching it over the network again.
       final web.HTMLImageElement img = web.document.createElement('img') as web.HTMLImageElement;
       img.src = paramsMap['src']! as String;
+      img.style.width = '100%';
+      img.style.height = '100%';
+      final String? objectFit = paramsMap['object-fit'] as String?;
+      if (objectFit != null) {
+        img.style.objectFit = objectFit;
+      }
       return img;
     });
     ui_web.debugOverridePlatformViewRegistry(fakePlatformViewRegistry);
@@ -50,13 +56,6 @@ void runTests() {
     debugRestoreImgElementFactory();
     _TestBinding.instance.overrideCodec = null;
     ui_web.debugOverridePlatformViewRegistry(null);
-  });
-
-  late final FakePlatformViewRegistry fakePlatformViewRegistry;
-  setUpAll(() {
-    fakePlatformViewRegistry = FakePlatformViewRegistry();
-    ImgElementPlatformView.debugOverrideRegisterViewFactory =
-        fakePlatformViewRegistry.registerViewFactory;
   });
 
   testWidgets('loads an image from the network with headers', (WidgetTester tester) async {
@@ -479,13 +478,24 @@ void runTests() {
   group(
     'ImgElementPlatformView create html element with the right object-fit, height and width',
     () {
-      testWidgets('BoxFit.contain set "cover" as object-fit', (WidgetTester tester) async {
+      testWidgets('If fit is null object-fit is not set', (WidgetTester tester) async {
+        final web.HTMLElement element = await _pumpImageAndGetHtmlElement(
+          tester,
+          fit: null,
+          fakePlatformViewRegistry: fakePlatformViewRegistry,
+        );
+        expect(element.style.objectFit, '');
+        expect(element.style.height, '100%');
+        expect(element.style.width, '100%');
+      });
+
+      testWidgets('BoxFit.contain set "contain" as object-fit', (WidgetTester tester) async {
         final web.HTMLElement element = await _pumpImageAndGetHtmlElement(
           tester,
           fit: BoxFit.contain,
           fakePlatformViewRegistry: fakePlatformViewRegistry,
         );
-        expect(element.style.objectFit, 'cover');
+        expect(element.style.objectFit, 'contain');
         expect(element.style.height, '100%');
         expect(element.style.width, '100%');
       });
@@ -534,7 +544,7 @@ void runTests() {
         expect(element.style.width, '100%');
       });
 
-      testWidgets('BoxFit.fill set "cover" as object-fit', (WidgetTester tester) async {
+      testWidgets('BoxFit.fill set "fill" as object-fit', (WidgetTester tester) async {
         final web.HTMLElement element = await _pumpImageAndGetHtmlElement(
           tester,
           fit: BoxFit.fill,
@@ -545,7 +555,7 @@ void runTests() {
         expect(element.style.width, '100%');
       });
 
-      testWidgets('BoxFit.none set "cover" as object-fit', (WidgetTester tester) async {
+      testWidgets('BoxFit.none set "none" as object-fit', (WidgetTester tester) async {
         final web.HTMLElement element = await _pumpImageAndGetHtmlElement(
           tester,
           fit: BoxFit.none,
@@ -728,7 +738,7 @@ class _TestFrameInfo implements ui.FrameInfo {
 
 Future<web.HTMLElement> _pumpImageAndGetHtmlElement(
   WidgetTester tester, {
-  required BoxFit fit,
+  required BoxFit? fit,
   required FakePlatformViewRegistry fakePlatformViewRegistry,
 }) async {
   final TestImgElement testImg = TestImgElement();


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Hello, I've found the issue #163288 and I've tried to fix it.
The problem was that, to make the image appear in the right way based on the given `BoxFit`, it was needed also set the right `object-fit` on the HTML `<img>` element.
So I've added it to the `ImgElementPlatformView` widget and I've also added some convenience thing in `web.dart` to set the `object-fit` property

Fixes  #163288

Here is the result

 **before**
![Screenshot 2025-02-26 230655](https://github.com/user-attachments/assets/9f9998fd-4576-4e24-a142-ce38d0b3801e)

 **after**
![Screenshot 2025-02-26 230732](https://github.com/user-attachments/assets/abf4bd47-80c2-41a2-99fc-ccdebfdda084)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
