### PR TITLE
Control paint order / z-order of slivers

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -32,7 +32,7 @@ enum CacheExtentStyle {
   viewport,
 }
 
-/// Specifies an order in which to paint the slivers of a [ScrollView].
+/// Specifies an order in which to paint the slivers of a [Viewport].
 ///
 /// The slivers of a [ScrollView] are the list returned by
 /// [ScrollView.buildSlivers].  For a [CustomScrollView], this is
@@ -51,17 +51,19 @@ enum CacheExtentStyle {
 enum SliverPaintOrder {
   /// The first sliver paints on top, and the last sliver on bottom.
   ///
-  /// The slivers are painted in the reverse order of [ScrollView.buildSlivers]
-  /// (for example, the reverse order of [CustomScrollView.slivers]),
-  /// and hit-tested in the same order as [ScrollView.buildSlivers].
+  /// The slivers are painted in the reverse order of [Viewport.slivers]
+  /// (for example, the reverse order of [ScrollView.buildSlivers]
+  /// or [CustomScrollView.slivers]),
+  /// and hit-tested in the same order as [Viewport.slivers].
   ///
   /// This is the default order.
   firstIsTop,
 
   /// The last sliver paints on top, and the first sliver on bottom.
   ///
-  /// The slivers are painted in the same order as [ScrollView.buildSlivers]
-  /// (for example, the same order as [CustomScrollView.slivers]),
+  /// The slivers are painted in the same order as [Viewport.slivers]
+  /// (for example, the same order as [ScrollView.buildSlivers]
+  /// or [CustomScrollView.slivers]),
   /// and hit-tested in the reverse order.
   lastIsTop,
 }

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -54,6 +54,8 @@ enum SliverPaintOrder {
   /// The slivers are painted in the reverse order of [ScrollView.buildSlivers]
   /// (for example, the reverse order of [CustomScrollView.slivers]),
   /// and hit-tested in the same order as [ScrollView.buildSlivers].
+  ///
+  /// This is the default order.
   firstIsTop,
 
   /// The last sliver paints on top, and the first sliver on bottom.
@@ -62,19 +64,6 @@ enum SliverPaintOrder {
   /// (for example, the same order as [CustomScrollView.slivers]),
   /// and hit-tested in the reverse order.
   lastIsTop,
-
-  /// The center sliver paints on top, and the first sliver paints on bottom.
-  ///
-  /// If [ScrollView.center] is null or corresponds to the first sliver
-  /// in the list, this order is equivalent to [firstIsTop].
-  /// Otherwise, the [ScrollView.center] sliver paints on top;
-  /// it's followed in the z-order by the slivers after it to the end
-  /// of the list; then the slivers before the center in reverse order,
-  /// with the first sliver in the list at the bottom in the z-direction.
-  ///
-  /// This order is only available when [ScrollView.shrinkWrap] is false;
-  /// i.e., for [RenderViewport] and not for [RenderShrinkWrappingViewport].
-  centerTopFirstBottom,
 }
 
 /// An interface for render objects that are bigger on the inside.
@@ -323,7 +312,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     required ViewportOffset offset,
     double? cacheExtent,
     CacheExtentStyle cacheExtentStyle = CacheExtentStyle.pixel,
-    required SliverPaintOrder paintOrder,
+    SliverPaintOrder paintOrder = SliverPaintOrder.firstIsTop,
     Clip clipBehavior = Clip.hardEdge,
   }) : assert(axisDirectionToAxis(axisDirection) != axisDirectionToAxis(crossAxisDirection)),
        assert(cacheExtent != null || cacheExtentStyle == CacheExtentStyle.pixel),
@@ -520,8 +509,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// is on the bottom.
   /// {@endtemplate}
   ///
