### PR TITLE
[android_engine_test] disable old HC mode tests.

### DIFF
--- a/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
@@ -44,29 +44,39 @@ void main() async {
     await flutterDriver.close();
   });
 
-  test('should screenshot and match a blue -> orange gradient', () async {
-    // TODO(matanlurey): Determining if this is a failure (the screen is always black on CI)
-    // or timing dependent (if we would have waited X more seconds it would have rendered).
-    // See:
-    // - Vulkan: https://github.com/flutter/flutter/issues/162362
-    // - OpenGLES: https://github.com/flutter/flutter/issues/162363
-    await expectLater(
-      nativeDriver.screenshot(),
-      matchesGoldenFileWithRetries('$goldenPrefix.blue_orange_gradient_portrait.png'),
-    );
-  }, timeout: Timeout.none, skip: 'https://github.com/flutter/flutter/issues/165032');
+  test(
+    'should screenshot and match a blue -> orange gradient',
+    () async {
+      // TODO(matanlurey): Determining if this is a failure (the screen is always black on CI)
+      // or timing dependent (if we would have waited X more seconds it would have rendered).
+      // See:
+      // - Vulkan: https://github.com/flutter/flutter/issues/162362
+      // - OpenGLES: https://github.com/flutter/flutter/issues/162363
+      await expectLater(
+        nativeDriver.screenshot(),
+        matchesGoldenFileWithRetries('$goldenPrefix.blue_orange_gradient_portrait.png'),
+      );
+    },
+    timeout: Timeout.none,
+    skip: 'https://github.com/flutter/flutter/issues/165032',
+  );
 
-  test('should rotate landscape and screenshot the gradient', () async {
-    await nativeDriver.rotateToLandscape();
-    await expectLater(
-      nativeDriver.screenshot(),
-      matchesGoldenFile('$goldenPrefix.blue_orange_gradient_landscape_rotated.png'),
-    );
+  test(
+    'should rotate landscape and screenshot the gradient',
+    () async {
+      await nativeDriver.rotateToLandscape();
+      await expectLater(
+        nativeDriver.screenshot(),
+        matchesGoldenFile('$goldenPrefix.blue_orange_gradient_landscape_rotated.png'),
+      );
 
-    await nativeDriver.rotateResetDefault();
-    await expectLater(
-      nativeDriver.screenshot(),
-      matchesGoldenFile('$goldenPrefix.blue_orange_gradient_portait_rotated_back.png'),
-    );
-  }, timeout: Timeout.none, skip: 'https://github.com/flutter/flutter/issues/165032');
+      await nativeDriver.rotateResetDefault();
+      await expectLater(
+        nativeDriver.screenshot(),
+        matchesGoldenFile('$goldenPrefix.blue_orange_gradient_portait_rotated_back.png'),
+      );
+    },
+    timeout: Timeout.none,
+    skip: 'https://github.com/flutter/flutter/issues/165032',
+  );
 }

--- a/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
@@ -58,7 +58,7 @@ void main() async {
       );
     },
     timeout: Timeout.none,
-    skip: 'https://github.com/flutter/flutter/issues/165032',
+    skip: true, // 'https://github.com/flutter/flutter/issues/165032'
   );
 
   test(
@@ -77,6 +77,6 @@ void main() async {
       );
     },
     timeout: Timeout.none,
-    skip: 'https://github.com/flutter/flutter/issues/165032',
+    skip: true, // https://github.com/flutter/flutter/issues/165032
   );
 }

--- a/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/platform_view/hybrid_composition_platform_view_main_test.dart
@@ -54,7 +54,7 @@ void main() async {
       nativeDriver.screenshot(),
       matchesGoldenFileWithRetries('$goldenPrefix.blue_orange_gradient_portrait.png'),
     );
-  }, timeout: Timeout.none);
+  }, timeout: Timeout.none, skip: 'https://github.com/flutter/flutter/issues/165032');
 
   test('should rotate landscape and screenshot the gradient', () async {
     await nativeDriver.rotateToLandscape();
@@ -68,5 +68,5 @@ void main() async {
       nativeDriver.screenshot(),
       matchesGoldenFile('$goldenPrefix.blue_orange_gradient_portait_rotated_back.png'),
     );
-  }, timeout: Timeout.none);
+  }, timeout: Timeout.none, skip: 'https://github.com/flutter/flutter/issues/165032');
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/165032

These tests are flaky due to existing bugs in old HC mode.