### PR TITLE
[DO NOT LAND][LAST RESORT] [ios][pv] regression on screen scale revert to deprecated api

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -903,7 +903,8 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 - (void)createLayerWithIosContext:(const std::shared_ptr<flutter::IOSContext>&)iosContext
                       pixelFormat:(MTLPixelFormat)pixelFormat
                       screenScale:(CGFloat)screenScale {
-  self.layerPool->CreateLayer(iosContext, pixelFormat, screenScale);
+  // TODO(hellohuanlin): pass in screenScale.
+  self.layerPool->CreateLayer(iosContext, pixelFormat);
 }
 
 - (void)removeUnusedLayers:(const std::vector<std::shared_ptr<flutter::OverlayLayer>>&)unusedLayers

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -4630,9 +4630,9 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   flutter::OverlayLayerPool pool;
 
   // Add layers to the pool.
-  pool.CreateLayer(ios_context, MTLPixelFormatBGRA8Unorm, 1);
+  pool.CreateLayer(ios_context, MTLPixelFormatBGRA8Unorm);
   XCTAssertEqual(pool.size(), 1u);
-  pool.CreateLayer(ios_context, MTLPixelFormatBGRA8Unorm, 1);
+  pool.CreateLayer(ios_context, MTLPixelFormatBGRA8Unorm);
   XCTAssertEqual(pool.size(), 2u);
 
   // Mark all layers as unused.
@@ -4655,22 +4655,16 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   flutter::OverlayLayerPool pool;
 
   // Add layers to the pool.
-  pool.CreateLayer(ios_context, MTLPixelFormatBGRA8Unorm, 1);
+  pool.CreateLayer(ios_context, MTLPixelFormatBGRA8Unorm);
   XCTAssertEqual(pool.size(), 1u);
 
   std::shared_ptr<flutter::OverlayLayer> layer = pool.GetNextLayer();
 
+  CGFloat screenScale = [UIScreen mainScreen].scale;
   layer->UpdateViewState(nil, SkRect::MakeXYWH(1, 2, 3, 4), 0, 0);
-  // Should not update the view state (e.g. overlay_view_wrapper's frame) when FlutterView is nil.
-  XCTAssertTrue(CGRectEqualToRect(layer->overlay_view_wrapper.frame, CGRectZero));
-
-  FlutterView* flutterView = [[FlutterView alloc] initWithDelegate:engine
-                                                            opaque:YES
-                                                   enableWideGamut:NO];
-  layer->UpdateViewState(flutterView, SkRect::MakeXYWH(1, 2, 3, 4), 0, 0);
-  // Should not update the view state (e.g. overlay_view_wrapper's frame) when FlutterView's screen
-  // is nil.
-  XCTAssertTrue(CGRectEqualToRect(layer->overlay_view_wrapper.frame, CGRectZero));
+  XCTAssertTrue(CGRectEqualToRect(
+      layer->overlay_view_wrapper.frame,
+      CGRectMake(1 / screenScale, 2 / screenScale, 3 / screenScale, 4 / screenScale)));
 }
 
 - (void)testFlutterPlatformViewControllerSubmitFramePreservingFrameDamage {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/overlay_layer_pool.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/overlay_layer_pool.h
@@ -58,9 +58,7 @@ class OverlayLayerPool {
   /// @brief Create a new overlay layer.
   ///
   /// This method can only be called on the Platform thread.
-  void CreateLayer(const std::shared_ptr<IOSContext>& ios_context,
-                   MTLPixelFormat pixel_format,
-                   CGFloat screenScale);
+  void CreateLayer(const std::shared_ptr<IOSContext>& ios_context, MTLPixelFormat pixel_format);
 
   /// @brief Removes unused layers from the pool. Returns the unused layers.
   std::vector<std::shared_ptr<OverlayLayer>> RemoveUnusedLayers();

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/overlay_layer_pool.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/overlay_layer_pool.mm
@@ -23,15 +23,10 @@ void OverlayLayer::UpdateViewState(UIView* flutter_view,
                                    SkRect rect,
                                    int64_t view_id,
                                    int64_t overlay_id) {
-  FlutterView* flutterView = (FlutterView*)flutter_view;
-  // There can be a race where UpdateViewState() is called when flutter_view or flutter_view's
-  // screen is nil when app is backgrounded.
-  // It's unlikely for scale to be 0, but just to be safe here since it's used in a scaling
-  // calculation division below
-  if (!flutterView || !flutterView.screen || flutterView.screen.scale == 0.0f) {
-    return;
-  }
-  CGFloat screenScale = flutterView.screen.scale;
+  // TODO(hellohuanlin): Remove this deprecated API usage. Watch out for flutter_view or
+  // flutter_view's screen being nil when background the app.
+  CGFloat screenScale = [UIScreen mainScreen].scale;
+
   // Set the size of the overlay view wrapper.
   // This wrapper view masks the overlay view.
   overlay_view_wrapper.frame = CGRectMake(rect.x() / screenScale, rect.y() / screenScale,
@@ -62,13 +57,15 @@ std::shared_ptr<OverlayLayer> OverlayLayerPool::GetNextLayer() {
 }
 
 void OverlayLayerPool::CreateLayer(const std::shared_ptr<IOSContext>& ios_context,
-                                   MTLPixelFormat pixel_format,
-                                   CGFloat screenScale) {
+                                   MTLPixelFormat pixel_format) {
   FML_DCHECK([[NSThread currentThread] isMainThread]);
   std::shared_ptr<OverlayLayer> layer;
   UIView* overlay_view;
   UIView* overlay_view_wrapper;
 
+  // TODO(hellohuanlin): Remove this deprecated API usage. Watch out for flutter_view or
+  // flutter_view's screen being nil when background the app.
+  CGFloat screenScale = [UIScreen mainScreen].scale;
   overlay_view = [[FlutterOverlayView alloc] initWithContentsScale:screenScale
                                                        pixelFormat:pixel_format];
   overlay_view_wrapper = [[FlutterOverlayView alloc] initWithContentsScale:screenScale


### PR DESCRIPTION
Just in case the previous PR https://github.com/flutter/flutter/pull/166024 fails. 

Reverts part of https://github.com/flutter/flutter/pull/162785

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

NA. See linked PR above. 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