-  /// The default is [SliverPaintOrder.centerTopFirstBottom] for [RenderViewport]
-  /// and [SliverPaintOrder.firstIsTop] for [RenderShrinkWrappingViewport].
+  /// The default is [SliverPaintOrder.firstIsTop].
   SliverPaintOrder get paintOrder => _paintOrder;
   SliverPaintOrder _paintOrder;
   set paintOrder(SliverPaintOrder value) {
@@ -1252,14 +1240,24 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   ///
   /// This should be the reverse order of [childrenInHitTestOrder].
   @protected
-  Iterable<RenderSliver> get childrenInPaintOrder;
+  Iterable<RenderSliver> get childrenInPaintOrder {
+    return switch (paintOrder) {
+      SliverPaintOrder.firstIsTop => _childrenLastToFirst,
+      SliverPaintOrder.lastIsTop => _childrenFirstToLast,
+    };
+  }
 
   /// Provides an iterable that walks the children of the viewport, in the order
   /// that hit-testing should use.
   ///
   /// This should be the reverse order of [childrenInPaintOrder].
   @protected
-  Iterable<RenderSliver> get childrenInHitTestOrder;
+  Iterable<RenderSliver> get childrenInHitTestOrder {
+    return switch (paintOrder) {
+      SliverPaintOrder.firstIsTop => _childrenFirstToLast,
+      SliverPaintOrder.lastIsTop => _childrenLastToFirst,
+    };
+  }
 
   Iterable<RenderSliver> get _childrenLastToFirst {
     final List<RenderSliver> children = <RenderSliver>[];
@@ -1424,7 +1422,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     RenderSliver? center,
     super.cacheExtent,
     super.cacheExtentStyle,
-    super.paintOrder = SliverPaintOrder.centerTopFirstBottom,
+    super.paintOrder,
     super.clipBehavior,
   }) : assert(anchor >= 0.0 && anchor <= 1.0),
        assert(cacheExtentStyle != CacheExtentStyle.viewport || cacheExtent != null),
@@ -1823,62 +1821,6 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
   }
 
   @override
-  Iterable<RenderSliver> get childrenInPaintOrder {
-    return switch (paintOrder) {
-      SliverPaintOrder.firstIsTop => _childrenLastToFirst,
-      SliverPaintOrder.lastIsTop => _childrenFirstToLast,
-      SliverPaintOrder.centerTopFirstBottom => _childrenFirstLastCenter,
-    };
-  }
-
-  @override
-  Iterable<RenderSliver> get childrenInHitTestOrder {
-    return switch (paintOrder) {
-      SliverPaintOrder.firstIsTop => _childrenFirstToLast,
-      SliverPaintOrder.lastIsTop => _childrenLastToFirst,
-      SliverPaintOrder.centerTopFirstBottom => _childrenCenterLastFirst,
-    };
-  }
-
-  Iterable<RenderSliver> get _childrenFirstLastCenter {
-    final List<RenderSliver> children = <RenderSliver>[];
-    if (firstChild == null) {
-      return children;
-    }
-    RenderSliver? child = firstChild;
-    while (child != center) {
-      children.add(child!);
-      child = childAfter(child);
-    }
-    child = lastChild;
-    while (true) {
-      children.add(child!);
-      if (child == center) {
-        return children;
-      }
-      child = childBefore(child);
-    }
-  }
-
-  Iterable<RenderSliver> get _childrenCenterLastFirst {
-    final List<RenderSliver> children = <RenderSliver>[];
-    if (firstChild == null) {
-      return children;
-    }
-    RenderSliver? child = center;
-    while (child != null) {
-      children.add(child);
-      child = childAfter(child);
-    }
-    child = childBefore(center!);
-    while (child != null) {
-      children.add(child);
-      child = childBefore(child);
-    }
-    return children;
-  }
-
-  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('anchor', anchor));
@@ -1920,11 +1862,10 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     super.axisDirection,
     required super.crossAxisDirection,
     required super.offset,
-    super.paintOrder = SliverPaintOrder.firstIsTop,
+    super.paintOrder,
     super.clipBehavior,
     List<RenderSliver>? children,
   }) {
-    assert(paintOrder != SliverPaintOrder.centerTopFirstBottom);
     addAll(children);
   }
 
@@ -2166,24 +2107,4 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
 
   @override
   String labelForChild(int index) => 'child $index';
-
-  @override
-  Iterable<RenderSliver> get childrenInPaintOrder {
-    return switch (paintOrder) {
-      SliverPaintOrder.firstIsTop => _childrenLastToFirst,
-      SliverPaintOrder.lastIsTop => _childrenFirstToLast,
-      // centerTopFirstBottom is not supported; fall back.
-      SliverPaintOrder.centerTopFirstBottom => _childrenLastToFirst,
-    };
-  }
-
-  @override
-  Iterable<RenderSliver> get childrenInHitTestOrder {
-    return switch (paintOrder) {
-      SliverPaintOrder.firstIsTop => _childrenFirstToLast,
-      SliverPaintOrder.lastIsTop => _childrenLastToFirst,
-      // centerTopFirstBottom is not supported; fall back.
-      SliverPaintOrder.centerTopFirstBottom => _childrenFirstToLast,
-    };
-  }
 }

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -32,6 +32,51 @@ enum CacheExtentStyle {
   viewport,
 }
 
