### PR TITLE
[web] Fixes for some text editing tests on Safari

### DIFF
--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -857,6 +857,17 @@ Future<void> testMain() async {
       const show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
 
+      // The "setSizeAndTransform" message has to be here before we call
+      // checkInputEditingState, since on some platforms (e.g. Desktop Safari)
+      // we don't put the input element into the DOM until we get its correct
+      // dimensions from the framework.
+      final MethodCall setSizeAndTransform = configureSetSizeAndTransformMethodCall(
+        150,
+        50,
+        Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+      );
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
+
       // Form elements
       {
         final formElement = textEditing!.configuration!.autofillGroup!.formElement;
@@ -3627,7 +3638,7 @@ Future<void> testMain() async {
 
     test('Multi-line text area scrollbars are zero-width', () {
       expect(createMultilineTextArea().style.scrollbarWidth, 'none');
-    });
+    }, skip: isSafari);
   });
 }
 


### PR DESCRIPTION
* Add a setSizeAndTransform call which is required to position the input element on Safari
* Disable a test that uses CSS scrollbar-width, which is not supported by the Safari version on the bots

See https://github.com/flutter/flutter/pull/166565