### PR TITLE
add onReset callback to FormField

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -434,11 +434,6 @@ typedef FormFieldErrorBuilder = Widget Function(BuildContext context, String err
 /// Used by [FormField.onSaved].
 typedef FormFieldSetter<T> = void Function(T? newValue);
 
-/// Signature for being notified when a form field is reset.
-///
-/// Used by [FormField.onReset].
-typedef FormFieldResetCallback<T> = void Function(FormFieldState<T> field);
-
 /// Signature for building the widget representing the form field.
 ///
 /// Used by [FormField.builder].
@@ -493,7 +488,7 @@ class FormField<T> extends StatefulWidget {
 
   /// An optional method to call when the form field is reset via
   /// [FormFieldState.reset].
-  final FormFieldResetCallback<T>? onReset;
+  final VoidCallback? onReset;
 
   /// An optional property that forces the [FormFieldState] into an error state
   /// by directly setting the [FormFieldState.errorText] property without
@@ -641,7 +636,7 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
       _hasInteractedByUser.value = false;
       _errorText.value = null;
     });
-    widget.onReset?.call(this);
+    widget.onReset?.call();
     Form.maybeOf(context)?._fieldDidChange();
   }
 

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -434,6 +434,11 @@ typedef FormFieldErrorBuilder = Widget Function(BuildContext context, String err
 /// Used by [FormField.onSaved].
 typedef FormFieldSetter<T> = void Function(T? newValue);
 
+/// Signature for being notified when a form field is reset.
+///
+/// Used by [FormField.onReset].
+typedef FormFieldResetCallback<T> = void Function(FormFieldState<T> field);
+
 /// Signature for building the widget representing the form field.
 ///
 /// Used by [FormField.builder].
@@ -466,6 +471,7 @@ class FormField<T> extends StatefulWidget {
     super.key,
     required this.builder,
     this.onSaved,
+    this.onReset,
     this.forceErrorText,
     this.validator,
     this.errorBuilder,
@@ -484,6 +490,10 @@ class FormField<T> extends StatefulWidget {
   /// An optional method to call with the final value when the form is saved via
   /// [FormState.save].
   final FormFieldSetter<T>? onSaved;
+
+  /// An optional method to call when the form field is reset via
+  /// [FormFieldState.reset].
+  final FormFieldResetCallback<T>? onReset;
 
   /// An optional property that forces the [FormFieldState] into an error state
   /// by directly setting the [FormFieldState.errorText] property without
@@ -631,6 +641,7 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
       _hasInteractedByUser.value = false;
       _errorText.value = null;
     });
+    widget.onReset?.call(this);
     Form.maybeOf(context)?._fieldDidChange();
   }
 

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -97,7 +97,7 @@ void main() {
       MaterialApp(
         home: Form(
           key: formKey,
-          child: FormField(
+          child: FormField<String>(
             builder: (_) => const SizedBox.shrink(),
             onReset: () {
               resetCalled = true;

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -89,6 +89,32 @@ void main() {
     await checkText('');
   });
 
+  testWidgets('onReset callback is called', (WidgetTester tester) async {
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    bool resetCalled = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Form(
+          key: formKey,
+          child: FormField(
+            builder: (_) => const SizedBox.shrink(),
+            onReset: () {
+              resetCalled = true;
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(resetCalled, isFalse);
+
+    formKey.currentState!.reset();
+    await tester.pump();
+
+    expect(resetCalled, isTrue);
+  });
+
   testWidgets('Validator sets the error text only when validate is called', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
This PR adds onReset callback to FormField

fixes #167057


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
