### PR TITLE
[fuchsia] Roll F26

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -215,7 +215,7 @@ vars = {
 
   # The version / instance id of the cipd:chromium/fuchsia/gn-sdk which will be
   # used altogether with fuchsia-sdk to generate gn based build rules.
-  'fuchsia_gn_sdk_version': 'T6ahk2PZvX-n2RabPqFNTu_AL3tTBGgQMnfAOavwCtsC',
+  'fuchsia_gn_sdk_version': 'K_1kHDN1WfObPYHyad1M8zegaI4awe8GiPhafqb99Y0C',
 }
 
 gclient_gn_args_file = 'engine/src/flutter/third_party/dart/build/config/gclient_args.gni'

--- a/engine/src/flutter/fml/platform/fuchsia/log_interest_listener_unittests.cc
+++ b/engine/src/flutter/fml/platform/fuchsia/log_interest_listener_unittests.cc
@@ -74,9 +74,6 @@ class MockLogSink : public component_testing::LocalComponentImpl,
     }
   }
 
-  void Connect(fuchsia_logger::LogSinkConnectRequest& request,
-               ConnectCompleter::Sync& completer) override {}
-
   void ConnectStructured(
       fuchsia_logger::LogSinkConnectStructuredRequest& request,
       ConnectStructuredCompleter::Sync& completer) override {}
@@ -87,6 +84,10 @@ class MockLogSink : public component_testing::LocalComponentImpl,
                                           fidl::kIgnoreBindingClosure)),
               ZX_OK);
   }
+
+  void handle_unknown_method(
+      fidl::UnknownMethodMetadata<fuchsia_logger::LogSink> metadata,
+      fidl::UnknownMethodCompleter::Sync& completer) override {}
 
  private:
   bool first_call_ = true;


### PR DESCRIPTION
Includes a change to:

- Remove LogSink.Connect and handle unknown interactions in mock.
  This method is gone in F26.

Bug: https://fxbug.dev/405407295

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
