### PR TITLE
[DisplayList] DlPath supports generic path dispatching

### DIFF
--- a/engine/src/flutter/display_list/geometry/dl_path.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path.cc
@@ -364,6 +364,8 @@ void DlPath::DispatchFromImpellerPath(const impeller::Path& path,
     }
   };
 
+  // The Impeller Point Count is way overestimated due to duplicate
+  // points between elements.
   receiver.RecommendSizes(path.GetComponentCount(), path.GetPointCount());
   std::optional<DlRect> bounds = path.GetBoundingBox();
   if (bounds.has_value()) {

--- a/engine/src/flutter/display_list/geometry/dl_path.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path.cc
@@ -379,6 +379,7 @@ Path DlPath::ConvertToImpellerPath(const SkPath& path, const DlPoint& shift) {
   DlPathReceiver receiver{
       .recommend_size =
           [&builder](size_t verb_count, size_t point_count) {
+            // Reserve a path size with some arbitrarily additional padding.
             builder.Reserve(point_count + 8, verb_count + 8);
           },
       .recommend_bounds =
@@ -396,6 +397,9 @@ Path DlPath::ConvertToImpellerPath(const SkPath& path, const DlPoint& shift) {
           [&builder](const DlPoint& cp, const DlPoint& p2) {  //
             builder.QuadraticCurveTo(cp, p2);
           },
+      // .conic_to = ... for legacy compatibility we let the SkPath dispatcher
+      //                 convert conics to quads until we update Impeller for
+      //                 full support of rational quadratics
       .cubic_to =
           [&builder](const DlPoint& cp1,   //
                      const DlPoint& cp2,   //

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -33,6 +33,7 @@ using DlPathBuilder = impeller::PathBuilder;
 /// original path does not contain such info.
 class DlPathReceiver {
  public:
+  virtual ~DlPathReceiver() = default;
   virtual void RecommendSizes(size_t verb_count, size_t point_count) {};
   virtual void RecommendBounds(const DlRect& bounds) {};
   virtual void SetPathInfo(DlPathFillType fill_type, bool is_convex) = 0;

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -181,11 +181,9 @@ class DlPath {
   static void DispatchFromImpellerPath(const impeller::Path& path,
                                        DlPathReceiver& receiver);
 
-  static SkPath ConvertToSkiaPath(const impeller::Path& path,
-                                  const DlPoint& shift = DlPoint());
+  static SkPath ConvertToSkiaPath(const impeller::Path& path);
 
-  static impeller::Path ConvertToImpellerPath(const SkPath& path,
-                                              const DlPoint& shift = DlPoint());
+  static impeller::Path ConvertToImpellerPath(const SkPath& path);
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -162,8 +162,6 @@ class DlPath {
   static SkPath ConvertToSkiaPath(const impeller::Path& path);
 
   static impeller::Path ConvertToImpellerPath(const SkPath& path);
-
-  friend class SkiaPathReceiver;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -31,22 +31,21 @@ using DlPathBuilder = impeller::PathBuilder;
 /// The dispatcher will always call the path_info function, though the
 /// is_convex parameter may be conservatively reported as false if the
 /// original path does not contain such info.
-struct DlPathReceiver {
-  std::function<void(size_t verb_count, size_t point_count)> recommend_size =
-      [](size_t, size_t) {};
-  std::function<void(const DlRect& bounds)> recommend_bounds =
-      [](const DlRect& bounds) {};
-  std::function<void(DlPathFillType fill_type, bool is_convex)> path_info;
-  std::function<void(const DlPoint& p2)> move_to;
-  std::function<void(const DlPoint& p2)> line_to;
-  std::function<void(const DlPoint& cp, const DlPoint& p2)> quad_to;
-  std::function<bool(const DlPoint& cp, const DlPoint& p2, DlScalar weight)>
-      conic_to = [](const DlPoint& cp, const DlPoint& p2, DlScalar weight) {
-        return false;
-      };
-  std::function<void(const DlPoint& cp1, const DlPoint& cp2, const DlPoint& p2)>
-      cubic_to;
-  std::function<void()> close;
+class DlPathReceiver {
+ public:
+  virtual void RecommendSizes(size_t verb_count, size_t point_count) {};
+  virtual void RecommendBounds(const DlRect& bounds) {};
+  virtual void SetPathInfo(DlPathFillType fill_type, bool is_convex) = 0;
+  virtual void MoveTo(const DlPoint& p2) = 0;
+  virtual void LineTo(const DlPoint& p2) = 0;
+  virtual void QuadTo(const DlPoint& cp, const DlPoint& p2) = 0;
+  virtual bool ConicTo(const DlPoint& cp, const DlPoint& p2, DlScalar weight) {
+    return false;
+  };
+  virtual void CubicTo(const DlPoint& cp1,
+                       const DlPoint& cp2,
+                       const DlPoint& p2) = 0;
+  virtual void Close() = 0;
 };
 
 class DlPath {
@@ -184,6 +183,8 @@ class DlPath {
   static SkPath ConvertToSkiaPath(const impeller::Path& path);
 
   static impeller::Path ConvertToImpellerPath(const SkPath& path);
+
+  friend class SkiaPathReceiver;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -151,27 +151,6 @@ class DlPath {
     const bool sk_path_original;
   };
 
-  inline constexpr static DlPathFillType ToDlFillType(SkPathFillType sk_type) {
-    switch (sk_type) {
-      case SkPathFillType::kEvenOdd:
-        return impeller::FillType::kOdd;
-      case SkPathFillType::kWinding:
-        return impeller::FillType::kNonZero;
-      case SkPathFillType::kInverseEvenOdd:
-      case SkPathFillType::kInverseWinding:
-        FML_UNREACHABLE();
-    }
-  }
-
-  inline constexpr static SkPathFillType ToSkFillType(DlPathFillType dl_type) {
-    switch (dl_type) {
-      case impeller::FillType::kOdd:
-        return SkPathFillType::kEvenOdd;
-      case impeller::FillType::kNonZero:
-        return SkPathFillType::kWinding;
-    }
-  }
-
   std::shared_ptr<Data> data_;
 
   static void DispatchFromSkiaPath(const SkPath& path,

--- a/engine/src/flutter/display_list/geometry/dl_path_unittests.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path_unittests.cc
@@ -553,6 +553,405 @@ TEST(DisplayListPath, ConstructFromImpellerEqualsConstructFromSkia) {
   EXPECT_EQ(DlPath(path_builder, DlPathFillType::kNonZero), DlPath(sk_path));
 }
 
+namespace {
+class TestPathElement {
+ public:
+  enum class Type {
+    kMoveTo,
+    kLineTo,
+    kQuadTo,
+    kConicTo,
+    kCubicTo,
+    kClose,
+  };
+
+  static TestPathElement MoveTo(const DlPoint& p) {
+    return {
+        .type = Type::kMoveTo,
+        .p1 = p,
+    };
+  }
+  static TestPathElement LineTo(const DlPoint& p) {
+    return {
+        .type = Type::kLineTo,
+        .p1 = p,
+    };
+  }
+  static TestPathElement QuadTo(const DlPoint& cp, const DlPoint& p2) {
+    return {
+        .type = Type::kQuadTo,
+        .p1 = cp,
+        .p2 = p2,
+    };
+  }
+  static TestPathElement ConicTo(const DlPoint& cp,
+                                 const DlPoint& p2,
+                                 DlScalar w) {
+    return {
+        .type = Type::kConicTo,
+        .p1 = cp,
+        .p2 = p2,
+        .weight = w,
+    };
+  }
+  static TestPathElement CubicTo(const DlPoint& cp1,
+                                 const DlPoint& cp2,
+                                 const DlPoint& p2) {
+    return {
+        .type = Type::kCubicTo,
+        .p1 = cp1,
+        .p2 = cp2,
+        .p3 = p2,
+    };
+  }
+  static TestPathElement Close() { return {.type = Type::kClose}; }
+
+  const Type type;
+  const DlPoint p1;
+  const DlPoint p2;
+  const DlPoint p3;
+  const DlScalar weight;
+};
+
+class TestPathReceiver : public DlPathReceiver {
+ public:
+  TestPathReceiver(DlPathFillType expected_fill_type,
+                   size_t expected_verb_count,
+                   size_t expected_point_count,
+                   std::optional<DlRect> expected_bounds,
+                   std::optional<bool> expected_is_convex,
+                   std::vector<TestPathElement> expected_path_elements)
+      : expected_bounds_(expected_bounds),
+        expected_verb_count_(expected_verb_count),
+        expected_point_count_(expected_point_count),
+        expected_fill_type_(expected_fill_type),
+        expected_is_convex_(expected_is_convex),
+        expected_path_elements_(std::move(expected_path_elements)) {}
+
+  void RecommendSizes(size_t verb_count, size_t point_count) override {
+    EXPECT_EQ(path_index_, 0u);
+    EXPECT_EQ(verb_count, expected_verb_count_);
+    EXPECT_EQ(point_count, expected_point_count_);
+  }
+  void RecommendBounds(const DlRect& bounds) override {
+    EXPECT_EQ(path_index_, 0u);
+    if (expected_bounds_.has_value()) {
+      EXPECT_NEAR(bounds.GetLeft(), expected_bounds_.value().GetLeft(),
+                  kEhCloseEnough);
+      EXPECT_NEAR(bounds.GetTop(), expected_bounds_.value().GetTop(),
+                  kEhCloseEnough);
+      EXPECT_NEAR(bounds.GetRight(), expected_bounds_.value().GetRight(),
+                  kEhCloseEnough);
+      EXPECT_NEAR(bounds.GetBottom(), expected_bounds_.value().GetBottom(),
+                  kEhCloseEnough);
+    }
+  }
+  void SetPathInfo(DlPathFillType type, bool is_convex) override {
+    EXPECT_EQ(path_index_, 0u);
+    EXPECT_FALSE(set_path_info_called_);
+    EXPECT_EQ(type, expected_fill_type_);
+    if (expected_is_convex_.has_value()) {
+      EXPECT_EQ(is_convex, expected_is_convex_.value());
+    }
+    set_path_info_called_ = true;
+  }
+  void MoveTo(const DlPoint& p) override {
+    if (const TestPathElement* element = GetElement()) {
+      EXPECT_EQ(element->type, TestPathElement::Type::kMoveTo) << label();
+      EXPECT_EQ(element->p1, p) << label();
+      path_index_++;
+    }
+  }
+  void LineTo(const DlPoint& p) override {
+    if (const TestPathElement* element = GetElement()) {
+      EXPECT_EQ(element->type, TestPathElement::Type::kLineTo) << label();
+      EXPECT_EQ(element->p1, p) << label();
+      path_index_++;
+    }
+  }
+  void QuadTo(const DlPoint& cp, const DlPoint& p2) override {
+    if (const TestPathElement* element = GetElement()) {
+      EXPECT_EQ(element->type, TestPathElement::Type::kQuadTo) << label();
+      EXPECT_EQ(element->p1, cp) << label();
+      EXPECT_EQ(element->p2, p2) << label();
+      path_index_++;
+    }
+  }
+  bool ConicTo(const DlPoint& cp, const DlPoint& p2, DlScalar w) override {
+    if (const TestPathElement* element = GetElement()) {
+      EXPECT_EQ(element->type, TestPathElement::Type::kConicTo) << label();
+      EXPECT_EQ(element->p1, cp) << label();
+      EXPECT_EQ(element->p2, p2) << label();
+      EXPECT_EQ(element->weight, w) << label();
+      path_index_++;
+    }
+    return true;
+  }
+  void CubicTo(const DlPoint& cp1,
+               const DlPoint& cp2,
+               const DlPoint& p2) override {
+    if (const TestPathElement* element = GetElement()) {
+      EXPECT_EQ(element->type, TestPathElement::Type::kCubicTo) << label();
+      EXPECT_EQ(element->p1, cp1) << label();
+      EXPECT_EQ(element->p2, cp2) << label();
+      EXPECT_EQ(element->p3, p2) << label();
+      path_index_++;
+    }
+  }
+  void Close() override {
+    if (const TestPathElement* element = GetElement()) {
+      EXPECT_EQ(element->type, TestPathElement::Type::kClose) << label();
+      path_index_++;
+    }
+  }
+
+  void CheckComplete() {
+    EXPECT_TRUE(set_path_info_called_);
+    EXPECT_EQ(path_index_, expected_path_elements_.size());
+  }
+
+ private:
+  const std::optional<DlRect> expected_bounds_;
+  const size_t expected_verb_count_;
+  const size_t expected_point_count_;
+  const DlPathFillType expected_fill_type_;
+  const std::optional<bool> expected_is_convex_;
+  const std::vector<TestPathElement> expected_path_elements_;
+
+  size_t path_index_ = 0u;
+  bool set_path_info_called_ = false;
+
+  const TestPathElement* GetElement() {
+    if (path_index_ < expected_path_elements_.size()) {
+      return &expected_path_elements_[path_index_];
+    } else {
+      EXPECT_LT(path_index_, expected_path_elements_.size()) << label();
+      return nullptr;
+    }
+  }
+
+  std::string label() { return "at index " + std::to_string(path_index_); }
+};
+}  // namespace
+
+TEST(DisplayListPath, DispatchSkiaPathEvenOdd) {
+  SkPath path;
+
+  path.setFillType(SkPathFillType::kEvenOdd);
+  path.moveTo(100, 200);
+  path.lineTo(101, 201);
+  path.quadTo(110, 202, 102, 210);
+  path.conicTo(150, 240, 250, 140, 0.5);
+  path.cubicTo(300, 300, 350, 300, 300, 350);
+  path.close();
+
+  TestPathReceiver receiver(
+      /* expected_fill_type   = */ DlPathFillType::kOdd,
+      /* expected_verb_count  = */ 6u,
+      /* expected_point_count = */ 9u,
+      /* expected_bounds      = */ DlRect::MakeLTRB(100, 140, 350, 350),
+      /* expected_is_convex   = */ false,
+      std::vector<TestPathElement>{
+          TestPathElement::MoveTo(DlPoint(100, 200)),
+          TestPathElement::LineTo(DlPoint(101, 201)),
+          TestPathElement::QuadTo(DlPoint(110, 202), DlPoint(102, 210)),
+          TestPathElement::ConicTo(DlPoint(150, 240), DlPoint(250, 140), 0.5f),
+          TestPathElement::CubicTo(DlPoint(300, 300), DlPoint(350, 300),
+                                   DlPoint(300, 350)),
+          // Closing LineTo added implicitly to return to first point
+          TestPathElement::LineTo(DlPoint(100, 200)),
+          TestPathElement::Close(),
+      });
+
+  DlPath(path).Dispatch(receiver);
+  receiver.CheckComplete();
+}
+
+TEST(DisplayListPath, DispatchSkiaPathNonZero) {
+  SkPath path;
+
+  path.setFillType(SkPathFillType::kWinding);
+  path.moveTo(100, 200);
+  path.lineTo(101, 201);
+  path.quadTo(110, 202, 102, 210);
+  path.conicTo(150, 240, 250, 140, 0.5);
+  path.cubicTo(300, 300, 350, 300, 300, 350);
+  path.close();
+
+  TestPathReceiver receiver(
+      /* expected_fill_type   = */ DlPathFillType::kNonZero,
+      /* expected_verb_count  = */ 6u,
+      /* expected_point_count = */ 9u,
+      /* expected_bounds      = */ DlRect::MakeLTRB(100, 140, 350, 350),
+      /* expected_is_convex   = */ false,
+      std::vector<TestPathElement>{
+          TestPathElement::MoveTo(DlPoint(100, 200)),
+          TestPathElement::LineTo(DlPoint(101, 201)),
+          TestPathElement::QuadTo(DlPoint(110, 202), DlPoint(102, 210)),
+          TestPathElement::ConicTo(DlPoint(150, 240), DlPoint(250, 140), 0.5f),
+          TestPathElement::CubicTo(DlPoint(300, 300), DlPoint(350, 300),
+                                   DlPoint(300, 350)),
+          // Closing LineTo added implicitly to return to first point
+          TestPathElement::LineTo(DlPoint(100, 200)),
+          TestPathElement::Close(),
+      });
+
+  DlPath(path).Dispatch(receiver);
+  receiver.CheckComplete();
+}
+
+TEST(DisplayListPath, DispatchSkiaPathConvex) {
+  SkPath path;
+
+  path.setFillType(SkPathFillType::kWinding);
+  // Keep it simple - a triangle is obviously convex
+  path.moveTo(100, 200);
+  path.lineTo(200, 200);
+  path.lineTo(100, 300);
+  path.close();
+
+  TestPathReceiver receiver(
+      /* expected_fill_type   = */ DlPathFillType::kNonZero,
+      /* expected_verb_count  = */ 4u,
+      /* expected_point_count = */ 3u,
+      /* expected_bounds      = */ DlRect::MakeLTRB(100, 200, 200, 300),
+      /* expected_is_convex   = */ true,
+      std::vector<TestPathElement>{
+          TestPathElement::MoveTo(DlPoint(100, 200)),
+          TestPathElement::LineTo(DlPoint(200, 200)),
+          TestPathElement::LineTo(DlPoint(100, 300)),
+          // Closing LineTo added implicitly to return to first point
+          TestPathElement::LineTo(DlPoint(100, 200)),
+          TestPathElement::Close(),
+      });
+
+  DlPath(path).Dispatch(receiver);
+  receiver.CheckComplete();
+}
+
+TEST(DisplayListPath, DispatchImpellerPathEvenOdd) {
+  DlPathBuilder path_builder;
+
+  path_builder.MoveTo(DlPoint(100, 200));
+  path_builder.LineTo(DlPoint(101, 201));
+  path_builder.QuadraticCurveTo(DlPoint(110, 202), DlPoint(102, 210));
+  path_builder.ConicCurveTo(DlPoint(150, 240), DlPoint(250, 140), 0.5);
+  path_builder.CubicCurveTo(DlPoint(300, 300), DlPoint(350, 300),
+                            DlPoint(300, 350));
+  path_builder.Close();
+
+  TestPathReceiver receiver(
+      /* expected_fill_type   = */ DlPathFillType::kOdd,
+      /* expected_verb_count  = */ 7u,
+      /* expected_point_count = */ 19u,
+      /* expected_bounds      = */ DlRect::MakeLTRB(100, 140, 320.711, 350),
+      /* expected_is_convex   = */ false,
+      std::vector<TestPathElement>{
+          TestPathElement::MoveTo(DlPoint(100, 200)),
+          TestPathElement::LineTo(DlPoint(101, 201)),
+          TestPathElement::QuadTo(DlPoint(110, 202), DlPoint(102, 210)),
+          TestPathElement::ConicTo(DlPoint(150, 240), DlPoint(250, 140), 0.5f),
+          TestPathElement::CubicTo(DlPoint(300, 300), DlPoint(350, 300),
+                                   DlPoint(300, 350)),
+          // Closing LineTo added implicitly to return to first point
+          TestPathElement::LineTo(DlPoint(100, 200)),
+          TestPathElement::Close(),
+      });
+
+  DlPath(path_builder, DlPathFillType::kOdd).Dispatch(receiver);
+  receiver.CheckComplete();
+}
+
+TEST(DisplayListPath, DispatchImpellerPathNonZero) {
+  DlPathBuilder path_builder;
+
+  path_builder.MoveTo(DlPoint(100, 200));
+  path_builder.LineTo(DlPoint(101, 201));
+  path_builder.QuadraticCurveTo(DlPoint(110, 202), DlPoint(102, 210));
+  path_builder.ConicCurveTo(DlPoint(150, 240), DlPoint(250, 140), 0.5);
+  path_builder.CubicCurveTo(DlPoint(300, 300), DlPoint(350, 300),
+                            DlPoint(300, 350));
+  path_builder.Close();
+
+  TestPathReceiver receiver(
+      /* expected_fill_type   = */ DlPathFillType::kNonZero,
+      /* expected_verb_count  = */ 7u,
+      /* expected_point_count = */ 19u,
+      /* expected_bounds      = */ DlRect::MakeLTRB(100, 140, 320.711, 350),
+      /* expected_is_convex   = */ false,
+      std::vector<TestPathElement>{
+          TestPathElement::MoveTo(DlPoint(100, 200)),
+          TestPathElement::LineTo(DlPoint(101, 201)),
+          TestPathElement::QuadTo(DlPoint(110, 202), DlPoint(102, 210)),
+          TestPathElement::ConicTo(DlPoint(150, 240), DlPoint(250, 140), 0.5f),
+          TestPathElement::CubicTo(DlPoint(300, 300), DlPoint(350, 300),
+                                   DlPoint(300, 350)),
+          // Closing LineTo added implicitly to return to first point
+          TestPathElement::LineTo(DlPoint(100, 200)),
+          TestPathElement::Close(),
+      });
+
+  DlPath(path_builder, DlPathFillType::kNonZero).Dispatch(receiver);
+  receiver.CheckComplete();
+}
+
+TEST(DisplayListPath, DispatchImpellerPathConvexUnspecified) {
+  DlPathBuilder path_builder;
+
+  // Keep it simple - a triangle is obviously convex
+  path_builder.MoveTo(DlPoint(100, 200));
+  path_builder.LineTo(DlPoint(200, 200));
+  path_builder.LineTo(DlPoint(100, 300));
+  path_builder.Close();
+
+  TestPathReceiver receiver(
+      /* expected_fill_type   = */ DlPathFillType::kNonZero,
+      /* expected_verb_count  = */ 5u,
+      /* expected_point_count = */ 10u,
+      /* expected_bounds      = */ DlRect::MakeLTRB(100, 200, 200, 300),
+      /* expected_is_convex   = */ false,  // Conservatively false by default
+      std::vector<TestPathElement>{
+          TestPathElement::MoveTo(DlPoint(100, 200)),
+          TestPathElement::LineTo(DlPoint(200, 200)),
+          TestPathElement::LineTo(DlPoint(100, 300)),
+          // Closing LineTo added implicitly to return to first point
+          TestPathElement::LineTo(DlPoint(100, 200)),
+          TestPathElement::Close(),
+      });
+
+  DlPath(path_builder, DlPathFillType::kNonZero).Dispatch(receiver);
+  receiver.CheckComplete();
+}
+
+TEST(DisplayListPath, DispatchImpellerPathConvexSpecified) {
+  DlPathBuilder path_builder;
+
+  // Keep it simple - a triangle is obviously convex
+  path_builder.MoveTo(DlPoint(100, 200));
+  path_builder.LineTo(DlPoint(200, 200));
+  path_builder.LineTo(DlPoint(100, 300));
+  path_builder.Close();
+  path_builder.SetConvexity(impeller::Convexity::kConvex);
+
+  TestPathReceiver receiver(
+      /* expected_fill_type   = */ DlPathFillType::kNonZero,
+      /* expected_verb_count  = */ 5u,
+      /* expected_point_count = */ 10u,
+      /* expected_bounds      = */ DlRect::MakeLTRB(100, 200, 200, 300),
+      /* expected_is_convex   = */ true,  // Set manually above
+      std::vector<TestPathElement>{
+          TestPathElement::MoveTo(DlPoint(100, 200)),
+          TestPathElement::LineTo(DlPoint(200, 200)),
+          TestPathElement::LineTo(DlPoint(100, 300)),
+          // Closing LineTo added implicitly to return to first point
+          TestPathElement::LineTo(DlPoint(100, 200)),
+          TestPathElement::Close(),
+      });
+
+  DlPath(path_builder, DlPathFillType::kNonZero).Dispatch(receiver);
+  receiver.CheckComplete();
+}
+
 #ifndef NDEBUG
 // Tests that verify we don't try to use inverse path modes as they aren't
 // supported by either Flutter public APIs or Impeller

--- a/engine/src/flutter/impeller/geometry/path.cc
+++ b/engine/src/flutter/impeller/geometry/path.cc
@@ -103,6 +103,10 @@ size_t Path::GetComponentCount(std::optional<ComponentType> type) const {
   return count;
 }
 
+size_t Path::GetPointCount() const {
+  return data_->points.size();
+}
+
 FillType Path::GetFillType() const {
   return data_->fill;
 }

--- a/engine/src/flutter/impeller/geometry/path.h
+++ b/engine/src/flutter/impeller/geometry/path.h
@@ -183,6 +183,8 @@ class Path {
 
   size_t GetComponentCount(std::optional<ComponentType> type = {}) const;
 
+  size_t GetPointCount() const;
+
   FillType GetFillType() const;
 
   bool IsConvex() const;

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -2140,6 +2140,7 @@ void PlatformViewAndroidJNIImpl::onDisplayPlatformView2(
                 [](DlPathFillType type, bool is_convex) {
                   // Need to convert the fill type to the Android enum and
                   // call setFillType on the path...
+                  // see https://github.com/flutter/flutter/issues/164808
                 },
             .move_to =
                 [&env, &androidPath](const DlPoint& p2) {

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -2023,7 +2023,8 @@ void PlatformViewAndroidJNIImpl::destroyOverlaySurface2() {
   FML_CHECK(fml::jni::CheckException(env));
 }
 
-class AndroidPathReceiver final : public virtual DlPathReceiver {
+namespace {
+class AndroidPathReceiver final : public DlPathReceiver {
  public:
   explicit AndroidPathReceiver(JNIEnv* env)
       : env_(env),
@@ -2068,6 +2069,7 @@ class AndroidPathReceiver final : public virtual DlPathReceiver {
   JNIEnv* env_;
   jobject android_path_;
 };
+}  // namespace
 
 void PlatformViewAndroidJNIImpl::onDisplayPlatformView2(
     int32_t view_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -389,6 +389,7 @@ static BOOL _preparedOnce = NO;
           [](flutter::DlPathFillType type, bool is_convex) {
             // CGPaths do not have an inherit fill type, we would need to remember
             // the fill type and employ it when we use the path.
+            // see https://github.com/flutter/flutter/issues/164826
           },
       .move_to =
           [&pathRef](const flutter::DlPoint& p2) {  //

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -44,7 +44,7 @@ CATransform3D GetCATransform3DFromDlMatrix(const flutter::DlMatrix& matrix) {
   return transform;
 }
 
-class CGPathReceiver final : public virtual flutter::DlPathReceiver {
+class CGPathReceiver final : public flutter::DlPathReceiver {
  public:
   void SetPathInfo(flutter::DlPathFillType type, bool is_convex) override {
     // CGPaths do not have an inherit fill type, we would need to remember

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -383,72 +383,42 @@ static BOOL _preparedOnce = NO;
 - (void)clipPath:(const flutter::DlPath&)dlPath matrix:(const flutter::DlMatrix&)matrix {
   containsNonRectPath_ = YES;
   CGMutablePathRef pathRef = CGPathCreateMutable();
-  bool subpath_needs_close = false;
-  std::optional<flutter::DlPoint> pending_moveto;
 
-  auto resolve_moveto = [&pending_moveto, &pathRef]() {
-    if (pending_moveto.has_value()) {
-      CGPathMoveToPoint(pathRef, nil, pending_moveto->x, pending_moveto->y);
-      pending_moveto.reset();
-    }
+  flutter::DlPathReceiver receiver{
+      .path_info =
+          [](flutter::DlPathFillType type, bool is_convex) {
+            // CGPaths do not have an inherit fill type, we would need to remember
+            // the fill type and employ it when we use the path.
+          },
+      .move_to =
+          [&pathRef](const flutter::DlPoint& p2) {  //
+            CGPathMoveToPoint(pathRef, nil, p2.x, p2.y);
+          },
+      .line_to =
+          [&pathRef](const flutter::DlPoint& p2) {
+            CGPathAddLineToPoint(pathRef, nil, p2.x, p2.y);
+          },
+      .quad_to =
+          [&pathRef](const flutter::DlPoint& cp, const flutter::DlPoint& p2) {
+            CGPathAddQuadCurveToPoint(pathRef, nil,  //
+                                      cp.x, cp.y,    //
+                                      p2.x, p2.y);
+          },
+      // .conic_to = ... CGPath has no equivalent to the conic curve type
+      .cubic_to =
+          [&pathRef](const flutter::DlPoint& cp1,  //
+                     const flutter::DlPoint& cp2,  //
+                     const flutter::DlPoint& p2) {
+            CGPathAddCurveToPoint(pathRef, nil,  //
+                                  cp1.x, cp1.y,  //
+                                  cp2.x, cp2.y,  //
+                                  p2.x, p2.y);
+          },
+      .close = [&pathRef]() { CGPathCloseSubpath(pathRef); },
   };
 
-  auto& path = dlPath.GetPath();
-  for (auto it = path.begin(), end = path.end(); it != end; ++it) {
-    switch (it.type()) {
-      case impeller::Path::ComponentType::kContour: {
-        const impeller::ContourComponent* contour = it.contour();
-        FML_DCHECK(contour != nullptr);
-        if (subpath_needs_close) {
-          CGPathCloseSubpath(pathRef);
-        }
-        pending_moveto = contour->destination;
-        subpath_needs_close = contour->IsClosed();
-        break;
-      }
-      case impeller::Path::ComponentType::kLinear: {
-        const impeller::LinearPathComponent* linear = it.linear();
-        FML_DCHECK(linear != nullptr);
-        resolve_moveto();
-        CGPathAddLineToPoint(pathRef, nil, linear->p2.x, linear->p2.y);
-        break;
-      }
-      case impeller::Path::ComponentType::kQuadratic: {
-        const impeller::QuadraticPathComponent* quadratic = it.quadratic();
-        FML_DCHECK(quadratic != nullptr);
-        resolve_moveto();
-        CGPathAddQuadCurveToPoint(pathRef, nil,                      //
-                                  quadratic->cp.x, quadratic->cp.y,  //
-                                  quadratic->p2.x, quadratic->p2.y);
-        break;
-      }
-      case impeller::Path::ComponentType::kConic: {
-        const impeller::ConicPathComponent* conic = it.conic();
-        FML_DCHECK(conic != nullptr);
-        resolve_moveto();
-        // Conic is not available in quartz, we use quad to approximate.
-        // TODO(cyanglaz): Better approximate the conic path.
-        // https://github.com/flutter/flutter/issues/35062
-        CGPathAddQuadCurveToPoint(pathRef, nil,              //
-                                  conic->cp.x, conic->cp.y,  //
-                                  conic->p2.x, conic->p2.y);
-        break;
-      }
-      case impeller::Path::ComponentType::kCubic: {
-        const impeller::CubicPathComponent* cubic = it.cubic();
-        FML_DCHECK(cubic != nullptr);
-        resolve_moveto();
-        CGPathAddCurveToPoint(pathRef, nil,                //
-                              cubic->cp1.x, cubic->cp1.y,  //
-                              cubic->cp2.x, cubic->cp2.y,  //
-                              cubic->p2.x, cubic->p2.y);
-        break;
-      }
-    }
-  }
-  if (subpath_needs_close) {
-    CGPathCloseSubpath(pathRef);
-  }
+  dlPath.Dispatch(receiver);
+
   // The `matrix` is based on the physical pixels, convert it to UIKit points.
   CATransform3D matrixInPoints =
       CATransform3DConcat(GetCATransform3DFromDlMatrix(matrix), _reverseScreenScale);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -52,27 +52,27 @@ class CGPathReceiver final : public flutter::DlPathReceiver {
     // see https://github.com/flutter/flutter/issues/164826
   }
   void MoveTo(const flutter::DlPoint& p2) override {  //
-    CGPathMoveToPoint(pathRef_, nil, p2.x, p2.y);
+    CGPathMoveToPoint(path_ref_, nil, p2.x, p2.y);
   }
   void LineTo(const flutter::DlPoint& p2) override {
-    CGPathAddLineToPoint(pathRef_, nil, p2.x, p2.y);
+    CGPathAddLineToPoint(path_ref_, nil, p2.x, p2.y);
   }
   void QuadTo(const flutter::DlPoint& cp, const flutter::DlPoint& p2) override {
-    CGPathAddQuadCurveToPoint(pathRef_, nil, cp.x, cp.y, p2.x, p2.y);
+    CGPathAddQuadCurveToPoint(path_ref_, nil, cp.x, cp.y, p2.x, p2.y);
   }
   // bool conic_to(...) { CGPath has no equivalent to the conic curve type }
   void CubicTo(const flutter::DlPoint& cp1,
                const flutter::DlPoint& cp2,
                const flutter::DlPoint& p2) override {
-    CGPathAddCurveToPoint(pathRef_, nil,  //
+    CGPathAddCurveToPoint(path_ref_, nil,  //
                           cp1.x, cp1.y, cp2.x, cp2.y, p2.x, p2.y);
   }
-  void Close() override { CGPathCloseSubpath(pathRef_); }
+  void Close() override { CGPathCloseSubpath(path_ref_); }
 
-  CGMutablePathRef TakePath() { return pathRef_; }
+  CGMutablePathRef TakePath() { return path_ref_; }
 
  private:
-  CGMutablePathRef pathRef_ = CGPathCreateMutable();
+  CGMutablePathRef path_ref_ = CGPathCreateMutable();
 };
 }  // namespace
 


### PR DESCRIPTION
There are different ways to iterate over an SkPath or an impeller::Path and various points in the engine source tree we have boilerplate duplicates of this code to transfer the contents of the DlPath wrapper object into some platform-specific path. This PR adds a dispatch/receiver mechanism to read back the contents of a DlPath - independent of whether it is backed by an SkPath or an impeller::Path - in a simpler form that avoids potential mistakes in the various conversion methods.

See DlPathReceiver and DlPath::Dispatch in the dl_path.h file