### PR TITLE
in `et`, support building the Dart SDK with dynamic module support

### DIFF
--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -629,6 +629,14 @@ def to_gn_args(args):
   if args.arm_float_abi:
     gn_args['arm_float_abi'] = args.arm_float_abi
 
+  if args.dart_dynamic_modules:
+    if not args.prebuilt_dart_sdk:
+      print('--dart-dynamic-modules can only be used with --no-prebuilt-dart-sdk')
+    gn_args['dart_dynamic_modules'] = True
+
+  if args.no_enable_unittests:
+    gn_args['dart_dynamic_modules'] = False
+
   # If we have a prebuilt for the Dart SDK for the target architecture, then
   # use it instead of building a new one.
   if args.prebuilt_dart_sdk:
@@ -1139,6 +1147,17 @@ def parse_args(args):
       default=False,
       action='store_true',
       help='Use mallinfo2 to collect malloc stats.'
+  )
+
+  parser.add_argument(
+      '--dart-dynamic-modules',
+      default=False,
+      action='store_true',
+      help='Whether to include the Dart dynamic module interpreter in the Dart '
+      'sdk build. Must be used with --no-prebuilt-dart-sdk.'
+  )
+  parser.add_argument(
+      '--no-dart-dynamic-modules', dest='dart-dynamic-modules', action='store_false'
   )
 
   # Impeller flags.


### PR DESCRIPTION
usage example: `et build -c host_release_arm64 --gn-args="--no-prebuilt-dart-sdk,--dart_dynamic_modules"`

<details>

<summary> Pre-launch checklist </summary> 


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

</details>


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
