### PR TITLE
Cherry pick to fix linux tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1212,7 +1212,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux tool_integration_tests_1_6
+  - name: Linux tool_integration_tests_1_7
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1228,7 +1229,7 @@ targets:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       shard: tool_integration_tests
-      subshard: "1_6"
+      subshard: "1_7"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "2700"
@@ -1240,7 +1241,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux tool_integration_tests_2_6
+  - name: Linux tool_integration_tests_2_7
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1256,7 +1258,7 @@ targets:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       shard: tool_integration_tests
-      subshard: "2_6"
+      subshard: "2_7"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "2700"
@@ -1268,7 +1270,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux tool_integration_tests_3_6
+  - name: Linux tool_integration_tests_3_7
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1284,7 +1287,7 @@ targets:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       shard: tool_integration_tests
-      subshard: "3_6"
+      subshard: "3_7"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "2700"
@@ -1296,7 +1299,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux tool_integration_tests_4_6
+  - name: Linux tool_integration_tests_4_7
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1312,7 +1316,7 @@ targets:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       shard: tool_integration_tests
-      subshard: "4_6"
+      subshard: "4_7"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "2700"
@@ -1324,7 +1328,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux tool_integration_tests_5_6
+  - name: Linux tool_integration_tests_5_7
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1340,7 +1345,7 @@ targets:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       shard: tool_integration_tests
-      subshard: "5_6"
+      subshard: "5_7"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "2700"
@@ -1352,7 +1357,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux tool_integration_tests_6_6
+  - name: Linux tool_integration_tests_6_7
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1368,7 +1374,36 @@ targets:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       shard: tool_integration_tests
-      subshard: "6_6"
+      subshard: "6_7"
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+      test_timeout_secs: "2700"
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+      - .ci.yaml
+      - engine/**
+      - DEPS
+
+  - name: Linux tool_integration_tests_7_7
+    bringup: true
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:35v1"},
+          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
+          {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
+          {"dependency": "ninja", "version": "version:1.9.0"},
+          {"dependency": "open_jdk", "version": "version:17"}
+        ]
+      shard: tool_integration_tests
+      subshard: "7_7"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "2700"

--- a/engine/src/flutter/ci/builders/linux_unopt.json
+++ b/engine/src/flutter/ci/builders/linux_unopt.json
@@ -16,7 +16,6 @@
                 "debug",
                 "--unoptimized",
                 "--prebuilt-dart-sdk",
-                "--asan",
                 "--dart-debug",
                 "--rbe",
                 "--no-goma"

--- a/engine/src/flutter/ci/builders/linux_unopt.json
+++ b/engine/src/flutter/ci/builders/linux_unopt.json
@@ -17,7 +17,6 @@
                 "--unoptimized",
                 "--prebuilt-dart-sdk",
                 "--asan",
-                "--lsan",
                 "--dart-debug",
                 "--rbe",
                 "--no-goma"

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -4377,7 +4377,7 @@ TEST_F(ShellTest, PointerPacketFlushMessageLoop) {
 }
 
 // Verifies a pointer event will flush the dart event loop.
-TEST_F(ShellTest, PointerPacketsAreDispatchedWithTask) {
+TEST_F(ShellTest, DISABLED_PointerPacketsAreDispatchedWithTask) {
   Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
                          ThreadHost::Type::kPlatform);


### PR DESCRIPTION
The `Linux tool_integration_tests*` have been failing on this release branch, blocking cherry picks https://github.com/flutter/flutter/pull/165430 and https://github.com/flutter/flutter/pull/165428. This PR attempts to cherry pick fixes that will make the tests go green.

This PR contains cherry-picks of three PRs:

  * https://github.com/flutter/flutter/pull/164935
  * https://github.com/flutter/flutter/pull/165620
  * https://github.com/flutter/flutter/pull/165661

Example of the failures I was seeing: https://github.com/flutter/flutter/pull/165428/checks?check_run_id=38997055797.

```
error: {
  code: 5
  message: builder not found: "Linux tool_integration_tests_1_6"
}
```