### PR TITLE
Deprecated methods that call setStatusBarColor, setNavigationBarColor, setNavigationBarDividerColor

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -808,6 +808,12 @@ public class FlutterActivity extends Activity
         /*shouldDelayFirstAndroidViewDraw=*/ getRenderMode() == RenderMode.surface);
   }
 
+  /**
+   * @deprecated This method is outdated because it calls {@code setStatusBarColor},
+   * which is deprecated in Android 15 and above.
+   * Consider using the new WindowInsetsController or other Android 15+ APIs for system UI styling.
+   */
+  @Deprecated
   private void configureStatusBarForFullscreenFlutterExperience() {
     Window window = getWindow();
     window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -600,6 +600,12 @@ public class FlutterFragmentActivity extends FragmentActivity
     }
   }
 
+  /**
+   * @deprecated This method is outdated because it calls {@code setStatusBarColor},
+   * which is deprecated in Android 15 and above.
+   * Consider using the new WindowInsetsController or other Android 15+ APIs for system UI styling.
+   */
+  @Deprecated
   private void configureStatusBarForFullscreenFlutterExperience() {
     Window window = getWindow();
     window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -403,7 +403,12 @@ public class PlatformPlugin {
     updateSystemUiOverlays();
   }
 
-  @SuppressWarnings("deprecation")
+  /**
+   * @deprecated This method is outdated because it calls {@code setStatusBarColor}, {@code setNavigationBarColor} and {@code setNavigationBarDividerColor},
+   * which are deprecated in Android 15 and above.
+   * Consider using the new WindowInsetsController or other Android 15+ APIs for system UI styling.
+   */
+  @Deprecated
   private void setSystemChromeSystemUIOverlayStyle(
       PlatformChannel.SystemChromeStyle systemChromeStyle) {
     Window window = activity.getWindow();


### PR DESCRIPTION
Added @Deprecated annotation and explanation to methods that use these methods: setStatusBarColor, setNavigationBarColor, setNavigationBarDividerColor

This PR fixes issue #165327