### PR TITLE
Unbreak presubmit for stable 

### DIFF
--- a/engine/src/flutter/lib/web_ui/test/engine/image_to_byte_data_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/image_to_byte_data_test.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/ui.dart';
 
 import '../common/test_initialization.dart';
@@ -39,12 +40,16 @@ Future<void> testMain() async {
     // test the header.
     final List<int> pngHeader = <int>[137, 80, 78, 71, 13, 10, 26, 10];
     expect(pngBytes.buffer.asUint8List().sublist(0, pngHeader.length), pngHeader);
-  });
+
+    // Firefox does not support WebGL in headless mode.
+  }, skip: isFirefox);
 
   test('Image.toByteData(format: ImageByteFormat.rawStraightRgba)', () async {
     final Image testImage = await createTestImageByColor(const Color(0xAAFFFF00));
 
     final ByteData bytes = (await testImage.toByteData(format: ImageByteFormat.rawStraightRgba))!;
     expect(bytes.buffer.asUint32List(), <int>[0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF]);
-  });
+
+    // Firefox does not support WebGL in headless mode.
+  }, skip: isFirefox);
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/image_to_byte_data_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/image_to_byte_data_test.dart
@@ -17,39 +17,38 @@ void main() {
 }
 
 Future<void> testMain() async {
-  setUpImplicitView();
+  group('toByteData test', () {
+    setUpUnitTests();
 
-  Future<Image> createTestImageByColor(Color color) async {
-    final EnginePictureRecorder recorder = EnginePictureRecorder();
-    final RecordingCanvas canvas = recorder.beginRecording(const Rect.fromLTRB(0, 0, 2, 2));
-    canvas.drawColor(color, BlendMode.srcOver);
-    final Picture testPicture = recorder.endRecording();
-    final Image testImage = await testPicture.toImage(2, 2);
-    return testImage;
-  }
+    Future<Image> createTestImageByColor(Color color) async {
+      final PictureRecorder recorder = PictureRecorder();
+      final Canvas canvas = Canvas(recorder, const Rect.fromLTRB(0, 0, 2, 2));
+      canvas.drawColor(color, BlendMode.srcOver);
+      final Picture testPicture = recorder.endRecording();
+      final Image testImage = await testPicture.toImage(2, 2);
+      return testImage;
+    }
 
-  test('Picture.toImage().toByteData()', () async {
-    final Image testImage = await createTestImageByColor(const Color(0xFFCCDD00));
+    test('Picture.toImage().toByteData()', () async {
+      final Image testImage = await createTestImageByColor(const Color(0xFFCCDD00));
 
-    final ByteData bytes = (await testImage.toByteData())!;
-    expect(bytes.buffer.asUint32List(), <int>[0xFF00DDCC, 0xFF00DDCC, 0xFF00DDCC, 0xFF00DDCC]);
+      final ByteData bytes = (await testImage.toByteData())!;
+      expect(bytes.buffer.asUint32List(), <int>[0xFF00DDCC, 0xFF00DDCC, 0xFF00DDCC, 0xFF00DDCC]);
 
-    final ByteData pngBytes = (await testImage.toByteData(format: ImageByteFormat.png))!;
+      final ByteData pngBytes = (await testImage.toByteData(format: ImageByteFormat.png))!;
 
-    // PNG-encoding is browser-specific, but the header is standard. We only
-    // test the header.
-    final List<int> pngHeader = <int>[137, 80, 78, 71, 13, 10, 26, 10];
-    expect(pngBytes.buffer.asUint8List().sublist(0, pngHeader.length), pngHeader);
+      // PNG-encoding is browser-specific, but the header is standard. We only
+      // test the header.
+      final List<int> pngHeader = <int>[137, 80, 78, 71, 13, 10, 26, 10];
+      expect(pngBytes.buffer.asUint8List().sublist(0, pngHeader.length), pngHeader);
+    });
 
-    // Firefox does not support WebGL in headless mode.
-  }, skip: isFirefox);
+    test('Image.toByteData(format: ImageByteFormat.rawStraightRgba)', () async {
+      final Image testImage = await createTestImageByColor(const Color(0xAAFFFF00));
 
-  test('Image.toByteData(format: ImageByteFormat.rawStraightRgba)', () async {
-    final Image testImage = await createTestImageByColor(const Color(0xAAFFFF00));
-
-    final ByteData bytes = (await testImage.toByteData(format: ImageByteFormat.rawStraightRgba))!;
-    expect(bytes.buffer.asUint32List(), <int>[0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF]);
-
+      final ByteData bytes = (await testImage.toByteData(format: ImageByteFormat.rawStraightRgba))!;
+      expect(bytes.buffer.asUint32List(), <int>[0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF]);
+    });
     // Firefox does not support WebGL in headless mode.
   }, skip: isFirefox);
 }

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -965,7 +965,7 @@ def uses_package_test_runner(package):
 #
 # The second element of each tuple is a list of additional command line
 # arguments to pass to each of the packages tests.
-def build_dart_host_test_list(build_dir):
+def build_dart_host_test_list():
   dart_host_tests = [
       os.path.join('flutter', 'ci'),
       os.path.join('flutter', 'flutter_frontend_server'),
@@ -1335,7 +1335,7 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
 
   if 'dart-host' in types:
     dart_filter = args.dart_host_filter.split(',') if args.dart_host_filter else None
-    dart_host_packages = build_dart_host_test_list(build_dir)
+    dart_host_packages = build_dart_host_test_list()
     tasks = []
     for dart_host_package in dart_host_packages:
       if dart_filter is None or dart_host_package in dart_filter:

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -983,8 +983,6 @@ def build_dart_host_test_list():
       os.path.join('flutter', 'tools', 'pkg', 'engine_repo_tools'),
       os.path.join('flutter', 'tools', 'pkg', 'git_repo_tools'),
   ]
-  if not is_asan(build_dir):
-    dart_host_tests += [os.path.join('flutter', 'tools', 'path_ops', 'dart')]
 
   return dart_host_tests
 


### PR DESCRIPTION
Similar to https://github.com/flutter/flutter/pull/166438 

Fixes #66553

Cherry pick the following prs to hopefully fix pre/post submits against 3.29. 

* https://github.com/flutter/flutter/pull/165692
* https://github.com/flutter/flutter/pull/165675
* https://github.com/flutter/flutter/pull/165678
* https://github.com/flutter/flutter/pull/166559
* Does not include https://github.com/flutter/flutter/pull/165818

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

