### PR TITLE
Add `withDurationAndBounce` to `SpringDescription`

### DIFF
--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -46,17 +46,12 @@ class SpringDescription {
   /// Creates a [SpringDescription] based on a desired animation duration and
   /// bounce.
   ///
-  /// This provides an intuitive way to define a spring, focusing on its visual
-  /// properties (duration and bounce) rather than explicit physical parameters
-  /// (mass, damping, stiffness). Internally, it approximates these visual
-  /// traits to compute the physical parameters.
+  /// This provides an intuitive way to define a spring based on its visual
+  /// properties, [duration] and [bounce]. Check the properties' documentation
+  /// for their definition.
   ///
-  /// - [duration]: The perceptual duration of the animation. Defaults to
-  ///   `Duration(milliseconds: 500)`. The real animation duration may differ.
-  /// - [bounce]: Determines the level of oscillation at the end of the
-  ///   animation, ranging from `0.0` (no bounce) to `1.0` (a strong bounce).
-  ///   Values above `1.0` can lead to more extreme oscillations, so use with
-  ///   caution. Defaults to `0.0` (no bounce).
+  /// This constructor produces the same result as SwiftUI's
+  /// `spring(duration:bounce:blendDuration:)` animation.
   ///
   /// {@tool snippet}
   /// ```dart
@@ -67,14 +62,11 @@ class SpringDescription {
   /// ```
   /// {@end-tool}
   ///
-  /// The conversion uses a mass of 1.0 and calculates appropriate stiffness
-  /// and damping values to achieve the desired visual effect.
-  ///
   /// See also:
-  /// * [SpringDescription.withDampingRatio] for creating a spring with a
-  ///   damping ratio.
-  /// * [SpringDescription] for creating a spring with explicit physical
-  ///   parameters.
+  /// * [SpringDescription], which creates a spring by explicitly providing
+  /// physical parameters.
+  /// * [SpringDescription.withDampingRatio], which creates a spring with a
+  ///   damping ratio and other physical parameters.
   factory SpringDescription.withDurationAndBounce({
     Duration duration = const Duration(milliseconds: 500),
     double bounce = 0.0,
@@ -124,42 +116,41 @@ class SpringDescription {
   /// driving the [SpringSimulation].
   final double damping;
 
-  /// Returns the perceptual duration of the spring animation.
+  /// The duration parameter used in [SpringDescription.withDurationAndBounce].
   ///
-  /// This getter estimates how long the spring appears to take to complete its
-  /// animation based on the current [mass] and [stiffness] values. This is
-  /// solely a perceptual estimate (the duration that the user perceives) and
-  /// may differ from the actual time taken by the simulation when measured
-  /// precisely. The real total duration can be influenced by initial
-  /// conditions and the [SpringSimulation.isDone] tolerance.
+  /// This value defines the perceptual duration of the spring, controlling
+  /// its overall pace. It is approximately equal to the time it takes for
+  /// the spring to settle, but for highly bouncy springs, it instead
+  /// corresponds to the oscillation period.
   ///
-  /// This is the inverse calculation of what's used in
-  /// [withDurationAndBounce]. The actual duration of a spring animation may
-  /// vary depending on initial conditions and when the
-  /// [SpringSimulation.isDone] tolerance is reached.
+  /// This duration does not represent the exact time for the spring to stop
+  /// moving. For example, when [bounce] is `1`, the spring oscillates
+  /// indefinitely, even though [duration] has a finite value. To determine
+  /// when the motion has effectively stopped within a certain tolerance,
+  /// use [SpringSimulation.isDone].
   ///
-  /// Returns a [Duration] object representing the estimated (perceptual)
-  /// animation time.
+  /// Defaults to 0.5 seconds.
   Duration get duration {
     final double durationInSeconds = math.sqrt((4 * math.pi * math.pi * mass) / stiffness);
     final int milliseconds = (durationInSeconds * Duration.millisecondsPerSecond).round();
     return Duration(milliseconds: milliseconds);
   }
 
-  /// Returns the approximate bounce factor of the spring.
+  /// The bounce parameter used in [SpringDescription.withDurationAndBounce].
   ///
-  /// The bounce factor ranges approximately from 0.0 (no bounce) to 1.0
-  /// (high bounce) and potentially higher for extremely bouncy springs.
+  /// This value controls how bouncy the spring is:
   ///
-  /// This is the inverse calculation of what's used in
-  /// [withDurationAndBounce]. It calculates the damping ratio and then
-  /// converts it to a bounce value.
+  ///  * A value of 0 results in a critically damped spring with no oscillation.
+  ///  * Values between 0 and 1 produce underdamping, where the spring oscillates a few times
+  ///    before settling. A value of 1 represents an undamped spring that
+  ///    oscillates indefinitely.
+  ///  * Negative values indicate overdamping, where the motion is slow and
+  ///    resistive, like moving through a thick fluid. The minimum value is -1.0.
   ///
-  /// A value of 0.0 indicates critical damping (no bounce), while values
-  /// greater than 0.0 indicate increasing levels of bounciness.
+  /// Defaults to 0.
   double get bounce {
     final double dampingRatio = damping / (2.0 * math.sqrt(mass * stiffness));
-    return 1.0 - dampingRatio;
+    return dampingRatio < 1.0 ? (1.0 - dampingRatio) : ((1 / dampingRatio) - 1);
   }
 
   @override

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -124,7 +124,7 @@ class SpringDescription {
   /// corresponds to the oscillation period.
   ///
   /// This duration does not represent the exact time for the spring to stop
-  /// moving. For example, when [bounce] is `1`, the spring oscillates
+  /// moving. For example, when [bounce] is 1, the spring oscillates
   /// indefinitely, even though [duration] has a finite value. To determine
   /// when the motion has effectively stopped within a certain tolerance,
   /// use [SpringSimulation.isDone].

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -52,7 +52,7 @@ class SpringDescription {
   /// traits to compute the physical parameters.
   ///
   /// - [duration]: The perceptual duration of the animation. Defaults to
-  ///   `Duration(milliseconds: 500)`. The real animation duration will differ.
+  ///   `Duration(milliseconds: 500)`. The real animation duration may differ.
   /// - [bounce]: Determines the level of oscillation at the end of the
   ///   animation, ranging from `0.0` (no bounce) to `1.0` (a strong bounce).
   ///   Values above `1.0` can lead to more extreme oscillations, so use with

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -52,8 +52,7 @@ class SpringDescription {
   /// traits to compute the physical parameters.
   ///
   /// - [duration]: The perceptual duration of the animation. Defaults to
-  ///   `Duration(milliseconds: 500)`. Note that the real animation
-  ///   duration may slightly differ for natural spring-like motion.
+  ///   `Duration(milliseconds: 500)`. The real animation duration will differ.
   /// - [bounce]: Determines the level of oscillation at the end of the
   ///   animation, ranging from `0.0` (no bounce) to `1.0` (a strong bounce).
   ///   Values above `1.0` can lead to more extreme oscillations, so use with
@@ -81,14 +80,10 @@ class SpringDescription {
     double bounce = 0.0,
   }) {
     assert(duration.inMilliseconds > 0, 'Duration must be positive');
-    // TODO(bernaferrari): bounce could be negative but it's tricky to guess
-    // the correct formula https://github.com/flutter/flutter/issues/152587).
-    assert(bounce >= 0, 'Bounce must be non-negative');
-
     final double durationInSeconds = duration.inMilliseconds / Duration.millisecondsPerSecond;
     const double mass = 1.0;
     final double stiffness = (4 * math.pi * math.pi * mass) / math.pow(durationInSeconds, 2);
-    final double dampingRatio = 1.0 - bounce;
+    final double dampingRatio = bounce > 0 ? (1.0 - bounce) : (1 / (bounce + 1));
     final double damping = dampingRatio * 2.0 * math.sqrt(mass * stiffness);
 
     return SpringDescription(mass: mass, stiffness: stiffness, damping: damping);

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -145,7 +145,7 @@ class SpringDescription {
   ///    before settling. A value of 1 represents an undamped spring that
   ///    oscillates indefinitely.
   ///  * Negative values indicate overdamping, where the motion is slow and
-  ///    resistive, like moving through a thick fluid. The minimum value is -1.0.
+  ///    resistive, like moving through a thick fluid.
   ///
   /// Defaults to 0.
   double get bounce {

--- a/packages/flutter/test/physics/spring_simulation_test.dart
+++ b/packages/flutter/test/physics/spring_simulation_test.dart
@@ -43,6 +43,10 @@ void main() {
       expect(spring.mass, equals(1.0));
       expect(spring.stiffness, moreOrLessEquals(157.91, epsilon: 0.01));
       expect(spring.damping, moreOrLessEquals(17.59, epsilon: 0.01));
+
+      // Verify that getters recalculate correctly
+      expect(spring.bounce, moreOrLessEquals(0.3, epsilon: 0.0001));
+      expect(spring.duration.inMilliseconds, equals(500));
     });
 
     test('creates spring with negative bounce', () {
@@ -51,6 +55,10 @@ void main() {
       expect(spring.mass, equals(1.0));
       expect(spring.stiffness, moreOrLessEquals(157.91, epsilon: 0.01));
       expect(spring.damping, moreOrLessEquals(35.90, epsilon: 0.01));
+
+      // Verify that getters recalculate correctly
+      expect(spring.bounce, moreOrLessEquals(-0.3, epsilon: 0.0001));
+      expect(spring.duration.inMilliseconds, equals(500));
     });
 
     test('get duration and bounce based on mass and stiffness', () {

--- a/packages/flutter/test/physics/spring_simulation_test.dart
+++ b/packages/flutter/test/physics/spring_simulation_test.dart
@@ -68,20 +68,20 @@ void main() {
         damping: 17.59,
       );
 
-      expect(spring.duration.inMilliseconds, const Duration(milliseconds: 500).inMilliseconds);
+      expect(spring.duration.inMilliseconds, equals(500));
       expect(spring.bounce, moreOrLessEquals(0.3, epsilon: 0.001));
     });
 
     test('custom duration', () {
       final SpringDescription spring = SpringDescription.withDurationAndBounce(
-        duration: const Duration(seconds: 1),
+        duration: const Duration(milliseconds: 100),
       );
 
       expect(spring.mass, equals(1.0));
-      expect(spring.stiffness, moreOrLessEquals(39.47, epsilon: 0.01));
-      expect(spring.damping, moreOrLessEquals(12.56, epsilon: 0.01));
+      expect(spring.stiffness, moreOrLessEquals(3947.84, epsilon: 0.01));
+      expect(spring.damping, moreOrLessEquals(125.66, epsilon: 0.01));
 
-      expect(spring.duration.inMilliseconds, const Duration(seconds: 1).inMilliseconds);
+      expect(spring.duration.inMilliseconds, equals(100));
       expect(spring.bounce, moreOrLessEquals(0, epsilon: 0.001));
     });
 

--- a/packages/flutter/test/physics/spring_simulation_test.dart
+++ b/packages/flutter/test/physics/spring_simulation_test.dart
@@ -72,6 +72,19 @@ void main() {
       expect(spring.bounce, moreOrLessEquals(0.3, epsilon: 0.001));
     });
 
+    test('custom duration', () {
+      final SpringDescription spring = SpringDescription.withDurationAndBounce(
+        duration: const Duration(seconds: 1),
+      );
+
+      expect(spring.mass, equals(1.0));
+      expect(spring.stiffness, moreOrLessEquals(39.47, epsilon: 0.01));
+      expect(spring.damping, moreOrLessEquals(12.56, epsilon: 0.01));
+
+      expect(spring.duration.inMilliseconds, const Duration(seconds: 1).inMilliseconds);
+      expect(spring.bounce, moreOrLessEquals(0, epsilon: 0.001));
+    });
+
     test('duration <= 0 should fail', () {
       expect(
         () => SpringDescription.withDurationAndBounce(

--- a/packages/flutter/test/physics/spring_simulation_test.dart
+++ b/packages/flutter/test/physics/spring_simulation_test.dart
@@ -68,8 +68,8 @@ void main() {
         damping: 17.59,
       );
 
-      expect(spring.duration.inMilliseconds, equals(500));
       expect(spring.bounce, moreOrLessEquals(0.3, epsilon: 0.001));
+      expect(spring.duration.inMilliseconds, equals(500));
     });
 
     test('custom duration', () {
@@ -81,8 +81,8 @@ void main() {
       expect(spring.stiffness, moreOrLessEquals(3947.84, epsilon: 0.01));
       expect(spring.damping, moreOrLessEquals(125.66, epsilon: 0.01));
 
-      expect(spring.duration.inMilliseconds, equals(100));
       expect(spring.bounce, moreOrLessEquals(0, epsilon: 0.001));
+      expect(spring.duration.inMilliseconds, equals(100));
     });
 
     test('duration <= 0 should fail', () {

--- a/packages/flutter/test/physics/spring_simulation_test.dart
+++ b/packages/flutter/test/physics/spring_simulation_test.dart
@@ -35,4 +35,50 @@ void main() {
     expect(snappingSimulation.x(time), 1);
     expect(snappingSimulation.dx(time), 0);
   });
+
+  group('SpringDescription.withDurationAndBounce', () {
+    test('creates spring with expected parameters for given duration and bounce', () {
+      final SpringDescription spring = SpringDescription.withDurationAndBounce(bounce: 0.3);
+
+      expect(spring.mass, equals(1.0));
+      expect(spring.stiffness, moreOrLessEquals(157.91, epsilon: 0.01));
+      expect(spring.damping, moreOrLessEquals(17.59, epsilon: 0.01));
+    });
+
+    test('get duration and bounce based on mass and stiffness', () {
+      const SpringDescription spring = SpringDescription(
+        mass: 1.0,
+        stiffness: 157.91,
+        damping: 17.59,
+      );
+
+      expect(spring.duration.inMilliseconds, const Duration(milliseconds: 500).inMilliseconds);
+      expect(spring.bounce, moreOrLessEquals(0.3, epsilon: 0.001));
+    });
+
+    test('duration <= 0 should fail', () {
+      expect(
+        () => SpringDescription.withDurationAndBounce(
+          duration: const Duration(seconds: -1),
+          bounce: 0.3,
+        ),
+        throwsA(isAssertionError),
+      );
+
+      expect(
+        () => SpringDescription.withDurationAndBounce(duration: Duration.zero, bounce: 0.3),
+        throwsA(isAssertionError),
+      );
+    });
+
+    test('negative bounce should fail', () {
+      expect(
+        () => SpringDescription.withDurationAndBounce(
+          duration: const Duration(milliseconds: 300),
+          bounce: -0.3,
+        ),
+        throwsA(isAssertionError),
+      );
+    });
+  });
 }

--- a/packages/flutter/test/physics/spring_simulation_test.dart
+++ b/packages/flutter/test/physics/spring_simulation_test.dart
@@ -37,12 +37,20 @@ void main() {
   });
 
   group('SpringDescription.withDurationAndBounce', () {
-    test('creates spring with expected parameters for given duration and bounce', () {
+    test('creates spring with expected results', () {
       final SpringDescription spring = SpringDescription.withDurationAndBounce(bounce: 0.3);
 
       expect(spring.mass, equals(1.0));
       expect(spring.stiffness, moreOrLessEquals(157.91, epsilon: 0.01));
       expect(spring.damping, moreOrLessEquals(17.59, epsilon: 0.01));
+    });
+
+    test('creates spring with negative bounce', () {
+      final SpringDescription spring = SpringDescription.withDurationAndBounce(bounce: -0.3);
+
+      expect(spring.mass, equals(1.0));
+      expect(spring.stiffness, moreOrLessEquals(157.91, epsilon: 0.01));
+      expect(spring.damping, moreOrLessEquals(35.90, epsilon: 0.01));
     });
 
     test('get duration and bounce based on mass and stiffness', () {
@@ -67,16 +75,6 @@ void main() {
 
       expect(
         () => SpringDescription.withDurationAndBounce(duration: Duration.zero, bounce: 0.3),
-        throwsA(isAssertionError),
-      );
-    });
-
-    test('negative bounce should fail', () {
-      expect(
-        () => SpringDescription.withDurationAndBounce(
-          duration: const Duration(milliseconds: 300),
-          bounce: -0.3,
-        ),
         throwsA(isAssertionError),
       );
     });


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/152587

###  Description:
With `withDurationAndBounce` (we could also rename to `withDuration`), the user only has to worry about a single attribute: the bounce (and duration, but they would have to worry with duration anyway. If they don't, there is a default value already). The standard `SpringDescription` has 3 values, so it is way more abstract. This should help a lot people to make beautiful spring animations using Flutter.

<img width="838" alt="image" src="https://github.com/user-attachments/assets/4d0dccc7-0f97-4a13-99a4-268228b87f08" />

### Negative bounce:

I didn't enable bounce to be negative because the behavior is super tricky. I don't know what formula Apple is using, but seems like it is not public. There are many different formulas we can use, including the one provided on the original issue, but then there is the risk of people complaining it works differently than SwiftUI. I need to check if other projects (react-spring, framer motion) support negative bounce, but feels like this is something 99.9999% of people wouldn't expect or use, so I think we are safe. I couldn't find a single usage of negative bounce on Swift in all GitHub (without a duration, using code-search, vs 5k cases with positive values). Not even sure the todo is needed, but won't hurt.


### Comparison

<details>
  <summary>Dart vs Swift testing results</summary>

```dart
 testWidgets('Spring Simulation Tests - Matching SwiftUI', (WidgetTester tester) async {
      // Test cases matching the Swift code's ranges
      List<({Duration duration, double bounce})> testCases = [
        (duration: const Duration(milliseconds: 100), bounce: 0.0),
        (duration: const Duration(milliseconds: 100), bounce: 0.3),
        (duration: const Duration(milliseconds: 100), bounce: 0.8),
        (duration: const Duration(milliseconds: 100), bounce: 1.0),
        (duration: const Duration(milliseconds: 500), bounce: 0.0),
        (duration: const Duration(milliseconds: 500), bounce: 0.3),
        (duration: const Duration(milliseconds: 500), bounce: 0.8),
        (duration: const Duration(milliseconds: 500), bounce: 1.0),
        (duration: const Duration(milliseconds: 1000), bounce: 0.0),
        (duration: const Duration(milliseconds: 1000), bounce: 0.3),
        (duration: const Duration(milliseconds: 1000), bounce: 0.8),
        (duration: const Duration(milliseconds: 1000), bounce: 1.0),
        (duration: const Duration(milliseconds: 2000), bounce: 0.0),
        (duration: const Duration(milliseconds: 2000), bounce: 0.3),
        (duration: const Duration(milliseconds: 2000), bounce: 0.8),
        (duration: const Duration(milliseconds: 2000), bounce: 1.0),
      ];

      for (final testCase in testCases) {
        SpringDescription springDesc = SpringDescription.withDurationAndBounce(
          duration: testCase.duration,
          bounce: testCase.bounce,
        );

        print(
          'Duration: ${testCase.duration.inMilliseconds / 1000}, Bounce: ${testCase.bounce}, Mass: ${springDesc.mass}, Stiffness: ${springDesc.stiffness}, Damping: ${springDesc.damping}',
        );
      }
    });
```
Output:
```
Duration: 0.1, Bounce: 0.0, Mass: 1.0, Stiffness: 3947.8417604357423, Damping: 125.66370614359171
Duration: 0.1, Bounce: 0.3, Mass: 1.0, Stiffness: 3947.8417604357423, Damping: 87.9645943005142
Duration: 0.1, Bounce: 0.8, Mass: 1.0, Stiffness: 3947.8417604357423, Damping: 25.132741228718338
Duration: 0.1, Bounce: 1.0, Mass: 1.0, Stiffness: 3947.8417604357423, Damping: 0.0
Duration: 0.5, Bounce: 0.0, Mass: 1.0, Stiffness: 157.91367041742973, Damping: 25.132741228718345
Duration: 0.5, Bounce: 0.3, Mass: 1.0, Stiffness: 157.91367041742973, Damping: 17.59291886010284
Duration: 0.5, Bounce: 0.8, Mass: 1.0, Stiffness: 157.91367041742973, Damping: 5.026548245743668
Duration: 0.5, Bounce: 1.0, Mass: 1.0, Stiffness: 157.91367041742973, Damping: 0.0
Duration: 1.0, Bounce: 0.0, Mass: 1.0, Stiffness: 39.47841760435743, Damping: 12.566370614359172
Duration: 1.0, Bounce: 0.3, Mass: 1.0, Stiffness: 39.47841760435743, Damping: 8.79645943005142
Duration: 1.0, Bounce: 0.8, Mass: 1.0, Stiffness: 39.47841760435743, Damping: 2.513274122871834
Duration: 1.0, Bounce: 1.0, Mass: 1.0, Stiffness: 39.47841760435743, Damping: 0.0
Duration: 2.0, Bounce: 0.0, Mass: 1.0, Stiffness: 9.869604401089358, Damping: 6.283185307179586
Duration: 2.0, Bounce: 0.3, Mass: 1.0, Stiffness: 9.869604401089358, Damping: 4.39822971502571
Duration: 2.0, Bounce: 0.8, Mass: 1.0, Stiffness: 9.869604401089358, Damping: 1.256637061435917
Duration: 2.0, Bounce: 1.0, Mass: 1.0, Stiffness: 9.869604401089358, Damping: 0.0
```

Swift:
```swift
import SwiftUI
import XCTest

class SpringParameterTests: XCTestCase {

    func printSpringParameters(duration: Double, bounce: Double) {
        let spring = Spring(duration: duration, bounce: bounce) // Let SwiftUI do its thing
        print("Duration: \(duration), Bounce: \(bounce), Mass: \(spring.mass), Stiffness: \(spring.stiffness), Damping: \(spring.damping)")
    }

    func testParameterExtraction() {
        // Test a range of durations and bounces
        let durations: [Double] = [0.1, 0.5, 1.0, 2.0]
        let bounces: [Double] = [0.0, 0.3, 0.8, 1.0]

        for duration in durations {
            for bounce in bounces {
                printSpringParameters(duration: duration, bounce: bounce)
            }
        }
    }
}
```
Output:
```
Duration: 0.1, Bounce: 0.0, Mass: 1.0, Stiffness: 3947.8417604357433, Damping: 125.66370614359172
Duration: 0.1, Bounce: 0.3, Mass: 1.0, Stiffness: 3947.841760435743, Damping: 87.96459430051421
Duration: 0.1, Bounce: 0.8, Mass: 1.0, Stiffness: 3947.8417604357423, Damping: 25.132741228718338
Duration: 0.1, Bounce: 1.0, Mass: 1.0, Stiffness: 3947.8417604357433, Damping: 0.0
Duration: 0.5, Bounce: 0.0, Mass: 1.0, Stiffness: 157.91367041742973, Damping: 25.132741228718345
Duration: 0.5, Bounce: 0.3, Mass: 1.0, Stiffness: 157.9136704174297, Damping: 17.59291886010284
Duration: 0.5, Bounce: 0.8, Mass: 1.0, Stiffness: 157.9136704174297, Damping: 5.026548245743668
Duration: 0.5, Bounce: 1.0, Mass: 1.0, Stiffness: 157.91367041742973, Damping: 0.0
Duration: 1.0, Bounce: 0.0, Mass: 1.0, Stiffness: 39.47841760435743, Damping: 12.566370614359172
Duration: 1.0, Bounce: 0.3, Mass: 1.0, Stiffness: 39.478417604357425, Damping: 8.79645943005142
Duration: 1.0, Bounce: 0.8, Mass: 1.0, Stiffness: 39.478417604357425, Damping: 2.513274122871834
Duration: 1.0, Bounce: 1.0, Mass: 1.0, Stiffness: 39.47841760435743, Damping: 0.0
Duration: 2.0, Bounce: 0.0, Mass: 1.0, Stiffness: 9.869604401089358, Damping: 6.283185307179586
Duration: 2.0, Bounce: 0.3, Mass: 1.0, Stiffness: 9.869604401089356, Damping: 4.39822971502571
Duration: 2.0, Bounce: 0.8, Mass: 1.0, Stiffness: 9.869604401089356, Damping: 1.256637061435917
Duration: 2.0, Bounce: 1.0, Mass: 1.0, Stiffness: 9.869604401089358, Damping: 0.0
```
There are minor differences which should be rounding errors.

</details>