### PR TITLE
Fix navbar blur clipping outside of Cupertino sheet

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -251,6 +251,7 @@ Widget _wrapWithBackground({
 
   return ClipRect(
     child: BackdropFilter(
+      blendMode: BlendMode.srcATop,
       enabled: backgroundColor.alpha != 0xFF && enableBackgroundFilterBlur,
       filter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
       child: childWithBackground,

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1631,7 +1631,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ) {
     // When secondary animation is stopped at the beginning, do not wrap the page
     // with the delegated transition.
-    if (receivedTransition == null || secondaryAnimation.isDismissed) {
+    if (receivedTransition == null) {
       return buildTransitions(context, animation, secondaryAnimation, child);
     }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1629,6 +1629,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
+    // When secondary animation is stopped at the beginning, do not wrap the page
+    // with the delegated transition.
     if (receivedTransition == null || secondaryAnimation.isDismissed) {
       return buildTransitions(context, animation, secondaryAnimation, child);
     }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1629,8 +1629,6 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    // When secondary animation is stopped at the beginning, do not wrap the page
-    // with the delegated transition.
     if (receivedTransition == null) {
       return buildTransitions(context, animation, secondaryAnimation, child);
     }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1629,7 +1629,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    if (receivedTransition == null) {
+    if (receivedTransition == null || secondaryAnimation.isDismissed) {
       return buildTransitions(context, animation, secondaryAnimation, child);
     }
 

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -154,7 +154,7 @@ void main() {
       await tester.pump();
 
       expect(
-        tester.widget(find.byType(BackdropFilter)),
+        tester.widget(find.byType(BackdropFilter).last),
         isA<BackdropFilter>().having((BackdropFilter f) => f.enabled, 'filter enabled', true),
       );
       expect(find.byType(CupertinoNavigationBar), paints..rect(color: background.darkColor));
@@ -190,7 +190,7 @@ void main() {
     await tester.pump();
 
     expect(
-      tester.widget(find.byType(BackdropFilter)),
+      tester.widget(find.byType(BackdropFilter).last),
       isA<BackdropFilter>().having(
         (BackdropFilter f) => f.blendMode == BlendMode.srcATop,
         'filter is srcATop',
@@ -229,7 +229,7 @@ void main() {
     await test.pump();
 
     expect(
-      test.widget(find.byType(BackdropFilter)),
+      test.widget(find.byType(BackdropFilter).last),
       isA<BackdropFilter>().having(
         (BackdropFilter filter) => filter.enabled,
         'filter enabled',

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -3032,6 +3032,7 @@ void main() {
               CupertinoSliverNavigationBar.search(
                 largeTitle: Text('Large title'),
                 searchField: CupertinoSearchTextField(),
+                enableBackgroundFilterBlur: false,
               ),
               SliverFillRemaining(child: SizedBox(height: 300.0)),
             ],

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -47,8 +47,6 @@ void main() {
         ),
       ),
     );
-    print(tester.getCenter(find.text('Title')));
-    print(tester.getCenter(find.text('Something')));
 
     expect(tester.getCenter(find.text('Title')).dx, greaterThan(110.0));
     expect(tester.getCenter(find.text('Title')).dx, lessThan(111.0));

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -48,8 +48,8 @@ void main() {
       ),
     );
 
-    expect(tester.getCenter(find.text('Title')).dx, greaterThan(110.0));
-    expect(tester.getCenter(find.text('Title')).dx, lessThan(111.0));
+    expect(tester.getCenter(find.text('Title')).dx, greaterThan(101.0));
+    expect(tester.getCenter(find.text('Title')).dx, lessThan(102.0));
   });
 
   testWidgets('Middle still in center with back button', (WidgetTester tester) async {
@@ -76,7 +76,9 @@ void main() {
 
   testWidgets('largeTitle still aligned with back button', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const CupertinoApp(home: CupertinoNavigationBar.large(largeTitle: Text('Title'))),
+      const CupertinoApp(
+        home: CupertinoPageScaffold(child: CupertinoNavigationBar.large(largeTitle: Text('Title'))),
+      ),
     );
 
     tester
@@ -84,7 +86,9 @@ void main() {
         .push(
           CupertinoPageRoute<void>(
             builder: (BuildContext context) {
-              return const CupertinoNavigationBar.large(largeTitle: Text('Page 2'));
+              return const CupertinoPageScaffold(
+                child: CupertinoNavigationBar.large(largeTitle: Text('Page 2')),
+              );
             },
           ),
         );
@@ -92,8 +96,8 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
 
-    expect(tester.getCenter(find.text('Page 2')).dx, greaterThan(129.0));
-    expect(tester.getCenter(find.text('Page 2')).dx, lessThan(130.0));
+    expect(tester.getCenter(find.text('Page 2')).dx, greaterThan(119.0));
+    expect(tester.getCenter(find.text('Page 2')).dx, lessThan(120.0));
   });
 
   testWidgets(

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -39,12 +39,16 @@ void main() {
   testWidgets('largeTitle is aligned with asymmetrical actions', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
-        home: CupertinoNavigationBar.large(
-          leading: CupertinoButton(onPressed: null, child: Text('Something')),
-          largeTitle: Text('Title'),
+        home: CupertinoPageScaffold(
+          child: CupertinoNavigationBar.large(
+            leading: CupertinoButton(onPressed: null, child: Text('Something')),
+            largeTitle: Text('Title'),
+          ),
         ),
       ),
     );
+    print(tester.getCenter(find.text('Title')));
+    print(tester.getCenter(find.text('Something')));
 
     expect(tester.getCenter(find.text('Title')).dx, greaterThan(110.0));
     expect(tester.getCenter(find.text('Title')).dx, lessThan(111.0));

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -112,7 +112,7 @@ Finder flying(WidgetTester tester, Finder finder) {
 
 void checkBackgroundBoxOffset(WidgetTester tester, int boxIndex, Offset offset) {
   final Widget transitionBackgroundBox = tester
-      .widget<Stack>(flying(tester, find.byType(Stack)))
+      .widget<Stack>(flying(tester, find.byType(Stack)).first)
       .children[boxIndex];
   final Offset testOffset = tester.getBottomRight(
     find.descendant(of: find.byWidget(transitionBackgroundBox), matching: find.byType(SizedBox)),


### PR DESCRIPTION
Fixes: #177420

When a Cupertino navbar had a blurred background, then a sheet is pushed onto the route containing that navbar, then the blur would spill outside of the background page once the transition was fully complete. This removed the rounded corners.

Before:

https://github.com/user-attachments/assets/1f43aec4-1912-45c1-9109-31e11532302b


After:

https://github.com/user-attachments/assets/99c35c3e-2ac9-43e8-95b5-d77334b14c15

I originally just changed the blendMode of the blur to srcATop, but this caused some tests that rendered a navbar over nothing to have the navbar disappear. So I changed it to a stack, with a middle layer that blends the destination below the navbar up if it exists, or provides a place for the navbar to blend onto if there is nothing below it.

If something is below the navbar, for example a page scaffold, then it works the same as before.

I also added scaffolds to some of the navbar tests to ensure they were testing what they should. In particular `CupertinoNavbar.large` tests without a scaffold were stretching to fill the screen, which was also providing incorrect values. This could, and probably should be it's own PR, but I have it here for now to figure out the approach.

<img width="429" alt="Screenshot 2025-04-08 at 2 41 17 PM" src="https://github.com/user-attachments/assets/0f13f84e-8602-4f85-ad21-b57690497fba" />



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
