### PR TITLE
[Impeller] add barrier into render pass start.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
@@ -162,7 +162,7 @@ vk::UniqueRenderPass RenderPassBuilderVK::Build(
 
   if (depth_stencil_.has_value()) {
     depth_stencil_ref.attachment = attachments_index;
-    depth_stencil_ref.layout = vk::ImageLayout::eGeneral;
+    depth_stencil_ref.layout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
     attachments.at(attachments_index++) = depth_stencil_.value();
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -189,6 +189,7 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
                          vk::AccessFlagBits::eTransferRead |
                          vk::AccessFlagBits::eColorAttachmentWrite;
     barrier.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput |
+                        vk::PipelineStageFlagBits::eFragmentShader |
                         vk::PipelineStageFlagBits::eTransfer;
     barrier.dst_access = vk::AccessFlagBits::eColorAttachmentWrite;
     barrier.dst_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -19,13 +19,11 @@ std::shared_ptr<YUVConversionVK> TextureSourceVK::GetYUVConversion() const {
 }
 
 vk::ImageLayout TextureSourceVK::GetLayout() const {
-  ReaderLock lock(layout_mutex_);
   return layout_;
 }
 
 vk::ImageLayout TextureSourceVK::SetLayoutWithoutEncoding(
     vk::ImageLayout layout) const {
-  WriterLock lock(layout_mutex_);
   const auto old_layout = layout_;
   layout_ = layout;
   return old_layout;
@@ -33,9 +31,6 @@ vk::ImageLayout TextureSourceVK::SetLayoutWithoutEncoding(
 
 fml::Status TextureSourceVK::SetLayout(const BarrierVK& barrier) const {
   const auto old_layout = SetLayoutWithoutEncoding(barrier.new_layout);
-  if (barrier.new_layout == old_layout) {
-    return {};
-  }
 
   vk::ImageMemoryBarrier image_barrier;
   image_barrier.srcAccessMask = barrier.src_access;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -159,9 +159,7 @@ class TextureSourceVK {
  private:
   SharedHandleVK<vk::Framebuffer> framebuffer_;
   SharedHandleVK<vk::RenderPass> render_pass_;
-  mutable RWMutex layout_mutex_;
-  mutable vk::ImageLayout layout_ IPLR_GUARDED_BY(layout_mutex_) =
-      vk::ImageLayout::eUndefined;
+  mutable vk::ImageLayout layout_ = vk::ImageLayout::eUndefined;
 };
 
 }  // namespace impeller


### PR DESCRIPTION
Also removes incorrect logic in texture_vk which drops barriers that don't change the layout which is incorrect.
