### PR TITLE
Feat: Add equality to NoDefaultCupertinoThemeData

### DIFF
--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -394,6 +394,7 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
 ///
 ///  * [CupertinoThemeData], which uses reasonable default values for
 ///    unspecified theme properties.
+@immutable
 class NoDefaultCupertinoThemeData {
   /// Creates a [NoDefaultCupertinoThemeData] styling specification.
   ///
@@ -541,6 +542,35 @@ class NoDefaultCupertinoThemeData {
       applyThemeToAll: applyThemeToAll ?? this.applyThemeToAll,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is NoDefaultCupertinoThemeData &&
+        other.brightness == brightness &&
+        other.primaryColor == primaryColor &&
+        other.primaryContrastingColor == primaryContrastingColor &&
+        other.textTheme == textTheme &&
+        other.barBackgroundColor == barBackgroundColor &&
+        other.scaffoldBackgroundColor == scaffoldBackgroundColor &&
+        other.applyThemeToAll == applyThemeToAll;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    brightness,
+    primaryColor,
+    primaryContrastingColor,
+    textTheme,
+    barBackgroundColor,
+    scaffoldBackgroundColor,
+    applyThemeToAll,
+  );
 }
 
 @immutable

--- a/packages/flutter/test/cupertino/theme_test.dart
+++ b/packages/flutter/test/cupertino/theme_test.dart
@@ -221,6 +221,14 @@ void main() {
     expect(c, isNot(equals(b)));
   });
 
+  testWidgets('NoDefaultCupertinoThemeData equality', (WidgetTester tester) async {
+    const NoDefaultCupertinoThemeData a = NoDefaultCupertinoThemeData();
+    final NoDefaultCupertinoThemeData b = a.copyWith();
+    final NoDefaultCupertinoThemeData c = a.copyWith(brightness: Brightness.light);
+    expect(a, equals(b));
+    expect(a, isNot(c));
+  });
+
   late Brightness currentBrightness;
   void colorMatches(Color? componentColor, Color expectedDynamicColor) {
     if (expectedDynamicColor is CupertinoDynamicColor) {


### PR DESCRIPTION
Feat: Add equality to NoDefaultCupertinoThemeData
fixes: #165455 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.