### PR TITLE
license checker: ignore git sha in dart license

### DIFF
--- a/engine/src/flutter/ci/licenses.sh
+++ b/engine/src/flutter/ci/licenses.sh
@@ -114,8 +114,26 @@ function verify_licenses() (
 
   collect_licenses
 
+  # The dart license includes a git sha in it. This is the line that contains
+  # it. We ignore that for the purposes of diffing. If the license file changes
+  # this will need to be updated.
+  dart_ignore_line=4865
   for f in out/license_script_output/licenses_*; do
-    if ! cmp -s "flutter/ci/licenses_golden/$(basename "$f")" "$f"; then
+    golden_file="flutter/ci/licenses_golden/$(basename "$f")"
+    if [[ $(basename "$f") == "licenses_dart" ]]; then
+      cmp -s <(sed "${dart_ignore_line}d" "$golden_file") <(sed "${dart_ignore_line}d" "$f")
+      cmp_result=$?
+      if ! sed -n "${dart_ignore_line}p" "$golden_file" | grep -q 'dart\.googlesource\.com'; then
+        echo "============================= ERROR ============================="
+        echo "Ignored dart license line did not include the googlesource url as expected."
+        echo "================================================================="
+        exitStatus=1
+      fi
+    else
+      cmp -s "$golden_file" "$f"
+      cmp_result=$?
+    fi
+    if [[ $cmp_result -ne 0 ]]; then
       echo "============================= ERROR ============================="
       echo "License script got different results than expected for $f."
       echo "Please rerun the licenses script locally to verify that it is"


### PR DESCRIPTION
This works around the problem of the git sha in the license golden for dart by:
1) Ignoring that line in the comparison
1) Verifying that that line includes the googlesource url

fixes https://github.com/flutter/flutter/issues/166807

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
