### PR TITLE
Add support for language hints in TextFields (Android only)

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.json.JSONArray;
@@ -478,6 +479,16 @@ public class TextInputChannel {
         }
       }
 
+      // Build an array of hint locales from the data in the JSON list.
+      Locale[] hintLocales = null;
+      if (!json.isNull("hintLocales")) {
+        JSONArray hintLocalesJson = json.getJSONArray("hintLocales");
+        hintLocales = new Locale[hintLocalesJson.length()];
+        for (int i = 0; i < hintLocalesJson.length(); i++) {
+          hintLocales[i] = Locale.forLanguageTag(hintLocalesJson.optString(i));
+        }
+      }
+
       return new Configuration(
           json.optBoolean("obscureText"),
           json.optBoolean("autocorrect", true),
@@ -490,7 +501,8 @@ public class TextInputChannel {
           json.isNull("actionLabel") ? null : json.getString("actionLabel"),
           json.isNull("autofill") ? null : Autofill.fromJson(json.getJSONObject("autofill")),
           contentList.toArray(new String[contentList.size()]),
-          fields);
+          fields,
+          hintLocales);
     }
 
     @NonNull
@@ -649,6 +661,7 @@ public class TextInputChannel {
     @Nullable public final Autofill autofill;
     @Nullable public final String[] contentCommitMimeTypes;
     @Nullable public final Configuration[] fields;
+    @Nullable public final Locale[] hintLocales;
 
     public Configuration(
         boolean obscureText,
@@ -662,7 +675,8 @@ public class TextInputChannel {
         @Nullable String actionLabel,
         @Nullable Autofill autofill,
         @Nullable String[] contentCommitMimeTypes,
-        @Nullable Configuration[] fields) {
+        @Nullable Configuration[] fields,
+        @Nullable Locale[] hintLocales) {
       this.obscureText = obscureText;
       this.autocorrect = autocorrect;
       this.enableSuggestions = enableSuggestions;
@@ -675,6 +689,7 @@ public class TextInputChannel {
       this.autofill = autofill;
       this.contentCommitMimeTypes = contentCommitMimeTypes;
       this.fields = fields;
+      this.hintLocales = hintLocales;
     }
   }
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.LocaleList;
 import android.text.Editable;
 import android.text.InputType;
 import android.util.SparseArray;
@@ -348,6 +349,10 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       outAttrs.actionId = enterAction;
     }
     outAttrs.imeOptions |= enterAction;
+
+    if (configuration.hintLocales != null) {
+      outAttrs.hintLocales = new LocaleList(configuration.hintLocales);
+    }
 
     if (configuration.contentCommitMimeTypes != null) {
       String[] imgTypeString = configuration.contentCommitMimeTypes;

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -350,7 +350,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     }
     outAttrs.imeOptions |= enterAction;
 
-    if (configuration.hintLocales != null) {
+    if (Build.VERSION.SDK_INT >= API_LEVELS.API_24 && configuration.hintLocales != null) {
       outAttrs.hintLocales = new LocaleList(configuration.hintLocales);
     }
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java
@@ -43,6 +43,8 @@ public class TextInputChannelTest {
   }
 
   @Test
+  @TargetApi(API_LEVELS.API_24)
+  @Config(sdk = API_LEVELS.API_24)
   public void configurationFromJsonParsesHintLocales() throws JSONException, NoSuchFieldException {
     JSONObject arguments = new JSONObject();
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.engine.systemchannels;
 
 import static io.flutter.Build.API_LEVELS;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -13,6 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import java.util.Locale;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -38,5 +40,26 @@ public class TextInputChannelTest {
     MethodChannel.Result result = mock(MethodChannel.Result.class);
     textInputChannel.parsingMethodHandler.onMethodCall(call, result);
     verify(result).success(null);
+  }
+
+  @Test
+  public void configurationFromJsonParsesHintLocales() throws JSONException, NoSuchFieldException {
+    JSONObject arguments = new JSONObject();
+
+    // Mandatory parameters.
+    arguments.put("inputAction", "TextInputAction.done");
+    arguments.put("textCapitalization", "TextCapitalization.none");
+    JSONObject inputType = new JSONObject();
+    inputType.put("name", "TextInputType.text");
+    arguments.put("inputType", inputType);
+
+    arguments.put("hintLocales", new JSONArray(new String[] {"en", "fr"}));
+    final TextInputChannel.Configuration configuration =
+        TextInputChannel.Configuration.fromJson(arguments);
+
+    final Locale[] hintLocales = {new Locale("en"), new Locale("fr")};
+    assertEquals(configuration.hintLocales.length, hintLocales.length);
+    assertEquals(configuration.hintLocales[0], hintLocales[0]);
+    assertEquals(configuration.hintLocales[1], hintLocales[1]);
   }
 }

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -2746,6 +2746,8 @@ public class TextInputPluginTest {
   }
 
   @Test
+  @TargetApi(API_LEVELS.API_24)
+  @Config(sdk = API_LEVELS.API_24)
   public void inputConnection_hintLocalesIsSetInEditorInfo() {
     View testView = new View(ctx);
     DartExecutor dartExecutor = mock(DartExecutor.class);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -29,6 +29,7 @@ import android.graphics.Insets;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.LocaleList;
 import android.provider.Settings;
 import android.text.InputType;
 import android.text.Selection;
@@ -68,6 +69,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -184,6 +186,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     textInputPlugin.setTextInputEditingState(
@@ -255,6 +258,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     textInputPlugin.setTextInputEditingState(
@@ -310,6 +314,7 @@ public class TextInputPluginTest {
             false, // Delta model is disabled.
             TextInputChannel.TextCapitalization.NONE,
             new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false),
+            null,
             null,
             null,
             null,
@@ -431,6 +436,7 @@ public class TextInputPluginTest {
             true, // Enable delta model.
             TextInputChannel.TextCapitalization.NONE,
             new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false),
+            null,
             null,
             null,
             null,
@@ -570,6 +576,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     // There's a pending restart since we initialized the text input client. Flush that now.
@@ -682,6 +689,7 @@ public class TextInputPluginTest {
             true, // Enable delta model.
             TextInputChannel.TextCapitalization.NONE,
             new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false),
+            null,
             null,
             null,
             null,
@@ -800,6 +808,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     // There's a pending restart since we initialized the text input client. Flush that now.
@@ -911,6 +920,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     // There's a pending restart since we initialized the text input client. Flush that now.
@@ -1006,6 +1016,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
     // There's a pending restart since we initialized the text input client. Flush that now.
     textInputPlugin.setTextInputEditingState(
@@ -1045,6 +1056,7 @@ public class TextInputPluginTest {
             true,
             false,
             TextInputChannel.TextCapitalization.NONE,
+            null,
             null,
             null,
             null,
@@ -1100,6 +1112,7 @@ public class TextInputPluginTest {
             false,
             TextInputChannel.TextCapitalization.NONE,
             new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false),
+            null,
             null,
             null,
             null,
@@ -1211,6 +1224,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
     // There's a pending restart since we initialized the text input client. Flush that now.
     textInputPlugin.setTextInputEditingState(
@@ -1262,6 +1276,7 @@ public class TextInputPluginTest {
             false,
             TextInputChannel.TextCapitalization.NONE,
             new TextInputChannel.InputType(textInputType, false, false),
+            null,
             null,
             null,
             null,
@@ -1347,6 +1362,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
     // There's a pending restart since we initialized the text input client. Flush that now.
     textInputPlugin.setTextInputEditingState(
@@ -1391,6 +1407,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     InputConnection connection =
@@ -1427,6 +1444,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     textInputPlugin.showTextInput(testView);
@@ -1457,6 +1475,7 @@ public class TextInputPluginTest {
             false,
             TextInputChannel.TextCapitalization.NONE,
             new TextInputChannel.InputType(TextInputChannel.TextInputType.WEB_SEARCH, false, false),
+            null,
             null,
             null,
             null,
@@ -1499,6 +1518,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     EditorInfo editorInfo = new EditorInfo();
@@ -1534,6 +1554,7 @@ public class TextInputPluginTest {
             false,
             TextInputChannel.TextCapitalization.NONE,
             new TextInputChannel.InputType(TextInputChannel.TextInputType.MULTILINE, false, false),
+            null,
             null,
             null,
             null,
@@ -1581,6 +1602,7 @@ public class TextInputPluginTest {
             null,
             null,
             null,
+            null,
             null));
 
     EditorInfo editorInfo = new EditorInfo();
@@ -1615,6 +1637,7 @@ public class TextInputPluginTest {
             false,
             TextInputChannel.TextCapitalization.NONE,
             new TextInputChannel.InputType(TextInputChannel.TextInputType.MULTILINE, false, false),
+            null,
             null,
             null,
             null,
@@ -1661,6 +1684,7 @@ public class TextInputPluginTest {
             null,
             autofill,
             null,
+            null,
             null);
 
     textInputPlugin.setTextInputClient(
@@ -1677,7 +1701,8 @@ public class TextInputPluginTest {
             null,
             autofill,
             null,
-            new TextInputChannel.Configuration[] {config}));
+            new TextInputChannel.Configuration[] {config},
+            null));
 
     final ViewStructure viewStructure = mock(ViewStructure.class);
     final ViewStructure[] children = {mock(ViewStructure.class), mock(ViewStructure.class)};
@@ -1722,6 +1747,7 @@ public class TextInputPluginTest {
             true,
             false,
             TextInputChannel.TextCapitalization.NONE,
+            null,
             null,
             null,
             null,
@@ -1772,6 +1798,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill,
+            null,
             null,
             null);
 
@@ -1830,6 +1857,7 @@ public class TextInputPluginTest {
             null,
             autofill1,
             null,
+            null,
             null);
     final TextInputChannel.Configuration config2 =
         new TextInputChannel.Configuration(
@@ -1843,6 +1871,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill2,
+            null,
             null,
             null);
 
@@ -1860,7 +1889,8 @@ public class TextInputPluginTest {
             null,
             autofill1,
             null,
-            new TextInputChannel.Configuration[] {config1, config2}));
+            new TextInputChannel.Configuration[] {config1, config2},
+            null));
 
     final ViewStructure viewStructure = mock(ViewStructure.class);
     final ViewStructure[] children = {mock(ViewStructure.class), mock(ViewStructure.class)};
@@ -1923,6 +1953,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill,
+            null,
             null,
             null));
 
@@ -1989,6 +2020,7 @@ public class TextInputPluginTest {
             null,
             autofill1,
             null,
+            null,
             null);
     final TextInputChannel.Configuration config2 =
         new TextInputChannel.Configuration(
@@ -2002,6 +2034,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill2,
+            null,
             null,
             null);
 
@@ -2020,7 +2053,8 @@ public class TextInputPluginTest {
             null,
             autofill1,
             null,
-            new TextInputChannel.Configuration[] {config1, config2});
+            new TextInputChannel.Configuration[] {config1, config2},
+            null);
 
     textInputPlugin.setTextInputClient(0, autofillConfiguration);
 
@@ -2061,6 +2095,7 @@ public class TextInputPluginTest {
             true,
             false,
             TextInputChannel.TextCapitalization.NONE,
+            null,
             null,
             null,
             null,
@@ -2132,6 +2167,7 @@ public class TextInputPluginTest {
             null,
             autofill1,
             null,
+            null,
             null);
     final TextInputChannel.Configuration config2 =
         new TextInputChannel.Configuration(
@@ -2145,6 +2181,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill2,
+            null,
             null,
             null);
 
@@ -2161,7 +2198,8 @@ public class TextInputPluginTest {
             null,
             autofill1,
             null,
-            new TextInputChannel.Configuration[] {config1, config2});
+            new TextInputChannel.Configuration[] {config1, config2},
+            null);
 
     textInputPlugin.setTextInputClient(0, autofillConfiguration);
     textInputPlugin.setTextInputEditingState(
@@ -2224,6 +2262,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofillConfig,
+            null,
             null,
             null);
 
@@ -2291,6 +2330,7 @@ public class TextInputPluginTest {
             null,
             autofill1,
             null,
+            null,
             null);
     final TextInputChannel.Configuration config2 =
         new TextInputChannel.Configuration(
@@ -2304,6 +2344,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill2,
+            null,
             null,
             null);
 
@@ -2320,7 +2361,8 @@ public class TextInputPluginTest {
             null,
             autofill1,
             null,
-            new TextInputChannel.Configuration[] {config1, config2});
+            new TextInputChannel.Configuration[] {config1, config2},
+            null);
 
     textInputPlugin.setTextInputClient(0, autofillConfiguration);
 
@@ -2701,6 +2743,44 @@ public class TextInputPluginTest {
 
     verify(flutterRenderer, atLeast(1)).setViewportMetrics(viewportMetricsCaptor.capture());
     assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
+  }
+
+  @Test
+  public void inputConnection_hintLocalesIsSetInEditorInfo() {
+    View testView = new View(ctx);
+    DartExecutor dartExecutor = mock(DartExecutor.class);
+    TextInputChannel textInputChannel = new TextInputChannel(dartExecutor);
+    ScribeChannel scribeChannel = new ScribeChannel(mock(DartExecutor.class));
+    TextInputPlugin textInputPlugin =
+        new TextInputPlugin(
+            testView,
+            textInputChannel,
+            scribeChannel,
+            mock(PlatformViewsController.class),
+            mock(PlatformViewsController2.class));
+    final Locale[] hintLocales = {new Locale("en")};
+    textInputPlugin.setTextInputClient(
+        0,
+        new TextInputChannel.Configuration(
+            false,
+            false,
+            true,
+            true,
+            false,
+            TextInputChannel.TextCapitalization.NONE,
+            new TextInputChannel.InputType(TextInputChannel.TextInputType.MULTILINE, false, false),
+            null,
+            null,
+            null,
+            null,
+            null,
+            hintLocales));
+
+    EditorInfo editorInfo = new EditorInfo();
+    InputConnection connection =
+        textInputPlugin.createInputConnection(testView, mock(KeyboardManager.class), editorInfo);
+
+    assertEquals(editorInfo.hintLocales, new LocaleList(hintLocales));
   }
 
   interface EventHandler {

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -316,6 +316,7 @@ class TextField extends StatefulWidget {
     this.canRequestFocus = true,
     this.spellCheckConfiguration,
     this.magnifierConfiguration,
+    this.hintLocales,
   }) : assert(obscuringCharacter.length == 1),
        smartDashesType =
            smartDashesType ?? (obscureText ? SmartDashesType.disabled : SmartDashesType.enabled),
@@ -845,6 +846,9 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.undoHistory.controller}
   final UndoHistoryController? undoController;
 
+  /// {@macro flutter.services.TextInputConfiguration.hintLocales}
+  final List<Locale>? hintLocales;
+
   static Widget _defaultContextMenuBuilder(
     BuildContext context,
     EditableTextState editableTextState,
@@ -1088,6 +1092,9 @@ class TextField extends StatefulWidget {
                 ? const <String>[]
                 : kDefaultContentInsertionMimeTypes,
       ),
+    );
+    properties.add(
+      DiagnosticsProperty<List<Locale>?>('hintLocales', hintLocales, defaultValue: null),
     );
   }
 }
