### PR TITLE
[Impeller] allow using AHB swapchain on non-HCPP supported devices.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -199,7 +199,9 @@ bool AHBSwapchainImplVK::Present(
     return false;
   }
 
-  android::SurfaceTransaction transaction = cb_();
+  android::SurfaceTransaction transaction =
+      (cb_) ? cb_() : impeller::android::SurfaceTransaction();
+
   if (!transaction.SetContents(control.get(),               //
                                texture->GetBackingStore(),  //
                                present_ready->CreateFD()    //

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
@@ -47,13 +47,14 @@ std::shared_ptr<SwapchainVK> SwapchainVK::Create(
 
   // Use AHB Swapchains if they are opted in.
   if (ContextVK::Cast(*context).GetShouldEnableSurfaceControlSwapchain() &&
-      AHBSwapchainVK::IsAvailableOnPlatform() &&
-      android_get_device_api_level() >= 34) {
-    FML_LOG(WARNING) << "Using Android SurfaceControl Swapchain.";
+      AHBSwapchainVK::IsAvailableOnPlatform()) {
+    CreateTransactionCB callback =
+        android_get_device_api_level() >= 34 ? cb : CreateTransactionCB({});
+
     auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
         context,             //
         window.GetHandle(),  //
-        cb,                  //
+        callback,            //
         window.GetSize(),    //
         enable_msaa          //
         ));

--- a/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
@@ -95,8 +95,7 @@ bool AndroidSurfaceVKImpeller::SetNativeWindow(
     return false;
   }
 
-  impeller::CreateTransactionCB cb = [jni_facade = jni_facade]() {
-    FML_CHECK(jni_facade) << "JNI was nullptr";
+  impeller::CreateTransactionCB cb = [jni_facade]() {
     ASurfaceTransaction* tx = jni_facade->createTransaction();
     if (tx == nullptr) {
       return impeller::android::SurfaceTransaction();


### PR DESCRIPTION
We want all Android devices to eventually use the same swapchain. Allow < 34 to use AHB without the platform view synchronization. Also in theory this will help start up. In theory.
