### PR TITLE
[Impeller] set correct depth for emulated advanced blend restore.

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_blend_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blend_unittests.cc
@@ -928,7 +928,6 @@ TEST_P(AiksTest, EmulatedAdvancedBlendRestore) {
 
   builder.DrawPaint(DlPaint(DlColor::kWhite()));
   builder.Save();
-  builder.ClipRect(DlRect::MakeLTRB(101, 101, 399, 301));
   builder.ClipRect(DlRect::MakeLTRB(100, 100, 400, 300));
 
   // Draw should apply the clip, even though it is an advanced blend.

--- a/engine/src/flutter/impeller/display_list/aiks_dl_blend_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blend_unittests.cc
@@ -923,5 +923,26 @@ TEST_P(AiksTest, AdvancedBlendColorFilterWithDestinationOpacity) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(AiksTest, EmulatedAdvancedBlendRestore) {
+  DisplayListBuilder builder;
+
+  builder.DrawPaint(DlPaint(DlColor::kWhite()));
+  builder.Save();
+  builder.ClipRect(DlRect::MakeLTRB(101, 101, 399, 301));
+  builder.ClipRect(DlRect::MakeLTRB(100, 100, 400, 300));
+
+  // Draw should apply the clip, even though it is an advanced blend.
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 400, 300),
+                   DlPaint()
+                       .setColor(DlColor::kRed())
+                       .setBlendMode(DlBlendMode::kDifference));
+  // This color should not show if clip is still functional.
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100),
+                   DlPaint().setColor(DlColor::kBlue()));
+  builder.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1658,9 +1658,6 @@ void Canvas::AddRenderEntityToCurrentPass(Entity& entity, bool reuse_depth) {
     }
   }
 
-  if (!reuse_depth) {
-    ++current_depth_;
-  }
   // We can render at a depth up to and including the depth of the currently
   // active clips and we will still be clipped out, but we cannot render at
   // a depth that is greater than the current clips or we will not be clipped.
@@ -1681,7 +1678,9 @@ void Canvas::AddRenderEntityToCurrentPass(Entity& entity, bool reuse_depth) {
       // to the render target texture so far need to execute before it's bound
       // for blending (otherwise the blend pass will end up executing before
       // all the previous commands in the active pass).
-      auto input_texture = FlipBackdrop(GetGlobalPassPosition());
+      auto input_texture = FlipBackdrop(GetGlobalPassPosition(),  //
+                                        /*should_remove_texture=*/false,
+                                        /*should_use_onscreen=*/false);
       if (!input_texture) {
         return;
       }
@@ -1702,6 +1701,10 @@ void Canvas::AddRenderEntityToCurrentPass(Entity& entity, bool reuse_depth) {
       entity.SetContents(std::move(contents));
       entity.SetBlendMode(BlendMode::kSrc);
     }
+  }
+
+  if (!reuse_depth) {
+    ++current_depth_;
   }
 
   const std::shared_ptr<RenderPass>& result =

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -337,7 +337,8 @@ class Canvas {
   /// supports framebuffer fetch.
   std::shared_ptr<Texture> FlipBackdrop(Point global_pass_position,
                                         bool should_remove_texture = false,
-                                        bool should_use_onscreen = false);
+                                        bool should_use_onscreen = false,
+                                        bool post_depth_increment = false);
 
   bool BlitToOnscreen(bool is_onscreen = false);
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -665,7 +665,7 @@ bool CapabilitiesVK::SupportsTextureToTextureBlits() const {
 
 // |Capabilities|
 bool CapabilitiesVK::SupportsFramebufferFetch() const {
-  return has_framebuffer_fetch_;
+  return false;
 }
 
 // |Capabilities|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -665,7 +665,7 @@ bool CapabilitiesVK::SupportsTextureToTextureBlits() const {
 
 // |Capabilities|
 bool CapabilitiesVK::SupportsFramebufferFetch() const {
-  return false;
+  return supports_framebuffer_fetch_;
 }
 
 // |Capabilities|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -665,7 +665,7 @@ bool CapabilitiesVK::SupportsTextureToTextureBlits() const {
 
 // |Capabilities|
 bool CapabilitiesVK::SupportsFramebufferFetch() const {
-  return supports_framebuffer_fetch_;
+  return has_framebuffer_fetch_;
 }
 
 // |Capabilities|


### PR DESCRIPTION
For emulated advanced blends, the depth value is off by one. When use flip backdrop for saveLayers, we call it before we increment the depth. When we call it for draws (to do an emulated advanced blend), we call it after we've incremented the depth. Correct this with a bool parameter.