### PR TITLE
Move `.cxx` directory out of `android/app`

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -169,7 +169,7 @@ Future<void> main() async {
           throw TaskResult.failure('Producing unexpected build artifacts in $defaultPath');
         }
         if (!Directory(modifiedPath).existsSync()) {
-          throw TaskResult.failure('Not producing expected build artifacts');
+          throw TaskResult.failure('Not producing external native build output directory in $modifiedPath');
         }
       });
 

--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -155,12 +155,7 @@ Future<void> main() async {
 
         section('AGP cxx build artifacts');
 
-        final String defaultPath = path.join(
-          project.rootPath,
-          'android',
-          'app',
-          '.cxx',
-        );
+        final String defaultPath = path.join(project.rootPath, 'android', 'app', '.cxx');
 
         final String modifiedPath = path.join(
           project.rootPath,

--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -169,7 +169,9 @@ Future<void> main() async {
           throw TaskResult.failure('Producing unexpected build artifacts in $defaultPath');
         }
         if (!Directory(modifiedPath).existsSync()) {
-          throw TaskResult.failure('Not producing external native build output directory in $modifiedPath');
+          throw TaskResult.failure(
+            'Not producing external native build output directory in $modifiedPath',
+          );
         }
       });
 

--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -152,6 +152,30 @@ Future<void> main() async {
             throw TaskResult.failure("Shared library doesn't exist");
           }
         }
+
+        section('AGP cxx build artifacts');
+
+        final String defaultPath = path.join(
+          project.rootPath,
+          'android',
+          'app',
+          '.cxx',
+        );
+
+        final String modifiedPath = path.join(
+          project.rootPath,
+          'build',
+          'app',
+          'intermediates',
+          'flutter',
+          '.cxx',
+        );
+        if (Directory(defaultPath).existsSync()) {
+          throw TaskResult.failure('Producing unexpected build artifacts in $defaultPath');
+        }
+        if (!Directory(modifiedPath).existsSync()) {
+          throw TaskResult.failure('Not producing expected build artifacts');
+        }
       });
 
       return TaskResult.success(null);

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -610,8 +610,16 @@ object FlutterPluginUtils {
             "$flutterSdkRootPath/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt"
         )
 
-        // AGP defaults to outputting build artifacts in `android/app/.cxx`. Move these build
-        // artifacts out of the source directories and to Flutter's build directory.
+        // AGP defaults to outputting build artifacts in `android/app/.cxx`. This directory is a
+        // build artifact, so we move it from that directory to within Flutter's build directory
+        // to avoid polluting source directories with build artifacts.
+        //
+        // AGP explicitely recommends not setting the buildStagingDirectory to be within a build
+        // directory in
+        // https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/Cmake#buildStagingDirectory(kotlin.Any),
+        // but as we are not actually building anything (and are instead only tricking AGP into
+        // downloading the NDK), it is acceptable for the buildStagingDirectory to be removed
+        // and rebuilt when running clean builds.
         gradleProjectAndroidExtension.externalNativeBuild.cmake.buildStagingDirectory(
             gradleProject.layout.buildDirectory
                 .dir("${FlutterPluginConstants.INTERMEDIATES_DIR}/flutter/.cxx")

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -610,6 +610,15 @@ object FlutterPluginUtils {
             "$flutterSdkRootPath/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt"
         )
 
+        // AGP defaults to outputting build artifacts in `android/app/.cxx`. Move these build
+        // artifacts out of the source directories and to Flutter's build directory.
+        gradleProjectAndroidExtension.externalNativeBuild.cmake.buildStagingDirectory(
+            gradleProject.layout.buildDirectory
+                .dir("${FlutterPluginConstants.INTERMEDIATES_DIR}/flutter/.cxx")
+                .get()
+                .asFile.path
+        )
+
         // CMake will print warnings when you try to build an empty project.
         // These arguments silence the warnings - our project is intentionally
         // empty.


### PR DESCRIPTION
This is a build artifact, so move to `build/app/intermediates/flutter`.

See/ fixes https://github.com/flutter/flutter/issues/160372

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
