### PR TITLE
`OverlayPortal.childLayoutBuilder` should rebuild when `OverlayPortal` rebuilds.

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -2613,9 +2613,6 @@ class _OverlayChildLayoutBuilder extends AbstractLayoutBuilder<OverlayChildLayou
   RenderAbstractLayoutBuilderMixin<OverlayChildLayoutInfo, RenderBox> createRenderObject(
     BuildContext context,
   ) => _RenderLayoutBuilder();
-
-  @override
-  bool updateShouldRebuild(_OverlayChildLayoutBuilder oldWidget) => true;
 }
 
 // A RenderBox that:

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -2615,7 +2615,7 @@ class _OverlayChildLayoutBuilder extends AbstractLayoutBuilder<OverlayChildLayou
   ) => _RenderLayoutBuilder();
 
   @override
-  bool updateShouldRebuild(_OverlayChildLayoutBuilder oldWidget) => oldWidget.builder != builder;
+  bool updateShouldRebuild(_OverlayChildLayoutBuilder oldWidget) => true;
 }
 
 // A RenderBox that:
@@ -2709,14 +2709,10 @@ class _RenderLayoutBuilder extends RenderProxyBox
   int? _callbackId;
   @override
   void performLayout() {
-    late OverlayChildLayoutInfo newLayoutInfo;
     // The invokeLayoutCallback allows arbitrary access to the sizes of
     // RenderBoxes the we know that have finished doing layout.
-    invokeLayoutCallback((_) => newLayoutInfo = _computeNewLayoutInfo());
-    if (newLayoutInfo != _layoutInfo) {
-      _layoutInfo = newLayoutInfo;
-      rebuildIfNecessary();
-    }
+    invokeLayoutCallback((_) => _layoutInfo = _computeNewLayoutInfo());
+    rebuildIfNecessary();
     assert(_callbackId == null);
     _callbackId ??= SchedulerBinding.instance.scheduleFrameCallback(
       _frameCallback,

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -45,7 +45,13 @@ class TestSchedulerBinding extends BindingBase with SchedulerBinding, ServicesBi
     PlatformDispatcher.instance
       ..onBeginFrame = null
       ..onDrawFrame = null;
-    ensureFrameCallbacksRegistered();
+  }
+
+  @override
+  void ensureFrameCallbacksRegistered() {
+    // The override is needed because the super implementation is annotated with
+    // @protected.
+    super.ensureFrameCallbacksRegistered();
   }
 }
 
@@ -304,6 +310,7 @@ void main() {
 
     warmUpBeginFrame();
 
+    scheduler.ensureFrameCallbacksRegistered();
     // Simulate an animation frame firing between warm-up begin frame and warm-up draw frame.
     // Expect a timer that reschedules the frame.
     expect(scheduler.hasScheduledFrame, isFalse);

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -47,11 +47,10 @@ class TestSchedulerBinding extends BindingBase with SchedulerBinding, ServicesBi
       ..onDrawFrame = null;
   }
 
-  @override
-  void ensureFrameCallbacksRegistered() {
-    // The override is needed because the super implementation is annotated with
-    // @protected.
-    super.ensureFrameCallbacksRegistered();
+  /// Ensures callbacks for [PlatformDispatcher.onBeginFrame] and
+  /// [PlatformDispatcher.onDrawFrame] are registered.
+  void registerFrameCallbacks() {
+    ensureFrameCallbacksRegistered();
   }
 }
 
@@ -310,7 +309,7 @@ void main() {
 
     warmUpBeginFrame();
 
-    scheduler.ensureFrameCallbacksRegistered();
+    scheduler.registerFrameCallbacks();
     // Simulate an animation frame firing between warm-up begin frame and warm-up draw frame.
     // Expect a timer that reschedules the frame.
     expect(scheduler.hasScheduledFrame, isFalse);

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -38,6 +38,15 @@ class TestSchedulerBinding extends BindingBase with SchedulerBinding, ServicesBi
   List<Map<String, dynamic>> getEventsDispatched(String eventKind) {
     return eventsDispatched.putIfAbsent(eventKind, () => <Map<String, dynamic>>[]);
   }
+
+  void tearDown() {
+    additionalHandleBeginFrame = null;
+    additionalHandleDrawFrame = null;
+    PlatformDispatcher.instance
+      ..onBeginFrame = null
+      ..onDrawFrame = null;
+    ensureFrameCallbacksRegistered();
+  }
 }
 
 class TestStrategy {
@@ -55,13 +64,7 @@ void main() {
     scheduler = TestSchedulerBinding();
   });
 
-  tearDown(() {
-    scheduler.additionalHandleBeginFrame = null;
-    scheduler.additionalHandleDrawFrame = null;
-    PlatformDispatcher.instance
-      ..onBeginFrame = null
-      ..onDrawFrame = null;
-  });
+  tearDown(() => scheduler.tearDown());
 
   test('Tasks are executed in the right order', () {
     final TestStrategy strategy = TestStrategy();


### PR DESCRIPTION
The builder callback can capture free variables. So it must be re-evaluated every time `OverlayPortal` rebuilds.

Also defining the builder callback as a method in the State class seems to be a common pattern. So the `oldWidget.builder != builder` check may prevent necessary rebuilds when that's the case.


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
