### PR TITLE
Macos BUGFIX: change strong ref to weak ref

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -801,7 +801,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
                         // We are already on UI thread right now, but have to do the
                         // extra hop to main thread.
                         [engine->_threadSynchronizer performOnPlatformThread:^{
-                          engine->_embedderAPI.OnVsync(_engine, baton, timeNanos, targetTimeNanos);
+                          engine->_embedderAPI.OnVsync(engine->_engine, baton, timeNanos, targetTimeNanos);
                         }];
                       }
                     }];


### PR DESCRIPTION
The erroneous strong reference to self->engine_ leads to an issue where the engine is deallocated in a background thread, triggering an assert failure or crash in certain scenarios.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
