### PR TITLE
Fix TreeSliver rendering offset.

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_tree.dart
+++ b/packages/flutter/lib/src/rendering/sliver_tree.dart
@@ -332,7 +332,8 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
       while (child != null && indexOf(child) <= index) {
         final double mainAxisDelta = childMainAxisPosition(child);
         final TreeSliverNodeParentData parentData = child.parentData! as TreeSliverNodeParentData;
-        final Offset childOffset = Offset(parentData.depth * indentation, parentData.layoutOffset!);
+        final Offset childOffset =
+            Offset(parentData.depth * indentation, parentData.layoutOffset!) + offset;
 
         // If the child's visible interval (mainAxisDelta, mainAxisDelta + paintExtentOf(child))
         // does not intersect the paint extent interval (0, constraints.remainingPaintExtent), it's hidden.

--- a/packages/flutter/test/widgets/sliver_tree_test.dart
+++ b/packages/flutter/test/widgets/sliver_tree_test.dart
@@ -861,4 +861,43 @@ void main() {
       });
     },
   );
+
+  testWidgets('TreeSliver and PinnedHeaderSliver can render correctly when used together.', (
+    WidgetTester tester,
+  ) async {
+    const ValueKey<String> key = ValueKey<String>('sliver_tree_pined_header');
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: RepaintBoundary(
+            key: key,
+            child: SizedBox(
+              height: 20,
+              width: 20,
+              child: CustomScrollView(
+                slivers: <Widget>[
+                  const PinnedHeaderSliver(child: SizedBox(height: 10)),
+                  TreeSliver<Object>(
+                    tree: <TreeSliverNode<Object>>[TreeSliverNode<Object>(Object())],
+                    treeRowExtentBuilder: (_, _) => 10,
+                    treeNodeBuilder: (
+                      BuildContext context,
+                      TreeSliverNode<Object?> node,
+                      AnimationStyle animationStyle,
+                    ) {
+                      return const ColoredBox(color: Colors.red);
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await expectLater(find.byKey(key), matchesGoldenFile('sliver_tree.pined_header.0.png'));
+    expect(tester.getTopLeft(find.byType(ColoredBox)), const Offset(0, 10));
+  });
 }

--- a/packages/flutter/test/widgets/sliver_tree_test.dart
+++ b/packages/flutter/test/widgets/sliver_tree_test.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This file is run as part of a reduced test set in CI on Mac and Windows
+// machines.
+@Tags(<String>['reduced-test-set'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Fixes: #166326

The issue lies only in the `paint` method, and there are no problems with `tester.getTopLeft`. Therefore, I used a golden file test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
