### PR TITLE
[reland] Fix regression in NDK version checking

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1511,10 +1511,12 @@ targets:
       test_timeout_secs: "2700"
     runIf:
       - packages/flutter_tools/templates/**
+      - packages/flutter_tools/gradle/**
       - .ci.yaml
       - engine/**
       - DEPS
       - dev/devicelab/bin/tasks/android_java11_dependency_smoke_tests.dart
+      - dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
 
   - name: Linux android_java17_dependency_smoke_tests
     recipe: devicelab/devicelab_drone
@@ -1533,10 +1535,12 @@ targets:
       test_timeout_secs: "2700"
     runIf:
       - packages/flutter_tools/templates/**
+      - packages/flutter_tools/gradle/**
       - .ci.yaml
       - engine/**
       - DEPS
       - dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
+      - dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
 
   - name: Linux tool_tests_commands
     recipe: flutter/flutter_drone

--- a/dev/devicelab/bin/tasks/android_java11_dependency_smoke_tests.dart
+++ b/dev/devicelab/bin/tasks/android_java11_dependency_smoke_tests.dart
@@ -40,11 +40,14 @@ List<VersionTuple> versionTuples = <VersionTuple>[
     kotlinVersion: '1.7.10',
     compileSdkVersion: '34',
   ),
+  // minSdk bump required due to a bug in the default version of r8 used by AGP
+  // 7.4.0. See http://issuetracker.google.com/issues/357553178.
   VersionTuple(
     agpVersion: '7.4.0',
     gradleVersion: '7.5',
     kotlinVersion: '1.8.10',
     compileSdkVersion: '34',
+    minSdkVersion: '24',
   ),
 ];
 

--- a/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
+++ b/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
@@ -61,6 +61,7 @@ distributionUrl=https\://services.gradle.org/distributions/gradle-GRADLE_REPLACE
 
 const String gradleReplacementString = 'GRADLE_REPLACE_ME';
 final RegExp flutterCompileSdkString = RegExp(r'flutter\.compileSdkVersion|flutter\.compileSdk');
+final RegExp flutterMinSdkString = RegExp(r'flutter\.minSdkVersion|flutter\.minSdk');
 
 /// A simple class containing a Kotlin, Gradle, and AGP version.
 class VersionTuple {
@@ -69,12 +70,14 @@ class VersionTuple {
     required this.gradleVersion,
     required this.kotlinVersion,
     this.compileSdkVersion,
+    this.minSdkVersion,
   });
 
   String agpVersion;
   String gradleVersion;
   String kotlinVersion;
   String? compileSdkVersion;
+  String? minSdkVersion;
 
   @override
   String toString() {
@@ -108,13 +111,21 @@ Future<TaskResult> buildFlutterApkWithSpecifiedDependencyVersions({
 
       final String appPath = '${innerTempDir.absolute.path}/dependency_checker_app';
 
+      final File appGradleBuild = getAndroidBuildFile(
+        localFileSystem.path.join(appPath, 'android', 'app'),
+      );
       if (versions.compileSdkVersion != null) {
-        final File appGradleBuild = getAndroidBuildFile(
-          localFileSystem.path.join(appPath, 'android', 'app'),
-        );
         final String appBuildContent = appGradleBuild.readAsStringSync().replaceFirst(
           flutterCompileSdkString,
           versions.compileSdkVersion!,
+        );
+        appGradleBuild.writeAsStringSync(appBuildContent);
+      }
+
+      if (versions.minSdkVersion != null) {
+        final String appBuildContent = appGradleBuild.readAsStringSync().replaceFirst(
+          flutterMinSdkString,
+          versions.minSdkVersion!,
         );
         appGradleBuild.writeAsStringSync(appBuildContent);
       }

--- a/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
+++ b/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
@@ -147,7 +147,7 @@ Future<TaskResult> buildFlutterApkWithSpecifiedDependencyVersions({
       section('Add a dependency on a plugin');
       await flutter(
         'pub',
-        options: <String>['add', 'shared_preferences_android:2.4.9'], // Chosen randomly.
+        options: <String>['add', 'shared_preferences_android:2.4.7'], // Chosen randomly.
         workingDirectory: appPath,
       );
 

--- a/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
+++ b/dev/devicelab/lib/framework/dependency_smoke_test_task_definition.dart
@@ -144,6 +144,13 @@ Future<TaskResult> buildFlutterApkWithSpecifiedDependencyVersions({
           .replaceFirst(kgpReplacementString, versions.kotlinVersion);
       await gradleSettingsFile.writeAsString(settingsContent, flush: true);
 
+      section('Add a dependency on a plugin');
+      await flutter(
+        'pub',
+        options: <String>['add', 'shared_preferences_android:2.4.9'], // Chosen randomly.
+        workingDirectory: appPath,
+      );
+
       // Ensure that gradle files exists from templates.
       section(
         "Ensure 'flutter build apk' succeeds with Gradle ${versions.gradleVersion}, AGP ${versions.agpVersion}, and Kotlin ${versions.kotlinVersion}",

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -526,7 +526,7 @@ object FlutterPluginUtils {
             //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
             @Suppress("USELESS_ELVIS")
             val projectNdkVersion: String =
-                getAndroidExtension(project).ndkVersion // ?: ndkVersionIfUnspecified
+                getAndroidExtension(project).ndkVersion ?: ndkVersionIfUnspecified
             var maxPluginNdkVersion = projectNdkVersion
             var numProcessedPlugins = pluginList.size
             val pluginsWithHigherSdkVersion = mutableListOf<PluginVersionPair>()
@@ -557,7 +557,7 @@ object FlutterPluginUtils {
                     //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
                     @Suppress("USELESS_ELVIS")
                     val pluginNdkVersion: String =
-                        getAndroidExtension(pluginProject).ndkVersion // ?: ndkVersionIfUnspecified
+                        getAndroidExtension(pluginProject).ndkVersion ?: ndkVersionIfUnspecified
                     maxPluginNdkVersion =
                         VersionUtils.mostRecentSemanticVersion(
                             pluginNdkVersion,

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -517,8 +517,16 @@ object FlutterPluginUtils {
                 getCompileSdkFromProject(project).toIntOrNull() ?: Int.MAX_VALUE
 
             var maxPluginCompileSdkVersion = projectCompileSdkVersion
-            val projectNdkVersion =
-                getAndroidExtension(project).ndkVersion
+            // TODO(gmackall): This should be updated to reflect newer templates.
+            // The default for AGP 4.1.0 used in old templates.
+            val ndkVersionIfUnspecified = "21.1.6352462"
+
+            // TODO(gmackall): We can remove this elvis when our minimum AGP is >= 8.2.
+            //  This value (ndkVersion) is nullable on AGP versions below that.
+            //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
+            @Suppress("USELESS_ELVIS")
+            val projectNdkVersion: String =
+                getAndroidExtension(project).ndkVersion // ?: ndkVersionIfUnspecified
             var maxPluginNdkVersion = projectNdkVersion
             var numProcessedPlugins = pluginList.size
             val pluginsWithHigherSdkVersion = mutableListOf<PluginVersionPair>()
@@ -543,8 +551,13 @@ object FlutterPluginUtils {
                             )
                         )
                     }
+
+                    // TODO(gmackall): We can remove this elvis when our minimum AGP is >= 8.2.
+                    //  This value (ndkVersion) is nullable on AGP versions below that.
+                    //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
+                    @Suppress("USELESS_ELVIS")
                     val pluginNdkVersion: String =
-                        getAndroidExtension(pluginProject).ndkVersion
+                        getAndroidExtension(pluginProject).ndkVersion // ?: ndkVersionIfUnspecified
                     maxPluginNdkVersion =
                         VersionUtils.mostRecentSemanticVersion(
                             pluginNdkVersion,


### PR DESCRIPTION
Relands https://github.com/flutter/flutter/pull/166998.

On top of the original PR:
1. fixes unfortunate mistake in commenting the fix
2. adds to the `runIf` cases to better cover when this test should be run in presubmit
3. pins a lower version of `shared_preferences_android`, as we need to use a plugin with `compileSdk 34` for those lower AGP versions.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
