### PR TITLE
[CP] Change fallback behavior for devices pre API 29 to Skia regardless of Impeller state.

### DIFF
--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -35,7 +35,7 @@
 
 namespace flutter {
 
-constexpr int kMinimumAndroidApiLevelForVulkan = 29;
+constexpr int kMinimumAndroidApiLevelForImpeller = 29;
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
@@ -295,15 +295,15 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
 #endif
 
   if (settings.enable_impeller) {
-    // Vulkan must only be used on API level 29+, as older API levels do not
+    // Impeller must only be used on API level 29+, as older API levels do not
     // have requisite features to support platform views.
     //
     // Even if this check returns true, Impeller may determine it cannot use
     // Vulkan for some other reason, such as a missing required extension or
     // feature.
     int api_level = android_get_device_api_level();
-    if (api_level < kMinimumAndroidApiLevelForVulkan) {
-      return kVulkanUnsupportedFallback;
+    if (api_level < kMinimumAndroidApiLevelForImpeller) {
+      return AndroidRenderingAPI::kSkiaOpenGLES;
     }
     char product_model[PROP_VALUE_MAX];
     __system_property_get("ro.product.model", product_model);


### PR DESCRIPTION
CP of https://github.com/flutter/flutter/pull/165075

> There are currently a large amount of crashes coming from older devices that we don't have good test coverage for. For now, lets remove the fallback to ImpellerGLES on old devices and instead use SkiaGLES, which we know from experience works on these older devices.