### PR TITLE
When using --local-web-sdk, use a locally built Dart SDK if one is available

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -1538,6 +1538,11 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
   }
 
   String _getDartSdkPath() {
+    // If the parent is a local engine, then use the locally built Dart SDK.
+    if (_parent.usesLocalArtifacts) {
+      return _parent.getArtifactPath(Artifact.engineDartSdkPath);
+    }
+
     // If we couldn't find a built dart sdk, let's look for a prebuilt one.
     final String prebuiltPath = _fileSystem.path.join(
       _getFlutterPrebuiltsPath(),

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -552,26 +552,39 @@ void main() {
     );
 
     testWithoutContext('uses prebuilt dart sdk for web platform', () {
+      final CachedLocalWebSdkArtifacts webArtifacts = CachedLocalWebSdkArtifacts(
+        parent: CachedArtifacts(
+          fileSystem: fileSystem,
+          cache: cache,
+          platform: platform,
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+        ),
+        webSdkPath: fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'wasm_release'),
+        fileSystem: fileSystem,
+        platform: platform,
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+      );
+
       final String failureMessage =
           'Unable to find a prebuilt dart sdk at:'
           ' "${fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk')}"';
 
       expect(
-        () => artifacts.getArtifactPath(
+        () => webArtifacts.getArtifactPath(
           Artifact.frontendServerSnapshotForEngineDartSdk,
           platform: TargetPlatform.web_javascript,
         ),
         throwsToolExit(message: failureMessage),
       );
       expect(
-        () => artifacts.getArtifactPath(
+        () => webArtifacts.getArtifactPath(
           Artifact.engineDartSdkPath,
           platform: TargetPlatform.web_javascript,
         ),
         throwsToolExit(message: failureMessage),
       );
       expect(
-        () => artifacts.getArtifactPath(
+        () => webArtifacts.getArtifactPath(
           Artifact.engineDartBinary,
           platform: TargetPlatform.web_javascript,
         ),
@@ -587,7 +600,7 @@ void main() {
           .createSync(recursive: true);
 
       expect(
-        artifacts.getArtifactPath(
+        webArtifacts.getArtifactPath(
           Artifact.frontendServerSnapshotForEngineDartSdk,
           platform: TargetPlatform.web_javascript,
         ),
@@ -602,21 +615,21 @@ void main() {
         ),
       );
       expect(
-        artifacts.getArtifactPath(
+        webArtifacts.getArtifactPath(
           Artifact.engineDartSdkPath,
           platform: TargetPlatform.web_javascript,
         ),
         fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk'),
       );
       expect(
-        artifacts.getArtifactPath(
+        webArtifacts.getArtifactPath(
           Artifact.engineDartBinary,
           platform: TargetPlatform.web_javascript,
         ),
         fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk', 'bin', 'dart'),
       );
       expect(
-        artifacts.getArtifactPath(
+        webArtifacts.getArtifactPath(
           Artifact.engineDartAotRuntime,
           platform: TargetPlatform.web_javascript,
         ),
@@ -628,6 +641,37 @@ void main() {
           'bin',
           'dartaotruntime',
         ),
+      );
+    });
+
+    testWithoutContext('uses local dart sdk for web platform wrapping a local engine', () {
+      final String failureMessage =
+          'Unable to find a built dart sdk at:'
+          ' "${fileSystem.path.join('/out', 'host_debug_unopt', 'dart-sdk')}"'
+          ' or a prebuilt dart sdk at:'
+          ' "${fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk')}"';
+
+      expect(
+        () => artifacts.getArtifactPath(
+          Artifact.engineDartSdkPath,
+          platform: TargetPlatform.web_javascript,
+        ),
+        throwsToolExit(message: failureMessage),
+      );
+
+      fileSystem
+          .directory('out')
+          .childDirectory('host_debug_unopt')
+          .childDirectory('dart-sdk')
+          .childDirectory('bin')
+          .createSync(recursive: true);
+
+      expect(
+        artifacts.getArtifactPath(
+          Artifact.engineDartSdkPath,
+          platform: TargetPlatform.web_javascript,
+        ),
+        fileSystem.path.join('/out', 'host_debug_unopt', 'dart-sdk'),
       );
     });
 


### PR DESCRIPTION
If flutter_tools is run with both a local Web SDK and a local engine, then use the Dart SDK from the local engine instead of the prebuilt Dart SDK.

This enables testing of a local Wasm build with a locally patched Dart SDK by setting --local-web-sdk to the Wasm engine output and --local-engine/--local-engine-host to a local engine built with --no-prebuilt-dart-sdk.