### PR TITLE
Add is_hwasan gn build config flag.

### DIFF
--- a/engine/src/build/config/BUILDCONFIG.gn
+++ b/engine/src/build/config/BUILDCONFIG.gn
@@ -143,6 +143,10 @@ declare_args() {
   # Compile for Address Sanitizer to find memory bugs.
   is_asan = false
 
+  # Compile with HWAddress Sanitizer to find memory bugs.
+  # Requires ARM64 hardware
+  is_hwasan = false
+
   # Compile for Leak Sanitizer to find leaks.
   is_lsan = false
 


### PR DESCRIPTION
This accommodates incoming fix in dart sdk to accommodate running under HWASAN https://github.com/dart-lang/sdk/commit/5f32e78a090d811fd1a61c4159dcd23529248938.

Necessity to make this change was flagged by hh build https://ci.chromium.org/ui/p/dart/builders/ci.sandbox/flutter-linux/10920/overview.
