### PR TITLE
Fix: Menu anchor respect alignment offset for right

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2944,7 +2944,7 @@ class _MenuLayout extends SingleChildLayoutDelegate {
   final Axis orientation;
 
   // The orientation of this menu's parent.
-  final Axis parentOrientation;
+  final Axis? parentOrientation;
 
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
@@ -3021,7 +3021,7 @@ class _MenuLayout extends SingleChildLayoutDelegate {
           }
         }
       } else if (offRightSide(x)) {
-        if (parentOrientation != orientation) {
+        if (parentOrientation != null && parentOrientation != orientation) {
           x = allowedRect.right - childSize.width;
         } else {
           final double newX = anchorRect.left - childSize.width - alignmentOffset.dx;
@@ -3048,10 +3048,10 @@ class _MenuLayout extends SingleChildLayoutDelegate {
         final double newY = anchorRect.top - childSize.height;
         if (!offTop(newY)) {
           // Only move the menu up if its parent is horizontal (MenuAnchor/MenuBar).
-          if (parentOrientation == Axis.horizontal) {
-            y = newY - alignmentOffset.dy;
-          } else {
+          if (parentOrientation == Axis.vertical) {
             y = newY;
+          } else {
+            y = newY - alignmentOffset.dy;
           }
         } else {
           y = allowedRect.bottom - childSize.height;
@@ -3396,7 +3396,7 @@ class _Submenu extends StatelessWidget {
                 alignmentOffset: alignmentOffset,
                 menuPosition: menuPosition.position,
                 orientation: anchor._orientation,
-                parentOrientation: anchor._parent?._orientation ?? Axis.horizontal,
+                parentOrientation: anchor._parent?._orientation,
               ),
               child: menuPanel,
             );

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3724,6 +3724,48 @@ void main() {
       },
     );
 
+    testWidgets('menu repositions to left of button when it would overflow on right with offset', (
+      WidgetTester tester,
+    ) async {
+      await changeSurfaceSize(tester, const Size(800, 600));
+      const Offset anchorAlignmentOffset = Offset(50, 0);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.bottomRight,
+            child: MenuAnchor(
+              alignmentOffset: anchorAlignmentOffset,
+              menuChildren: const <Widget>[MenuItemButton(child: Text('Button1'))],
+              builder: (BuildContext context, MenuController controller, Widget? child) {
+                return FilledButton(
+                  onPressed: () {
+                    if (controller.isOpen) {
+                      controller.close();
+                    } else {
+                      controller.open();
+                    }
+                  },
+                  child: const Text('Tap me'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.tap(find.text('Tap me'));
+      await tester.pump();
+
+      expect(find.byType(MenuItemButton), findsOneWidget);
+
+      final Offset buttonOffset = tester.getTopLeft(find.byType(FilledButton));
+      final Rect submenuRect = collectSubmenuRects().first;
+
+      // Submenu should be rendered 50 pixels to the left of the button.
+      expect(buttonOffset.dx - submenuRect.right, anchorAlignmentOffset.dx);
+    });
+
     Future<void> buildDensityPaddingApp(
       WidgetTester tester, {
       required TextDirection textDirection,


### PR DESCRIPTION
Fix: Menu anchor respect alignment offset for right
fixes: #159413 

Before this PR :-

https://github.com/user-attachments/assets/644ec10f-c1c6-454d-a709-b98abfc3af05

After this PR :-

https://github.com/user-attachments/assets/116dfad5-1ca8-44f7-81f5-f39ca30d3c7d

So, change after this PR is after overflow it doesn't just stick to the wall, rather it comes other side of button and adjust the offset on other side.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.