+/// Specifies an order in which to paint the slivers of a [ScrollView].
+///
+/// The slivers of a [ScrollView] are the list returned by
+/// [ScrollView.buildSlivers].  For a [CustomScrollView], this is
+/// the same list as [CustomScrollView.slivers].
+/// For the other built-in subclasses of [ScrollView],
+/// there is only one sliver in the list, and this ordering has no effect.
+///
+/// Whichever order the slivers are painted in,
+/// they will be hit-tested in the opposite order.
+///
+/// This can also be thought of as an ordering in the z-direction:
+/// whichever sliver is painted last (and hit-tested first) is on top,
+/// because it will paint over other slivers if there is overlap.
+/// Similarly, whichever sliver is painted first (and hit-tested last)
+/// is on the bottom.
+enum SliverPaintOrder {
+  /// The first sliver paints on top, and the last sliver on bottom.
+  ///
+  /// The slivers are painted in the reverse order of [ScrollView.buildSlivers]
+  /// (for example, the reverse order of [CustomScrollView.slivers]),
+  /// and hit-tested in the same order as [ScrollView.buildSlivers].
+  firstIsTop,
+
+  /// The last sliver paints on top, and the first sliver on bottom.
+  ///
+  /// The slivers are painted in the same order as [ScrollView.buildSlivers]
+  /// (for example, the same order as [CustomScrollView.slivers]),
+  /// and hit-tested in the reverse order.
+  lastIsTop,
+
+  /// The center sliver paints on top, and the first sliver paints on bottom.
+  ///
+  /// If [ScrollView.center] is null or corresponds to the first sliver
+  /// in the list, this order is equivalent to [firstIsTop].
+  /// Otherwise, the [ScrollView.center] sliver paints on top;
+  /// it's followed in the z-order by the slivers after it to the end
+  /// of the list; then the slivers before the center in reverse order,
+  /// with the first sliver in the list at the bottom in the z-direction.
+  ///
+  /// This order is only available when [ScrollView.shrinkWrap] is false;
+  /// i.e., for [RenderViewport] and not for [RenderShrinkWrappingViewport].
+  centerTopFirstBottom,
+}
+
 /// An interface for render objects that are bigger on the inside.
 ///
 /// Some render objects, such as [RenderViewport], present a portion of their
@@ -278,6 +323,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     required ViewportOffset offset,
     double? cacheExtent,
     CacheExtentStyle cacheExtentStyle = CacheExtentStyle.pixel,
+    required SliverPaintOrder paintOrder,
     Clip clipBehavior = Clip.hardEdge,
   }) : assert(axisDirectionToAxis(axisDirection) != axisDirectionToAxis(crossAxisDirection)),
        assert(cacheExtent != null || cacheExtentStyle == CacheExtentStyle.pixel),
@@ -286,6 +332,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
        _offset = offset,
        _cacheExtent = cacheExtent ?? RenderAbstractViewport.defaultCacheExtent,
        _cacheExtentStyle = cacheExtentStyle,
+       _paintOrder = paintOrder,
        _clipBehavior = clipBehavior;
 
   /// Report the semantics of this node, for example for accessibility purposes.
@@ -457,6 +504,32 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     }
     _cacheExtentStyle = value;
     markNeedsLayout();
