### PR TITLE
Add ability to customize the default `RangeSlider` padding

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -392,10 +392,10 @@ class RangeSlider extends StatefulWidget {
 
   /// Determines the padding around the [RangeSlider].
   ///
-  /// If specified, this padding overrides the default vertical padding of
-  /// the [RangeSlider], defaults to the height of the overlay shape, and the
-  /// horizontal padding, defaults to the width of the thumb shape or
-  /// overlay shape, whichever is larger.
+  /// If specified, this padding overrides the vertical padding and the
+  /// horizontal padding of the [RangeSlider]. By default, the vertical padding
+  /// is the height of the overlay shape, and the horizontal padding is the
+  /// larger size between the width of the thumb shape and overlay shape.
   final EdgeInsetsGeometry? padding;
 
   // Touch width for the tap boundary of the slider thumbs.

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -165,6 +165,7 @@ class RangeSlider extends StatefulWidget {
     this.overlayColor,
     this.mouseCursor,
     this.semanticFormatterCallback,
+    this.padding,
   }) : assert(min <= max),
        assert(values.start <= values.end),
        assert(values.start >= min && values.start <= max),
@@ -388,6 +389,14 @@ class RangeSlider extends StatefulWidget {
   /// ```
   /// {@end-tool}
   final SemanticFormatterCallback? semanticFormatterCallback;
+
+  /// Determines the padding around the [RangeSlider].
+  ///
+  /// If specified, this padding overrides the default vertical padding of
+  /// the [RangeSlider], defaults to the height of the overlay shape, and the
+  /// horizontal padding, defaults to the width of the thumb shape or
+  /// overlay shape, whichever is larger.
+  final EdgeInsetsGeometry? padding;
 
   // Touch width for the tap boundary of the slider thumbs.
   static const double _minTouchTargetWidth = kMinInteractiveDimension;
@@ -701,6 +710,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
           theme.textTheme.bodyLarge!.copyWith(color: theme.colorScheme.onPrimary),
       minThumbSeparation: sliderTheme.minThumbSeparation ?? defaultMinThumbSeparation,
       thumbSelector: sliderTheme.thumbSelector ?? _defaultRangeThumbSelector,
+      padding: widget.padding ?? sliderTheme.padding,
     );
     final MouseCursor effectiveMouseCursor =
         widget.mouseCursor?.resolve(states) ??
@@ -717,28 +727,35 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     final double effectiveTextScale =
         MediaQuery.textScalerOf(context).scale(fontSizeToScale) / fontSizeToScale;
 
+    Widget result = CompositedTransformTarget(
+      link: _layerLink,
+      child: _RangeSliderRenderObjectWidget(
+        values: _unlerpRangeValues(widget.values),
+        divisions: widget.divisions,
+        labels: widget.labels,
+        sliderTheme: sliderTheme,
+        textScaleFactor: effectiveTextScale,
+        screenSize: screenSize(),
+        onChanged: _enabled && (widget.max > widget.min) ? _handleChanged : null,
+        onChangeStart: widget.onChangeStart != null ? _handleDragStart : null,
+        onChangeEnd: widget.onChangeEnd != null ? _handleDragEnd : null,
+        state: this,
+        semanticFormatterCallback: widget.semanticFormatterCallback,
+        hovering: _hovering,
+      ),
+    );
+
+    final EdgeInsetsGeometry? padding = widget.padding ?? sliderTheme.padding;
+    if (padding != null) {
+      result = Padding(padding: padding, child: result);
+    }
+
     return FocusableActionDetector(
       enabled: _enabled,
       onShowHoverHighlight: _handleHoverChanged,
       includeFocusSemantics: false,
       mouseCursor: effectiveMouseCursor,
-      child: CompositedTransformTarget(
-        link: _layerLink,
-        child: _RangeSliderRenderObjectWidget(
-          values: _unlerpRangeValues(widget.values),
-          divisions: widget.divisions,
-          labels: widget.labels,
-          sliderTheme: sliderTheme,
-          textScaleFactor: effectiveTextScale,
-          screenSize: screenSize(),
-          onChanged: _enabled && (widget.max > widget.min) ? _handleChanged : null,
-          onChangeStart: widget.onChangeStart != null ? _handleDragStart : null,
-          onChangeEnd: widget.onChangeEnd != null ? _handleDragEnd : null,
-          state: this,
-          semanticFormatterCallback: widget.semanticFormatterCallback,
-          hovering: _hovering,
-        ),
-      ),
+      child: result,
     );
   }
 
