### PR TITLE
[DisplayList] Use internal conversion for opacity->alpha

### DIFF
--- a/engine/src/flutter/display_list/dl_paint.h
+++ b/engine/src/flutter/display_list/dl_paint.h
@@ -76,8 +76,7 @@ class DlPaint {
   DlPaint& setAlpha(uint8_t alpha) { return setColor(color_.withAlpha(alpha)); }
   DlScalar getOpacity() const { return color_.getAlphaF(); }
   DlPaint& setOpacity(DlScalar opacity) {
-    setAlpha(SkScalarRoundToInt(opacity * 0xff));
-    return *this;
+    return setAlpha(DlColor::toAlpha(opacity));
   }
 
   DlBlendMode getBlendMode() const {


### PR DESCRIPTION
Removing an unnecessary dependence on an external library for doing opacity->alpha conversions in DlPaint.