### PR TITLE
[macOS] Enable merged platform and UI thread by default

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -681,7 +681,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 
   flutterArguments.engine_id = reinterpret_cast<int64_t>((__bridge void*)self);
 
-  BOOL mergedPlatformUIThread = NO;
+  BOOL mergedPlatformUIThread = YES;
   NSNumber* enableMergedPlatformUIThread =
       [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTEnableMergedPlatformUIThread"];
   if (enableMergedPlatformUIThread != nil) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -150,18 +150,18 @@ TEST_F(FlutterEngineTest, HasNonNullExecutableName) {
   ASSERT_FALSE(executable_name.empty());
 
   // Block until notified by the Dart test of the value of Platform.executable.
-  BOOL signalled = NO;
+  BOOL signaled = NO;
   AddNativeCallback("NotifyStringValue", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
                       const auto dart_string = tonic::DartConverter<std::string>::FromDart(
                           Dart_GetNativeArgument(args, 0));
                       EXPECT_EQ(executable_name, dart_string);
-                      signalled = YES;
+                      signaled = YES;
                     }));
 
   // Launch the test entrypoint.
   EXPECT_TRUE([engine runWithEntrypoint:@"executableNameNotNull"]);
 
-  while (!signalled) {
+  while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, YES);
   }
 }
@@ -205,9 +205,9 @@ TEST_F(FlutterEngineTest, MessengerSend) {
 
 TEST_F(FlutterEngineTest, CanLogToStdout) {
   // Block until completion of print statement.
-  BOOL signalled = NO;
+  BOOL signaled = NO;
   AddNativeCallback("SignalNativeTest",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { signalled = YES; }));
+                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { signaled = YES; }));
 
   // Replace stdout stream buffer with our own.
   StreamCapture stdout_capture(&std::cout);
@@ -217,7 +217,7 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
   EXPECT_TRUE([engine runWithEntrypoint:@"canLogToStdout"]);
   ASSERT_TRUE(engine.running);
 
-  while (!signalled) {
+  while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, YES);
   }
 
@@ -231,7 +231,7 @@ TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {
   FlutterEngine* engine = GetFlutterEngine();
 
   // Latch to ensure the entire layer tree has been generated and presented.
-  BOOL signalled = NO;
+  BOOL signaled = NO;
   AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
                       CALayer* rootLayer = engine.viewController.flutterView.layer;
                       EXPECT_TRUE(rootLayer.backgroundColor != nil);
@@ -240,7 +240,7 @@ TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {
                             [NSColor colorWithCGColor:rootLayer.backgroundColor];
                         EXPECT_EQ(actualBackgroundColor, [NSColor blackColor]);
                       }
-                      signalled = YES;
+                      signaled = YES;
                     }));
 
   // Launch the test entrypoint.
@@ -253,7 +253,7 @@ TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {
   [viewController loadView];
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
 
-  while (!signalled) {
+  while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, YES);
   }
 }
@@ -262,7 +262,7 @@ TEST_F(FlutterEngineTest, DISABLED_CanOverrideBackgroundColor) {
   FlutterEngine* engine = GetFlutterEngine();
 
   // Latch to ensure the entire layer tree has been generated and presented.
-  BOOL signalled = NO;
+  BOOL signaled = NO;
   AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
                       CALayer* rootLayer = engine.viewController.flutterView.layer;
                       EXPECT_TRUE(rootLayer.backgroundColor != nil);
@@ -271,7 +271,7 @@ TEST_F(FlutterEngineTest, DISABLED_CanOverrideBackgroundColor) {
                             [NSColor colorWithCGColor:rootLayer.backgroundColor];
                         EXPECT_EQ(actualBackgroundColor, [NSColor whiteColor]);
                       }
-                      signalled = YES;
+                      signaled = YES;
                     }));
 
   // Launch the test entrypoint.
@@ -285,7 +285,7 @@ TEST_F(FlutterEngineTest, DISABLED_CanOverrideBackgroundColor) {
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
   viewController.flutterView.backgroundColor = [NSColor whiteColor];
 
-  while (!signalled) {
+  while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, YES);
   }
 }
@@ -879,7 +879,7 @@ TEST_F(FlutterEngineTest, ResponseFromBackgroundThread) {
 TEST_F(FlutterEngineTest, CanGetEngineForId) {
   FlutterEngine* engine = GetFlutterEngine();
 
-  BOOL signalled = NO;
+  BOOL signaled = NO;
   std::optional<int64_t> engineId;
   AddNativeCallback("NotifyEngineId", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
                       const auto argument = Dart_GetNativeArgument(args, 0);
@@ -887,11 +887,11 @@ TEST_F(FlutterEngineTest, CanGetEngineForId) {
                         const auto id = tonic::DartConverter<int64_t>::FromDart(argument);
                         engineId = id;
                       }
-                      signalled = YES;
+                      signaled = YES;
                     }));
 
   EXPECT_TRUE([engine runWithEntrypoint:@"testEngineId"]);
-  while (!signalled) {
+  while (!signaled) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, YES);
   }
 


### PR DESCRIPTION
This enables running UI isolate on platform thread by default.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
