### PR TITLE
Add factory constructors for shorthands that would collide

### DIFF
--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -26,6 +26,12 @@ abstract class AlignmentGeometry {
   /// const constructors so that they can be used in const expressions.
   const AlignmentGeometry();
 
+  /// Creates an [Alignment].
+  factory AlignmentGeometry.xy(double x, double y) => Alignment(x, y);
+
+  /// Creates a directional alignment, or [AlignmentDirectional].
+  factory AlignmentGeometry.directional(double start, double y) => AlignmentDirectional(start, y);
+
   double get _x;
 
   double get _start;

--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -27,10 +27,10 @@ abstract class AlignmentGeometry {
   const AlignmentGeometry();
 
   /// Creates an [Alignment].
-  factory AlignmentGeometry.xy(double x, double y) => Alignment(x, y);
+  const factory AlignmentGeometry.xy(double x, double y) = Alignment;
 
   /// Creates a directional alignment, or [AlignmentDirectional].
-  factory AlignmentGeometry.directional(double start, double y) => AlignmentDirectional(start, y);
+  const factory AlignmentGeometry.directional(double start, double y) = AlignmentDirectional;
 
   double get _x;
 

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -26,6 +26,82 @@ abstract class BorderRadiusGeometry {
   /// const constructors so that they can be used in const expressions.
   const BorderRadiusGeometry();
 
+  /// Creates a [BorderRadius] where all radii are `radius`.
+  // The radius applies equally on all sides, so BorderRadiusDirectional is
+  // irrelevant in this case.
+  factory BorderRadiusGeometry.all(Radius radius) => BorderRadius.all(radius);
+
+  /// Creates a [BorderRadius] where all radii are [Radius.circular(radius)].
+  // The radius applies equally on all sides, so BorderRadiusDirectional is
+  // irrelevant in this case.
+  factory BorderRadiusGeometry.circular(double radius) => BorderRadius.circular(radius);
+
+  /// Creates a horizontally symmetrical border radius.
+  ///
+  /// Utilizing the `left` and `right` properties will return a [BorderRadius],
+  /// while `start` and `end` will yield a [BorderRadiusDirectional]. These
+  /// properties cannot be used interchangeably.
+  factory BorderRadiusGeometry.horizontal({
+    Radius? left, // BorderRadius
+    Radius? right, // BorderRadius
+    Radius? start, // BorderRadiusDirectional
+    Radius? end, // BorderRadiusDirectional
+  }) {
+    assert(
+      (left == null && right == null) || (start == null && end == null),
+      'The left and right values cannot be used in conjunction with start and end.',
+    );
+
+    if (start != null || end != null) {
+      return BorderRadiusDirectional.horizontal(
+        start: start ?? Radius.zero,
+        end: end ?? Radius.zero,
+      );
+    }
+    return BorderRadius.horizontal(left: left ?? Radius.zero, right: right ?? Radius.zero);
+  }
+
+  /// Creates a [BorderRadius] with only the given non-zero values.
+  ///
+  /// The other corners will be right angles.
+  factory BorderRadiusGeometry.only({
+    Radius? topLeft,
+    Radius? topRight,
+    Radius? bottomLeft,
+    Radius? bottomRight,
+  }) => BorderRadius.only(
+    topLeft: topLeft ?? Radius.zero,
+    topRight: topRight ?? Radius.zero,
+    bottomLeft: bottomLeft ?? Radius.zero,
+    bottomRight: bottomRight ?? Radius.zero,
+  );
+
+  /// Creates a [BorderRadiusDirectional] with only the given non-zero values.
+  ///
+  /// The other corners will be right angles.
+  factory BorderRadiusGeometry.directional({
+    Radius? topStart,
+    Radius? topEnd,
+    Radius? bottomStart,
+    Radius? bottomEnd,
+  }) => BorderRadiusDirectional.only(
+    topStart: topStart ?? Radius.zero,
+    topEnd: topEnd ?? Radius.zero,
+    bottomStart: bottomStart ?? Radius.zero,
+    bottomEnd: bottomEnd ?? Radius.zero,
+  );
+
+  /// Creates a vertically symmetric [BorderRadius] where the top and bottom
+  /// sides of the rectangle have the same radii.
+  factory BorderRadiusGeometry.vertical({Radius top = Radius.zero, Radius bottom = Radius.zero}) {
+    // Directionality does not apply vertically, and so BorderRadiusDirectional
+    // is not needed.
+    return BorderRadius.vertical(top: top, bottom: bottom);
+  }
+
+  /// A [BorderRadius] with all zero radii.
+  static const BorderRadiusGeometry zero = BorderRadius.zero;
+
   Radius get _topLeft;
   Radius get _topRight;
   Radius get _bottomLeft;

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -29,12 +29,12 @@ abstract class BorderRadiusGeometry {
   /// Creates a [BorderRadius] where all radii are `radius`.
   // The radius applies equally on all sides, so BorderRadiusDirectional is
   // irrelevant in this case.
-  factory BorderRadiusGeometry.all(Radius radius) => BorderRadius.all(radius);
+  const factory BorderRadiusGeometry.all(Radius radius) = BorderRadius.all;
 
   /// Creates a [BorderRadius] where all radii are [Radius.circular(radius)].
   // The radius applies equally on all sides, so BorderRadiusDirectional is
   // irrelevant in this case.
-  factory BorderRadiusGeometry.circular(double radius) => BorderRadius.circular(radius);
+  factory BorderRadiusGeometry.circular(double radius) = BorderRadius.circular;
 
   /// Creates a horizontally symmetrical border radius.
   ///
@@ -64,40 +64,26 @@ abstract class BorderRadiusGeometry {
   /// Creates a [BorderRadius] with only the given non-zero values.
   ///
   /// The other corners will be right angles.
-  factory BorderRadiusGeometry.only({
-    Radius? topLeft,
-    Radius? topRight,
-    Radius? bottomLeft,
-    Radius? bottomRight,
-  }) => BorderRadius.only(
-    topLeft: topLeft ?? Radius.zero,
-    topRight: topRight ?? Radius.zero,
-    bottomLeft: bottomLeft ?? Radius.zero,
-    bottomRight: bottomRight ?? Radius.zero,
-  );
+  const factory BorderRadiusGeometry.only({
+    Radius topLeft,
+    Radius topRight,
+    Radius bottomLeft,
+    Radius bottomRight,
+  }) = BorderRadius.only;
 
   /// Creates a [BorderRadiusDirectional] with only the given non-zero values.
   ///
   /// The other corners will be right angles.
-  factory BorderRadiusGeometry.directional({
-    Radius? topStart,
-    Radius? topEnd,
-    Radius? bottomStart,
-    Radius? bottomEnd,
-  }) => BorderRadiusDirectional.only(
-    topStart: topStart ?? Radius.zero,
-    topEnd: topEnd ?? Radius.zero,
-    bottomStart: bottomStart ?? Radius.zero,
-    bottomEnd: bottomEnd ?? Radius.zero,
-  );
+  const factory BorderRadiusGeometry.directional({
+    Radius topStart,
+    Radius topEnd,
+    Radius bottomStart,
+    Radius bottomEnd,
+  }) = BorderRadiusDirectional.only;
 
   /// Creates a vertically symmetric [BorderRadius] where the top and bottom
   /// sides of the rectangle have the same radii.
-  factory BorderRadiusGeometry.vertical({Radius top = Radius.zero, Radius bottom = Radius.zero}) {
-    // Directionality does not apply vertically, and so BorderRadiusDirectional
-    // is not needed.
-    return BorderRadius.vertical(top: top, bottom: bottom);
-  }
+  const factory BorderRadiusGeometry.vertical({Radius top, Radius bottom}) = BorderRadius.vertical;
 
   /// A [BorderRadius] with all zero radii.
   static const BorderRadiusGeometry zero = BorderRadius.zero;

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -67,6 +67,54 @@ abstract class BoxBorder extends ShapeBorder {
   /// const constructors so that they can be used in const expressions.
   const BoxBorder();
 
+  /// Creates a [Border].
+  ///
+  /// All the sides of the border default to [BorderSide.none].
+  factory BoxBorder.fromLTRB({
+    BorderSide top = BorderSide.none,
+    BorderSide right = BorderSide.none,
+    BorderSide bottom = BorderSide.none,
+    BorderSide left = BorderSide.none,
+  }) => Border(top: top, right: right, bottom: bottom, left: left);
+
+  /// A uniform [Border] with all sides the same color and width.
+  ///
+  /// The sides default to black solid borders, one logical pixel wide.
+  factory BoxBorder.all({
+    Color color = const Color(0xFF000000),
+    double width = 1.0,
+    BorderStyle style = BorderStyle.solid,
+    double strokeAlign = BorderSide.strokeAlignInside,
+  }) => Border.all(color: color, width: width, style: style, strokeAlign: strokeAlign);
+
+  /// Creates a [Border] whose sides are all the same.
+  factory BoxBorder.fromBorderSide(BorderSide side) => Border.fromBorderSide(side);
+
+  /// Creates a [Border] with symmetrical vertical and horizontal sides.
+  ///
+  /// The `vertical` argument applies to the [left] and [right] sides, and the
+  /// `horizontal` argument applies to the [top] and [bottom] sides.
+  ///
+  /// All arguments default to [BorderSide.none].
+  factory BoxBorder.symmetric({
+    BorderSide vertical = BorderSide.none,
+    BorderSide horizontal = BorderSide.none,
+  }) => Border.symmetric(vertical: vertical, horizontal: horizontal);
+
+  /// Creates a [BorderDirectional].
+  ///
+  /// The [start] and [end] sides represent the horizontal sides; the start side
+  /// is on the leading edge given the reading direction, and the end side is on
+  /// the trailing edge. They are resolved during [paint].
+  ///
+  /// All the sides of the border default to [BorderSide.none].
+  factory BoxBorder.fromSTEB({
+    BorderSide top = BorderSide.none,
+    BorderSide start = BorderSide.none,
+    BorderSide end = BorderSide.none,
+    BorderSide bottom = BorderSide.none,
+  }) => BorderDirectional(top: top, start: start, end: end, bottom: bottom);
+
   /// The top side of this border.
   ///
   /// This getter is available on both [Border] and [BorderDirectional]. If

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -80,15 +80,11 @@ abstract class BoxBorder extends ShapeBorder {
   /// A uniform [Border] with all sides the same color and width.
   ///
   /// The sides default to black solid borders, one logical pixel wide.
-  factory BoxBorder.all({
-    Color color = const Color(0xFF000000),
-    double width = 1.0,
-    BorderStyle style = BorderStyle.solid,
-    double strokeAlign = BorderSide.strokeAlignInside,
-  }) => Border.all(color: color, width: width, style: style, strokeAlign: strokeAlign);
+  factory BoxBorder.all({Color color, double width, BorderStyle style, double strokeAlign}) =
+      Border.all;
 
   /// Creates a [Border] whose sides are all the same.
-  factory BoxBorder.fromBorderSide(BorderSide side) => Border.fromBorderSide(side);
+  const factory BoxBorder.fromBorderSide(BorderSide side) = Border.fromBorderSide;
 
   /// Creates a [Border] with symmetrical vertical and horizontal sides.
   ///
@@ -96,10 +92,8 @@ abstract class BoxBorder extends ShapeBorder {
   /// `horizontal` argument applies to the [top] and [bottom] sides.
   ///
   /// All arguments default to [BorderSide.none].
-  factory BoxBorder.symmetric({
-    BorderSide vertical = BorderSide.none,
-    BorderSide horizontal = BorderSide.none,
-  }) => Border.symmetric(vertical: vertical, horizontal: horizontal);
+  const factory BoxBorder.symmetric({BorderSide vertical, BorderSide horizontal}) =
+      Border.symmetric;
 
   /// Creates a [BorderDirectional].
   ///

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -32,6 +32,59 @@ abstract class EdgeInsetsGeometry {
   /// const constructors so that they can be used in const expressions.
   const EdgeInsetsGeometry();
 
+  /// Creates insets where all the offsets are `value`.
+  const factory EdgeInsetsGeometry.all(double value) = EdgeInsets.all;
+
+  /// Creates [EdgeInsets] with only the given values non-zero.
+  factory EdgeInsetsGeometry.only({double? left, double? right, double? top, double? bottom}) =>
+      EdgeInsets.only(
+        left: left ?? 0.0,
+        top: top ?? 0.0,
+        right: right ?? 0.0,
+        bottom: bottom ?? 0.0,
+      );
+
+  /// Creates [EdgeInsetsDirectional] with only the given values non-zero.
+  factory EdgeInsetsGeometry.directional({
+    double? start,
+    double? end,
+    double? top,
+    double? bottom,
+  }) => EdgeInsetsDirectional.only(
+    start: start ?? 0.0,
+    top: top ?? 0.0,
+    end: end ?? 0.0,
+    bottom: bottom ?? 0.0,
+  );
+
+  /// Creates [EdgeInsets] with symmetrical vertical and horizontal offsets.
+  factory EdgeInsetsGeometry.symmetric({double? vertical, double? horizontal}) =>
+      EdgeInsets.symmetric(horizontal: horizontal ?? 0.0, vertical: vertical ?? 0.0);
+
+  /// Creates [EdgeInsets] from offsets from the left, top, right, and bottom.
+  factory EdgeInsetsGeometry.fromLTRB(double left, double top, double right, double bottom) {
+    return EdgeInsets.fromLTRB(left, top, right, bottom);
+  }
+
+  /// Creates [EdgeInsets] that match the given view padding.
+  ///
+  /// If you need the current system padding or view insets in the context of a
+  /// widget, consider using [MediaQuery.paddingOf] to obtain these values
+  /// rather than using the value from a [FlutterView] directly, so that you get
+  /// notified of changes.
+  factory EdgeInsetsGeometry.fromViewPadding(ui.ViewPadding padding, double devicePixelRatio) {
+    return EdgeInsets.fromViewPadding(padding, devicePixelRatio);
+  }
+
+  /// Creates [EdgeInsetsDirectional] from offsets from the start, top, end, and
+  /// bottom.
+  factory EdgeInsetsGeometry.fromSTEB(double start, double top, double end, double bottom) {
+    return EdgeInsetsDirectional.fromSTEB(start, top, end, bottom);
+  }
+
+  /// An [EdgeInsets] with zero offsets in each direction.
+  static const EdgeInsetsGeometry zero = EdgeInsets.zero;
+
   double get _bottom;
   double get _end;
   double get _left;

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -36,35 +36,24 @@ abstract class EdgeInsetsGeometry {
   const factory EdgeInsetsGeometry.all(double value) = EdgeInsets.all;
 
   /// Creates [EdgeInsets] with only the given values non-zero.
-  factory EdgeInsetsGeometry.only({double? left, double? right, double? top, double? bottom}) =>
-      EdgeInsets.only(
-        left: left ?? 0.0,
-        top: top ?? 0.0,
-        right: right ?? 0.0,
-        bottom: bottom ?? 0.0,
-      );
+  const factory EdgeInsetsGeometry.only({double left, double right, double top, double bottom}) =
+      EdgeInsets.only;
 
   /// Creates [EdgeInsetsDirectional] with only the given values non-zero.
-  factory EdgeInsetsGeometry.directional({
-    double? start,
-    double? end,
-    double? top,
-    double? bottom,
-  }) => EdgeInsetsDirectional.only(
-    start: start ?? 0.0,
-    top: top ?? 0.0,
-    end: end ?? 0.0,
-    bottom: bottom ?? 0.0,
-  );
+  const factory EdgeInsetsGeometry.directional({
+    double start,
+    double end,
+    double top,
+    double bottom,
+  }) = EdgeInsetsDirectional.only;
 
   /// Creates [EdgeInsets] with symmetrical vertical and horizontal offsets.
-  factory EdgeInsetsGeometry.symmetric({double? vertical, double? horizontal}) =>
-      EdgeInsets.symmetric(horizontal: horizontal ?? 0.0, vertical: vertical ?? 0.0);
+  const factory EdgeInsetsGeometry.symmetric({double vertical, double horizontal}) =
+      EdgeInsets.symmetric;
 
   /// Creates [EdgeInsets] from offsets from the left, top, right, and bottom.
-  factory EdgeInsetsGeometry.fromLTRB(double left, double top, double right, double bottom) {
-    return EdgeInsets.fromLTRB(left, top, right, bottom);
-  }
+  const factory EdgeInsetsGeometry.fromLTRB(double left, double top, double right, double bottom) =
+      EdgeInsets.fromLTRB;
 
   /// Creates [EdgeInsets] that match the given view padding.
   ///
@@ -72,15 +61,13 @@ abstract class EdgeInsetsGeometry {
   /// widget, consider using [MediaQuery.paddingOf] to obtain these values
   /// rather than using the value from a [FlutterView] directly, so that you get
   /// notified of changes.
-  factory EdgeInsetsGeometry.fromViewPadding(ui.ViewPadding padding, double devicePixelRatio) {
-    return EdgeInsets.fromViewPadding(padding, devicePixelRatio);
-  }
+  factory EdgeInsetsGeometry.fromViewPadding(ui.ViewPadding padding, double devicePixelRatio) =
+      EdgeInsets.fromViewPadding;
 
   /// Creates [EdgeInsetsDirectional] from offsets from the start, top, end, and
   /// bottom.
-  factory EdgeInsetsGeometry.fromSTEB(double start, double top, double end, double bottom) {
-    return EdgeInsetsDirectional.fromSTEB(start, top, end, bottom);
-  }
+  const factory EdgeInsetsGeometry.fromSTEB(double start, double top, double end, double bottom) =
+      EdgeInsetsDirectional.fromSTEB;
 
   /// An [EdgeInsets] with zero offsets in each direction.
   static const EdgeInsetsGeometry zero = EdgeInsets.zero;

--- a/packages/flutter/test/painting/alignment_test.dart
+++ b/packages/flutter/test/painting/alignment_test.dart
@@ -335,7 +335,7 @@ void main() {
   });
 
   test('AlignmentGeometry factories', () {
-    expect(AlignmentGeometry.xy(4, 5), const Alignment(4, 5));
-    expect(AlignmentGeometry.directional(4, 5), const AlignmentDirectional(4, 5));
+    expect(const AlignmentGeometry.xy(4, 5), const Alignment(4, 5));
+    expect(const AlignmentGeometry.directional(4, 5), const AlignmentDirectional(4, 5));
   });
 }

--- a/packages/flutter/test/painting/alignment_test.dart
+++ b/packages/flutter/test/painting/alignment_test.dart
@@ -333,4 +333,9 @@ void main() {
       'Alignment(1.0, 2.0) + AlignmentDirectional.centerEnd',
     );
   });
+
+  test('AlignmentGeometry factories', () {
+    expect(AlignmentGeometry.xy(4, 5), const Alignment(4, 5));
+    expect(AlignmentGeometry.directional(4, 5), const AlignmentDirectional(4, 5));
+  });
 }

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -627,7 +627,7 @@ void main() {
     const Radius radius10 = Radius.circular(10);
     const Radius radius15 = Radius.circular(15);
     const Radius radius20 = Radius.circular(20);
-    expect(BorderRadiusGeometry.all(radius10), const BorderRadius.all(radius10));
+    expect(const BorderRadiusGeometry.all(radius10), const BorderRadius.all(radius10));
     expect(BorderRadiusGeometry.circular(10), BorderRadius.circular(10));
     expect(
       BorderRadiusGeometry.horizontal(left: radius5, right: radius10),
@@ -652,7 +652,7 @@ void main() {
       );
     }, throwsAssertionError);
     expect(
-      BorderRadiusGeometry.only(
+      const BorderRadiusGeometry.only(
         topLeft: radius5,
         topRight: radius10,
         bottomLeft: radius15,
@@ -666,7 +666,7 @@ void main() {
       ),
     );
     expect(
-      BorderRadiusGeometry.directional(
+      const BorderRadiusGeometry.directional(
         topStart: radius5,
         topEnd: radius10,
         bottomStart: radius15,
@@ -680,7 +680,7 @@ void main() {
       ),
     );
     expect(
-      BorderRadiusGeometry.vertical(top: radius5, bottom: radius10),
+      const BorderRadiusGeometry.vertical(top: radius5, bottom: radius10),
       const BorderRadius.vertical(top: radius5, bottom: radius10),
     );
     expect(BorderRadiusGeometry.zero, BorderRadius.zero);

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -621,4 +621,68 @@ void main() {
       borderRadius,
     );
   });
+
+  test('BorderRadiusGeometry factories', () {
+    const Radius radius5 = Radius.circular(5);
+    const Radius radius10 = Radius.circular(10);
+    const Radius radius15 = Radius.circular(15);
+    const Radius radius20 = Radius.circular(20);
+    expect(BorderRadiusGeometry.all(radius10), const BorderRadius.all(radius10));
+    expect(BorderRadiusGeometry.circular(10), BorderRadius.circular(10));
+    expect(
+      BorderRadiusGeometry.horizontal(left: radius5, right: radius10),
+      const BorderRadius.horizontal(left: radius5, right: radius10),
+    );
+    expect(
+      BorderRadiusGeometry.horizontal(start: radius5, end: radius10),
+      const BorderRadiusDirectional.horizontal(start: radius5, end: radius10),
+    );
+    expect(() {
+      BorderRadiusGeometry.horizontal(start: radius5, left: radius10);
+    }, throwsAssertionError);
+    expect(() {
+      BorderRadiusGeometry.horizontal(end: radius5, right: radius10);
+    }, throwsAssertionError);
+    expect(() {
+      BorderRadiusGeometry.horizontal(
+        end: radius5,
+        right: radius10,
+        start: radius5,
+        left: radius10,
+      );
+    }, throwsAssertionError);
+    expect(
+      BorderRadiusGeometry.only(
+        topLeft: radius5,
+        topRight: radius10,
+        bottomLeft: radius15,
+        bottomRight: radius20,
+      ),
+      const BorderRadius.only(
+        topLeft: radius5,
+        topRight: radius10,
+        bottomLeft: radius15,
+        bottomRight: radius20,
+      ),
+    );
+    expect(
+      BorderRadiusGeometry.directional(
+        topStart: radius5,
+        topEnd: radius10,
+        bottomStart: radius15,
+        bottomEnd: radius20,
+      ),
+      const BorderRadiusDirectional.only(
+        topStart: radius5,
+        topEnd: radius10,
+        bottomStart: radius15,
+        bottomEnd: radius20,
+      ),
+    );
+    expect(
+      BorderRadiusGeometry.vertical(top: radius5, bottom: radius10),
+      const BorderRadius.vertical(top: radius5, bottom: radius10),
+    );
+    expect(BorderRadiusGeometry.zero, BorderRadius.zero);
+  });
 }

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -493,9 +493,9 @@ void main() {
       const Border(left: side1, top: side2, right: side3, bottom: side4),
     );
     expect(BoxBorder.all(width: 4), Border.all(width: 4));
-    expect(BoxBorder.fromBorderSide(side3), const Border.fromBorderSide(side3));
+    expect(const BoxBorder.fromBorderSide(side3), const Border.fromBorderSide(side3));
     expect(
-      BoxBorder.symmetric(horizontal: side2, vertical: side3),
+      const BoxBorder.symmetric(horizontal: side2, vertical: side3),
       const Border.symmetric(horizontal: side2, vertical: side3),
     );
     expect(

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -482,6 +482,27 @@ void main() {
     expect((ShapeWithoutInterior() + ShapeWithInterior()).preferPaintInterior, isFalse);
     expect((ShapeWithoutInterior() + ShapeWithoutInterior()).preferPaintInterior, isFalse);
   });
+
+  test('BoxBorder factories', () {
+    const BorderSide side1 = BorderSide();
+    const BorderSide side2 = BorderSide(width: 2);
+    const BorderSide side3 = BorderSide(width: 3);
+    const BorderSide side4 = BorderSide(width: 4);
+    expect(
+      BoxBorder.fromLTRB(left: side1, top: side2, right: side3, bottom: side4),
+      const Border(left: side1, top: side2, right: side3, bottom: side4),
+    );
+    expect(BoxBorder.all(width: 4), Border.all(width: 4));
+    expect(BoxBorder.fromBorderSide(side3), const Border.fromBorderSide(side3));
+    expect(
+      BoxBorder.symmetric(horizontal: side2, vertical: side3),
+      const Border.symmetric(horizontal: side2, vertical: side3),
+    );
+    expect(
+      BoxBorder.fromSTEB(start: side1, top: side2, end: side3, bottom: side4),
+      const BorderDirectional(start: side1, top: side2, end: side3, bottom: side4),
+    );
+  });
 }
 
 class ShapeWithInterior extends ShapeBorder {

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -448,24 +448,27 @@ void main() {
   test('EdgeInsetsGeometry factories', () {
     expect(const EdgeInsetsGeometry.all(10), const EdgeInsets.all(10));
     expect(
-      EdgeInsetsGeometry.only(left: 10, top: 20, right: 30, bottom: 40),
+      const EdgeInsetsGeometry.only(left: 10, top: 20, right: 30, bottom: 40),
       const EdgeInsets.only(left: 10, top: 20, right: 30, bottom: 40),
     );
     expect(
-      EdgeInsetsGeometry.directional(start: 10, top: 20, end: 30, bottom: 40),
+      const EdgeInsetsGeometry.directional(start: 10, top: 20, end: 30, bottom: 40),
       const EdgeInsetsDirectional.only(start: 10, top: 20, end: 30, bottom: 40),
     );
     expect(
-      EdgeInsetsGeometry.symmetric(horizontal: 10, vertical: 20),
+      const EdgeInsetsGeometry.symmetric(horizontal: 10, vertical: 20),
       const EdgeInsets.symmetric(horizontal: 10, vertical: 20),
     );
-    expect(EdgeInsetsGeometry.fromLTRB(10, 20, 30, 40), const EdgeInsets.fromLTRB(10, 20, 30, 40));
+    expect(
+      const EdgeInsetsGeometry.fromLTRB(10, 20, 30, 40),
+      const EdgeInsets.fromLTRB(10, 20, 30, 40),
+    );
     expect(
       EdgeInsetsGeometry.fromViewPadding(ui.ViewPadding.zero, 10),
       EdgeInsets.fromViewPadding(ui.ViewPadding.zero, 10),
     );
     expect(
-      EdgeInsetsGeometry.fromSTEB(10, 20, 20, 40),
+      const EdgeInsetsGeometry.fromSTEB(10, 20, 20, 40),
       const EdgeInsetsDirectional.fromSTEB(10, 20, 20, 40),
     );
     expect(EdgeInsetsGeometry.zero, EdgeInsets.zero);

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -441,5 +443,31 @@ void main() {
     );
     final EdgeInsetsDirectional copy = sourceEdgeInsets.copyWith(start: 5.0, top: 6.0);
     expect(copy, const EdgeInsetsDirectional.only(start: 5.0, top: 6.0, bottom: 3.0, end: 4.0));
+  });
+
+  test('EdgeInsetsGeometry factories', () {
+    expect(const EdgeInsetsGeometry.all(10), const EdgeInsets.all(10));
+    expect(
+      EdgeInsetsGeometry.only(left: 10, top: 20, right: 30, bottom: 40),
+      const EdgeInsets.only(left: 10, top: 20, right: 30, bottom: 40),
+    );
+    expect(
+      EdgeInsetsGeometry.directional(start: 10, top: 20, end: 30, bottom: 40),
+      const EdgeInsetsDirectional.only(start: 10, top: 20, end: 30, bottom: 40),
+    );
+    expect(
+      EdgeInsetsGeometry.symmetric(horizontal: 10, vertical: 20),
+      const EdgeInsets.symmetric(horizontal: 10, vertical: 20),
+    );
+    expect(EdgeInsetsGeometry.fromLTRB(10, 20, 30, 40), const EdgeInsets.fromLTRB(10, 20, 30, 40));
+    expect(
+      EdgeInsetsGeometry.fromViewPadding(ui.ViewPadding.zero, 10),
+      EdgeInsets.fromViewPadding(ui.ViewPadding.zero, 10),
+    );
+    expect(
+      EdgeInsetsGeometry.fromSTEB(10, 20, 20, 40),
+      const EdgeInsetsDirectional.fromSTEB(10, 20, 20, 40),
+    );
+    expect(EdgeInsetsGeometry.zero, EdgeInsets.zero);
   });
 }


### PR DESCRIPTION
EdgeInsets and EdgeInsetsDirectional are subtypes of EdgeInsetsGeometry.
The both have only, all, and symmetric constructors, which creates collisions in a world where Dart support shorthand notation such as:

```dart
Padding(
  padding: .only(bottom: 10.0),
),
```
 The same goes for all these classes: 

- AlignmentGeometry
  - Alignment
  - AlignmentDirectional
- BorderRadiusGeometry
  - BorderRadius
  - BorderRadiusDirectional
- BoxBorder
  - Border
  - BorderDirectional
- EdgeInsetsGeometry
  - EdgeInsets
  - EdgeInsetsDirectional


The shorthands feature is not planning to exhaustively check subtypes. However, these classes were identified as the most impactful for the shorthands feature (❗ ). Adding these factories in the super classes enables future shorthand support.

Prior in https://github.com/flutter/flutter/pull/159703

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
