### PR TITLE
android: Clean up gen_snapshot artifact build

### DIFF
--- a/engine/src/flutter/lib/snapshot/BUILD.gn
+++ b/engine/src/flutter/lib/snapshot/BUILD.gn
@@ -28,21 +28,25 @@ group("generate_snapshot_bins") {
     ":generate_snapshot_bin",
     ":kernel_platform_files",
   ]
+  public_deps = []
 
   # Build gen_snapshot for the currently specified target_cpu.
-  #
-  # For macOS target builds: needed for both target CPUs (arm64, x64).
-  # For iOS, Android target builds: all AOT target CPUs are arm/arm64.
   if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
-    deps += [ ":create_macos_gen_snapshots" ]
+    # For macOS target builds: needed for both target CPUs (arm64, x64).
+    public_deps += [ ":create_macos_gen_snapshots" ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [ ":create_arm_gen_snapshot" ]
+    # For iOS, Android target builds: all AOT target CPUs are arm/arm64.
+    public_deps += [ ":create_arm_gen_snapshot" ]
+  } else if (target_cpu == "arm" || target_cpu == "arm64" ||
+             target_cpu == "x64") {
+    # For other host OSes, build gen_snapshot directly.
+    public_deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
   if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
-    deps += [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
+    public_deps += [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
   }
 }
 
@@ -173,7 +177,7 @@ if (host_os == "mac" && target_os != "mac" &&
 
     sources = [ "${host_output_dir}/gen_snapshot" ]
     outputs = [ "${host_output_dir}/gen_snapshot_${target_cpu_suffix}" ]
-    deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
+    public_deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
     visibility = [ ":*" ]
   }
 }

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -681,11 +681,20 @@ generated_file("android_entitlement_config") {
 
 if (target_cpu != "x86") {
   zip_bundle("gen_snapshot") {
-    gen_snapshot_bin = "gen_snapshot"
     gen_snapshot_out_dir =
         get_label_info("$dart_src/runtime/bin:gen_snapshot($host_toolchain)",
                        "root_out_dir")
-    gen_snapshot_path = rebase_path("$gen_snapshot_out_dir/$gen_snapshot_bin")
+
+    # The source gen_snapshot binary from the build outputs.
+    gen_snapshot_src = rebase_path("$gen_snapshot_out_dir/gen_snapshot")
+
+    # The output gen_snapshot binary name in the archive.
+    gen_snapshot_dest = "gen_snapshot"
+
+    if (host_os == "win") {
+      gen_snapshot_src = rebase_path("$root_out_dir/gen_snapshot.exe")
+      gen_snapshot_dest = "gen_snapshot.exe"
+    }
 
     if (host_os == "linux") {
       output = "$android_zip_archive_dir/linux-x64.zip"
@@ -693,18 +702,16 @@ if (target_cpu != "x86") {
       output = "$android_zip_archive_dir/darwin-x64.zip"
     } else if (host_os == "win") {
       output = "$android_zip_archive_dir/windows-x64.zip"
-      gen_snapshot_bin = "gen_snapshot.exe"
-      gen_snapshot_path = rebase_path("$root_out_dir/$gen_snapshot_bin")
     }
 
     files = [
       {
-        source = gen_snapshot_path
-        destination = gen_snapshot_bin
+        source = gen_snapshot_src
+        destination = gen_snapshot_dest
       },
     ]
 
-    deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
+    deps = [ "//flutter/lib/snapshot:generate_snapshot_bins" ]
 
     if (host_os == "mac") {
       deps += [ ":android_entitlement_config" ]


### PR DESCRIPTION
Previously, when producing the Android artifacts zip archive, we were relying directly on the transitively deep-down target in `//flutter/third_party/dart` that produces it rather than on the `//flutter/lib/snapshot:generate_snapshot_bins` target that generates the gen_snapshot binaries for Flutter.

Also documents and renames `gen_snapshot_path` and `gen_snapshot_bin` for clarity.

In a followup patch, I'll be refactoring Flutter's `generate_snapshot_bins` target to produce a universal (x64/arm64) `gen_snapshot` on macOS hosts, so we should rely on our own target instead.

Issue: https://github.com/flutter/flutter/issues/69157


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
