### PR TITLE
[Android 16] Updated emu_unstable to 36 AVD in Framework CI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -50,8 +50,8 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:35v1"},
-          {"dependency": "android_virtual_device", "version": "android_36_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8719769919782256833"},
+          {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8733065022087935185"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       os: Ubuntu
@@ -69,8 +69,8 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:35v1"},
-          {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8723189955818532721"},
+          {"dependency": "android_virtual_device", "version": "android_36_google_apis_x64.textpb"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8719362231152674241"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       os: Ubuntu

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -50,8 +50,8 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:35v1"},
-          {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8733065022087935185"},
+          {"dependency": "android_virtual_device", "version": "android_36_google_apis_x64.textpb"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8719769919782256833"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       os: Ubuntu

--- a/engine/src/flutter/ci/builders/linux_android_emulator.json
+++ b/engine/src/flutter/ci/builders/linux_android_emulator.json
@@ -43,11 +43,11 @@
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",
-                            "version": "android_35_google_apis_x64.textpb"
+                            "version": "android_36_google_apis_x64.textpb"
                         },
                         {
                             "dependency": "avd_cipd_version",
-                            "version": "build_id:8733065022087935185"
+                            "version": "build_id:8719769919782256833"
                         }
                     ],
                     "contexts": [

--- a/engine/src/flutter/ci/builders/linux_android_emulator.json
+++ b/engine/src/flutter/ci/builders/linux_android_emulator.json
@@ -43,11 +43,11 @@
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",
-                            "version": "android_36_google_apis_x64.textpb"
+                            "version": "android_35_google_apis_x64.textpb"
                         },
                         {
                             "dependency": "avd_cipd_version",
-                            "version": "build_id:8719769919782256833"
+                            "version": "build_id:8733065022087935185"
                         }
                     ],
                     "contexts": [


### PR DESCRIPTION
Updated test targets to depend on the latest AVD version that supports Android 16(API 36) for framework. Updated to a 36 emulator at `linux_android_emu_unstable` only to experiment and monitor potential flakiness. After confirmed stability (~200 commits), I will update other targets to depend on a 36 emulator in framework, packages, and engine.

Partially Addresses #165922 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
