### PR TITLE
[Impeller] fix min filter for GL external textures.

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/texture_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/texture_contents.cc
@@ -208,6 +208,10 @@ bool TextureContents::Render(const ContentContext& renderer,
     // coordinates.
     sampler_desc.width_address_mode = SamplerAddressMode::kClampToEdge;
     sampler_desc.height_address_mode = SamplerAddressMode::kClampToEdge;
+    sampler_desc.min_filter = sampler_descriptor_.min_filter;
+    sampler_desc.mag_filter = sampler_descriptor_.mag_filter;
+    sampler_desc.mip_filter = MipFilter::kBase;
+
     FSExternal::BindSAMPLEREXTERNALOESTextureSampler(
         pass, texture_,
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(sampler_desc));

--- a/engine/src/flutter/impeller/entity/contents/tiled_texture_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/tiled_texture_contents.cc
@@ -5,6 +5,7 @@
 #include "impeller/entity/contents/tiled_texture_contents.h"
 
 #include "fml/logging.h"
+#include "impeller/core/formats.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/tiled_texture_fill.frag.h"
 #include "impeller/entity/tiled_texture_fill_external.frag.h"
@@ -159,6 +160,10 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
           // coordinates.
           sampler_desc.width_address_mode = SamplerAddressMode::kClampToEdge;
           sampler_desc.height_address_mode = SamplerAddressMode::kClampToEdge;
+          sampler_desc.min_filter = sampler_descriptor_.min_filter;
+          sampler_desc.mag_filter = sampler_descriptor_.mag_filter;
+          sampler_desc.mip_filter = MipFilter::kBase;
+
           FSExternal::BindSAMPLEREXTERNALOESTextureSampler(
               pass, texture_,
               renderer.GetContext()->GetSamplerLibrary()->GetSampler(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/165976

Pass through sampler options for oes external textures.