### PR TITLE
[Impeller] Enable mediatek on API 34+.

### DIFF
--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -32,6 +32,7 @@
 namespace flutter {
 
 constexpr int kMinimumAndroidApiLevelForImpeller = 29;
+constexpr int kMinimumAndroidApiLevelForMediaTekVulkan = 34;
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
@@ -324,9 +325,10 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
       return kVulkanUnsupportedFallback;
     }
 
-    if (api_level < 34 &&
+    if (api_level < kMinimumAndroidApiLevelForMediaTekVulkan &&
         __system_property_find("ro.vendor.mediatek.platform") != nullptr) {
-      // Probably MediaTek. Avoid Vulkan if older.
+      // Probably MediaTek. Avoid Vulkan if older than 34 to work around
+      // crashes when importing AHB.
       return kVulkanUnsupportedFallback;
     }
 

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -324,8 +324,9 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
       return kVulkanUnsupportedFallback;
     }
 
-    if (__system_property_find("ro.vendor.mediatek.platform") != nullptr) {
-      // Probably MediaTek. Avoid Vulkan.
+    if (api_level < 34 &&
+        __system_property_find("ro.vendor.mediatek.platform") != nullptr) {
+      // Probably MediaTek. Avoid Vulkan if older.
       return kVulkanUnsupportedFallback;
     }
 


### PR DESCRIPTION
Most of the reported Mediatek issues are API 29/30, maybe up to 31. By 34 it should work, and the mokey device we have works fine with Vulkan and runs on CI. This is necessary to allow MediaTek devices to use HCPP without us having to write a new rendering surface abstraction for GL.

This does _not_ enable PowerVR, which is still denylisted in the vulkan backend.