### PR TITLE
[macOS] wide gamut support for Impeller applications on macOS.

### DIFF
--- a/dev/integration_tests/ui/lib/solid_color.dart
+++ b/dev/integration_tests/ui/lib/solid_color.dart
@@ -2,11 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
 
 void main() {
   enableFlutterDriverExtension();
 
-  runApp(Container(color: const Color(0xFFFF0000)));
+  final Color color = defaultTargetPlatform == TargetPlatform.macOS
+    ? const Color.from(red: 1, green: 0, blue: 0, alpha: 1, colorSpace: ColorSpace.displayP3)
+    : const Color(0xFFFF0000);
+
+  runApp(Container(color: color));
 }

--- a/dev/integration_tests/ui/macos/Runner/Info.plist
+++ b/dev/integration_tests/ui/macos/Runner/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+		<key>FLTEnableImpeller</key>
+		<true />
 </dict>
 </plist>

--- a/dev/integration_tests/ui/test_driver/solid_color_test.dart
+++ b/dev/integration_tests/ui/test_driver/solid_color_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' show Platform;
 import 'dart:typed_data';
 
 import 'package:flutter_driver/flutter_driver.dart';
@@ -22,6 +23,20 @@ void main() {
 
     expect(data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3], 0xFF0000FF);
   }, timeout: Timeout.none);
