### PR TITLE
Feat: Add a11y for loading indicators

### DIFF
--- a/engine/src/flutter/lib/ui/fixtures/ui_test.dart
+++ b/engine/src/flutter/lib/ui/fixtures/ui_test.dart
@@ -258,6 +258,8 @@ void sendSemanticsUpdate() {
     controlsNodes: null,
     inputType: SemanticsInputType.none,
     locale: null,
+    minValue: '0',
+    maxValue: '0',
   );
   _semanticsUpdate(builder.build());
 }
@@ -319,6 +321,8 @@ void sendSemanticsUpdateWithRole() {
     controlsNodes: null,
     inputType: SemanticsInputType.none,
     locale: null,
+    minValue: '0',
+    maxValue: '0',
   );
   _semanticsUpdate(builder.build());
 }
@@ -380,6 +384,8 @@ void sendSemanticsUpdateWithLocale() {
     controlsNodes: null,
     inputType: SemanticsInputType.none,
     locale: Locale('es', 'MX'),
+    minValue: '0',
+    maxValue: '0',
   );
   _semanticsUpdate(builder.build());
 }
@@ -436,6 +442,8 @@ void sendSemanticsUpdateWithIsLink() {
     controlsNodes: null,
     inputType: SemanticsInputType.none,
     locale: Locale('es', 'MX'),
+    minValue: '0',
+    maxValue: '0',
   );
   _semanticsUpdate(builder.build());
 }

--- a/engine/src/flutter/lib/ui/semantics.dart
+++ b/engine/src/flutter/lib/ui/semantics.dart
@@ -1975,6 +1975,8 @@ abstract class SemanticsUpdateBuilder {
     SemanticsHitTestBehavior hitTestBehavior = SemanticsHitTestBehavior.defer,
     required SemanticsInputType inputType,
     required Locale? locale,
+    required String minValue,
+    required String maxValue,
   });
 
   /// Update the custom semantics action associated with the given `id`.
@@ -2056,6 +2058,8 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
     SemanticsHitTestBehavior hitTestBehavior = SemanticsHitTestBehavior.defer,
     required SemanticsInputType inputType,
     required Locale? locale,
+    required String minValue,
+    required String maxValue,
   }) {
     assert(_matrix4IsValid(transform));
     assert(
@@ -2107,6 +2111,8 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
       hitTestBehavior.index,
       inputType.index,
       locale?.toLanguageTag() ?? '',
+      minValue,
+      maxValue,
     );
   }
 
@@ -2157,6 +2163,8 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
       Int32,
       Int32,
       Handle,
+      Handle,
+      Handle,
     )
   >(symbol: 'SemanticsUpdateBuilder::updateNode')
   external void _updateNode(
@@ -2204,6 +2212,8 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1
     int hitTestBehaviorIndex,
     int inputType,
     String locale,
+    String minValue,
+    String maxValue,
   );
 
   @override

