### PR TITLE
Fix CupertinoSwitch intermediate toggle behavior

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -567,10 +567,18 @@ class _CupertinoSwitchState extends State<CupertinoSwitch>
         ..curve = Curves.linear
         ..reverseCurve = Curves.linear;
       final double delta = details.primaryDelta! / _trackInnerLength;
-      positionController.value += switch (Directionality.of(context)) {
+      final double newDelta = switch (Directionality.of(context)) {
         TextDirection.rtl => -delta,
         TextDirection.ltr => delta,
       };
+
+      final double newPosition = positionController.value + newDelta;
+
+      if ((widget.value && newPosition < 0.5) || (!widget.value && newPosition > 0.5)) {
+        widget.onChanged?.call(!widget.value);
+      } else {
+        positionController.value += newDelta;
+      }
     }
   }
 

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -4188,6 +4188,54 @@ void main() {
 
     expect(tester.getSize(find.byType(Switch)), const Size(60.0, 56.0));
   });
+
+  testWidgets('CupertinoSwitch should not stay in intermediate position during drag', (
+    WidgetTester tester,
+  ) async {
+    bool value = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Center(
+              child: CupertinoSwitch(
+                value: value,
+                onChanged: (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(value, isFalse);
+
+    final Rect switchRect = tester.getRect(find.byType(CupertinoSwitch));
+
+    final TestGesture gesture = await tester.startGesture(switchRect.centerLeft);
+    await gesture.moveBy(Offset(switchRect.width * 0.6, 0.0));
+    await tester.pump();
+
+    expect(value, isTrue);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(value, isTrue);
+
+    final TestGesture gesture2 = await tester.startGesture(switchRect.centerRight);
+    await gesture2.moveBy(Offset(-switchRect.width * 0.6, 0.0));
+    await tester.pump();
+
+    expect(value, isFalse);
+
+    await gesture2.up();
+    await tester.pumpAndSettle();
+    expect(value, isFalse);
+  });
 }
 
 class DelayedImageProvider extends ImageProvider<DelayedImageProvider> {


### PR DESCRIPTION
#### Fixes #166485

This PR fixes the issue where CupertinoSwitch can be held in an intermediate position during drag, which is inconsistent with native iOS behavior. The native iOS switch immediately snaps to one side when crossing the middle threshold.

The fix prevents the thumb from staying in middle positions by toggling the switch value as soon as the drag crosses the middle threshold (50%).

Added a test that verifies both directions (on->off, off->on) properly toggle when crossing the center point during drag.


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.