### PR TITLE
[web:skwasm] be consistent about handling imbalanced layer push/pop sequence

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/scene_builder.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/scene_builder.dart
@@ -472,11 +472,12 @@ class EngineSceneBuilder implements ui.SceneBuilder {
 
   @override
   void pop() {
-    final PictureEngineLayer layer = currentBuilder.build();
     final LayerBuilder? parentBuilder = currentBuilder.parent;
     if (parentBuilder == null) {
-      throw StateError('Popped too many times.');
+      // Root layer. Nothing to pop.
+      return;
     }
+    final PictureEngineLayer layer = currentBuilder.build();
     currentBuilder = parentBuilder;
     currentBuilder.mergeLayer(layer);
   }

--- a/engine/src/flutter/lib/web_ui/test/ui/scene_builder_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/scene_builder_test.dart
@@ -645,6 +645,18 @@ Future<void> testMain() async {
         region: const ui.Rect.fromLTWH(0, 0, 10 * 50, 10 * 50),
       );
     });
+
+    test('push pop balance enfocement is consistent', () async {
+      final sceneBuilder = ui.SceneBuilder();
+      // Normally pop() must follow a previously non-popped layer push. However,
+      // the Flutter engine chooses to be lenient and allows calling pop() with
+      // no layers.
+      sceneBuilder.pop();
+
+      // Just checking that a scene can be built without crashing after a stray
+      // pop() from above.
+      sceneBuilder.build();
+    });
   });
 }
 


### PR DESCRIPTION
Skwasm was the only renderer that enforced that the root layer cannot be popped. However, canvaskit and the native engines all allow popping the root layer. It's just a noop.

Also, `EngineSceneBuilder` called `currentBuilder.build()` before checking if the layer that's being popped is a root layer. This means skwasm would call `rootLayer.build()` twice when push/pop are unbalanced. It is called once on the last `pop()` on the root layer. Then it is called again in `EngineSceneBuilder.build`.

Not a guarantee, but this may help reduce the skwasm error rates from DevTools that look like this:

```
org-dartlang-sdk:///dart-sdk/lib/_internal/wasm/lib/error_utils.dart 130:15 | _throwIndexError
org-dartlang-sdk:///dart-sdk/lib/_internal/wasm/lib/error_utils.dart 24:7 | checkIndexBCE
org-dartlang-sdk:///lib/_engine/engine/scene_builder.dart 458:53 | pop
file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/layer.dart 1520:13 | addToScene
file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/layer.dart 721:5 | _addToSceneWithRetainedRendering
file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/layer.dart 1519:5 | addToScene
file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/layer.dart 721:5 | _addToSceneWithRetainedRendering
```