### PR TITLE
Add support for building release/profile mode for custom devices

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_targets.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_targets.dart
@@ -5,6 +5,7 @@
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../base/file_system.dart';
+import '../build_info.dart';
 import '../web/compiler_config.dart';
 import './build_system.dart';
 
@@ -12,8 +13,6 @@ import './build_system.dart';
 abstract class BuildTargets {
   const BuildTargets();
 
-  Target get copyFlutterBundle;
-  Target get releaseCopyFlutterBundle;
   Target get generateLocalizationsTarget;
   Target get dartPluginRegistrantTarget;
   Target webServiceWorker(
@@ -21,17 +20,19 @@ abstract class BuildTargets {
     List<WebCompilerConfig> compileConfigs,
     Analytics analytics,
   );
+  Target buildFlutterBundle({
+    required BuildMode mode,
+    @Deprecated(
+      'Use the build environment `outputDir` instead. '
+      'This feature was deprecated after v3.31.0-1.0.pre.',
+    )
+    Directory? assetDir,
+  });
 }
 
 /// BuildTargets that return NoOpTarget for every action.
 class NoOpBuildTargets extends BuildTargets {
   const NoOpBuildTargets();
-
-  @override
-  Target get copyFlutterBundle => const _NoOpTarget();
-
-  @override
-  Target get releaseCopyFlutterBundle => const _NoOpTarget();
 
   @override
   Target get generateLocalizationsTarget => const _NoOpTarget();
@@ -45,6 +46,16 @@ class NoOpBuildTargets extends BuildTargets {
     List<WebCompilerConfig> compileConfigs,
     Analytics analytics,
   ) => const _NoOpTarget();
+
+  @override
+  Target buildFlutterBundle({
+    required BuildMode mode,
+    @Deprecated(
+      'Use the build environment `outputDir` instead. '
+      'This feature was deprecated after v3.31.0-1.0.pre.',
+    )
+    Directory? assetDir,
+  }) => const _NoOpTarget();
 }
 
 /// A [Target] that does nothing.

--- a/packages/flutter_tools/lib/src/build_system/build_targets.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_targets.dart
@@ -21,7 +21,9 @@ abstract class BuildTargets {
     Analytics analytics,
   );
   Target buildFlutterBundle({
+    required TargetPlatform platform,
     required BuildMode mode,
+    bool buildAOTAssets = true,
     @Deprecated(
       'Use the build environment `outputDir` instead. '
       'This feature was deprecated after v3.31.0-1.0.pre.',
@@ -49,7 +51,9 @@ class NoOpBuildTargets extends BuildTargets {
 
   @override
   Target buildFlutterBundle({
+    required TargetPlatform platform,
     required BuildMode mode,
+    bool buildAOTAssets = true,
     @Deprecated(
       'Use the build environment `outputDir` instead. '
       'This feature was deprecated after v3.31.0-1.0.pre.',

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -28,7 +28,19 @@ import 'native_assets.dart';
 /// Copies the pre-built flutter bundle.
 // This is a one-off rule for implementing build bundle in terms of assemble.
 class CopyFlutterBundle extends Target {
-  const CopyFlutterBundle();
+  const CopyFlutterBundle({
+    @Deprecated(
+      'Use the build environment `outputDir` instead. '
+      'This feature was deprecated after v3.31.0-1.0.pre.',
+    )
+    this.assetDir,
+  });
+
+  @Deprecated(
+    'Use the build environment `outputDir` instead. '
+    'This feature was deprecated after v3.31.0-1.0.pre.',
+  )
+  final Directory? assetDir;
 
   @override
   String get name => 'copy_flutter_bundle';
@@ -44,9 +56,9 @@ class CopyFlutterBundle extends Target {
 
   @override
   List<Source> get outputs => const <Source>[
-    Source.pattern('{OUTPUT_DIR}/vm_snapshot_data'),
-    Source.pattern('{OUTPUT_DIR}/isolate_snapshot_data'),
-    Source.pattern('{OUTPUT_DIR}/kernel_blob.bin'),
+    Source.pattern('{OUTPUT_DIR}/flutter_assets/vm_snapshot_data'),
+    Source.pattern('{OUTPUT_DIR}/flutter_assets/isolate_snapshot_data'),
+    Source.pattern('{OUTPUT_DIR}/flutter_assets/kernel_blob.bin'),
   ];
 
   @override
@@ -61,7 +73,9 @@ class CopyFlutterBundle extends Target {
     final String? flavor = environment.defines[kFlavor];
 
     final buildMode = BuildMode.fromCliName(buildModeEnvironment);
-    environment.outputDir.createSync(recursive: true);
+    final Directory assetOutputDir =
+        assetDir ?? environment.outputDir.childDirectory('flutter_assets');
+    assetOutputDir.createSync(recursive: true);
 
     // Only copy the prebuilt runtimes and kernel blob in debug mode.
     if (buildMode == BuildMode.debug) {
@@ -75,17 +89,17 @@ class CopyFlutterBundle extends Target {
       );
       environment.buildDir
           .childFile('app.dill')
-          .copySync(environment.outputDir.childFile('kernel_blob.bin').path);
+          .copySync(assetOutputDir.childFile('kernel_blob.bin').path);
       environment.fileSystem
           .file(vmSnapshotData)
-          .copySync(environment.outputDir.childFile('vm_snapshot_data').path);
+          .copySync(assetOutputDir.childFile('vm_snapshot_data').path);
       environment.fileSystem
           .file(isolateSnapshotData)
-          .copySync(environment.outputDir.childFile('isolate_snapshot_data').path);
+          .copySync(assetOutputDir.childFile('isolate_snapshot_data').path);
     }
     final Depfile assetDepfile = await copyAssets(
       environment,
-      environment.outputDir,
+      assetOutputDir,
       targetPlatform: TargetPlatform.android,
       buildMode: buildMode,
       flavor: flavor,
@@ -107,7 +121,13 @@ class CopyFlutterBundle extends Target {
 
 /// Copies the pre-built flutter bundle for release mode.
 class ReleaseCopyFlutterBundle extends CopyFlutterBundle {
-  const ReleaseCopyFlutterBundle();
+  const ReleaseCopyFlutterBundle({
+    @Deprecated(
+      'Use the build environment `outputDir` instead. '
+      'This feature was deprecated after v3.31.0-1.0.pre.',
+    )
+    super.assetDir,
+  });
 
   @override
   String get name => 'release_flutter_bundle';

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -87,15 +87,16 @@ class UnpackLinux extends Target {
 
 /// Creates a bundle for the Linux desktop target.
 abstract class BundleLinuxAssets extends Target {
-  const BundleLinuxAssets(this.targetPlatform);
+  const BundleLinuxAssets(this.targetPlatform, {this.unpackDesktopEmbedder = true});
 
   final TargetPlatform targetPlatform;
+  final bool unpackDesktopEmbedder;
 
   @override
   List<Target> get dependencies => <Target>[
     const KernelSnapshot(),
     const InstallCodeAssets(),
-    UnpackLinux(targetPlatform),
+    if (unpackDesktopEmbedder) UnpackLinux(targetPlatform),
   ];
 
   @override
@@ -194,7 +195,7 @@ class LinuxAotBundle extends Target {
 }
 
 class DebugBundleLinuxAssets extends BundleLinuxAssets {
-  const DebugBundleLinuxAssets(super.targetPlatform);
+  const DebugBundleLinuxAssets(super.targetPlatform, {super.unpackDesktopEmbedder});
 
   @override
   String get name => 'debug_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
@@ -209,7 +210,7 @@ class DebugBundleLinuxAssets extends BundleLinuxAssets {
 }
 
 class ProfileBundleLinuxAssets extends BundleLinuxAssets {
-  const ProfileBundleLinuxAssets(super.targetPlatform);
+  const ProfileBundleLinuxAssets(super.targetPlatform, {super.unpackDesktopEmbedder});
 
   @override
   String get name => 'profile_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
@@ -225,7 +226,7 @@ class ProfileBundleLinuxAssets extends BundleLinuxAssets {
 }
 
 class ReleaseBundleLinuxAssets extends BundleLinuxAssets {
-  const ReleaseBundleLinuxAssets(super.targetPlatform);
+  const ReleaseBundleLinuxAssets(super.targetPlatform, {super.unpackDesktopEmbedder});
 
   @override
   String get name => 'release_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -47,6 +47,7 @@ class BundleBuilder {
     )
     String? assetDirPath,
     String? outputDirPath,
+    bool buildAOTAssets = false,
     bool buildNativeAssets = true,
     @visibleForTesting BuildSystem? buildSystem,
   }) async {
@@ -85,7 +86,9 @@ class BundleBuilder {
     );
     final Directory? assetDir = assetDirPath != null ? globals.fs.directory(assetDirPath) : null;
     final Target target = globals.buildTargets.buildFlutterBundle(
+      platform: platform,
       mode: buildInfo.mode,
+      buildAOTAssets: buildAOTAssets,
       assetDir: assetDir,
     );
     final BuildResult result = await buildSystem.build(target, environment);

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -690,7 +690,7 @@ class CustomDevice extends Device {
 
   @override
   FutureOr<bool> supportsRuntimeMode(BuildMode buildMode) {
-    return buildMode == BuildMode.debug;
+    return true;
   }
 
   @override
@@ -723,7 +723,7 @@ class CustomDevice extends Device {
     };
 
     if (!prebuiltApplication) {
-      final String assetBundleDir = getAssetBuildDirectory();
+      final String outputDirPath = getBuildDirectory();
 
       bundleBuilder ??= BundleBuilder();
 
@@ -733,7 +733,8 @@ class CustomDevice extends Device {
         buildInfo: debuggingOptions.buildInfo,
         mainPath: mainPath,
         depfilePath: defaultDepfilePath,
-        assetDirPath: assetBundleDir,
+        outputDirPath: outputDirPath,
+        buildAOTAssets: true,
       );
 
       // if we have a post build step (needed for some embedders), execute it
@@ -744,7 +745,7 @@ class CustomDevice extends Device {
         }
         await _tryPostBuild(
           appName: packageName,
-          localPath: assetBundleDir,
+          localPath: outputDirPath,
           additionalReplacementValues: additionalReplacementValues,
         );
       }

--- a/packages/flutter_tools/lib/src/isolated/build_targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/build_targets.dart
@@ -5,6 +5,7 @@
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../base/file_system.dart';
+import '../build_info.dart';
 import '../build_system/build_system.dart';
 import '../build_system/build_targets.dart';
 import '../build_system/targets/common.dart';
@@ -15,12 +16,6 @@ import '../web/compiler_config.dart';
 
 class BuildTargetsImpl extends BuildTargets {
   const BuildTargetsImpl();
-
-  @override
-  Target get copyFlutterBundle => const CopyFlutterBundle();
-
-  @override
-  Target get releaseCopyFlutterBundle => const ReleaseCopyFlutterBundle();
 
   @override
   Target get generateLocalizationsTarget => const GenerateLocalizationsTarget();
@@ -34,4 +29,18 @@ class BuildTargetsImpl extends BuildTargets {
     List<WebCompilerConfig> compileConfigs,
     Analytics analytics,
   ) => WebServiceWorker(fileSystem, compileConfigs, analytics);
+
+  @override
+  Target buildFlutterBundle({
+    required BuildMode mode,
+    @Deprecated(
+      'Use the build environment `outputDir` instead. '
+      'This feature was deprecated after v3.31.0-1.0.pre.',
+    )
+    Directory? assetDir,
+  }) {
+    return mode == BuildMode.debug
+        ? CopyFlutterBundle(assetDir: assetDir)
+        : ReleaseCopyFlutterBundle(assetDir: assetDir);
+  }
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -634,6 +634,7 @@ class FakeBundleBuilder extends Fake implements BundleBuilder {
     String? applicationKernelFilePath,
     String? depfilePath,
     String? assetDirPath,
+    String? outputDirPath,
     bool buildNativeAssets = true,
     @visibleForTesting BuildSystem? buildSystem,
   }) async {}

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -635,6 +635,7 @@ class FakeBundleBuilder extends Fake implements BundleBuilder {
     String? depfilePath,
     String? assetDirPath,
     String? outputDirPath,
+    bool buildAOTAssets = false,
     bool buildNativeAssets = true,
     @visibleForTesting BuildSystem? buildSystem,
   }) async {}

--- a/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
@@ -172,6 +172,22 @@ void main() {
     );
   });
 
+  testWithoutContext('DebugBundleLinuxAssets honors unpackDesktopEmbedder flag', () async {
+    expect(
+      const DebugBundleLinuxAssets(
+        TargetPlatform.linux_x64,
+      ).dependencies.map((Target dep) => dep.name),
+      contains('unpack_linux'),
+    );
+    expect(
+      const DebugBundleLinuxAssets(
+        TargetPlatform.linux_x64,
+        unpackDesktopEmbedder: false,
+      ).dependencies.map((Target dep) => dep.name),
+      isNot(contains('unpack_linux')),
+    );
+  });
+
   testUsingContext(
     'ProfileBundleLinuxAssets copies artifacts to out directory',
     () async {
@@ -217,6 +233,22 @@ void main() {
     );
   });
 
+  testWithoutContext('ProfileBundleLinuxAssets honors unpackDesktopEmbedder flag', () async {
+    expect(
+      const ProfileBundleLinuxAssets(
+        TargetPlatform.linux_x64,
+      ).dependencies.map((Target dep) => dep.name),
+      contains('unpack_linux'),
+    );
+    expect(
+      const ProfileBundleLinuxAssets(
+        TargetPlatform.linux_x64,
+        unpackDesktopEmbedder: false,
+      ).dependencies.map((Target dep) => dep.name),
+      isNot(contains('unpack_linux')),
+    );
+  });
+
   testUsingContext(
     'ReleaseBundleLinuxAssets copies artifacts to out directory',
     () async {
@@ -259,6 +291,22 @@ void main() {
     expect(
       const ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64).name,
       'release_bundle_linux-arm64_assets',
+    );
+  });
+
+  testWithoutContext('ReleaseBundleLinuxAssets honors unpackDesktopEmbedder flag', () async {
+    expect(
+      const ReleaseBundleLinuxAssets(
+        TargetPlatform.linux_x64,
+      ).dependencies.map((Target dep) => dep.name),
+      contains('unpack_linux'),
+    );
+    expect(
+      const ReleaseBundleLinuxAssets(
+        TargetPlatform.linux_x64,
+        unpackDesktopEmbedder: false,
+      ).dependencies.map((Target dep) => dep.name),
+      isNot(contains('unpack_linux')),
     );
   });
 }

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -300,6 +300,36 @@ void main() {
       ProcessManager: () => FakeProcessManager.any(),
     },
   );
+
+  testUsingContext(
+    'Release bundle includes AOT assets',
+    () async {
+      final dependencies = <String>[];
+      final BuildSystem buildSystem = TestBuildSystem.all(BuildResult(success: true), (
+        Target target,
+        Environment environment,
+      ) {
+        for (final Target dep in target.dependencies) {
+          dependencies.add(dep.name);
+        }
+      });
+      await BundleBuilder().build(
+        platform: TargetPlatform.linux_x64,
+        buildInfo: BuildInfo.release,
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
+        mainPath: globals.fs.path.join('lib', 'main.dart'),
+        outputDirPath: 'example',
+        depfilePath: 'example.d',
+        buildAOTAssets: true,
+        buildSystem: buildSystem,
+      );
+      expect(dependencies, contains('linux_aot_bundle'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    },
+  );
 }
 
 class FakeAssetBundle extends Fake implements AssetBundle {

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -36,10 +36,11 @@ void main() {
         Target target,
         Environment environment,
       ) {
-        environment.outputDir.childFile('kernel_blob.bin').createSync(recursive: true);
-        environment.outputDir.childFile('isolate_snapshot_data').createSync();
-        environment.outputDir.childFile('vm_snapshot_data').createSync();
-        environment.outputDir.childFile('LICENSE').createSync(recursive: true);
+        final Directory assetsOutputDir = environment.outputDir.childDirectory('flutter_assets');
+        assetsOutputDir.childFile('kernel_blob.bin').createSync(recursive: true);
+        assetsOutputDir.childFile('isolate_snapshot_data').createSync();
+        assetsOutputDir.childFile('vm_snapshot_data').createSync();
+        assetsOutputDir.childFile('LICENSE').createSync(recursive: true);
       });
 
       await BundleBuilder().build(
@@ -47,15 +48,20 @@ void main() {
         buildInfo: BuildInfo.debug,
         project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
         mainPath: globals.fs.path.join('lib', 'main.dart'),
-        assetDirPath: 'example',
+        outputDirPath: 'example',
         depfilePath: 'example.d',
         buildSystem: buildSystem,
       );
       expect(
-        globals.fs.file(globals.fs.path.join('example', 'kernel_blob.bin')).existsSync(),
+        globals.fs
+            .file(globals.fs.path.join('example', 'flutter_assets', 'kernel_blob.bin'))
+            .existsSync(),
         true,
       );
-      expect(globals.fs.file(globals.fs.path.join('example', 'LICENSE')).existsSync(), true);
+      expect(
+        globals.fs.file(globals.fs.path.join('example', 'flutter_assets', 'LICENSE')).existsSync(),
+        true,
+      );
       expect(globals.fs.file(globals.fs.path.join('example.d')).existsSync(), false);
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -751,6 +751,7 @@ class FakeBundleBuilder extends Fake implements BundleBuilder {
     String? assetDirPath,
     String? outputDirPath,
     Uri? nativeAssets,
+    bool buildAOTAssets = false,
     bool buildNativeAssets = true,
     @visibleForTesting BuildSystem? buildSystem,
   }) async {}

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -128,9 +128,9 @@ void main() {
       expect(device.category, Category.mobile);
 
       expect(device.supportsRuntimeMode(BuildMode.debug), true);
-      expect(device.supportsRuntimeMode(BuildMode.profile), false);
-      expect(device.supportsRuntimeMode(BuildMode.release), false);
-      expect(device.supportsRuntimeMode(BuildMode.jitRelease), false);
+      expect(device.supportsRuntimeMode(BuildMode.profile), true);
+      expect(device.supportsRuntimeMode(BuildMode.release), true);
+      expect(device.supportsRuntimeMode(BuildMode.jitRelease), true);
     },
     overrides: <Type, dynamic Function()>{
       FileSystem: () => MemoryFileSystem.test(),

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -749,6 +749,7 @@ class FakeBundleBuilder extends Fake implements BundleBuilder {
     String? applicationKernelFilePath,
     String? depfilePath,
     String? assetDirPath,
+    String? outputDirPath,
     Uri? nativeAssets,
     bool buildNativeAssets = true,
     @visibleForTesting BuildSystem? buildSystem,


### PR DESCRIPTION
Add support for building the AOT assets (when building in profile/release mode) and wire it up for:
- `flutter build bundle` command:
```
flutter build bundle --profile --build-aot-assets --target-platform=linux-x64
```
- custom devices:
```
flutter run --profile --device-id foobar
```
Fixes #79681, #164228.
### Implementation details
The AOT asset support is currently only implemented for the Linux platform (`x64` and `arm64`).

In order to maintain backwards compatibility, a new flag `--build-aot-assets` (disabled by default) has been introduced to the `flutter build bundle` command.

Additionally, in order to make it possible to generate the AOT shared library in a `lib` directory that's a *sibling* of the `flutter_assets` directory, the `--asset-dir` flag has been marked as deprecated and replaced with a new `--output-dir` flag.
### Additional context about enabling AOT support for `fluter build bundle`
[jonahwilliams](https://github.com/jonahwilliams) [on May 18, 2021](https://github.com/flutter/flutter/issues/79406#issuecomment-843341430)
> we could definitely make build bundle (or some new command) support producing the dart AOT artifacts and leave compiling the embedder up to other tools/scripts

[jonahwilliams](https://github.com/jonahwilliams) [on Oct 14, 2023](https://github.com/flutter/flutter/issues/136547#issuecomment-1763035972)
> To start with, I would probably want the native assets feature disabled for build bundle

[stuartmorgan](https://github.com/stuartmorgan) [on Oct 14, 2023](https://github.com/flutter/flutter/issues/136547#issuecomment-1763113121)
> Agreed, I was actually envisioning a new flag to `bundle` that would provide the requested architecture(s). That's why I figured we'd need a fallback behavior of disabling it when the flag isn't present.

[stuartmorgan](https://github.com/stuartmorgan) [on Oct 15, 2023](https://github.com/flutter/flutter/issues/136547#issuecomment-1763414827)
> In that scenario we could potentially either add native asset support, or have a new command for native assets. Longer term we'd have distinct commands for this for Windows and Linux. (For macOS there's already `framework`; if there's a reason you can't use that please let us know).
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