+  }
+
+  /// {@template flutter.rendering.RenderViewportBase.paintOrder}
+  /// The order in which to paint the slivers;
+  /// equivalently, the order in which to arrange them in the z-direction.
+  ///
+  /// Whichever order the slivers are painted in,
+  /// they will be hit-tested in the opposite order.
+  ///
+  /// To think of this as an ordering in the z-direction:
+  /// whichever sliver is painted last (and hit-tested first) is on top,
+  /// because it will paint over other slivers if there is overlap.
+  /// Similarly, whichever sliver is painted first (and hit-tested last)
+  /// is on the bottom.
+  /// {@endtemplate}
+  ///
+  /// The default is [SliverPaintOrder.centerTopFirstBottom] for [RenderViewport]
+  /// and [SliverPaintOrder.firstIsTop] for [RenderShrinkWrappingViewport].
+  SliverPaintOrder get paintOrder => _paintOrder;
+  SliverPaintOrder _paintOrder;
+  set paintOrder(SliverPaintOrder value) {
+    if (value != _paintOrder) {
+      _paintOrder = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
   }
 
   /// {@macro flutter.material.Material.clipBehavior}
@@ -1188,6 +1261,26 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   @protected
   Iterable<RenderSliver> get childrenInHitTestOrder;
 
+  Iterable<RenderSliver> get _childrenLastToFirst {
+    final List<RenderSliver> children = <RenderSliver>[];
+    RenderSliver? child = lastChild;
+    while (child != null) {
+      children.add(child);
+      child = childBefore(child);
+    }
+    return children;
+  }
+
+  Iterable<RenderSliver> get _childrenFirstToLast {
+    final List<RenderSliver> children = <RenderSliver>[];
+    RenderSliver? child = firstChild;
+    while (child != null) {
+      children.add(child);
+      child = childAfter(child);
+    }
+    return children;
+  }
+
   @override
   void showOnScreen({
     RenderObject? descendant,
@@ -1331,6 +1424,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     RenderSliver? center,
     super.cacheExtent,
     super.cacheExtentStyle,
+    super.paintOrder = SliverPaintOrder.centerTopFirstBottom,
     super.clipBehavior,
   }) : assert(anchor >= 0.0 && anchor <= 1.0),
        assert(cacheExtentStyle != CacheExtentStyle.viewport || cacheExtent != null),
@@ -1730,6 +1824,23 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
 
   @override
   Iterable<RenderSliver> get childrenInPaintOrder {
+    return switch (paintOrder) {
+      SliverPaintOrder.firstIsTop => _childrenLastToFirst,
+      SliverPaintOrder.lastIsTop => _childrenFirstToLast,
+      SliverPaintOrder.centerTopFirstBottom => _childrenFirstLastCenter,
+    };
+  }
+
+  @override
+  Iterable<RenderSliver> get childrenInHitTestOrder {
+    return switch (paintOrder) {
+      SliverPaintOrder.firstIsTop => _childrenFirstToLast,
+      SliverPaintOrder.lastIsTop => _childrenLastToFirst,
+      SliverPaintOrder.centerTopFirstBottom => _childrenCenterLastFirst,
+    };
+  }
+
+  Iterable<RenderSliver> get _childrenFirstLastCenter {
     final List<RenderSliver> children = <RenderSliver>[];
     if (firstChild == null) {
       return children;
@@ -1749,8 +1860,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     }
   }
 
-  @override
-  Iterable<RenderSliver> get childrenInHitTestOrder {
+  Iterable<RenderSliver> get _childrenCenterLastFirst {
     final List<RenderSliver> children = <RenderSliver>[];
     if (firstChild == null) {
       return children;
@@ -1810,9 +1920,11 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     super.axisDirection,
     required super.crossAxisDirection,
     required super.offset,
+    super.paintOrder = SliverPaintOrder.firstIsTop,
     super.clipBehavior,
     List<RenderSliver>? children,
   }) {
+    assert(paintOrder != SliverPaintOrder.centerTopFirstBottom);
     addAll(children);
   }
 
@@ -2057,23 +2169,21 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
 
   @override
   Iterable<RenderSliver> get childrenInPaintOrder {
-    final List<RenderSliver> children = <RenderSliver>[];
-    RenderSliver? child = lastChild;
-    while (child != null) {
-      children.add(child);
-      child = childBefore(child);
-    }
-    return children;
+    return switch (paintOrder) {
+      SliverPaintOrder.firstIsTop => _childrenLastToFirst,
+      SliverPaintOrder.lastIsTop => _childrenFirstToLast,
+      // centerTopFirstBottom is not supported; fall back.
+      SliverPaintOrder.centerTopFirstBottom => _childrenLastToFirst,
+    };
   }
 
   @override
   Iterable<RenderSliver> get childrenInHitTestOrder {
-    final List<RenderSliver> children = <RenderSliver>[];
-    RenderSliver? child = firstChild;
-    while (child != null) {
-      children.add(child);
-      child = childAfter(child);
-    }
-    return children;
+    return switch (paintOrder) {
+      SliverPaintOrder.firstIsTop => _childrenFirstToLast,
+      SliverPaintOrder.lastIsTop => _childrenLastToFirst,
+      // centerTopFirstBottom is not supported; fall back.
+      SliverPaintOrder.centerTopFirstBottom => _childrenFirstToLast,
+    };
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -117,7 +117,7 @@ abstract class ScrollView extends StatelessWidget {
     this.anchor = 0.0,
     this.cacheExtent,
     this.semanticChildCount,
-    this.paintOrder,
+    this.paintOrder = SliverPaintOrder.firstIsTop,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior,
     this.restorationId,
@@ -132,7 +132,6 @@ abstract class ScrollView extends StatelessWidget {
        assert(!shrinkWrap || center == null),
        assert(anchor >= 0.0 && anchor <= 1.0),
        assert(semanticChildCount == null || semanticChildCount >= 0),
-       assert(!shrinkWrap || paintOrder != SliverPaintOrder.centerTopFirstBottom),
        physics =
            physics ??
            ((primary ?? false) ||
@@ -374,12 +373,8 @@ abstract class ScrollView extends StatelessWidget {
 
   /// {@macro flutter.rendering.RenderViewportBase.paintOrder}
   ///
-  /// When [shrinkWrap] is true, the value [SliverPaintOrder.centerTopFirstBottom]
-  /// is not available.
-  ///
-  /// Defaults to [SliverPaintOrder.centerTopFirstBottom] if [shrinkWrap] is false,
-  /// and [SliverPaintOrder.firstIsTop] if [shrinkWrap] is true.
-  final SliverPaintOrder? paintOrder;
+  /// Defaults to [SliverPaintOrder.firstIsTop].
+  final SliverPaintOrder paintOrder;
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
@@ -473,7 +468,7 @@ abstract class ScrollView extends StatelessWidget {
         axisDirection: axisDirection,
         offset: offset,
         slivers: slivers,
-        paintOrder: paintOrder ?? SliverPaintOrder.firstIsTop,
+        paintOrder: paintOrder,
         clipBehavior: clipBehavior,
       );
     }
@@ -484,7 +479,7 @@ abstract class ScrollView extends StatelessWidget {
       cacheExtent: cacheExtent,
       center: center,
       anchor: anchor,
-      paintOrder: paintOrder ?? SliverPaintOrder.centerTopFirstBottom,
+      paintOrder: paintOrder,
       clipBehavior: clipBehavior,
     );
   }

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -117,6 +117,7 @@ abstract class ScrollView extends StatelessWidget {
     this.anchor = 0.0,
     this.cacheExtent,
     this.semanticChildCount,
+    this.paintOrder,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior,
     this.restorationId,
@@ -131,6 +132,7 @@ abstract class ScrollView extends StatelessWidget {
        assert(!shrinkWrap || center == null),
        assert(anchor >= 0.0 && anchor <= 1.0),
        assert(semanticChildCount == null || semanticChildCount >= 0),
+       assert(!shrinkWrap || paintOrder != SliverPaintOrder.centerTopFirstBottom),
        physics =
            physics ??
            ((primary ?? false) ||
@@ -370,6 +372,15 @@ abstract class ScrollView extends StatelessWidget {
   ///  * [SemanticsConfiguration.scrollChildCount], the corresponding semantics property.
   final int? semanticChildCount;
 
+  /// {@macro flutter.rendering.RenderViewportBase.paintOrder}
+  ///
+  /// When [shrinkWrap] is true, the value [SliverPaintOrder.centerTopFirstBottom]
+  /// is not available.
+  ///
+  /// Defaults to [SliverPaintOrder.centerTopFirstBottom] if [shrinkWrap] is false,
+  /// and [SliverPaintOrder.firstIsTop] if [shrinkWrap] is true.
+  final SliverPaintOrder? paintOrder;
+
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
 
@@ -462,6 +473,7 @@ abstract class ScrollView extends StatelessWidget {
         axisDirection: axisDirection,
         offset: offset,
         slivers: slivers,
+        paintOrder: paintOrder ?? SliverPaintOrder.firstIsTop,
         clipBehavior: clipBehavior,
       );
     }
@@ -472,6 +484,7 @@ abstract class ScrollView extends StatelessWidget {
       cacheExtent: cacheExtent,
       center: center,
       anchor: anchor,
+      paintOrder: paintOrder ?? SliverPaintOrder.centerTopFirstBottom,
       clipBehavior: clipBehavior,
     );
   }
@@ -701,6 +714,7 @@ class CustomScrollView extends ScrollView {
     super.center,
     super.anchor,
     super.cacheExtent,
+    super.paintOrder,
     this.slivers = const <Widget>[],
     super.semanticChildCount,
     super.dragStartBehavior,

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -69,6 +69,7 @@ class Viewport extends MultiChildRenderObjectWidget {
     this.center,
     this.cacheExtent,
     this.cacheExtentStyle = CacheExtentStyle.pixel,
+    this.paintOrder = SliverPaintOrder.centerTopFirstBottom,
     this.clipBehavior = Clip.hardEdge,
     List<Widget> slivers = const <Widget>[],
   }) : assert(center == null || slivers.where((Widget child) => child.key == center).length == 1),
@@ -135,6 +136,11 @@ class Viewport extends MultiChildRenderObjectWidget {
   /// {@macro flutter.rendering.RenderViewportBase.cacheExtentStyle}
   final CacheExtentStyle cacheExtentStyle;
 
+  /// {@macro flutter.rendering.RenderViewportBase.paintOrder}
+  ///
+  /// Defaults to [SliverPaintOrder.centerTopFirstBottom].
+  final SliverPaintOrder paintOrder;
+
   /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
@@ -189,6 +195,7 @@ class Viewport extends MultiChildRenderObjectWidget {
       offset: offset,
       cacheExtent: cacheExtent,
       cacheExtentStyle: cacheExtentStyle,
+      paintOrder: paintOrder,
       clipBehavior: clipBehavior,
     );
   }
@@ -203,6 +210,7 @@ class Viewport extends MultiChildRenderObjectWidget {
       ..offset = offset
       ..cacheExtent = cacheExtent
       ..cacheExtentStyle = cacheExtentStyle
+      ..paintOrder = paintOrder
       ..clipBehavior = clipBehavior;
   }
 
@@ -357,9 +365,11 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
     this.axisDirection = AxisDirection.down,
     this.crossAxisDirection,
     required this.offset,
+    this.paintOrder = SliverPaintOrder.firstIsTop,
     this.clipBehavior = Clip.hardEdge,
     List<Widget> slivers = const <Widget>[],
-  }) : super(children: slivers);
+  }) : assert(paintOrder != SliverPaintOrder.centerTopFirstBottom),
+       super(children: slivers);
 
   /// The direction in which the [offset]'s [ViewportOffset.pixels] increases.
   ///
@@ -389,6 +399,11 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
   /// Typically a [ScrollPosition].
   final ViewportOffset offset;
 
+  /// {@macro flutter.rendering.RenderViewportBase.paintOrder}
+  ///
+  /// Defaults to [SliverPaintOrder.firstIsTop].
+  final SliverPaintOrder paintOrder;
+
   /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
@@ -401,6 +416,7 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
       crossAxisDirection:
           crossAxisDirection ?? Viewport.getDefaultCrossAxisDirection(context, axisDirection),
       offset: offset,
+      paintOrder: paintOrder,
       clipBehavior: clipBehavior,
     );
   }
@@ -412,6 +428,7 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
       ..crossAxisDirection =
           crossAxisDirection ?? Viewport.getDefaultCrossAxisDirection(context, axisDirection)
       ..offset = offset
+      ..paintOrder = paintOrder
       ..clipBehavior = clipBehavior;
   }
 

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -16,7 +16,7 @@ import 'debug.dart';
 import 'framework.dart';
 import 'scroll_notification.dart';
 
