### PR TITLE
[Impeller] fix barriers on PowerVR hardware / ensure Render pass cached on non-MSAA.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
@@ -34,7 +34,8 @@ class RenderPassBuilderVK {
       SampleCount sample_count,
       LoadAction load_action,
       StoreAction store_action,
-      vk::ImageLayout current_layout = vk::ImageLayout::eUndefined);
+      vk::ImageLayout current_layout = vk::ImageLayout::eUndefined,
+      bool is_swapchain = false);
 
   RenderPassBuilderVK& SetDepthStencilAttachment(PixelFormat format,
                                                  SampleCount sample_count,

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
@@ -48,7 +48,7 @@ TEST(RenderPassBuilder, RenderPassWithLoadOpUsesCurrentLayout) {
   vk::AttachmentDescription color = maybe_color.value();
 
   EXPECT_EQ(color.initialLayout, vk::ImageLayout::eColorAttachmentOptimal);
-  EXPECT_EQ(color.finalLayout, vk::ImageLayout::eGeneral);
+  EXPECT_EQ(color.finalLayout, vk::ImageLayout::eShaderReadOnlyOptimal);
   EXPECT_EQ(color.loadOp, vk::AttachmentLoadOp::eLoad);
   EXPECT_EQ(color.storeOp, vk::AttachmentStoreOp::eStore);
 }
@@ -77,7 +77,7 @@ TEST(RenderPassBuilder, CreatesRenderPassWithCombinedDepthStencil) {
   vk::AttachmentDescription color = maybe_color.value();
 
   EXPECT_EQ(color.initialLayout, vk::ImageLayout::eUndefined);
-  EXPECT_EQ(color.finalLayout, vk::ImageLayout::eGeneral);
+  EXPECT_EQ(color.finalLayout, vk::ImageLayout::eShaderReadOnlyOptimal);
   EXPECT_EQ(color.loadOp, vk::AttachmentLoadOp::eClear);
   EXPECT_EQ(color.storeOp, vk::AttachmentStoreOp::eStore);
 
@@ -165,7 +165,7 @@ TEST(RenderPassBuilder, CreatesMSAAResolveWithCorrectStore) {
 
   // MSAA Resolve Texture.
   EXPECT_EQ(resolve.initialLayout, vk::ImageLayout::eUndefined);
-  EXPECT_EQ(resolve.finalLayout, vk::ImageLayout::eGeneral);
+  EXPECT_EQ(resolve.finalLayout, vk::ImageLayout::eShaderReadOnlyOptimal);
   EXPECT_EQ(resolve.loadOp, vk::AttachmentLoadOp::eClear);
   EXPECT_EQ(resolve.storeOp, vk::AttachmentStoreOp::eStore);
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
@@ -21,10 +21,45 @@ TEST_P(RendererTest, CachesRenderPassAndFramebuffer) {
   auto allocator = std::make_shared<RenderTargetAllocator>(
       GetContext()->GetResourceAllocator());
 
-  auto render_target =
+  RenderTarget render_target =
       allocator->CreateOffscreenMSAA(*GetContext(), {100, 100}, 1);
-  auto resolve_texture = render_target.GetColorAttachment(0).resolve_texture;
-  auto& texture_vk = TextureVK::Cast(*resolve_texture);
+  std::shared_ptr<Texture> resolve_texture =
+      render_target.GetColorAttachment(0).resolve_texture;
+  TextureVK& texture_vk = TextureVK::Cast(*resolve_texture);
+
+  EXPECT_EQ(texture_vk.GetCachedFramebuffer(), nullptr);
+  EXPECT_EQ(texture_vk.GetCachedRenderPass(), nullptr);
+
+  auto buffer = GetContext()->CreateCommandBuffer();
+  auto render_pass = buffer->CreateRenderPass(render_target);
+
+  EXPECT_NE(texture_vk.GetCachedFramebuffer(), nullptr);
+  EXPECT_NE(texture_vk.GetCachedRenderPass(), nullptr);
+
+  render_pass->EncodeCommands();
+  GetContext()->GetCommandQueue()->Submit({buffer});
+
+  // Can be reused without error.
+  auto buffer_2 = GetContext()->CreateCommandBuffer();
+  auto render_pass_2 = buffer_2->CreateRenderPass(render_target);
+
+  EXPECT_TRUE(render_pass_2->EncodeCommands());
+  EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer_2}).ok());
+}
+
+TEST_P(RendererTest, CachesRenderPassAndFramebufferNonMSAA) {
+  if (GetBackend() != PlaygroundBackend::kVulkan) {
+    GTEST_SKIP() << "Test only applies to Vulkan";
+  }
+
+  auto allocator = std::make_shared<RenderTargetAllocator>(
+      GetContext()->GetResourceAllocator());
+
+  RenderTarget render_target =
+      allocator->CreateOffscreen(*GetContext(), {100, 100}, 1);
+  std::shared_ptr<Texture> color_texture =
+      render_target.GetColorAttachment(0).texture;
+  TextureVK& texture_vk = TextureVK::Cast(*color_texture);
 
   EXPECT_EQ(texture_vk.GetCachedFramebuffer(), nullptr);
   EXPECT_EQ(texture_vk.GetCachedRenderPass(), nullptr);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
@@ -37,7 +37,7 @@ TEST_P(RendererTest, CachesRenderPassAndFramebuffer) {
   EXPECT_NE(texture_vk.GetCachedRenderPass(), nullptr);
 
   render_pass->EncodeCommands();
-  GetContext()->GetCommandQueue()->Submit({buffer});
+  EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer}).ok());
 
   // Can be reused without error.
   auto buffer_2 = GetContext()->CreateCommandBuffer();
