### PR TITLE
Remove the path_ops library test from the run_tests script

### DIFF
--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -976,8 +976,6 @@ def build_dart_host_test_list(build_dir):
       os.path.join('flutter', 'tools', 'pkg', 'engine_repo_tools'),
       os.path.join('flutter', 'tools', 'pkg', 'git_repo_tools'),
   ]
-  if not is_asan(build_dir):
-    dart_host_tests += [os.path.join('flutter', 'tools', 'path_ops', 'dart')]
 
   return dart_host_tests
 


### PR DESCRIPTION
This test was not running previously on the Linux builder, but it started running again when ASAN was disabled due to the Ubuntu 24 upgrade on LUCI.  The test is not currently functioning as intended and needs to be disabled until the Ubuntu upgrade is stable.

See https://github.com/flutter/flutter/pull/165661