### PR TITLE
[macos] prefer integrated GPU.

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
@@ -46,7 +46,7 @@ namespace {
 id<MTLDevice> SelectMetalDevice() {
   NSArray<id<MTLDevice>>* devices = MTLCopyAllDevices();
   for (id<MTLDevice> device in devices) {
-    if (!device.isRemovable && device.isLowPower) {
+    if (device.hasUnifiedMemory) {
       return device;
     }
   }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
@@ -39,7 +39,10 @@ static bool OnAcquireExternalTexture(void* user_data,
 }
 
 namespace {
-/// Attempts to find the integrated GPU backed metal device.
+
+// Attempts to find the integrated GPU backed metal device.
+//
+// See also: https://developer.apple.com/documentation/metal/multi-gpu-systems?language=objc
 id<MTLDevice> SelectMetalDevice() {
   NSArray<id<MTLDevice>>* devices = MTLCopyAllDevices();
   for (id<MTLDevice> device in devices) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
@@ -38,10 +38,23 @@ static bool OnAcquireExternalTexture(void* user_data,
   FlutterDarwinContextMetalSkia* _darwinMetalContext;
 }
 
+namespace {
+/// Attempts to find the integrated GPU backed metal device.
+id<MTLDevice> SelectMetalDevice() {
+  NSArray<id<MTLDevice>>* devices = MTLCopyAllDevices();
+  for (id<MTLDevice> device in devices) {
+    if (!device.isRemovable && device.isLowPower) {
+      return device;
+    }
+  }
+  return MTLCreateSystemDefaultDevice();
+}
+}  // namespace
+
 - (instancetype)initWithFlutterEngine:(nonnull FlutterEngine*)flutterEngine {
   self = [super initWithDelegate:self engine:flutterEngine];
   if (self) {
-    _device = MTLCreateSystemDefaultDevice();
+    _device = SelectMetalDevice();
     if (!_device) {
       NSLog(@"Could not acquire Metal device.");
       return nil;


### PR DESCRIPTION
Attempted fix for https://github.com/flutter/flutter/issues/163218

There are very few macOS devices with multiple GPUs and they were only brielfy sold. We seem to have a problem o the specific devices when choosing the dedicated GPU. INstead, lets try forcing the integrated GPU when its available.