@@ -71,7 +71,7 @@ TEST_P(RendererTest, CachesRenderPassAndFramebufferNonMSAA) {
   EXPECT_NE(texture_vk.GetCachedRenderPass(), nullptr);
 
   render_pass->EncodeCommands();
-  GetContext()->GetCommandQueue()->Submit({buffer});
+  EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer}).ok());
 
   // Can be reused without error.
   auto buffer_2 = GetContext()->CreateCommandBuffer();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -215,12 +215,12 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   if (resolve_image_vk_) {
     TextureVK::Cast(*resolve_image_vk_)
         .SetLayoutWithoutEncoding(
-            is_swapchain ? vk::ImageLayout::eColorAttachmentOptimal
+            is_swapchain ? vk::ImageLayout::eGeneral
                          : vk::ImageLayout::eShaderReadOnlyOptimal);
   }
   if (color_image_vk_) {
     TextureVK::Cast(*color_image_vk_)
-        .SetLayoutWithoutEncoding(vk::ImageLayout::eColorAttachmentOptimal);
+        .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
   }
 
   // Set the initial viewport.

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -78,20 +78,21 @@ static size_t GetVKClearValues(
 SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     const ContextVK& context,
     const SharedHandleVK<vk::RenderPass>& recycled_renderpass,
-    const std::shared_ptr<CommandBufferVK>& command_buffer) const {
+    const std::shared_ptr<CommandBufferVK>& command_buffer,
+    bool is_swapchain) const {
   RenderPassBuilderVK builder;
 
   render_target_.IterateAllColorAttachments([&](size_t bind_point,
                                                 const ColorAttachment&
                                                     attachment) -> bool {
     builder.SetColorAttachment(
-        bind_point,                                                          //
-        attachment.texture->GetTextureDescriptor().format,                   //
-        attachment.texture->GetTextureDescriptor().sample_count,             //
-        attachment.load_action,                                              //
-        attachment.store_action,                                             //
-        /*current_layout=*/TextureVK::Cast(*attachment.texture).GetLayout()  //
-    );
+        bind_point,                                                           //
+        attachment.texture->GetTextureDescriptor().format,                    //
+        attachment.texture->GetTextureDescriptor().sample_count,              //
+        attachment.load_action,                                               //
+        attachment.store_action,                                              //
+        /*current_layout=*/TextureVK::Cast(*attachment.texture).GetLayout(),  //
+        /*is_swapchain=*/is_swapchain);
     return true;
   });
 
@@ -151,12 +152,24 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
         TextureVK::Cast(*resolve_image_vk_).GetCachedRenderPass();
     recycled_framebuffer =
         TextureVK::Cast(*resolve_image_vk_).GetCachedFramebuffer();
