### PR TITLE
Disable firefox image_to_byte_data_test as a group.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -384,7 +384,6 @@ targets:
       cores: "8"
 
   - name: Linux linux_web_engine_tests
-    bringup: true # https://github.com/flutter/flutter/issues/165610 - Ubuntu 24.04 + Firefox
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:

--- a/engine/src/flutter/lib/web_ui/test/engine/image_to_byte_data_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/image_to_byte_data_test.dart
@@ -16,39 +16,38 @@ void main() {
 }
 
 Future<void> testMain() async {
-  setUpUnitTests();
+  group('toByteData test', () {
+    setUpUnitTests();
 
-  Future<Image> createTestImageByColor(Color color) async {
-    final PictureRecorder recorder = PictureRecorder();
-    final Canvas canvas = Canvas(recorder, const Rect.fromLTRB(0, 0, 2, 2));
-    canvas.drawColor(color, BlendMode.srcOver);
-    final Picture testPicture = recorder.endRecording();
-    final Image testImage = await testPicture.toImage(2, 2);
-    return testImage;
-  }
+    Future<Image> createTestImageByColor(Color color) async {
+      final PictureRecorder recorder = PictureRecorder();
+      final Canvas canvas = Canvas(recorder, const Rect.fromLTRB(0, 0, 2, 2));
+      canvas.drawColor(color, BlendMode.srcOver);
+      final Picture testPicture = recorder.endRecording();
+      final Image testImage = await testPicture.toImage(2, 2);
+      return testImage;
+    }
 
-  test('Picture.toImage().toByteData()', () async {
-    final Image testImage = await createTestImageByColor(const Color(0xFFCCDD00));
+    test('Picture.toImage().toByteData()', () async {
+      final Image testImage = await createTestImageByColor(const Color(0xFFCCDD00));
 
-    final ByteData bytes = (await testImage.toByteData())!;
-    expect(bytes.buffer.asUint32List(), <int>[0xFF00DDCC, 0xFF00DDCC, 0xFF00DDCC, 0xFF00DDCC]);
+      final ByteData bytes = (await testImage.toByteData())!;
+      expect(bytes.buffer.asUint32List(), <int>[0xFF00DDCC, 0xFF00DDCC, 0xFF00DDCC, 0xFF00DDCC]);
 
-    final ByteData pngBytes = (await testImage.toByteData(format: ImageByteFormat.png))!;
+      final ByteData pngBytes = (await testImage.toByteData(format: ImageByteFormat.png))!;
 
-    // PNG-encoding is browser-specific, but the header is standard. We only
-    // test the header.
-    final List<int> pngHeader = <int>[137, 80, 78, 71, 13, 10, 26, 10];
-    expect(pngBytes.buffer.asUint8List().sublist(0, pngHeader.length), pngHeader);
+      // PNG-encoding is browser-specific, but the header is standard. We only
+      // test the header.
+      final List<int> pngHeader = <int>[137, 80, 78, 71, 13, 10, 26, 10];
+      expect(pngBytes.buffer.asUint8List().sublist(0, pngHeader.length), pngHeader);
+    });
 
-    // Firefox does not support WebGL in headless mode.
-  }, skip: isFirefox);
+    test('Image.toByteData(format: ImageByteFormat.rawStraightRgba)', () async {
+      final Image testImage = await createTestImageByColor(const Color(0xAAFFFF00));
 
-  test('Image.toByteData(format: ImageByteFormat.rawStraightRgba)', () async {
-    final Image testImage = await createTestImageByColor(const Color(0xAAFFFF00));
-
-    final ByteData bytes = (await testImage.toByteData(format: ImageByteFormat.rawStraightRgba))!;
-    expect(bytes.buffer.asUint32List(), <int>[0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF]);
-
+      final ByteData bytes = (await testImage.toByteData(format: ImageByteFormat.rawStraightRgba))!;
+      expect(bytes.buffer.asUint32List(), <int>[0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF]);
+    });
     // Firefox does not support WebGL in headless mode.
   }, skip: isFirefox);
 }


### PR DESCRIPTION
Grouping allows us to avoid running the setup function when the tests are skipped, and the setup function is where it was actually stalling. Skipping as a group seems to avoid this problem.

We can turn `bringup: true` off of the web unit tests now.