### PR TITLE
Set enableDebuggingSupport in DWDS based on specified device ID (defa…

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -49,6 +49,7 @@ typedef DwdsLauncher =
       required Stream<BuildResult> buildResults,
       required ConnectionProvider chromeConnection,
       required ToolConfiguration toolConfiguration,
+      bool enableDebuggingSupport,
     });
 
 // A minimal index for projects that do not yet support web. A meta tag is used
@@ -428,6 +429,9 @@ class WebAssetServer implements AssetReader {
         ),
         appMetadata: AppMetadata(hostname: hostname),
       ),
+      // Defaults to 'chrome' if deviceManager or specifiedDeviceId is null,
+      // ensuring the condition is true by default.
+      enableDebuggingSupport: (globals.deviceManager?.specifiedDeviceId ?? 'chrome') == 'chrome',
     );
     shelf.Pipeline pipeline = const shelf.Pipeline();
     if (enableDwds) {

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   archive: 3.6.1
   args: 2.6.0
   dds: 5.0.0
-  dwds: 24.3.7
+  dwds: 24.3.8
   code_builder: 4.10.1
   completion: 1.0.1
   coverage: 1.11.1
@@ -122,4 +122,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 776d
+# PUBSPEC CHECKSUM: 946e


### PR DESCRIPTION
This change ensures that `enableDebuggingSupport` in DWDS is set based on the specified device ID, defaulting to Chrome. This complements the changes made in https://github.com/dart-lang/webdev/pull/2601 and ensures that debugging support is correctly configured for different environments.

fixes https://github.com/dart-lang/sdk/issues/60289