### PR TITLE
[Impeller] small cpu perf for text contents.

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
@@ -69,12 +69,12 @@ std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
 }
 
 Rect PerVertexDataPositionToRect(
-    GlyphAtlasPipeline::VertexShader::PerVertexData data[6]) {
+    GlyphAtlasPipeline::VertexShader::PerVertexData data[4]) {
   Scalar right = FLT_MIN;
   Scalar left = FLT_MAX;
   Scalar top = FLT_MAX;
   Scalar bottom = FLT_MIN;
-  for (int i = 0; i < 6; ++i) {
+  for (int i = 0; i < 4; ++i) {
     right = std::max(right, data[i].position.x);
     left = std::min(left, data[i].position.x);
     top = std::min(top, data[i].position.y);
@@ -85,13 +85,13 @@ Rect PerVertexDataPositionToRect(
 }
 
 Rect PerVertexDataUVToRect(
-    GlyphAtlasPipeline::VertexShader::PerVertexData data[6],
+    GlyphAtlasPipeline::VertexShader::PerVertexData data[4],
     ISize texture_size) {
   Scalar right = FLT_MIN;
   Scalar left = FLT_MAX;
   Scalar top = FLT_MAX;
   Scalar bottom = FLT_MIN;
-  for (int i = 0; i < 6; ++i) {
+  for (int i = 0; i < 4; ++i) {
     right = std::max(right, data[i].uv.x * texture_size.width);
     left = std::min(left, data[i].uv.x * texture_size.width);
     top = std::min(top, data[i].uv.y * texture_size.height);
@@ -111,7 +111,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[6];
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame =
       MakeTextFrame("1", "ahem.ttf", TextOptions{.font_size = 50});
@@ -147,7 +147,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData2x) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[6];
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame =
       MakeTextFrame("1", "ahem.ttf", TextOptions{.font_size = 50});
@@ -212,8 +212,8 @@ TEST_P(TextContentsTest, MaintainsShape) {
           /*glyph_properties=*/std::nullopt, atlas);
       position_rect[0] = PerVertexDataPositionToRect(data);
       uv_rect[0] = PerVertexDataUVToRect(data, texture_size);
-      position_rect[1] = PerVertexDataPositionToRect(data + 6);
-      uv_rect[1] = PerVertexDataUVToRect(data + 6, texture_size);
+      position_rect[1] = PerVertexDataPositionToRect(data + 4);
+      uv_rect[1] = PerVertexDataUVToRect(data + 4, texture_size);
     }
     EXPECT_NEAR(GetAspectRatio(position_rect[1]), GetAspectRatio(uv_rect[1]),
                 0.001)
@@ -226,7 +226,7 @@ TEST_P(TextContentsTest, SimpleSubpixel) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[6];
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -263,7 +263,7 @@ TEST_P(TextContentsTest, SimpleSubpixel3x) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[6];
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -307,7 +307,7 @@ TEST_P(TextContentsTest, SimpleSubpixel26) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[6];
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -344,7 +344,7 @@ TEST_P(TextContentsTest, SimpleSubpixel80) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[6];
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});

--- a/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
@@ -69,7 +69,8 @@ std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
 }
 
 Rect PerVertexDataPositionToRect(
-    GlyphAtlasPipeline::VertexShader::PerVertexData data[4]) {
+    std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData>::iterator
+        data) {
   Scalar right = FLT_MIN;
   Scalar left = FLT_MAX;
   Scalar top = FLT_MAX;
@@ -85,7 +86,7 @@ Rect PerVertexDataPositionToRect(
 }
 
 Rect PerVertexDataUVToRect(
-    GlyphAtlasPipeline::VertexShader::PerVertexData data[4],
+    std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData>::iterator data,
     ISize texture_size) {
   Scalar right = FLT_MIN;
   Scalar left = FLT_MAX;
@@ -111,7 +112,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data(4);
 
   std::shared_ptr<TextFrame> text_frame =
       MakeTextFrame("1", "ahem.ttf", TextOptions{.font_size = 50});
@@ -128,13 +129,13 @@ TEST_P(TextContentsTest, SimpleComputeVertexData) {
                        atlas_context, text_frame, /*offset=*/{0, 0});
 
   ISize texture_size = atlas->GetTexture()->GetSize();
-  TextContents::ComputeVertexData(data, text_frame, /*scale=*/1.0,
+  TextContents::ComputeVertexData(data.data(), text_frame, /*scale=*/1.0,
                                   /*entity_transform=*/Matrix(),
                                   /*offset=*/Vector2(0, 0),
                                   /*glyph_properties=*/std::nullopt, atlas);
 
-  Rect position_rect = PerVertexDataPositionToRect(data);
-  Rect uv_rect = PerVertexDataUVToRect(data, texture_size);
+  Rect position_rect = PerVertexDataPositionToRect(data.begin());
+  Rect uv_rect = PerVertexDataUVToRect(data.begin(), texture_size);
   // The -1 offset comes from Skia in `ComputeGlyphSize`. So since the font size
   // is 50, the math appears to be to get back a 50x50 rect and apply 1 pixel
   // of padding.
@@ -147,8 +148,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData2x) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
-
+  std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data(4);
   std::shared_ptr<TextFrame> text_frame =
       MakeTextFrame("1", "ahem.ttf", TextOptions{.font_size = 50});
 
@@ -166,15 +166,15 @@ TEST_P(TextContentsTest, SimpleComputeVertexData2x) {
 
   ISize texture_size = atlas->GetTexture()->GetSize();
   TextContents::ComputeVertexData(
-      data, text_frame, static_cast<Scalar>(font_scale),
+      data.data(), text_frame, static_cast<Scalar>(font_scale),
       /*entity_transform=*/
       Matrix::MakeScale({static_cast<Scalar>(font_scale),
                          static_cast<Scalar>(font_scale), 1}),
       /*offset=*/Vector2(0, 0),
       /*glyph_properties=*/std::nullopt, atlas);
 
-  Rect position_rect = PerVertexDataPositionToRect(data);
-  Rect uv_rect = PerVertexDataUVToRect(data, texture_size);
+  Rect position_rect = PerVertexDataPositionToRect(data.begin());
+  Rect uv_rect = PerVertexDataUVToRect(data.begin(), texture_size);
   EXPECT_RECT_NEAR(position_rect, Rect::MakeXYWH(-1, -81, 102, 102));
   EXPECT_RECT_NEAR(uv_rect, Rect::MakeXYWH(1.0, 1.0, 102, 102));
 }
@@ -196,7 +196,8 @@ TEST_P(TextContentsTest, MaintainsShape) {
     Rect uv_rect[2];
 
     {
-      GlyphAtlasPipeline::VertexShader::PerVertexData data[12];
+      std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data(12);
+
       std::shared_ptr<GlyphAtlas> atlas =
           CreateGlyphAtlas(*GetContext(), context.get(), *host_buffer,
                            GlyphAtlas::Type::kAlphaBitmap, font_scale,
@@ -204,16 +205,16 @@ TEST_P(TextContentsTest, MaintainsShape) {
       ISize texture_size = atlas->GetTexture()->GetSize();
 
       TextContents::ComputeVertexData(
-          data, text_frame, static_cast<Scalar>(font_scale),
+          data.data(), text_frame, static_cast<Scalar>(font_scale),
           /*entity_transform=*/
           Matrix::MakeScale({static_cast<Scalar>(font_scale),
                              static_cast<Scalar>(font_scale), 1}),
           /*offset=*/Vector2(0, 0),
           /*glyph_properties=*/std::nullopt, atlas);
-      position_rect[0] = PerVertexDataPositionToRect(data);
-      uv_rect[0] = PerVertexDataUVToRect(data, texture_size);
-      position_rect[1] = PerVertexDataPositionToRect(data + 4);
-      uv_rect[1] = PerVertexDataUVToRect(data + 4, texture_size);
+      position_rect[0] = PerVertexDataPositionToRect(data.begin());
+      uv_rect[0] = PerVertexDataUVToRect(data.begin(), texture_size);
+      position_rect[1] = PerVertexDataPositionToRect(data.begin() + 4);
+      uv_rect[1] = PerVertexDataUVToRect(data.begin() + 4, texture_size);
     }
     EXPECT_NEAR(GetAspectRatio(position_rect[1]), GetAspectRatio(uv_rect[1]),
                 0.001)
@@ -226,7 +227,7 @@ TEST_P(TextContentsTest, SimpleSubpixel) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data(4);
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -245,12 +246,12 @@ TEST_P(TextContentsTest, SimpleSubpixel) {
 
   ISize texture_size = atlas->GetTexture()->GetSize();
   TextContents::ComputeVertexData(
-      data, text_frame, /*scale=*/1.0,
+      data.data(), text_frame, /*scale=*/1.0,
       /*entity_transform=*/Matrix::MakeTranslation(offset), offset,
       /*glyph_properties=*/std::nullopt, atlas);
 
-  Rect position_rect = PerVertexDataPositionToRect(data);
-  Rect uv_rect = PerVertexDataUVToRect(data, texture_size);
+  Rect position_rect = PerVertexDataPositionToRect(data.begin());
+  Rect uv_rect = PerVertexDataUVToRect(data.begin(), texture_size);
   // The values at Point(0, 0).
   // EXPECT_RECT_NEAR(position_rect, Rect::MakeXYWH(-1, -41, 52, 52));
   // EXPECT_RECT_NEAR(uv_rect, Rect::MakeXYWH(1.0, 1.0, 52, 52));
@@ -263,7 +264,7 @@ TEST_P(TextContentsTest, SimpleSubpixel3x) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data(4);
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -283,7 +284,7 @@ TEST_P(TextContentsTest, SimpleSubpixel3x) {
 
   ISize texture_size = atlas->GetTexture()->GetSize();
   TextContents::ComputeVertexData(
-      data, text_frame, static_cast<Scalar>(font_scale),
+      data.data(), text_frame, static_cast<Scalar>(font_scale),
       /*entity_transform=*/
       Matrix::MakeTranslation(offset) *
           Matrix::MakeScale({static_cast<Scalar>(font_scale),
@@ -291,8 +292,8 @@ TEST_P(TextContentsTest, SimpleSubpixel3x) {
       offset,
       /*glyph_properties=*/std::nullopt, atlas);
 
-  Rect position_rect = PerVertexDataPositionToRect(data);
-  Rect uv_rect = PerVertexDataUVToRect(data, texture_size);
+  Rect position_rect = PerVertexDataPositionToRect(data.begin());
+  Rect uv_rect = PerVertexDataUVToRect(data.begin(), texture_size);
   // Values at Point(0, 0)
   // EXPECT_RECT_NEAR(position_rect, Rect::MakeXYWH(-1, -121, 152, 152));
   // EXPECT_RECT_NEAR(uv_rect, Rect::MakeXYWH(1.0, 1.0, 152, 152));
@@ -307,7 +308,7 @@ TEST_P(TextContentsTest, SimpleSubpixel26) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data(4);
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -326,12 +327,12 @@ TEST_P(TextContentsTest, SimpleSubpixel26) {
 
   ISize texture_size = atlas->GetTexture()->GetSize();
   TextContents::ComputeVertexData(
-      data, text_frame, /*scale=*/1.0,
+      data.data(), text_frame, /*scale=*/1.0,
       /*entity_transform=*/Matrix::MakeTranslation(offset), offset,
       /*glyph_properties=*/std::nullopt, atlas);
 
-  Rect position_rect = PerVertexDataPositionToRect(data);
-  Rect uv_rect = PerVertexDataUVToRect(data, texture_size);
+  Rect position_rect = PerVertexDataPositionToRect(data.begin());
+  Rect uv_rect = PerVertexDataUVToRect(data.begin(), texture_size);
   // The values without subpixel.
   // EXPECT_RECT_NEAR(position_rect, Rect::MakeXYWH(-1, -41, 52, 52));
   // EXPECT_RECT_NEAR(uv_rect, Rect::MakeXYWH(1.0, 1.0, 52, 52));
@@ -344,7 +345,7 @@ TEST_P(TextContentsTest, SimpleSubpixel80) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data;
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -363,12 +364,12 @@ TEST_P(TextContentsTest, SimpleSubpixel80) {
 
   ISize texture_size = atlas->GetTexture()->GetSize();
   TextContents::ComputeVertexData(
-      data, text_frame, /*scale=*/1.0,
+      data.data(), text_frame, /*scale=*/1.0,
       /*entity_transform=*/Matrix::MakeTranslation(offset), offset,
       /*glyph_properties=*/std::nullopt, atlas);
 
-  Rect position_rect = PerVertexDataPositionToRect(data);
-  Rect uv_rect = PerVertexDataUVToRect(data, texture_size);
+  Rect position_rect = PerVertexDataPositionToRect(data.begin());
+  Rect uv_rect = PerVertexDataUVToRect(data.begin(), texture_size);
   // The values without subpixel.
   // EXPECT_RECT_NEAR(position_rect, Rect::MakeXYWH(-1, -41, 52, 52));
   // EXPECT_RECT_NEAR(uv_rect, Rect::MakeXYWH(1.0, 1.0, 52, 52));

--- a/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
@@ -69,7 +69,7 @@ std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
 }
 
 Rect PerVertexDataPositionToRect(
-    GlyphAtlasPipeline::VertexShader::PerVertexData data[4]) {
+    std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4>& data) {
   Scalar right = FLT_MIN;
   Scalar left = FLT_MAX;
   Scalar top = FLT_MAX;
@@ -85,7 +85,7 @@ Rect PerVertexDataPositionToRect(
 }
 
 Rect PerVertexDataUVToRect(
-    GlyphAtlasPipeline::VertexShader::PerVertexData data[4],
+    std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4>& data,
     ISize texture_size) {
   Scalar right = FLT_MIN;
   Scalar left = FLT_MAX;
@@ -111,7 +111,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
 
   std::shared_ptr<TextFrame> text_frame =
       MakeTextFrame("1", "ahem.ttf", TextOptions{.font_size = 50});
@@ -147,7 +147,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData2x) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
 
   std::shared_ptr<TextFrame> text_frame =
       MakeTextFrame("1", "ahem.ttf", TextOptions{.font_size = 50});
@@ -226,7 +226,7 @@ TEST_P(TextContentsTest, SimpleSubpixel) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -263,7 +263,7 @@ TEST_P(TextContentsTest, SimpleSubpixel3x) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -307,7 +307,7 @@ TEST_P(TextContentsTest, SimpleSubpixel26) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -344,7 +344,7 @@ TEST_P(TextContentsTest, SimpleSubpixel80) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
+  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});

--- a/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
@@ -69,7 +69,7 @@ std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
 }
 
 Rect PerVertexDataPositionToRect(
-    std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4>& data) {
+    GlyphAtlasPipeline::VertexShader::PerVertexData data[4]) {
   Scalar right = FLT_MIN;
   Scalar left = FLT_MAX;
   Scalar top = FLT_MAX;
@@ -85,7 +85,7 @@ Rect PerVertexDataPositionToRect(
 }
 
 Rect PerVertexDataUVToRect(
-    std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4>& data,
+    GlyphAtlasPipeline::VertexShader::PerVertexData data[4],
     ISize texture_size) {
   Scalar right = FLT_MIN;
   Scalar left = FLT_MAX;
@@ -111,7 +111,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame =
       MakeTextFrame("1", "ahem.ttf", TextOptions{.font_size = 50});
@@ -147,7 +147,7 @@ TEST_P(TextContentsTest, SimpleComputeVertexData2x) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame =
       MakeTextFrame("1", "ahem.ttf", TextOptions{.font_size = 50});
@@ -226,7 +226,7 @@ TEST_P(TextContentsTest, SimpleSubpixel) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -263,7 +263,7 @@ TEST_P(TextContentsTest, SimpleSubpixel3x) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -307,7 +307,7 @@ TEST_P(TextContentsTest, SimpleSubpixel26) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});
@@ -344,7 +344,7 @@ TEST_P(TextContentsTest, SimpleSubpixel80) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  std::array<GlyphAtlasPipeline::VertexShader::PerVertexData, 4> data;
+  GlyphAtlasPipeline::VertexShader::PerVertexData data[4];
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});

--- a/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents_unittests.cc
@@ -345,7 +345,7 @@ TEST_P(TextContentsTest, SimpleSubpixel80) {
   GTEST_SKIP() << "Results aren't stable across linux and macos.";
 #endif
 
-  std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data;
+  std::vector<GlyphAtlasPipeline::VertexShader::PerVertexData> data(4);
 
   std::shared_ptr<TextFrame> text_frame = MakeTextFrame(
       "1", "ahem.ttf", TextOptions{.font_size = 50, .is_subpixel = true});


### PR DESCRIPTION
* Compute scaling matrices once per frame instead of per glyph.
* Use index buffer to avoid performing redundant computations for second triangle.