### PR TITLE
in RBE doc, remove bit about `gcloud` being included in the engine source

### DIFF
--- a/engine/src/flutter/docs/rbe/rbe.md
+++ b/engine/src/flutter/docs/rbe/rbe.md
@@ -46,15 +46,8 @@ proxy is correctly initialized and shut down around invocations of `ninja`.
 ### gcloud
 
 Before running an RBE build, you must be authenticated with the Google cloud
-project that owns the RBE worker pool. A gcloud SDK is checked out with the
-engine repo under e.g. `//flutter/buildtools/mac-arm64/gcloud`.
-(Replace `mac-arm64` with the directory name that is correct for your host
-platform.)
-
-The `gcloud` tool in this SDK must be on your path. The tool lives under
-`//flutter/buildtools/mac-arm64/gcloud/bin`, which is the path to add to your
-`PATH` environment variable. Alternatively, you can get the gcloud SDK on your
-path by installing it on your system by following the instructions at
+project that owns the RBE worker pool. You'll need the `gcloud` SDK, which you
+can install by following the instructions at
 [https://cloud.google.com/sdk/docs/install](https://cloud.google.com/sdk/docs/install).
 
 On macOS, before running the `gcloud` command ensure that `python3` is on your


### PR DESCRIPTION
Looks like we don't include `gcloud` in the engine src anymore.

<details>

<summary> Pre-launch checklist </summary> 


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

</details>

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