+
+  if (Platform.isMacOS) {
+    test('Can render wide gamut red', () async {
+      // RGBA Encoded Bytes.
+      final Float32List data =
+          ((await driver.screenshot(format: ScreenshotFormat.rawExtendedRgba128)) as Uint8List).buffer.asFloat32List();
+
+      expect(data[0], closeTo(1.09, 0.01));
+      expect(data[1], closeTo(-0.23, .01));
+      expect(data[2], closeTo(-0.15, .01));
+      expect(data[3], closeTo(1, 0.01));
+    }, timeout: Timeout.none);
+  }
+
 
   tearDownAll(() async {
     await driver.close();

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -68,6 +68,15 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
   return NO;
 }
 
+- (BOOL)enableWideGamut {
+  NSNumber* enableWideGamut =
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTEnableWideGamut"];
+  if (enableWideGamut != nil) {
+    return enableWideGamut.boolValue;
+  }
+  return YES;
+}
+
 - (NSString*)assetsPath {
   if (_assetsPath) {
     return _assetsPath;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h
@@ -37,6 +37,11 @@
 @property(nonatomic, readonly) BOOL enableImpeller;
 
 /**
+ * Whether Wide gamut rendering is enabled
+ */
+@property(nonatomic, readonly) BOOL enableWideGamut;
+
+/**
  * Instead of looking up the assets and ICU data path in the application bundle, this initializer
  * allows callers to create a Dart project with custom locations specified for the both.
  */

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -590,6 +590,10 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 }
 
+- (BOOL)enableWideGamut {
+  return _project.enableImpeller && _project.enableWideGamut;
+}
+
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint {
   if (self.running) {
     return NO;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -232,6 +232,12 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
  * This function must be called on the main thread.
  */
 + (nullable FlutterEngine*)engineForIdentifier:(int64_t)identifier;
+
+/**
+ * Whether wide gamut color should be enabled where supported.
+ */
+- (BOOL)enableWideGamut;
+
 @end
 
 @interface FlutterEngine (Tests)

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
@@ -27,7 +27,9 @@
  */
 @interface FlutterSurface (Private)
 
-- (nonnull instancetype)initWithSize:(CGSize)size device:(nonnull id<MTLDevice>)device;
+- (nonnull instancetype)initWithSize:(CGSize)size
+                              device:(nonnull id<MTLDevice>)device
+                         pixelFormat:(MTLPixelFormat)pixelFormat;
 
 @property(readonly, nonatomic, nonnull) IOSurfaceRef ioSurface;
 @property(readonly, nonatomic) CGSize size;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
@@ -50,7 +50,8 @@
 - (nullable instancetype)initWithDevice:(nonnull id<MTLDevice>)device
                            commandQueue:(nonnull id<MTLCommandQueue>)commandQueue
                                   layer:(nonnull CALayer*)containingLayer
-                               delegate:(nonnull id<FlutterSurfaceManagerDelegate>)delegate;
+                               delegate:(nonnull id<FlutterSurfaceManagerDelegate>)delegate
+                        enableWideGamut:(BOOL)enableWideGamut;
 
 /**
  * Returns a back buffer surface of the given size to which Flutter can render content.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -42,7 +42,7 @@
                                   delegate:(nonnull id<FlutterViewDelegate>)delegate
                         threadSynchronizer:(nonnull FlutterThreadSynchronizer*)threadSynchronizer
                             viewIdentifier:(FlutterViewIdentifier)viewIdentifier
-    NS_DESIGNATED_INITIALIZER;
+                           enableWideGamut:(BOOL)enableWideGamut NS_DESIGNATED_INITIALIZER;
 
 - (nullable instancetype)initWithFrame:(NSRect)frameRect
                            pixelFormat:(nullable NSOpenGLPixelFormat*)format NS_UNAVAILABLE;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -25,7 +25,8 @@
                      commandQueue:(id<MTLCommandQueue>)commandQueue
                          delegate:(id<FlutterViewDelegate>)delegate
                threadSynchronizer:(FlutterThreadSynchronizer*)threadSynchronizer
-                   viewIdentifier:(FlutterViewIdentifier)viewIdentifier {
+                   viewIdentifier:(FlutterViewIdentifier)viewIdentifier
+                  enableWideGamut:(BOOL)enableWideGamut {
   self = [super initWithFrame:NSZeroRect];
   if (self) {
     [self setWantsLayer:YES];
@@ -37,7 +38,8 @@
     _surfaceManager = [[FlutterSurfaceManager alloc] initWithDevice:device
                                                        commandQueue:commandQueue
                                                               layer:self.layer
-                                                           delegate:self];
+                                                           delegate:self
+                                                    enableWideGamut:enableWideGamut];
   }
   return self;
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -792,7 +792,8 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
                                    commandQueue:commandQueue
                                        delegate:self
                              threadSynchronizer:_threadSynchronizer
-                                 viewIdentifier:_viewIdentifier];
+                                 viewIdentifier:_viewIdentifier
+                                enableWideGamut:_engine.enableWideGamut];
 }
 
 - (NSString*)lookupKeyForAsset:(NSString*)asset {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
@@ -34,7 +34,8 @@ TEST(FlutterView, ShouldInheritContentsScaleReturnsYes) {
                                                 commandQueue:queue
                                                     delegate:delegate
                                           threadSynchronizer:threadSynchronizer
-                                              viewIdentifier:kImplicitViewId];
+                                              viewIdentifier:kImplicitViewId
+                                             enableWideGamut:NO];
   EXPECT_EQ([view layer:view.layer shouldInheritContentsScale:3.0 fromWindow:view.window], YES);
 }
 
@@ -79,7 +80,8 @@ TEST(FlutterView, CursorUpdateDoesHitTest) {
                                                         commandQueue:queue
                                                             delegate:delegate
                                                   threadSynchronizer:threadSynchronizer
-                                                      viewIdentifier:kImplicitViewId];
+                                                      viewIdentifier:kImplicitViewId
+                                                     enableWideGamut:NO];
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask
                                                    backing:NSBackingStoreBuffered
@@ -123,7 +125,8 @@ TEST(FlutterView, CursorUpdateDoesNotOverridePlatformView) {
                                                         commandQueue:queue
                                                             delegate:delegate
                                                   threadSynchronizer:threadSynchronizer
-                                                      viewIdentifier:kImplicitViewId];
+                                                      viewIdentifier:kImplicitViewId
+                                                     enableWideGamut:NO];
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask
                                                    backing:NSBackingStoreBuffered


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/164557

Enables Wide gamut support when impeller is enabled via manifest. Can be disabled by specifying FLTEnableWideGamut as false. 
