### PR TITLE
[Impeller] disable no decal metal test.

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
@@ -1253,57 +1253,6 @@ TEST_P(AiksTest, BlurredRectangleWithShader) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
-TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
-  if (GetParam() != PlaygroundBackend::kMetal) {
-    GTEST_SKIP()
-        << "This backend doesn't yet support setting device capabilities.";
-  }
-  if (!WillRenderSomething()) {
-    // Sometimes these tests are run without playgrounds enabled which is
-    // pointless for this test since we are asserting that
-    // `SupportsDecalSamplerAddressMode` is called.
-    GTEST_SKIP() << "This test requires playgrounds.";
-  }
-
-  std::shared_ptr<const Capabilities> old_capabilities =
-      GetContext()->GetCapabilities();
-  auto mock_capabilities = std::make_shared<MockCapabilities>();
-  EXPECT_CALL(*mock_capabilities, SupportsDecalSamplerAddressMode())
-      .Times(::testing::AtLeast(1))
-      .WillRepeatedly(::testing::Return(false));
-  FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultColorFormat);
-  FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultStencilFormat);
-  FLT_FORWARD(mock_capabilities, old_capabilities,
-              GetDefaultDepthStencilFormat);
-  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsOffscreenMSAA);
-  FLT_FORWARD(mock_capabilities, old_capabilities,
-              SupportsImplicitResolvingMSAA);
-  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsReadFromResolve);
-  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsFramebufferFetch);
-  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsSSBO);
-  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsCompute);
-  FLT_FORWARD(mock_capabilities, old_capabilities,
-              SupportsTextureToTextureBlits);
-  FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultGlyphAtlasFormat);
-  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsTriangleFan);
-  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsPrimitiveRestart);
-  ASSERT_TRUE(SetCapabilities(mock_capabilities).ok());
-
-  auto texture = DlImageImpeller::Make(CreateTextureForFixture("boston.jpg"));
-
-  DisplayListBuilder builder;
-  builder.Scale(GetContentScale().x * 0.5, GetContentScale().y * 0.5);
-
-  DlPaint paint;
-  paint.setColor(DlColor::kBlack());
-  builder.DrawPaint(paint);
-
-  auto blur_filter = DlImageFilter::MakeBlur(20, 20, DlTileMode::kDecal);
-  paint.setImageFilter(blur_filter);
-  builder.DrawImage(texture, DlPoint(200, 200), {}, &paint);
-  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
-}
-
 // This addresses a bug where tiny blurs could result in mip maps that beyond
 // the limits for the textures used for blurring.
 // See also: b/323402168


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/166020

This test is invalid because the renderer assumes metal/vulkan will always have decal support (they do, its in base 1.0 for both). DIsabling decal causes this test to attempt to use a GLES only shader that is not available on the metal backend.
