### PR TITLE
Re-enable bash_entrypoint_test.dart

### DIFF
--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -94,7 +94,7 @@ echo downloaded dart sdk
 ''');
       makeExecutable(updateDartSdk);
 
-      final File udpateEngine = tempDir
+      final File updateEngine = tempDir
         .childDirectory('bin')
         .childDirectory('internal')
         .childFile('update_engine_version.sh')..writeAsStringSync('''
@@ -102,7 +102,7 @@ echo downloaded dart sdk
 
 echo engine version
 ''');
-      makeExecutable(udpateEngine);
+      makeExecutable(updateEngine);
 
       // create a fake dart runtime
       final File dartBin = (tempDir
@@ -130,7 +130,7 @@ echo executed dart binary
     } finally {
       tryToDelete(tempDir);
     }
-  }, skip: true); // [intended] https://github.com/flutter/flutter/issues/160689
+  });
 }
 
 // A test Dart app that will run until it receives SIGTERM

--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -130,7 +130,7 @@ echo executed dart binary
     } finally {
       tryToDelete(tempDir);
     }
-  });
+  }, skip: platform.isWindows); // [intended] Windows does not use the bash entrypoint);
 }
 
 // A test Dart app that will run until it receives SIGTERM


### PR DESCRIPTION
The test was fixed in https://github.com/flutter/flutter/commit/d443df008b8e7ab700ed0be5d458d81285cfb4cb but never re-enabled.

Fixes https://github.com/flutter/flutter/issues/160689