+  } else {
+    recycled_render_pass =
+        TextureVK::Cast(*color_image_vk_).GetCachedRenderPass();
+    recycled_framebuffer =
+        TextureVK::Cast(*color_image_vk_).GetCachedFramebuffer();
   }
 
   const auto& target_size = render_target_.GetRenderTargetSize();
 
-  render_pass_ =
-      CreateVKRenderPass(vk_context, recycled_render_pass, command_buffer_);
+  bool is_swapchain = false;
+  if (resolve_image_vk_) {
+    is_swapchain = TextureVK::Cast(*resolve_image_vk_).IsSwapchainImage();
+  } else {
+    is_swapchain = TextureVK::Cast(*color_image_vk_).IsSwapchainImage();
+  }
+
+  render_pass_ = CreateVKRenderPass(vk_context, recycled_render_pass,
+                                    command_buffer_, is_swapchain);
   if (!render_pass_) {
     VALIDATION_LOG << "Could not create renderpass.";
     is_valid_ = false;
@@ -180,8 +193,9 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   if (resolve_image_vk_) {
     TextureVK::Cast(*resolve_image_vk_).SetCachedFramebuffer(framebuffer);
     TextureVK::Cast(*resolve_image_vk_).SetCachedRenderPass(render_pass_);
-    TextureVK::Cast(*resolve_image_vk_)
-        .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
+  } else {
+    TextureVK::Cast(*color_image_vk_).SetCachedFramebuffer(framebuffer);
+    TextureVK::Cast(*color_image_vk_).SetCachedRenderPass(render_pass_);
   }
 
   std::array<vk::ClearValue, kMaxAttachments> clears;
@@ -200,11 +214,13 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
 
   if (resolve_image_vk_) {
     TextureVK::Cast(*resolve_image_vk_)
-        .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
+        .SetLayoutWithoutEncoding(
+            is_swapchain ? vk::ImageLayout::eColorAttachmentOptimal
+                         : vk::ImageLayout::eShaderReadOnlyOptimal);
   }
   if (color_image_vk_) {
     TextureVK::Cast(*color_image_vk_)
-        .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
+        .SetLayoutWithoutEncoding(vk::ImageLayout::eColorAttachmentOptimal);
   }
 
   // Set the initial viewport.
@@ -659,29 +675,6 @@ bool RenderPassVK::BindResource(ShaderStage stage,
 
 bool RenderPassVK::OnEncodeCommands(const Context& context) const {
   command_buffer_->GetCommandBuffer().endRenderPass();
-
-  // If this render target will be consumed by a subsequent render pass,
-  // perform a layout transition to a shader read state.
-  const std::shared_ptr<Texture>& result_texture =
-      resolve_image_vk_ ? resolve_image_vk_ : color_image_vk_;
-  if (result_texture->GetTextureDescriptor().usage &
-      TextureUsage::kShaderRead) {
-    BarrierVK barrier;
-    barrier.cmd_buffer = command_buffer_vk_;
-    barrier.src_access = vk::AccessFlagBits::eColorAttachmentWrite |
-                         vk::AccessFlagBits::eTransferWrite;
-    barrier.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput |
-                        vk::PipelineStageFlagBits::eTransfer;
-    barrier.dst_access = vk::AccessFlagBits::eShaderRead;
-    barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader;
-
-    barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
-
-    if (!TextureVK::Cast(*result_texture).SetLayout(barrier)) {
-      return false;
-    }
-  }
-
   return true;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -135,7 +135,8 @@ class RenderPassVK final : public RenderPass {
   SharedHandleVK<vk::RenderPass> CreateVKRenderPass(
       const ContextVK& context,
       const SharedHandleVK<vk::RenderPass>& recycled_renderpass,
-      const std::shared_ptr<CommandBufferVK>& command_buffer) const;
+      const std::shared_ptr<CommandBufferVK>& command_buffer,
+      bool is_swapchain) const;
 
   SharedHandleVK<vk::Framebuffer> CreateVKFramebuffer(
       const ContextVK& context,


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/162033

- barriers for render pass are not correct, but only causes a problem on powervr/imagination. Added new external subpass dependencies that have better descriptions for what they do. We now use the subpass to transition images that are sampled to the final shaderReadOnlylayout, while keeping swapchain images in eGeneral.

- missing cache for render pass objects when using non-msaa passes. This mostly impacts powervr hardware because render pass construction is much slower there.