### PR TITLE
fix(a11y): check for remaining relevant text direction properties

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7566,16 +7566,16 @@ class Semantics extends SingleChildRenderObjectWidget {
     }
 
     final bool containsText =
-        properties.attributedLabel != null ||
         properties.label != null ||
-        properties.attributedDecreasedValue != null ||
-        properties.attributedIncreasedValue != null ||
-        properties.attributedValue != null ||
-        properties.decreasedValue != null ||
-        properties.increasedValue != null ||
+        properties.attributedLabel != null ||
         properties.value != null ||
-        properties.attributedHint != null ||
+        properties.attributedValue != null ||
+        properties.increasedValue != null ||
+        properties.attributedIncreasedValue != null ||
+        properties.decreasedValue != null ||
+        properties.attributedDecreasedValue != null ||
         properties.hint != null ||
+        properties.attributedHint != null ||
         properties.tooltip != null;
 
     if (!containsText) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7568,7 +7568,13 @@ class Semantics extends SingleChildRenderObjectWidget {
     final bool containsText =
         properties.attributedLabel != null ||
         properties.label != null ||
+        properties.attributedDecreasedValue != null ||
+        properties.attributedIncreasedValue != null ||
+        properties.attributedValue != null ||
+        properties.decreasedValue != null ||
+        properties.increasedValue != null ||
         properties.value != null ||
+        properties.attributedHint != null ||
         properties.hint != null ||
         properties.tooltip != null;
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:matcher/matcher.dart';
 
 import 'semantics_tester.dart';
 
@@ -514,6 +515,84 @@ void main() {
       expect(attributedLabel.attributes[0].range, const TextRange(start: 0, end: 5));
       expect(attributedLabel.attributes[1] is SpellOutStringAttribute, isTrue);
       expect(attributedLabel.attributes[1].range, const TextRange(start: 15, end: 17));
+    });
+
+    testWidgets('Semantics with attributedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Semantics(
+            attributedValue: AttributedString('test value'),
+            child: const Placeholder(),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('Semantics with attributedDecreasedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Semantics(
+            attributedDecreasedValue: AttributedString('test value'),
+            child: const Placeholder(),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('Semantics with attributedIncreasedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Semantics(
+            attributedIncreasedValue: AttributedString('test value'),
+            child: const Placeholder(),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('Semantics with decreasedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Semantics(
+            decreasedValue: 'test value',
+            child: const Placeholder(),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('Semantics with increasedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Semantics(
+            increasedValue: 'test value',
+            child: const Placeholder(),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('Semantics with attributedHint should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Semantics(
+            attributedHint: AttributedString('test value'),
+            child: const Placeholder(),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
     });
   });
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -565,12 +565,7 @@ void main() {
       'Semantics with decreasedValue should be recognized as containing text and not fail',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            home: Semantics(
-              decreasedValue: 'test value',
-              child: const Placeholder(),
-            ),
-          ),
+          MaterialApp(home: Semantics(decreasedValue: 'test value', child: const Placeholder())),
         );
         expect(tester.takeException(), isNull);
       },
@@ -580,12 +575,7 @@ void main() {
       'Semantics with increasedValue should be recognized as containing text and not fail',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            home: Semantics(
-              increasedValue: 'test value',
-              child: const Placeholder(),
-            ),
-          ),
+          MaterialApp(home: Semantics(increasedValue: 'test value', child: const Placeholder())),
         );
         expect(tester.takeException(), isNull);
       },

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -516,8 +516,7 @@ void main() {
       expect(attributedLabel.attributes[1].range, const TextRange(start: 15, end: 17));
     });
 
