### PR TITLE
[dart:ui] Implement RSuperellipse.contains

### DIFF
--- a/engine/src/flutter/impeller/geometry/round_superellipse_param.h
+++ b/engine/src/flutter/impeller/geometry/round_superellipse_param.h
@@ -14,6 +14,9 @@ namespace impeller {
 
 // A utility struct that expands input parameters for a rounded superellipse to
 // drawing variables.
+//
+// This class and its related code should be kept in synchronize with
+// `geometry.dart`.
 struct RoundSuperellipseParam {
   // Parameters for drawing a square-like rounded superellipse.
   //

--- a/engine/src/flutter/lib/web_ui/lib/geometry.dart
+++ b/engine/src/flutter/lib/web_ui/lib/geometry.dart
@@ -1188,6 +1188,15 @@ class RSuperellipse extends _RRectLike<RSuperellipse> {
 
   static const RSuperellipse zero = RSuperellipse._raw();
 
+  bool contains(Offset point) {
+    // Web doesn't support RSE, but falls back to RRect in all use cases.
+    // Therefore this `contains` is implemented as RRect. Once Web supports RSE
+    // this method should be changed to the correct RSE shape.
+    // TODO(dkwingsmt): Properly implement clipRSE on Web instead of falling
+    // back to RRect.  https://github.com/flutter/flutter/issues/163718
+    return toApproximateRRect().contains(point);
+  }
+
   static RSuperellipse? lerp(RSuperellipse? a, RSuperellipse? b, double t) {
     if (a == null) {
       if (b == null) {

--- a/engine/src/flutter/testing/dart/geometry_test.dart
+++ b/engine/src/flutter/testing/dart/geometry_test.dart
@@ -573,4 +573,140 @@ void main() {
     expect(rrect.brRadiusX, 0);
     expect(rrect.brRadiusY, 0);
   });
+
+  test('RSuperellipse.contains NoCornerRoundSuperellipseContains', () {
+    // RRect of bounds with no corners contains corners just barely
+    final RSuperellipse no_corners = RSuperellipse.fromLTRBXY(-50, -50, 50, 50, 0, 0);
+
+    expect(no_corners.contains(Offset(-50, -50)), isTrue);
+    // Rectangles have half-in, half-out containment so we need
+    // to be careful about testing containment of right/bottom corners.
+    expect(no_corners.contains(Offset(-50, 49.99)), isTrue);
+    expect(no_corners.contains(Offset(49.99, -50)), isTrue);
+    expect(no_corners.contains(Offset(49.99, 49.99)), isTrue);
+    expect(no_corners.contains(Offset(-50.01, -50)), isFalse);
+    expect(no_corners.contains(Offset(-50, -50.01)), isFalse);
+    expect(no_corners.contains(Offset(-50.01, 50)), isFalse);
+    expect(no_corners.contains(Offset(-50, 50.01)), isFalse);
+    expect(no_corners.contains(Offset(50.01, -50)), isFalse);
+    expect(no_corners.contains(Offset(50, -50.01)), isFalse);
+    expect(no_corners.contains(Offset(50.01, 50)), isFalse);
+    expect(no_corners.contains(Offset(50, 50.01)), isFalse);
+  });
+
+  test('RSuperellipse.contains TinyCornerContains', () {
+    // RRect of bounds with even the tiniest corners does not contain corners
+    final RSuperellipse tiny_corners = RSuperellipse.fromLTRBXY(-50, -50, 50, 50, 0.01, 0.01);
+
+    expect(tiny_corners.contains(Offset(-50, -50)), isFalse);
+    expect(tiny_corners.contains(Offset(-50, 50)), isFalse);
+    expect(tiny_corners.contains(Offset(50, -50)), isFalse);
+    expect(tiny_corners.contains(Offset(50, 50)), isFalse);
+  });
+
+  test('RSuperellipse.contains UniformSquareContains', () {
+    final RSuperellipse rr = RSuperellipse.fromLTRBXY(-50, -50, 50, 50, 5.0, 5.0);
+
+    void checkPointAndMirrors(Offset p) {
+      checkPointWithOffset(rr, Offset(p.dx, p.dy), Offset(0.02, 0.02));
+      checkPointWithOffset(rr, Offset(p.dx, -p.dy), Offset(0.02, -0.02));
+      checkPointWithOffset(rr, Offset(-p.dx, p.dy), Offset(-0.02, 0.02));
+      checkPointWithOffset(rr, Offset(-p.dx, -p.dy), Offset(-0.02, -0.02));
+    }
+
+    checkPointAndMirrors(Offset(0, 49.995)); // Top
+    checkPointAndMirrors(Offset(44.245, 49.995)); // Top stretch end
+    checkPointAndMirrors(Offset(45.72, 49.92)); // Top joint
+    checkPointAndMirrors(Offset(48.53, 48.53)); // Circular arc mid
+    checkPointAndMirrors(Offset(49.92, 45.72)); // Right joint
+    checkPointAndMirrors(Offset(49.995, 44.245)); // Right stretch end
+    checkPointAndMirrors(Offset(49.995, 0)); // Right
+  });
+
+  test('RSuperellipse.contains UniformEllipticalContains', () {
+    final RSuperellipse rr = RSuperellipse.fromLTRBXY(-50, -50, 50, 50, 5.0, 10.0);
+
+    void checkPointAndMirrors(Offset p) {
+      checkPointWithOffset(rr, Offset(p.dx, p.dy), Offset(0.02, 0.02));
+      checkPointWithOffset(rr, Offset(p.dx, -p.dy), Offset(0.02, -0.02));
+      checkPointWithOffset(rr, Offset(-p.dx, p.dy), Offset(-0.02, 0.02));
+      checkPointWithOffset(rr, Offset(-p.dx, -p.dy), Offset(-0.02, -0.02));
+    }
+
+    checkPointAndMirrors(Offset(0, 49.995)); // Top
+    checkPointAndMirrors(Offset(44.245, 49.995)); // Top stretch end
+    checkPointAndMirrors(Offset(45.72, 49.84)); // Top joint
+    checkPointAndMirrors(Offset(48.51, 47.07)); // Circular arc mid
+    checkPointAndMirrors(Offset(49.92, 41.44)); // Right joint
+    checkPointAndMirrors(Offset(49.995, 38.49)); // Right stretch end
+    checkPointAndMirrors(Offset(49.995, 0)); // Right
+  });
+
+  test('RSuperellipse.contains UniformRectangularContains', () {
+    // The bounds is not centered at the origin and has unequal height and width.
+    final RSuperellipse rr = RSuperellipse.fromLTRBXY(0, 0, 50, 100, 23.0, 30.0);
+
+    final Offset center = rr.outerRect.center;
+    void checkPointAndMirrors(Offset globalPoint) {
+      final Offset p = globalPoint - center;
+      checkPointWithOffset(rr, Offset(p.dx, p.dy) + center, Offset(0.02, 0.02));
+      checkPointWithOffset(rr, Offset(p.dx, -p.dy) + center, Offset(0.02, -0.02));
+      checkPointWithOffset(rr, Offset(-p.dx, p.dy) + center, Offset(-0.02, 0.02));
+      checkPointWithOffset(rr, Offset(-p.dx, -p.dy) + center, Offset(-0.02, -0.02));
+    }
+
+    checkPointAndMirrors(Offset(24.99, 99.99)); // Bottom mid-edge
+    checkPointAndMirrors(Offset(29.99, 99.64));
+    checkPointAndMirrors(Offset(34.99, 98.06));
+    checkPointAndMirrors(Offset(39.99, 94.73));
+    checkPointAndMirrors(Offset(44.13, 89.99));
+    checkPointAndMirrors(Offset(48.60, 79.99));
+    checkPointAndMirrors(Offset(49.93, 69.99));
+    checkPointAndMirrors(Offset(49.99, 59.99));
+    checkPointAndMirrors(Offset(49.99, 49.99)); // Right mid-edge
+  });
+
+  test('RSuperellipse.contains SlimDiagnalContains', () {
+    // This shape has large radii on one diagnal and tiny radii on the other,
+    // resulting in a almond-like shape placed diagnally (NW to SE).
+    final RSuperellipse rr = RSuperellipse.fromLTRBAndCorners(
+      -50,
+      -50,
+      50,
+      50,
+      topLeft: Radius.circular(1.0),
+      topRight: Radius.circular(99.0),
+      bottomLeft: Radius.circular(99.0),
+      bottomRight: Radius.circular(1.0),
+    );
+
+    expect(rr.contains(Offset(0, 0)), isTrue);
+    expect(rr.contains(Offset(-49.999, -49.999)), isFalse);
+    expect(rr.contains(Offset(-49.999, 49.999)), isFalse);
+    expect(rr.contains(Offset(49.999, 49.999)), isFalse);
+    expect(rr.contains(Offset(49.999, -49.999)), isFalse);
+
+    // The pointy ends at the NE and SW corners
+    checkPointWithOffset(rr, Offset(-49.70, -49.70), Offset(-0.02, -0.02));
+    checkPointWithOffset(rr, Offset(49.70, 49.70), Offset(0.02, 0.02));
+
+    // Checks two points symmetrical to the origin.
+    void checkDiagnalPoints(Offset p) {
+      checkPointWithOffset(rr, p, Offset(0.02, -0.02));
+      checkPointWithOffset(rr, Offset(-p.dx, -p.dy), Offset(-0.02, 0.02));
+    }
+
+    // A few other points along the edge
+    checkDiagnalPoints(Offset(-40.0, -49.59));
+    checkDiagnalPoints(Offset(-20.0, -45.64));
+    checkDiagnalPoints(Offset(0.0, -37.01));
+    checkDiagnalPoints(Offset(20.0, -21.96));
+    checkDiagnalPoints(Offset(21.05, -20.92));
+    checkDiagnalPoints(Offset(40.0, 5.68));
+  });
+}
+
+void checkPointWithOffset(RSuperellipse rse, Offset inPoint, Offset outwardOffset) {
+  expect(rse.contains(inPoint), isTrue);
+  expect(rse.contains(inPoint + outwardOffset), isFalse);
 }


### PR DESCRIPTION
This PR implements `RSuperellipse.contains` for non-Web. (On Web it falls back to RRect.)

This method is needed to implement hit testing.

Unfortunately the full `params` class is needed for this one method, meaning this PR is basically a copy of the engine's `RoundSuperellipseParam` class. I'm looking for ways to share these code (such as making these methods FFI functions), but for now we'll implement them as Dart - which should be fine in terms of performance, since hit testing is not calculated every frame.



## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
