### PR TITLE
Remove unnecessary cache busting mechanism in hot restart

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -147,10 +147,6 @@ class WebAssetServer implements AssetReader {
   final Map<String, String> _modules;
   final Map<String, String> _digests;
 
-  // The generation number that maps to the number of hot restarts. This is used
-  // to suffix a query to source paths in order to cache-bust.
-  int _hotRestartGeneration = 0;
-
   int get selectedPort => _httpServer.port;
 
   /// Given a list of [modules] that need to be loaded, compute module names and
@@ -180,14 +176,13 @@ class WebAssetServer implements AssetReader {
       _modules[name] = path;
       _digests[name] = _webMemoryFS.files[moduleName].hashCode.toString();
     }
-    if (writeRestartScripts && _hotRestartGeneration > 0) {
+    if (writeRestartScripts) {
       final List<Map<String, String>> srcIdsList = <Map<String, String>>[];
       for (final String src in modules) {
-        srcIdsList.add(<String, String>{'src': '$src?gen=$_hotRestartGeneration', 'id': src});
+        srcIdsList.add(<String, String>{'src': src, 'id': src});
       }
       writeFile('restart_scripts.json', json.encode(srcIdsList));
     }
-    _hotRestartGeneration++;
   }
 
   static const String _reloadScriptsFileName = 'reload_scripts.json';
@@ -1179,7 +1174,10 @@ class WebDevFS implements DevFS {
       throwToolExit('Failed to load recompiled sources:\n$err');
     }
     if (fullRestart) {
-      webAssetServer.performRestart(modules, writeRestartScripts: ddcModuleSystem);
+      webAssetServer.performRestart(
+        modules,
+        writeRestartScripts: ddcModuleSystem && !bundleFirstUpload,
+      );
     } else {
       webAssetServer.performReload(modules);
     }

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -269,11 +269,6 @@ $_simpleLoaderScript
               if (script.id == null) continue;
               var src = _currentDirectory + script.src.toString();
               var oldSrc = window.\$dartLoader.moduleIdToUrl.get(script.id);
-              // Only compare the search parameters which contain the cache
-              // busting portion of the uri. The path might be different if the
-              // script is loaded from a different application on the page.
-              if (window.\$dartLoader.moduleIdToUrl.has(script.id) &&
-                  new URL(oldSrc).search == new URL(src).search) continue;
 
               // We might actually load from a different uri, delete the old one
               // just to be sure.


### PR DESCRIPTION
In the case of a multi-app scenario, different applications may store files in different locations. In order to avoid reloading files that were unchanged, a suffix can be added to indicate which "version" of this file we're loading. Even if it has a different path, because the id and "version" (which is URL(...).search) are the same, the file would not be reloaded.

With Flutter tools, this scenario doesn't occur. The running application ultimately does not need to worry about the same file in different locations.

The benefit to avoid this caching is that the user only ever sees one copy of every file, which is the latest version, instead of the current behavior where a "gen=N" suffix is added to a newer version.

Note that this is unrelated to the XHR or its headers or any of its caching mechanisms. The XHR is only used to fetch the *list* of changed files, not the files themselves. The files get loaded as part of the `appendChild` call.

https://github.com/flutter/flutter/issues/166294

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
