### PR TITLE
[Impeller] make empty texture lazy.

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/content_context.cc
+++ b/engine/src/flutter/impeller/entity/contents/content_context.cc
@@ -7,7 +7,7 @@
 #include <memory>
 #include <utility>
 
-#include "fml/trace_event.h"
+#include "fml/mapping.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
@@ -536,29 +536,6 @@ ContentContext::ContentContext(
     return;
   }
 
-  {
-    TextureDescriptor desc;
-    desc.storage_mode = StorageMode::kDevicePrivate;
-    desc.format = PixelFormat::kR8G8B8A8UNormInt;
-    desc.size = ISize{1, 1};
-    empty_texture_ = GetContext()->GetResourceAllocator()->CreateTexture(desc);
-
-    std::array<uint8_t, 4> data = Color::BlackTransparent().ToR8G8B8A8();
-    std::shared_ptr<CommandBuffer> cmd_buffer =
-        GetContext()->CreateCommandBuffer();
-    std::shared_ptr<BlitPass> blit_pass = cmd_buffer->CreateBlitPass();
-    HostBuffer& host_buffer = GetTransientsBuffer();
-    BufferView buffer_view = host_buffer.Emplace(data);
-    blit_pass->AddCopy(buffer_view, empty_texture_);
-
-    if (!blit_pass->EncodeCommands() || !GetContext()
-                                             ->GetCommandQueue()
-                                             ->Submit({std::move(cmd_buffer)})
-                                             .ok()) {
-      VALIDATION_LOG << "Failed to create empty texture.";
-    }
-  }
-
   auto options = ContentContextOptions{
       .sample_count = SampleCount::kCount4,
       .color_attachment_pixel_format =
@@ -827,10 +804,6 @@ ContentContext::~ContentContext() = default;
 
 bool ContentContext::IsValid() const {
   return is_valid_;
-}
-
-std::shared_ptr<Texture> ContentContext::GetEmptyTexture() const {
-  return empty_texture_;
 }
 
 fml::StatusOr<RenderTarget> ContentContext::MakeSubpass(

--- a/engine/src/flutter/impeller/entity/contents/content_context.h
+++ b/engine/src/flutter/impeller/entity/contents/content_context.h
@@ -5,15 +5,11 @@
 #ifndef FLUTTER_IMPELLER_ENTITY_CONTENTS_CONTENT_CONTEXT_H_
 #define FLUTTER_IMPELLER_ENTITY_CONTENTS_CONTENT_CONTEXT_H_
 
-#include <initializer_list>
 #include <memory>
-#include <optional>
 #include <unordered_map>
-#include <utility>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/status_or.h"
-#include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/host_buffer.h"
 #include "impeller/geometry/color.h"
@@ -231,10 +227,6 @@ class ContentContext {
 #endif  // IMPELLER_ENABLE_OPENGLES
   // clang-format on
 
-  // An empty 1x1 texture for binding drawVertices/drawAtlas or other cases
-  // that don't always have a texture (due to blending).
-  std::shared_ptr<Texture> GetEmptyTexture() const;
-
   std::shared_ptr<Context> GetContext() const;
 
   const Capabilities& GetDeviceCapabilities() const;
@@ -339,7 +331,6 @@ class ContentContext {
   std::shared_ptr<Tessellator> tessellator_;
   std::shared_ptr<RenderTargetAllocator> render_target_cache_;
   std::shared_ptr<HostBuffer> host_buffer_;
-  std::shared_ptr<Texture> empty_texture_;
 
   ContentContext(const ContentContext&) = delete;
 

--- a/engine/src/flutter/impeller/entity/contents/vertices_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/vertices_contents.cc
@@ -110,7 +110,19 @@ bool VerticesSimpleBlendContents::Render(const ContentContext& renderer,
       texture = texture_;
     }
   } else {
-    texture = renderer.GetEmptyTexture();
+    TextureDescriptor desc;
+    desc.storage_mode = StorageMode::kDevicePrivate;
+    desc.format = PixelFormat::kR8G8B8A8UNormInt;
+    desc.size = ISize{1, 1};
+    texture =
+        renderer.GetContext()->GetResourceAllocator()->CreateTexture(desc);
+
+    std::array<uint8_t, 4> data = Color::BlackTransparent().ToR8G8B8A8();
+    std::shared_ptr<fml::NonOwnedMapping> data_mapping =
+        std::make_shared<fml::NonOwnedMapping>(data.data(), data.size());
+    if (!texture->SetContents(std::move(data_mapping))) {
+      VALIDATION_LOG << "Failed to set contents for empty texture";
+    }
   }
   if (!texture) {
     VALIDATION_LOG << "Missing texture for VerticesSimpleBlendContents";


### PR DESCRIPTION
Empty texture construction is currently failing on GLES because the context is current when we construct the content context (oops). Make it so this texture is constructed on demand. Not the best for performance but that is sort of irrelevant for now, as it is only used to support an edge case in drawVertices.