@@ -1708,6 +1715,7 @@ class _TextFieldState extends State<TextField>
           spellCheckConfiguration: spellCheckConfiguration,
           magnifierConfiguration:
               widget.magnifierConfiguration ?? TextMagnifier.adaptiveMagnifierConfiguration,
+          hintLocales: widget.hintLocales,
         ),
       ),
     );

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -685,14 +685,16 @@ class TextInputConfiguration {
   final List<String> allowedMimeTypes;
 
   /// {@template flutter.services.TextInputConfiguration.hintLocales}
-  /// List of the languages that the user is supposed to switch to.
+  /// List of the languages that the user is expected to use.
+  ///
   /// This special "hint" can be used mainly for, but not limited to,
   /// multilingual users who want IMEs to switch language based on editor's context.
+  ///
   /// Pass an empty list to express the intention that a specific hint should not be set.
   ///
-  /// Defaults to null.
+  /// Defaults to null, which indicates no preference in keyboard language.
   ///
-  /// This setting is only honored on Android devices.
+  /// This setting is only honored on Android devices running API 24 and above.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -13,7 +13,7 @@ library;
 
 import 'dart:async';
 import 'dart:io' show Platform;
-import 'dart:ui' show FlutterView, FontWeight, Offset, Rect, Size, TextAlign, TextDirection;
+import 'dart:ui' show FlutterView, FontWeight, Locale, Offset, Rect, Size, TextAlign, TextDirection;
 
 import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math_64.dart' show Matrix4;
@@ -530,6 +530,7 @@ class TextInputConfiguration {
     this.enableIMEPersonalizedLearning = true,
     this.allowedMimeTypes = const <String>[],
     this.enableDeltaModel = false,
+    this.hintLocales = const <Locale>[],
   }) : smartDashesType =
            smartDashesType ?? (obscureText ? SmartDashesType.disabled : SmartDashesType.enabled),
        smartQuotesType =
