### PR TITLE
Changes message when web folder is not present

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -218,7 +218,10 @@ class BuildWebCommand extends BuildSubCommand {
       );
     }
     if (!project.web.existsSync()) {
-      throwToolExit('Run flutter create . --platforms web');
+      throwToolExit(
+        'This project is not configured for the web.\n'
+        'To configure this project for the web, run flutter create . --platforms web',
+      );
     }
     if (!_fileSystem.currentDirectory
             .childDirectory('web')

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -218,7 +218,7 @@ class BuildWebCommand extends BuildSubCommand {
       );
     }
     if (!project.web.existsSync()) {
-      throwToolExit('Missing index.html.');
+      throwToolExit('Run flutter create . --platforms web');
     }
     if (!_fileSystem.currentDirectory
             .childDirectory('web')

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -483,6 +483,33 @@ void main() {
       ProcessManager: () => processManager,
     },
   );
+
+  testUsingContext(
+    'Refuses to build for web when folder is missing',
+    () async {
+      fileSystem.file(fileSystem.path.join('web')).deleteSync(recursive: true);
+      final CommandRunner<void> runner = createTestCommandRunner(
+        BuildCommand(
+          androidSdk: FakeAndroidSdk(),
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          fileSystem: fileSystem,
+          logger: logger,
+          osUtils: FakeOperatingSystemUtils(),
+        ),
+      );
+
+      expect(
+        () => runner.run(<String>['build', 'web', '--no-pub']),
+        throwsToolExit(message: 'Run flutter create . --platforms web'),
+      );
+    },
+    overrides: <Type, Generator>{
+      Platform: () => fakePlatform,
+      FileSystem: () => fileSystem,
+      FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+      ProcessManager: () => processManager,
+    },
+  );
 }
 
 void setupFileSystemForEndToEndTest(FileSystem fileSystem) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -63,7 +63,7 @@ void main() {
 
       expect(
         () => runner.run(<String>['build', 'web', '--no-pub']),
-        throwsToolExit(message: 'Missing index.html.'),
+        throwsToolExit(message: 'Run flutter create . --platforms web'),
       );
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -63,7 +63,11 @@ void main() {
 
       expect(
         () => runner.run(<String>['build', 'web', '--no-pub']),
-        throwsToolExit(message: 'Run flutter create . --platforms web'),
+        throwsToolExit(
+          message:
+              'This project is not configured for the web.\n'
+              'To configure this project for the web, run flutter create . --platforms web',
+        ),
       );
     },
     overrides: <Type, Generator>{
@@ -500,7 +504,11 @@ void main() {
 
       expect(
         () => runner.run(<String>['build', 'web', '--no-pub']),
-        throwsToolExit(message: 'Run flutter create . --platforms web'),
+        throwsToolExit(
+          message:
+              'This project is not configured for the web.\n'
+              'To configure this project for the web, run flutter create . --platforms web',
+        ),
       );
     },
     overrides: <Type, Generator>{


### PR DESCRIPTION
This PR addresses: https://github.com/flutter/flutter/issues/164921

The old message for when the web folder wasnt present and a build for web command was executed the following message was thrown:
```Missing index.html.```

The new message is going to be:

```Run flutter create . --platforms web```

<img width="1087" alt="Screenshot 2025-03-12 at 5 16 15 PM" src="https://github.com/user-attachments/assets/0676083e-03a5-4bea-afac-8321eb9358f9" />
<img width="1440" alt="Screenshot 2025-03-12 at 5 33 15 PM" src="https://github.com/user-attachments/assets/4eab879c-23d8-4bd0-b08a-a5728009a943" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md