### PR TITLE
Revert removal of generateDDCMainModule

### DIFF
--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -471,6 +471,40 @@ document.addEventListener('dart-app-ready', function (e) {
 ''';
 }
 
+// TODO(srujzs): Delete this once it's no longer used internally.
+String generateDDCMainModule({
+  required String entrypoint,
+  required bool nullAssertions,
+  required bool nativeNullAssertions,
+  String? exportedMain,
+}) {
+  final String entrypointMainName = exportedMain ?? entrypoint.split('.')[0];
+  // The typo below in "EXTENTION" is load-bearing, package:build depends on it.
+  return '''
+/* ENTRYPOINT_EXTENTION_MARKER */
+
+(function() {
+  // Flutter Web uses a generated main entrypoint, which shares app and module names.
+  let appName = "$entrypoint";
+  let moduleName = "$entrypoint";
+
+  // Use a dummy UUID since multi-apps are not supported on Flutter Web.
+  let uuid = "00000000-0000-0000-0000-000000000000";
+
+  let child = {};
+  child.main = function() {
+    let dart = self.dart_library.import('dart_sdk', appName).dart;
+    dart.nonNullAsserts($nullAssertions);
+    dart.nativeNonNullAsserts($nativeNullAssertions);
+    self.dart_library.start(appName, uuid, moduleName, "$entrypointMainName");
+  }
+
+  /* MAIN_EXTENSION_MARKER */
+  child.main();
+})();
+''';
+}
+
 const String _onLoadEndCallback = r'$onLoadEndCallback';
 
 String generateDDCLibraryBundleMainModule({


### PR DESCRIPTION
Partially reverts https://github.com/flutter/flutter/pull/164026.

Context: cl/731933135. This cl depends on `generateDDCMainModule`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