@@ -683,6 +684,22 @@ class TextInputConfiguration {
   /// {@macro flutter.widgets.contentInsertionConfiguration.allowedMimeTypes}
   final List<String> allowedMimeTypes;
 
+  /// {@template flutter.services.TextInputConfiguration.hintLocales}
+  /// List of the languages that the user is supposed to switch to.
+  /// This special "hint" can be used mainly for, but not limited to,
+  /// multilingual users who want IMEs to switch language based on editor's context.
+  /// Pass an empty list to express the intention that a specific hint should not be set.
+  ///
+  /// Defaults to null.
+  ///
+  /// This setting is only honored on Android devices.
+  ///
+  /// See also:
+  ///
+  ///  * <https://developer.android.com/reference/android/view/inputmethod/EditorInfo#hintLocales>
+  /// {@endtemplate}
+  final List<Locale>? hintLocales;
+
   /// Creates a copy of this [TextInputConfiguration] with the given fields
   /// replaced with new values.
   TextInputConfiguration copyWith({
@@ -703,6 +720,7 @@ class TextInputConfiguration {
     List<String>? allowedMimeTypes,
     AutofillConfiguration? autofillConfiguration,
     bool? enableDeltaModel,
+    List<Locale>? hintLocales,
   }) {
     return TextInputConfiguration(
       viewId: viewId ?? this.viewId,
@@ -723,6 +741,7 @@ class TextInputConfiguration {
       allowedMimeTypes: allowedMimeTypes ?? this.allowedMimeTypes,
       autofillConfiguration: autofillConfiguration ?? this.autofillConfiguration,
       enableDeltaModel: enableDeltaModel ?? this.enableDeltaModel,
+      hintLocales: hintLocales ?? this.hintLocales,
     );
   }
 
@@ -772,6 +791,7 @@ class TextInputConfiguration {
       'contentCommitMimeTypes': allowedMimeTypes,
       if (autofill != null) 'autofill': autofill,
       'enableDeltaModel': enableDeltaModel,
+      'hintLocales': hintLocales?.map((Locale locale) => locale.toLanguageTag()).toList(),
     };
   }
 
@@ -800,7 +820,8 @@ class TextInputConfiguration {
         other.autofillConfiguration == autofillConfiguration &&
         other.enableIMEPersonalizedLearning == enableIMEPersonalizedLearning &&
         listEquals(other.allowedMimeTypes, allowedMimeTypes) &&
-        other.enableDeltaModel == enableDeltaModel;
+        other.enableDeltaModel == enableDeltaModel &&
+        other.hintLocales == hintLocales;
   }
 
   @override
@@ -823,6 +844,7 @@ class TextInputConfiguration {
       enableIMEPersonalizedLearning,
       Object.hashAll(allowedMimeTypes),
       enableDeltaModel,
+      hintLocales,
     );
   }
 
@@ -846,6 +868,7 @@ class TextInputConfiguration {
       'enableIMEPersonalizedLearning: $enableIMEPersonalizedLearning',
       'allowedMimeTypes: $allowedMimeTypes',
       'enableDeltaModel: $enableDeltaModel',
+      if (hintLocales != null) 'hintLocales: $hintLocales',
     ];
     return 'TextInputConfiguration(${description.join(', ')})';
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -907,6 +907,7 @@ class EditableText extends StatefulWidget {
     this.spellCheckConfiguration,
     this.magnifierConfiguration = TextMagnifierConfiguration.disabled,
     this.undoController,
+    this.hintLocales,
   }) : assert(obscuringCharacter.length == 1),
        autocorrect = autocorrect ?? _inferAutocorrect(autofillHints: autofillHints),
        smartDashesType =
