### PR TITLE
[Impeller] fix crash when loading shader before AiksContext is initialized.

### DIFF
--- a/engine/src/flutter/shell/common/rasterizer.cc
+++ b/engine/src/flutter/shell/common/rasterizer.cc
@@ -457,7 +457,9 @@ sk_sp<SkImage> Rasterizer::ConvertToRasterImage(sk_sp<SkImage> image) {
 // |SnapshotDelegate|
 void Rasterizer::CacheRuntimeStage(
     const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) {
-  snapshot_controller_->CacheRuntimeStage(runtime_stage);
+  if (snapshot_controller_) {
+    snapshot_controller_->CacheRuntimeStage(runtime_stage);
+  }
 }
 
 fml::Milliseconds Rasterizer::GetFrameBudget() const {

--- a/engine/src/flutter/shell/common/rasterizer.h
+++ b/engine/src/flutter/shell/common/rasterizer.h
@@ -674,7 +674,6 @@ class Rasterizer final : public SnapshotDelegate,
   bool IsAiksContextInitialized() const override {
 #if IMPELLER_SUPPORTS_RENDERING
     return surface_ && surface_->GetAiksContext();
-    return false;
 #else
     return false;
 #endif

--- a/engine/src/flutter/shell/common/rasterizer.h
+++ b/engine/src/flutter/shell/common/rasterizer.h
@@ -671,6 +671,16 @@ class Rasterizer final : public SnapshotDelegate,
   }
 
   // |SnapshotController::Delegate|
+  bool IsAiksContextInitialized() const override {
+#if IMPELLER_SUPPORTS_RENDERING
+    return surface_ && surface_->GetAiksContext();
+    return false;
+#else
+    return false;
+#endif
+  }
+
+  // |SnapshotController::Delegate|
   std::shared_ptr<impeller::AiksContext> GetAiksContext() const override {
 #if IMPELLER_SUPPORTS_RENDERING
     if (surface_) {

--- a/engine/src/flutter/shell/common/rasterizer_unittests.cc
+++ b/engine/src/flutter/shell/common/rasterizer_unittests.cc
@@ -135,6 +135,18 @@ TEST(RasterizerTest, create) {
   EXPECT_TRUE(rasterizer != nullptr);
 }
 
+TEST(RasterizerTest, isAiksContextInitialized) {
+  NiceMock<MockDelegate> delegate;
+  Settings settings;
+  ON_CALL(delegate, GetSettings()).WillByDefault(ReturnRef(settings));
+  auto rasterizer = std::make_shared<Rasterizer>(delegate);
+
+  EXPECT_TRUE(rasterizer != nullptr);
+  std::shared_ptr<SnapshotController::Delegate> snapshot_delegate = rasterizer;
+
+  EXPECT_FALSE(snapshot_delegate->IsAiksContextInitialized());
+}
+
 static std::unique_ptr<FrameTimingsRecorder> CreateFinishedBuildRecorder(
     fml::TimePoint timestamp) {
   std::unique_ptr<FrameTimingsRecorder> recorder =

--- a/engine/src/flutter/shell/common/snapshot_controller.h
+++ b/engine/src/flutter/shell/common/snapshot_controller.h
@@ -24,6 +24,7 @@ class SnapshotController {
    public:
     virtual ~Delegate() = default;
     virtual const std::unique_ptr<Surface>& GetSurface() const = 0;
+    virtual bool IsAiksContextInitialized() const = 0;
     virtual std::shared_ptr<impeller::AiksContext> GetAiksContext() const = 0;
     virtual const std::unique_ptr<SnapshotSurfaceProducer>&
     GetSnapshotSurfaceProducer() const = 0;

--- a/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
+++ b/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
@@ -146,12 +146,15 @@ sk_sp<DlImage> SnapshotControllerImpeller::MakeRasterSnapshotSync(
 
 void SnapshotControllerImpeller::CacheRuntimeStage(
     const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) {
-  impeller::RuntimeEffectContents runtime_effect;
-  runtime_effect.SetRuntimeStage(runtime_stage);
+  if (!GetDelegate().IsAiksContextInitialized()) {
+    return;
+  }
   auto context = GetDelegate().GetAiksContext();
   if (!context) {
     return;
   }
+  impeller::RuntimeEffectContents runtime_effect;
+  runtime_effect.SetRuntimeStage(runtime_stage);
   runtime_effect.BootstrapShader(context->GetContentContext());
 }
 


### PR DESCRIPTION
If the aiks context isn't initialized, we will create one on the fly which can actually crash on the GLES backend. Add a check if the context is already initialized and cancel precaching of the shader which triggers this crash. The precache is only a performance improvement and is not critical for usability.

Fixes https://github.com/flutter/flutter/issues/164757