### PR TITLE
[Impeller] fix validation check when restoring to onscreen with BDF and mips.

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
@@ -20,6 +20,7 @@
 #include "flutter/display_list/dl_paint.h"
 #include "flutter/testing/testing.h"
 #include "fml/synchronization/count_down_latch.h"
+#include "gtest/gtest.h"
 #include "imgui.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/device_buffer.h"
@@ -30,6 +31,7 @@
 #include "impeller/display_list/dl_dispatcher.h"
 #include "impeller/display_list/dl_image_impeller.h"
 #include "impeller/geometry/scalar.h"
+#include "impeller/playground/playground.h"
 
 namespace impeller {
 namespace testing {
@@ -1117,6 +1119,27 @@ TEST_P(AiksTest, DisplayListToTextureAllocationFailure) {
       DisplayListToTexture(builder.Build(), ISize{0, 0}, aiks_context);
 
   EXPECT_EQ(texture, nullptr);
+}
+
+TEST_P(AiksTest, DisplayListToTextureWithMipGenerationOnGLES) {
+  if (GetBackend() != PlaygroundBackend::kOpenGLES) {
+    GTEST_SKIP() << "Only relevant for GLES";
+  }
+  DisplayListBuilder builder;
+
+  std::shared_ptr<DlImageFilter> filter =
+      DlImageFilter::MakeBlur(8, 8, DlTileMode::kClamp);
+  builder.SaveLayer(std::nullopt, nullptr, filter.get());
+  builder.Restore();
+
+  AiksContext aiks_context(GetContext(), nullptr);
+  // Use intentionally invalid dimensions that would trigger an allocation
+  // failure.
+  auto texture =
+      DisplayListToTexture(builder.Build(), ISize{10, 10}, aiks_context,
+                           /*reset_host_buffer=*/true, /*generate_mips=*/true);
+
+  EXPECT_FALSE(texture->NeedsMipmapGeneration());
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1792,9 +1792,10 @@ void Canvas::EndReplay() {
   if (requires_readback_) {
     BlitToOnscreen(/*is_onscreen_=*/is_onscreen_);
   }
-
-  if (!EnsureFinalMipmapGeneration() ||
-      !renderer_.GetContext()->FlushCommandBuffers()) {
+  if (!EnsureFinalMipmapGeneration()) {
+    VALIDATION_LOG << "Failed to generate onscreen mipmaps.";
+  }
+  if (!renderer_.GetContext()->FlushCommandBuffers()) {
     // Not much we can do.
     VALIDATION_LOG << "Failed to submit command buffers";
   }

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1116,7 +1116,6 @@ void Canvas::SaveLayer(const Paint& paint,
       const bool should_use_onscreen =
           renderer_.GetDeviceCapabilities().SupportsFramebufferFetch() &&
           backdrop_count_ == 0 && render_passes_.size() == 1u;
-      FML_LOG(ERROR) << "should_use_onscreen: " << should_use_onscreen;
       input_texture = FlipBackdrop(
           GetGlobalPassPosition(),                                //
           /*should_remove_texture=*/will_cache_backdrop_texture,  //

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -263,6 +263,10 @@ class Canvas {
   // Visible for testing.
   bool SupportsBlitToOnscreen() const;
 
+  /// For picture snapshots we need addition steps to verify that final mipmaps
+  /// are generated.
+  bool EnsureFinalMipmapGeneration() const;
+
  private:
   ContentContext& renderer_;
   RenderTarget render_target_;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/163421

If we restore to the onscreen but need to generate mips (because its a toImage call) then we could miss the mip map generation. This will primarily happen on Android emulators as they do not support framebuffer fetch.