### PR TITLE
[Impeller] fix macOS managed memory.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl.h
@@ -44,6 +44,11 @@ class AllocatorMTL final : public Allocator {
   // |Allocator|
   Bytes DebugGetHeapUsage() const override;
 
+  // visible for testing.
+  void DebugSetSupportsUMA(bool value);
+
+  AllocatorMTL(id<MTLDevice> device, std::string label);
+
  private:
   friend class ContextMTL;
 
@@ -59,8 +64,6 @@ class AllocatorMTL final : public Allocator {
 #endif  // IMPELLER_DEBUG
 
   ISize max_texture_supported_;
-
-  AllocatorMTL(id<MTLDevice> device, std::string label);
 
   // |Allocator|
   bool IsValid() const;

--- a/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl.mm
@@ -255,6 +255,10 @@ ISize AllocatorMTL::GetMaxTextureSizeSupported() const {
   return max_texture_supported_;
 }
 
+void AllocatorMTL::DebugSetSupportsUMA(bool value) {
+  supports_uma_ = value;
+}
+
 Bytes AllocatorMTL::DebugGetHeapUsage() const {
 #ifdef IMPELLER_DEBUG
   return debug_allocater_->GetAllocationSize();

--- a/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl_unittests.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl_unittests.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/testing/testing.h"
+#include "impeller/core/device_buffer_descriptor.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/playground/playground_test.h"
@@ -68,6 +69,22 @@ TEST_P(AllocatorMTLTest, DebugTraceMemoryStatistics) {
   // After all textures are out of scope, memory has been decremented.
   EXPECT_EQ(allocator->DebugGetHeapUsage().ConvertTo<MebiBytes>().GetSize(),
             0u);
+}
+
+TEST_P(AllocatorMTLTest, ManagedMemory) {
+  auto& context_mtl = ContextMTL::Cast(*GetContext());
+  auto allocator = std::make_unique<AllocatorMTL>(context_mtl.GetMTLDevice(),
+                                                  "test-allocator");
+  allocator->DebugSetSupportsUMA(false);
+
+  DeviceBufferDescriptor desc;
+  desc.size = 100;
+  desc.storage_mode = StorageMode::kHostVisible;
+
+  auto buffer = allocator->CreateBuffer(desc);
+  ASSERT_TRUE(buffer);
+
+  EXPECT_NE(buffer->OnGetContents(), nullptr);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/metal/device_buffer_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/device_buffer_mtl.mm
@@ -25,7 +25,7 @@ id<MTLBuffer> DeviceBufferMTL::GetMTLBuffer() const {
 uint8_t* DeviceBufferMTL::OnGetContents() const {
 #if !FML_OS_IOS
   if (storage_mode_ != MTLStorageModeShared &&
-      storage_mode_ != MTLResourceStorageModeManaged) {
+      storage_mode_ != MTLStorageModeManaged) {
     return nullptr;
   }
 #else


### PR DESCRIPTION
Still crashes with non UMA GPU. Reason is that the if check is using `MTLResourceStorageModeManaged` when it should be using `MTLStorageModeManaged`

Fixes https://github.com/flutter/flutter/issues/163218