### PR TITLE
[Impeller] detect external GPU on macOS.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl.h
@@ -49,6 +49,7 @@ class AllocatorMTL final : public Allocator {
 
   id<MTLDevice> device_;
   std::string allocator_label_;
+  bool has_multiple_devices_ = false;
   bool supports_memoryless_targets_ = false;
   bool supports_uma_ = false;
   bool is_valid_ = false;
@@ -60,7 +61,9 @@ class AllocatorMTL final : public Allocator {
 
   ISize max_texture_supported_;
 
-  AllocatorMTL(id<MTLDevice> device, std::string label);
+  AllocatorMTL(id<MTLDevice> device,
+               bool has_multiple_devices,
+               std::string label);
 
   // |Allocator|
   bool IsValid() const;

--- a/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl.mm
@@ -103,14 +103,20 @@ Bytes DebugAllocatorStats::GetAllocationSize() {
   return Bytes{size_.load()};
 }
 
-AllocatorMTL::AllocatorMTL(id<MTLDevice> device, std::string label)
-    : device_(device), allocator_label_(std::move(label)) {
+AllocatorMTL::AllocatorMTL(id<MTLDevice> device,
+                           bool has_multiple_devices,
+                           std::string label)
+    : device_(device),
+      allocator_label_(std::move(label)),
+      has_multiple_devices_(has_multiple_devices) {
   if (!device_) {
     return;
   }
 
-  supports_memoryless_targets_ = DeviceSupportsDeviceTransientTargets(device_);
-  supports_uma_ = DeviceHasUnifiedMemoryArchitecture(device_);
+  supports_memoryless_targets_ =
+      DeviceSupportsDeviceTransientTargets(device_) && !has_multiple_devices_;
+  supports_uma_ =
+      DeviceHasUnifiedMemoryArchitecture(device_) && !has_multiple_devices_;
   max_texture_supported_ = DeviceMaxTextureSizeSupported(device_);
 
   is_valid_ = true;

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.h
@@ -81,6 +81,7 @@ class ContextMTL final : public Context,
       id<MTLCommandQueue> command_queue,
       const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries_data,
       std::shared_ptr<const fml::SyncSwitch> is_gpu_disabled_sync_switch,
+      bool has_multiple_devices,
       const std::string& label);
 
   // |Context|
@@ -172,6 +173,7 @@ class ContextMTL final : public Context,
       tasks_awaiting_gpu_mutex_);
   std::unique_ptr<SyncSwitchObserver> sync_switch_observer_;
   std::shared_ptr<CommandQueue> command_queue_ip_;
+  bool has_multiple_devices_ = false;
 #ifdef IMPELLER_DEBUG
   std::shared_ptr<GPUTracerMTL> gpu_tracer_;
   std::shared_ptr<ImpellerMetalCaptureManager> capture_manager_;
@@ -181,6 +183,7 @@ class ContextMTL final : public Context,
   ContextMTL(id<MTLDevice> device,
              id<MTLCommandQueue> command_queue,
              NSArray<id<MTLLibrary>>* shader_libraries,
+             bool has_multiple_devices,
              std::shared_ptr<const fml::SyncSwitch> is_gpu_disabled_sync_switch,
              std::optional<PixelFormat> pixel_format_override = std::nullopt);
 

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.h
@@ -81,8 +81,8 @@ class ContextMTL final : public Context,
       id<MTLCommandQueue> command_queue,
       const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries_data,
       std::shared_ptr<const fml::SyncSwitch> is_gpu_disabled_sync_switch,
-      bool has_multiple_devices,
-      const std::string& label);
+      const std::string& label,
+      std::optional<bool> has_multiple_devices = std::nullopt);
 
   // |Context|
   ~ContextMTL() override;

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -34,7 +34,6 @@ static bool HasMultipleDevices() {
   return false;
 #else
   NSArray<id<MTLDevice>>* devices = MTLCopyAllDevices();
-  FML_LOG(ERROR) << "Devices Count: " << [devices count];
   return [devices count] > 1;
 #endif  // FML_OS_IOS
 }

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -292,13 +292,14 @@ std::shared_ptr<ContextMTL> ContextMTL::Create(
     id<MTLCommandQueue> command_queue,
     const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries_data,
     std::shared_ptr<const fml::SyncSwitch> is_gpu_disabled_sync_switch,
-    bool has_multiple_devices,
-    const std::string& library_label) {
-  auto context = std::shared_ptr<ContextMTL>(new ContextMTL(
-      device, command_queue,
-      MTLShaderLibraryFromFileData(device, shader_libraries_data,
-                                   library_label),
-      has_multiple_devices, std::move(is_gpu_disabled_sync_switch)));
+    const std::string& library_label,
+    std::optional<bool> has_multiple_devices) {
+  auto context = std::shared_ptr<ContextMTL>(
+      new ContextMTL(device, command_queue,
+                     MTLShaderLibraryFromFileData(device, shader_libraries_data,
+                                                  library_label),
+                     has_multiple_devices.value_or(HasMultipleDevices()),
+                     std::move(is_gpu_disabled_sync_switch)));
   if (!context->IsValid()) {
     FML_LOG(ERROR) << "Could not create Metal context.";
     return nullptr;

--- a/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller_unittests.mm
+++ b/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller_unittests.mm
@@ -127,6 +127,25 @@ TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
   EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 1u);
 }
 
+TEST(GPUSurfaceMetalImpeller, CreatesMultipleDevices) {
+  std::vector<std::shared_ptr<fml::Mapping>> shader_mappings = {
+      std::make_shared<fml::NonOwnedMapping>(impeller_entity_shaders_data,
+                                             impeller_entity_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_modern_shaders_data,
+                                             impeller_modern_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_framebuffer_blend_shaders_data,
+                                             impeller_framebuffer_blend_shaders_length),
+  };
+  auto sync_switch = std::make_shared<fml::SyncSwitch>(false);
+  auto device = ::MTLCreateSystemDefaultDevice();
+  auto command_queue = device.newCommandQueue;
+  auto context = impeller::ContextMTL::Create(device, command_queue, shader_mappings, sync_switch,
+                                              /*has_multiple_devices=*/true, "Impeller Library");
+
+  // This test runs on arm macs which should return true here.
+  EXPECT_FALSE(context->GetCapabilities()->SupportsFramebufferFetch());
+}
+
 #ifdef IMPELLER_DEBUG
 TEST(GPUSurfaceMetalImpeller, CreatesImpellerCaptureScope) {
   auto delegate = std::make_shared<TestGPUSurfaceMetalDelegate>();

--- a/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller_unittests.mm
+++ b/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller_unittests.mm
@@ -140,7 +140,7 @@ TEST(GPUSurfaceMetalImpeller, CreatesMultipleDevices) {
   auto device = ::MTLCreateSystemDefaultDevice();
   auto command_queue = device.newCommandQueue;
   auto context = impeller::ContextMTL::Create(device, command_queue, shader_mappings, sync_switch,
-                                              /*has_multiple_devices=*/true, "Impeller Library");
+                                              "Impeller Library", /*has_multiple_devices=*/true);
 
   // This test runs on arm macs which should return true here.
   EXPECT_FALSE(context->GetCapabilities()->SupportsFramebufferFetch());


### PR DESCRIPTION
This is an attempted work around for https://github.com/flutter/flutter/issues/163218 . If a device has multiple GPUs, its possible for them to have mismatched feature sets. If this case can be detected, fall back to a more conservative feature set.