-    testWidgets('Semantics with attributedValue should be recognized as containing text and not fail',
-      (WidgetTester tester) async {
+    testWidgets('Semantics with attributedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Semantics(
@@ -529,8 +528,7 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('Semantics with attributedDecreasedValue should be recognized as containing text and not fail',
-      (WidgetTester tester) async {
+    testWidgets('Semantics with attributedDecreasedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Semantics(
@@ -542,8 +540,7 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('Semantics with attributedIncreasedValue should be recognized as containing text and not fail',
-      (WidgetTester tester) async {
+    testWidgets('Semantics with attributedIncreasedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Semantics(
@@ -555,8 +552,7 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('Semantics with decreasedValue should be recognized as containing text and not fail',
-      (WidgetTester tester) async {
+    testWidgets('Semantics with decreasedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Semantics(
@@ -568,8 +564,7 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('Semantics with increasedValue should be recognized as containing text and not fail',
-      (WidgetTester tester) async {
+    testWidgets('Semantics with increasedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Semantics(
@@ -581,8 +576,7 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('Semantics with attributedHint should be recognized as containing text and not fail',
-      (WidgetTester tester) async {
+    testWidgets('Semantics with attributedHint should be recognized as containing text and not fail', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Semantics(

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -15,7 +15,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:matcher/matcher.dart';
 
 import 'semantics_tester.dart';
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -516,77 +516,95 @@ void main() {
       expect(attributedLabel.attributes[1].range, const TextRange(start: 15, end: 17));
     });
 
-    testWidgets('Semantics with attributedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Semantics(
-            attributedValue: AttributedString('test value'),
-            child: const Placeholder(),
+    testWidgets(
+      'Semantics with attributedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Semantics(
+              attributedValue: AttributedString('test value'),
+              child: const Placeholder(),
+            ),
           ),
-        ),
-      );
-      expect(tester.takeException(), isNull);
-    });
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
 
-    testWidgets('Semantics with attributedDecreasedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Semantics(
-            attributedDecreasedValue: AttributedString('test value'),
-            child: const Placeholder(),
+    testWidgets(
+      'Semantics with attributedDecreasedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Semantics(
+              attributedDecreasedValue: AttributedString('test value'),
+              child: const Placeholder(),
+            ),
           ),
-        ),
-      );
-      expect(tester.takeException(), isNull);
-    });
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
 
-    testWidgets('Semantics with attributedIncreasedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Semantics(
-            attributedIncreasedValue: AttributedString('test value'),
-            child: const Placeholder(),
+    testWidgets(
+      'Semantics with attributedIncreasedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Semantics(
+              attributedIncreasedValue: AttributedString('test value'),
+              child: const Placeholder(),
+            ),
           ),
-        ),
-      );
-      expect(tester.takeException(), isNull);
-    });
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
 
-    testWidgets('Semantics with decreasedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Semantics(
-            decreasedValue: 'test value',
-            child: const Placeholder(),
+    testWidgets(
+      'Semantics with decreasedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Semantics(
+              decreasedValue: 'test value',
+              child: const Placeholder(),
+            ),
           ),
-        ),
-      );
-      expect(tester.takeException(), isNull);
-    });
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
 
-    testWidgets('Semantics with increasedValue should be recognized as containing text and not fail', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Semantics(
-            increasedValue: 'test value',
-            child: const Placeholder(),
+    testWidgets(
+      'Semantics with increasedValue should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Semantics(
+              increasedValue: 'test value',
+              child: const Placeholder(),
+            ),
           ),
-        ),
-      );
-      expect(tester.takeException(), isNull);
-    });
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
 
-    testWidgets('Semantics with attributedHint should be recognized as containing text and not fail', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Semantics(
-            attributedHint: AttributedString('test value'),
-            child: const Placeholder(),
+    testWidgets(
+      'Semantics with attributedHint should be recognized as containing text and not fail',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Semantics(
+              attributedHint: AttributedString('test value'),
+              child: const Placeholder(),
+            ),
           ),
-        ),
-      );
-      expect(tester.takeException(), isNull);
-    });
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
   });
 
   group('Row', () {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

We faced an issue that the assert at https://github.com/flutter/flutter/blob/3.29.1/packages/flutter/lib/src/semantics/semantics.dart#L497-L500 was triggering although our widget was placed under a `MaterialApp` and therefore had a text direction set.

Turns out that `_getTextDirection()` just was not checking for `attributedValue`, etc.

Related issue: https://github.com/flutter/flutter/issues/165051
fixes https://github.com/flutter/flutter/issues/165051
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
