### PR TITLE
[macOS] Enable Impeller by default on macOS.

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -65,7 +65,7 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
   if (enableImpeller != nil) {
     return enableImpeller.boolValue;
   }
-  return NO;
+  return YES;
 }
 
 - (NSString*)assetsPath {


### PR DESCRIPTION
Enables impeller by default on macOS devices. An opt out can still be configured by passing --no-enable-impeller or using the FLTEnableImpeller / NO setting in the Info.plist.