-export 'package:flutter/rendering.dart' show AxisDirection, GrowthDirection;
+export 'package:flutter/rendering.dart' show AxisDirection, GrowthDirection, SliverPaintOrder;
 
 /// A widget through which a portion of larger content can be viewed, typically
 /// in combination with a [Scrollable].

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -69,7 +69,7 @@ class Viewport extends MultiChildRenderObjectWidget {
     this.center,
     this.cacheExtent,
     this.cacheExtentStyle = CacheExtentStyle.pixel,
-    this.paintOrder = SliverPaintOrder.centerTopFirstBottom,
+    this.paintOrder = SliverPaintOrder.firstIsTop,
     this.clipBehavior = Clip.hardEdge,
     List<Widget> slivers = const <Widget>[],
   }) : assert(center == null || slivers.where((Widget child) => child.key == center).length == 1),
@@ -138,7 +138,7 @@ class Viewport extends MultiChildRenderObjectWidget {
 
   /// {@macro flutter.rendering.RenderViewportBase.paintOrder}
   ///
-  /// Defaults to [SliverPaintOrder.centerTopFirstBottom].
+  /// Defaults to [SliverPaintOrder.firstIsTop].
   final SliverPaintOrder paintOrder;
 
   /// {@macro flutter.material.Material.clipBehavior}
@@ -368,8 +368,7 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
     this.paintOrder = SliverPaintOrder.firstIsTop,
     this.clipBehavior = Clip.hardEdge,
     List<Widget> slivers = const <Widget>[],
-  }) : assert(paintOrder != SliverPaintOrder.centerTopFirstBottom),
-       super(children: slivers);
+  }) : super(children: slivers);
 
   /// The direction in which the [offset]'s [ViewportOffset.pixels] increases.
   ///

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -11,8 +11,8 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/src/gestures/hit_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -12,6 +12,7 @@ library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/src/gestures/hit_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -1893,54 +1894,98 @@ void main() {
     );
   });
 
