### PR TITLE
[Impeller] keep device holder and allocator alive until last vk image is destroyed.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
@@ -74,7 +74,7 @@ TEST(AllocatorVKTest, MemoryTypeSelectionTwoHeap) {
   EXPECT_EQ(AllocatorVK::FindMemoryTypeIndex(4, properties), -1);
 }
 
-TEST(AllocatorVKTest, ImageResourceKeepsVulkanContextAlive) {
+TEST(AllocatorVKTest, ImageResourceKeepsVulkanDeviceAlive) {
   std::shared_ptr<Texture> texture;
   std::weak_ptr<Allocator> weak_allocator;
   {
@@ -84,6 +84,7 @@ TEST(AllocatorVKTest, ImageResourceKeepsVulkanContextAlive) {
 
     texture = allocator->CreateTexture(TextureDescriptor{
         .storage_mode = StorageMode::kDevicePrivate,
+        .format = PixelFormat::kR8G8B8A8UNormInt,
         .size = {1, 1},
     });
     context->Shutdown();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -12,7 +12,6 @@
 #include "impeller/renderer/backend/vulkan/shared_object_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/backend/vulkan/yuv_conversion_vk.h"
-#include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/166410

keep the potentially shutdown context alive until the last texture is reclaimed, to work around issues where pending UI tasks aren't flushed during platform view shutdown.