### PR TITLE
Implement RawMenuAnchorAnimationDelegate for animating menus. 

### DIFF
--- a/examples/api/lib/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.0.dart
+++ b/examples/api/lib/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.0.dart
@@ -1,0 +1,169 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
+
+/// Flutter code sample for a [RawMenuAnchorAnimationDelegate] that animates a
+/// [RawMenuAnchor] with a [SpringSimulation].
+void main() {
+  runApp(const RawMenuAnchorAnimationDelegateApp());
+}
+
+class _AnimationDelegate extends RawMenuAnchorAnimationDelegate {
+  _AnimationDelegate({required this.animationController});
+
+  final AnimationController animationController;
+  SpringSimulation get forwardSpring => SpringSimulation(
+    SpringDescription.withDampingRatio(mass: 1.0, stiffness: 150, ratio: 0.7),
+    animationController.value,
+    1.0,
+    0.0,
+  );
+  SpringSimulation get reverseSpring => SpringSimulation(
+    SpringDescription.withDampingRatio(mass: 1.0, stiffness: 200, ratio: 0.7),
+    animationController.value,
+    0.0,
+    0.0,
+  );
+
+  @override
+  void handleMenuOpenRequest({ui.Offset? position}) {
+    // Call whenComplete() rather than whenCompleteOrCancel() to avoid marking
+    // the menu as opened when the [AnimationStatus] moves from forward to
+    // reverse.
+    animationController.animateWith(forwardSpring).whenComplete(markMenuOpened);
+  }
+
+  @override
+  void handleMenuCloseRequest() {
+    // Call whenComplete() rather than whenCompleteOrCancel() to avoid marking
+    // the menu as closed when the [AnimationStatus] moves from reverse to
+    // forward.
+    animationController.animateBackWith(reverseSpring).whenComplete(markMenuClosed);
+  }
+}
+
+class RawMenuAnchorAnimationDelegateExample extends StatefulWidget {
+  const RawMenuAnchorAnimationDelegateExample({super.key});
+
+  @override
+  State<RawMenuAnchorAnimationDelegateExample> createState() => _RawMenuAnchorAnimationDelegateExampleState();
+}
+
+class _RawMenuAnchorAnimationDelegateExampleState extends State<RawMenuAnchorAnimationDelegateExample>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController animationController;
+  late final RawMenuAnchorAnimationDelegate _menuAnimator = _AnimationDelegate(
+    animationController: animationController,
+  );
+  final MenuController menuController = MenuController();
+
+  @override
+  void initState() {
+    super.initState();
+    // Use an unbounded animation controller so that simulations are not clamped.
+    animationController = AnimationController.unbounded(vsync: this);
+  }
+
+  @override
+  void dispose() {
+    animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RawMenuAnchor(
+      controller: menuController,
+      delegate: _menuAnimator,
+      overlayBuilder: (BuildContext context, RawMenuOverlayInfo info) {
+        // Center the menu below the anchor.
+        final ui.Offset position = info.anchorRect.bottomCenter.translate(-75, 4);
+        final ColorScheme colorScheme = ColorScheme.of(context);
+        return Positioned(
+          top: position.dy,
+          left: position.dx,
+          child: Semantics(
+            explicitChildNodes: true,
+            scopesRoute: true,
+            child: ExcludeFocus(
+              excluding: MenuController.maybeAnimationStatusOf(context) == AnimationStatus.reverse,
+              child: TapRegion(
+                groupId: info.tapRegionGroupId,
+                onTapOutside: (PointerDownEvent event) {
+                  menuController.close();
+                },
+                child: ScaleTransition(
+                  scale: animationController.view,
+                  child: FadeTransition(
+                    opacity: animationController.drive(
+                      Animatable<double>.fromCallback(
+                        (double value) => ui.clampDouble(value, 0, 1),
+                      ),
+                    ),
+                    child: Material(
+                      elevation: 8,
+                      clipBehavior: Clip.antiAlias,
+                      borderRadius: BorderRadius.circular(16),
+                      color: colorScheme.primary,
+                      child: SizeTransition(
+                        axisAlignment: -1,
+                        sizeFactor: animationController.view,
+                        fixedCrossAxisSizeFactor: 1.0,
+                        child: SizedBox(
+                          height: 200,
+                          width: 150,
+                          child: Text(
+                            'ANIMATION STATUS:\n${animationController.status.name}',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(color: colorScheme.onPrimary, fontSize: 12),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+      builder: (BuildContext context, MenuController menuController, Widget? child) {
+        return FilledButton(
+          onPressed: () {
+            if (menuController.animationStatus.isForwardOrCompleted) {
+              menuController.close();
+            } else {
+              menuController.open();
+            }
+          },
+          child: Text(menuController.animationStatus.isForwardOrCompleted ? 'Close' : 'Open'),
+        );
+      },
+    );
+  }
+}
+
+class RawMenuAnchorAnimationDelegateApp extends StatelessWidget {
+  const RawMenuAnchorAnimationDelegateApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData.from(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.blue,
+          dynamicSchemeVariant: DynamicSchemeVariant.vibrant,
+        ),
+      ),
+      home: const Scaffold(body: Center(child: RawMenuAnchorAnimationDelegateExample())),
+    );
+  }
+}

--- a/examples/api/lib/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.1.dart
+++ b/examples/api/lib/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.1.dart
@@ -1,0 +1,201 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for a [RawMenuAnchorAnimationDelegate] that animates a
+/// nested menu.
+void main() {
+  runApp(const NestedRawMenuAnchorAnimationDelegateApp());
+}
+
+class NestedRawMenuAnchorAnimationDelegateExample extends StatelessWidget {
+  const NestedRawMenuAnchorAnimationDelegateExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Menu(
+      panel: Builder(
+        builder: (BuildContext context) {
+          final MenuController rootMenuController = MenuController.maybeOf(context)!;
+          return Align(
+            alignment: Alignment.topRight,
+            child: Column(
+              children: <Widget>[
+                for (int i = 0; i < 4; i++)
+                  Menu(
+                    panel: Builder(
+                      builder: (BuildContext context) {
+                        final String animationStatus =
+                            MenuController.maybeAnimationStatusOf(context)!.name;
+                        return SizedBox(
+                          height: 120,
+                          width: 120,
+                          child: Center(
+                            child: Text('Panel $i:\n$animationStatus', textAlign: TextAlign.center),
+                          ),
+                        );
+                      },
+                    ),
+                    builder: (BuildContext context, MenuController controller) {
+                      return MenuItemButton(
+                        onFocusChange: (bool focused) {
+                          if (focused) {
+                            rootMenuController.closeChildren();
+                            controller.open();
+                          }
+                        },
+                        onPressed: () {
+                          if (!controller.animationStatus.isForwardOrCompleted) {
+                            rootMenuController.closeChildren();
+                            controller.open();
+                          } else {
+                            controller.close();
+                          }
+                        },
+                        trailingIcon: const Text('▶'),
+                        child: Text('Submenu $i'),
+                      );
+                    },
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+      builder: (BuildContext context, MenuController controller) {
+        return FilledButton(
+          onPressed: () {
+            if (controller.animationStatus.isForwardOrCompleted) {
+              controller.close();
+            } else {
+              controller.open();
+            }
+          },
+          child: const Text('Menu'),
+        );
+      },
+    );
+  }
+}
+
+class Menu extends StatefulWidget {
+  const Menu({super.key, required this.panel, required this.builder});
+  final Widget panel;
+  final Widget Function(BuildContext, MenuController) builder;
+
+  @override
+  State<Menu> createState() => MenuState();
+}
+
+class MenuState extends State<Menu>
+    with SingleTickerProviderStateMixin, RawMenuAnchorAnimationDelegate {
+  final MenuController menuController = MenuController();
+  late final AnimationController animationController;
+  late final CurvedAnimation animation;
+  bool get isSubmenu => MenuController.maybeOf(context) != null;
+
+  @override
+  void initState() {
+    super.initState();
+    animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    animation = CurvedAnimation(parent: animationController, curve: Curves.easeOutQuart);
+  }
+
+  @override
+  void dispose() {
+    animationController.dispose();
+    animation.dispose();
+    super.dispose();
+  }
+
+  @override
+  void handleMenuOpenRequest({ui.Offset? position}) {
+    // Call whenComplete() rather than whenCompleteOrCancel() to avoid marking
+    // the menu as opened when the AnimationStatus moves from forward to
+    // reverse.
+    animationController.forward().whenComplete(markMenuOpened);
+  }
+
+  @override
+  void handleMenuCloseRequest() {
+    // Animate the children of this menu closed.
+    menuController.closeChildren();
+    animationController.reverse().whenComplete(markMenuClosed);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RawMenuAnchor(
+      controller: menuController,
+      delegate: this,
+      overlayBuilder: (BuildContext context, RawMenuOverlayInfo info) {
+        final ui.Offset position =
+            isSubmenu ? info.anchorRect.topRight : info.anchorRect.bottomLeft;
+        final ColorScheme colorScheme = ColorScheme.of(context);
+        return Positioned(
+          top: position.dy,
+          left: position.dx,
+          child: Semantics(
+            explicitChildNodes: true,
+            scopesRoute: true,
+            child: ExcludeFocus(
+              // Remove focus while the menu is closing.
+              excluding: animation.status == AnimationStatus.reverse,
+              child: TapRegion(
+                groupId: info.tapRegionGroupId,
+                onTapOutside: (PointerDownEvent event) {
+                  menuController.close();
+                },
+                child: FadeTransition(
+                  opacity: animation,
+                  child: Material(
+                    elevation: 8,
+                    clipBehavior: Clip.antiAlias,
+                    borderRadius: BorderRadius.circular(8),
+                    shadowColor: colorScheme.shadow,
+                    child: SizeTransition(
+                      axisAlignment: position.dx < 0 ? 1 : -1,
+                      sizeFactor: animation,
+                      fixedCrossAxisSizeFactor: 1.0,
+                      child: widget.panel,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+      builder: (BuildContext context, MenuController controller, Widget? child) {
+        return widget.builder(context, controller);
+      },
+    );
+  }
+}
+
+class NestedRawMenuAnchorAnimationDelegateApp extends StatelessWidget {
+  const NestedRawMenuAnchorAnimationDelegateApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData.from(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.blue,
+          dynamicSchemeVariant: DynamicSchemeVariant.vibrant,
+        ),
+      ),
+      home: const Scaffold(body: Center(child: NestedRawMenuAnchorAnimationDelegateExample())),
+    );
+  }
+}

--- a/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.0_test.dart
+++ b/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.0_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Menu opens and closes', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.RawMenuAnchorAnimationDelegateApp());
+
+    // Open the menu.
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+
+    final Finder message =
+        find
+            .ancestor(of: find.textContaining('ANIMATION STATUS:'), matching: find.byType(Material))
+            .first;
+
+    expect(find.text('Open'), findsNothing);
+    expect(find.text('Close'), findsOneWidget);
+    expect(message, findsOneWidget);
+    expect(tester.getRect(message), const Rect.fromLTRB(400.0, 328.0, 400.0, 328.0));
+
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(
+      tester.getRect(message),
+      rectMoreOrLessEquals(const Rect.fromLTRB(323.7, 326.2, 476.3, 533.2), epsilon: 0.1),
+    );
+
+    await tester.pump(const Duration(milliseconds: 1100));
+
+    expect(
+      tester.getRect(message),
+      rectMoreOrLessEquals(const Rect.fromLTRB(325.0, 328.0, 475.0, 528.0), epsilon: 0.1),
+    );
+
+    // Close the menu.
+    await tester.tap(find.text('Close'));
+    await tester.pump();
+
+    await tester.pump(const Duration(milliseconds: 150));
+
+    expect(
+      tester.getRect(message),
+      rectMoreOrLessEquals(const Rect.fromLTRB(382.4, 345.9, 417.6, 356.9), epsilon: 0.1),
+    );
+
+    await tester.pump(const Duration(milliseconds: 920));
+
+    expect(find.widgetWithText(Material, 'ANIMATION STATUS:'), findsNothing);
+    expect(find.text('Close'), findsNothing);
+    expect(find.text('Open'), findsOneWidget);
+  });
+
+  testWidgets('Panel text contains the animation status', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.RawMenuAnchorAnimationDelegateApp());
+
+    // Open the menu.
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+
+    expect(find.textContaining('forward'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 1100));
+
+    expect(find.textContaining('completed'), findsOneWidget);
+
+    await tester.tapAt(Offset.zero);
+    await tester.pump();
+
+    expect(find.textContaining('reverse'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 920));
+
+    // The panel text should be removed when the animation is dismissed.
+    expect(find.textContaining('reverse'), findsNothing);
+  });
+}

--- a/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.1_test.dart
+++ b/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.1_test.dart
@@ -1,0 +1,149 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/raw_menu_anchor/raw_menu_anchor_animation_delegate.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+String getPanelText(int i, AnimationStatus status) => 'Panel $i:\n${status.name}';
+
+Future<TestGesture> hoverOver(WidgetTester tester, Offset location) async {
+  final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+  addTearDown(gesture.removePointer);
+  await gesture.moveTo(location);
+  return gesture;
+}
+
+void main() {
+  testWidgets('Root menu opens when anchor button is pressed', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.NestedRawMenuAnchorAnimationDelegateApp());
+
+    final Finder button = find.byType(FilledButton);
+    await tester.tap(button);
+    await tester.pump();
+
+    final Finder panel =
+        find
+            .ancestor(of: find.textContaining('Submenu 0'), matching: find.byType(ExcludeFocus))
+            .first;
+
+    expect(
+      tester.getRect(panel),
+      rectMoreOrLessEquals(const Rect.fromLTRB(347.8, 324.0, 524.8, 324.0), epsilon: 0.1),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(
+      tester.getRect(panel),
+      rectMoreOrLessEquals(const Rect.fromLTRB(347.8, 324.0, 524.8, 499.7), epsilon: 0.1),
+    );
+
+    await tester.pump(const Duration(milliseconds: 101));
+    expect(
+      tester.getRect(panel),
+      rectMoreOrLessEquals(const Rect.fromLTRB(347.8, 324.0, 524.8, 516.0), epsilon: 0.1),
+    );
+
+    expect(find.textContaining('Submenu'), findsNWidgets(4));
+  });
+
+  testWidgets('Hover traversal opens one submenu at a time', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.NestedRawMenuAnchorAnimationDelegateApp());
+
+    // Open root menu
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final Finder menuItem = find.widgetWithText(MenuItemButton, 'Submenu 0').first;
+    await hoverOver(tester, tester.getCenter(menuItem));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 201));
+
+    for (int i = 1; i < 4; i++) {
+      final Finder menuItem = find.widgetWithText(MenuItemButton, 'Submenu $i').first;
+      await hoverOver(tester, tester.getCenter(menuItem));
+      await tester.pump();
+
+      expect(find.text(getPanelText(i - 1, AnimationStatus.reverse)), findsOneWidget);
+      expect(find.text(getPanelText(i, AnimationStatus.forward)), findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 201));
+
+      expect(find.text(getPanelText(i - 1, AnimationStatus.dismissed)), findsNothing);
+      expect(find.text(getPanelText(i, AnimationStatus.completed)), findsOneWidget);
+    }
+  });
+
+  testWidgets('Submenu opens at expected rate', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.NestedRawMenuAnchorAnimationDelegateApp());
+
+    // Open root menu
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 201));
+
+    // Start hovering over submenu item
+    final Finder menuItem = find.widgetWithText(MenuItemButton, 'Submenu 0').first;
+    await hoverOver(tester, tester.getCenter(menuItem));
+    await tester.pump();
+
+    final Finder panel =
+        find
+            .ancestor(of: find.textContaining('Panel 0'), matching: find.byType(ExcludeFocus))
+            .first;
+
+    // 25% through, 70% height
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(tester.getSize(panel).height, moreOrLessEquals(0.7 * 120, epsilon: 1));
+
+    // 50% through, 91.5% height
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(tester.getSize(panel).height, moreOrLessEquals(0.91 * 120, epsilon: 1));
+
+    // 100% through, full height
+    await tester.pump(const Duration(milliseconds: 101));
+    expect(tester.getSize(panel).height, moreOrLessEquals(120, epsilon: 1));
+
+    // Close submenu
+    final Finder menuItem1 = find.widgetWithText(MenuItemButton, 'Submenu 1').first;
+    await hoverOver(tester, tester.getCenter(menuItem1));
+    await tester.pump();
+
+    // 25% through, ~98% height
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(tester.getSize(panel).height, moreOrLessEquals(0.98 * 120, epsilon: 1));
+
+    // 50% through, ~91.5% height
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(tester.getSize(panel).height, moreOrLessEquals(0.91 * 120, epsilon: 1));
+  });
+
+  testWidgets('Outside tap closes all menus', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.NestedRawMenuAnchorAnimationDelegateApp());
+
+    // Open root menu and submenu
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 201));
+
+    await hoverOver(
+      tester,
+      tester.getCenter(find.widgetWithText(MenuItemButton, 'Submenu 0').first),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 201));
+
+    expect(find.textContaining(AnimationStatus.completed.name), findsOneWidget);
+    expect(find.textContaining(AnimationStatus.reverse.name), findsNothing);
+
+    // Tap outside
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pump();
+
+    expect(find.textContaining(AnimationStatus.completed.name), findsNothing);
+    expect(find.textContaining(AnimationStatus.reverse.name), findsOneWidget);
+  });
+}

