### PR TITLE
Remove bringup flag for customer tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -572,7 +572,6 @@ targets:
     enabled_branches:
       - master
     recipe: flutter/flutter_drone
-    bringup: true
     # Timeout in minutes for the whole task.
     timeout: 60
     properties:


### PR DESCRIPTION
Fixes #166160 by reverting #166103.

Customer tests were not finishing due to errors in devtools, caused by package:vm_service_protos being upgraded to 1.1.0 and desyncing with package:protobuf. [package:vm_service_protos ](https://pub.dev/packages/vm_service_protos)has been rolled back to 1.0.0, and the [devtool checks are passing again](https://github.com/flutter/devtools/actions/workflows/build.yaml), so marking the customer tests as unflaky again.