### PR TITLE
Fix regression in NDK version checking

### DIFF
--- a/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
+++ b/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
@@ -144,6 +144,13 @@ Future<TaskResult> buildFlutterApkWithSpecifiedDependencyVersions({
           .replaceFirst(kgpReplacementString, versions.kotlinVersion);
       await gradleSettingsFile.writeAsString(settingsContent, flush: true);
 
+      section('Add a dependency on a plugin');
+      await flutter(
+        'pub',
+        options: <String>['add', 'shared_preferences_android'], // Chosen randomly.
+        workingDirectory: appPath,
+      );
+
       // Ensure that gradle files exists from templates.
       section(
         "Ensure 'flutter build apk' succeeds with Gradle ${versions.gradleVersion}, AGP ${versions.agpVersion}, and Kotlin ${versions.kotlinVersion}",

--- a/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
+++ b/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
@@ -147,7 +147,7 @@ Future<TaskResult> buildFlutterApkWithSpecifiedDependencyVersions({
       section('Add a dependency on a plugin');
       await flutter(
         'pub',
-        options: <String>['add', 'shared_preferences_android'], // Chosen randomly.
+        options: <String>['add', 'shared_preferences_android:2.4.9'], // Chosen randomly.
         workingDirectory: appPath,
       );
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -517,8 +517,16 @@ object FlutterPluginUtils {
                 getCompileSdkFromProject(project).toIntOrNull() ?: Int.MAX_VALUE
 
             var maxPluginCompileSdkVersion = projectCompileSdkVersion
-            val projectNdkVersion =
-                getAndroidExtension(project).ndkVersion
+            // TODO(gmackall): This should be updated to reflect newer templates.
+            // The default for AGP 4.1.0 used in old templates.
+            val ndkVersionIfUnspecified = "21.1.6352462"
+
+            // TODO(gmackall): We can remove this elvis when our minimum AGP is >= 8.2.
+            //  This value (ndkVersion) is nullable on AGP versions below that.
+            //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
+            @Suppress("USELESS_ELVIS")
+            val projectNdkVersion: String =
+                getAndroidExtension(project).ndkVersion ?: ndkVersionIfUnspecified
             var maxPluginNdkVersion = projectNdkVersion
             var numProcessedPlugins = pluginList.size
             val pluginsWithHigherSdkVersion = mutableListOf<PluginVersionPair>()
@@ -543,8 +551,13 @@ object FlutterPluginUtils {
                             )
                         )
                     }
+
+                    // TODO(gmackall): We can remove this elvis when our minimum AGP is >= 8.2.
+                    //  This value (ndkVersion) is nullable on AGP versions below that.
+                    //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
+                    @Suppress("USELESS_ELVIS")
                     val pluginNdkVersion: String =
-                        getAndroidExtension(pluginProject).ndkVersion
+                        getAndroidExtension(pluginProject).ndkVersion ?: ndkVersionIfUnspecified
                     maxPluginNdkVersion =
                         VersionUtils.mostRecentSemanticVersion(
                             pluginNdkVersion,

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -526,7 +526,7 @@ object FlutterPluginUtils {
             //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
             @Suppress("USELESS_ELVIS")
             val projectNdkVersion: String =
-                getAndroidExtension(project).ndkVersion ?: ndkVersionIfUnspecified
+                getAndroidExtension(project).ndkVersion // ?: ndkVersionIfUnspecified
             var maxPluginNdkVersion = projectNdkVersion
             var numProcessedPlugins = pluginList.size
             val pluginsWithHigherSdkVersion = mutableListOf<PluginVersionPair>()
@@ -557,7 +557,7 @@ object FlutterPluginUtils {
                     //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
                     @Suppress("USELESS_ELVIS")
                     val pluginNdkVersion: String =
-                        getAndroidExtension(pluginProject).ndkVersion ?: ndkVersionIfUnspecified
+                        getAndroidExtension(pluginProject).ndkVersion // ?: ndkVersionIfUnspecified
                     maxPluginNdkVersion =
                         VersionUtils.mostRecentSemanticVersion(
                             pluginNdkVersion,


### PR DESCRIPTION
Fixes a regression from https://github.com/flutter/flutter/pull/166727/, see https://discord.com/channels/608014603317936148/846507907876257822/1360306682999210204

Adds a dependency on `shared_preferences_android` to the smoke tests we have that run across the range of AGP/Gradle versions we support. Chosen randomly, just to recreate the error. Hopefully this doesn't push the test target into timeout range, it was already a kind of long running one.

The IDE suggestion here was misleading, as this value switched from nullable to non nullable in AGP 8.1/8.2. Unfortunately the IDE makes these suggestions based on one AGP version, specified in the project level `build.gradle.kts`. I checked all other files with our minimum supported AGP version, and this was the only error.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