--- a/engine/src/flutter/lib/ui/semantics/semantics_node.h
+++ b/engine/src/flutter/lib/ui/semantics/semantics_node.h
@@ -145,6 +145,8 @@ struct SemanticsNode {
   double scrollPosition = std::nan("");
   double scrollExtentMax = std::nan("");
   double scrollExtentMin = std::nan("");
+  std::string minValue;
+  std::string maxValue;
   std::string identifier;
   std::string label;
   StringAttributes labelAttributes;

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.cc
@@ -74,7 +74,9 @@ void SemanticsUpdateBuilder::updateNode(
     int validationResult,
     int hitTestBehavior,
     int inputType,
-    std::string locale) {
+    std::string locale,
+    std::string minValue,
+    std::string maxValue) {
   FML_CHECK(scrollChildren == 0 ||
             (scrollChildren > 0 && childrenInHitTestOrder.data()))
       << "Semantics update contained scrollChildren but did not have "
@@ -96,6 +98,8 @@ void SemanticsUpdateBuilder::updateNode(
   node.scrollPosition = scrollPosition;
   node.scrollExtentMax = scrollExtentMax;
   node.scrollExtentMin = scrollExtentMin;
+  node.minValue = std::move(minValue);
+  node.maxValue = std::move(maxValue);
   node.rect = SkRect::MakeLTRB(SafeNarrow(left), SafeNarrow(top),
                                SafeNarrow(right), SafeNarrow(bottom));
   node.identifier = std::move(identifier);

--- a/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
+++ b/engine/src/flutter/lib/ui/semantics/semantics_update_builder.h
@@ -73,7 +73,9 @@ class SemanticsUpdateBuilder
       int validationResult,
       int hitTestBehavior,
       int inputType,
-      std::string locale);
+      std::string locale,
+      std::string minValue,
+      std::string maxValue);
 
   void updateCustomAction(int id,
                           std::string label,

--- a/engine/src/flutter/lib/web_ui/lib/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/semantics.dart
@@ -753,6 +753,8 @@ class SemanticsUpdateBuilder {
     SemanticsHitTestBehavior hitTestBehavior = SemanticsHitTestBehavior.defer,
     required SemanticsInputType inputType,
     required Locale? locale,
+    required String minValue,
+    required String maxValue,
   }) {
     if (transform.length != 16) {
       throw ArgumentError('transform argument must have 16 entries.');
@@ -800,6 +802,8 @@ class SemanticsUpdateBuilder {
         hitTestBehavior: hitTestBehavior,
         inputType: inputType,
         locale: locale,
+        minValue: minValue,
+        maxValue: maxValue,
       ),
     );
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine.dart
@@ -116,6 +116,7 @@ export 'engine/semantics/list.dart';
 export 'engine/semantics/live_region.dart';
 export 'engine/semantics/menus.dart';
 export 'engine/semantics/platform_view.dart';
+export 'engine/semantics/progress_bar.dart';
 export 'engine/semantics/requirable.dart';
 export 'engine/semantics/route.dart';
 export 'engine/semantics/scrollable.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics.dart
@@ -20,6 +20,7 @@ export 'semantics/list.dart';
 export 'semantics/live_region.dart';
 export 'semantics/menus.dart';
 export 'semantics/platform_view.dart';
+export 'semantics/progress_bar.dart';
 export 'semantics/requirable.dart';
 export 'semantics/scrollable.dart';
 export 'semantics/semantics.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/progress_bar.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/progress_bar.dart
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'label_and_value.dart';
+import 'semantics.dart';
+
+/// Indicates a progress bar element.
+///
+/// Uses aria progressbar role to convey this semantic information to the element.
+///
+/// Screen-readers take advantage of "aria-label" to describe the visual.
+class SemanticsProgressBar extends SemanticRole {
+  SemanticsProgressBar(SemanticsObject semanticsObject)
+    : super.withBasics(
+        EngineSemanticsRole.progressBar,
+        semanticsObject,
+        preferredLabelRepresentation: LabelRepresentation.ariaLabel,
+      ) {
+    setAriaRole('progressbar');
+
+    // Set ARIA attributes for min, max and current value.
+    if (semanticsObject.minValue != null) {
+      setAttribute('aria-valuemin', semanticsObject.minValue!);
+    }
+    if (semanticsObject.maxValue != null) {
+      setAttribute('aria-valuemax', semanticsObject.maxValue!);
+    }
+
+    if (semanticsObject.value != null) {
+      setAttribute('aria-valuenow', semanticsObject.value!);
+    }
+  }
+
+  @override
+  void update() {
+    super.update();
+
+    if (semanticsObject.minValue != null) {
+      setAttribute('aria-valuemin', semanticsObject.minValue!);
+    }
+
+    if (semanticsObject.maxValue != null) {
+      setAttribute('aria-valuemax', semanticsObject.maxValue!);
+    }
+
+    if (semanticsObject.value != null) {
+      setAttribute('aria-valuenow', semanticsObject.value!);
+    }
+  }
+
+  @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
+}
+
+/// Indicates a loading spinner element.
+class SementicsLoadingSpinner extends SemanticRole {
+  SementicsLoadingSpinner(SemanticsObject semanticsObject)
+    : super.withBasics(
+        EngineSemanticsRole.loadingSpinner,
+        semanticsObject,
+        preferredLabelRepresentation: LabelRepresentation.ariaLabel,
+      );
+
+  @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
+}

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -37,6 +37,7 @@ import 'list.dart';
 import 'live_region.dart';
 import 'menus.dart';
 import 'platform_view.dart';
+import 'progress_bar.dart';
 import 'requirable.dart';
 import 'route.dart';
 import 'scrollable.dart';
@@ -275,6 +276,8 @@ class SemanticsNodeUpdate {
     this.hitTestBehavior = ui.SemanticsHitTestBehavior.defer,
     required this.inputType,
     required this.locale,
+    required this.minValue,
+    required this.maxValue,
   });
 
   /// See [ui.SemanticsUpdateBuilder.updateNode].
@@ -399,6 +402,12 @@ class SemanticsNodeUpdate {
 
   /// See [ui.SemanticsUpdateBuilder.updateNode].
   final ui.Locale? locale;
+
+  /// See [ui.SemanticsUpdateBuilder.updateNode].
+  final String minValue;
+
+  /// See [ui.SemanticsUpdateBuilder.updateNode].
+  final String maxValue;
 }
 
 /// Identifies [SemanticRole] implementations.
@@ -502,6 +511,12 @@ enum EngineSemanticsRole {
 
   /// An item in a [list].
   listItem,
+
+  /// A graphic object that shows progress with a numeric number.
+  progressBar,
+
+  /// A graphic object that spins to indicate the application is busy.
+  loadingSpinner,
 
   /// A role used when a more specific role cannot be assigend to
   /// a [SemanticsObject].
@@ -1550,6 +1565,31 @@ class SemanticsObject {
     _dirtyFields |= _hitTestBehaviorIndex;
   }
 
+  String? get minValue => _minValue;
+  String? _minValue;
+
+  static const int _minValueIndex = 1 << 29;
+
+  /// Whether the [minValue] field has been updated but has not been
+  /// applied to the DOM yet.
+  bool get isMinValueDirty => _isDirty(_minValueIndex);
+  void _markMinValueDirty() {
+    _dirtyFields |= _minValueIndex;
+  }
+
+  /// See [ui.SemanticsUpdateBuilder.updateNode].
+  String? get maxValue => _maxValue;
+  String? _maxValue;
+
+  static const int _maxValueIndex = 1 << 30;
+
+  /// Whether the [maxValue] field has been updated but has not been
+  /// applied to the DOM yet.
+  bool get isMaxValueDirty => _isDirty(_maxValueIndex);
+  void _markMaxValueDirty() {
+    _dirtyFields |= _maxValueIndex;
+  }
+
   /// A unique permanent identifier of the semantics node in the tree.
   final int id;
 
@@ -1887,6 +1927,16 @@ class SemanticsObject {
       _markHitTestBehaviorDirty();
     }
 
+    if (_minValue != update.minValue) {
+      _minValue = update.minValue;
+      _markMinValueDirty();
+    }
+
+    if (_maxValue != update.maxValue) {
+      _maxValue = update.maxValue;
+      _markMaxValueDirty();
+    }
+
     role = update.role;
 
     inputType = update.inputType;
@@ -2139,14 +2189,16 @@ class SemanticsObject {
         return EngineSemanticsRole.region;
       case ui.SemanticsRole.form:
         return EngineSemanticsRole.form;
+      case ui.SemanticsRole.loadingSpinner:
+        return EngineSemanticsRole.loadingSpinner;
+      case ui.SemanticsRole.progressBar:
+        return EngineSemanticsRole.progressBar;
       // TODO(chunhtai): implement these roles.
       // https://github.com/flutter/flutter/issues/159741.
       case ui.SemanticsRole.dragHandle:
       case ui.SemanticsRole.spinButton:
       case ui.SemanticsRole.comboBox:
       case ui.SemanticsRole.tooltip:
-      case ui.SemanticsRole.loadingSpinner:
-      case ui.SemanticsRole.progressBar:
       case ui.SemanticsRole.hotKey:
       case ui.SemanticsRole.none:
       // fallback to checking semantics properties.
@@ -2213,6 +2265,8 @@ class SemanticsObject {
       EngineSemanticsRole.menuItemRadio => SemanticMenuItemRadio(this),
       EngineSemanticsRole.alert => SemanticAlert(this),
       EngineSemanticsRole.status => SemanticStatus(this),
+      EngineSemanticsRole.progressBar => SemanticsProgressBar(this),
+      EngineSemanticsRole.loadingSpinner => SementicsLoadingSpinner(this),
       EngineSemanticsRole.generic => GenericRole(this),
       EngineSemanticsRole.complementary => SemanticComplementary(this),
       EngineSemanticsRole.contentInfo => SemanticContentInfo(this),

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -160,6 +160,12 @@ void runSemanticsTests() {
   group('forms', () {
     _testForms();
   });
+  group('progressBar', () {
+    _testProgressBar();
+  });
+  group('loadingSpinner', () {
+    _testLoadingSpinner();
+  });
 }
 
 void _testSemanticRole() {
@@ -6153,6 +6159,55 @@ void _testForms() {
   semantics().semanticsEnabled = false;
 }
 
+void _testProgressBar() {
+  test('nodes with progress bar role', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    SemanticsObject pumpSemantics() {
+      final SemanticsTester tester = SemanticsTester(owner());
+      tester.updateNode(
+        id: 0,
+        role: ui.SemanticsRole.progressBar,
+        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      );
+      tester.apply();
+      return tester.getSemanticsObject(0);
+    }
+
+    final SemanticsObject object = pumpSemantics();
+    expect(object.semanticRole?.kind, EngineSemanticsRole.progressBar);
+    expect(object.element.getAttribute('role'), 'progressbar');
+  });
+
+  semantics().semanticsEnabled = false;
+}
+
+void _testLoadingSpinner() {
+  test('nodes with loading spinner role', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    SemanticsObject pumpSemantics() {
+      final SemanticsTester tester = SemanticsTester(owner());
+      tester.updateNode(
+        id: 0,
+        role: ui.SemanticsRole.loadingSpinner,
+        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      );
+      tester.apply();
+      return tester.getSemanticsObject(0);
+    }
+
+    final SemanticsObject object = pumpSemantics();
+    expect(object.semanticRole?.kind, EngineSemanticsRole.loadingSpinner);
+  });
+
+  semantics().semanticsEnabled = false;
+}
+
 /// A facade in front of [ui.SemanticsUpdateBuilder.updateNode] that
 /// supplies default values for semantics attributes.
 void updateNode(
@@ -6197,6 +6252,8 @@ void updateNode(
   ui.SemanticsHitTestBehavior hitTestBehavior = ui.SemanticsHitTestBehavior.defer,
   ui.SemanticsInputType inputType = ui.SemanticsInputType.none,
   ui.Locale? locale,
+  String minValue = '0',
+  String maxValue = '0',
 }) {
   transform ??= Float64List.fromList(Matrix4.identity().storage);
   hitTestTransform ??= Float64List.fromList(Matrix4.identity().storage);
@@ -6244,6 +6301,8 @@ void updateNode(
     hitTestBehavior: hitTestBehavior,
     inputType: inputType,
     locale: locale,
+    minValue: minValue,
+    maxValue: maxValue,
   );
 }
 

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -92,6 +92,8 @@ class SemanticsTester {
     ui.SemanticsHitTestBehavior hitTestBehavior = ui.SemanticsHitTestBehavior.defer,
     ui.SemanticsInputType inputType = ui.SemanticsInputType.none,
     ui.Locale? locale,
+    String? minValue,
+    String? maxValue,
   }) {
     // Actions
     if (hasTap ?? false) {
@@ -228,6 +230,8 @@ class SemanticsTester {
       hitTestBehavior: hitTestBehavior,
       inputType: inputType,
       locale: locale,
+      minValue: minValue ?? '0',
+      maxValue: maxValue ?? '0',
     );
     _nodeUpdates.add(update);
     return update;

--- a/engine/src/flutter/runtime/fixtures/runtime_test.dart
+++ b/engine/src/flutter/runtime/fixtures/runtime_test.dart
@@ -316,6 +316,8 @@ void sendSemanticsUpdate() {
     controlsNodes: null,
     inputType: SemanticsInputType.none,
     locale: null,
+    minValue: '0',
+    maxValue: '0',
   );
   _semanticsUpdate(builder.build());
 }

--- a/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
@@ -200,6 +200,8 @@ Future<void> a11y_main() async {
       controlsNodes: null,
       inputType: SemanticsInputType.none,
       locale: null,
+      minValue: '0',
+      maxValue: '0',
     )
     ..updateNode(
       id: 84,
@@ -238,6 +240,8 @@ Future<void> a11y_main() async {
       controlsNodes: null,
       inputType: SemanticsInputType.none,
       locale: null,
+      minValue: '0',
+      maxValue: '0',
     )
     ..updateNode(
       id: 96,
@@ -276,6 +280,8 @@ Future<void> a11y_main() async {
       controlsNodes: null,
       inputType: SemanticsInputType.none,
       locale: null,
+      minValue: '0',
+      maxValue: '0',
     )
     ..updateNode(
       id: 128,
@@ -314,6 +320,8 @@ Future<void> a11y_main() async {
       controlsNodes: null,
       inputType: SemanticsInputType.none,
       locale: null,
+      minValue: '0',
+      maxValue: '0',
     )
     ..updateCustomAction(id: 21, label: 'Archive', hint: 'archive message');
 
@@ -399,6 +407,8 @@ Future<void> a11y_string_attributes() async {
       controlsNodes: null,
       inputType: SemanticsInputType.none,
       locale: null,
+      minValue: '0',
+      maxValue: '0',
     );
 
   PlatformDispatcher.instance.setSemanticsTreeEnabled(true);
@@ -1690,6 +1700,8 @@ Future<void> a11y_main_multi_view() async {
       controlsNodes: null,
       inputType: SemanticsInputType.none,
       locale: null,
+      minValue: '0',
+      maxValue: '0',
     );
   }
 

--- a/engine/src/flutter/shell/platform/windows/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/windows/fixtures/main.dart
@@ -478,6 +478,8 @@ Future<void> sendSemanticsTreeInfo() async {
       controlsNodes: null,
       inputType: ui.SemanticsInputType.none,
       locale: null,
+      minValue: '0',
+      maxValue: '0',
     );
     return builder.build();
   }

--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/locale_initialization.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/locale_initialization.dart
@@ -77,6 +77,8 @@ class LocaleInitialization extends Scenario {
         controlsNodes: null,
         inputType: SemanticsInputType.none,
         locale: null,
+        minValue: '0',
+        maxValue: '0',
       );
 
     final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();
@@ -139,6 +141,8 @@ class LocaleInitialization extends Scenario {
         controlsNodes: null,
         inputType: SemanticsInputType.none,
         locale: null,
+        minValue: '0',
+        maxValue: '0',
       );
 
     final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -8,6 +8,7 @@
 library;
 
 import 'dart:math' as math;
+import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -141,11 +142,20 @@ abstract class ProgressIndicator extends StatefulWidget {
   }
 
   Widget _buildSemanticsWrapper({required BuildContext context, required Widget child}) {
+    bool isProgressBar = false;
     String? expandedSemanticsValue = semanticsValue;
     if (value != null) {
-      expandedSemanticsValue ??= '${(value! * 100).round()}%';
+      expandedSemanticsValue ??= '${(value! * 100).round()}';
+      isProgressBar = true;
     }
-    return Semantics(label: semanticsLabel, value: expandedSemanticsValue, child: child);
+    return Semantics(
+      label: semanticsLabel,
+      role: isProgressBar ? SemanticsRole.progressBar : SemanticsRole.loadingSpinner,
+      minValue: isProgressBar ? '0' : null,
+      maxValue: isProgressBar ? '100' : null,
+      value: expandedSemanticsValue,
+      child: child,
+    );
   }
 }
 
@@ -1185,28 +1195,32 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator>
 
   @override
   Widget build(BuildContext context) {
-    switch (widget._indicatorType) {
-      case _ActivityIndicatorType.material:
-        if (widget.value != null) {
-          return _buildMaterialIndicator(context, 0.0, 0.0, 0, 0.0);
-        }
-        return _buildAnimation();
-      case _ActivityIndicatorType.adaptive:
-        final ThemeData theme = Theme.of(context);
-        switch (theme.platform) {
-          case TargetPlatform.iOS:
-          case TargetPlatform.macOS:
-            return _buildCupertinoIndicator(context);
-          case TargetPlatform.android:
-          case TargetPlatform.fuchsia:
-          case TargetPlatform.linux:
-          case TargetPlatform.windows:
+    return Builder(
+      builder: (BuildContext context) {
+        switch (widget._indicatorType) {
+          case _ActivityIndicatorType.material:
             if (widget.value != null) {
               return _buildMaterialIndicator(context, 0.0, 0.0, 0, 0.0);
             }
             return _buildAnimation();
+          case _ActivityIndicatorType.adaptive:
+            final ThemeData theme = Theme.of(context);
+            switch (theme.platform) {
+              case TargetPlatform.iOS:
+              case TargetPlatform.macOS:
+                return _buildCupertinoIndicator(context);
+              case TargetPlatform.android:
+              case TargetPlatform.fuchsia:
+              case TargetPlatform.linux:
+              case TargetPlatform.windows:
+                if (widget.value != null) {
+                  return _buildMaterialIndicator(context, 0.0, 0.0, 0, 0.0);
+                }
+                return _buildAnimation();
+            }
         }
-    }
+      },
+    );
   }
 }
 

--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -1051,6 +1051,12 @@ class RenderCustomPaint extends RenderProxyBox {
     if (properties.inputType != null) {
       config.inputType = properties.inputType!;
     }
+    if (properties.minValue != null) {
+      config.minValue = properties.minValue;
+    }
+    if (properties.maxValue != null) {
+      config.maxValue = properties.maxValue;
+    }
     if (properties.onTap != null) {
       config.onTap = properties.onTap;
     }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4938,6 +4938,12 @@ mixin SemanticsAnnotationsMixin on RenderObject {
     if (_properties.inputType != null) {
       config.inputType = _properties.inputType!;
     }
+    if (_properties.minValue != null) {
+      config.minValue = _properties.minValue;
+    }
+    if (_properties.maxValue != null) {
+      config.maxValue = _properties.maxValue;
+    }
 
     // Registering _perform* as action handlers instead of the user provided
     // ones to ensure that changing a user provided handler from a non-null to

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4050,6 +4050,8 @@ sealed class _SemanticsBase extends SingleChildRenderObjectWidget {
     required SemanticsValidationResult validationResult,
     required ui.SemanticsInputType? inputType,
     required Locale? localeForSubtree,
+    required String? minValue,
+    required String? maxValue,
   }) : this.fromProperties(
          key: key,
          child: child,
@@ -4134,6 +4136,8 @@ sealed class _SemanticsBase extends SingleChildRenderObjectWidget {
            controlsNodes: controlsNodes,
            validationResult: validationResult,
            inputType: inputType,
+           minValue: minValue,
+           maxValue: maxValue,
          ),
        );
 
@@ -4384,6 +4388,8 @@ class SliverSemantics extends _SemanticsBase {
     super.validationResult = SemanticsValidationResult.none,
     super.inputType,
     super.localeForSubtree,
+    super.minValue,
+    super.maxValue,
   }) : super(child: sliver);
 
   /// {@macro flutter.widgets.SemanticsBase.fromProperties}
@@ -7962,6 +7968,8 @@ class Semantics extends _SemanticsBase {
     super.validationResult = SemanticsValidationResult.none,
     super.inputType,
     super.localeForSubtree,
+    super.minValue,
+    super.maxValue,
   });
 
   /// {@macro flutter.widgets.SemanticsBase.fromProperties}

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -378,7 +378,12 @@ void main() {
 
       expect(
         tester.getSemantics(find.byType(CircularProgressIndicator)),
-        matchesSemantics(value: '0%', textDirection: TextDirection.ltr),
+        matchesSemantics(
+          value: '0',
+          textDirection: TextDirection.ltr,
+          minValue: '0',
+          maxValue: '100',
+        ),
       );
       handle.dispose();
     },
@@ -940,7 +945,7 @@ void main() {
     final SemanticsHandle handle = tester.ensureSemantics();
     final GlobalKey key = GlobalKey();
     const String label = 'Label';
-    const String value = '25%';
+    const String value = '25';
     await tester.pumpWidget(
       Theme(
         data: theme,
@@ -982,7 +987,7 @@ void main() {
 
     expect(
       tester.getSemantics(find.byKey(key)),
-      matchesSemantics(textDirection: TextDirection.ltr, label: label, value: '25%'),
+      matchesSemantics(textDirection: TextDirection.ltr, label: label, value: '25'),
     );
 
     handle.dispose();
@@ -1037,7 +1042,7 @@ void main() {
     final SemanticsHandle handle = tester.ensureSemantics();
     final GlobalKey key = GlobalKey();
     const String label = 'Label';
-    const String value = '25%';
+    const String value = '25';
     await tester.pumpWidget(
       Theme(
         data: theme,
@@ -1065,7 +1070,7 @@ void main() {
     final SemanticsHandle handle = tester.ensureSemantics();
     final GlobalKey key = GlobalKey();
     const String label = 'Label';
-    const String value = '25%';
+    const String value = '25';
     await tester.pumpWidget(
       Theme(
         data: theme,

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -723,7 +723,9 @@ void main() {
       '   scrollPosition: null\n'
       '   scrollExtentMax: null\n'
       '   indexInParent: null\n'
-      '   headingLevel: 0\n',
+      '   headingLevel: 0\n'
+      '   minValue: null\n'
+      '   maxValue: null\n',
     );
 
     final SemanticsConfiguration config = SemanticsConfiguration()
@@ -871,7 +873,9 @@ void main() {
       '   scrollPosition: null\n'
       '   scrollExtentMax: null\n'
       '   indexInParent: null\n'
-      '   headingLevel: 0\n',
+      '   headingLevel: 0\n'
+      '   minValue: null\n'
+      '   maxValue: null\n',
     );
   });
 

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -234,6 +234,8 @@ class SemanticsUpdateBuilderSpy extends Fake implements ui.SemanticsUpdateBuilde
     ui.SemanticsHitTestBehavior hitTestBehavior = ui.SemanticsHitTestBehavior.defer,
     required ui.SemanticsInputType inputType,
     required ui.Locale? locale,
+    required String minValue,
+    required String maxValue,
   }) {
     // Makes sure we don't send the same id twice.
     assert(!observations.containsKey(id));

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -713,6 +713,8 @@ class SemanticsTester {
     double? scrollExtentMin,
     int? currentValueLength,
     int? maxValueLength,
+    String? maxValue,
+    String? minValue,
     SemanticsNode? ancestor,
     SemanticsInputType? inputType,
   }) {
@@ -808,6 +810,12 @@ class SemanticsTester {
         return false;
       }
       if (inputType != null && node.inputType != inputType) {
+        return false;
+      }
+      if (maxValue != null && node.maxValue != maxValue) {
+        return false;
+      }
+      if (minValue != null && node.minValue != minValue) {
         return false;
       }
       return true;
@@ -1120,6 +1128,8 @@ class _IncludesNodeWith extends Matcher {
     this.maxValueLength,
     this.currentValueLength,
     this.inputType,
+    this.minValue,
+    this.maxValue,
   }) : assert(
          label != null ||
              value != null ||
@@ -1135,6 +1145,7 @@ class _IncludesNodeWith extends Matcher {
              maxValueLength != null ||
              currentValueLength != null ||
              inputType != null,
+         minValue != null || maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;
@@ -1155,6 +1166,8 @@ class _IncludesNodeWith extends Matcher {
   final int? currentValueLength;
   final int? maxValueLength;
   final SemanticsInputType? inputType;
+  final String? minValue;
+  final String? maxValue;
 
   @override
   bool matches(covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
@@ -1179,6 +1192,8 @@ class _IncludesNodeWith extends Matcher {
           currentValueLength: currentValueLength,
           maxValueLength: maxValueLength,
           inputType: inputType,
+          minValue: minValue,
+          maxValue: maxValue,
         )
         .isNotEmpty;
   }
@@ -1215,6 +1230,8 @@ class _IncludesNodeWith extends Matcher {
       if (currentValueLength != null) 'currentValueLength "$currentValueLength"',
       if (maxValueLength != null) 'maxValueLength "$maxValueLength"',
       if (inputType != null) 'inputType $inputType',
+      if (minValue != null) 'minValue "$minValue"',
+      if (maxValue != null) 'maxValue "$maxValue"',
     ];
     return strings.join(', ');
   }
@@ -1244,6 +1261,8 @@ Matcher includesNodeWith({
   int? maxValueLength,
   int? currentValueLength,
   SemanticsInputType? inputType,
+  String? minValue,
+  String? maxValue,
 }) {
   return _IncludesNodeWith(
     label: label,
@@ -1265,5 +1284,7 @@ Matcher includesNodeWith({
     maxValueLength: maxValueLength,
     currentValueLength: currentValueLength,
     inputType: inputType,
+    minValue: minValue,
+    maxValue: maxValue,
   );
 }

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -687,6 +687,8 @@ Matcher matchesSemantics({
   int? currentValueLength,
   SemanticsValidationResult validationResult = SemanticsValidationResult.none,
   ui.SemanticsInputType? inputType,
+  String? maxValue,
+  String? minValue,
   // Flags //
   bool hasCheckedState = false,
   bool isChecked = false,
@@ -772,6 +774,8 @@ Matcher matchesSemantics({
     currentValueLength: currentValueLength,
     validationResult: validationResult,
     inputType: inputType,
+    minValue: minValue,
+    maxValue: maxValue,
     // Flags
     hasCheckedState: hasCheckedState,
     isChecked: isChecked,
@@ -887,6 +891,8 @@ Matcher containsSemantics({
   int? currentValueLength,
   SemanticsValidationResult? validationResult,
   ui.SemanticsInputType? inputType,
+  String? maxValue,
+  String? minValue,
   // Flags
   bool? hasCheckedState,
   bool? isChecked,
@@ -972,6 +978,8 @@ Matcher containsSemantics({
     currentValueLength: currentValueLength,
     validationResult: validationResult,
     inputType: inputType,
+    minValue: minValue,
+    maxValue: maxValue,
     // Flags
     hasCheckedState: hasCheckedState,
     isChecked: isChecked,
@@ -2404,6 +2412,8 @@ class _MatchesSemanticsData extends Matcher {
     required this.currentValueLength,
     required this.validationResult,
     required this.inputType,
+    required this.minValue,
+    required this.maxValue,
     // Flags
     required bool? hasCheckedState,
     required bool? isChecked,
@@ -2551,6 +2561,8 @@ class _MatchesSemanticsData extends Matcher {
   final ui.SemanticsInputType? inputType;
   final List<Matcher>? children;
   final SemanticsValidationResult? validationResult;
+  final String? maxValue;
+  final String? minValue;
 
   /// There are three possible states for these two maps:
   ///
@@ -2659,6 +2671,12 @@ class _MatchesSemanticsData extends Matcher {
     }
     if (validationResult != null) {
       description.add(' with validation result: $validationResult');
+    }
+    if (minValue != null) {
+      description.add(' with minValue: $minValue');
+    }
+    if (maxValue != null) {
+      description.add(' with maxValue: $maxValue');
     }
     if (children != null) {
       description.add(' with children:\n  ');
@@ -2795,6 +2813,12 @@ class _MatchesSemanticsData extends Matcher {
     }
     if (inputType != null && inputType != data.inputType) {
       return failWithDescription(matchState, 'inputType was: ${data.inputType}');
+    }
+    if (minValue != null && minValue != data.minValue) {
+      return failWithDescription(matchState, 'minValue was: ${data.minValue}');
+    }
+    if (maxValue != null && maxValue != data.maxValue) {
+      return failWithDescription(matchState, 'maxValue was: ${data.maxValue}');
     }
     if (actions.isNotEmpty) {
       final List<SemanticsAction> unexpectedActions = <SemanticsAction>[];

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -755,6 +755,8 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        minValue: '0',
+        maxValue: '0',
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1057,6 +1059,8 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        minValue: '0',
+        maxValue: '0',
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1159,6 +1163,8 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        minValue: '0',
+        maxValue: '0',
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1266,6 +1272,8 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        minValue: '0',
+        maxValue: '0',
       );
       final _FakeSemanticsNode emptyNode = _FakeSemanticsNode(emptyData);
 
@@ -1301,6 +1309,8 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        minValue: '0',
+        maxValue: '0',
       );
       final _FakeSemanticsNode fullNode = _FakeSemanticsNode(fullData);
 
@@ -1435,6 +1445,8 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        minValue: '0',
+        maxValue: '0',
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 


### PR DESCRIPTION
Feat: Add a11y for loading indicators
fixes: #161631 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.