### PR TITLE
Mark Linux customer tests as flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -571,6 +571,7 @@ targets:
     enabled_branches:
       - master
     recipe: flutter/flutter_drone
+    bringup: true
     # Timeout in minutes for the whole task.
     timeout: 60
     properties:


### PR DESCRIPTION
Marks tests as flaky to unblock tree. Related to #166102