-  group('Viewport childrenInPaintOrder control test', () {
-    test('RenderViewport', () async {
-      final List<RenderSliver> children = <RenderSliver>[
-        RenderSliverToBoxAdapter(),
-        RenderSliverToBoxAdapter(),
-        RenderSliverToBoxAdapter(),
-      ];
+  group('Viewport paint order', () {
+    final List<int> paintLog = <int>[];
 
-      final RenderViewport renderViewport = RenderViewport(
-        crossAxisDirection: AxisDirection.right,
-        offset: ViewportOffset.zero(),
-        children: children,
+    Widget makeSliver(int i) {
+      return SliverToBoxAdapter(
+        key: ValueKey<int>(i),
+        child: CustomPaint(
+          painter: TestCustomPainter()..onPaint = (_, _) => paintLog.add(i),
+          child: Text('Item $i'),
+        ),
+      );
+    }
+
+    testWidgets('default (firstIsTop)', (WidgetTester tester) async {
+      addTearDown(paintLog.clear);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CustomScrollView(
+            center: const ValueKey<int>(2),
+            slivers: List<Widget>.generate(5, makeSliver),
+          ),
+        ),
       );
 
-      // Children should be painted in reverse order to the list given
-      // ignore: invalid_use_of_protected_member
-      expect(renderViewport.childrenInPaintOrder, equals(children.reversed));
-      // childrenInPaintOrder should be reverse of childrenInHitTestOrder
+      // First sliver paints last, over other slivers; last sliver paints first.
+      expect(paintLog, equals(<int>[4, 3, 2, 1, 0]));
+    });
+
+    testWidgets('lastIsTop', (WidgetTester tester) async {
+      addTearDown(paintLog.clear);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CustomScrollView(
+            paintOrder: SliverPaintOrder.lastIsTop,
+            center: const ValueKey<int>(2),
+            slivers: List<Widget>.generate(5, makeSliver),
+          ),
+        ),
+      );
+
+      // Last sliver paints last, over other slivers; first sliver paints first.
+      expect(paintLog, equals(<int>[0, 1, 2, 3, 4]));
+    });
+  });
+
+  group('Viewport hit-test order', () {
+    Widget makeSliver(int i) {
+      return _AllOverlapSliver(key: ValueKey<int>(i), id: i);
+    }
+
+    testWidgets('default (firstIsTop)', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CustomScrollView(
+            center: const ValueKey<int>(2),
+            slivers: List<Widget>.generate(5, makeSliver),
+          ),
+        ),
+      );
+
+      final HitTestResult result = tester.hitTestOnBinding(const Offset(400, 300));
       expect(
-        // ignore: invalid_use_of_protected_member
-        renderViewport.childrenInPaintOrder,
-        // ignore: invalid_use_of_protected_member
-        equals(renderViewport.childrenInHitTestOrder.toList().reversed),
+        result.path
+            .map((HitTestEntry<HitTestTarget> e) => e.target)
+            .map((HitTestTarget t) => t is _RenderAllOverlapSliver ? t.id : null)
+            .nonNulls,
+        equals(<int>[0, 1, 2, 3, 4]),
       );
     });
 
