### PR TITLE
[fuchsia][sysmem2] switch to sysmem2 tokens

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/software_surface.cc
@@ -159,8 +159,7 @@ bool SoftwareSurface::SetupSkiaSurface(
 
   fuchsia::ui::composition::RegisterBufferCollectionArgs args;
   args.set_export_token(std::move(export_token));
-  args.set_buffer_collection_token(
-      fuchsia::sysmem::BufferCollectionTokenHandle(scenic_token.TakeChannel()));
+  args.set_buffer_collection_token2(std::move(scenic_token));
   args.set_usage(
       fuchsia::ui::composition::RegisterBufferCollectionUsage::DEFAULT);
   flatland_allocator->RegisterBufferCollection(

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/external_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/external_view_embedder_unittests.cc
@@ -67,7 +67,7 @@ constexpr static int64_t kImplicitViewId = 0;
 class FakeSurfaceProducerSurface : public SurfaceProducerSurface {
  public:
   explicit FakeSurfaceProducerSurface(
-      fidl::InterfaceRequest<fuchsia::sysmem::BufferCollectionToken>
+      fidl::InterfaceRequest<fuchsia::sysmem2::BufferCollectionToken>
           sysmem_token_request,
       fuchsia::ui::composition::BufferCollectionImportToken buffer_import_token,
       const SkISize& size)
@@ -124,7 +124,7 @@ class FakeSurfaceProducerSurface : public SurfaceProducerSurface {
       const std::function<void(void)>& on_writes_committed) override {}
 
  private:
-  fidl::InterfaceRequest<fuchsia::sysmem::BufferCollectionToken>
+  fidl::InterfaceRequest<fuchsia::sysmem2::BufferCollectionToken>
       sysmem_token_request_;
   fuchsia::ui::composition::BufferCollectionImportToken buffer_import_token_;
   zx::event acquire_fence_;
@@ -155,13 +155,14 @@ class FakeSurfaceProducer : public SurfaceProducer {
       const SkISize& size) override {
     auto [buffer_export_token, buffer_import_token] =
         BufferCollectionTokenPair::New();
-    fuchsia::sysmem::BufferCollectionTokenHandle sysmem_token;
+    fuchsia::sysmem2::BufferCollectionTokenHandle sysmem_token;
     auto sysmem_token_request = sysmem_token.NewRequest();
 
     fuchsia::ui::composition::RegisterBufferCollectionArgs
         buffer_collection_args;
     buffer_collection_args.set_export_token(std::move(buffer_export_token));
-    buffer_collection_args.set_buffer_collection_token(std::move(sysmem_token));
+    buffer_collection_args.set_buffer_collection_token2(
+        std::move(sysmem_token));
     buffer_collection_args.set_usage(
         fuchsia::ui::composition::RegisterBufferCollectionUsage::DEFAULT);
     flatland_allocator_->RegisterBufferCollection(

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -73,13 +73,24 @@ void FakeFlatland::RegisterBufferCollection(
     fuchsia::ui::composition::RegisterBufferCollectionArgs args,
     RegisterBufferCollectionCallback callback) {
   auto [export_token_koid, _] = GetKoids(args.export_token());
+
+  // Callers must not set both.
+  ZX_ASSERT(!args.has_buffer_collection_token2() ||
+            !args.has_buffer_collection_token());
+  fuchsia::sysmem2::BufferCollectionTokenHandle sysmem_token;
+  if (args.has_buffer_collection_token2()) {
+    sysmem_token = std::move(*args.mutable_buffer_collection_token2());
+  } else {
+    sysmem_token = fuchsia::sysmem2::BufferCollectionTokenHandle(
+        args.mutable_buffer_collection_token()->TakeChannel());
+  }
+
   auto [__, emplace_binding_success] =
       graph_bindings_.buffer_collections.emplace(
           export_token_koid,
           BufferCollectionBinding{
               .export_token = std::move(*args.mutable_export_token()),
-              .sysmem_token =
-                  std::move(*args.mutable_buffer_collection_token()),
+              .sysmem_token = std::move(sysmem_token),
               .usage = args.usage(),
           });
   // TODO(fxb/85619): Disconnect the Allocator here

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h
@@ -7,7 +7,7 @@
 
 #include <fuchsia/math/cpp/fidl.h>
 #include <fuchsia/scenic/scheduling/cpp/fidl.h>
-#include <fuchsia/sysmem/cpp/fidl.h>
+#include <fuchsia/sysmem2/cpp/fidl.h>
 #include <fuchsia/ui/composition/cpp/fidl.h>
 #include <fuchsia/ui/composition/cpp/fidl_test_base.h>
 #include <fuchsia/ui/views/cpp/fidl.h>
@@ -175,7 +175,7 @@ class FakeFlatland
 
   struct BufferCollectionBinding {
     fuchsia::ui::composition::BufferCollectionExportToken export_token;
-    fuchsia::sysmem::BufferCollectionTokenHandle sysmem_token;
+    fuchsia::sysmem2::BufferCollectionTokenHandle sysmem_token;
 
     fuchsia::ui::composition::RegisterBufferCollectionUsage usage;
   };

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -297,8 +297,7 @@ bool VulkanSurface::AllocateDeviceMemory(
 
   fuchsia::ui::composition::RegisterBufferCollectionArgs args;
   args.set_export_token(std::move(export_token));
-  args.set_buffer_collection_token(fuchsia::sysmem::BufferCollectionTokenHandle(
-      scenic_token.Unbind().TakeChannel()));
+  args.set_buffer_collection_token2(std::move(scenic_token));
   args.set_usage(
       fuchsia::ui::composition::RegisterBufferCollectionUsage::DEFAULT);
   flatland_allocator->RegisterBufferCollection(


### PR DESCRIPTION
Now that fuchsia protocols can convey sysmem2 tokens, avoid token conversions.

fixes #166121

[cl/741415017](http://cl/741415017) per [go/flutter-fuchsia-pr-policy](http://go/flutter-fuchsia-pr-policy)

## Pre-launch Checklist

- [y] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [y] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [y] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [y] I signed the [CLA].
- [y] I listed at least one issue that this PR fixes in the description above.
- [na] I updated/added relevant documentation (doc comments with `///`).
- [tbd] I added new tests to check the change I am making, or this PR is [test-exempt].
  - identical functionalilty; covered by existing tests
- [na] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [y] All existing and new tests are passing.