### PR TITLE
Make LLDB check a warning instead of a failure

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -503,11 +503,13 @@ abstract class IosLLDBInit extends Target {
     // an error.
     final String? srcRoot = environment.defines[kSrcRoot];
     if (srcRoot == null) {
-      throw MissingDefineException(kSdkRoot, name);
+      environment.logger.printError('Failed to find $srcRoot');
+      return;
     }
     final Directory xcodeProjectDir = environment.fileSystem.directory(srcRoot);
     if (!xcodeProjectDir.existsSync()) {
-      throw Exception('Failed to find ${xcodeProjectDir.path}');
+      environment.logger.printError('Failed to find ${xcodeProjectDir.path}');
+      return;
     }
 
     bool anyLLDBInitFound = false;
@@ -522,14 +524,20 @@ abstract class IosLLDBInit extends Target {
     if (!anyLLDBInitFound) {
       final FlutterProject flutterProject = FlutterProject.fromDirectory(environment.projectDir);
       if (flutterProject.isModule) {
-        throwToolExit(
-          'Debugging Flutter on new iOS versions requires an LLDB Init File. To '
+        // We use print here to make sure Xcode adds the message to the build logs. See
+        // https://developer.apple.com/documentation/xcode/running-custom-scripts-during-a-build#Log-errors-and-warnings-from-your-script
+        // ignore: avoid_print
+        print(
+          'warning: Debugging Flutter on new iOS versions requires an LLDB Init File. To '
           'ensure debug mode works, please run "flutter build ios --config-only" '
           'in your Flutter project and follow the instructions to add the file.',
         );
       } else {
-        throwToolExit(
-          'Debugging Flutter on new iOS versions requires an LLDB Init File. To '
+        // We use print here to make sure Xcode adds the message to the build logs. See
+        // https://developer.apple.com/documentation/xcode/running-custom-scripts-during-a-build#Log-errors-and-warnings-from-your-script
+        // ignore: avoid_print
+        print(
+          'warning: Debugging Flutter on new iOS versions requires an LLDB Init File. To '
           'ensure debug mode works, please run "flutter build ios --config-only" '
           'in your Flutter project and automatically add the files.',
         );


### PR DESCRIPTION
We added LLDB file in https://github.com/flutter/flutter/pull/164344. This adjusts it so if the LLDB file is missing it gives a warning rather than an error that fails the build.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
