### PR TITLE
[Impeller] fix vulkan/gl color space decode.

### DIFF
--- a/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
@@ -176,7 +176,8 @@ DecompressResult ImageDecoderImpeller::DecompressTexture(
         base_image_info.makeWH(decode_size.width(), decode_size.height())
             .makeColorType(
                 ChooseCompatibleColorType(base_image_info.colorType()))
-            .makeAlphaType(alpha_type);
+            .makeAlphaType(alpha_type)
+            .makeColorSpace(SkColorSpace::MakeSRGB());
   }
 
   const auto pixel_format = ToPixelFormat(image_info.colorType());

--- a/engine/src/flutter/lib/ui/painting/image_decoder_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_unittests.cc
@@ -443,8 +443,8 @@ TEST_F(ImageDecoderFixtureTest, ImpellerNullColorspace) {
   auto data = SkData::MakeWithoutCopy(bitmap.getPixels(), 10 * 10 * 4);
   auto image = SkImages::RasterFromBitmap(bitmap);
   ASSERT_TRUE(image != nullptr);
-  ASSERT_EQ(SkISize::Make(10, 10), image->dimensions());
-  ASSERT_EQ(nullptr, image->colorSpace());
+  EXPECT_EQ(SkISize::Make(10, 10), image->dimensions());
+  EXPECT_EQ(nullptr, image->colorSpace());
 
   auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
       std::move(data), image->imageInfo(), 10 * 4);
@@ -461,8 +461,8 @@ TEST_F(ImageDecoderFixtureTest, ImpellerNullColorspace) {
           descriptor.get(), SkISize::Make(100, 100), {100, 100},
           /*supports_wide_gamut=*/true, capabilities, allocator);
   ASSERT_TRUE(decompressed.has_value());
-  ASSERT_EQ(decompressed->image_info.colorType(), kRGBA_8888_SkColorType);
-  ASSERT_EQ(decompressed->image_info.colorSpace(), nullptr);
+  EXPECT_EQ(decompressed->image_info.colorType(), kRGBA_8888_SkColorType);
+  EXPECT_EQ(decompressed->image_info.colorSpace(), SkColorSpace::MakeSRGB());
 #endif  // IMPELLER_SUPPORTS_RENDERING
 }
 
@@ -473,9 +473,10 @@ TEST_F(ImageDecoderFixtureTest, ImpellerPixelConversion32F) {
   bitmap.allocPixels(info, 10 * 16);
   auto data = SkData::MakeWithoutCopy(bitmap.getPixels(), 10 * 10 * 16);
   auto image = SkImages::RasterFromBitmap(bitmap);
+
   ASSERT_TRUE(image != nullptr);
-  ASSERT_EQ(SkISize::Make(10, 10), image->dimensions());
-  ASSERT_EQ(nullptr, image->colorSpace());
+  EXPECT_EQ(SkISize::Make(10, 10), image->dimensions());
+  EXPECT_EQ(nullptr, image->colorSpace());
 
   auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
       std::move(data), image->imageInfo(), 10 * 16);
@@ -493,8 +494,8 @@ TEST_F(ImageDecoderFixtureTest, ImpellerPixelConversion32F) {
           /*supports_wide_gamut=*/true, capabilities, allocator);
 
   ASSERT_TRUE(decompressed.has_value());
-  ASSERT_EQ(decompressed->image_info.colorType(), kRGBA_F16_SkColorType);
-  ASSERT_EQ(decompressed->image_info.colorSpace(), nullptr);
+  EXPECT_EQ(decompressed->image_info.colorType(), kRGBA_F16_SkColorType);
+  EXPECT_EQ(decompressed->image_info.colorSpace(), SkColorSpace::MakeSRGB());
 #endif  // IMPELLER_SUPPORTS_RENDERING
 }
 

--- a/engine/src/flutter/lib/ui/painting/image_decoder_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_unittests.cc
@@ -462,7 +462,8 @@ TEST_F(ImageDecoderFixtureTest, ImpellerNullColorspace) {
           /*supports_wide_gamut=*/true, capabilities, allocator);
   ASSERT_TRUE(decompressed.has_value());
   EXPECT_EQ(decompressed->image_info.colorType(), kRGBA_8888_SkColorType);
-  EXPECT_EQ(decompressed->image_info.colorSpace(), SkColorSpace::MakeSRGB());
+  EXPECT_EQ(decompressed->image_info.colorSpace(),
+            SkColorSpace::MakeSRGB().get());
 #endif  // IMPELLER_SUPPORTS_RENDERING
 }
 
@@ -495,7 +496,8 @@ TEST_F(ImageDecoderFixtureTest, ImpellerPixelConversion32F) {
 
   ASSERT_TRUE(decompressed.has_value());
   EXPECT_EQ(decompressed->image_info.colorType(), kRGBA_F16_SkColorType);
-  EXPECT_EQ(decompressed->image_info.colorSpace(), SkColorSpace::MakeSRGB());
+  EXPECT_EQ(decompressed->image_info.colorSpace(),
+            SkColorSpace::MakeSRGB().get());
 #endif  // IMPELLER_SUPPORTS_RENDERING
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/166954
Improves https://github.com/flutter/flutter/issues/164452

We need to force conversion to an SRGB color space otherwise images look wrong if they happen to have things like a color profile. I believe this is the correct change, as it matches the wide gamut decode above.