### PR TITLE
[Impeller] test empty snapshot and allocation failure.

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
@@ -21,10 +21,12 @@
 #include "flutter/testing/testing.h"
 #include "fml/synchronization/count_down_latch.h"
 #include "imgui.h"
+#include "impeller/base/validation.h"
 #include "impeller/core/device_buffer.h"
 #include "impeller/core/device_buffer_descriptor.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
+#include "impeller/display_list/aiks_context.h"
 #include "impeller/display_list/dl_dispatcher.h"
 #include "impeller/display_list/dl_image_impeller.h"
 #include "impeller/geometry/scalar.h"
@@ -1102,6 +1104,17 @@ TEST_P(AiksTest, ToImageFromImage) {
   canvas.DrawImage(DlImageImpeller::Make(reupload_texture), DlPoint(0, 100),
                    DlImageSampling::kNearestNeighbor, &paint);
   OpenPlaygroundHere(canvas.Build());
+}
+
+TEST_P(AiksTest, DisplayListToTextureAllocationFailure) {
+  ScopedValidationDisable disable_validations;
+  DisplayListBuilder builder;
+
+  AiksContext aiks_context(GetContext(), nullptr);
+  auto texture =
+      DisplayListToTexture(builder.Build(), ISize{0, 0}, aiks_context);
+
+  EXPECT_EQ(texture, nullptr);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
@@ -1111,6 +1111,8 @@ TEST_P(AiksTest, DisplayListToTextureAllocationFailure) {
   DisplayListBuilder builder;
 
   AiksContext aiks_context(GetContext(), nullptr);
+  // Use intentionally invalid dimensions that would trigger an allocation
+  // failure.
   auto texture =
       DisplayListToTexture(builder.Build(), ISize{0, 0}, aiks_context);
 

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1309,6 +1309,9 @@ std::shared_ptr<Texture> DisplayListToTexture(
             kDefaultColorAttachmentConfig  // color_attachment_config
     );
   }
+  if (!target.IsValid()) {
+    return nullptr;
+  }
 
   SkIRect sk_cull_rect = SkIRect::MakeWH(size.width, size.height);
   impeller::FirstPassDispatcher collector(

--- a/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
+++ b/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
@@ -58,7 +58,7 @@ sk_sp<DlImage> DoMakeRasterSnapshot(
     const sk_sp<DisplayList>& display_list,
     SkISize size,
     const SnapshotController::Delegate& delegate) {
-  // Ensure that the current thread has a rendering context.  This must be done
+  // Ensure that the current thread has a rendering context. This must be done
   // before calling GetAiksContext because constructing the AiksContext may
   // invoke graphics APIs.
   std::unique_ptr<Surface> pbuffer_surface;

--- a/engine/src/flutter/testing/dart/painting_test.dart
+++ b/engine/src/flutter/testing/dart/painting_test.dart
@@ -276,4 +276,19 @@ void main() {
       expect(colors[i], isNot(const Color(0xFF0000FF)));
     }
   });
+
+  test('Picture.toImage with empty image', () async {
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    canvas.drawPaint(Paint()..color = const Color(0xFF0000FF));
+
+    final Picture picture = recorder.endRecording();
+    Object? error;
+    try {
+      final Image image = await picture.toImage(0, 0);
+    } catch (err, st) {
+      error = err;
+    }
+    expect(error, isNot(null));
+  });
 }

--- a/engine/src/flutter/testing/dart/painting_test.dart
+++ b/engine/src/flutter/testing/dart/painting_test.dart
@@ -285,8 +285,8 @@ void main() {
     final Picture picture = recorder.endRecording();
     Object? error;
     try {
-      final Image image = await picture.toImage(0, 0);
-    } catch (err, st) {
+      await picture.toImage(0, 0);
+    } catch (err) {
       error = err;
     }
     expect(error, isNot(null));

--- a/engine/src/flutter/testing/dart/painting_test.dart
+++ b/engine/src/flutter/testing/dart/painting_test.dart
@@ -276,19 +276,4 @@ void main() {
       expect(colors[i], isNot(const Color(0xFF0000FF)));
     }
   });
-
-  test('Picture.toImage with empty image', () async {
-    final PictureRecorder recorder = PictureRecorder();
-    final Canvas canvas = Canvas(recorder);
-    canvas.drawPaint(Paint()..color = const Color(0xFF0000FF));
-
-    final Picture picture = recorder.endRecording();
-    Object? error;
-    try {
-      final Image image = await picture.toImage(0, 0);
-    } catch (err, st) {
-      error = err;
-    }
-    expect(error, isNot(null));
-  });
 }


### PR DESCRIPTION
Speculative fix for https://github.com/flutter/flutter/issues/164628

If our render target allocation failed, we need to bail out of toImage so that we don't crash. Adds a test that simulates this by asking for a 0x0 texture.