### PR TITLE
🌟  [Proposal][ListTile]: Add WidgetStatesController for interactive state management 🌟 

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -425,6 +425,7 @@ class ListTile extends StatelessWidget {
     this.minTileHeight,
     this.titleAlignment,
     this.internalAddSemanticForOnTap = true,
+    this.statesController,
   }) : assert(!isThreeLine || subtitle != null);
 
   /// A widget to display before the title.
@@ -471,6 +472,19 @@ class ListTile extends StatelessWidget {
   /// whose second child is the metadata text, instead of using the [trailing]
   /// property.
   final Widget? trailing;
+
+  /// {@template flutter.material.inkwell.statesController}
+  /// Represents the interactive "state" of this widget in terms of
+  /// a set of [WidgetState]s, like [WidgetState.pressed] and
+  /// [WidgetState.focused].
+  ///
+  /// Classes based on this one can provide their own
+  /// [WidgetStatesController] to which they've added listeners.
+  /// They can also update the controller's [WidgetStatesController.value]
+  /// however, this may only be done when it's safe to call
+  /// [State.setState], like in an event handler.
+  /// {@endtemplate}
+  final WidgetStatesController? statesController;
 
   /// Whether this list tile is intended to display three lines of text.
   ///
@@ -963,6 +977,7 @@ class ListTile extends StatelessWidget {
       splashColor: splashColor,
       autofocus: autofocus,
       enableFeedback: enableFeedback ?? tileTheme.enableFeedback ?? true,
+      statesController: statesController,
       child: Semantics(
         button: internalAddSemanticForOnTap && (onTap != null || onLongPress != null),
         selected: selected,
@@ -1030,6 +1045,7 @@ class ListTile extends StatelessWidget {
     properties.add(
       DiagnosticsProperty<VisualDensity>('visualDensity', visualDensity, defaultValue: null),
     );
+    properties.add(DiagnosticsProperty<WidgetStatesController>('statesController', statesController, defaultValue: null));
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<ListTileStyle>('style', style, defaultValue: null));
     properties.add(ColorProperty('selectedColor', selectedColor, defaultValue: null));

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -200,6 +200,65 @@ void main() {
       ),
     );
 
+    testWidgets('ListTile statesController updates states correctly', (WidgetTester tester) async {
+      final WidgetStatesController controller = WidgetStatesController();
+      bool? isPressed;
+      bool? isHovered;
+
+      controller.addListener(() {
+        isPressed = controller.value.contains(WidgetState.pressed);
+        isHovered = controller.value.contains(WidgetState.hovered);
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: ListTile(
+                title: const Text('ListTile'),
+                statesController: controller,
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final TestGesture hoverGesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await hoverGesture.moveTo(tester.getCenter(find.byType(ListTile)));
+      await tester.pumpAndSettle();
+      expect(isHovered, true);
+
+      await tester.tap(find.byType(ListTile));
+      await tester.pump();
+      expect(isPressed, true);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(isPressed, false);
+
+      await hoverGesture.moveTo(const Offset(0, 0));
+      await tester.pumpAndSettle();
+      expect(isHovered, false);
+    });
+
+    testWidgets('ListTile without statesController works normally', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: ListTile(
+                title: const Text('ListTile'),
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(ListTile), findsOneWidget);
+      await tester.tap(find.byType(ListTile));
+      await tester.pump();
+    });
+
     double left(String text) => tester.getTopLeft(find.text(text)).dx;
     double right(String text) => tester.getTopRight(find.text(text)).dx;
 


### PR DESCRIPTION
This PR adds support for WidgetStatesController in ListTile, enabling developers to track and respond to the widget's interactive states through an external controller.

resolves issue: #166611 

