### PR TITLE
Add LSAN supression for gdk_display_get_default

### DIFF
--- a/engine/src/flutter/testing/lsan_suppressions.txt
+++ b/engine/src/flutter/testing/lsan_suppressions.txt
@@ -69,3 +69,5 @@ leak:libfontconfig
 # False (?) positives in gdk
 leak:gdk_display_get_default
 leak:gdk_window_get_display
+leak:gdk_display_get_monitor
+leak:fl_event_channel_new

--- a/engine/src/flutter/testing/lsan_suppressions.txt
+++ b/engine/src/flutter/testing/lsan_suppressions.txt
@@ -65,3 +65,6 @@ leak:egl::*
 
 # False positives in libfontconfig. http://crbug.com/39050
 leak:libfontconfig
+
+# False (?) positives in gtk
+leak:gdk_display_get_default

--- a/engine/src/flutter/testing/lsan_suppressions.txt
+++ b/engine/src/flutter/testing/lsan_suppressions.txt
@@ -66,5 +66,6 @@ leak:egl::*
 # False positives in libfontconfig. http://crbug.com/39050
 leak:libfontconfig
 
-# False (?) positives in gtk
+# False (?) positives in gdk
 leak:gdk_display_get_default
+leak:gdk_window_get_display


### PR DESCRIPTION
After the update to ubuntu 24, most/all linux tests are failign with LSAN :


https://github.com/flutter/flutter/issues/165594

```
Indirect leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x55c5760940f5 in malloc ../../../../../../llvm-llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:69:3
    #1 0x73d6be5d6af9 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x62af9) (BuildId: 461eff2b4df472ba9c32b2358ae9ba018a59a8c5)
    #2 0x73d6be5b844a in g_hash_table_new_full (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4444a) (BuildId: 461eff2b4df472ba9c32b2358ae9ba018a59a8c5)
    #3 0x73d6beb36db3  (/lib/x86_64-linux-gnu/libgdk-3.so.0+0x31db3) (BuildId: 6c19633f8a9f0eb5844b6d499056cfda9a81348f)
    #4 0x73d6be6ffff8 in g_type_create_instance (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x40ff8) (BuildId: 50e74d06ce9d0786ace21363c5ed045be0a52983)
    #5 0x73d6be6e5a63  (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x26a63) (BuildId: 50e74d06ce9d0786ace21363c5ed045be0a52983)
    #6 0x73d6be6e7015 in g_object_new_with_properties (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x28015) (BuildId: 50e74d06ce9d0786ace21363c5ed045be0a52983)
    #7 0x73d6be6e7f70 in g_object_new (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x28f70) (BuildId: 50e74d06ce9d0786ace21363c5ed045be0a52983)
    #8 0x55c57677eaca in gdk_display_get_default out/ci/host_debug_unopt/../../../flutter/shell/platform/linux/testing/mock_gtk.cc:50:10
    #9 0x55c57684e739 in fl_keyboard_manager_init(_FlKeyboardManager*) out/ci/host_debug_unopt/../../../flutter/shell/platform/linux/fl_keyboard_manager.cc:350:45
    #10 0x73d6be6ffff8 in g_type_create_instance (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x40ff8) (BuildId: 50e74d06ce9d0786ace21363c5ed045be0a52983)
    #11 0x73d6be6e5a63  (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x26a63) (BuildId: 50e74d06ce9d0786ace21363c5ed045be0a52983)
    #12 0x73d6be6e7015 in g_object_new_with_properties (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x28015) (BuildId: 50e74d06ce9d0786ace21363c5ed045be0a52983)
    #13 0x73d6be6e7f70 in g_object_new (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x28f70) (BuildId: 50e74d06ce9d0786ace21363c5ed045be0a52983)
    #14 0x55c57684ae3e in fl_keyboard_manager_new out/ci/host_debug_unopt/../../../flutter/shell/platform/linux/fl_keyboard_manager.cc:358:7
    #15 0x55c576816cb3 in fl_engine_new_full(_FlDartProject*, _FlRenderer*, _FlBinaryMessenger*) out/ci/host_debug_unopt/../../../flutter/shell/platform/linux/fl_engine.cc:557:28
    #16 0x55c5768168d5 in fl_engine_new_with_renderer out/ci/host_debug_unopt/../../../flutter/shell/platform/linux/fl_engine.cc:577:10
    #17 0x55c576816f1e in fl_engine_new out/ci/host_debug_unopt/../../../flutter/shell/platform/linux/fl_engine.cc:582:10
    #18 0x55c5761be0d2 in FlEngineTest_DuplicateLocale_Test::TestBody() out/ci/host_debug_unopt/../../../flutter/shell/platform/linux/fl_engine_test.cc:533:32
    #19 0x55c57c1ea4cf in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:2613:10
    #20 0x55c57c1ad570 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:2668:12
    #21 0x55c57c17007d in testing::Test::Run() out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:2688:5
    #22 0x55c57c17162a in testing::TestInfo::Run() out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:2837:11
    #23 0x55c57c172926 in testing::TestSuite::Run() out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:3016:30
    #24 0x55c57c18b219 in testing::internal::UnitTestImpl::RunAllTests() out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:5922:44
    #25 0x55c57c1fd4ff in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:2613:10
    #26 0x55c57c1b22cd in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:2668:12
    #27 0x55c57c18a68f in testing::UnitTest::Run() out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/src/gtest.cc:5486:10
    #28 0x55c5768b7890 in RUN_ALL_TESTS() out/ci/host_debug_unopt/../../../flutter/third_party/googletest/googletest/include/gtest/gtest.h:2316:73
    #29 0x55c5768b735a in main out/ci/host_debug_unopt/../../../flutter/testing/run_all_unittests.cc:72:17
    ```
