### PR TITLE
Clarify deprecation notice for jumpToWithoutSettling in scroll_position.dart

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -975,7 +975,10 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   /// Deprecated. Use [jumpTo] or a custom [ScrollPosition] instead.
   // flutter_ignore: deprecation_syntax, https://github.com/flutter/flutter/issues/44609
-  @Deprecated('This will lead to bugs.')
+  @Deprecated(
+    'This method bypasses scroll activity management and can cause inconsistent layouts '
+    'or scrolling behavior. Use jumpTo or a custom ScrollPosition instead.',
+  )
   void jumpToWithoutSettling(double value);
 
   /// Stop the current activity and start a [HoldScrollActivity].


### PR DESCRIPTION
## Description

Improved the `@Deprecated` message for `jumpToWithoutSettling` to clarify the risks
and suggest appropriate alternatives like `jumpTo` or using a custom `ScrollPosition`.

This makes the warning more informative for developers, in line with Flutter's documentation practices.

## Checklist

- [x] Documentation-only change
- [x] No functional logic modified
- [x] Analysis and tests unaffected
