### PR TITLE
[gradle] fix local engine property name

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -16,7 +16,7 @@ object FlutterPluginUtils {
     // Gradle properties.
     internal const val PROP_SHOULD_SHRINK_RESOURCES = "shrink"
     internal const val PROP_SPLIT_PER_ABI = "split-per-abi"
-    internal const val PROP_LOCAL_ENGINE_REPO = "localEngineRepo"
+    internal const val PROP_LOCAL_ENGINE_REPO = "local-engine-repo"
     internal const val PROP_IS_VERBOSE = "verbose"
     internal const val PROP_IS_FAST_START = "fast-start"
     internal const val PROP_TARGET = "target"
@@ -153,7 +153,7 @@ object FlutterPluginUtils {
         if (buildGradle.exists() && buildGradleKts.exists()) {
             logger.error(
                 """
-                Both build.gradle and build.gradle.kts exist, so 
+                Both build.gradle and build.gradle.kts exist, so
                 build.gradle.kts is ignored. This is likely a mistake.
                 """.trimIndent()
             )


### PR DESCRIPTION
I would recommend changing the propety mock so that the properties are given as strings and not constants, otherwise you can run into problems like this where the mock does exactly what you want :)