### PR TITLE
[Impeller] use DeviceLocal textures for gifs on non-iOS devices.

### DIFF
--- a/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
@@ -466,7 +466,11 @@ ImageDecoderImpeller::UploadTextureToStorage(
   }
 
   impeller::TextureDescriptor texture_descriptor;
+#ifdef FML_OS_IOS
   texture_descriptor.storage_mode = impeller::StorageMode::kHostVisible;
+#else
+  texture_descriptor.storage_mode = impeller::StorageMode::kDevicePrivate;
+#endif  // FML_OS_IOS
   texture_descriptor.format = pixel_format.value();
   texture_descriptor.size = {image_info.width(), image_info.height()};
   texture_descriptor.mip_count = 1;

--- a/engine/src/flutter/lib/ui/painting/image_decoder_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_unittests.cc
@@ -24,6 +24,7 @@
 #include "flutter/testing/test_gl_surface.h"
 #include "flutter/testing/testing.h"
 #include "fml/logging.h"
+#include "impeller/core/formats.h"
 #include "impeller/core/runtime_types.h"
 #include "impeller/renderer/command_queue.h"
 #include "third_party/skia/include/codec/SkCodecAnimation.h"
@@ -385,6 +386,16 @@ TEST_F(ImageDecoderFixtureTest, ImpellerUploadToSharedNoGpu) {
   ASSERT_EQ(no_gpu_access_context->command_buffer_count_, 0ul);
   ASSERT_EQ(result.second, "");
   EXPECT_EQ(no_gpu_access_context->DidDisposeResources(), true);
+
+#if FML_OS_IOS
+  EXPECT_EQ(
+      result.first->impeller_texture()->GetTextureDescriptor().storage_mode,
+      impeller::StorageMode::kHostVisible);
+#else
+  EXPECT_EQ(
+      result.first->impeller_texture()->GetTextureDescriptor().storage_mode,
+      impeller::StorageMode::kDevicePrivate);
+#endif  // FML_OS_IOS
 
   no_gpu_access_context->FlushTasks(/*fail=*/true);
 }


### PR DESCRIPTION
Part of  https://github.com/flutter/flutter/issues/136365, https://github.com/flutter/flutter/issues/134399


We only use DeviceLocal on iOS to work around background requirements. On other platforms there is no need for this.