### PR TITLE
Remove `bringup:true` from Linux tool_tests_widget_preview_scaffold

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1592,7 +1592,6 @@ targets:
   - name: Linux tool_tests_widget_preview_scaffold
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-


### PR DESCRIPTION
New shard seems to be stable and passing consistently.