### PR TITLE
[Impeller] Lower min API for MTK down to 31.

### DIFF
--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -32,7 +32,7 @@
 namespace flutter {
 
 constexpr int kMinimumAndroidApiLevelForImpeller = 29;
-constexpr int kMinimumAndroidApiLevelForMediaTekVulkan = 34;
+constexpr int kMinimumAndroidApiLevelForMediaTekVulkan = 31;
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG


### PR DESCRIPTION
34 was overly conservative. Most of the bug reports concerned API 29 and 30.
