### PR TITLE
[Impeller] Fixes to YUV imports on Android, Incomplete read of pipeline cache data, missing enabled extensions.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -67,13 +67,6 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
         ]
     timeout: 90
-    runIf:
-      - DEPS
-      - engine/src/flutter/.ci.yaml
-      - engine/src/flutter/ci/builders/linux_android_emulator.json
-      - engine/src/flutter/lib/ui/**
-      - engine/src/flutter/shell/platform/android/**
-      - engine/src/flutter/testing/skia_gold_client/**
 
   - name: Linux builder_cache
     enabled_branches:

--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -170,7 +170,8 @@ group("unittests") {
   public_deps = []
   if (is_android) {
     public_deps += [
-      "//flutter/impeller/renderer/backend/vulkan:apk_unittests",
+      "//flutter/impeller/renderer/backend/vulkan:vulkan_android_apk_unittests",
+      "//flutter/impeller/renderer/backend/vulkan:vulkan_android_unittests",
       "//flutter/impeller/toolkit/android:apk_unittests",
       "//flutter/impeller/toolkit/android:unittests",
       "//flutter/shell/platform/android:flutter_shell_native_unittests",

--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -170,6 +170,7 @@ group("unittests") {
   public_deps = []
   if (is_android) {
     public_deps += [
+      "//flutter/impeller/renderer/backend/vulkan:apk_unittests",
       "//flutter/impeller/toolkit/android:apk_unittests",
       "//flutter/impeller/toolkit/android:unittests",
       "//flutter/shell/platform/android:flutter_shell_native_unittests",

--- a/engine/src/flutter/ci/builders/linux_android_emulator.json
+++ b/engine/src/flutter/ci/builders/linux_android_emulator.json
@@ -30,6 +30,8 @@
             "ninja": {
                 "config": "ci/android_emulator_debug_x64",
                 "targets": [
+                    "flutter/impeller/renderer/backend/vulkan:vulkan_android_unittests",
+                    "flutter/impeller/renderer/backend/vulkan:vulkan_android_apk_unittests",
                     "flutter/impeller/toolkit/android:unittests",
                     "flutter/shell/platform/android:flutter_shell_native_unittests"
                 ]
@@ -97,6 +99,8 @@
             "ninja": {
                 "config": "ci/android_emulator_debug_x86",
                 "targets": [
+                    "flutter/impeller/renderer/backend/vulkan:vulkan_android_unittests",
+                    "flutter/impeller/renderer/backend/vulkan:vulkan_android_apk_unittests",
                     "flutter/impeller/toolkit/android:unittests",
                     "flutter/shell/platform/android:flutter_shell_native_unittests"
                 ]

--- a/engine/src/flutter/ci/licenses_golden/excluded_files
+++ b/engine/src/flutter/ci/licenses_golden/excluded_files
@@ -192,6 +192,7 @@
 ../../../flutter/impeller/renderer/backend/metal/swapchain_transients_mtl_unittests.mm
 ../../../flutter/impeller/renderer/backend/metal/texture_mtl_unittests.mm
 ../../../flutter/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+../../../flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/command_encoder_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/testing/android/native_activity/native_activity.gni")
 import("//flutter/vulkan/config.gni")
 import("../../../tools/impeller.gni")
 
@@ -159,4 +160,49 @@ impeller_component("vulkan") {
   if (is_android) {
     public_deps += [ "../../../toolkit/android" ]
   }
+}
+
+config("public_android_config") {
+  defines = [ "__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__" ]
+}
+
+test_fixtures("unittests_fixtures") {
+  fixtures = []
+}
+
+source_set("unittests_lib") {
+  visibility = [ ":*" ]
+
+  testonly = true
+
+  sources = [ "android/ahb_texture_source_vk_unittests.cc" ]
+
+  deps = [
+    ":unittests_fixtures",
+    ":vulkan",
+    "//flutter/testing",
+  ]
+
+  defines = [ "TESTING" ]
+}
+
+executable("unittests") {
+  assert(is_android)
+
+  testonly = true
+
+  output_name = "impeller_vulkan_android_unittests"
+
+  deps = [ ":unittests_lib" ]
+}
+
+native_activity_apk("apk_unittests") {
+  apk_name = "impeller_vulkan_android_unittests"
+
+  testonly = true
+
+  deps = [
+    ":unittests_lib",
+    "//flutter/testing/android/native_activity:gtest_activity",
+  ]
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -162,47 +162,49 @@ impeller_component("vulkan") {
   }
 }
 
-config("public_android_config") {
-  defines = [ "__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__" ]
-}
+if (is_android) {
+  config("public_android_config") {
+    defines = [ "__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__" ]
+  }
 
-test_fixtures("unittests_fixtures") {
-  fixtures = []
-}
+  test_fixtures("unittests_fixtures") {
+    fixtures = []
+  }
 
-source_set("unittests_lib") {
-  visibility = [ ":*" ]
+  source_set("unittests_lib") {
+    visibility = [ ":*" ]
 
-  testonly = true
+    testonly = true
 
-  sources = [ "android/ahb_texture_source_vk_unittests.cc" ]
+    sources = [ "android/ahb_texture_source_vk_unittests.cc" ]
 
-  deps = [
-    ":unittests_fixtures",
-    ":vulkan",
-    "//flutter/testing",
-  ]
+    deps = [
+      ":unittests_fixtures",
+      ":vulkan",
+      "//flutter/testing",
+    ]
 
-  defines = [ "TESTING" ]
-}
+    defines = [ "TESTING" ]
+  }
 
-executable("unittests") {
-  assert(is_android)
+  executable("unittests") {
+    assert(is_android)
 
-  testonly = true
+    testonly = true
 
-  output_name = "impeller_vulkan_android_unittests"
+    output_name = "impeller_vulkan_android_unittests"
 
-  deps = [ ":unittests_lib" ]
-}
+    deps = [ ":unittests_lib" ]
+  }
 
-native_activity_apk("apk_unittests") {
-  apk_name = "impeller_vulkan_android_unittests"
+  native_activity_apk("apk_unittests") {
+    apk_name = "impeller_vulkan_android_unittests"
 
-  testonly = true
+    testonly = true
 
-  deps = [
-    ":unittests_lib",
-    "//flutter/testing/android/native_activity:gtest_activity",
-  ]
+    deps = [
+      ":unittests_lib",
+      "//flutter/testing/android/native_activity:gtest_activity",
+    ]
+  }
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -187,7 +187,7 @@ if (is_android) {
     defines = [ "TESTING" ]
   }
 
-  executable("unittests") {
+  executable("vulkan_android_unittests") {
     assert(is_android)
 
     testonly = true
@@ -197,7 +197,7 @@ if (is_android) {
     deps = [ ":unittests_lib" ]
   }
 
-  native_activity_apk("apk_unittests") {
+  native_activity_apk("vulkan_android_apk_unittests") {
     apk_name = "impeller_vulkan_android_unittests"
 
     testonly = true

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -8,13 +8,12 @@
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_source_vk.h"
 #include "impeller/renderer/backend/vulkan/yuv_conversion_library_vk.h"
-#include "vulkan/vulkan_to_string.hpp"
 
 namespace impeller {
 
 namespace {
 
-static bool RequiresYCBCRConversion(vk::Format format) {
+bool RequiresYCBCRConversion(vk::Format format) {
   switch (format) {
     case vk::Format::eG8B8R83Plane420Unorm:
     case vk::Format::eG8B8R82Plane420Unorm:
@@ -35,7 +34,7 @@ using AHBProperties = vk::StructureChain<
     // For VK_ANDROID_external_memory_android_hardware_buffer
     vk::AndroidHardwareBufferFormatPropertiesANDROID>;
 
-static vk::UniqueImage CreateVKImageWrapperForAndroidHarwareBuffer(
+vk::UniqueImage CreateVKImageWrapperForAndroidHarwareBuffer(
     const vk::Device& device,
     const AHBProperties& ahb_props,
     const AHardwareBuffer_Desc& ahb_desc) {
@@ -112,7 +111,7 @@ static vk::UniqueImage CreateVKImageWrapperForAndroidHarwareBuffer(
   return std::move(image.value);
 }
 
-static vk::UniqueDeviceMemory ImportVKDeviceMemoryFromAndroidHarwareBuffer(
+vk::UniqueDeviceMemory ImportVKDeviceMemoryFromAndroidHarwareBuffer(
     const vk::Device& device,
     const vk::PhysicalDevice& physical_device,
     const vk::Image& image,
@@ -156,7 +155,7 @@ static vk::UniqueDeviceMemory ImportVKDeviceMemoryFromAndroidHarwareBuffer(
   return std::move(device_memory.value);
 }
 
-static std::shared_ptr<YUVConversionVK> CreateYUVConversion(
+std::shared_ptr<YUVConversionVK> CreateYUVConversion(
     const ContextVK& context,
     const AHBProperties& ahb_props) {
   YUVConversionDescriptorVK conversion_chain;
@@ -194,7 +193,7 @@ static std::shared_ptr<YUVConversionVK> CreateYUVConversion(
   return context.GetYUVConversionLibrary()->GetConversion(conversion_chain);
 }
 
-static vk::UniqueImageView CreateVKImageView(
+vk::UniqueImageView CreateVKImageView(
     const vk::Device& device,
     const vk::Image& image,
     const std::shared_ptr<YUVConversionVK>& yuv_conversion_wrapper,
@@ -241,7 +240,7 @@ static vk::UniqueImageView CreateVKImageView(
   return std::move(image_view.value);
 }
 
-static PixelFormat ToPixelFormat(AHardwareBuffer_Format format) {
+PixelFormat ToPixelFormat(AHardwareBuffer_Format format) {
   switch (format) {
     case AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM:
       return PixelFormat::kR8G8B8A8UNormInt;
@@ -275,7 +274,7 @@ static PixelFormat ToPixelFormat(AHardwareBuffer_Format format) {
   return PixelFormat::kR8G8B8A8UNormInt;
 }
 
-static TextureType ToTextureType(const AHardwareBuffer_Desc& ahb_desc) {
+TextureType ToTextureType(const AHardwareBuffer_Desc& ahb_desc) {
   if (ahb_desc.layers == 1u) {
     return TextureType::kTexture2D;
   }
@@ -288,8 +287,7 @@ static TextureType ToTextureType(const AHardwareBuffer_Desc& ahb_desc) {
   return TextureType::kTexture2D;
 }
 
-static TextureDescriptor ToTextureDescriptor(
-    const AHardwareBuffer_Desc& ahb_desc) {
+TextureDescriptor ToTextureDescriptor(const AHardwareBuffer_Desc& ahb_desc) {
   const auto ahb_size = ISize{ahb_desc.width, ahb_desc.height};
   TextureDescriptor desc;
   // We are not going to touch hardware buffers on the CPU or use them as

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
@@ -38,7 +38,10 @@ std::shared_ptr<Context> CreateContext() {
 }
 
 TEST(AndroidVulkanTest, CanImportRGBA) {
-  std::cout << "A" << std::endl;
+  if (!HardwareBuffer::IsAvailableOnPlatform()) {
+    GTEST_SKIP() << "Hardware buffers are not supported on this platform.";
+  }
+
   HardwareBufferDescriptor desc;
   desc.size = ISize{1, 1};
   desc.format = HardwareBufferFormat::kR8G8B8A8UNormInt;
@@ -59,6 +62,10 @@ TEST(AndroidVulkanTest, CanImportRGBA) {
 }
 
 TEST(AndroidVulkanTest, CanImportWithYUB) {
+  if (!HardwareBuffer::IsAvailableOnPlatform()) {
+    GTEST_SKIP() << "Hardware buffers are not supported on this platform.";
+  }
+
   AHardwareBuffer_Desc desc;
   desc.width = 16;
   desc.height = 16;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
@@ -2,18 +2,89 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/fml/synchronization/waitable_event.h"
+#include <android/hardware_buffer.h>
+#include <memory>
+
 #include "flutter/testing/testing.h"
-#include "impeller/toolkit/android/choreographer.h"
+#include "gtest/gtest.h"
+#include "impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/surface_context_vk.h"
 #include "impeller/toolkit/android/hardware_buffer.h"
-#include "impeller/toolkit/android/proc_table.h"
-#include "impeller/toolkit/android/surface_control.h"
 #include "impeller/toolkit/android/surface_transaction.h"
 
 namespace impeller::android::testing {
 
-TEST(AndroidVulkanTest, CanFail) {
-  EXPECT_TRUE(false);
+// Set up context.
+std::shared_ptr<Context> CreateContext() {
+  auto vulkan_dylib = fml::NativeLibrary::Create("libvulkan.so");
+  auto instance_proc_addr =
+      vulkan_dylib->ResolveFunction<PFN_vkGetInstanceProcAddr>(
+          "vkGetInstanceProcAddr");
+
+  if (!instance_proc_addr.has_value()) {
+    VALIDATION_LOG << "Could not setup Vulkan proc table.";
+    return nullptr;
+  }
+
+  impeller::ContextVK::Settings settings;
+  settings.proc_address_callback = instance_proc_addr.value();
+  settings.shader_libraries_data = {};
+  settings.enable_validation = false;
+  settings.enable_gpu_tracing = false;
+  settings.enable_surface_control = false;
+
+  return ContextVK::Create(std::move(settings));
+}
+
+TEST(AndroidVulkanTest, CanImportRGBA) {
+  std::cout << "A" << std::endl;
+  HardwareBufferDescriptor desc;
+  desc.size = ISize{1, 1};
+  desc.format = HardwareBufferFormat::kR8G8B8A8UNormInt;
+  desc.usage = HardwareBufferUsageFlags::kSampledImage;
+
+  auto ahb = std::make_unique<HardwareBuffer>(desc);
+  ASSERT_TRUE(ahb);
+  auto context_vk = CreateContext();
+  ASSERT_TRUE(context_vk);
+
+  AHBTextureSourceVK source(context_vk, std::move(ahb),
+                            /*is_swapchain_image=*/false);
+
+  EXPECT_TRUE(source.IsValid());
+  EXPECT_EQ(source.GetYUVConversion(), nullptr);
+
+  context_vk->Shutdown();
+}
+
+TEST(AndroidVulkanTest, CanImportWithYUB) {
+  AHardwareBuffer_Desc desc;
+  desc.width = 16;
+  desc.height = 16;
+  desc.format = AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420;
+  desc.stride = 0;
+  desc.layers = 1;
+  desc.rfu0 = 0;
+  desc.rfu1 = 0;
+  desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE |
+               AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK |
+               AHARDWAREBUFFER_USAGE_CPU_READ_MASK;
+
+  EXPECT_EQ(AHardwareBuffer_isSupported(&desc), 1);
+
+  AHardwareBuffer* buffer = nullptr;
+  ASSERT_EQ(AHardwareBuffer_allocate(&desc, &buffer), 0);
+
+  auto context_vk = CreateContext();
+  ASSERT_TRUE(context_vk);
+
+  AHBTextureSourceVK source(context_vk, buffer, desc);
+
+  EXPECT_TRUE(source.IsValid());
+  EXPECT_NE(source.GetYUVConversion(), nullptr);
+
+  context_vk->Shutdown();
 }
 
 }  // namespace impeller::android::testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/testing/testing.h"
