### PR TITLE
[native assets] Use workspace pubspec for user-defines

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -34,14 +34,15 @@ abstract class DartBuild extends Target {
     } else {
       final TargetPlatform targetPlatform = _getTargetPlatformFromEnvironment(environment, name);
 
+      final File packageConfigFile = fileSystem.file(environment.packageConfigPath);
       final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-        fileSystem.file(environment.packageConfigPath),
+        packageConfigFile,
         logger: environment.logger,
       );
       final Uri projectUri = environment.projectDir.uri;
       final String? runPackageName =
           packageConfig.packages.where((Package p) => p.root == projectUri).firstOrNull?.name;
-      final String pubspecPath = projectUri.resolve('pubspec.yaml').toFilePath();
+      final String pubspecPath = packageConfigFile.uri.resolve('../pubspec.yaml').toFilePath();
       final FlutterNativeAssetsBuildRunner buildRunner =
           _buildRunner ??
           FlutterNativeAssetsBuildRunnerImpl(

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -32,7 +32,8 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
   final Uri projectUri = FlutterProject.current().directory.uri;
   final String runPackageName =
       buildInfo.packageConfig.packages.firstWhere((Package p) => p.root == projectUri).name;
-  final String pubspecPath = projectUri.resolve('pubspec.yaml').toFilePath();
+  final String pubspecPath =
+      Uri.file(buildInfo.packageConfigPath).resolve('../pubspec.yaml').toFilePath();
   final FlutterNativeAssetsBuildRunner buildRunner = FlutterNativeAssetsBuildRunnerImpl(
     buildInfo.packageConfigPath,
     buildInfo.packageConfig,


### PR DESCRIPTION
If pub workspaces are used, then native assets are shared across the whole pub workspace. Using a different user-define, invalidates the cache. Therefore, we want to avoid having different user-defines in different pubspecs belonging to the same workspace. So, only use the workspace pubspec for user-defines.

Analogous Dart SDK CL: https://dart-review.googlesource.com/c/sdk/+/422101

### Testing

Covered by the integration tests added in https://github.com/flutter/flutter/pull/166940 for user-defines.

### Design discussion

We could allow adding user-defines in root package pubspecs later, but this will likely deteriorate caching behavior (either invalidating the cache often, or requiring a cache directory per root package, which increases latency for new root packages).

Also, we'd likely add command-line user-defines later, these are expected to deteriorate caching behavior.

For design discussion, refer to:

* https://github.com/dart-lang/native/issues/39
* https://github.com/dart-lang/native/issues/2187
