### PR TITLE
Revert "Removed superfluous copy in license checker (#167146)"

### DIFF
--- a/engine/src/flutter/ci/licenses_golden/tool_signature
+++ b/engine/src/flutter/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: bff1faf38fdddc991c42ef472cefd3e7
+Signature: 72079bc1edfa9c01900da12816e18f0e
 

--- a/engine/src/flutter/tools/licenses/lib/regexp_debug.dart
+++ b/engine/src/flutter/tools/licenses/lib/regexp_debug.dart
@@ -103,7 +103,7 @@ class RegExp implements core.RegExp {
   @override
   Iterable<RegExpMatch> allMatches(String input, [int start = 0]) {
     _stopwatch.start();
-    final Iterable<RegExpMatch> result = _pattern.allMatches(input, start);
+    final List<RegExpMatch> result = _pattern.allMatches(input, start).toList();
     _stopwatch.stop();
     _testCount += 1;
     if (result.isNotEmpty) {


### PR DESCRIPTION
This reverts commit b4dc23333c286bd6fb9b1aaeea63a933a2d62733.

The license script provides a RegExp wrapper that tracks the cost of the script's regexes. Dart's RegExp.allMatches returns an Iterable whose iterators lazily execute the regex.  Calling toList will execute the regex on the entire input within allMatches, allowing measurement of the regex's cost.  Returning the Iterable will instead shift the execution cost to the caller.

Also, in local measurements I'm seeing significantly better performance from finding all of the matches immediately with toList versus having the caller use the lazy iterator.