### PR TITLE
Fix arrowHeadColor breaks differentiation between states

### DIFF
--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -557,28 +557,32 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
       const SizedBox(width: 32.0),
       if (widget.showFirstLastButtons)
         IconButton(
-          icon: Icon(Icons.skip_previous, color: widget.arrowHeadColor),
+          icon: const Icon(Icons.skip_previous),
           padding: EdgeInsets.zero,
+          color: widget.arrowHeadColor,
           tooltip: localizations.firstPageTooltip,
           onPressed: _firstRowIndex <= 0 ? null : _handleFirst,
         ),
       IconButton(
-        icon: Icon(Icons.chevron_left, color: widget.arrowHeadColor),
+        icon: const Icon(Icons.chevron_left),
         padding: EdgeInsets.zero,
+        color: widget.arrowHeadColor,
         tooltip: localizations.previousPageTooltip,
         onPressed: _firstRowIndex <= 0 ? null : _handlePrevious,
       ),
       const SizedBox(width: 24.0),
       IconButton(
-        icon: Icon(Icons.chevron_right, color: widget.arrowHeadColor),
+        icon: const Icon(Icons.chevron_right),
         padding: EdgeInsets.zero,
+        color: widget.arrowHeadColor,
         tooltip: localizations.nextPageTooltip,
         onPressed: _isNextPageUnavailable() ? null : _handleNext,
       ),
       if (widget.showFirstLastButtons)
         IconButton(
-          icon: Icon(Icons.skip_next, color: widget.arrowHeadColor),
+          icon: const Icon(Icons.skip_next),
           padding: EdgeInsets.zero,
+          color: widget.arrowHeadColor,
           tooltip: localizations.lastPageTooltip,
           onPressed: _isNextPageUnavailable() ? null : _handleLast,
         ),

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -1308,7 +1308,7 @@ void main() {
       ),
     );
 
-    final Iterable<Icon> icons = tester.widgetList(find.byType(Icon));
+    final Iterable<IconButton> icons = tester.widgetList(find.byType(IconButton));
 
     expect(icons.elementAt(0).color, arrowHeadColor);
     expect(icons.elementAt(1).color, arrowHeadColor);


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/160458

The arrowheads color is currently displayed wrong when passing `arrowHeadColor` parameter, it's due to the `arrowHeadColor` is passing to IconButton.icon widget, not IconButton.color itself. Meanwhile, the IconButton state depends on `onPressed` callback and the button color logic happens in IconButton, not in Icon widget. The fix is simply to pass `arrowHeadColor` to IconButton so that buttons will be displaying correct color when state changes.

| before | after |
| --------------- | --------------- |
<video src="https://github.com/user-attachments/assets/20f08366-7c42-4f00-bfea-40f1c6498dd7"/> | <video src="https://github.com/user-attachments/assets/a018a60f-4238-4f8a-9784-1db71592f08c"/>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
