### PR TITLE
Roll Dartdoc to 8.3.3

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -121,7 +121,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 8.3.0
+    "$DART" pub global activate dartdoc 8.3.3
 
     # Build and install the snippets tool, which resides in
     # the dev/docs/snippets directory.


### PR DESCRIPTION
This is required for the latest Dart SDK roll which removes the macros package (see https://github.com/flutter/flutter/pull/167223)