### PR TITLE
Mark `Linux linux_web_engine` as bringup

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -384,6 +384,7 @@ targets:
       cores: "8"
 
   - name: Linux linux_web_engine_tests
+    bringup: true # https://github.com/flutter/flutter/issues/165610 - Ubuntu 24.04 + Firefox
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:


### PR DESCRIPTION
After upgrading Ubuntu to 24.04, these tests started flaking.
