### PR TITLE
Update the Dart package creation script to copy source files instead of creating symlinks to the source tree

### DIFF
--- a/engine/src/flutter/sky/dist/BUILD.gn
+++ b/engine/src/flutter/sky/dist/BUILD.gn
@@ -11,7 +11,6 @@ if (is_android) {
     source = "$root_gen_dir/dart-pkg/sky_engine"
     dest = "$root_build_dir/dist/packages/sky_engine"
 
-    inputs = [ source ]
     outputs = [ dest ]
 
     args = [

--- a/engine/src/flutter/sky/packages/sky_engine/BUILD.gn
+++ b/engine/src/flutter/sky/packages/sky_engine/BUILD.gn
@@ -293,9 +293,7 @@ generated_file("_embedder_yaml") {
 action("sky_engine") {
   package_name = "sky_engine"
   pkg_directory = rebase_path("$root_gen_dir/dart-pkg")
-  package_root = rebase_path("$root_gen_dir/dart-pkg/packages")
   stamp_file = "$root_gen_dir/dart-pkg/${package_name}.stamp"
-  entries_file = "$root_gen_dir/dart-pkg/${package_name}.entries"
 
   sources = [
     "LICENSE",
@@ -322,12 +320,7 @@ action("sky_engine") {
     "$service_isolate_dir/vmservice_server.dart",
   ]
 
-  outputs = [
-    "$root_gen_dir/dart-pkg/${package_name}",
-    "$root_gen_dir/dart-pkg/${package_name}/pubspec.yaml",
-    "$root_gen_dir/dart-pkg/packages/${package_name}",
-    stamp_file,
-  ]
+  outputs = [ stamp_file ]
 
   script = rebase_path("//flutter/build/dart/tools/dart_pkg.py", ".", "//")
 
@@ -340,12 +333,8 @@ action("sky_engine") {
            rebase_path(dart_sdk_root),
            "--pkg-directory",
            pkg_directory,
-           "--package-root",
-           package_root,
            "--stamp-file",
            rebase_path(stamp_file),
-           "--entries-file",
-           rebase_path(entries_file),
            "--package-sources",
          ] + rebase_path(sources) + [ "--sdk-ext-directories" ] +
          rebase_path(sdk_ext_directory) + [ "--sdk-ext-files" ] +


### PR DESCRIPTION
The use of symlinks and the use of a directory as a GN output path may cause unnecessary rebuilds when Ninja checks file modification times to determine whether build outputs are up to date.

Also remove various other unused featues that were copied from the original version of the script in the Mojo project.