### PR TITLE
Throw an error if --local-engine-host is used without --local-engine

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -330,6 +330,8 @@ class UserMessages {
       'You are using a locally built engine (--local-engine) but have not specified --local-engine-host.\n'
       'You may be building with a different engine than the one you are running with. '
       'See https://github.com/flutter/flutter/issues/132245 for details.';
+  String get runnerHostEngineRequiresLocalEngine =>
+      'You must specify --local-engine if you are using --local-engine-host.';
   String runnerNoEngineBuild(String engineBuildPath) =>
       'No Flutter engine build found at $engineBuildPath.';
   String runnerNoWebSdk(String webSdkPath) => 'No Flutter web sdk found at $webSdkPath.';

--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -50,6 +50,10 @@ class LocalEngineLocator {
     String? localWebSdk,
     String? packagePath,
   }) async {
+    if (localHostEngine != null && localEngine == null) {
+      throwToolExit(_userMessages.runnerHostEngineRequiresLocalEngine, exitCode: 2);
+    }
+
     engineSourcePath ??= _platform.environment[kFlutterEngineEnvironmentVariableName];
     if (engineSourcePath == null &&
         localEngine == null &&

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -482,6 +482,33 @@ void main() {
       );
     },
   );
+
+  testWithoutContext('fails if --local-engine-host is used without --local-engine', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Directory localEngine = fileSystem.directory(
+      '$kArbitraryEngineRoot/src/out/android_debug_unopt_arm64/',
+    )..createSync(recursive: true);
+    fileSystem
+        .directory('$kArbitraryEngineRoot/src/out/host_debug_unopt/')
+        .createSync(recursive: true);
+
+    final BufferLogger logger = BufferLogger.test();
+    final LocalEngineLocator localEngineLocator = LocalEngineLocator(
+      fileSystem: fileSystem,
+      flutterRoot: 'flutter/flutter',
+      logger: logger,
+      userMessages: UserMessages(),
+      platform: FakePlatform(environment: <String, String>{}),
+    );
+
+    await expectLater(
+      localEngineLocator.findEnginePath(localHostEngine: localEngine.path),
+      throwsToolExit(
+        message:
+            'You must specify --local-engine if you are using --local-engine-host.',
+      ),
+    );
+  });
 }
 
 Matcher matchesEngineBuildPaths({String? hostEngine, String? targetEngine}) {

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -504,8 +504,7 @@ void main() {
     await expectLater(
       localEngineLocator.findEnginePath(localHostEngine: localEngine.path),
       throwsToolExit(
-        message:
-            'You must specify --local-engine if you are using --local-engine-host.',
+        message: 'You must specify --local-engine if you are using --local-engine-host.',
       ),
     );
   });


### PR DESCRIPTION
The artifact selector will only use artifacts from the local engine if both of these flags are provided.