### PR TITLE
[native assets] Add the native asset manifest to the bundle dependencies in non-debug modes

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -123,7 +123,7 @@ class ReleaseCopyFlutterBundle extends CopyFlutterBundle {
   List<String> get depfiles => const <String>['flutter_assets.d'];
 
   @override
-  List<Target> get dependencies => const <Target>[];
+  List<Target> get dependencies => const <Target>[InstallCodeAssets()];
 }
 
 /// Generate a snapshot of the dart code used in the program.

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -270,7 +270,7 @@ void main() {
   testUsingContext(
     'Release bundle includes native assets',
     () async {
-      List<String> dependencies = <String>[];
+      final List<String> dependencies = <String>[];
       final BuildSystem buildSystem = TestBuildSystem.all(BuildResult(success: true), (
         Target target,
         Environment environment,

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -266,6 +266,35 @@ void main() {
       'build/95b595cca01caa5f0ca0a690339dd7f6.cache.dill.track.dill',
     );
   });
+
+  testUsingContext(
+    'Release bundle includes native assets',
+    () async {
+      List<String> dependencies = <String>[];
+      final BuildSystem buildSystem = TestBuildSystem.all(BuildResult(success: true), (
+        Target target,
+        Environment environment,
+      ) {
+        for (final Target dep in target.dependencies) {
+          dependencies.add(dep.name);
+        }
+      });
+      await BundleBuilder().build(
+        platform: TargetPlatform.ios,
+        buildInfo: BuildInfo.release,
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
+        mainPath: globals.fs.path.join('lib', 'main.dart'),
+        assetDirPath: 'example',
+        depfilePath: 'example.d',
+        buildSystem: buildSystem,
+      );
+      expect(dependencies, contains('install_code_assets'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    },
+  );
 }
 
 class FakeAssetBundle extends Fake implements AssetBundle {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/164149