### PR TITLE
[Impeller] Adds oval shortcut to `DisplayListMatrixClipState::clip{RRect,RSuperellipse}` 

### DIFF
--- a/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/engine/src/flutter/display_list/utils/dl_matrix_clip_tracker.cc
@@ -89,6 +89,9 @@ void DisplayListMatrixClipState::clipRRect(const DlRoundRect& rrect,
   if (rrect.IsRect()) {
     return clipRect(bounds, op, is_aa);
   }
+  if (rrect.IsOval()) {
+    return clipOval(bounds, op, is_aa);
+  }
   switch (op) {
     case DlClipOp::kIntersect:
       adjustCullRect(bounds, op, is_aa);
@@ -113,6 +116,9 @@ void DisplayListMatrixClipState::clipRSuperellipse(
   DlRect bounds = rse.GetBounds();
   if (rse.IsRect()) {
     return clipRect(bounds, op, is_aa);
+  }
+  if (rse.IsOval()) {
+    return clipOval(bounds, op, is_aa);
   }
   switch (op) {
     case DlClipOp::kIntersect:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/163717

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
