### PR TITLE
[Impeller] cache for text shadows.

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_unittests.cc
@@ -78,6 +78,7 @@ TEST_P(AiksTest, CollapsedDrawPaintInSubpassBackdropFilter) {
 
 TEST_P(AiksTest, ColorMatrixFilterSubpassCollapseOptimization) {
   DisplayListBuilder builder(DlRect::MakeSize(GetWindowSize()));
+  builder.DrawPaint(DlPaint().setColor(DlColor::kWhite()));
 
   const float matrix[20] = {
       -1.0, 0,    0,    1.0, 0,  //

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1472,8 +1472,9 @@ bool Canvas::AttemptBlurredTextOptimization(
     const std::shared_ptr<TextContents>& text_contents,
     Entity& entity,
     const Paint& paint) {
-  if (!paint.mask_blur_descriptor.has_value() ||
-      paint.image_filter != nullptr || paint.color_filter != nullptr ||
+  if (!paint.mask_blur_descriptor.has_value() ||  //
+      paint.image_filter != nullptr ||            //
+      paint.color_filter != nullptr ||            //
       paint.invert_colors) {
     return false;
   }
@@ -1497,7 +1498,8 @@ bool Canvas::AttemptBlurredTextOptimization(
       /*p_max_basis=*/entity.GetTransform().GetMaxBasisLengthXY(),
       /*p_identifier=*/identifier,
       /*p_is_single_glyph=*/maybe_glyph.has_value(),
-      /*p_font=*/text_frame->GetFont());
+      /*p_font=*/text_frame->GetFont(),
+      /*p_sigma=*/paint.mask_blur_descriptor->sigma);
 
   std::optional<Entity> result = renderer_.GetTextShadowCache().Lookup(
       renderer_, entity, filter, cache_key);

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1504,9 +1504,11 @@ bool Canvas::AttemptBlurredTextOptimization(
   std::optional<Entity> result = renderer_.GetTextShadowCache().Lookup(
       renderer_, entity, filter, cache_key);
   if (result.has_value()) {
-    AddRenderEntityToCurrentPass(result.value(), false);
+    AddRenderEntityToCurrentPass(result.value(), /*reuse_depth=*/false);
+    return true;
+  } else {
+    return false;
   }
-  return true;
 }
 
 void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -20,7 +20,6 @@
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/display_list/color_filter.h"
-#include "impeller/display_list/dl_atlas_geometry.h"
 #include "impeller/display_list/image_filter.h"
 #include "impeller/display_list/skia_conversions.h"
 #include "impeller/entity/contents/atlas_contents.h"
@@ -32,6 +31,7 @@
 #include "impeller/entity/contents/line_contents.h"
 #include "impeller/entity/contents/solid_rrect_blur_contents.h"
 #include "impeller/entity/contents/text_contents.h"
+#include "impeller/entity/contents/text_shadow_cache.h"
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/contents/vertices_contents.h"
 #include "impeller/entity/geometry/circle_geometry.h"
@@ -1467,6 +1467,46 @@ bool Canvas::Restore() {
   return true;
 }
 
+bool Canvas::AttemptBlurredTextOptimization(
+    const std::shared_ptr<TextFrame>& text_frame,
+    const std::shared_ptr<TextContents>& text_contents,
+    Entity& entity,
+    const Paint& paint) {
+  if (!paint.mask_blur_descriptor.has_value() ||
+      paint.image_filter != nullptr || paint.color_filter != nullptr ||
+      paint.invert_colors) {
+    return false;
+  }
+
+  // TODO(bdero): This mask blur application is a hack. It will always wind up
+  //              doing a gaussian blur that affects the color source itself
+  //              instead of just the mask. The color filter text support
+  //              needs to be reworked in order to interact correctly with
+  //              mask filters.
+  //              https://github.com/flutter/flutter/issues/133297
+  std::shared_ptr<FilterContents> filter =
+      paint.mask_blur_descriptor->CreateMaskBlur(
+          FilterInput::Make(text_contents),
+          /*is_solid_color=*/true, GetCurrentTransform());
+
+  std::optional<Glyph> maybe_glyph = text_frame->AsSingleGlyph();
+  int64_t identifier = maybe_glyph.has_value()
+                           ? maybe_glyph.value().index
+                           : reinterpret_cast<int64_t>(text_frame.get());
+  TextShadowCache::TextShadowCacheKey cache_key(
+      /*p_max_basis=*/entity.GetTransform().GetMaxBasisLengthXY(),
+      /*p_identifier=*/identifier,
+      /*p_is_single_glyph=*/maybe_glyph.has_value(),
+      /*p_font=*/text_frame->GetFont());
+
+  std::optional<Entity> result = renderer_.GetTextShadowCache().Lookup(
+      renderer_, entity, filter, cache_key);
+  if (result.has_value()) {
+    AddRenderEntityToCurrentPass(result.value(), false);
+  }
+  return true;
+}
+
 void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
                            Point position,
                            const Paint& paint) {
@@ -1491,15 +1531,12 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
   entity.SetTransform(GetCurrentTransform() *
                       Matrix::MakeTranslation(position));
 
-  // TODO(bdero): This mask blur application is a hack. It will always wind up
-  //              doing a gaussian blur that affects the color source itself
-  //              instead of just the mask. The color filter text support
-  //              needs to be reworked in order to interact correctly with
-  //              mask filters.
-  //              https://github.com/flutter/flutter/issues/133297
-  entity.SetContents(paint.WithFilters(paint.WithMaskBlur(
-      std::move(text_contents), true, GetCurrentTransform())));
+  if (AttemptBlurredTextOptimization(text_frame, text_contents, entity,
+                                     paint)) {
+    return;
+  }
 
+  entity.SetContents(paint.WithFilters(std::move(text_contents)));
   AddRenderEntityToCurrentPass(entity, false);
 }
 

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -17,6 +17,7 @@
 #include "impeller/display_list/paint.h"
 #include "impeller/entity/contents/atlas_contents.h"
 #include "impeller/entity/contents/clip_contents.h"
+#include "impeller/entity/contents/text_contents.h"
 #include "impeller/entity/entity.h"
 #include "impeller/entity/entity_pass_clip_stack.h"
 #include "impeller/entity/geometry/geometry.h"
@@ -367,6 +368,12 @@ class Canvas {
                                       const Paint& paint,
                                       const SamplerDescriptor& sampler,
                                       SourceRectConstraint src_rect_constraint);
+
+  bool AttemptBlurredTextOptimization(
+      const std::shared_ptr<TextFrame>& text_frame,
+      const std::shared_ptr<TextContents>& text_contents,
+      Entity& entity,
+      const Paint& paint);
 
   RenderPass& GetCurrentRenderPass() const;
 

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1333,12 +1333,14 @@ std::shared_ptr<Texture> DisplayListToTexture(
   );
   const auto& [data, count] = collector.TakeBackdropData();
   impeller_dispatcher.SetBackdropData(data, count);
+  context.GetContentContext().GetTextShadowCache().MarkFrameStart();
   display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
   impeller_dispatcher.FinishRecording();
 
   if (reset_host_buffer) {
     context.GetContentContext().GetTransientsBuffer().Reset();
   }
+  context.GetContentContext().GetTextShadowCache().MarkFrameEnd();
   context.GetContentContext().GetLazyGlyphAtlas()->ResetTextFrames();
   context.GetContext()->DisposeThreadLocalCachedResources();
 
@@ -1366,11 +1368,13 @@ bool RenderToTarget(ContentContext& context,
   );
   const auto& [data, count] = collector.TakeBackdropData();
   impeller_dispatcher.SetBackdropData(data, count);
+  context.GetTextShadowCache().MarkFrameStart();
   display_list->Dispatch(impeller_dispatcher, cull_rect);
   impeller_dispatcher.FinishRecording();
   if (reset_host_buffer) {
     context.GetTransientsBuffer().Reset();
   }
+  context.GetTextShadowCache().MarkFrameEnd();
   context.GetLazyGlyphAtlas()->ResetTextFrames();
 
   return true;

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1335,7 +1335,7 @@ std::shared_ptr<Texture> DisplayListToTexture(
   const auto& [data, count] = collector.TakeBackdropData();
   impeller_dispatcher.SetBackdropData(data, count);
   context.GetContentContext().GetTextShadowCache().MarkFrameStart();
-  fml::ScopedCleanupClosure([&] {
+  fml::ScopedCleanupClosure cleanup([&] {
     if (reset_host_buffer) {
       context.GetContentContext().GetTransientsBuffer().Reset();
     }
@@ -1372,7 +1372,7 @@ bool RenderToTarget(ContentContext& context,
   const auto& [data, count] = collector.TakeBackdropData();
   impeller_dispatcher.SetBackdropData(data, count);
   context.GetTextShadowCache().MarkFrameStart();
-  fml::ScopedCleanupClosure([&] {
+  fml::ScopedCleanupClosure cleanup([&] {
     if (reset_host_buffer) {
       context.GetTransientsBuffer().Reset();
     }

--- a/engine/src/flutter/impeller/entity/BUILD.gn
+++ b/engine/src/flutter/impeller/entity/BUILD.gn
@@ -179,6 +179,8 @@ impeller_component("entity") {
     "contents/sweep_gradient_contents.h",
     "contents/text_contents.cc",
     "contents/text_contents.h",
+    "contents/text_shadow_cache.cc",
+    "contents/text_shadow_cache.h",
     "contents/texture_contents.cc",
     "contents/texture_contents.h",
     "contents/tiled_texture_contents.cc",

--- a/engine/src/flutter/impeller/entity/contents/content_context.cc
+++ b/engine/src/flutter/impeller/entity/contents/content_context.cc
@@ -13,6 +13,7 @@
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/entity/contents/framebuffer_blend_contents.h"
 #include "impeller/entity/contents/pipelines.h"
+#include "impeller/entity/contents/text_shadow_cache.h"
 #include "impeller/entity/entity.h"
 #include "impeller/entity/render_target_cache.h"
 #include "impeller/renderer/command_buffer.h"
@@ -532,7 +533,8 @@ ContentContext::ContentContext(
                                      context_->GetResourceAllocator())
                                : std::move(render_target_allocator)),
       host_buffer_(HostBuffer::Create(context_->GetResourceAllocator(),
-                                      context_->GetIdleWaiter())) {
+                                      context_->GetIdleWaiter())),
+      text_shadow_cache_(std::make_unique<TextShadowCache>()) {
   if (!context_ || !context_->IsValid()) {
     return;
   }

--- a/engine/src/flutter/impeller/entity/contents/content_context.h
+++ b/engine/src/flutter/impeller/entity/contents/content_context.h
@@ -16,6 +16,7 @@
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/host_buffer.h"
+#include "impeller/entity/contents/text_shadow_cache.h"
 #include "impeller/geometry/color.h"
 #include "impeller/renderer/capabilities.h"
 #include "impeller/renderer/command_buffer.h"
@@ -294,6 +295,8 @@ class ContentContext {
   /// allocate their own device buffers.
   HostBuffer& GetTransientsBuffer() const { return *host_buffer_; }
 
+  TextShadowCache& GetTextShadowCache() const { return *text_shadow_cache_; }
+
  private:
   std::shared_ptr<Context> context_;
   std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas_;
@@ -340,6 +343,7 @@ class ContentContext {
   std::shared_ptr<RenderTargetAllocator> render_target_cache_;
   std::shared_ptr<HostBuffer> host_buffer_;
   std::shared_ptr<Texture> empty_texture_;
+  std::unique_ptr<TextShadowCache> text_shadow_cache_;
 
   ContentContext(const ContentContext&) = delete;
 

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
@@ -34,10 +34,8 @@ void TextShadowCache::MarkFrameStart() {
 }
 
 void TextShadowCache::MarkFrameEnd() {
-  absl::erase_if(entries_, [](const TextShadowCacheKey& key,
-                              const TextShadowCacheData& data) {
-    return !data.used_this_frame;
-  });
+  absl::erase_if(entries_,
+                 [](const auto& pair) { return !pair.second.used_this_frame; });
 }
 
 std::optional<Entity> TextShadowCache::Lookup(
@@ -63,9 +61,9 @@ std::optional<Entity> TextShadowCache::Lookup(
   // Execute the filter to produce a snapshot that can be resued on subsequent
   // frames. To prevent this texture from being re-used by the render target
   // cache, we temporarily disable any RT caching.
-  renderer.GetRenderTargetCache()->Disable();
+  renderer.GetRenderTargetCache()->DisableCache();
   fml::ScopedCleanupClosure closure(
-      [&] { renderer.GetRenderTargetCache()->Enable(); });
+      [&] { renderer.GetRenderTargetCache()->EnableCache(); });
   std::optional<Entity> maybe_entity =
       contents->GetEntity(renderer, entity, contents->GetCoverageHint());
   if (!maybe_entity.has_value()) {

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
@@ -18,14 +18,13 @@ void TextShadowCache::MarkFrameStart() {
 }
 
 void TextShadowCache::MarkFrameEnd() {
-  std::vector<TextShadowCacheKey> to_remove;
-  for (auto& entry : entries_) {
-    if (!entry.second.used_this_frame) {
-      to_remove.push_back(entry.first);
+  auto it = entries_.begin();
+  while (it != entries_.end()) {
+    if (!it->second.used_this_frame) {
+      it = entries_.erase(it);
+    } else {
+      it++;
     }
-  }
-  for (const auto& key : to_remove) {
-    entries_.erase(key);
   }
 }
 
@@ -34,8 +33,7 @@ std::optional<Entity> TextShadowCache::Lookup(
     const Entity& entity,
     const std::shared_ptr<FilterContents>& contents,
     const TextShadowCacheKey& text_key) {
-  std::unordered_map<TextShadowCacheKey, TextShadowCacheData>::iterator it =
-      entries_.find(text_key);
+  auto it = entries_.find(text_key);
 
   if (it != entries_.end()) {
     it->second.used_this_frame = true;

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -1,0 +1,82 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_ENTITY_CONTENTS_TEXT_SHADOW_CACHE_H_
+#define FLUTTER_IMPELLER_ENTITY_CONTENTS_TEXT_SHADOW_CACHE_H_
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+
+#include "impeller/entity/entity.h"
+#include "impeller/geometry/scalar.h"
+#include "impeller/renderer/render_pass.h"
+
+namespace impeller {
+
+class TextShadowCache {
+ public:
+  TextShadowCache() = default;
+
+  ~TextShadowCache() = default;
+
+  struct TextShadowCacheKey {
+    Scalar max_basis;
+    int64_t identifier;
+    bool is_single_glyph;
+    Font font;
+
+    TextShadowCacheKey(Scalar p_max_basis,
+                       int64_t p_identifier,
+                       bool p_is_single_glyph,
+                       const Font& p_font)
+        : max_basis(p_max_basis),
+          identifier(p_identifier),
+          is_single_glyph(p_is_single_glyph),
+          font(p_font) {}
+
+    struct Hash {
+      std::size_t operator()(const TextShadowCacheKey& key) const {
+        return fml::HashCombine(key.max_basis, key.identifier,
+                                key.is_single_glyph, key.font.GetHash());
+      }
+    };
+
+    struct Equal {
+      constexpr bool operator()(const TextShadowCacheKey& lhs,
+                                const TextShadowCacheKey& rhs) const {
+        return lhs.max_basis == rhs.max_basis &&
+               lhs.identifier == rhs.identifier &&
+               lhs.is_single_glyph == rhs.is_single_glyph &&
+               lhs.font.IsEqual(rhs.font);
+      }
+    };
+  };
+
+  void MarkFrameStart();
+
+  void MarkFrameEnd();
+
+  std::optional<Entity> Lookup(const ContentContext& renderer,
+                               const Entity& entity,
+                               const std::shared_ptr<FilterContents>& contents,
+                               const TextShadowCacheKey&);
+
+ private:
+  struct TextShadowCacheData {
+    Entity entity;
+    bool used_this_frame = true;
+    Matrix key_matrix;
+  };
+
+  std::unordered_map<TextShadowCacheKey,
+                     TextShadowCacheData,
+                     TextShadowCacheKey::Hash,
+                     TextShadowCacheKey::Equal>
+      entries_;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_ENTITY_CONTENTS_TEXT_SHADOW_CACHE_H_

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -11,35 +11,53 @@
 
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/scalar.h"
-#include "impeller/renderer/render_pass.h"
+#include "impeller/geometry/sigma.h"
 
 namespace impeller {
 
+/// @brief A cache for blurred text that re-uses these across frames.
+///
+/// Text shadows are generally stable, but expensive to compute as we use a
+/// full gaussian blur. This class caches these shadows by text blob identifier
+/// and holds them for at least one frame.
+///
+/// Additionally, there is an optimization for a single glyph (generally an
+/// Icon) that uses the content itself as a key.
+///
+/// If there was a cheaper method of text frame identity, or a per-glyph caching
+/// system this could be more efficient. As it exists, this mostly ameliorate
+/// severe performance degradation for glyph shadows but does not provide
+/// substantially better performance than Skia.
 class TextShadowCache {
  public:
   TextShadowCache() = default;
 
   ~TextShadowCache() = default;
 
+  /// @brief A key to look up cached glyph textures.
   struct TextShadowCacheKey {
     Scalar max_basis;
     int64_t identifier;
     bool is_single_glyph;
     Font font;
+    Sigma sigma;
 
     TextShadowCacheKey(Scalar p_max_basis,
                        int64_t p_identifier,
                        bool p_is_single_glyph,
-                       const Font& p_font)
+                       const Font& p_font,
+                       Sigma p_sigma)
         : max_basis(p_max_basis),
           identifier(p_identifier),
           is_single_glyph(p_is_single_glyph),
-          font(p_font) {}
+          font(p_font),
+          sigma(p_sigma) {}
 
     struct Hash {
       std::size_t operator()(const TextShadowCacheKey& key) const {
         return fml::HashCombine(key.max_basis, key.identifier,
-                                key.is_single_glyph, key.font.GetHash());
+                                key.is_single_glyph, key.font.GetHash(),
+                                key.sigma.sigma);
       }
     };
 
@@ -49,21 +67,34 @@ class TextShadowCache {
         return lhs.max_basis == rhs.max_basis &&
                lhs.identifier == rhs.identifier &&
                lhs.is_single_glyph == rhs.is_single_glyph &&
-               lhs.font.IsEqual(rhs.font);
+               lhs.font.IsEqual(rhs.font) && lhs.sigma.sigma == rhs.sigma.sigma;
       }
     };
   };
 
+  /// @brief Mark all glyph textures as unused this frame.
   void MarkFrameStart();
 
+  /// @brief Remove all glyph textures that were not referenced at least once.
   void MarkFrameEnd();
 
+  /// @brief Lookup the entity in the cache with the given filter/text contents,
+  ///        returning the new entity to render.
+  ///
+  /// If the entity is not present, render and place in the cache.
   std::optional<Entity> Lookup(const ContentContext& renderer,
                                const Entity& entity,
                                const std::shared_ptr<FilterContents>& contents,
                                const TextShadowCacheKey&);
 
+  // Visible for testing.
+  size_t GetCacheSizeForTesting() const { return entries_.size(); }
+
  private:
+  TextShadowCache(const TextShadowCache&) = delete;
+
+  TextShadowCache& operator=(const TextShadowCache&) = delete;
+
   struct TextShadowCacheData {
     Entity entity;
     bool used_this_frame = true;

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -7,8 +7,8 @@
 
 #include <cstdint>
 #include <memory>
-#include <unordered_map>
 
+#include "flutter/third_party/abseil-cpp/absl/container/flat_hash_map.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/sigma.h"
@@ -40,24 +40,19 @@ class TextShadowCache {
     int64_t identifier;
     bool is_single_glyph;
     Font font;
-    Sigma sigma;
+    Rational rounded_sigma;
 
     TextShadowCacheKey(Scalar p_max_basis,
                        int64_t p_identifier,
                        bool p_is_single_glyph,
                        const Font& p_font,
-                       Sigma p_sigma)
-        : max_basis(p_max_basis),
-          identifier(p_identifier),
-          is_single_glyph(p_is_single_glyph),
-          font(p_font),
-          sigma(p_sigma) {}
+                       Sigma p_sigma);
 
     struct Hash {
       std::size_t operator()(const TextShadowCacheKey& key) const {
         return fml::HashCombine(key.max_basis, key.identifier,
                                 key.is_single_glyph, key.font.GetHash(),
-                                key.sigma.sigma);
+                                key.rounded_sigma.GetHash());
       }
     };
 
@@ -67,7 +62,8 @@ class TextShadowCache {
         return lhs.max_basis == rhs.max_basis &&
                lhs.identifier == rhs.identifier &&
                lhs.is_single_glyph == rhs.is_single_glyph &&
-               lhs.font.IsEqual(rhs.font) && lhs.sigma.sigma == rhs.sigma.sigma;
+               lhs.font.IsEqual(rhs.font) &&
+               lhs.rounded_sigma == rhs.rounded_sigma;
       }
     };
   };
@@ -101,10 +97,10 @@ class TextShadowCache {
     Matrix key_matrix;
   };
 
-  std::unordered_map<TextShadowCacheKey,
-                     TextShadowCacheData,
-                     TextShadowCacheKey::Hash,
-                     TextShadowCacheKey::Equal>
+  absl::flat_hash_map<TextShadowCacheKey,
+                      TextShadowCacheData,
+                      TextShadowCacheKey::Hash,
+                      TextShadowCacheKey::Equal>
       entries_;
 };
 

--- a/engine/src/flutter/impeller/entity/render_target_cache.cc
+++ b/engine/src/flutter/impeller/entity/render_target_cache.cc
@@ -35,7 +35,7 @@ void RenderTargetCache::End() {
   render_target_data_.swap(retain);
 }
 
-void RenderTargetCache::Disable() {
+void RenderTargetCache::DisableCache() {
   cache_disabled_count_++;
 }
 
@@ -43,7 +43,7 @@ bool RenderTargetCache::CacheEnabled() const {
   return cache_disabled_count_ == 0;
 }
 
-void RenderTargetCache::Enable() {
+void RenderTargetCache::EnableCache() {
   FML_DCHECK(cache_disabled_count_ > 0);
   if (cache_disabled_count_ == 0) {
     return;

--- a/engine/src/flutter/impeller/entity/render_target_cache.cc
+++ b/engine/src/flutter/impeller/entity/render_target_cache.cc
@@ -39,7 +39,12 @@ void RenderTargetCache::Disable() {
   cache_disabled_count_++;
 }
 
+bool RenderTargetCache::CacheEnabled() const {
+  return cache_disabled_count_ == 0;
+}
+
 void RenderTargetCache::Enable() {
+  FML_DCHECK(cache_disabled_count_ > 0);
   if (cache_disabled_count_ == 0) {
     return;
   }
@@ -68,7 +73,7 @@ RenderTarget RenderTargetCache::CreateOffscreen(
       .has_depth_stencil = stencil_attachment_config.has_value(),
   };
 
-  if (cache_disabled_count_ == 0) {
+  if (CacheEnabled()) {
     for (RenderTargetData& render_target_data : render_target_data_) {
       const RenderTargetConfig other_config = render_target_data.config;
       if (!render_target_data.used_this_frame && other_config == config) {
@@ -123,7 +128,7 @@ RenderTarget RenderTargetCache::CreateOffscreenMSAA(
       .has_msaa = true,
       .has_depth_stencil = stencil_attachment_config.has_value(),
   };
-  if (cache_disabled_count_ == 0) {
+  if (CacheEnabled()) {
     for (RenderTargetData& render_target_data : render_target_data_) {
       const RenderTargetConfig other_config = render_target_data.config;
       if (!render_target_data.used_this_frame && other_config == config) {

--- a/engine/src/flutter/impeller/entity/render_target_cache.cc
+++ b/engine/src/flutter/impeller/entity/render_target_cache.cc
@@ -14,12 +14,14 @@ RenderTargetCache::RenderTargetCache(std::shared_ptr<Allocator> allocator,
       keep_alive_frame_count_(keep_alive_frame_count) {}
 
 void RenderTargetCache::Start() {
+  cache_disabled_count_ = 0;
   for (auto& td : render_target_data_) {
     td.used_this_frame = false;
   }
 }
 
 void RenderTargetCache::End() {
+  cache_disabled_count_ = 0;
   std::vector<RenderTargetData> retain;
 
   for (RenderTargetData& td : render_target_data_) {
@@ -31,6 +33,17 @@ void RenderTargetCache::End() {
     }
   }
   render_target_data_.swap(retain);
+}
+
+void RenderTargetCache::Disable() {
+  cache_disabled_count_++;
+}
+
+void RenderTargetCache::Enable() {
+  if (cache_disabled_count_ == 0) {
+    return;
+  }
+  cache_disabled_count_--;
 }
 
 RenderTarget RenderTargetCache::CreateOffscreen(
@@ -54,19 +67,22 @@ RenderTarget RenderTargetCache::CreateOffscreen(
       .has_msaa = false,
       .has_depth_stencil = stencil_attachment_config.has_value(),
   };
-  for (RenderTargetData& render_target_data : render_target_data_) {
-    const RenderTargetConfig other_config = render_target_data.config;
-    if (!render_target_data.used_this_frame && other_config == config) {
-      render_target_data.used_this_frame = true;
-      render_target_data.keep_alive_frame_count = keep_alive_frame_count_;
-      ColorAttachment color0 =
-          render_target_data.render_target.GetColorAttachment(0);
-      std::optional<DepthAttachment> depth =
-          render_target_data.render_target.GetDepthAttachment();
-      std::shared_ptr<Texture> depth_tex = depth ? depth->texture : nullptr;
-      return RenderTargetAllocator::CreateOffscreen(
-          context, size, mip_count, label, color_attachment_config,
-          stencil_attachment_config, color0.texture, depth_tex);
+
+  if (cache_disabled_count_ == 0) {
+    for (RenderTargetData& render_target_data : render_target_data_) {
+      const RenderTargetConfig other_config = render_target_data.config;
+      if (!render_target_data.used_this_frame && other_config == config) {
+        render_target_data.used_this_frame = true;
+        render_target_data.keep_alive_frame_count = keep_alive_frame_count_;
+        ColorAttachment color0 =
+            render_target_data.render_target.GetColorAttachment(0);
+        std::optional<DepthAttachment> depth =
+            render_target_data.render_target.GetDepthAttachment();
+        std::shared_ptr<Texture> depth_tex = depth ? depth->texture : nullptr;
+        return RenderTargetAllocator::CreateOffscreen(
+            context, size, mip_count, label, color_attachment_config,
+            stencil_attachment_config, color0.texture, depth_tex);
+      }
     }
   }
   RenderTarget created_target = RenderTargetAllocator::CreateOffscreen(
@@ -107,20 +123,22 @@ RenderTarget RenderTargetCache::CreateOffscreenMSAA(
       .has_msaa = true,
       .has_depth_stencil = stencil_attachment_config.has_value(),
   };
-  for (RenderTargetData& render_target_data : render_target_data_) {
-    const RenderTargetConfig other_config = render_target_data.config;
-    if (!render_target_data.used_this_frame && other_config == config) {
-      render_target_data.used_this_frame = true;
-      render_target_data.keep_alive_frame_count = keep_alive_frame_count_;
-      ColorAttachment color0 =
-          render_target_data.render_target.GetColorAttachment(0);
-      std::optional<DepthAttachment> depth =
-          render_target_data.render_target.GetDepthAttachment();
-      std::shared_ptr<Texture> depth_tex = depth ? depth->texture : nullptr;
-      return RenderTargetAllocator::CreateOffscreenMSAA(
-          context, size, mip_count, label, color_attachment_config,
-          stencil_attachment_config, color0.texture, color0.resolve_texture,
-          depth_tex);
+  if (cache_disabled_count_ == 0) {
+    for (RenderTargetData& render_target_data : render_target_data_) {
+      const RenderTargetConfig other_config = render_target_data.config;
+      if (!render_target_data.used_this_frame && other_config == config) {
+        render_target_data.used_this_frame = true;
+        render_target_data.keep_alive_frame_count = keep_alive_frame_count_;
+        ColorAttachment color0 =
+            render_target_data.render_target.GetColorAttachment(0);
+        std::optional<DepthAttachment> depth =
+            render_target_data.render_target.GetDepthAttachment();
+        std::shared_ptr<Texture> depth_tex = depth ? depth->texture : nullptr;
+        return RenderTargetAllocator::CreateOffscreenMSAA(
+            context, size, mip_count, label, color_attachment_config,
+            stencil_attachment_config, color0.texture, color0.resolve_texture,
+            depth_tex);
+      }
     }
   }
   RenderTarget created_target = RenderTargetAllocator::CreateOffscreenMSAA(

--- a/engine/src/flutter/impeller/entity/render_target_cache.h
+++ b/engine/src/flutter/impeller/entity/render_target_cache.h
@@ -29,10 +29,10 @@ class RenderTargetCache : public RenderTargetAllocator {
   void End() override;
 
   // |RenderTargetAllocator|
-  void Disable() override;
+  void DisableCache() override;
 
   // |RenderTargetAllocator|
-  void Enable() override;
+  void EnableCache() override;
 
   RenderTarget CreateOffscreen(
       const Context& context,

--- a/engine/src/flutter/impeller/entity/render_target_cache.h
+++ b/engine/src/flutter/impeller/entity/render_target_cache.h
@@ -72,6 +72,8 @@ class RenderTargetCache : public RenderTargetAllocator {
     RenderTarget render_target;
   };
 
+  bool CacheEnabled() const;
+
   std::vector<RenderTargetData> render_target_data_;
   uint32_t keep_alive_frame_count_;
   uint32_t cache_disabled_count_ = 0;

--- a/engine/src/flutter/impeller/entity/render_target_cache.h
+++ b/engine/src/flutter/impeller/entity/render_target_cache.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_ENTITY_RENDER_TARGET_CACHE_H_
 
 #include <string_view>
+
 #include "impeller/renderer/render_target.h"
 
 namespace impeller {
@@ -26,6 +27,12 @@ class RenderTargetCache : public RenderTargetAllocator {
 
   // |RenderTargetAllocator|
   void End() override;
+
+  // |RenderTargetAllocator|
+  void Disable() override;
+
+  // |RenderTargetAllocator|
+  void Enable() override;
 
   RenderTarget CreateOffscreen(
       const Context& context,
@@ -67,6 +74,7 @@ class RenderTargetCache : public RenderTargetAllocator {
 
   std::vector<RenderTargetData> render_target_data_;
   uint32_t keep_alive_frame_count_;
+  uint32_t cache_disabled_count_ = 0;
 
   RenderTargetCache(const RenderTargetCache&) = delete;
 

--- a/engine/src/flutter/impeller/geometry/sigma.h
+++ b/engine/src/flutter/impeller/geometry/sigma.h
@@ -21,7 +21,7 @@ namespace impeller {
 /// quality blurs (with exponentially diminishing returns for the same sigma
 /// input). Making this value any lower results in a noticable loss of
 /// quality in the blur.
-constexpr static float kKernelRadiusPerSigma = 1.73205080757;
+constexpr static float kKernelRadiusPerSigma = 1.73205080757f;
 
 struct Radius;
 

--- a/engine/src/flutter/impeller/renderer/render_target.h
+++ b/engine/src/flutter/impeller/renderer/render_target.h
@@ -177,6 +177,12 @@ class RenderTargetAllocator {
       const std::shared_ptr<Texture>& existing_color_resolve_texture = nullptr,
       const std::shared_ptr<Texture>& existing_depth_stencil_texture = nullptr);
 
+  /// @brief Disable the cache until another call to enable.
+  virtual void Disable() {}
+
+  /// @brief Re-enable the cache if disabled.
+  virtual void Enable() {}
+
   /// @brief Mark the beginning of a frame workload.
   ///
   ///       This may be used to reset any tracking state on whether or not a

--- a/engine/src/flutter/impeller/renderer/render_target.h
+++ b/engine/src/flutter/impeller/renderer/render_target.h
@@ -177,11 +177,11 @@ class RenderTargetAllocator {
       const std::shared_ptr<Texture>& existing_color_resolve_texture = nullptr,
       const std::shared_ptr<Texture>& existing_depth_stencil_texture = nullptr);
 
-  /// @brief Disable the cache until another call to enable.
-  virtual void Disable() {}
+  /// @brief Disable any caching until the next call to `EnabledCache`.
+  virtual void DisableCache() {}
 
-  /// @brief Re-enable the cache if disabled.
-  virtual void Enable() {}
+  /// @brief Re-enable any caching if disabled.
+  virtual void EnableCache() {}
 
   /// @brief Mark the beginning of a frame workload.
   ///

--- a/engine/src/flutter/impeller/typographer/text_frame.cc
+++ b/engine/src/flutter/impeller/typographer/text_frame.cc
@@ -146,6 +146,17 @@ bool TextFrame::IsFrameComplete() const {
   return bound_values_.size() == run_size;
 }
 
+Font TextFrame::GetFont() const {
+  return runs_[0].GetFont();
+}
+
+std::optional<Glyph> TextFrame::AsSingleGlyph() const {
+  if (runs_.size() == 1 && runs_[0].GetGlyphCount() == 1) {
+    return runs_[0].GetGlyphPositions()[0].glyph;
+  }
+  return std::nullopt;
+}
+
 const FrameBounds& TextFrame::GetFrameBounds(size_t index) const {
   FML_DCHECK(index < bound_values_.size());
   return bound_values_[index];

--- a/engine/src/flutter/impeller/typographer/text_frame.cc
+++ b/engine/src/flutter/impeller/typographer/text_frame.cc
@@ -146,7 +146,7 @@ bool TextFrame::IsFrameComplete() const {
   return bound_values_.size() == run_size;
 }
 
-Font TextFrame::GetFont() const {
+const Font& TextFrame::GetFont() const {
   return runs_[0].GetFont();
 }
 

--- a/engine/src/flutter/impeller/typographer/text_frame.h
+++ b/engine/src/flutter/impeller/typographer/text_frame.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include "impeller/geometry/rational.h"
+#include "impeller/typographer/glyph.h"
 #include "impeller/typographer/glyph_atlas.h"
 #include "impeller/typographer/text_run.h"
 
@@ -79,6 +80,13 @@ class TextFrame {
   ///
   /// This method is only valid if [IsFrameComplete] returns true.
   const FrameBounds& GetFrameBounds(size_t index) const;
+
+  /// @brief If this text frame contains a single glyph (such as for an Icon),
+  ///        then return it, otherwise std::nullopt.
+  std::optional<Glyph> AsSingleGlyph() const;
+
+  /// @brief Return the font of the first glyph run.
+  Font GetFont() const;
 
   /// @brief Store text frame scale, offset, and properties for hashing in th
   /// glyph atlas.

--- a/engine/src/flutter/impeller/typographer/text_frame.h
+++ b/engine/src/flutter/impeller/typographer/text_frame.h
@@ -86,7 +86,7 @@ class TextFrame {
   std::optional<Glyph> AsSingleGlyph() const;
 
   /// @brief Return the font of the first glyph run.
-  Font GetFont() const;
+  const Font& GetFont() const;
 
   /// @brief Store text frame scale, offset, and properties for hashing in th
   /// glyph atlas.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/164303
Fixes https://github.com/flutter/flutter/issues/165116

When rendering a text shadow, cache the resulting snapshot for at least one frame. Only attempts to content-aware hash for single glyphs (Icons). in other cases the exact layout may be different enough that its not worth trying to cache.