### PR TITLE
Normalize path before searching for package config

### DIFF
--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -24,8 +24,8 @@ Future<PackageConfig> currentPackageConfig() async {
 // TODO(sigurdm): Only call this once per run - and read in from BuildInfo.
 File? findPackageConfigFile(Directory dir) {
   final FileSystem fileSystem = dir.fileSystem;
+  Directory candidateDir = fileSystem.directory(fileSystem.path.normalize(dir.absolute.path));
 
-  Directory candidateDir = fileSystem.directory(dir.path).absolute;
   while (true) {
     final File candidatePackageConfigFile = candidateDir
         .childDirectory('.dart_tool')

--- a/packages/flutter_tools/test/general.shard/dart/package_map_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/package_map_test.dart
@@ -45,5 +45,14 @@ void main() {
         isNotNull,
       );
     });
+
+    test('Works with a relative directory', () {
+      final Directory child = fileSystem.currentDirectory.childDirectory('child');
+
+      child.createSync(recursive: true);
+      fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+      fileSystem.currentDirectory = child;
+      expect(findPackageConfigFile(fileSystem.directory('.')), isNotNull);
+    });
   });
 }


### PR DESCRIPTION
If we don't normalize the `.absolute.path` will look like `/child/.`
And `Directory('/child/.').parent` is `Directory('/child)`.