-    test('RenderShrinkWrappingViewport', () async {
-      final List<RenderSliver> children = <RenderSliver>[
-        RenderSliverToBoxAdapter(),
-        RenderSliverToBoxAdapter(),
-        RenderSliverToBoxAdapter(),
-      ];
-
-      final RenderShrinkWrappingViewport renderViewport = RenderShrinkWrappingViewport(
-        crossAxisDirection: AxisDirection.right,
-        offset: ViewportOffset.zero(),
-        children: children,
+    testWidgets('lastIsTop', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CustomScrollView(
+            paintOrder: SliverPaintOrder.lastIsTop,
+            center: const ValueKey<int>(2),
+            slivers: List<Widget>.generate(5, makeSliver),
+          ),
+        ),
       );
 
-      // Children should be painted in reverse order to the list given
-      // ignore: invalid_use_of_protected_member
-      expect(renderViewport.childrenInPaintOrder, equals(children.reversed));
-      // childrenInPaintOrder should be reverse of childrenInHitTestOrder
+      final HitTestResult result = tester.hitTestOnBinding(const Offset(400, 300));
       expect(
-        // ignore: invalid_use_of_protected_member
-        renderViewport.childrenInPaintOrder,
-        // ignore: invalid_use_of_protected_member
-        equals(renderViewport.childrenInHitTestOrder.toList().reversed),
+        result.path
+            .map((HitTestEntry<HitTestTarget> e) => e.target)
+            .map((HitTestTarget t) => t is _RenderAllOverlapSliver ? t.id : null)
+            .nonNulls,
+        equals(<int>[4, 3, 2, 1, 0]),
       );
     });
   });
@@ -2444,6 +2489,69 @@ void main() {
       tester: tester,
     );
   });
