### PR TITLE
Point ktlint AS docs to the `.editorconfig` that is actually used by ci, instead of making a copy in the README

### DIFF
--- a/docs/platforms/android/Kotlin-android-studio-formatting.md
+++ b/docs/platforms/android/Kotlin-android-studio-formatting.md
@@ -13,15 +13,9 @@ then there is good news! Android Studio can be configured to use `ktlint` to aut
 
    a. On Mac, this is `Android Studio > Settings > Plugins > ` Search for `ktlint`.
 
-2. Set the ruleset to be the same as the version used in [`.ci.yaml`](../../../.ci.yaml) (as of writing this is 1.1.1), and the baseline to be `dev/bots/test/analyze-test-input/ktlint-baseline.xml`.
+2. Set the ruleset to be the same as the version used in [`.ci.yaml`](../../../.ci.yaml) (as of writing this is 1.5), and the baseline to be `dev/bots/test/analyze-test-input/ktlint-baseline.xml`.
 
    a. Both of these options should be available under `Android Studio > Settings > Tools > ktlint`.
 
 3. Additionally, Kotlin code in the Flutter repository currently uses some additional rules for compatibility with older versions of Kotlin.
-These rules can only be configured by an `.editorconfig` file in the directory from which Android Studio was opened. To configure these rules, create a new `.editorconfig` file in the root of your flutter repository with the following content
-```
-[*.{kt,kts}]
-# Disable trailing commas to allow compatibility with Kotlin versions less than 1.4.
-ij_kotlin_allow_trailing_comma = false
-ij_kotlin_allow_trailing_comma_on_call_site = false
-```
+These rules can only be configured by an `.editorconfig` file in the directory from which Android Studio was opened. To configure these rules, create a copy of the [`.editorconfig` that is used by tests](../../../dev/bots/test/analyze-test-input/.editorconfig) in the root directory you intend to open with Android Studio.

--- a/docs/platforms/android/Kotlin-android-studio-formatting.md
+++ b/docs/platforms/android/Kotlin-android-studio-formatting.md
@@ -18,4 +18,4 @@ then there is good news! Android Studio can be configured to use `ktlint` to aut
    a. Both of these options should be available under `Android Studio > Settings > Tools > ktlint`.
 
 3. Additionally, Kotlin code in the Flutter repository currently uses some additional rules for compatibility with older versions of Kotlin.
-These rules can only be configured by an `.editorconfig` file in the directory from which Android Studio was opened. To configure these rules, create a copy of the [`.editorconfig` that is used by tests](../../../dev/bots/test/analyze-test-input/.editorconfig) in the root directory you intend to open with Android Studio.
+These rules can only be configured by an `.editorconfig` file in the directory from which Android Studio was opened. To configure these rules, create a copy of the [`.editorconfig`](../../../dev/bots/test/analyze-test-input/.editorconfig) that is used by tests in the root directory you intend to open with Android Studio.


### PR DESCRIPTION
Points `ktlint` Android Studio setup docs to the `.editorconfig` that is actually used by ci, instead of making a copy in the README

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