--- a/packages/flutter/test/widgets/raw_menu_anchor_test.dart
+++ b/packages/flutter/test/widgets/raw_menu_anchor_test.dart
@@ -105,6 +105,42 @@ void main() {
     expect(find.text(Tag.a.text), findsNothing);
   });
 
+  testWidgets("MenuController.animationStatus is completed when a menu's overlay is shown", (
+    WidgetTester tester,
+  ) async {
+    final MenuController anchorController = MenuController();
+    await tester.pumpWidget(
+      App(
+        RawMenuAnchorGroup(
+          controller: controller,
+          child: Menu(
+            controller: anchorController,
+            menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.animationStatus, equals(AnimationStatus.dismissed));
+    expect(anchorController.animationStatus, equals(AnimationStatus.dismissed));
+    expect(find.text(Tag.a.text), findsNothing);
+
+    await tester.tap(find.text(Tag.anchor.text));
+    await tester.pump();
+
+    expect(controller.animationStatus, equals(AnimationStatus.completed));
+    expect(anchorController.animationStatus, equals(AnimationStatus.completed));
+    expect(find.text(Tag.a.text), findsOneWidget);
+
+    await tester.tap(find.text(Tag.anchor.text));
+    await tester.pump();
+
+    expect(controller.animationStatus, equals(AnimationStatus.dismissed));
+    expect(anchorController.animationStatus, equals(AnimationStatus.dismissed));
+    expect(find.text(Tag.a.text), findsNothing);
+  });
+
   testWidgets('[Default] MenuController.open() and .close() toggle overlay visibility', (
     WidgetTester tester,
   ) async {
@@ -612,6 +648,272 @@ void main() {
     expect(overlayBuilds, equals(1));
   });
 
+  testWidgets(
+    'MenuController.maybeAnimationStatusOf notifies dependents when AnimationStatus changes',
+    (WidgetTester tester) async {
+      final MenuController groupController = MenuController();
+      final MenuController controller = MenuController();
+      final MenuController nestedController = MenuController();
+      AnimationStatus? panelAnimationStatus;
+      AnimationStatus? overlayAnimationStatus;
+      AnimationStatus? anchorAnimationStatus;
+      int panelBuilds = 0;
+      int anchorBuilds = 0;
+      int overlayBuilds = 0;
+
+      await tester.pumpWidget(
+        App(
+          RawMenuAnchorGroup(
+            controller: groupController,
+            child: Column(
+              children: <Widget>[
+                // Panel context.
+                Builder(
+                  builder: (BuildContext context) {
+                    panelAnimationStatus = MenuController.maybeAnimationStatusOf(context);
+                    panelBuilds += 1;
+                    return Text(Tag.a.text);
+                  },
+                ),
+                Menu(
+                  controller: controller,
+                  menuPanel: Panel(
+                    children: <Widget>[
+                      // Overlay context.
+                      Builder(
+                        builder: (BuildContext context) {
+                          overlayAnimationStatus = MenuController.maybeAnimationStatusOf(context);
+                          overlayBuilds += 1;
+                          return Text(Tag.b.a.a.text);
+                        },
+                      ),
+                      Menu(
+                        controller: nestedController,
+                        menuPanel: Panel(children: <Widget>[Button.tag(Tag.b.a.b.a)]),
+                        child: Button.tag(Tag.b.a.b),
+                      ),
+                    ],
+                  ),
+                  // Anchor context.
+                  child: Builder(
+                    builder: (BuildContext context) {
+                      anchorAnimationStatus = MenuController.maybeAnimationStatusOf(context);
+                      anchorBuilds += 1;
+                      return Text(Tag.b.a.text);
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(panelAnimationStatus, equals(AnimationStatus.dismissed));
+      expect(anchorAnimationStatus, equals(AnimationStatus.dismissed));
+      expect(panelBuilds, equals(1));
+      expect(anchorBuilds, equals(1));
+      expect(overlayBuilds, equals(0));
+
+      controller.open();
+      await tester.pump();
+
+      expect(panelAnimationStatus, equals(AnimationStatus.completed));
+      expect(anchorAnimationStatus, equals(AnimationStatus.completed));
+      expect(overlayAnimationStatus, equals(AnimationStatus.completed));
+      expect(panelBuilds, equals(2));
+      expect(anchorBuilds, equals(2));
+      expect(overlayBuilds, equals(1));
+
+      nestedController.open();
+      await tester.pump();
+
+      // No new builds should have occurred since all controllers are already open.
+      expect(panelAnimationStatus, equals(AnimationStatus.completed));
+      expect(anchorAnimationStatus, equals(AnimationStatus.completed));
+      expect(overlayAnimationStatus, equals(AnimationStatus.completed));
+      expect(panelBuilds, equals(2));
+      expect(anchorBuilds, equals(2));
+      expect(overlayBuilds, equals(1));
+
+      controller.close();
+      await tester.pump();
+
+      expect(panelAnimationStatus, equals(AnimationStatus.dismissed));
+      expect(anchorAnimationStatus, equals(AnimationStatus.dismissed));
+
+      // Will be true because builder cannot rebuild when the menu is closed.
+      expect(overlayAnimationStatus, equals(AnimationStatus.completed));
+      expect(panelBuilds, equals(3));
+      expect(anchorBuilds, equals(3));
+      expect(overlayBuilds, equals(1));
+    },
+  );
+
+  testWidgets('MenuController can be changed', (WidgetTester tester) async {
+    final MenuController controller = MenuController();
+    final MenuController groupController = MenuController();
+
+    final MenuController newController = MenuController();
+    final MenuController newGroupController = MenuController();
+
+    await tester.pumpWidget(
+      App(
+        RawMenuAnchorGroup(
+          controller: controller,
+          child: Menu(
+            controller: groupController,
+            menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text(Tag.anchor.text));
+    await tester.pump();
+
+    expect(find.text(Tag.a.text), findsOneWidget);
+    expect(controller.isOpen, isTrue);
+    expect(groupController.isOpen, isTrue);
+    expect(newController.isOpen, isFalse);
+    expect(newGroupController.isOpen, isFalse);
+
+    // Swap the controllers.
+    await tester.pumpWidget(
+      App(
+        RawMenuAnchorGroup(
+          controller: newController,
+          child: Menu(
+            controller: newGroupController,
+            menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(Tag.a.text), findsOneWidget);
+    expect(controller.isOpen, isFalse);
+    expect(groupController.isOpen, isFalse);
+    expect(newController.isOpen, isTrue);
+    expect(newGroupController.isOpen, isTrue);
+
+    // Close the new controller.
+    newController.close();
+    await tester.pump();
+
+    expect(newController.isOpen, isFalse);
+    expect(newGroupController.isOpen, isFalse);
+    expect(find.text(Tag.a.text), findsNothing);
+  });
+
+  testWidgets('[Group] MenuController can be moved to a different menu', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      App(
+        RawMenuAnchorGroup(
+          controller: controller,
+          child: Menu(
+            menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text(Tag.anchor.text));
+    await tester.pump();
+
+    expect(find.text(Tag.a.text), findsOneWidget);
+    expect(controller.isOpen, isTrue);
+
+    // Swap the controllers.
+    await tester.pumpWidget(
+      App(
+        RawMenuAnchorGroup(
+          key: UniqueKey(),
+          controller: controller,
+          child: Menu(
+            menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(Tag.a.text), findsNothing);
+    expect(controller.isOpen, isFalse);
+
+    await tester.tap(find.text(Tag.anchor.text));
+    await tester.pump();
+
+    expect(find.text(Tag.a.text), findsOneWidget);
+    expect(controller.isOpen, isTrue);
+
+    // Close the menu.
+    controller.close();
+    await tester.pump();
+
+    expect(controller.isOpen, isFalse);
+    expect(find.text(Tag.a.text), findsNothing);
+  });
+
+  testWidgets('[Default] MenuController can be moved to a different menu', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      App(
+        RawMenuAnchorGroup(
+          controller: MenuController(),
+          child: Menu(
+            controller: controller,
+            menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text(Tag.anchor.text));
+    await tester.pump();
+
+    expect(find.text(Tag.a.text), findsOneWidget);
+    expect(controller.isOpen, isTrue);
+
+    // Swap the controllers.
+    await tester.pumpWidget(
+      App(
+        RawMenuAnchorGroup(
+          controller: MenuController(),
+          child: Menu(
+            key: UniqueKey(),
+            controller: controller,
+            menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(Tag.a.text), findsNothing);
+    expect(controller.isOpen, isFalse);
+
+    await tester.tap(find.text(Tag.anchor.text));
+    await tester.pump();
+
+    expect(find.text(Tag.a.text), findsOneWidget);
+    expect(controller.isOpen, isTrue);
+
+    // Close the menu.
+    controller.close();
+    await tester.pump();
+
+    expect(controller.isOpen, isFalse);
+    expect(find.text(Tag.a.text), findsNothing);
+  });
+
   testWidgets('MenuController.maybeOf does not notify dependents when MenuController changes', (
     WidgetTester tester,
   ) async {
@@ -700,7 +1002,7 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/156572.
-  testWidgets('Unattached MenuController does not throw when calling close', (
+  testWidgets('Detached MenuController does not throw when calling close', (
     WidgetTester tester,
   ) async {
     final MenuController controller = MenuController();
@@ -709,12 +1011,20 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Unattached MenuController returns false when calling isOpen', (
+  testWidgets('Detached MenuController returns false when calling isOpen', (
     WidgetTester tester,
   ) async {
     final MenuController controller = MenuController();
     expect(controller.isOpen, false);
   });
+
+  testWidgets(
+    'Detached MenuController returns AnimationStatus.dismissed when calling animationStatus',
+    (WidgetTester tester) async {
+      final MenuController controller = MenuController();
+      expect(controller.animationStatus, AnimationStatus.dismissed);
+    },
+  );
 
   testWidgets('[Default] MenuController is detached on update', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -1629,7 +1939,7 @@ void main() {
   // Menu implementations differ as to whether tabbing traverses a closes a
   // menu or traverses its items. By default, we let the user choose whether
   // to close the menu or traverse its items.
-  testWidgets('Tab traversal is not handled.', (WidgetTester tester) async {
+  testWidgets('Tab traversal is not handled', (WidgetTester tester) async {
     final FocusNode bFocusNode = FocusNode(debugLabel: Tag.b.focusNode);
     final FocusNode bbFocusNode = FocusNode(debugLabel: Tag.b.b.focusNode);
     addTearDown(bFocusNode.dispose);
@@ -2122,6 +2432,794 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  group('RawMenuAnchorAnimationDelegate', () {
+    testWidgets('Delegated controller triggers opening and closing animations', (
+      WidgetTester tester,
+    ) async {
+      final Key panelKey = UniqueKey();
+      late AnimationController animationController;
+
+      await tester.pumpWidget(
+        App(
+          DecoratedMenu(
+            controller: controller,
+            builder: (
+              BuildContext context,
+              MenuController controller,
+              RawMenuAnchorAnimationDelegate delegate,
+              AnimationController animation,
+            ) {
+              animationController = animation;
+              return Menu(
+                menuPanel: SizedBox(key: panelKey),
+                controller: controller,
+                delegate: delegate,
+                child: const AnchorButton(Tag.anchor),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Overlay is closed, animation is at 0.
+      expect(controller.isOpen, isFalse);
+      expect(animationController.value, equals(0));
+      expect(find.byKey(panelKey), findsNothing);
+
+      // Open menu
+      controller.open();
+
+      expect(controller.isOpen, isTrue);
+      expect(find.byKey(panelKey), findsNothing);
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(controller.isOpen, isTrue);
+      expect(animationController.value, closeTo(0.5, 0.01));
+      expect(find.byKey(panelKey), findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 101));
+
+      // Fully open
+      expect(controller.isOpen, isTrue);
+      expect(animationController.value, equals(1));
+      expect(find.byKey(panelKey), findsOneWidget);
+
+      // Close menu
+      controller.close();
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(controller.isOpen, isTrue);
+      expect(animationController.value, closeTo(0.5, 0.01));
+      expect(find.byKey(panelKey), findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 101));
+
+      // Fully closed
+      expect(controller.isOpen, isFalse);
+      expect(animationController.value, equals(0));
+      expect(find.byKey(panelKey), findsNothing);
+    });
+
+    testWidgets('Animations can be interrupted', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        App(
+          DecoratedMenu(
+            controller: controller,
+            builder: (
+              BuildContext context,
+              MenuController controller,
+              RawMenuAnchorAnimationDelegate delegate,
+              AnimationController animation,
+            ) {
+              return Menu(
+                delegate: delegate,
+                controller: controller,
+                menuPanel: SizeTransition(
+                  sizeFactor: animation,
+                  child: Container(color: const Color(0xFF000000), width: 100, height: 100),
+                ),
+                child: Button.tag(
+                  Tag.anchor,
+                  onPressed: () {
+                    if (controller.isOpen) {
+                      controller.close();
+                    } else {
+                      controller.open();
+                    }
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Start opening
+      controller.open();
+      await tester.pump();
+
+      expect(controller.animationStatus, equals(AnimationStatus.forward));
+
+      // Reverse before animation completes
+      await tester.pump(const Duration(milliseconds: 100));
+      controller.close();
+      await tester.pump();
+
+      expect(controller.animationStatus, equals(AnimationStatus.reverse));
+
+      // Test that the interrupted animation dismisses
+      await tester.pump(const Duration(milliseconds: 101));
+
+      expect(controller.isOpen, isFalse);
+      expect(controller.animationStatus, equals(AnimationStatus.dismissed));
+
+      // Reopen halfway
+      controller.open();
+      await tester.pump();
+
+      expect(controller.animationStatus, equals(AnimationStatus.forward));
+
+      // Reverse
+      await tester.pump(const Duration(milliseconds: 100));
+      controller.close();
+      await tester.pump();
+
+      expect(controller.animationStatus, equals(AnimationStatus.reverse));
+
+      await tester.pump(const Duration(milliseconds: 25));
+
+      // Reverse again
+      controller.open();
+
+      await tester.pump(const Duration(milliseconds: 25));
+
+      expect(controller.animationStatus, equals(AnimationStatus.forward));
+
+      // Test that the interrupted animation completes
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(controller.isOpen, isTrue);
+      expect(controller.animationStatus, equals(AnimationStatus.completed));
+    });
+
+    testWidgets(
+      'MenuController.maybeAnimationStatusOf notifies dependents on AnimationStatus changes',
+      (WidgetTester tester) async {
+        final MenuController groupController = MenuController();
+        final MenuController controller = MenuController();
+        final MenuController nestedController = MenuController();
+        AnimationStatus? panelAnimationStatus;
+        AnimationStatus? overlayAnimationStatus;
+        AnimationStatus? anchorAnimationStatus;
+        int panelBuilds = 0;
+        int anchorBuilds = 0;
+        int overlayBuilds = 0;
+
+        await tester.pumpWidget(
+          App(
+            RawMenuAnchorGroup(
+              controller: groupController,
+              child: Column(
+                children: <Widget>[
+                  // Panel context.
+                  Builder(
+                    builder: (BuildContext context) {
+                      panelAnimationStatus = MenuController.maybeAnimationStatusOf(context);
+                      panelBuilds += 1;
+                      return Text(Tag.a.text);
+                    },
+                  ),
+                  DecoratedMenu(
+                    controller: controller,
+                    builder: (
+                      BuildContext context,
+                      MenuController controller,
+                      RawMenuAnchorAnimationDelegate delegate,
+                      AnimationController animation,
+                    ) {
+                      return Menu(
+                        delegate: delegate,
+                        controller: controller,
+                        menuPanel: Panel(
+                          children: <Widget>[
+                            Builder(
+                              builder: (BuildContext context) {
+                                overlayAnimationStatus = MenuController.maybeAnimationStatusOf(
+                                  context,
+                                );
+                                overlayBuilds += 1;
+                                return Text(Tag.b.a.a.text);
+                              },
+                            ),
+                            Menu(
+                              controller: nestedController,
+                              menuPanel: Panel(children: <Widget>[Button.tag(Tag.b.a.b.a)]),
+                              child: Button.tag(Tag.b.a.b),
+                            ),
+                          ],
+                        ),
+                        child: Builder(
+                          builder: (BuildContext context) {
+                            anchorAnimationStatus = MenuController.maybeAnimationStatusOf(context);
+                            anchorBuilds += 1;
+                            return Text(Tag.b.a.text);
+                          },
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(panelAnimationStatus, equals(AnimationStatus.dismissed));
+        expect(anchorAnimationStatus, equals(AnimationStatus.dismissed));
+        expect(panelBuilds, equals(1));
+        expect(anchorBuilds, equals(1));
+        expect(overlayBuilds, equals(0));
+
+        controller.open();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(panelAnimationStatus, equals(AnimationStatus.completed));
+        expect(anchorAnimationStatus, equals(AnimationStatus.forward));
+        expect(overlayAnimationStatus, equals(AnimationStatus.forward));
+        expect(panelBuilds, equals(2));
+        expect(anchorBuilds, equals(2));
+        expect(overlayBuilds, equals(1));
+
+        await tester.pump(const Duration(milliseconds: 151));
+
+        expect(panelAnimationStatus, equals(AnimationStatus.completed));
+        expect(anchorAnimationStatus, equals(AnimationStatus.completed));
+        expect(overlayAnimationStatus, equals(AnimationStatus.completed));
+        expect(panelBuilds, equals(2));
+        expect(anchorBuilds, equals(3));
+        expect(overlayBuilds, equals(2));
+
+        nestedController.open();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 201));
+
+        // No new builds should have occurred since all controllers are already open.
+        expect(panelAnimationStatus, equals(AnimationStatus.completed));
+        expect(anchorAnimationStatus, equals(AnimationStatus.completed));
+        expect(overlayAnimationStatus, equals(AnimationStatus.completed));
+        expect(panelBuilds, equals(2));
+        expect(anchorBuilds, equals(3));
+        expect(overlayBuilds, equals(2));
+
+        controller.close();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(panelAnimationStatus, equals(AnimationStatus.completed));
+        expect(overlayAnimationStatus, equals(AnimationStatus.reverse));
+        expect(anchorAnimationStatus, equals(AnimationStatus.reverse));
+        expect(panelBuilds, equals(2));
+        expect(anchorBuilds, equals(4));
+        expect(overlayBuilds, equals(3));
+
+        await tester.pump(const Duration(milliseconds: 101));
+
+        // overlayAnimationStatus will be AnimationStatus.reverse because the
+        // builder cannot rebuild when the menu is closed.
+        expect(panelAnimationStatus, equals(AnimationStatus.dismissed));
+        expect(overlayAnimationStatus, equals(AnimationStatus.reverse));
+        expect(anchorAnimationStatus, equals(AnimationStatus.dismissed));
+        expect(panelBuilds, equals(3));
+        expect(anchorBuilds, equals(5));
+        expect(overlayBuilds, equals(3));
+      },
+    );
+
+    testWidgets('Delegated controller transitions through all menu animation states', (
+      WidgetTester tester,
+    ) async {
+      RawMenuAnchorAnimationDelegate? menuDelegate;
+      late Animation<double> menuAnimation;
+
+      await tester.pumpWidget(
+        App(
+          DecoratedMenu(
+            controller: controller,
+            builder: (
+              BuildContext context,
+              MenuController menuController,
+              RawMenuAnchorAnimationDelegate delegate,
+              AnimationController animation,
+            ) {
+              controller = menuController;
+              menuDelegate = delegate;
+              menuAnimation = animation;
+              return Menu(
+                delegate: delegate,
+                controller: menuController,
+                menuPanel: const SizedBox(),
+                child: const AnchorButton(Tag.anchor),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Checks that the status of the decorated menu controller and the menu
+      // animation, are in sync. This is done before and after a pump to ensure
+      // that the status is updated synchronously and stays updated.
+      Future<void> statusMatches(AnimationStatus status) async {
+        expect(controller.animationStatus, status);
+        expect(menuAnimation.status, status);
+
+        await tester.pump();
+
+        expect(controller.animationStatus, status);
+        expect(menuAnimation.status, status);
+      }
+
+      // Initial state should be closed
+      await statusMatches(AnimationStatus.dismissed);
+
+      // Test: closed -> opening
+      controller.open();
+
+      await statusMatches(AnimationStatus.forward);
+
+      // Test: opening -> opened
+      await tester.pump(const Duration(milliseconds: 201));
+
+      await statusMatches(AnimationStatus.completed);
+
+      // Test: opened -> closing
+      controller.close();
+
+      await statusMatches(AnimationStatus.reverse);
+
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Test: closing -> opening
+      controller.open();
+
+      await statusMatches(AnimationStatus.forward);
+
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Test: opening -> closing
+      controller.close();
+
+      await statusMatches(AnimationStatus.reverse);
+
+      // Test: closing -> closed
+      await tester.pump(const Duration(milliseconds: 201));
+
+      await statusMatches(AnimationStatus.dismissed);
+
+      // Test: closed -> opened (forced with markMenuOpened)
+      menuDelegate!.markMenuOpened();
+
+      await statusMatches(AnimationStatus.completed);
+
+      // Test: opened -> closed (forced with markMenuClosed)
+      menuDelegate!.markMenuClosed();
+
+      await statusMatches(AnimationStatus.dismissed);
+
+      controller.open();
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      await statusMatches(AnimationStatus.forward);
+
+      // Test: opening -> opened (forced with markMenuOpened)
+      menuDelegate!.markMenuOpened();
+
+      await statusMatches(AnimationStatus.completed);
+
+      // Test: closing -> closed (forced with markMenuClosed)
+      controller.close();
+
+      await statusMatches(AnimationStatus.reverse);
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      menuDelegate!.markMenuClosed();
+
+      await statusMatches(AnimationStatus.dismissed);
+
+      controller.open();
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      await statusMatches(AnimationStatus.forward);
+
+      // Test: opening -> closed (forced with markMenuClosed)
+      menuDelegate!.markMenuClosed();
+
+      await statusMatches(AnimationStatus.dismissed);
+
+      controller.open();
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      controller.close();
+
+      await statusMatches(AnimationStatus.reverse);
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Test: closing -> opened (forced with markMenuOpened)
+      menuDelegate!.markMenuOpened();
+
+      await statusMatches(AnimationStatus.completed);
+    });
+
+    testWidgets('Position is passed to handleMenuOpenRequest.', (WidgetTester tester) async {
+      Offset? position;
+
+      await tester.pumpWidget(
+        App(
+          DecoratedMenu(
+            controller: controller,
+            onOpenRequest: (ui.Offset? value) {
+              position = value;
+            },
+            builder: (
+              BuildContext context,
+              MenuController controller,
+              RawMenuAnchorAnimationDelegate delegate,
+              AnimationController animation,
+            ) {
+              return Menu(
+                controller: controller,
+                delegate: delegate,
+                consumeOutsideTaps: true,
+                menuPanel: SizeTransition(sizeFactor: animation, child: const SizedBox()),
+                child: const AnchorButton(Tag.anchor),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Pass empty position.
+      controller.open();
+      await tester.pump();
+
+      expect(position, isNull);
+
+      // Pass position.
+      controller.open(position: const Offset(100, 100));
+      await tester.pump();
+
+      expect(position, equals(const Offset(100, 100)));
+    });
+
+    testWidgets('Position is received by overlayBuilder', (WidgetTester tester) async {
+      Offset? position;
+      await tester.pumpWidget(
+        App(
+          DecoratedMenu(
+            controller: controller,
+            onOpenRequest: (ui.Offset? value) {
+              position = value;
+            },
+            builder: (
+              BuildContext context,
+              MenuController controller,
+              RawMenuAnchorAnimationDelegate delegate,
+              AnimationController animation,
+            ) {
+              return Menu(
+                controller: controller,
+                delegate: delegate,
+                consumeOutsideTaps: true,
+                overlayBuilder: (BuildContext context, RawMenuOverlayInfo info) {
+                  position = info.position;
+                  return Positioned(left: position?.dx, top: position?.dy, child: const SizedBox());
+                },
+                child: const AnchorButton(Tag.anchor),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Pass empty position.
+      controller.open();
+      await tester.pump();
+
+      expect(position, isNull);
+
+      // Pass position.
+      controller.open(position: const Offset(100, 100));
+      await tester.pump();
+
+      expect(position, equals(const Offset(100, 100)));
+    });
+
+    testWidgets('Ancestor scroll triggers handleMenuCloseRequest', (WidgetTester tester) async {
+      final ScrollController scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      late Animation<double> rootMenuAnimation;
+
+      await tester.pumpWidget(
+        App(
+          SingleChildScrollView(
+            controller: scrollController,
+            child: Container(
+              height: 1000,
+              alignment: Alignment.center,
+              child: DecoratedMenu(
+                controller: controller,
+                builder: (
+                  BuildContext context,
+                  MenuController controller,
+                  RawMenuAnchorAnimationDelegate delegate,
+                  AnimationController animation,
+                ) {
+                  rootMenuAnimation = animation;
+                  return Menu(
+                    controller: controller,
+                    delegate: delegate,
+                    consumeOutsideTaps: true,
+                    menuPanel: SizeTransition(
+                      sizeFactor: animation,
+                      child: Panel(
+                        decoration: const BoxDecoration(color: Color(0xFF121212)),
+                        children: <Widget>[
+                          Button.tag(Tag.a),
+                          Button.tag(Tag.b),
+                          Button.tag(Tag.c),
+                          Button.tag(Tag.d),
+                        ],
+                      ),
+                    ),
+                    child: const AnchorButton(Tag.anchor),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(Tag.anchor.text));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 202));
+
+      expect(controller.animationStatus, equals(AnimationStatus.completed));
+      expect(rootMenuAnimation.value, equals(1.0));
+
+      scrollController.jumpTo(1000);
+      await tester.pump();
+
+      expect(controller.animationStatus, equals(AnimationStatus.reverse));
+
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(controller.animationStatus, equals(AnimationStatus.reverse));
+      expect(rootMenuAnimation.value, closeTo(0.5, 0.01));
+
+      await tester.pump(const Duration(milliseconds: 101));
+
+      expect(controller.animationStatus, equals(AnimationStatus.dismissed));
+      expect(rootMenuAnimation.value, equals(0.0));
+    });
+
+    testWidgets('View size change triggers handleMenuCloseRequest', (WidgetTester tester) async {
+      final ScrollController scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      late Animation<double> rootMenuAnimation;
+      final MediaQueryData mediaQueryData = MediaQueryData.fromView(tester.view);
+
+      Widget buildWidget(MediaQueryData data) {
+        return MediaQuery(
+          data: data,
+          child: App(
+            SingleChildScrollView(
+              controller: scrollController,
+              child: Container(
+                height: 1000,
+                alignment: Alignment.center,
+                child: DecoratedMenu(
+                  controller: controller,
+                  builder: (
+                    BuildContext context,
+                    MenuController controller,
+                    RawMenuAnchorAnimationDelegate delegate,
+                    AnimationController animation,
+                  ) {
+                    rootMenuAnimation = animation;
+                    return Menu(
+                      controller: controller,
+                      delegate: delegate,
+                      consumeOutsideTaps: true,
+                      menuPanel: SizeTransition(
+                        sizeFactor: animation,
+                        child: Panel(
+                          decoration: const BoxDecoration(color: Color(0xFF121212)),
+                          children: <Widget>[
+                            Button.tag(Tag.a),
+                            Button.tag(Tag.b),
+                            Button.tag(Tag.c),
+                            Button.tag(Tag.d),
+                          ],
+                        ),
+                      ),
+                      child: const AnchorButton(Tag.anchor),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildWidget(mediaQueryData));
+
+      await tester.tap(find.text(Tag.anchor.text));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 202));
+
+      expect(controller.animationStatus, equals(AnimationStatus.completed));
+      expect(rootMenuAnimation.value, equals(1.0));
+
+      const Size smallSize = Size(200, 200);
+      await changeSurfaceSize(tester, smallSize);
+      await tester.pumpWidget(buildWidget(mediaQueryData.copyWith(size: smallSize)));
+
+      await tester.pump();
+
+      expect(controller.animationStatus, equals(AnimationStatus.reverse));
+
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(controller.animationStatus, equals(AnimationStatus.reverse));
+      expect(rootMenuAnimation.value, closeTo(0.5, 0.01));
+
+      await tester.pump(const Duration(milliseconds: 101));
+
+      expect(controller.animationStatus, equals(AnimationStatus.dismissed));
+      expect(rootMenuAnimation.value, equals(0.0));
+    });
+
+    testWidgets('DismissMenuAction triggers handleMenuCloseRequest', (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        App(
+          DecoratedMenu(
+            controller: controller,
+            builder: (
+              BuildContext context,
+              MenuController controller,
+              RawMenuAnchorAnimationDelegate delegate,
+              AnimationController animation,
+            ) {
+              return Menu(
+                controller: controller,
+                delegate: delegate,
+                consumeOutsideTaps: true,
+                menuPanel: SizeTransition(
+                  sizeFactor: animation,
+                  child: Panel(
+                    decoration: const BoxDecoration(color: Color(0xFF121212)),
+                    children: <Widget>[
+                      Button.tag(Tag.a),
+                      Button.tag(Tag.b),
+                      Button.tag(Tag.c),
+                      Button.tag(Tag.d),
+                    ],
+                  ),
+                ),
+
+                child: const AnchorButton(Tag.anchor, autofocus: true),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(Tag.anchor.text));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 201));
+
+      expect(controller.isOpen, isTrue);
+      expect(controller.animationStatus, equals(AnimationStatus.completed));
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      const ActionDispatcher().invokeAction(
+        DismissMenuAction(controller: controller),
+        const DismissIntent(),
+        focusNode.context,
+      );
+
+      await tester.pump();
+
+      expect(controller.isOpen, isTrue);
+      expect(controller.animationStatus, equals(AnimationStatus.reverse));
+
+      await tester.pump(const Duration(milliseconds: 201));
+
+      expect(controller.isOpen, isFalse);
+      expect(controller.animationStatus, equals(AnimationStatus.dismissed));
+    });
+
+    testWidgets('Outside tap triggers handleMenuCloseRequest', (WidgetTester tester) async {
+      final MenuController groupController = MenuController();
+
+      await tester.pumpWidget(
+        App(
+          RawMenuAnchorGroup(
+            controller: groupController,
+            child: DecoratedMenu(
+              controller: controller,
+              builder: (
+                BuildContext context,
+                MenuController controller,
+                RawMenuAnchorAnimationDelegate delegate,
+                AnimationController animation,
+              ) {
+                return Menu(
+                  controller: controller,
+                  delegate: delegate,
+                  consumeOutsideTaps: true,
+                  menuPanel: SizeTransition(
+                    sizeFactor: animation,
+                    child: Panel(
+                      decoration: const BoxDecoration(color: Color(0xFF121212)),
+                      children: <Widget>[
+                        Button.tag(Tag.a),
+                        Button.tag(Tag.b),
+                        Button.tag(Tag.c),
+                        Button.tag(Tag.d),
+                      ],
+                    ),
+                  ),
+
+                  child: const AnchorButton(Tag.anchor, autofocus: true),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(Tag.anchor.text));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 201));
+
+      expect(controller.isOpen, isTrue);
+      expect(controller.animationStatus, equals(AnimationStatus.completed));
+
+      await tester.tapAt(Offset.zero);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 25));
+
+      expect(controller.isOpen, isTrue);
+      expect(controller.animationStatus, equals(AnimationStatus.reverse));
+
+      await tester.pump(const Duration(milliseconds: 201));
+
+      expect(controller.isOpen, isFalse);
+      expect(controller.animationStatus, equals(AnimationStatus.dismissed));
+    });
+  });
 }
 
 // ********* UTILITIES *********  //
@@ -2446,8 +3544,9 @@ class Panel extends StatelessWidget {
 class Menu extends StatefulWidget {
   const Menu({
     super.key,
-    required this.menuPanel,
+    this.menuPanel,
     this.controller,
+    this.delegate,
     this.child,
     this.builder,
     this.focusNode,
@@ -2455,14 +3554,17 @@ class Menu extends StatefulWidget {
     this.onClose,
     this.useRootOverlay = false,
     this.consumeOutsideTaps = false,
+    this.overlayBuilder,
   });
-  final Widget menuPanel;
+  final Widget? menuPanel;
   final Widget? child;
   final bool useRootOverlay;
   final VoidCallback? onOpen;
   final VoidCallback? onClose;
   final FocusNode? focusNode;
   final RawMenuAnchorChildBuilder? builder;
+  final RawMenuAnchorAnimationDelegate? delegate;
+  final RawMenuAnchorOverlayBuilder? overlayBuilder;
   final MenuController? controller;
   final bool consumeOutsideTaps;
 
@@ -2475,6 +3577,7 @@ class _MenuState extends State<Menu> {
   @override
   Widget build(BuildContext context) {
     return RawMenuAnchor(
+      delegate: widget.delegate,
       childFocusNode: widget.focusNode,
       controller: widget.controller ?? (_controller ??= MenuController()),
       onOpen: widget.onOpen,
@@ -2482,13 +3585,15 @@ class _MenuState extends State<Menu> {
       consumeOutsideTaps: widget.consumeOutsideTaps,
       useRootOverlay: widget.useRootOverlay,
       builder: widget.builder,
-      overlayBuilder: (BuildContext context, RawMenuOverlayInfo info) {
-        return Positioned(
-          top: info.anchorRect.bottom,
-          left: info.anchorRect.left,
-          child: widget.menuPanel,
-        );
-      },
+      overlayBuilder:
+          widget.overlayBuilder ??
+          (BuildContext context, RawMenuOverlayInfo info) {
+            return Positioned(
+              top: info.anchorRect.bottom,
+              left: info.anchorRect.left,
+              child: widget.menuPanel!,
+            );
+          },
       child: widget.child,
     );
   }
@@ -2518,7 +3623,7 @@ class AnchorButton extends StatelessWidget {
       onPressed: () {
         onPressed?.call(tag);
         if (controller != null) {
-          if (controller.isOpen) {
+          if (MenuController.maybeAnimationStatusOf(context)!.isForwardOrCompleted) {
             controller.close();
           } else {
             controller.open();
@@ -2529,6 +3634,76 @@ class AnchorButton extends StatelessWidget {
       constraints: constraints,
       autofocus: autofocus,
     );
+  }
+}
+
+class DecoratedMenu extends StatefulWidget {
+  const DecoratedMenu({
+    super.key,
+    required this.controller,
+    required this.builder,
+    this.onOpenRequest,
+  });
+
+  final MenuController controller;
+  final Widget Function(
+    BuildContext context,
+    MenuController controller,
+    RawMenuAnchorAnimationDelegate delegate,
+    AnimationController animation,
+  )
+  builder;
+  final void Function(Offset? position)? onOpenRequest;
+
+  @override
+  State<DecoratedMenu> createState() => _DecoratedMenuState();
+}
+
+class _DecoratedMenuState extends State<DecoratedMenu>
+    with SingleTickerProviderStateMixin, RawMenuAnchorAnimationDelegate {
+  late final AnimationController animationController;
+
+  @override
+  void initState() {
+    super.initState();
+    animationController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+  }
+
+  @override
+  void dispose() {
+    animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void handleMenuOpenRequest({ui.Offset? position}) {
+    widget.onOpenRequest?.call(position);
+    animationController.forward().whenComplete(markMenuOpened);
+  }
+
+  @override
+  void handleMenuCloseRequest() {
+    animationController.reverse().whenComplete(markMenuClosed);
+  }
+
+  @override
+  void markMenuOpened() {
+    super.markMenuOpened();
+    animationController.value = 1.0;
+  }
+
+  @override
+  void markMenuClosed() {
+    super.markMenuClosed();
+    animationController.value = 0.0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder.call(context, widget.controller, this, animationController);
   }
 }
 


### PR DESCRIPTION
Delegate alternative to https://github.com/flutter/flutter/pull/163481.

@dkwingsmt 

I'm still leaning a bit towards the decorator because it doesn't need to be attached and detached to the anchor, and, as a result, it is const. 

<hr />

This PR adds a `RawMenuAnchorAnimationDelegate` mixin class that intercepts calls to MenuController.open() and MenuController.close() to allow users to run an animation or add a delay prior to a menu opening or closing. 

Additionally, this PR adds a `MenuController.animationStatus` getter and a `MenuController.maybeAnimationStatusOf` static method to interrogate the current animation status of the nearest menu. I was torn between creating a new enum, such as 
```dart
enum MenuStatus  {
  opened,
  opening,
  closed,
  closing
}
```
and sticking with `AnimationStatus`. I stuck with AnimationStatus, but let me know if you have a preference.

Precursor for https://github.com/flutter/flutter/pull/143416, https://github.com/flutter/flutter/issues/135025, https://github.com/flutter/flutter/pull/143712

## Demo

https://github.com/user-attachments/assets/bb14abca-af26-45fe-8d45-289b5d07dab2
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