@@ -2033,6 +2034,9 @@ class EditableText extends StatefulWidget {
   /// {@macro flutter.widgets.magnifier.intro}
   final TextMagnifierConfiguration magnifierConfiguration;
 
+  /// {@macro flutter.services.TextInputConfiguration.hintLocales}
+  final List<Locale>? hintLocales;
+
   /// The default value for [stylusHandwritingEnabled].
   static const bool defaultStylusHandwritingEnabled = true;
 
@@ -2390,6 +2394,9 @@ class EditableText extends StatefulWidget {
                 ? const <String>[]
                 : kDefaultContentInsertionMimeTypes,
       ),
+    );
+    properties.add(
+      DiagnosticsProperty<List<Locale>?>('hintLocales', hintLocales, defaultValue: null),
     );
   }
 }
@@ -5097,6 +5104,7 @@ class EditableTextState extends State<EditableText>
           widget.contentInsertionConfiguration == null
               ? const <String>[]
               : widget.contentInsertionConfiguration!.allowedMimeTypes,
+      hintLocales: widget.hintLocales,
     );
   }
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -13320,6 +13320,7 @@ void main() {
       scrollPadding: EdgeInsets.zero,
       scrollPhysics: ClampingScrollPhysics(),
       enableInteractiveSelection: false,
+      hintLocales: <Locale>[Locale('en'), Locale('fr')],
     ).debugFillProperties(builder);
 
     final List<String> description =
