### PR TITLE
Release the SurfaceTextureSurfaceProducer's surface in the release method

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java
@@ -52,6 +52,8 @@ final class SurfaceTextureSurfaceProducer
   @Override
   public void release() {
     texture.release();
+    surface.release();
+    surface = null;
     released = true;
   }
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducerTest.java
@@ -6,6 +6,8 @@ package io.flutter.embedding.engine.renderer;
 
 import static io.flutter.Build.API_LEVELS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -66,5 +68,20 @@ public final class SurfaceTextureSurfaceProducerTest {
     // Done.
     fakeJNI.detachFromNativeAndReleaseResources();
     producer.release();
+  }
+
+  @Test
+  public void releaseWillReleaseSurface() {
+    final FlutterRenderer flutterRenderer = new FlutterRenderer(fakeJNI);
+
+    // Create a surface and set the initial size.
+    final Handler handler = new Handler(Looper.getMainLooper());
+    final SurfaceTextureSurfaceProducer producer =
+        new SurfaceTextureSurfaceProducer(
+            0, handler, fakeJNI, flutterRenderer.registerSurfaceTexture(new SurfaceTexture(0)));
+    final Surface surface = producer.getSurface();
+    assertTrue(surface.isValid());
+    producer.release();
+    assertFalse(surface.isValid());
   }
 }


### PR DESCRIPTION
The TextureRegistry.SurfaceProducer interface specifies that callers of getSurface should not cache the returned surface.  Therefore, it should be safe for SurfaceTextureSurfaceProducer to release this surface when releasing the texture.

Fixes https://github.com/flutter/flutter/issues/163235