### PR TITLE
Change fallback behavior for devices pre API 29 to Skia regardless of Impeller state.

### DIFF
--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -31,7 +31,7 @@
 
 namespace flutter {
 
-constexpr int kMinimumAndroidApiLevelForVulkan = 29;
+constexpr int kMinimumAndroidApiLevelForImpeller = 29;
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
@@ -301,14 +301,14 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
 #endif
 
   if (settings.enable_impeller) {
-    // Vulkan must only be used on API level 29+, as older API levels do not
+    // Impeller must only be used on API level 29+, as older API levels do not
     // have requisite features to support platform views.
     //
     // Even if this check returns true, Impeller may determine it cannot use
     // Vulkan for some other reason, such as a missing required extension or
-    // feature.
-    if (api_level < kMinimumAndroidApiLevelForVulkan) {
-      return kVulkanUnsupportedFallback;
+    // feature. In these cases it will use OpenGLES.
+    if (api_level < kMinimumAndroidApiLevelForImpeller) {
+      return AndroidRenderingAPI::kSkiaOpenGLES;
     }
     char product_model[PROP_VALUE_MAX];
     __system_property_get("ro.product.model", product_model);
@@ -321,6 +321,7 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
     if (strcmp(product_model, kAndroidHuawei) == 0) {
       // Avoid using Vulkan on Huawei as AHB imports do not
       // consistently work.
+      return kVulkanUnsupportedFallback;
     }
 
     if (__system_property_find("ro.vendor.mediatek.platform") != nullptr) {


### PR DESCRIPTION
There are currently a large amount of crashes coming from older devices that we don't have good test coverage for. For now, lets remove the fallback to ImpellerGLES on old devices and instead use SkiaGLES, which we know from experience works on these older devices.