### PR TITLE
[tool, web] Go back to --dump-info for dart2js

### DIFF
--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -122,7 +122,7 @@ class JsCompilerConfig extends WebCompilerConfig {
     if (buildMode != BuildMode.release) '--no-minify',
     ...toSharedCommandOptions(buildMode),
     '-O${optimizationLevelForBuildMode(buildMode)}',
-    if (dumpInfo) '--stage=dump-info-all',
+    if (dumpInfo) '--dump-info',
     if (noFrequencyBasedMinification) '--no-frequency-based-minification',
     if (csp) '--csp',
   ];

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -1071,7 +1071,7 @@ name: foo
             '--no-minify',
             '--no-source-maps',
             '-O4',
-            '--stage=dump-info-all',
+            '--dump-info',
             '-o',
             environment.buildDir.childFile('main.dart.js').absolute.path,
             environment.buildDir.childFile('app.dill').absolute.path,


### PR DESCRIPTION
SDK was updated at https://github.com/dart-lang/sdk/commit/1722d6791c15042f4b824c9672ce5bb2d628b6d9
