### PR TITLE
[Android] match dequeued images to FIF.

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -971,6 +971,11 @@ public class FlutterRenderer implements TextureRegistry {
       }
       return r;
     }
+
+    @VisibleForTesting
+    public int pendingDequeuedImages() {
+      return lastDequeuedImage.size();
+    }
   }
 
   @Keep

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -435,7 +435,15 @@ public class FlutterRenderer implements TextureRegistry {
           TextureRegistry.ImageConsumer,
           TextureRegistry.OnTrimMemoryListener {
     private static final String TAG = "ImageReaderSurfaceProducer";
-    private static final int MAX_IMAGES = 5;
+    private static final int MAX_IMAGES = 6;
+    // The ImageReaderSurfaceProducer must not close images until the renderer,
+    // either Skia OpenGL, Impeller OpenGL, or Impeller Vulkan is done reading
+    // from them. The Vulkan renderer allows up to two frames in flight before
+    // backpressure is applied. This implies that we may need to keep up to
+    // two images beyond the current image alive. Closing the images before
+    // the frame that references them has finished rendering can result in
+    // tearing or other incorrect rendering.
+    private static final int MAX_DEQUEUED_IMAGES = 2;
 
     // Flip when debugging to see verbose logs.
     private static final boolean VERBOSE_LOGS = false;
@@ -478,7 +486,7 @@ public class FlutterRenderer implements TextureRegistry {
     // REQUIRED: The following fields must only be accessed when lock is held.
     private final ArrayDeque<PerImageReader> imageReaderQueue = new ArrayDeque<>();
     private final HashMap<ImageReader, PerImageReader> perImageReaders = new HashMap<>();
-    private PerImage lastDequeuedImage = null;
+    private ArrayList<PerImage> lastDequeuedImage = new ArrayList<PerImage>();
     private PerImageReader lastReaderDequeuedFrom = null;
     private Callback callback = null;
 
@@ -662,22 +670,25 @@ public class FlutterRenderer implements TextureRegistry {
               lastDequeueTime = System.nanoTime();
             }
           }
-          if (lastDequeuedImage != null) {
+          while (lastDequeuedImage.size() > MAX_DEQUEUED_IMAGES) {
+            // We must keep the last image dequeued open until we are done presenting
+            // it. We have just dequeued a new image (r). Close the previously dequeued
+            // image. This is a very conservative check, we know based on the max frames
+            // in flight being 2 that dequing a 4th images implies that the driver is done
+            // reading from the 1st image.
+            PerImage last = lastDequeuedImage.remove(0);
             if (VERBOSE_LOGS) {
               Log.i(
                   TAG,
                   lastReaderDequeuedFrom.reader.hashCode()
                       + " closing image="
-                      + lastDequeuedImage.image.hashCode());
+                      + last.image.hashCode());
             }
-            // We must keep the last image dequeued open until we are done presenting
-            // it. We have just dequeued a new image (r). Close the previously dequeued
-            // image.
-            lastDequeuedImage.image.close();
+            last.image.close();
           }
           // Remember the last image and reader dequeued from. We do this because we must
           // keep both of these alive until we are done presenting the image.
-          lastDequeuedImage = r;
+          lastDequeuedImage.add(r);
           lastReaderDequeuedFrom = reader;
           break;
         }
@@ -737,9 +748,11 @@ public class FlutterRenderer implements TextureRegistry {
           pir.close();
         }
         perImageReaders.clear();
-        if (lastDequeuedImage != null) {
-          lastDequeuedImage.image.close();
-          lastDequeuedImage = null;
+        if (lastDequeuedImage.size() > 0) {
+          for (PerImage image : lastDequeuedImage) {
+            image.image.close();
+          }
+          lastDequeuedImage.clear();
         }
         if (lastReaderDequeuedFrom != null) {
           lastReaderDequeuedFrom.close();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -582,6 +582,7 @@ public class FlutterRendererTest {
 
     assertEquals(1, texture.numImageReaders());
     assertEquals(1, texture.numImages());
+    assertEquals(0, texture.pendingDequeuedImages());
 
     // Resize.
     texture.setSize(4, 4);
@@ -596,6 +597,7 @@ public class FlutterRendererTest {
 
     assertEquals(1, texture.numImageReaders());
     assertEquals(2, texture.numImages());
+    assertEquals(0, texture.pendingDequeuedImages());
 
     // Render a new frame with the current size.
     surface = texture.getSurface();
@@ -609,6 +611,7 @@ public class FlutterRendererTest {
 
     assertEquals(2, texture.numImageReaders());
     assertEquals(3, texture.numImages());
+    assertEquals(0, texture.pendingDequeuedImages());
 
     // Acquire first frame.
     Image produced = texture.acquireLatestImage();
@@ -617,6 +620,8 @@ public class FlutterRendererTest {
     assertEquals(1, produced.getHeight());
     assertEquals(2, texture.numImageReaders());
     assertEquals(2, texture.numImages());
+    assertEquals(1, texture.pendingDequeuedImages());
+
     // Acquire second frame. This won't result in the first reader being closed because it has
     // an active image from it.
     produced = texture.acquireLatestImage();
@@ -625,6 +630,8 @@ public class FlutterRendererTest {
     assertEquals(1, produced.getHeight());
     assertEquals(2, texture.numImageReaders());
     assertEquals(1, texture.numImages());
+    assertEquals(2, texture.pendingDequeuedImages());
+
     // Acquire third frame. We will now close the first reader.
     produced = texture.acquireLatestImage();
     assertNotNull(produced);
@@ -632,11 +639,64 @@ public class FlutterRendererTest {
     assertEquals(4, produced.getHeight());
     assertEquals(1, texture.numImageReaders());
     assertEquals(0, texture.numImages());
+    assertEquals(3, texture.pendingDequeuedImages());
 
     // Returns null image when no more images are queued.
     assertNull(texture.acquireLatestImage());
     assertEquals(1, texture.numImageReaders());
     assertEquals(0, texture.numImages());
+    assertEquals(3, texture.pendingDequeuedImages());
+  }
+
+  @Test
+  public void ImageReaderSurfaceProducerDequeueManyImages() {
+    // Demonstrates maximum dequeued image count.
+    FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
+    TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        (FlutterRenderer.ImageReaderSurfaceProducer) producer;
+    texture.disableFenceForTest();
+
+    // Give the texture an initial size.
+    texture.setSize(1, 1);
+
+    Surface surface = texture.getSurface();
+    Canvas canvas = surface.lockHardwareCanvas();
+    canvas.drawARGB(255, 255, 0, 0);
+    surface.unlockCanvasAndPost(canvas);
+    shadowOf(Looper.getMainLooper()).idle();
+
+    // Acquire first frame.
+    Image produced = texture.acquireLatestImage();
+    assertNotNull(produced);
+    assertEquals(1, texture.pendingDequeuedImages());
+
+    canvas = surface.lockHardwareCanvas();
+    canvas.drawARGB(255, 255, 0, 0);
+    surface.unlockCanvasAndPost(canvas);
+    shadowOf(Looper.getMainLooper()).idle();
+
+    // 2
+    produced = texture.acquireLatestImage();
+    assertEquals(2, texture.pendingDequeuedImages());
+
+    canvas = surface.lockHardwareCanvas();
+    canvas.drawARGB(255, 255, 0, 0);
+    surface.unlockCanvasAndPost(canvas);
+    shadowOf(Looper.getMainLooper()).idle();
+
+    // 3
+    produced = texture.acquireLatestImage();
+    assertEquals(3, texture.pendingDequeuedImages());
+
+    canvas = surface.lockHardwareCanvas();
+    canvas.drawARGB(255, 255, 0, 0);
+    surface.unlockCanvasAndPost(canvas);
+    shadowOf(Looper.getMainLooper()).idle();
+
+    // 4
+    produced = texture.acquireLatestImage();
+    assertEquals(3, texture.pendingDequeuedImages());
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/162795


The ImageReaderSurfaceProducer must not close images until the renderer, either Skia OpenGL, Impeller OpenGL, or Impeller Vulkan is done reading from them. The Vulkan renderer allows up to two frames in flight before backpressure is applied. This implies that we may need to keep up to two images beyond the current image alive. Closing the images before the frame that references them has finished rendering can result in tearing or other incorrect rendering.

How do I test?