### PR TITLE
Add emptyBuilder to ListView

### DIFF
--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -1814,4 +1814,21 @@ void main() {
 
     expect(tester.testTextInput.isVisible, isFalse);
   });
+
+  testWidgets('ListView displays emptyBuilder when list is empty', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ListView.builder(
+            itemCount: 0,
+            emptyBuilder: (context) => Center(child: Text('No items found')),
+            itemBuilder: (context, index) => Container(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('No items found'), findsOneWidget);
+  });
+
 }


### PR DESCRIPTION
ref: [164867](https://github.com/flutter/flutter/issues/164867)

Currently, when working with ListView.builder, handling empty states requires additional widgets like Column and conditional logic to display a message when the list is empty. This results in extra boilerplate code.

For example, without an emptyBuilder, developers need to write:
```dart
return Scaffold(
  appBar: AppBar(title: Text("My app")),
  body: Column(
    children: [
      if (listTest.isEmpty) Center(child: Text("No items found.")),
      if (listTest.isNotEmpty)
        ListView.builder(
          padding: EdgeInsets.zero,
          shrinkWrap: true,
          itemCount: listTest.length,
          itemBuilder: (context, index) {
            return Padding(
              padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 5),
              child: Card(
                elevation: 0,
                child: Padding(
                  padding: const EdgeInsets.all(1.0),
                  child: ListTile(
                    title: Text(listTest[index], maxLines: 1, overflow: TextOverflow.ellipsis),
                  ),
                ),
              ),
            );
          },
        ),
    ],
  ),
  floatingActionButton: FloatingActionButton(
    onPressed: addItem,
    tooltip: 'ADD',
    child: const Icon(Icons.add),
  ),
);
```

With an emptyBuilder property in ListView.builder, this can be simplified:
```dart
return Scaffold(
  appBar: AppBar(title: Text("My app")),
  body: ListView.builder(
    padding: EdgeInsets.zero,
    shrinkWrap: true,
    itemCount: listTest.length,
    itemBuilder: (context, index) {
      return Padding(
        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 5),
        child: Card(
          elevation: 0,
          child: Padding(
            padding: const EdgeInsets.all(1.0),
            child: ListTile(
              title: Text(listTest[index], maxLines: 1, overflow: TextOverflow.ellipsis),
            ),
          ),
        ),
      );
    },
    emptyBuilder: (context) {
      return SizedBox(
        height: MediaQuery.of(context).size.height,
        child: Center(child: Text("No items found.")),
      );
    },
  ),
  floatingActionButton: FloatingActionButton(
    onPressed: addItem,
    tooltip: 'ADD',
    child: const Icon(Icons.add),
  ),
);
```

This property would work similarly to separatorBuilder, allowing developers to provide a widget that will be displayed when the list is empty. This reduces boilerplate and makes the API more intuitive.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
