### PR TITLE
[Impeller] remove overriding of sampler mode to decal.

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -727,6 +727,7 @@ std::optional<Entity> BlendFilterContents::CreateFramebufferAdvancedBlend(
       // Next, we render the second contents to a snapshot, or create a 1x1
       // texture for the foreground color.
       std::shared_ptr<Texture> src_texture;
+      SamplerDescriptor src_sampler_descriptor = SamplerDescriptor{};
       if (foreground_color.has_value()) {
         src_texture = foreground_texture;
       } else {
@@ -739,6 +740,7 @@ std::optional<Entity> BlendFilterContents::CreateFramebufferAdvancedBlend(
         // different, but we only need to support blending two contents together
         // in limited circumstances (mask blur).
         src_texture = src_snapshot->texture;
+        src_sampler_descriptor = src_snapshot->sampler_descriptor;
       }
 
       std::array<VS::PerVertexData, 4> vertices = {
@@ -820,11 +822,6 @@ std::optional<Entity> BlendFilterContents::CreateFramebufferAdvancedBlend(
       VS::FrameInfo frame_info;
       FS::FragInfo frag_info;
 
-      SamplerDescriptor src_sampler_descriptor = SamplerDescriptor{};
-      if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {
-        src_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
-        src_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
-      }
       raw_ptr<const Sampler> src_sampler =
           renderer.GetContext()->GetSamplerLibrary()->GetSampler(
               src_sampler_descriptor);

--- a/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -199,14 +199,9 @@ static std::optional<Entity> AdvancedBlend(
     typename FS::BlendInfo blend_info;
     typename VS::FrameInfo frame_info;
 
-    auto dst_sampler_descriptor = dst_snapshot->sampler_descriptor;
-    if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {
-      dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
-      dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
-    }
     raw_ptr<const Sampler> dst_sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-            dst_sampler_descriptor);
+            dst_snapshot->sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
     frame_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
     blend_info.dst_input_alpha =
@@ -222,14 +217,9 @@ static std::optional<Entity> AdvancedBlend(
       // binding.
       FS::BindTextureSamplerSrc(pass, dst_snapshot->texture, dst_sampler);
     } else {
-      auto src_sampler_descriptor = src_snapshot->sampler_descriptor;
-      if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {
-        src_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
-        src_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
-      }
       raw_ptr<const Sampler> src_sampler =
           renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-              src_sampler_descriptor);
+              src_snapshot->sampler_descriptor);
       blend_info.color_factor = 0;
       blend_info.src_input_alpha = src_snapshot->opacity;
       FS::BindTextureSamplerSrc(pass, src_snapshot->texture, src_sampler);
@@ -372,14 +362,9 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
     FS::BlendInfo blend_info;
     VS::FrameInfo frame_info;
 
-    auto dst_sampler_descriptor = dst_snapshot->sampler_descriptor;
-    if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {
-      dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
-      dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
-    }
     raw_ptr<const Sampler> dst_sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-            dst_sampler_descriptor);
+            dst_snapshot->sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
     frame_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
 
@@ -479,14 +464,9 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
         entity.GetShaderClipDepth(), pass,
         entity.GetTransform() * dst_snapshot->transform);
 
-    auto dst_sampler_descriptor = dst_snapshot->sampler_descriptor;
-    if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {
-      dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
-      dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
-    }
     raw_ptr<const Sampler> dst_sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-            dst_sampler_descriptor);
+            dst_snapshot->sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
     frame_info.texture_sampler_y_coord_scale =
         dst_snapshot->texture->GetYCoordScale();
@@ -840,7 +820,7 @@ std::optional<Entity> BlendFilterContents::CreateFramebufferAdvancedBlend(
       VS::FrameInfo frame_info;
       FS::FragInfo frag_info;
 
-      auto src_sampler_descriptor = SamplerDescriptor{};
+      SamplerDescriptor src_sampler_descriptor = SamplerDescriptor{};
       if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {
         src_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
         src_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/165788

We can't remember why we did this.