@@ -917,8 +934,15 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       _sliderPartSizes.map((Size size) => size.width).reduce(math.max);
   double get _maxSliderPartHeight =>
       _sliderPartSizes.map((Size size) => size.height).reduce(math.max);
+  double get _thumbSizeHeight =>
+      _sliderTheme.rangeThumbShape!.getPreferredSize(isEnabled, isDiscrete).height;
+  double get _overlayHeight =>
+      _sliderTheme.overlayShape!.getPreferredSize(isEnabled, isDiscrete).height;
   List<Size> get _sliderPartSizes => <Size>[
-    _sliderTheme.overlayShape!.getPreferredSize(isEnabled, isDiscrete),
+    Size(
+      _sliderTheme.overlayShape!.getPreferredSize(isEnabled, isDiscrete).width,
+      _sliderTheme.padding != null ? _thumbSizeHeight : _overlayHeight,
+    ),
     _sliderTheme.rangeThumbShape!.getPreferredSize(isEnabled, isDiscrete),
     _sliderTheme.rangeTickMarkShape!.getPreferredSize(
       isEnabled: isEnabled,

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -2195,8 +2195,7 @@ mixin BaseRangeSliderTrackShape {
     assert(sliderTheme.rangeThumbShape != null);
     assert(sliderTheme.overlayShape != null);
     assert(sliderTheme.trackHeight != null);
-    final double thumbWidth =
-        sliderTheme.rangeThumbShape!.getPreferredSize(isEnabled, isDiscrete).width;
+    final Size thumbSize = sliderTheme.rangeThumbShape!.getPreferredSize(isEnabled, isDiscrete);
     final double overlayWidth =
         sliderTheme.overlayShape!.getPreferredSize(isEnabled, isDiscrete).width;
     double trackHeight = sliderTheme.trackHeight!;
@@ -2210,9 +2209,16 @@ mixin BaseRangeSliderTrackShape {
       trackHeight = 0;
     }
 
-    final double trackLeft = offset.dx + math.max(overlayWidth / 2, thumbWidth / 2);
+    final double trackLeft =
+        offset.dx +
+        (sliderTheme.padding == null
+            ? math.max(overlayWidth / 2, thumbSize.width / 2)
+            : (thumbSize.width / 2));
     final double trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
-    final double trackRight = trackLeft + parentBox.size.width - math.max(thumbWidth, overlayWidth);
+    final double trackRight =
+        trackLeft +
+        parentBox.size.width -
+        (sliderTheme.padding == null ? math.max(thumbSize.width, overlayWidth) : (thumbSize.width));
     final double trackBottom = trackTop + trackHeight;
     // If the parentBox's size less than slider's size the trackRight will be less than trackLeft, so switch them.
     return Rect.fromLTRB(

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2946,4 +2946,151 @@ void main() {
       isNot(paints..circle(color: hoverColor)),
     );
   });
+
+  testWidgets('RangeSlider.padding can override the default RangeSlider padding', (
+    WidgetTester tester,
+  ) async {
+    Widget buildRangeSlider({EdgeInsetsGeometry? padding}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: IntrinsicHeight(
+              child: RangeSlider(
+                padding: padding,
+                values: const RangeValues(0, 1.0),
+                onChanged: (RangeValues values) {},
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    RenderBox sliderRenderBox() {
+      return tester.allRenderObjects.firstWhere(
+            (RenderObject object) => object.runtimeType.toString() == '_RenderRangeSlider',
+          )
+          as RenderBox;
+    }
+
+    // Test RangeSlider height and tracks spacing with zero padding.
+    await tester.pumpWidget(buildRangeSlider(padding: EdgeInsets.zero));
+    await tester.pumpAndSettle();
+
+    // The height equals to the default thumb height.
+    expect(sliderRenderBox().size, const Size(800, 20));
+    expect(
+      find.byType(RangeSlider),
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            10.0,
+            8.0,
+            10.0,
+            12.0,
+            topLeft: const Radius.circular(2.0),
+            bottomLeft: const Radius.circular(2.0),
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            790.0,
+            8.0,
+            790.0,
+            12.0,
+            topRight: const Radius.circular(2.0),
+            bottomRight: const Radius.circular(2.0),
+          ),
+        )
+        // Active track.
+        ..rrect(rrect: RRect.fromLTRBR(8.0, 7.0, 792.0, 13.0, const Radius.circular(2.0))),
+    );
+
+    // Test RangeSlider height and tracks spacing with directional padding.
+    const double startPadding = 100;
+    const double endPadding = 20;
+    await tester.pumpWidget(
+      buildRangeSlider(
+        padding: const EdgeInsetsDirectional.only(start: startPadding, end: endPadding),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(sliderRenderBox().size, const Size(800 - startPadding - endPadding, 20));
+    expect(
+      find.byType(RangeSlider),
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            10.0,
+            8.0,
+            10.0,
+            12.0,
+            topLeft: const Radius.circular(2.0),
+            bottomLeft: const Radius.circular(2.0),
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            670.0,
+            8.0,
+            670.0,
+            12.0,
+            topRight: const Radius.circular(2.0),
+            bottomRight: const Radius.circular(2.0),
+          ),
+        )
+        // Active track.
+        ..rrect(rrect: RRect.fromLTRBR(8.0, 7.0, 672.0, 13.0, const Radius.circular(2.0))),
+    );
+
+    // Test RangeSlider height and tracks spacing with top and bottom padding.
+    const double topPadding = 100;
+    const double bottomPadding = 20;
+    const double trackHeight = 20;
+    await tester.pumpWidget(
+      buildRangeSlider(
+        padding: const EdgeInsetsDirectional.only(top: topPadding, bottom: bottomPadding),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSize(find.byType(RangeSlider)),
+      const Size(800, topPadding + trackHeight + bottomPadding),
+    );
+    expect(sliderRenderBox().size, const Size(800, 20));
+    expect(
+      find.byType(RangeSlider),
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            10.0,
+            8.0,
+            10.0,
+            12.0,
+            topLeft: const Radius.circular(2.0),
+            bottomLeft: const Radius.circular(2.0),
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            790.0,
+            8.0,
+            790.0,
+            12.0,
+            topRight: const Radius.circular(2.0),
+            bottomRight: const Radius.circular(2.0),
+          ),
+        )
+        // Active track.
+        ..rrect(rrect: RRect.fromLTRBR(8.0, 7.0, 792.0, 13.0, const Radius.circular(2.0))),
+    );
+  });
 }

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -2779,6 +2779,153 @@ void main() {
     );
   });
 
