### PR TITLE
Public nodes needing paint or layout

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1090,9 +1090,11 @@ base class PipelineOwner with DiagnosticableTreeMixin {
 
   /// The [RenderObject]s which need to be laid out in the next [flushLayout] pass.
   ///
-  /// The returned list is an unmodifiable copy of the internal cache.
-  /// The internal cache will continue to update without notifying this copy.
-  List<RenderObject> get nodesNeedingLayout => List<RenderObject>.unmodifiable(_nodesNeedingLayout);
+  /// [RenderObject]s with [RenderObject.isRepaintBoundary] are added to this list
+  /// when they are marked for layout. Subclasses of [PipelineOwner] may use this list
+  /// to invalidate caches or otherwise make performance optimizations.
+  @protected
+  List<RenderObject> get nodesNeedingLayout => _nodesNeedingLayout;
 
   /// Whether this pipeline is currently in the layout phase.
   ///
@@ -1240,9 +1242,11 @@ base class PipelineOwner with DiagnosticableTreeMixin {
 
   /// The [RenderObject]s which need to be painted in the next [flushPaint] pass.
   ///
-  /// The returned list is an unmodifiable copy of the internal cache.
-  /// The internal cache will continue to update without notifying this copy.
-  @protected List<RenderObject> get nodesNeedingPaint => _nodesNeedingPaint;
+  /// [RenderObject]s marked with [RenderObject.isRepaintBoundary] are added to this list
+  /// when they are marked needing paint. Subclasses of [PipelineOwner] may use this list
+  /// to invalidate caches or otherwise make performance optimizations.
+  @protected
+  List<RenderObject> get nodesNeedingPaint => _nodesNeedingPaint;
 
   /// Whether this pipeline is currently in the paint phase.
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1088,6 +1088,12 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   bool _shouldMergeDirtyNodes = false;
   List<RenderObject> _nodesNeedingLayout = <RenderObject>[];
 
+  /// The [RenderObject]s which need to be laid out in the next [flushLayout] pass.
+  ///
+  /// The returned list is an unmodifiable copy of the internal cache.
+  /// The internal cache will continue to update without notifying this copy.
+  List<RenderObject> get nodesNeedingLayout => List<RenderObject>.unmodifiable(_nodesNeedingLayout);
+
   /// Whether this pipeline is currently in the layout phase.
   ///
   /// Specifically, whether [flushLayout] is currently running.
@@ -1231,6 +1237,12 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   }
 
   List<RenderObject> _nodesNeedingPaint = <RenderObject>[];
+
+  /// The [RenderObject]s which need to be painted in the next [flushPaint] pass.
+  ///
+  /// The returned list is an unmodifiable copy of the internal cache.
+  /// The internal cache will continue to update without notifying this copy.
+  List<RenderObject> get nodesNeedingPaint => List<RenderObject>.unmodifiable(_nodesNeedingPaint);
 
   /// Whether this pipeline is currently in the paint phase.
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1099,7 +1099,8 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   /// Relayout boundaries owned by child [PipelineOwner]s are not included here.
   ///
   /// Boundaries appear in an arbitrary order, and may appear multiple times.
-  @protected @nonVirtual
+  @protected
+  @nonVirtual
   Iterable<RenderObject> get nodesNeedingLayout => _nodesNeedingLayout;
 
   /// Whether this pipeline is currently in the layout phase.
@@ -1255,7 +1256,8 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   /// [flushPaint].
   ///
   /// Marked children of child [PipelineOwner]s are not included here.
-  @protected @nonVirtual
+  @protected
+  @nonVirtual
   Iterable<RenderObject> get nodesNeedingPaint => _nodesNeedingPaint;
 
   /// Whether this pipeline is currently in the paint phase.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1093,6 +1093,10 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   /// [RenderObject]s with [RenderObject.isRepaintBoundary] are added
   /// when they are marked for layout. Subclasses of [PipelineOwner] may use them
   /// to invalidate caches or otherwise make performance optimizations.
+  /// Since nodes may be marked for layout at any time, they are best checked during
+  /// [flushLayout].
+  ///
+  /// Note that this does not include marked children of child [PipelineOwner]s.
   @protected
   Iterable<RenderObject> get nodesNeedingLayout => _nodesNeedingLayout;
 
@@ -1245,6 +1249,10 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   /// [RenderObject]s marked with [RenderObject.isRepaintBoundary] are added
   /// when they are marked needing paint. Subclasses of [PipelineOwner] may use them
   /// to invalidate caches or otherwise make performance optimizations.
+  /// Since nodes may be marked for layout at any time, they are best checked during
+  /// [flushPaint].
+  ///
+  /// Note that this does not include marked children of child [PipelineOwner]s.
   @protected
   Iterable<RenderObject> get nodesNeedingPaint => _nodesNeedingPaint;
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1242,7 +1242,7 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   ///
   /// The returned list is an unmodifiable copy of the internal cache.
   /// The internal cache will continue to update without notifying this copy.
-  List<RenderObject> get nodesNeedingPaint => List<RenderObject>.unmodifiable(_nodesNeedingPaint);
+  @protected List<RenderObject> get nodesNeedingPaint => _nodesNeedingPaint;
 
   /// Whether this pipeline is currently in the paint phase.
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1090,11 +1090,11 @@ base class PipelineOwner with DiagnosticableTreeMixin {
 
   /// The [RenderObject]s which need to be laid out in the next [flushLayout] pass.
   ///
-  /// [RenderObject]s with [RenderObject.isRepaintBoundary] are added to this list
-  /// when they are marked for layout. Subclasses of [PipelineOwner] may use this list
+  /// [RenderObject]s with [RenderObject.isRepaintBoundary] are added
+  /// when they are marked for layout. Subclasses of [PipelineOwner] may use them
   /// to invalidate caches or otherwise make performance optimizations.
   @protected
-  List<RenderObject> get nodesNeedingLayout => _nodesNeedingLayout;
+  Iterable<RenderObject> get nodesNeedingLayout => _nodesNeedingLayout;
 
   /// Whether this pipeline is currently in the layout phase.
   ///
@@ -1242,11 +1242,11 @@ base class PipelineOwner with DiagnosticableTreeMixin {
 
   /// The [RenderObject]s which need to be painted in the next [flushPaint] pass.
   ///
-  /// [RenderObject]s marked with [RenderObject.isRepaintBoundary] are added to this list
-  /// when they are marked needing paint. Subclasses of [PipelineOwner] may use this list
+  /// [RenderObject]s marked with [RenderObject.isRepaintBoundary] are added
+  /// when they are marked needing paint. Subclasses of [PipelineOwner] may use them
   /// to invalidate caches or otherwise make performance optimizations.
   @protected
-  List<RenderObject> get nodesNeedingPaint => _nodesNeedingPaint;
+  Iterable<RenderObject> get nodesNeedingPaint => _nodesNeedingPaint;
 
   /// Whether this pipeline is currently in the paint phase.
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1091,13 +1091,14 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   /// The [RenderObject]s representing relayout boundaries which need to be laid out
   /// in the next [flushLayout] pass.
   ///
-  /// [RenderObject]s with [RenderObject.isRela] are added
-  /// when they are marked for layout. Subclasses of [PipelineOwner] may use them
-  /// to invalidate caches or otherwise make performance optimizations.
-  /// Since nodes may be marked for layout at any time, they are best checked during
-  /// [flushLayout].
+  /// Relayout boundaries are added when they are marked for layout.
+  /// Subclasses of [PipelineOwner] may use them to invalidate caches or
+  /// otherwise make performance optimizations. Since nodes may be marked for
+  /// layout at any time, they are best checked during [flushLayout].
   ///
-  /// Note that this does not include marked children of child [PipelineOwner]s.
+  /// Relayout boundaries owned by child [PipelineOwner]s are not included here.
+  ///
+  /// Boundaries appear in an arbitrary order, and may appear multiple times.
   @protected @nonVirtual
   Iterable<RenderObject> get nodesNeedingLayout => _nodesNeedingLayout;
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1088,16 +1088,17 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   bool _shouldMergeDirtyNodes = false;
   List<RenderObject> _nodesNeedingLayout = <RenderObject>[];
 
-  /// The [RenderObject]s which need to be laid out in the next [flushLayout] pass.
+  /// The [RenderObject]s representing relayout boundaries which need to be laid out
+  /// in the next [flushLayout] pass.
   ///
-  /// [RenderObject]s with [RenderObject.isRepaintBoundary] are added
+  /// [RenderObject]s with [RenderObject.isRela] are added
   /// when they are marked for layout. Subclasses of [PipelineOwner] may use them
   /// to invalidate caches or otherwise make performance optimizations.
   /// Since nodes may be marked for layout at any time, they are best checked during
   /// [flushLayout].
   ///
   /// Note that this does not include marked children of child [PipelineOwner]s.
-  @protected
+  @protected @nonVirtual
   Iterable<RenderObject> get nodesNeedingLayout => _nodesNeedingLayout;
 
   /// Whether this pipeline is currently in the layout phase.
@@ -1252,8 +1253,8 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   /// Since nodes may be marked for layout at any time, they are best checked during
   /// [flushPaint].
   ///
-  /// Note that this does not include marked children of child [PipelineOwner]s.
-  @protected
+  /// Marked children of child [PipelineOwner]s are not included here.
+  @protected @nonVirtual
   Iterable<RenderObject> get nodesNeedingPaint => _nodesNeedingPaint;
 
   /// Whether this pipeline is currently in the paint phase.

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -26,14 +26,14 @@ void main() {
     final _TestPipelineOwner owner = _TestPipelineOwner();
     final TestRenderObject renderObject = TestRenderObject()..isRepaintBoundary = true;
     renderObject.attach(owner);
-    expect(owner.nodesNeedingLayout, isEmpty);
+    expect(owner.needLayout, isEmpty);
 
     renderObject.layout(const BoxConstraints.tightForFinite());
     renderObject.markNeedsLayout();
-    expect(owner.nodesNeedingLayout, contains(renderObject));
+    expect(owner.needLayout, contains(renderObject));
 
     owner.flushLayout();
-    expect(owner.nodesNeedingLayout, isEmpty);
+    expect(owner.needLayout, isEmpty);
   });
 
   test('nodesNeedingPaint updated with paint changes', () {
@@ -43,14 +43,14 @@ void main() {
     final OffsetLayer layer = OffsetLayer();
     layer.attach(owner);
     renderObject.attach(owner);
-    expect(owner.nodesNeedingPaint, isEmpty);
+    expect(owner.needPaint, isEmpty);
 
     renderObject.markNeedsPaint();
     renderObject.scheduleInitialPaint(layer);
-    expect(owner.nodesNeedingPaint, contains(renderObject));
+    expect(owner.needPaint, contains(renderObject));
 
     owner.flushPaint();
-    expect(owner.nodesNeedingPaint, isEmpty);
+    expect(owner.needPaint, isEmpty);
   });
 
   test('ensure frame is scheduled for markNeedsSemanticsUpdate', () {
@@ -720,9 +720,7 @@ class TestThrowingRenderObject extends RenderObject {
 
 final class _TestPipelineOwner extends PipelineOwner {
   // Make these protected fields visible for testing.
-  @override
-  Iterable<RenderObject> get nodesNeedingLayout => super.nodesNeedingLayout;
+  Iterable<RenderObject> get needLayout => super.nodesNeedingLayout;
 
-  @override
-  Iterable<RenderObject> get nodesNeedingPaint => super.nodesNeedingPaint;
+  Iterable<RenderObject> get needPaint => super.nodesNeedingPaint;
 }

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -23,7 +23,7 @@ void main() {
   });
 
   test('nodesNeedingLayout updated with layout changes', () {
-    final PipelineOwner owner = PipelineOwner();
+    final _TestPipelineOwner owner = _TestPipelineOwner();
     final TestRenderObject renderObject = TestRenderObject()..isRepaintBoundary = true;
     renderObject.attach(owner);
     expect(owner.nodesNeedingLayout, isEmpty);
@@ -37,7 +37,7 @@ void main() {
   });
 
   test('nodesNeedingPaint updated with paint changes', () {
-    final PipelineOwner owner = PipelineOwner();
+    final _TestPipelineOwner owner = _TestPipelineOwner();
     final TestRenderObject renderObject = TestRenderObject(allowPaintBounds: true)
       ..isRepaintBoundary = true;
     final OffsetLayer layer = OffsetLayer();
@@ -716,4 +716,12 @@ class TestThrowingRenderObject extends RenderObject {
     assert(false); // The test shouldn't call this.
     return Rect.zero;
   }
+}
+final class _TestPipelineOwner extends PipelineOwner {
+  // Make these protected fields visible for testing.
+  @override
+  Iterable<RenderObject> get nodesNeedingLayout => super.nodesNeedingLayout;
+
+  @override
+  Iterable<RenderObject> get nodesNeedingPaint => super.nodesNeedingPaint;
 }

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -22,6 +22,37 @@ void main() {
     );
   });
 
+  test('nodesNeedingLayout updated with layout changes', () {
+    final PipelineOwner owner = PipelineOwner();
+    final TestRenderObject renderObject = TestRenderObject()..isRepaintBoundary = true;
+    renderObject.attach(owner);
+    expect(owner.nodesNeedingLayout, isEmpty);
+
+    renderObject.layout(const BoxConstraints.tightForFinite());
+    renderObject.markNeedsLayout();
+    expect(owner.nodesNeedingLayout, contains(renderObject));
+
+    owner.flushLayout();
+    expect(owner.nodesNeedingLayout, isEmpty);
+  });
+
+  test('nodesNeedingPaint updated with paint changes', () {
+    final PipelineOwner owner = PipelineOwner();
+    final TestRenderObject renderObject = TestRenderObject(allowPaintBounds: true)
+      ..isRepaintBoundary = true;
+    final OffsetLayer layer = OffsetLayer();
+    layer.attach(owner);
+    renderObject.attach(owner);
+    expect(owner.nodesNeedingPaint, isEmpty);
+
+    renderObject.markNeedsPaint();
+    renderObject.scheduleInitialPaint(layer);
+    expect(owner.nodesNeedingPaint, contains(renderObject));
+
+    owner.flushPaint();
+    expect(owner.nodesNeedingPaint, isEmpty);
+  });
+
   test('ensure frame is scheduled for markNeedsSemanticsUpdate', () {
     // Initialize all bindings because owner.flushSemantics() requires a window
     final TestRenderObject renderObject = TestRenderObject();

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -717,6 +717,7 @@ class TestThrowingRenderObject extends RenderObject {
     return Rect.zero;
   }
 }
+
 final class _TestPipelineOwner extends PipelineOwner {
   // Make these protected fields visible for testing.
   @override


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR adds 2 new `@protected` fields to `PipelineOwner` which list the RenderObjects currently needing paint or layout for the next frame.

This PR addresses https://github.com/flutter/flutter/issues/166147, which has further discussion of the motivation.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
