### PR TITLE
Allow dart pub deps --json to fail without causing an explicit crash.

### DIFF
--- a/packages/flutter_tools/lib/src/compute_dev_dependencies.dart
+++ b/packages/flutter_tools/lib/src/compute_dev_dependencies.dart
@@ -18,7 +18,13 @@ Future<Set<String>> computeExclusiveDevDependencies(
   required Logger logger,
   required FlutterProject project,
 }) async {
-  final Map<String, Object?> jsonResult = await pub.deps(project);
+  final Map<String, Object?>? jsonResult = await pub.deps(project);
+
+  // Avoid crashing if dart pub deps is not ready.
+  // See https://github.com/flutter/flutter/issues/166648.
+  if (jsonResult == null) {
+    return <String>{};
+  }
 
   Never fail([String? reason]) {
     logger.printTrace(const JsonEncoder.withIndent('  ').convert(jsonResult));

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -158,7 +158,9 @@ abstract class Pub {
   /// While it is guaranteed that, if successful, that the result are a valid
   /// JSON object, the exact contents returned are _not_ validated, and are left
   /// as a responsibility of the caller.
-  Future<Map<String, Object?>> deps(FlutterProject project);
+  ///
+  /// If `null` is returned, it should be assumed deps could not be determined.
+  Future<Map<String, Object?>?> deps(FlutterProject project);
 
   /// Runs pub in 'batch' mode.
   ///
@@ -354,13 +356,22 @@ class _DefaultPub implements Pub {
   }
 
   @override
-  Future<Map<String, Object?>> deps(FlutterProject project) async {
+  Future<Map<String, Object?>?> deps(FlutterProject project) async {
     final List<String> pubCommand = <String>[..._pubCommand, 'deps', '--json'];
+    final RunResult runResult;
 
-    final RunResult runResult = await _processUtils.run(
-      pubCommand,
-      workingDirectory: project.directory.path,
-    );
+    // Don't treat this command as terminal if it fails.
+    // See https://github.com/flutter/flutter/issues/166648
+    try {
+      runResult = await _processUtils.run(
+        pubCommand,
+        workingDirectory: project.directory.path,
+        throwOnError: true,
+      );
+    } on io.ProcessException catch (e) {
+      _logger.printWarning('${pubCommand.join(' ')} ${e.message}');
+      return null;
+    }
 
     Never fail([String? reason]) {
       final String stdout = runResult.stdout;
@@ -372,11 +383,6 @@ class _DefaultPub implements Pub {
         '${pubCommand.join(' ')} ${reason != null ? 'had unexpected output: $reason' : 'failed'}'
         '${stderr.isNotEmpty ? '\n$stderr' : ''}',
       );
-    }
-
-    // Guard against dart pub deps crashing.
-    if (runResult.exitCode != 0) {
-      fail();
     }
 
     // Guard against dart pub deps having explicitly invalid output.

--- a/packages/flutter_tools/test/general.shard/dart/pub_deps_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_deps_test.dart
@@ -43,7 +43,7 @@ void main() {
     );
   });
 
-  testWithoutContext('fails on non-zero exit code', () async {
+  testWithoutContext('returns null on non-zero exit code', () async {
     final BufferLogger logger = BufferLogger.test();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final ProcessManager processManager = _dartPubDepsFails(
@@ -62,14 +62,8 @@ void main() {
     );
 
     await expectLater(
-      () => pub.deps(FlutterProject.fromDirectoryTest(fileSystem.currentDirectory)),
-      throwsA(
-        isA<StateError>().having(
-          (StateError e) => e.message,
-          'message',
-          contains('dart pub --suppress-analytics deps --json failed'),
-        ),
-      ),
+      pub.deps(FlutterProject.fromDirectoryTest(fileSystem.currentDirectory)),
+      completion(isNull),
     );
   });
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/166648.

I think a better fix is to stop using `dart pub deps --json` and use @sigurdm's new `.dart_tool/` vendored solution, but that can be a follow-up change.