### PR TITLE
[Impeller] fix image shader matrix to 3x3.

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -938,6 +938,7 @@ TEST_P(AiksTest, ImageColorSourceEffectTransform) {
 
   // Scale
   {
+    builder.Save();
     builder.Translate(100, 0);
     builder.Scale(100, 100);
     DlPaint paint;
@@ -948,6 +949,23 @@ TEST_P(AiksTest, ImageColorSourceEffectTransform) {
         DlImageSampling::kNearestNeighbor, &matrix));
 
     builder.DrawRect(DlRect::MakeLTRB(0, 0, 1, 1), paint);
+    builder.Restore();
+  }
+
+  // Perspective
+  {
+    builder.Save();
+    builder.Translate(150, 150);
+    DlPaint paint;
+
+    DlMatrix matrix =
+        DlMatrix::MakePerspective(Radians{0.5}, ISize{200, 200}, 0.05, 1);
+    paint.setColorSource(DlColorSource::MakeImage(
+        texture, DlTileMode::kRepeat, DlTileMode::kRepeat,
+        DlImageSampling::kNearestNeighbor, &matrix));
+
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 200, 200), paint);
+    builder.Restore();
   }
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));

--- a/engine/src/flutter/impeller/display_list/paint.cc
+++ b/engine/src/flutter/impeller/display_list/paint.cc
@@ -197,7 +197,8 @@ std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
           image_color_source->vertical_tile_mode());
       auto sampler_descriptor =
           skia_conversions::ToSamplerDescriptor(image_color_source->sampling());
-      auto effect_transform = image_color_source->matrix();
+      // See https://github.com/flutter/flutter/issues/165205
+      flutter::DlMatrix effect_transform = image_color_source->matrix().To3x3();
 
       auto contents = std::make_shared<TiledTextureContents>();
       contents->SetOpacityFactor(color.alpha);

--- a/engine/src/flutter/impeller/geometry/matrix.h
+++ b/engine/src/flutter/impeller/geometry/matrix.h
@@ -247,6 +247,19 @@ struct Matrix {
     // clang-format on
   }
 
+  // Converts the second row/col to identity to make this an equivalent
+  // to a Skia 3x3 Matrix.
+  constexpr Matrix To3x3() const {
+    // clang-format off
+    return Matrix(
+      m[0], m[1], 0,  m[3],
+      m[4], m[5], 0,  m[7],
+      0, 0, 1, 0,
+      m[12], m[13], 0, m[15]
+    );
+    // clang-format on
+  }
+
   constexpr Matrix Translate(const Vector3& t) const {
     // clang-format off
     return Matrix(m[0], m[1], m[2], m[3],

--- a/engine/src/flutter/impeller/geometry/matrix_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/matrix_unittests.cc
@@ -313,5 +313,14 @@ TEST(MatrixTest, MakeScaleTranslate) {
       Matrix::MakeTranslation({0, 0, 0}) * Matrix::MakeScale({0, 0, 0})));
 }
 
+TEST(MatrixTest, To3x3) {
+  Matrix x(1.0, 0.0, 4.0, 0.0,    //
+           0.0, 1.0, 4.0, 0.0,    //
+           6.0, 5.0, 111.0, 7.0,  //
+           0.0, 0.0, 9.0, 1.0);
+
+  EXPECT_TRUE(MatrixNear(x.To3x3(), Matrix()));
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/165205

Our users expect image shader matrices to be converted to 3x3