### PR TITLE
[Impeller] disable GLES tracing unless opted in.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -129,7 +129,7 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
 
 #undef IMPELLER_PROC
 
-  if (!description_->HasDebugExtension() || !ENABLE_GLES_LABELING) {
+  if (!IMP_ENABLE_GLES_LABELING || !description_->HasDebugExtension()) {
     PushDebugGroupKHR.Reset();
     PopDebugGroupKHR.Reset();
     ObjectLabelKHR.Reset();

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -129,7 +129,7 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
 
 #undef IMPELLER_PROC
 
-  if (!IMP_ENABLE_GLES_LABELING || !description_->HasDebugExtension()) {
+  if (!IP_ENABLE_GLES_LABELING || !description_->HasDebugExtension()) {
     PushDebugGroupKHR.Reset();
     PopDebugGroupKHR.Reset();
     ObjectLabelKHR.Reset();

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -129,7 +129,7 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
 
 #undef IMPELLER_PROC
 
-  if (!description_->HasDebugExtension()) {
+  if (!description_->HasDebugExtension() || !ENABLE_GLES_LABELING) {
     PushDebugGroupKHR.Reset();
     PopDebugGroupKHR.Reset();
     ObjectLabelKHR.Reset();

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -15,7 +15,7 @@
 #include "impeller/renderer/backend/gles/gles.h"
 
 /// Enable to allow GLES to push/pop labels for usage in GPU traces
-#define IMP_ENABLE_GLES_LABELING false
+#define IP_ENABLE_GLES_LABELING false
 
 namespace impeller {
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -15,7 +15,7 @@
 #include "impeller/renderer/backend/gles/gles.h"
 
 /// Enable to allow GLES to push/pop labels for usage in GPU traces
-#define ENABLE_GLES_LABELING false
+#define IMP_ENABLE_GLES_LABELING false
 
 namespace impeller {
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -14,6 +14,9 @@
 #include "impeller/renderer/backend/gles/description_gles.h"
 #include "impeller/renderer/backend/gles/gles.h"
 
+/// Enable to allow GLES to push/pop labels for usage in GPU traces
+#define ENABLE_GLES_LABELING false
+
 namespace impeller {
 
 const char* GLErrorToString(GLenum value);

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/reactor_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/reactor_unittests.cc
@@ -96,35 +96,6 @@ TEST(ReactorGLES, UntrackedHandle) {
   EXPECT_TRUE(reactor->React());
 }
 
-#ifdef IP_ENABLE_GLES_LABELING
-TEST(ReactorGLES, NameUntrackedHandle) {
-  auto mock_gles_impl = std::make_unique<NiceMock<MockGLESImpl>>();
-
-  EXPECT_CALL(*mock_gles_impl, GenTextures(1, _))
-      .WillOnce([](GLsizei size, GLuint* queries) { queries[0] = 1234; });
-  EXPECT_CALL(*mock_gles_impl,
-              ObjectLabelKHR(_, 1234, _, ::testing::StrEq("hello, joe!")))
-      .Times(1);
-  ON_CALL(*mock_gles_impl, IsTexture).WillByDefault(::testing::Return(GL_TRUE));
-
-  std::shared_ptr<MockGLES> mock_gles =
-      MockGLES::Init(std::move(mock_gles_impl));
-  ProcTableGLES::Resolver resolver = kMockResolverGLES;
-  auto proc_table = std::make_unique<ProcTableGLES>(resolver);
-
-  if (!proc_table->SupportsDebugLabels()) {
-    GTEST_SKIP() << "This device doesn't support labelling.";
-  }
-
-  auto worker = std::make_shared<TestWorker>();
-  auto reactor = std::make_shared<ReactorGLES>(std::move(proc_table));
-  reactor->AddWorker(worker);
-
-  HandleGLES handle = reactor->CreateUntrackedHandle(HandleType::kTexture);
-  reactor->SetDebugLabel(handle, "hello, joe!");
-}
-#endif  // IP_ENABLE_GLES_LABELING
-
 TEST(ReactorGLES, PerThreadOperationQueues) {
   auto mock_gles = MockGLES::Init();
   ProcTableGLES::Resolver resolver = kMockResolverGLES;

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/reactor_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/reactor_unittests.cc
@@ -96,6 +96,7 @@ TEST(ReactorGLES, UntrackedHandle) {
   EXPECT_TRUE(reactor->React());
 }
 
+#ifdef IP_ENABLE_GLES_LABELING
 TEST(ReactorGLES, NameUntrackedHandle) {
   auto mock_gles_impl = std::make_unique<NiceMock<MockGLESImpl>>();
 
@@ -122,6 +123,7 @@ TEST(ReactorGLES, NameUntrackedHandle) {
   HandleGLES handle = reactor->CreateUntrackedHandle(HandleType::kTexture);
   reactor->SetDebugLabel(handle, "hello, joe!");
 }
+#endif  // IP_ENABLE_GLES_LABELING
 
 TEST(ReactorGLES, PerThreadOperationQueues) {
   auto mock_gles = MockGLES::Init();


### PR DESCRIPTION
GLES tracing may add substantial overhead on some devices. Since this is only useful when using frame capture tools, and its unlikely anyone that isn't an engine developer (or who knows how to compile the engine) will use them - we can turn off with a define.

If there are other usecases we need to cover later this can be made to use the new flag system.