@@ -13350,6 +13351,7 @@ void main() {
       'scrollPadding: EdgeInsets.zero',
       'selection disabled',
       'scrollPhysics: ClampingScrollPhysics',
+      'hintLocales: [en, fr]',
     ]);
   });
 
@@ -17540,6 +17542,16 @@ void main() {
     },
     variant: TargetPlatformVariant.all(),
   );
+
+  testWidgets('hintLocales is passed to EditableText', (WidgetTester tester) async {
+    const List<Locale> hintLocales = <Locale>[Locale('en'), Locale('fr')];
+    await tester.pumpWidget(
+      const MaterialApp(home: Material(child: TextField(hintLocales: hintLocales))),
+    );
+
+    final EditableText editableText = tester.widget(find.byType(EditableText));
+    expect(editableText.hintLocales, hintLocales);
+  });
 }
 
 /// A Simple widget for testing the obscure text.

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -495,6 +495,7 @@ void main() {
     expect(editableText.cursorWidth, 2.0);
     expect(editableText.cursorHeight, isNull);
     expect(editableText.textHeightBehavior, isNull);
+    expect(editableText.hintLocales, isNull);
   });
 
   testWidgets('when backgroundCursorColor is updated, RenderEditable should be updated', (
@@ -1271,6 +1272,39 @@ void main() {
       tester.testTextInput.setClientArgs!['enableIMEPersonalizedLearning'],
       enableIMEPersonalizedLearning,
     );
+  });
+
+  testWidgets('hintLocales is sent to the engine', (WidgetTester tester) async {
+    const List<Locale> hintLocales = <Locale>[Locale('en'), Locale('fr')];
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusScope(
+            node: focusScopeNode,
+            autofocus: true,
+            child: EditableText(
+              controller: controller,
+              backgroundCursorColor: Colors.grey,
+              focusNode: focusNode,
+              hintLocales: hintLocales,
+              style: textStyle,
+              cursorColor: cursorColor,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.showKeyboard(find.byType(EditableText));
+    await tester.idle();
+
+    // hintLocales is sent to the engine as a list of language tags.
+    final List<String> localesLanguageTags =
+        hintLocales.map((Locale locale) => locale.toLanguageTag()).toList();
+    expect(tester.testTextInput.setClientArgs!['hintLocales'], localesLanguageTags);
   });
 
   group('smartDashesType and smartQuotesType', () {


### PR DESCRIPTION
## Description

This PR adds support for language hints in TextFields.
This is supported only on Android for the moment and the property name, aka `TextField.hintLocales`, is based on Android's `EditorInfo.hintLocales` property, see https://developer.android.com/reference/android/view/inputmethod/EditorInfo#hintLocales.

## Related Issue

Fixes [Support for language hints in TextFields](https://github.com/flutter/flutter/issues/163698)

## Tests

Adds 4 tests.
Updates several tests.