+#include "impeller/toolkit/android/choreographer.h"
+#include "impeller/toolkit/android/hardware_buffer.h"
+#include "impeller/toolkit/android/proc_table.h"
+#include "impeller/toolkit/android/surface_control.h"
+#include "impeller/toolkit/android/surface_transaction.h"
+
+namespace impeller::android::testing {
+
+TEST(AndroidVulkanTest, CanFail) {
+  EXPECT_TRUE(false);
+}
+
+}  // namespace impeller::android::testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -298,6 +298,17 @@ CapabilitiesVK::GetEnabledDeviceExtensions(
     return true;
   };
 
+  auto for_each_optional_android_extension =
+      [&](OptionalAndroidDeviceExtensionVK ext) {
+#ifdef FML_OS_ANDROID
+        auto name = GetExtensionName(ext);
+        if (exts.find(name) != exts.end()) {
+          enabled.push_back(name);
+        }
+#endif  //  FML_OS_ANDROID
+        return true;
+      };
+
   auto for_each_optional_extension = [&](OptionalDeviceExtensionVK ext) {
     auto name = GetExtensionName(ext);
     if (exts.find(name) != exts.end()) {
@@ -311,7 +322,10 @@ CapabilitiesVK::GetEnabledDeviceExtensions(
           for_each_common_extension) &&
       IterateExtensions<RequiredAndroidDeviceExtensionVK>(
           for_each_android_extension) &&
-      IterateExtensions<OptionalDeviceExtensionVK>(for_each_optional_extension);
+      IterateExtensions<OptionalDeviceExtensionVK>(
+          for_each_optional_extension) &&
+      IterateExtensions<OptionalAndroidDeviceExtensionVK>(
+          for_each_optional_android_extension);
 
   if (!iterate_extensions) {
     VALIDATION_LOG << "Device not suitable since required extensions are not "
@@ -623,6 +637,7 @@ bool CapabilitiesVK::SetPhysicalDevice(
       HasExtension(OptionalAndroidDeviceExtensionVK::kKHRExternalFence) &&
       HasExtension(OptionalAndroidDeviceExtensionVK::kKHRExternalSemaphore) &&
       HasExtension(OptionalAndroidDeviceExtensionVK::kKHRExternalSemaphoreFd)) {
+    FML_LOG(ERROR) << "HAS EXTENSIONS!!!";
     supports_external_fence_and_semaphore_ = true;
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -637,7 +637,6 @@ bool CapabilitiesVK::SetPhysicalDevice(
       HasExtension(OptionalAndroidDeviceExtensionVK::kKHRExternalFence) &&
       HasExtension(OptionalAndroidDeviceExtensionVK::kKHRExternalSemaphore) &&
       HasExtension(OptionalAndroidDeviceExtensionVK::kKHRExternalSemaphoreFd)) {
-    FML_LOG(ERROR) << "HAS EXTENSIONS!!!";
     supports_external_fence_and_semaphore_ = true;
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk.cc
@@ -29,13 +29,12 @@ bool PipelineCacheDataPersist(const fml::UniqueFD& cache_directory,
     return true;
   }
   auto allocation = std::make_shared<Allocation>();
-  if (!allocation->Truncate(
-          Bytes{sizeof(PipelineCacheHeaderVK) + data_size + 16}, false)) {
+  if (!allocation->Truncate(Bytes{sizeof(PipelineCacheHeaderVK) + data_size},
+                            false)) {
     VALIDATION_LOG << "Could not allocate pipeline cache data staging buffer.";
     return false;
   }
   const auto header = PipelineCacheHeaderVK{props, data_size};
-  size_t max_data_size = data_size;
   std::memcpy(allocation->GetBuffer(), &header, sizeof(header));
   vk::Result lookup_result = cache.getOwner().getPipelineCacheData(
       *cache, &data_size, allocation->GetBuffer() + sizeof(header));

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk.cc
@@ -27,8 +27,7 @@ bool PipelineCacheDataPersist(const fml::UniqueFD& cache_directory,
   }
   // If the maximum size that can be written is smaller than the header
   // metadata, we effectively cannot write anything to the cache.
-  if (maximum_data_size == 0u ||
-      maximum_data_size <= sizeof(PipelineCacheHeaderVK)) {
+  if (maximum_data_size <= sizeof(PipelineCacheHeaderVK)) {
     return true;
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk.cc
@@ -37,9 +37,9 @@ bool PipelineCacheDataPersist(const fml::UniqueFD& cache_directory,
     return false;
   }
 
-  const auto header = PipelineCacheHeaderVK{props, maximum_data_size};
-  std::memcpy(allocation->GetBuffer(), &header, sizeof(header));
   size_t written_data_size = maximum_data_size - sizeof(PipelineCacheHeaderVK);
+  const auto header = PipelineCacheHeaderVK{props, written_data_size};
+  std::memcpy(allocation->GetBuffer(), &header, sizeof(header));
   vk::Result result = cache.getOwner().getPipelineCacheData(
       *cache, &written_data_size, allocation->GetBuffer() + sizeof(header));
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
@@ -5,6 +5,7 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/file.h"
 #include "flutter/testing/testing.h"
+#include "gtest/gtest.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/renderer/backend/vulkan/capabilities_vk.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
@@ -103,6 +104,15 @@ TEST_P(PipelineCacheDataVKPlaygroundTest, CanPersistAndRetrievePipelineCache) {
 
   {
     auto cache = context_vk.GetDevice().createPipelineCacheUnique({});
+
+    size_t max_size = 0;
+    EXPECT_EQ(cache.value.getOwner().getPipelineCacheData(*cache.value,
+                                                          &max_size, nullptr),
+              vk::Result::eSuccess);
+    if (max_size < sizeof(PipelineCacheHeaderVK)) {
+      GTEST_SKIP() << "Pipeline cache too small for test.";
+    }
+
     EXPECT_EQ(cache.result, vk::Result::eSuccess);
     EXPECT_FALSE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
     EXPECT_TRUE(PipelineCacheDataPersist(
@@ -131,6 +141,15 @@ TEST_P(PipelineCacheDataVKPlaygroundTest,
 
   {
     auto cache = context_vk.GetDevice().createPipelineCacheUnique({});
+
+    size_t max_size = 0;
+    EXPECT_EQ(cache.value.getOwner().getPipelineCacheData(*cache.value,
+                                                          &max_size, nullptr),
+              vk::Result::eSuccess);
+    if (max_size < sizeof(PipelineCacheHeaderVK)) {
+      GTEST_SKIP() << "Pipeline cache too small for test.";
+    }
+
     ASSERT_EQ(cache.result, vk::Result::eSuccess);
     ASSERT_FALSE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
     ASSERT_TRUE(PipelineCacheDataPersist(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
@@ -103,12 +103,12 @@ TEST_P(PipelineCacheDataVKPlaygroundTest, CanPersistAndRetrievePipelineCache) {
 
   {
     auto cache = context_vk.GetDevice().createPipelineCacheUnique({});
-    ASSERT_EQ(cache.result, vk::Result::eSuccess);
-    ASSERT_FALSE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
-    ASSERT_TRUE(PipelineCacheDataPersist(
+    EXPECT_EQ(cache.result, vk::Result::eSuccess);
+    EXPECT_FALSE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
+    EXPECT_TRUE(PipelineCacheDataPersist(
         temp_dir.fd(), caps.GetPhysicalDeviceProperties(), cache.value));
   }
-  ASSERT_TRUE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
+  EXPECT_TRUE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
 
   auto mapping = PipelineCacheDataRetrieve(temp_dir.fd(),
                                            caps.GetPhysicalDeviceProperties());

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
@@ -5,7 +5,6 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/file.h"
 #include "flutter/testing/testing.h"
-#include "gtest/gtest.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/renderer/backend/vulkan/capabilities_vk.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
@@ -104,21 +103,12 @@ TEST_P(PipelineCacheDataVKPlaygroundTest, CanPersistAndRetrievePipelineCache) {
 
   {
     auto cache = context_vk.GetDevice().createPipelineCacheUnique({});
-
-    size_t max_size = 0;
-    EXPECT_EQ(cache.value.getOwner().getPipelineCacheData(*cache.value,
-                                                          &max_size, nullptr),
-              vk::Result::eSuccess);
-    if (max_size < sizeof(PipelineCacheHeaderVK)) {
-      GTEST_SKIP() << "Pipeline cache too small for test.";
-    }
-
-    EXPECT_EQ(cache.result, vk::Result::eSuccess);
-    EXPECT_FALSE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
-    EXPECT_TRUE(PipelineCacheDataPersist(
+    ASSERT_EQ(cache.result, vk::Result::eSuccess);
+    ASSERT_FALSE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
+    ASSERT_TRUE(PipelineCacheDataPersist(
         temp_dir.fd(), caps.GetPhysicalDeviceProperties(), cache.value));
   }
-  EXPECT_TRUE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
+  ASSERT_TRUE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
 
   auto mapping = PipelineCacheDataRetrieve(temp_dir.fd(),
                                            caps.GetPhysicalDeviceProperties());
@@ -141,15 +131,6 @@ TEST_P(PipelineCacheDataVKPlaygroundTest,
 
   {
     auto cache = context_vk.GetDevice().createPipelineCacheUnique({});
-
-    size_t max_size = 0;
-    EXPECT_EQ(cache.value.getOwner().getPipelineCacheData(*cache.value,
-                                                          &max_size, nullptr),
-              vk::Result::eSuccess);
-    if (max_size < sizeof(PipelineCacheHeaderVK)) {
-      GTEST_SKIP() << "Pipeline cache too small for test.";
-    }
-
     ASSERT_EQ(cache.result, vk::Result::eSuccess);
     ASSERT_FALSE(fml::FileExists(temp_dir.fd(), "flutter.impeller.vkcache"));
     ASSERT_TRUE(PipelineCacheDataPersist(

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -765,6 +765,7 @@ def run_android_tests(android_variant='android_debug_unopt', adb_path=None):
 
   run_android_unittest('flutter_shell_native_unittests', android_variant, adb_path)
   run_android_unittest('impeller_toolkit_android_unittests', android_variant, adb_path)
+  run_android_unittest('impeller_vulkan_android_unittests', android_variant, adb_path)
 
 
 def run_objc_tests(ios_variant='ios_debug_sim_unopt', test_filter=None):


### PR DESCRIPTION
- Handle textures that require a YUV import but aren't an undefined format.
- INCOMPLETE is actually a success case for the pipeline cache. CERTAIN drivers ALWAYS return incomplete, even when they wrote all the data. Probably an off by one or something like that...
- Ensures Optional AndroidExtensions are enabled
- Only creates a YUV conversion if necessary