### PR TITLE
[ Device Lab ] Upgrade Device Lab projects to Java 18

### DIFF
--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -106,12 +106,6 @@ class AndroidRunOutputTest extends RunOutputTask {
   }
 
   @override
-  bool isExpectedStderr(String line) {
-    // TODO(egarciad): Remove once https://github.com/flutter/flutter/issues/95131 is fixed.
-    return line.contains('Mapping new ns');
-  }
-
-  @override
   TaskResult verify(List<String> stdout, List<String> stderr) {
     final String gradleTask = release ? 'assembleRelease' : 'assembleDebug';
     final String apk = release ? 'app-release.apk' : 'app-debug.apk';

--- a/dev/integration_tests/android_engine_test/android/app/build.gradle
+++ b/dev/integration_tests/android_engine_test/android/app/build.gradle
@@ -23,12 +23,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/android_semantics_testing/android/app/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/app/build.gradle
@@ -30,12 +30,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/android_views/android/app/build.gradle
+++ b/dev/integration_tests/android_views/android/app/build.gradle
@@ -39,8 +39,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -40,12 +40,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/deferred_components_test/android/component1/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/component1/build.gradle
@@ -50,8 +50,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/dev/integration_tests/external_textures/android/app/build.gradle
+++ b/dev/integration_tests/external_textures/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -55,8 +55,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
@@ -18,8 +18,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/platform_interaction/android/app/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/app/build.gradle.kts
+++ b/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
         jvmTarget = "1.8"

--- a/dev/integration_tests/release_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/release_smoke_test/android/app/build.gradle
@@ -40,12 +40,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/dev/integration_tests/spell_check/android/app/build.gradle
+++ b/dev/integration_tests/spell_check/android/app/build.gradle
@@ -40,12 +40,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     sourceSets {

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -22,12 +22,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {


### PR DESCRIPTION
Should resolve issues related to the following messages being output on stderr:

```
warning: [options] source value 8 is obsolete and will be removed in a future release"
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
```

Fixes https://github.com/flutter/flutter/issues/165973