### PR TITLE
flush UI tasks when shutting down shell if threads are merged.

### DIFF
--- a/engine/src/flutter/fml/message_loop.cc
+++ b/engine/src/flutter/fml/message_loop.cc
@@ -11,7 +11,6 @@
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/task_runner.h"
-#include "fml/message_loop_task_queues.h"
 
 namespace fml {
 

--- a/engine/src/flutter/fml/message_loop.cc
+++ b/engine/src/flutter/fml/message_loop.cc
@@ -11,6 +11,7 @@
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/task_runner.h"
+#include "fml/message_loop_task_queues.h"
 
 namespace fml {
 

--- a/engine/src/flutter/fml/message_loop_impl.h
+++ b/engine/src/flutter/fml/message_loop_impl.h
@@ -51,6 +51,8 @@ class MessageLoopImpl : public Wakeable,
 
   virtual TaskQueueId GetTaskQueueId() const;
 
+  void FlushTasks(FlushType type);
+
  protected:
   // Exposed for the embedder shell which allows clients to poll for events
   // instead of dedicating a thread to the message loop.
@@ -68,8 +70,6 @@ class MessageLoopImpl : public Wakeable,
   TaskQueueId queue_id_;
 
   std::atomic_bool terminated_;
-
-  void FlushTasks(FlushType type);
 
   FML_DISALLOW_COPY_AND_ASSIGN(MessageLoopImpl);
 };

--- a/engine/src/flutter/fml/task_runner.cc
+++ b/engine/src/flutter/fml/task_runner.cc
@@ -79,4 +79,8 @@ void TaskRunner::RunNowAndFlushMessages(
   }
 }
 
+void TaskRunner::FlushAllTasks() {
+  loop_->FlushTasks(FlushType::kAll);
+}
+
 }  // namespace fml

--- a/engine/src/flutter/fml/task_runner.h
+++ b/engine/src/flutter/fml/task_runner.h
@@ -73,6 +73,8 @@ class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner>,
   static void RunNowAndFlushMessages(const fml::RefPtr<fml::TaskRunner>& runner,
                                      const fml::closure& task);
 
+  void FlushAllTasks();
+
  protected:
   explicit TaskRunner(fml::RefPtr<MessageLoopImpl> loop);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/166410

With merged threads, shell shutdown can't run at the same time as UI tasks that may retain vulkan resources. Explicitly flush UI tasks when shutting down with merged threads so that these tasks are guarnateed to complete before we tear down vulkan context.
