### PR TITLE
Write macOS universal gen_snapshot binaries to a separate output directory

### DIFF
--- a/engine/src/flutter/ci/builders/mac_host_engine.json
+++ b/engine/src/flutter/ci/builders/mac_host_engine.json
@@ -1141,9 +1141,9 @@
                     "--dst",
                     "out/debug/snapshot",
                     "--arm64-path",
-                    "out/ci/mac_debug_gen_snapshot_arm64/gen_snapshot_arm64",
+                    "out/ci/mac_debug_gen_snapshot_arm64/universal/gen_snapshot_arm64",
                     "--x64-path",
-                    "out/ci/host_debug_gen_snapshot/gen_snapshot_x64",
+                    "out/ci/host_debug_gen_snapshot/universal/gen_snapshot_x64",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
@@ -1154,9 +1154,9 @@
                     "--dst",
                     "out/profile/snapshot",
                     "--arm64-path",
-                    "out/ci/mac_profile_gen_snapshot_arm64/gen_snapshot_arm64",
+                    "out/ci/mac_profile_gen_snapshot_arm64/universal/gen_snapshot_arm64",
                     "--x64-path",
-                    "out/ci/host_profile_gen_snapshot/gen_snapshot_x64",
+                    "out/ci/host_profile_gen_snapshot/universal/gen_snapshot_x64",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
@@ -1167,9 +1167,9 @@
                     "--dst",
                     "out/release/snapshot",
                     "--arm64-path",
-                    "out/ci/mac_release_gen_snapshot_arm64/gen_snapshot_arm64",
+                    "out/ci/mac_release_gen_snapshot_arm64/universal/gen_snapshot_arm64",
                     "--x64-path",
-                    "out/ci/host_release_gen_snapshot/gen_snapshot_x64",
+                    "out/ci/host_release_gen_snapshot/universal/gen_snapshot_x64",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"

--- a/engine/src/flutter/lib/snapshot/BUILD.gn
+++ b/engine/src/flutter/lib/snapshot/BUILD.gn
@@ -228,10 +228,19 @@ if (host_os == "mac" &&
     host_arch = "x64"
   }
 
+  if (target_os == "android") {
+    # Each Android engine build targets a specific architecture and does not
+    # need to add the target architecture to the universal binary filename.
+    universal_binary_name = "gen_snapshot"
+  } else {
+    universal_binary_name = "gen_snapshot${gen_snapshot_suffix}"
+  }
+  universal_output_path = "${root_out_dir}/universal/${universal_binary_name}"
+
   # Create a universal binary from the two architecture-specific gen_snapshots.
   action("create_macos_gen_snapshots") {
     script = "//flutter/sky/tools/create_macos_binary.py"
-    outputs = [ "${root_out_dir}/gen_snapshot${gen_snapshot_suffix}" ]
+    outputs = [ universal_output_path ]
     args = [
       "--in-arm64",
       rebase_path(
@@ -240,7 +249,7 @@ if (host_os == "mac" &&
       rebase_path(
           "${root_out_dir}/artifacts_x64/gen_snapshot${gen_snapshot_suffix}"),
       "--out",
-      rebase_path("${root_out_dir}/gen_snapshot${gen_snapshot_suffix}"),
+      rebase_path(universal_output_path),
     ]
     deps = [
       ":create_macos_gen_snapshot_arm64${gen_snapshot_suffix}",

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -693,8 +693,7 @@ if (target_cpu != "x86") {
     gen_snapshot_dest = "gen_snapshot"
 
     if (host_os == "mac") {
-      gen_snapshot_src =
-          rebase_path("$root_out_dir/gen_snapshot${gen_snapshot_suffix}")
+      gen_snapshot_src = rebase_path("$root_out_dir/universal/gen_snapshot")
     } else if (host_os == "win") {
       gen_snapshot_src = rebase_path("$root_out_dir/gen_snapshot.exe")
       gen_snapshot_dest = "gen_snapshot.exe"

--- a/engine/src/flutter/sky/tools/create_ios_framework.py
+++ b/engine/src/flutter/sky/tools/create_ios_framework.py
@@ -84,10 +84,10 @@ def main():
 
   # Copy gen_snapshot binary to destination directory.
   if arm64_out_dir:
-    gen_snapshot = os.path.join(arm64_out_dir, 'gen_snapshot_arm64')
+    gen_snapshot = os.path.join(arm64_out_dir, 'universal', 'gen_snapshot_arm64')
     sky_utils.copy_binary(gen_snapshot, os.path.join(dst, 'gen_snapshot_arm64'))
   if x64_out_dir:
-    gen_snapshot = os.path.join(x64_out_dir, 'gen_snapshot_x64')
+    gen_snapshot = os.path.join(x64_out_dir, 'universal', 'gen_snapshot_x64')
     sky_utils.copy_binary(gen_snapshot, os.path.join(dst, 'gen_snapshot_x64'))
 
   zip_archive(dst, args)

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -1366,6 +1366,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
   String _genSnapshotPath(Artifact artifact) {
     const List<String> clangDirs = <String>[
       '.',
+      'universal',
       'clang_x64',
       'clang_x86',
       'clang_i386',

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -288,6 +288,7 @@ void main() {
     late Cache cache;
     late FileSystem fileSystem;
     late Platform platform;
+    late FakeProcessManager processManager;
 
     setUp(() {
       fileSystem = MemoryFileSystem.test();
@@ -301,6 +302,7 @@ void main() {
         osUtils: FakeOperatingSystemUtils(),
         artifacts: <ArtifactSet>[],
       );
+      processManager = FakeProcessManager.any();
       artifacts = CachedLocalWebSdkArtifacts(
         parent: CachedLocalEngineArtifacts(
           fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'host_debug_unopt'),
@@ -312,7 +314,7 @@ void main() {
           cache: cache,
           fileSystem: fileSystem,
           platform: platform,
-          processManager: FakeProcessManager.any(),
+          processManager: processManager,
           operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
         webSdkPath: fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'wasm_release'),
@@ -510,6 +512,12 @@ void main() {
       expect(
         artifacts.getHostArtifact(HostArtifact.libtessellator).path,
         fileSystem.path.join('/out', 'host_debug_unopt', 'libtessellator.so'),
+      );
+
+      processManager.excludedExecutables.add('/out/android_debug_unopt/./gen_snapshot');
+      expect(
+        artifacts.getArtifactPath(Artifact.genSnapshot),
+        fileSystem.path.join('/out', 'android_debug_unopt', 'universal', 'gen_snapshot'),
       );
     });
 


### PR DESCRIPTION
Also use the name "gen_snapshot" when building for Android targets instead of appending a target architecture to the filename.

This allows flutter_tools to find the universal gen_snapshot binary when using a locally built engine.  Previously the tools would search directories like "clang_x64" and find build outputs that may not match the host architecture.

Moving the universal gen_snapshot binary to a separate directory avoids conflicts with Dart's gen_snapshot binary, which is placed at the root of the target output directory.