### PR TITLE
[flutter_tools] Call reassemble with DWDS 24.3.7 and update hot reload and restart analytics

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -927,7 +927,7 @@ class AppDomain extends Domain {
     final Map<String, Object?>? result = await device.vmService!.invokeFlutterExtensionRpcRaw(
       methodName,
       args: params,
-      isolateId: views.first.uiIsolate!.id!,
+      isolateId: views.first.uiIsolate!.id,
     );
     if (result == null) {
       throw DaemonException('method not available: $methodName');

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -380,13 +380,15 @@ class UpdateFSReport {
     Duration compileDuration = Duration.zero,
     Duration transferDuration = Duration.zero,
     Duration findInvalidatedDuration = Duration.zero,
+    bool hotReloadRejected = false,
   }) : _success = success,
        _invalidatedSourcesCount = invalidatedSourcesCount,
        _syncedBytes = syncedBytes,
        _scannedSourcesCount = scannedSourcesCount,
        _compileDuration = compileDuration,
        _transferDuration = transferDuration,
-       _findInvalidatedDuration = findInvalidatedDuration;
+       _findInvalidatedDuration = findInvalidatedDuration,
+       _hotReloadRejected = hotReloadRejected;
 
   bool get success => _success;
   int get invalidatedSourcesCount => _invalidatedSourcesCount;
@@ -396,6 +398,12 @@ class UpdateFSReport {
   Duration get transferDuration => _transferDuration;
   Duration get findInvalidatedDuration => _findInvalidatedDuration;
 
+  /// Whether there was a hot reload rejection in this compile.
+  ///
+  /// On the web, hot reload can be rejected during compile time instead of at
+  /// runtime.
+  bool get hotReloadRejected => _hotReloadRejected;
+
   bool _success;
   int _invalidatedSourcesCount;
   int _syncedBytes;
@@ -403,6 +411,7 @@ class UpdateFSReport {
   Duration _compileDuration;
   Duration _transferDuration;
   Duration _findInvalidatedDuration;
+  bool _hotReloadRejected;
 
   void incorporateResults(UpdateFSReport report) {
     if (!report._success) {
@@ -414,6 +423,9 @@ class UpdateFSReport {
     _compileDuration += report._compileDuration;
     _transferDuration += report._transferDuration;
     _findInvalidatedDuration += report._findInvalidatedDuration;
+    if (report._hotReloadRejected) {
+      _hotReloadRejected = true;
+    }
   }
 }
 

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -1139,7 +1139,14 @@ class WebDevFS implements DevFS {
       recompileRestart: fullRestart,
     );
     if (compilerOutput == null || compilerOutput.errorCount > 0) {
-      return UpdateFSReport();
+      return UpdateFSReport(
+        // TODO(srujzs): We're currently reliant on compile error string parsing
+        // as hot reload rejections are sent to stderr just like other
+        // compilation errors. Ideally, we should have some shared parsing
+        // functionality, but that would require a shared package.
+        // See https://github.com/dart-lang/sdk/issues/60275.
+        hotReloadRejected: compilerOutput?.errorMessage?.contains('Hot reload rejected') ?? false,
+      );
     }
 
     // Only update the last compiled time if we successfully compiled.

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -432,19 +432,40 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       status = _logger.startProgress('Performing hot reload...', progressId: 'hot.reload');
     }
 
+    final String targetPlatform = getNameForTargetPlatform(TargetPlatform.web_javascript);
+    final String sdkName = await device!.device!.sdkNameAndVersion;
+
+    late UpdateFSReport report;
     if (debuggingOptions.buildInfo.isDebug && !debuggingOptions.webUseWasm) {
       await runSourceGenerators();
       // Don't reset the resident compiler for web, since the extra recompile is
       // wasteful.
-      final UpdateFSReport report = await _updateDevFS(
-        fullRestart: fullRestart,
-        resetCompiler: false,
-      );
+      report = await _updateDevFS(fullRestart: fullRestart, resetCompiler: false);
       if (report.success) {
         device!.generator!.accept();
       } else {
         status.stop();
         await device!.generator!.reject();
+        if (report.hotReloadRejected) {
+          // We cannot capture the reason why the reload was rejected as it may
+          // contain user information.
+          HotEvent(
+            'reload-reject',
+            targetPlatform: targetPlatform,
+            sdkName: sdkName,
+            emulator: false,
+            fullRestart: fullRestart,
+          ).send();
+          _analytics.send(
+            Event.hotRunnerInfo(
+              label: 'reload-reject',
+              targetPlatform: targetPlatform,
+              sdkName: sdkName,
+              emulator: false,
+              fullRestart: fullRestart,
+            ),
+          );
+        }
         return OperationResult(1, 'Failed to recompile application.');
       }
     } else {
@@ -469,6 +490,8 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       }
     }
 
+    late Duration reloadDuration;
+    late Duration reassembleDuration;
     try {
       if (!deviceIsDebuggable) {
         _logger.printStatus('Recompile complete. Page requires refresh.');
@@ -482,7 +505,9 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         } else {
           // Isolates don't work on web. For lack of a better value, pass an
           // empty string for the isolate id.
+          final DateTime reloadStart = _systemClock.now();
           final vmservice.ReloadReport report = await _vmService.service.reloadSources('');
+          reloadDuration = _systemClock.now().difference(reloadStart);
           final ReloadReportContents contents = ReloadReportContents.fromReloadReport(report);
           final bool success = contents.success ?? false;
           if (!success) {
@@ -497,6 +522,21 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
               _logger.printError(reason.toString());
             }
             return OperationResult(1, reloadFailedMessage);
+          }
+          String? failedReassemble;
+          final DateTime reassembleStart = _systemClock.now();
+          await _vmService
+              .flutterReassemble(isolateId: null)
+              .then(
+                (Object? o) => o,
+                onError: (Object error, StackTrace stackTrace) {
+                  failedReassemble = 'Reassembling failed: $error\n$stackTrace';
+                  _logger.printError(failedReassemble!);
+                },
+              );
+          reassembleDuration = _systemClock.now().difference(reassembleStart);
+          if (failedReassemble != null) {
+            return OperationResult(1, failedReassemble!);
           }
         }
       } else {
@@ -522,11 +562,6 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
 
     // Don't track restart times for dart2js builds or web-server devices.
     if (debuggingOptions.buildInfo.isDebug && deviceIsDebuggable) {
-      // TODO(srujzs): There are a number of fields that the VM tracks in the
-      // analytics that we do not for both hot restart and reload. We should
-      // unify that.
-      final String targetPlatform = getNameForTargetPlatform(TargetPlatform.web_javascript);
-      final String sdkName = await device!.device!.sdkNameAndVersion;
       if (fullRestart) {
         _analytics.send(
           Event.timing(
@@ -543,6 +578,12 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           fullRestart: true,
           reason: reason,
           overallTimeInMs: elapsed.inMilliseconds,
+          syncedBytes: report.syncedBytes,
+          invalidatedSourcesCount: report.invalidatedSourcesCount,
+          transferTimeInMs: report.transferDuration.inMilliseconds,
+          compileTimeInMs: report.compileDuration.inMilliseconds,
+          findInvalidatedTimeInMs: report.findInvalidatedDuration.inMilliseconds,
+          scannedSourcesCount: report.scannedSourcesCount,
         ).send();
         _analytics.send(
           Event.hotRunnerInfo(
@@ -553,6 +594,12 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
             fullRestart: true,
             reason: reason,
             overallTimeInMs: elapsed.inMilliseconds,
+            syncedBytes: report.syncedBytes,
+            invalidatedSourcesCount: report.invalidatedSourcesCount,
+            transferTimeInMs: report.transferDuration.inMilliseconds,
+            compileTimeInMs: report.compileDuration.inMilliseconds,
+            findInvalidatedTimeInMs: report.findInvalidatedDuration.inMilliseconds,
+            scannedSourcesCount: report.scannedSourcesCount,
           ),
         );
       } else {
@@ -571,6 +618,14 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           fullRestart: false,
           reason: reason,
           overallTimeInMs: elapsed.inMilliseconds,
+          syncedBytes: report.syncedBytes,
+          invalidatedSourcesCount: report.invalidatedSourcesCount,
+          transferTimeInMs: report.transferDuration.inMilliseconds,
+          compileTimeInMs: report.compileDuration.inMilliseconds,
+          findInvalidatedTimeInMs: report.findInvalidatedDuration.inMilliseconds,
+          scannedSourcesCount: report.scannedSourcesCount,
+          reassembleTimeInMs: reassembleDuration.inMilliseconds,
+          reloadVMTimeInMs: reloadDuration.inMilliseconds,
         ).send();
         _analytics.send(
           Event.hotRunnerInfo(
@@ -581,6 +636,14 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
             fullRestart: false,
             reason: reason,
             overallTimeInMs: elapsed.inMilliseconds,
+            syncedBytes: report.syncedBytes,
+            invalidatedSourcesCount: report.invalidatedSourcesCount,
+            transferTimeInMs: report.transferDuration.inMilliseconds,
+            compileTimeInMs: report.compileDuration.inMilliseconds,
+            findInvalidatedTimeInMs: report.findInvalidatedDuration.inMilliseconds,
+            scannedSourcesCount: report.scannedSourcesCount,
+            reassembleTimeInMs: reassembleDuration.inMilliseconds,
+            reloadVMTimeInMs: reloadDuration.inMilliseconds,
           ),
         );
       }

--- a/packages/flutter_tools/lib/src/resident_devtools_handler.dart
+++ b/packages/flutter_tools/lib/src/resident_devtools_handler.dart
@@ -298,7 +298,7 @@ class FlutterResidentDevtoolsHandler implements ResidentDevtoolsHandler {
     await device.vmService!.invokeFlutterExtensionRpcRaw(
       method,
       args: params,
-      isolateId: views.first.uiIsolate!.id!,
+      isolateId: views.first.uiIsolate!.id,
     );
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1416,7 +1416,7 @@ Future<ReassembleResult> _defaultReassembleHelper(
         // If the tool identified a change in a single widget, do a fast instead
         // of a full reassemble.
         final Future<void> reassembleWork = device.vmService!.flutterReassemble(
-          isolateId: view.uiIsolate!.id!,
+          isolateId: view.uiIsolate!.id,
         );
         reassembleFutures.add(
           reassembleWork.then(

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -684,7 +684,7 @@ class FlutterVmService {
     );
   }
 
-  Future<Map<String, Object?>?> flutterReassemble({required String isolateId}) {
+  Future<Map<String, Object?>?> flutterReassemble({required String? isolateId}) {
     return invokeFlutterExtensionRpcRaw('ext.flutter.reassemble', isolateId: isolateId);
   }
 
@@ -803,12 +803,12 @@ class FlutterVmService {
   /// available, returns null.
   Future<Map<String, Object?>?> invokeFlutterExtensionRpcRaw(
     String method, {
-    required String isolateId,
+    required String? isolateId,
     Map<String, Object?>? args,
   }) async {
     final vm_service.Response? response = await _checkedCallServiceExtension(
       method,
-      args: <String, Object?>{'isolateId': isolateId, ...?args},
+      args: <String, Object?>{if (isolateId != null) 'isolateId': isolateId, ...?args},
     );
     return response?.json;
   }

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   archive: 3.6.1
   args: 2.6.0
   dds: 5.0.0
-  dwds: 24.3.6
+  dwds: 24.3.7
   code_builder: 4.10.1
   completion: 1.0.1
   coverage: 1.11.1
@@ -122,4 +122,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 5a6c
+# PUBSPEC CHECKSUM: 776d

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -261,6 +261,11 @@ class FakeWebDevice extends Fake implements Device {
   }
 
   @override
+  Future<String> get sdkNameAndVersion async {
+    return 'Flutter Tools';
+  }
+
+  @override
   Future<LaunchResult> startApp(
     ApplicationPackage? package, {
     String? mainPath,


### PR DESCRIPTION
https://github.com/dart-lang/webdev/issues/2584

Reassemble was being called in DWDS in the injected client until v24.3.7. Flutter tools should now instead be the one to call the service extension. Now that it's in Flutter tools, we can also report how long it took. Similarly, we should update analytics on various things like, whether there was a reload rejection, how long the compile took, and more.

Adds test to check that these analytics are being reported correctly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
