### PR TITLE
Add run tests to engine tool

### DIFF
--- a/engine/src/flutter/tools/engine_tool/lib/src/build_plan.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/build_plan.dart
@@ -16,6 +16,7 @@ const _flagConfig = 'config';
 const _flagConcurrency = 'concurrency';
 const _flagStrategy = 'build-strategy';
 const _flagRbe = 'rbe';
+const _flagRunTests = 'run-tests';
 const _flagLto = 'lto';
 const _flagExtraGnArgs = 'gn-args';
 
@@ -50,6 +51,7 @@ final class BuildPlan {
     return BuildPlan._(
       build: build,
       strategy: BuildStrategy.values.byName(args.option(_flagStrategy)!),
+      runTests: args.flag(_flagRunTests),
       useRbe: () {
         final useRbe = args.flag(_flagRbe);
         if (useRbe && !environment.hasRbeConfigInTree()) {
@@ -84,6 +86,7 @@ final class BuildPlan {
   BuildPlan._({
     required this.build,
     required this.strategy,
+    required this.runTests,
     required this.useRbe,
     required this.useLto,
     required this.concurrency,
@@ -202,6 +205,19 @@ final class BuildPlan {
       hide: !environment.verbose,
     );
 
+    // Add --run-tests.
+    parser.addFlag(
+      _flagRunTests,
+      defaultsTo: false,
+      help: () {
+        var runTestsHelp = 'Run tests (tests will not run by default).';
+        if (environment.verbose) {
+          runTestsHelp += '\n\n$runTestsHelp';
+        }
+        return runTestsHelp;
+      }(),
+    );
+
     // Add --rbe.
     final hasRbeConfigInTree = environment.hasRbeConfigInTree();
     parser.addFlag(
@@ -244,6 +260,9 @@ final class BuildPlan {
 
     return builds;
   }
+
+  /// Whether to run tests
+  final bool runTests;
 
   /// The build configuration to use.
   final Build build;

--- a/engine/src/flutter/tools/engine_tool/lib/src/build_plan.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/build_plan.dart
@@ -208,7 +208,6 @@ final class BuildPlan {
     // Add --run-tests.
     parser.addFlag(
       _flagRunTests,
-      defaultsTo: false,
       help: () {
         var runTestsHelp = 'Run tests (tests will not run by default).';
         if (environment.verbose) {

--- a/engine/src/flutter/tools/engine_tool/lib/src/build_utils.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/build_utils.dart
@@ -80,6 +80,7 @@ Future<int> runBuild(
   Environment environment,
   Build build, {
   required bool enableRbe,
+  bool runTests = false,
   List<String> extraGnArgs = const <String>[],
   List<Label> targets = const <Label>[],
   int concurrency = 0,
@@ -97,7 +98,7 @@ Future<int> runBuild(
     rbeConfig: rbeConfig,
     concurrency: concurrency,
     extraGnArgs: gnArgs,
-    runTests: false,
+    runTests: runTests,
     extraNinjaArgs: <String>[
       ...targets.map((Label label) => label.toNinjaLabel()),
       // If the environment is verbose, pass the verbose flag to ninja.

--- a/engine/src/flutter/tools/engine_tool/lib/src/commands/build_command.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/commands/build_command.dart
@@ -76,6 +76,7 @@ et build //flutter/fml:fml_benchmarks  # Build a specific target in `//flutter/f
       concurrency: plan.concurrency ?? 0,
       extraGnArgs: plan.toGnArgs(),
       targets: allTargets.toList(),
+      runTests: plan.runTests,
       enableRbe: plan.useRbe,
       rbeConfig: plan.toRbeConfig(),
     );

--- a/engine/src/flutter/tools/engine_tool/test/src/test_build_configs.dart
+++ b/engine/src/flutter/tools/engine_tool/test/src/test_build_configs.dart
@@ -41,7 +41,7 @@ final class TestBuilderConfig {
       'description': description,
       'ninja': <String, Object?>{
         // Tests assume we always have a ninja config, so let's make sure we have one
-        'config': targetDir ?? "test",
+        'config': targetDir ?? 'test',
         'targets': ['ninja_target'],
       },
       'tests': _testTask(testTask),

--- a/engine/src/flutter/tools/engine_tool/test/src/test_build_configs.dart
+++ b/engine/src/flutter/tools/engine_tool/test/src/test_build_configs.dart
@@ -40,10 +40,9 @@ final class TestBuilderConfig {
       'name': name,
       'description': description,
       'ninja': <String, Object?>{
-        if (targetDir case final targetDir?) ...{
-          'config': targetDir,
-          'targets': ['ninja_target'],
-        },
+        // Tests assume we always have a ninja config, so let's make sure we have one
+        'config': targetDir ?? "test",
+        'targets': ['ninja_target'],
       },
       'tests': _testTask(testTask),
       'generators': _generatorTask(generatorTask),

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config.dart
@@ -223,7 +223,6 @@ final class Build extends BuildConfigBase {
     }
 
     if (name == null ||
-        description == null ||
         gn == null ||
         ninja == null ||
         archives == null ||
@@ -231,11 +230,12 @@ final class Build extends BuildConfigBase {
         generators == null ||
         droneDimensions == null ||
         gclientVariables == null) {
+
       return Build._invalid(errors);
     }
     return Build._(
       name,
-      description,
+      description ?? "",
       gn,
       ninja,
       tests,
@@ -374,13 +374,12 @@ final class BuildTest extends BuildConfigBase {
     final List<String>? parameters = stringListOfJson(map, 'parameters', errors);
     final List<String>? contexts = stringListOfJson(map, 'contexts', errors);
     if (name == null ||
-        language == null ||
         script == null ||
         parameters == null ||
         contexts == null) {
       return BuildTest._invalid(errors);
     }
-    return BuildTest._(name, language, script, parameters, contexts);
+    return BuildTest._(name, language ?? "", script, parameters, contexts);
   }
 
   BuildTest._(this.name, this.language, this.script, this.parameters, this.contexts) : super(null);
@@ -435,10 +434,10 @@ final class BuildTask extends BuildConfigBase {
     final String? language = stringOfJson(map, 'language', errors);
     final List<String>? scripts = stringListOfJson(map, 'scripts', errors);
     final List<String>? parameters = stringListOfJson(map, 'parameters', errors);
-    if (name == null || language == null || scripts == null || parameters == null) {
+    if (name == null || scripts == null || parameters == null) {
       return BuildTask._invalid(errors);
     }
-    return BuildTask._(name, language, scripts, parameters);
+    return BuildTask._(name, language ?? "", scripts, parameters);
   }
 
   BuildTask._invalid(super.errors)
@@ -788,7 +787,7 @@ List<String>? stringListOfJson(Map<String, Object?> map, String field, List<Stri
 
 String? stringOfJson(Map<String, Object?> map, String field, List<String> errors) {
   if (map[field] == null) {
-    return '<undef>';
+    return null;
   }
   if (map[field]! is! String) {
     appendTypeError(map, field, 'string', errors);

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config.dart
@@ -520,7 +520,7 @@ final class GlobalTest extends BuildConfigBase {
   factory GlobalTest.fromJson(Map<String, Object?> map) {
     final List<String> errors = <String>[];
     final String? name = stringOfJson(map, 'name', errors);
-    final String? recipe = stringOfJson(map, 'recipe', errors);
+    final String? recipe = stringOfJson(map, 'recipe', errors, defaultValue: undef);
     final List<String>? droneDimensions = stringListOfJson(map, 'drone_dimensions', errors);
     final List<String>? dependencies = stringListOfJson(map, 'dependencies', errors);
     final List<TestDependency>? testDependencies = objListOfJson(
@@ -640,14 +640,10 @@ final class TestTask extends BuildConfigBase {
     final String? script = stringOfJson(map, 'script', errors);
     final int? maxAttempts = intOfJson(map, 'max_attempts', fallback: 1, errors);
     final List<String>? parameters = stringListOfJson(map, 'parameters', errors);
-    if (name == null ||
-        language == null ||
-        script == null ||
-        maxAttempts == null ||
-        parameters == null) {
+    if (name == null || script == null || maxAttempts == null || parameters == null) {
       return TestTask._invalid(errors);
     }
-    return TestTask._(name, language, script, maxAttempts, parameters);
+    return TestTask._(name, language ?? '', script, maxAttempts, parameters);
   }
 
   TestTask._invalid(super.error)

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config.dart
@@ -230,7 +230,6 @@ final class Build extends BuildConfigBase {
         generators == null ||
         droneDimensions == null ||
         gclientVariables == null) {
-
       return Build._invalid(errors);
     }
     return Build._(
@@ -373,10 +372,7 @@ final class BuildTest extends BuildConfigBase {
     final String? script = stringOfJson(map, 'script', errors);
     final List<String>? parameters = stringListOfJson(map, 'parameters', errors);
     final List<String>? contexts = stringListOfJson(map, 'contexts', errors);
-    if (name == null ||
-        script == null ||
-        parameters == null ||
-        contexts == null) {
+    if (name == null || script == null || parameters == null || contexts == null) {
       return BuildTest._invalid(errors);
     }
     return BuildTest._(name, language ?? "", script, parameters, contexts);

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config.dart
@@ -234,7 +234,7 @@ final class Build extends BuildConfigBase {
     }
     return Build._(
       name,
-      description ?? "",
+      description ?? '',
       gn,
       ninja,
       tests,
@@ -375,7 +375,7 @@ final class BuildTest extends BuildConfigBase {
     if (name == null || script == null || parameters == null || contexts == null) {
       return BuildTest._invalid(errors);
     }
-    return BuildTest._(name, language ?? "", script, parameters, contexts);
+    return BuildTest._(name, language ?? '', script, parameters, contexts);
   }
 
   BuildTest._(this.name, this.language, this.script, this.parameters, this.contexts) : super(null);
@@ -433,7 +433,7 @@ final class BuildTask extends BuildConfigBase {
     if (name == null || scripts == null || parameters == null) {
       return BuildTask._invalid(errors);
     }
-    return BuildTask._(name, language ?? "", scripts, parameters);
+    return BuildTask._(name, language ?? '', scripts, parameters);
   }
 
   BuildTask._invalid(super.errors)

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
@@ -575,6 +575,9 @@ final class BuildRunner extends Runner {
   }
 
   Future<bool> _runNinja(RunnerEventHandler eventHandler) async {
+    if (build.ninja.config.isEmpty) {
+      return true;
+    }
     if (_isRbe) {
       if (!await _bootstrapRbe(eventHandler)) {
         return false;
@@ -807,7 +810,7 @@ final class BuildTestRunner extends Runner {
 
   @override
   Future<bool> run(RunnerEventHandler eventHandler) async {
-    final String interpreter = _interpreter(test.language);
+    final String interpreter = test.language != null ? _interpreter(test.language!) : "";
     final List<String> command = <String>[
       if (interpreter.isNotEmpty) interpreter,
       test.script,

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
@@ -810,7 +810,7 @@ final class BuildTestRunner extends Runner {
 
   @override
   Future<bool> run(RunnerEventHandler eventHandler) async {
-    final String interpreter = test.language != null ? _interpreter(test.language!) : "";
+    final String interpreter = _interpreter(test.language);
     final List<String> command = <String>[
       if (interpreter.isNotEmpty) interpreter,
       test.script,

--- a/engine/src/flutter/tools/pkg/engine_build_configs/test/build_config_test.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/test/build_config_test.dart
@@ -84,7 +84,7 @@ int main() {
     final TestTask globalTestTask = globalTest.tasks[0];
     expect(globalTestTask.name, equals('global test task'));
     expect(globalTestTask.script, equals('global/test/script.py'));
-    expect(globalTestTask.language, equals('<undef>'));
+    expect(globalTestTask.language, equals(''));
   });
 
   test('BuildConfig flags invalid input', () {


### PR DESCRIPTION
Previously, runTests was hardcoded to false when running et --build. This PR adds a --run-tests option to engine_tool to allow running the tests.

It fixes the error encountered in #165769, properly handling builds without ninja configuration and missing language arguments on scripts. However, for the tests in #165769 to run, engine tool actually needs support for running GlobalTests, which are not included in the build specific test config.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
