### PR TITLE
[skwasm] Clear font collection cache when font is loaded manually.

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -180,6 +180,7 @@ class SkwasmFontCollection implements FlutterFontCollection {
     } else {
       fontCollectionRegisterTypeface(handle, typeface.handle, nullptr);
     }
+    fontCollectionClearCaches(handle);
     return true;
   }
 

--- a/engine/src/flutter/lib/web_ui/test/ui/text_golden_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/text_golden_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -181,6 +182,19 @@ Future<void> testMain() async {
 
   test('text styles - non-existent font family', () async {
     await testTextStyle('non-existent font family', fontFamily: 'DoesNotExist');
+  });
+
+  test('text styles - changes font after font manually loaded', () async {
+    await testTextStyle('before font load', fontFamily: 'Roboto Slab');
+    final FlutterFontCollection collection = renderer.fontCollection;
+    final ByteBuffer robotoSlabData = await httpFetchByteBuffer(
+      '/assets/fonts/RobotoSlab-VariableFont_wght.ttf',
+    );
+    expect(
+      await collection.loadFontFromList(robotoSlabData.asUint8List(), fontFamily: 'Roboto Slab'),
+      true,
+    );
+    await testTextStyle('after font load', fontFamily: 'Roboto Slab');
   });
 
   test('text styles - family fallback', () async {


### PR DESCRIPTION
This addresses https://github.com/flutter/flutter/issues/159375

We just need to clear the font collection's cache if we added a font via the `loadFontFromList` API.