+}
+
+class TestCustomPainter extends CustomPainter {
+  void Function(Canvas canvas, Size size)? onPaint;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (onPaint != null) {
+      onPaint!(canvas, size);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return true;
+  }
+}
+
+/// A sliver that overlaps with other slivers as far as possible,
+/// and does nothing else.
+class _AllOverlapSliver extends LeafRenderObjectWidget {
+  const _AllOverlapSliver({super.key, required this.id});
+
+  final int id;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => _RenderAllOverlapSliver(id);
+}
+
+class _RenderAllOverlapSliver extends RenderSliver {
+  _RenderAllOverlapSliver(this.id);
+
+  final int id;
+
+  @override
+  void performLayout() {
+    geometry = SliverGeometry(
+      paintExtent: constraints.remainingPaintExtent,
+      maxPaintExtent: constraints.remainingPaintExtent,
+      layoutExtent: 0.0,
+    );
+  }
+
+  @override
+  bool hitTest(
+    SliverHitTestResult result, {
+    required double mainAxisPosition,
+    required double crossAxisPosition,
+  }) {
+    if (mainAxisPosition >= 0.0 &&
+        mainAxisPosition < geometry!.hitTestExtent &&
+        crossAxisPosition >= 0.0 &&
+        crossAxisPosition < constraints.crossAxisExtent) {
+      result.add(
+        SliverHitTestEntry(
+          this,
+          mainAxisPosition: mainAxisPosition,
+          crossAxisPosition: crossAxisPosition,
+        ),
+      );
+    }
+    return false;
+  }
 }
 
 // Simple sliver that applies N scroll offset corrections.

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1914,6 +1914,7 @@ void main() {
           textDirection: TextDirection.ltr,
           child: CustomScrollView(
             center: const ValueKey<int>(2),
+            anchor: 0.5,
             slivers: List<Widget>.generate(5, makeSliver),
           ),
         ),
@@ -1931,6 +1932,7 @@ void main() {
           child: CustomScrollView(
             paintOrder: SliverPaintOrder.lastIsTop,
             center: const ValueKey<int>(2),
+            anchor: 0.5,
             slivers: List<Widget>.generate(5, makeSliver),
           ),
         ),
@@ -1952,6 +1954,7 @@ void main() {
           textDirection: TextDirection.ltr,
           child: CustomScrollView(
             center: const ValueKey<int>(2),
+            anchor: 0.5,
             slivers: List<Widget>.generate(5, makeSliver),
           ),
         ),
@@ -1974,6 +1977,7 @@ void main() {
           child: CustomScrollView(
             paintOrder: SliverPaintOrder.lastIsTop,
             center: const ValueKey<int>(2),
+            anchor: 0.5,
             slivers: List<Widget>.generate(5, makeSliver),
           ),
         ),

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1908,10 +1908,13 @@ void main() {
       );
 
       // Children should be painted in reverse order to the list given
+      // ignore: invalid_use_of_protected_member
       expect(renderViewport.childrenInPaintOrder, equals(children.reversed));
       // childrenInPaintOrder should be reverse of childrenInHitTestOrder
       expect(
+        // ignore: invalid_use_of_protected_member
         renderViewport.childrenInPaintOrder,
+        // ignore: invalid_use_of_protected_member
         equals(renderViewport.childrenInHitTestOrder.toList().reversed),
       );
     });
@@ -1930,10 +1933,13 @@ void main() {
       );
 
       // Children should be painted in reverse order to the list given
+      // ignore: invalid_use_of_protected_member
       expect(renderViewport.childrenInPaintOrder, equals(children.reversed));
       // childrenInPaintOrder should be reverse of childrenInHitTestOrder
       expect(
+        // ignore: invalid_use_of_protected_member
         renderViewport.childrenInPaintOrder,
+        // ignore: invalid_use_of_protected_member
         equals(renderViewport.childrenInHitTestOrder.toList().reversed),
       );
     });


### PR DESCRIPTION
Fixes #145592.

When slivers in a CustomScrollView overlap, this makes it possible to control which of the slivers will sit in front of the other one, meaning that it paints last and gets hit-tested first.

In this version there are two choices: the first sliver paints in front, or the last sliver paints in front. The first sliver in front is the default; it's the behavior needed for SliverAppBar, or other situations where the first sliver is some sort of header.

The existing behavior is actually quite a bit more complicated than that, with the "center" sliver painting in front, plus it varies depending on `shrinkWrap`. As far as I can tell this behavior isn't documented anywhere. It's equivalent to first-sliver-in-front whenever `CustomScrollView.center` isn't being used; and in fact there don't seem to be any tests in the tree that notice the difference between the existing behavior and first-sliver-in-front.

So although I actually have an implementation that preserves the more complex existing defaults, I'm hopeful we won't need it: if neither google3 nor customer tests are relying on that undocumented distinction either, then we can go ahead and simplify this behavior without a breaking change.
