### PR TITLE
Fix build_android_host_app_with_module_source device lab tests

### DIFF
--- a/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/app/build.gradle.kts
+++ b/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
Fixes a type error where String was expected but JavaVersion was inferred.