### PR TITLE
add minTaps argument to BaseTapAndDragGestureRecognizer and TapAndPanGestureRecognizer

### DIFF
--- a/packages/flutter/lib/src/gestures/tap_and_drag.dart
+++ b/packages/flutter/lib/src/gestures/tap_and_drag.dart
@@ -768,6 +768,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
     super.supportedDevices,
     super.allowedButtonsFilter,
     this.eagerVictoryOnDrag = true,
+    this.minTaps = 1,
   }) : _deadline = kPressTimeout,
        dragStartBehavior = DragStartBehavior.start;
 
@@ -810,6 +811,10 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
   ///
   /// Defaults to `true`.
   bool eagerVictoryOnDrag;
+
+  /// The minimum number of consecutive taps required for this recognizer to resolve
+  /// when a drag is detected.
+  final int minTaps;
 
   /// {@macro flutter.gestures.tap.TapGestureRecognizer.onTapDown}
   ///
@@ -1112,8 +1117,10 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
         _currentPosition = OffsetPair.fromEventPosition(event);
         _checkDragUpdate(event);
       } else if (_dragState == _DragState.possible) {
-        if (_start == null) {
-          // Only check for a drag if the start of a drag was not already identified.
+        if (_start == null && _consecutiveTapCount >= minTaps) {
+          // Only check for a drag if the start of a drag was not already identified
+          // and the tap series is greater than or equal to the minimum number of taps
+          // required for this recognizer to resolve when a drag is detected.
           _checkDrag(event);
         }
 
@@ -1447,7 +1454,7 @@ class TapAndHorizontalDragGestureRecognizer extends BaseTapAndDragGestureRecogni
 /// {@endtemplate}
 class TapAndPanGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   /// Create a gesture recognizer for interactions on a plane.
-  TapAndPanGestureRecognizer({super.debugOwner, super.supportedDevices});
+  TapAndPanGestureRecognizer({super.debugOwner, super.supportedDevices, super.minTaps});
 
   @override
   bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind) {

--- a/packages/flutter/lib/src/gestures/tap_and_drag.dart
+++ b/packages/flutter/lib/src/gestures/tap_and_drag.dart
@@ -814,7 +814,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
 
   /// The minimum number of consecutive taps required for this recognizer to resolve
   /// when a drag is detected.
-  final int minTaps;
+  int minTaps;
 
   /// {@macro flutter.gestures.tap.TapGestureRecognizer.onTapDown}
   ///
@@ -1022,7 +1022,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
     // resolve(GestureDisposition.accepted) will be called when the [PointerMoveEvent]
     // has moved a sufficient global distance to be considered a drag and
     // `eagerVictoryOnDrag` is set to `true`.
-    if (_start != null && eagerVictoryOnDrag) {
+    if (_start != null && eagerVictoryOnDrag && consecutiveTapCount >= minTaps) {
       assert(_dragState == _DragState.accepted);
       assert(currentUp == null);
       _acceptDrag(_start!);
@@ -1030,7 +1030,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
 
     // This recognizer will wait until it is the last one in the gesture arena
     // before accepting a drag when `eagerVictoryOnDrag` is set to `false`.
-    if (_start != null && !eagerVictoryOnDrag) {
+    if (_start != null && !eagerVictoryOnDrag && consecutiveTapCount >= minTaps) {
       assert(_dragState == _DragState.possible);
       assert(currentUp == null);
       _dragState = _DragState.accepted;
@@ -1052,7 +1052,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
       case _DragState.possible:
         if (_pastSlopTolerance) {
           // This means the pointer was not accepted as a tap.
-          if (_wonArenaForPrimaryPointer) {
+          if (_wonArenaForPrimaryPointer && consecutiveTapCount >= minTaps) {
             // If the recognizer has already won the arena for the primary pointer being tracked
             // but the pointer has exceeded the tap tolerance, then the pointer is accepted as a
             // drag gesture.
@@ -1117,7 +1117,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
         _currentPosition = OffsetPair.fromEventPosition(event);
         _checkDragUpdate(event);
       } else if (_dragState == _DragState.possible) {
-        if (_start == null && _consecutiveTapCount >= minTaps) {
+        if (_start == null && consecutiveTapCount >= minTaps) {
           // Only check for a drag if the start of a drag was not already identified
           // and the tap series is greater than or equal to the minimum number of taps
           // required for this recognizer to resolve when a drag is detected.
@@ -1126,7 +1126,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
 
         // This can occur when the recognizer is accepted before a [PointerMoveEvent] has been
         // received that moves the pointer a sufficient global distance to be considered a drag.
-        if (_start != null && _wonArenaForPrimaryPointer) {
+        if (_start != null && _wonArenaForPrimaryPointer && consecutiveTapCount >= minTaps) {
           _dragState = _DragState.accepted;
           _acceptDrag(_start!);
         }

--- a/packages/flutter/test/gestures/tap_and_drag_test.dart
+++ b/packages/flutter/test/gestures/tap_and_drag_test.dart
@@ -1026,7 +1026,6 @@ void main() {
     expect(events, <String>['down#1', 'up#1', 'down#2', 'panstart#2', 'panupdate#2', 'panend#2']);
   });
 
-
   testGesture('Does drag when consecutive taps is greater than minTaps', (GestureTester tester) {
     setUpTapAndPanGestureRecognizer(minTaps: 2);
 
@@ -1068,8 +1067,9 @@ void main() {
     ]);
   });
 
-
-  testGesture('Does not drag when consecutive taps is reset and less than min taps', (GestureTester tester) {
+  testGesture('Does not drag when consecutive taps is reset and less than min taps', (
+    GestureTester tester,
+  ) {
     setUpTapAndPanGestureRecognizer(minTaps: 3);
 
     final TestPointer pointer = TestPointer(5);
@@ -1129,7 +1129,6 @@ void main() {
       'cancel',
     ]);
   });
-
 
   // This is a regression or https://github.com/flutter/flutter/issues/102084.
   testGesture('Does not call onDragEnd if not provided', (GestureTester tester) {

--- a/packages/flutter/test/gestures/tap_and_drag_test.dart
+++ b/packages/flutter/test/gestures/tap_and_drag_test.dart
@@ -19,9 +19,11 @@ void main() {
 
   void setUpTapAndPanGestureRecognizer({
     bool eagerVictoryOnDrag = true, // This is the default for [BaseTapAndDragGestureRecognizer].
+    int minTaps = 1,
   }) {
     tapAndDrag =
         TapAndPanGestureRecognizer()
+          ..minTaps = minTaps
           ..dragStartBehavior = DragStartBehavior.down
           ..eagerVictoryOnDrag = eagerVictoryOnDrag
           ..maxConsecutiveTap = 3
@@ -988,7 +990,148 @@ void main() {
     expect(events, <String>['down#1', 'up#1']);
   });
 
-  // This is a regression test for https://github.com/flutter/flutter/issues/102084.
+  testGesture('Does not drag when minTaps is not satisfied', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer(minTaps: 2);
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent down = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(down);
+    tester.closeArena(5);
+    tester.route(down);
+    tester.route(pointer.move(const Offset(40.0, 45.0)));
+    tester.route(pointer.up());
+    GestureBinding.instance.gestureArena.sweep(5);
+    expect(events, <String>['down#1', 'cancel']);
+  });
+
+  testGesture('Does drag when consecutive taps equal minTaps', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer(minTaps: 2);
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent downA = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downA);
+    tester.closeArena(5);
+    tester.route(downA);
+    tester.route(pointer.up());
+    GestureBinding.instance.gestureArena.sweep(5);
+
+    tester.async.elapse(kConsecutiveTapDelay);
+
+    final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downB);
+    tester.closeArena(5);
+    tester.route(downB);
+    tester.route(pointer.move(const Offset(40.0, 45.0)));
+    tester.route(pointer.up());
+    expect(events, <String>['down#1', 'up#1', 'down#2', 'panstart#2', 'panupdate#2', 'panend#2']);
+  });
+
+
+  testGesture('Does drag when consecutive taps is greater than minTaps', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer(minTaps: 2);
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent downA = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downA);
+    tester.closeArena(5);
+    tester.route(downA);
+    tester.route(pointer.up());
+    GestureBinding.instance.gestureArena.sweep(5);
+
+    tester.async.elapse(kConsecutiveTapDelay);
+
+    final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downB);
+    tester.closeArena(5);
+    tester.route(downB);
+    tester.route(pointer.up());
+    GestureBinding.instance.gestureArena.sweep(5);
+
+    tester.async.elapse(kConsecutiveTapDelay);
+
+    final PointerDownEvent downC = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downC);
+    tester.closeArena(5);
+    tester.route(downC);
+    tester.route(pointer.move(const Offset(40.0, 45.0)));
+    tester.route(pointer.up());
+
+    expect(events, <String>[
+      'down#1',
+      'up#1',
+      'down#2',
+      'up#2',
+      'down#3',
+      'panstart#3',
+      'panupdate#3',
+      'panend#3',
+    ]);
+  });
+
+
+  testGesture('Does not drag when consecutive taps is reset and less than min taps', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer(minTaps: 3);
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent downA = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downA);
+    tester.closeArena(5);
+    tester.route(downA);
+    tester.route(pointer.up());
+    GestureBinding.instance.gestureArena.sweep(5);
+
+    tester.async.elapse(kConsecutiveTapDelay);
+
+    final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downB);
+    tester.closeArena(5);
+    tester.route(downB);
+    tester.route(pointer.up());
+    GestureBinding.instance.gestureArena.sweep(5);
+
+    tester.async.elapse(kConsecutiveTapDelay);
+
+    final PointerDownEvent downC = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downC);
+    tester.closeArena(5);
+    tester.route(downC);
+    tester.route(pointer.up());
+    GestureBinding.instance.gestureArena.sweep(5);
+
+    tester.async.elapse(kConsecutiveTapDelay);
+
+    final PointerDownEvent downD = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downD);
+    tester.closeArena(5);
+    tester.route(downD);
+    tester.route(pointer.up());
+    GestureBinding.instance.gestureArena.sweep(5);
+
+    tester.async.elapse(kConsecutiveTapDelay);
+
+    final PointerDownEvent downE = pointer.down(const Offset(10.0, 10.0));
+    tapAndDrag.addPointer(downE);
+    tester.closeArena(5);
+    tester.route(downE);
+    tester.route(pointer.move(const Offset(40.0, 45.0)));
+    tester.route(pointer.up());
+
+    expect(events, <String>[
+      'down#1',
+      'up#1',
+      'down#2',
+      'up#2',
+      'down#3',
+      'up#3',
+      'down#1',
+      'up#1',
+      'down#2',
+      'cancel',
+    ]);
+  });
+
+
+  // This is a regression or https://github.com/flutter/flutter/issues/102084.
   testGesture('Does not call onDragEnd if not provided', (GestureTester tester) {
     tapAndDrag =
         TapAndDragGestureRecognizer()


### PR DESCRIPTION
This adds a `minTaps` parameter to `BaseTapAndDragGestureRecognizer` and `TapAndPanGestureRecognizer`, allowing `ScaleGestureRecognizer` to resolve on single taps and `TapAndPanGestureRecognizer` to only win when there is a double tap first by setting `minTaps` to 2. See the related issue "Add double tap and pan/double tap and drag gesture (#164889)"

Closes #164889

Note: we should probably check that `minTaps` <= `maxConsecutiveTap`. Not sure where to check for that. I guess we would add setters for `maxConsecutiveTap` and `minTaps` and check there?

<details>

<summary>Before</summary>

```dart

import 'package:flutter/gestures.dart';
import 'package:flutter/material.dart';

/// Flutter code sample for [TapAndPanGestureRecognizer].

void main() {
  runApp(const TapAndDragToZoomApp());
}

class TapAndDragToZoomApp extends StatelessWidget {
  const TapAndDragToZoomApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: Scaffold(body: Center(child: TapAndDragToZoomWidget(child: MyBoxWidget()))),
    );
  }
}

class MyBoxWidget extends StatelessWidget {
  const MyBoxWidget({super.key});

  @override
  Widget build(BuildContext context) {
    return Container(color: Colors.blueAccent, height: 100.0, width: 100.0);
  }
}

// This widget will scale its child up when it detects a drag up, after a
// double tap/click. It will scale the widget down when it detects a drag down,
// after a double tap. Dragging down and then up after a double tap/click will
// zoom the child in/out. The scale of the child will be reset when the drag ends.
class TapAndDragToZoomWidget extends StatefulWidget {
  const TapAndDragToZoomWidget({super.key, required this.child});

  final Widget child;

  @override
  State<TapAndDragToZoomWidget> createState() => _TapAndDragToZoomWidgetState();
}

class _TapAndDragToZoomWidgetState extends State<TapAndDragToZoomWidget> {
  final double scaleMultiplier = -0.0001;
  double _currentScale = 1.0;
  Offset? _previousDragPosition;

  static double _keepScaleWithinBounds(double scale) {
    const double minScale = 0.1;
    const double maxScale = 30;
    if (scale <= 0) {
      return minScale;
    }
    if (scale >= 30) {
      return maxScale;
    }
    return scale;
  }

  void _zoomLogic(Offset currentDragPosition) {
    final double dx = (_previousDragPosition!.dx - currentDragPosition.dx).abs();
    final double dy = (_previousDragPosition!.dy - currentDragPosition.dy).abs();

    if (dx > dy) {
      // Ignore horizontal drags.
      _previousDragPosition = currentDragPosition;
      return;
    }

    if (currentDragPosition.dy < _previousDragPosition!.dy) {
      // Zoom out on drag up.
      setState(() {
        _currentScale += currentDragPosition.dy * scaleMultiplier;
        _currentScale = _keepScaleWithinBounds(_currentScale);
      });
    } else {
      // Zoom in on drag down.
      setState(() {
        _currentScale -= currentDragPosition.dy * scaleMultiplier;
        _currentScale = _keepScaleWithinBounds(_currentScale);
      });
    }
    _previousDragPosition = currentDragPosition;
  }

  @override
  Widget build(BuildContext context) {
    return RawGestureDetector(
      gestures: <Type, GestureRecognizerFactory>{
        TapAndPanGestureRecognizer:
            GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
              () => TapAndPanGestureRecognizer( ),
              (TapAndPanGestureRecognizer instance) {
                instance
                  ..onTapDown = (TapDragDownDetails details) {
                    _previousDragPosition = details.globalPosition;
                  }
                  ..onDragStart = (TapDragStartDetails details) {
                      print("Drag Start");
                      _zoomLogic(details.globalPosition);
                  }
                  ..onDragUpdate = (TapDragUpdateDetails details) {
                      print("Drag Update");
                      _zoomLogic(details.globalPosition);
                  }
                  ..onDragEnd = (TapDragEndDetails details) {      
                    print("Drag End");              
                    setState(() {
                      _currentScale = 1.0;
                    });
                    _previousDragPosition = null;
                  };
              },
            ),
            //ScaleGestureRecognizer never wins the arena
            ScaleGestureRecognizer:
            GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
              () => ScaleGestureRecognizer(),
              (ScaleGestureRecognizer instance) {
                instance
                  ..onStart = (ScaleStartDetails details) {
                    print('Scale Start');
                  }
                  ..onUpdate = (ScaleUpdateDetails details) {
                    print('Scale Update');
                  }
                  ..onEnd = (ScaleEndDetails details) {
                    print('Scale End');
                  };
              },
            ),
      },
      child: Transform.scale(scale: _currentScale, child: widget.child),
    );
  }
}

```

</details>


<details>

<summary>After</summary>

```dart

import 'package:flutter/gestures.dart';
import 'package:flutter/material.dart';

/// Flutter code sample for [TapAndPanGestureRecognizer].

void main() {
  runApp(const TapAndDragToZoomApp());
}

class TapAndDragToZoomApp extends StatelessWidget {
  const TapAndDragToZoomApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: Scaffold(body: Center(child: TapAndDragToZoomWidget(child: MyBoxWidget()))),
    );
  }
}

class MyBoxWidget extends StatelessWidget {
  const MyBoxWidget({super.key});

  @override
  Widget build(BuildContext context) {
    return Container(color: Colors.blueAccent, height: 100.0, width: 100.0);
  }
}

// This widget will scale its child up when it detects a drag up, after a
// double tap/click. It will scale the widget down when it detects a drag down,
// after a double tap. Dragging down and then up after a double tap/click will
// zoom the child in/out. The scale of the child will be reset when the drag ends.
class TapAndDragToZoomWidget extends StatefulWidget {
  const TapAndDragToZoomWidget({super.key, required this.child});

  final Widget child;

  @override
  State<TapAndDragToZoomWidget> createState() => _TapAndDragToZoomWidgetState();
}

class _TapAndDragToZoomWidgetState extends State<TapAndDragToZoomWidget> {
  final double scaleMultiplier = -0.0001;
  double _currentScale = 1.0;
  Offset? _previousDragPosition;

  static double _keepScaleWithinBounds(double scale) {
    const double minScale = 0.1;
    const double maxScale = 30;
    if (scale <= 0) {
      return minScale;
    }
    if (scale >= 30) {
      return maxScale;
    }
    return scale;
  }

  void _zoomLogic(Offset currentDragPosition) {
    final double dx = (_previousDragPosition!.dx - currentDragPosition.dx).abs();
    final double dy = (_previousDragPosition!.dy - currentDragPosition.dy).abs();

    if (dx > dy) {
      // Ignore horizontal drags.
      _previousDragPosition = currentDragPosition;
      return;
    }

    if (currentDragPosition.dy < _previousDragPosition!.dy) {
      // Zoom out on drag up.
      setState(() {
        _currentScale += currentDragPosition.dy * scaleMultiplier;
        _currentScale = _keepScaleWithinBounds(_currentScale);
      });
    } else {
      // Zoom in on drag down.
      setState(() {
        _currentScale -= currentDragPosition.dy * scaleMultiplier;
        _currentScale = _keepScaleWithinBounds(_currentScale);
      });
    }
    _previousDragPosition = currentDragPosition;
  }

  @override
  Widget build(BuildContext context) {
    return RawGestureDetector(
      gestures: <Type, GestureRecognizerFactory>{
        TapAndPanGestureRecognizer:
            GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
              () => TapAndPanGestureRecognizer(
                minTaps: 2,    //<----- new argument
              ),
              (TapAndPanGestureRecognizer instance) {
                instance
                  ..onTapDown = (TapDragDownDetails details) {
                    _previousDragPosition = details.globalPosition;
                  }
                  ..onDragStart = (TapDragStartDetails details) {
                      print("Drag Start");
                      _zoomLogic(details.globalPosition);
                  }
                  ..onDragUpdate = (TapDragUpdateDetails details) {
                      print("Drag Update");
                      _zoomLogic(details.globalPosition);
                  }
                  ..onDragEnd = (TapDragEndDetails details) {      
                    print("Drag End");              
                    setState(() {
                      _currentScale = 1.0;
                    });
                    _previousDragPosition = null;
                  };
              },
            ),
            //wins the arena if there is only one tap followed by a pan
            ScaleGestureRecognizer:
            GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
              () => ScaleGestureRecognizer(),
              (ScaleGestureRecognizer instance) {
                instance
                  ..onStart = (ScaleStartDetails details) {
                    print('Scale Start');
                  }
                  ..onUpdate = (ScaleUpdateDetails details) {
                    print('Scale Update');
                  }
                  ..onEnd = (ScaleEndDetails details) {
                    print('Scale End');
                  };
              },
            ),
      },
      child: Transform.scale(scale: _currentScale, child: widget.child),
    );
  }
}


```

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