+  testWidgets('SliderThemeData.padding can override the default RangeSlider padding', (
+    WidgetTester tester,
+  ) async {
+    Widget buildRangeSlider({EdgeInsetsGeometry? padding}) {
+      return MaterialApp(
+        theme: ThemeData(sliderTheme: SliderThemeData(padding: padding)),
+        home: Material(
+          child: Center(
+            child: IntrinsicHeight(
+              child: RangeSlider(
+                values: const RangeValues(0, 1.0),
+                onChanged: (RangeValues values) {},
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    RenderBox sliderRenderBox() {
+      return tester.allRenderObjects.firstWhere(
+            (RenderObject object) => object.runtimeType.toString() == '_RenderRangeSlider',
+          )
+          as RenderBox;
+    }
+
+    // Test RangeSlider height and tracks spacing with zero padding.
+    await tester.pumpWidget(buildRangeSlider(padding: EdgeInsets.zero));
+    await tester.pumpAndSettle();
+
+    // The height equals to the default thumb height.
+    expect(sliderRenderBox().size, const Size(800, 20));
+    expect(
+      find.byType(RangeSlider),
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            10.0,
+            8.0,
+            10.0,
+            12.0,
+            topLeft: const Radius.circular(2.0),
+            bottomLeft: const Radius.circular(2.0),
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            790.0,
+            8.0,
+            790.0,
+            12.0,
+            topRight: const Radius.circular(2.0),
+            bottomRight: const Radius.circular(2.0),
+          ),
+        )
+        // Active track.
+        ..rrect(rrect: RRect.fromLTRBR(8.0, 7.0, 792.0, 13.0, const Radius.circular(2.0))),
+    );
+
+    // Test RangeSlider height and tracks spacing with directional padding.
+    const double startPadding = 100;
+    const double endPadding = 20;
+    await tester.pumpWidget(
+      buildRangeSlider(
+        padding: const EdgeInsetsDirectional.only(start: startPadding, end: endPadding),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(sliderRenderBox().size, const Size(800 - startPadding - endPadding, 20));
+    expect(
+      find.byType(RangeSlider),
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            10.0,
+            8.0,
+            10.0,
+            12.0,
+            topLeft: const Radius.circular(2.0),
+            bottomLeft: const Radius.circular(2.0),
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            670.0,
+            8.0,
+            670.0,
+            12.0,
+            topRight: const Radius.circular(2.0),
+            bottomRight: const Radius.circular(2.0),
+          ),
+        )
+        // Active track.
+        ..rrect(rrect: RRect.fromLTRBR(8.0, 7.0, 672.0, 13.0, const Radius.circular(2.0))),
+    );
+
+    // Test RangeSlider height and tracks spacing with top and bottom padding.
+    const double topPadding = 100;
+    const double bottomPadding = 20;
+    const double trackHeight = 20;
+    await tester.pumpWidget(
+      buildRangeSlider(
+        padding: const EdgeInsetsDirectional.only(top: topPadding, bottom: bottomPadding),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSize(find.byType(RangeSlider)),
+      const Size(800, topPadding + trackHeight + bottomPadding),
+    );
+    expect(sliderRenderBox().size, const Size(800, 20));
+    expect(
+      find.byType(RangeSlider),
+      paints
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            10.0,
+            8.0,
+            10.0,
+            12.0,
+            topLeft: const Radius.circular(2.0),
+            bottomLeft: const Radius.circular(2.0),
+          ),
+        )
+        // Inactive track.
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(
+            790.0,
+            8.0,
+            790.0,
+            12.0,
+            topRight: const Radius.circular(2.0),
+            bottomRight: const Radius.circular(2.0),
+          ),
+        )
+        // Active track.
+        ..rrect(rrect: RRect.fromLTRBR(8.0, 7.0, 792.0, 13.0, const Radius.circular(2.0))),
+    );
+  });
+
   testWidgets('Can customize track gap when year2023 is false', (WidgetTester tester) async {
     Widget buildSlider({double? trackGap}) {
       return MaterialApp(


### PR DESCRIPTION
Fixes [Ability to change RangeSlider padding](https://github.com/flutter/flutter/issues/165046)

Add ability to override default padding so the `RangeSlider` can fit better in a layout.

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatefulWidget {
  const MyApp({super.key});

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  RangeValues _sliderValues = const RangeValues(0.0, 1.0);

  @override
  Widget build(BuildContext context) {

    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(
        sliderTheme: const SliderThemeData(
          // padding: EdgeInsets.symmetric(vertical: 4),
          thumbColor: Colors.red,
          inactiveTrackColor: Colors.amber,
        ),
      ),
      home: Scaffold(
        body: Directionality(
          textDirection: TextDirection.ltr,
          child: Center(
            child: Card(
              shape: const RoundedRectangleBorder(
                borderRadius: BorderRadius.all(Radius.circular(4.0)),
              ),
              color: Theme.of(context).colorScheme.surfaceContainerHighest,
              margin: const EdgeInsets.symmetric(horizontal: 16.0),
              child: Padding(
                padding: const EdgeInsetsDirectional.all(16),
                child: Column(
                  mainAxisSize: MainAxisSize.min,
                  children: [
                    const Placeholder(fallbackHeight: 100.0),
                    RangeSlider(
                      values: _sliderValues,
                      onChanged: (RangeValues values) {
                        setState(() {
                          _sliderValues = values;
                        });
                      },
                    ),
                    const Placeholder(fallbackHeight: 100.0),
                  ],
                ),
              ),
            ),
          ),
        ),
      ),
    );
  }
}

```

</details>

### Before
(Cannot adjust default `RangeSlider` padding to fill the horizontal space in a `Column` and reduce the padded height)


<img width="862" alt="Screenshot 2025-03-17 at 17 08 35" src="https://github.com/user-attachments/assets/8786f2a5-5383-4611-b025-2151bc0f9fa7" />


### After 
Can adjust default `RangeSlider` padding via `SliderThemeData,padding` or `RangeSlider.padding`)

<img width="862" alt="Screenshot 2025-03-17 at 17 08 26" src="https://github.com/user-attachments/assets/38a34cf1-a372-4160-9189-aa4133582b0a" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
