### PR TITLE
Use EGLImage to pass Flutter frames between GTK OpenGL contexts

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
@@ -32,6 +32,18 @@ G_DECLARE_FINAL_TYPE(FlFramebuffer, fl_framebuffer, FL, FRAMEBUFFER, GObject)
 FlFramebuffer* fl_framebuffer_new(GLint format, size_t width, size_t height);
 
 /**
+ * fl_framebuffer_create_sibling:
+ * @framebuffer: an #FlFramebuffer.
+ *
+ * Creates a new framebuffer with the same backing texture as the original. This
+ * uses EGLImage to share the texture and allows a framebuffer created in one
+ * OpenGL context to be used in another.
+ *
+ * Returns: a new #FlFramebuffer.
+ */
+FlFramebuffer* fl_framebuffer_create_sibling(FlFramebuffer* framebuffer);
+
+/**
  * fl_framebuffer_get_id:
  * @framebuffer: an #FlFramebuffer.
  *

--- a/engine/src/flutter/shell/platform/linux/fl_renderer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_renderer.cc
@@ -693,9 +693,9 @@ void fl_renderer_setup(FlRenderer* self) {
        epoxy_has_gl_extension("GL_EXT_framebuffer_blit"));
 
   EGLDisplay egl_display = eglGetCurrentDisplay();
+  // EGLImage
   if (egl_display != nullptr) {
     gboolean has_egl_image =
-        epoxy_egl_version(egl_display) >= 15 ||
         epoxy_has_egl_extension(egl_display, "EGL_KHR_image_base") ||
         epoxy_has_egl_extension(egl_display, "EGL_KHR_image");
     priv->has_egl_image =

--- a/engine/src/flutter/shell/platform/linux/fl_renderer_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_renderer_test.cc
@@ -371,6 +371,79 @@ TEST(FlRendererTest, MultiView) {
   ON_CALL(epoxy, epoxy_is_desktop_gl).WillByDefault(::testing::Return(true));
   EXPECT_CALL(epoxy, epoxy_gl_version).WillRepeatedly(::testing::Return(30));
 
+  EXPECT_CALL(epoxy, glEGLImageTargetTexture2DOES).Times(0);
+
+  g_autoptr(FlMockRenderable) renderable = fl_mock_renderable_new();
+  g_autoptr(FlMockRenderable) secondary_renderable = fl_mock_renderable_new();
+
+  g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
+  fl_renderer_setup(FL_RENDERER(renderer));
+  fl_renderer_set_engine(FL_RENDERER(renderer), engine);
+  fl_renderer_add_renderable(FL_RENDERER(renderer),
+                             flutter::kFlutterImplicitViewId,
+                             FL_RENDERABLE(renderable));
+  fl_renderer_add_renderable(FL_RENDERER(renderer), 1,
+                             FL_RENDERABLE(secondary_renderable));
+  fl_renderer_wait_for_frame(FL_RENDERER(renderer), 1024, 1024);
+
+  EXPECT_EQ(fl_mock_renderable_get_redraw_count(renderable),
+            static_cast<size_t>(0));
+  EXPECT_EQ(fl_mock_renderable_get_redraw_count(secondary_renderable),
+            static_cast<size_t>(0));
+
+  FlutterBackingStoreConfig config = {
+      .struct_size = sizeof(FlutterBackingStoreConfig),
+      .size = {.width = 1024, .height = 1024}};
+  FlutterBackingStore backing_store;
+  fl_renderer_create_backing_store(FL_RENDERER(renderer), &config,
+                                   &backing_store);
+
+  fml::AutoResetWaitableEvent latch;
+
+  // Simulate raster thread.
+  std::thread([&]() {
+    const FlutterLayer layer0 = {.struct_size = sizeof(FlutterLayer),
+                                 .type = kFlutterLayerContentTypeBackingStore,
+                                 .backing_store = &backing_store,
+                                 .size = {.width = 1024, .height = 1024}};
+    const FlutterLayer* layers[] = {&layer0};
+    fl_renderer_present_layers(FL_RENDERER(renderer), 1, layers, 1);
+    latch.Signal();
+  }).detach();
+
+  while (fl_mock_renderable_get_redraw_count(secondary_renderable) == 0) {
+    g_main_context_iteration(nullptr, true);
+  }
+
+  EXPECT_EQ(fl_mock_renderable_get_redraw_count(renderable),
+            static_cast<size_t>(0));
+  EXPECT_EQ(fl_mock_renderable_get_redraw_count(secondary_renderable),
+            static_cast<size_t>(1));
+
+  // Wait until the raster thread has finished before letting
+  // the engine go out of scope.
+  latch.Wait();
+}
+
+TEST(FlRendererTest, MultiViewEGLImage) {
+  ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project);
+
+  // OpenGL 3.0
+  ON_CALL(epoxy, glGetString(GL_VENDOR))
+      .WillByDefault(
+          ::testing::Return(reinterpret_cast<const GLubyte*>("Intel")));
+  ON_CALL(epoxy, epoxy_is_desktop_gl).WillByDefault(::testing::Return(true));
+  EXPECT_CALL(epoxy, epoxy_gl_version).WillRepeatedly(::testing::Return(30));
+  ON_CALL(epoxy, epoxy_has_egl_extension(::testing::_,
+                                         ::testing::StrEq("EGL_KHR_image")))
+      .WillByDefault(::testing::Return(true));
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::StrEq("GL_OES_EGL_image")))
+      .WillByDefault(::testing::Return(true));
+
+  EXPECT_CALL(epoxy, glEGLImageTargetTexture2DOES);
+
   g_autoptr(FlMockRenderable) renderable = fl_mock_renderable_new();
   g_autoptr(FlMockRenderable) secondary_renderable = fl_mock_renderable_new();
 

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
@@ -427,7 +427,9 @@ void _glDeleteShader(GLuint shader) {}
 
 void _glDeleteTextures(GLsizei n, const GLuint* textures) {}
 
-void _glEGLImageTargetTexture2DOES(GLenum target, EGLImage image) {}
+void _glEGLImageTargetTexture2DOES(GLenum target, EGLImage image) {
+  mock->glEGLImageTargetTexture2DOES(target, image);
+}
 
 static void _glFramebufferRenderbuffer(GLenum target,
                                        GLenum attachment,

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
@@ -18,8 +18,12 @@ class MockEpoxy {
   MockEpoxy();
   ~MockEpoxy();
 
+  MOCK_METHOD(bool,
+              epoxy_has_egl_extension,
+              (EGLDisplay display, const char* extension));
   MOCK_METHOD(bool, epoxy_has_gl_extension, (const char* extension));
   MOCK_METHOD(bool, epoxy_is_desktop_gl, ());
+  MOCK_METHOD(int, epoxy_egl_version, (EGLDisplay display));
   MOCK_METHOD(int, epoxy_gl_version, ());
   MOCK_METHOD(void, glClearColor, (GLfloat r, GLfloat g, GLfloat b, GLfloat a));
   MOCK_METHOD(void,

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
@@ -38,6 +38,9 @@ class MockEpoxy {
                GLint dstY1,
                GLbitfield mask,
                GLenum filter));
+  MOCK_METHOD(void,
+              glEGLImageTargetTexture2DOES,
+              (GLenum target, EGLImage image));
   MOCK_METHOD(const GLubyte*, glGetString, (GLenum pname));
 };
 

--- a/engine/src/flutter/shell/platform/linux/testing/mock_gtk.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_gtk.cc
@@ -124,6 +124,8 @@ void gtk_window_deiconify(GtkWindow* window) {
   mock->gtk_window_deiconify(window);
 }
 
+void gtk_widget_realize(GtkWidget* widget) {}
+
 void gtk_widget_show(GtkWidget* widget) {}
 
 void gtk_widget_destroy(GtkWidget* widget) {

--- a/packages/flutter_tools/lib/src/linux/linux_doctor.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_doctor.dart
@@ -285,23 +285,36 @@ class LinuxDoctorValidator extends DoctorValidator {
         }
 
         // Check if has specified OpenGL extension.
-        ValidationMessage extensionStatus(String variableName, String extensionName) {
-          final List<String> waylandExtensions =
-              driverInfo.getListVariable(kWaylandPlatform, variableName) ?? <String>[];
-          final List<String> x11Extensions =
-              driverInfo.getListVariable(kX11Platform, variableName) ?? <String>[];
+        ValidationMessage extensionStatus(String extensionName) {
+          final List<String> coreWaylandExtensions =
+              driverInfo.getListVariable(kWaylandPlatform, kOpenGLCoreProfileExtensions) ??
+              <String>[];
+          final List<String> coreX11Extensions =
+              driverInfo.getListVariable(kX11Platform, kOpenGLCoreProfileExtensions) ?? <String>[];
+          final List<String> esWaylandExtensions =
+              driverInfo.getListVariable(kWaylandPlatform, kOpenGLESProfileExtensions) ??
+              <String>[];
+          final List<String> esX11Extensions =
+              driverInfo.getListVariable(kX11Platform, kOpenGLESProfileExtensions) ?? <String>[];
 
-          final bool hasWayland = waylandExtensions.contains(extensionName);
-          final bool hasX11 = x11Extensions.contains(extensionName);
+          List<String> cases = <String>[];
+          if (coreWaylandExtensions.contains(extensionName)) {
+            cases.add('core/Wayland');
+          }
+          if (coreX11Extensions.contains(extensionName)) {
+            cases.add('core/X11');
+          }
+          if (esWaylandExtensions.contains(extensionName)) {
+            cases.add('ES/Wayland');
+          }
+          if (esX11Extensions.contains(extensionName)) {
+            cases.add('ES/X11');
+          }
           String status;
-          if (!hasWayland && !hasX11) {
-            status = 'no';
-          } else if (!hasWayland) {
-            status = 'yes (X11)';
-          } else if (!hasX11) {
-            status = 'yes (Wayland)';
+          if (cases.isNotEmpty) {
+            status = 'yes (${cases.join(", ")})';
           } else {
-            status = 'yes';
+            status = 'no';
           }
 
           return ValidationMessage('$extensionName: $status');
@@ -329,8 +342,10 @@ class LinuxDoctorValidator extends DoctorValidator {
             ValidationMessage('OpenGL ES shading language version: $shadingLanguageVersion'),
           );
         }
-        messages.add(extensionStatus(kOpenGLCoreProfileExtensions, 'GL_EXT_framebuffer_blit'));
-        messages.add(extensionStatus(kOpenGLESProfileExtensions, 'GL_EXT_texture_format_BGRA8888'));
+        messages.add(extensionStatus('GL_EXT_framebuffer_blit'));
+        messages.add(extensionStatus('GL_EXT_texture_format_BGRA8888'));
+        messages.add(extensionStatus('GL_OES_EGL_image'));
+        messages.add(extensionStatus('GL_OES_EGL_image_external'));
       }
     }
 

--- a/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
@@ -95,7 +95,7 @@ OpenGL core profile renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)
 OpenGL core profile version: 4.6 (Core Profile) Mesa 24.2.8-1ubuntu1~24.10.1
 OpenGL core profile shading language version: 4.60
 OpenGL core profile extensions:
-    GL_ARB_blend_func_extended, GL_EXT_framebuffer_blit
+    GL_ARB_blend_func_extended, GL_EXT_framebuffer_blit, GL_OES_EGL_image
 ''';
     }
     if (es) {
@@ -105,7 +105,7 @@ OpenGL ES profile renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)
 OpenGL ES profile version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1
 OpenGL ES profile shading language version: OpenGL ES GLSL ES 3.20
 OpenGL ES profile extensions:
-    GL_EXT_EGL_image_storage, GL_EXT_texture_format_BGRA8888
+    GL_EXT_EGL_image_storage, GL_EXT_texture_format_BGRA8888, GL_OES_EGL_image, GL_OES_EGL_image_external
 ''';
     }
     stdout += '''
@@ -133,7 +133,7 @@ OpenGL core profile renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)
 OpenGL core profile version: 4.6 (Core Profile) Mesa 24.2.8-1ubuntu1~24.10.1
 OpenGL core profile shading language version: 4.60
 OpenGL core profile extensions:
-    GL_ARB_blend_func_extended, GL_EXT_framebuffer_blit
+    GL_ARB_blend_func_extended, GL_EXT_framebuffer_blit, GL_OES_EGL_image
 ''';
     }
     if (es) {
@@ -143,7 +143,7 @@ OpenGL ES profile renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)
 OpenGL ES profile version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1
 OpenGL ES profile shading language version: OpenGL ES GLSL ES 3.20
 OpenGL ES profile extensions:
-    GL_EXT_EGL_image_storage, GL_EXT_texture_format_BGRA8888
+    GL_EXT_EGL_image_storage, GL_EXT_texture_format_BGRA8888, GL_OES_EGL_image, GL_OES_EGL_image_external
 ''';
     }
     stdout += '''
@@ -220,8 +220,10 @@ void main() {
         ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
         ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
         ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-        ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-        ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+        ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+        ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+        ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+        ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
       ]);
     },
   );
@@ -254,8 +256,10 @@ void main() {
       ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -287,8 +291,10 @@ void main() {
       ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -320,8 +326,10 @@ void main() {
       ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -353,8 +361,10 @@ void main() {
       ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -412,8 +422,10 @@ void main() {
       const ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       const ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       const ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      const ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      const ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -447,8 +459,10 @@ void main() {
       const ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       const ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       const ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      const ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      const ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -482,8 +496,10 @@ void main() {
       const ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       const ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       const ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      const ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      const ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -517,8 +533,10 @@ void main() {
       const ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       const ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       const ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      const ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      const ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -552,8 +570,10 @@ void main() {
       const ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       const ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       const ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      const ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      const ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -587,8 +607,10 @@ void main() {
       const ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       const ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       const ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      const ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      const ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -673,8 +695,10 @@ void main() {
       const ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       const ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       const ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
-      const ValidationMessage('GL_EXT_framebuffer_blit: yes'),
-      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      const ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
+      const ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11, ES/Wayland, ES/X11)'),
+      const ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 
@@ -751,8 +775,10 @@ void main() {
       ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2) (Wayland)'),
       ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1 (Wayland)'),
       ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20 (Wayland)'),
-      ValidationMessage('GL_EXT_framebuffer_blit: yes (Wayland)'),
-      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (Wayland)'),
+      ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland)'),
+      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland)'),
+      ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, ES/Wayland)'),
+      ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland)'),
     ]);
   });
 
@@ -785,8 +811,10 @@ void main() {
       ValidationMessage('OpenGL ES renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2) (X11)'),
       ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1 (X11)'),
       ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20 (X11)'),
-      ValidationMessage('GL_EXT_framebuffer_blit: yes (X11)'),
-      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (X11)'),
+      ValidationMessage('GL_EXT_framebuffer_blit: yes (core/X11)'),
+      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image: yes (core/X11, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image_external: yes (ES/X11)'),
     ]);
   });
 
@@ -814,8 +842,10 @@ void main() {
       ValidationMessage('OpenGL core renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)'),
       ValidationMessage('OpenGL core version: 4.6 (Core Profile) Mesa 24.2.8-1ubuntu1~24.10.1'),
       ValidationMessage('OpenGL core shading language version: 4.60'),
-      ValidationMessage('GL_EXT_framebuffer_blit: yes'),
+      ValidationMessage('GL_EXT_framebuffer_blit: yes (core/Wayland, core/X11)'),
       ValidationMessage('GL_EXT_texture_format_BGRA8888: no'),
+      ValidationMessage('GL_OES_EGL_image: yes (core/Wayland, core/X11)'),
+      ValidationMessage('GL_OES_EGL_image_external: no'),
     ]);
   });
 
@@ -844,7 +874,9 @@ void main() {
       ValidationMessage('OpenGL ES version: OpenGL ES 3.2 Mesa 24.2.8-1ubuntu1~24.10.1'),
       ValidationMessage('OpenGL ES shading language version: OpenGL ES GLSL ES 3.20'),
       ValidationMessage('GL_EXT_framebuffer_blit: no'),
-      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes'),
+      ValidationMessage('GL_EXT_texture_format_BGRA8888: yes (ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image: yes (ES/Wayland, ES/X11)'),
+      ValidationMessage('GL_OES_EGL_image_external: yes (ES/Wayland, ES/X11)'),
     ]);
   });
 }


### PR DESCRIPTION
Optimize multi-view by passing the frames between OpenGL contexts using EGLImage (i.e. no copy). If we don't have the required extensions, fall back to the existing method (copy via CPU).