### PR TITLE
Fix CarouselView crashes when initlal viewportDimension is 0.0

### DIFF
--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -503,7 +503,7 @@ class _CarouselViewState extends State<CarouselView> {
           Axis.vertical => constraints.maxHeight,
         };
         _itemExtent =
-            _itemExtent == null ? _itemExtent : clampDouble(_itemExtent!, 0, mainAxisExtent);
+            widget.itemExtent == null ? null : clampDouble(widget.itemExtent!, 0, mainAxisExtent);
 
         return Scrollable(
           axisDirection: axisDirection,
@@ -1405,7 +1405,7 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
     if (_itemExtent == value) {
       return;
     }
-    if (hasPixels && _itemExtent != null) {
+    if (hasPixels && _itemExtent != null && viewportDimension != 0.0) {
       final double leadingItem = getItemFromPixels(pixels, viewportDimension);
       final double newPixel = getPixelsFromItem(leadingItem, flexWeights, value);
       forcePixels(newPixel);
@@ -1500,7 +1500,8 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
     } else {
       item = getItemFromPixels(oldPixels, oldViewportDimensions ?? viewportDimension);
     }
-    final double newPixels = getPixelsFromItem(item, flexWeights, itemExtent);
+    final double newPixels =
+        (viewportDimension == 0.0) ? 0.0 : getPixelsFromItem(item, flexWeights, itemExtent);
     // If the viewportDimension is zero, cache the item
     // in case the viewport is resized to be non-zero.
     _cachedItem = (viewportDimension == 0.0) ? item : null;
@@ -1510,6 +1511,18 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
       return false;
     }
     return result;
+  }
+
+  @override
+  void absorb(ScrollPosition other) {
+    super.absorb(other);
+
+    if (other is! _CarouselPosition) {
+      return;
+    }
+
+    _cachedItem = other._cachedItem;
+    _itemExtent = other._itemExtent;
   }
 
   @override

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -1472,6 +1472,9 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
 
   double getPixelsFromItem(double item, List<int>? flexWeights, double? itemExtent) {
     double fraction;
+    if (viewportDimension == 0.0) {
+      return 0.0;
+    }
     if (itemExtent != null) {
       fraction = itemExtent / viewportDimension;
     } else {
@@ -1500,8 +1503,7 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
     } else {
       item = getItemFromPixels(oldPixels, oldViewportDimensions ?? viewportDimension);
     }
-    final double newPixels =
-        (viewportDimension == 0.0) ? 0.0 : getPixelsFromItem(item, flexWeights, itemExtent);
+    final double newPixels = getPixelsFromItem(item, flexWeights, itemExtent);
     // If the viewportDimension is zero, cache the item
     // in case the viewport is resized to be non-zero.
     _cachedItem = (viewportDimension == 0.0) ? item : null;

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1474,6 +1474,121 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/160679.
+  testWidgets('Does not crash when parent size is zero', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 0,
+            child: CarouselView(itemExtent: 40.0, children: <Widget>[FlutterLogo()]),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('itemExtent can be set to double.infinity', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CarouselView(itemExtent: double.infinity, children: <Widget>[FlutterLogo()]),
+        ),
+      ),
+    );
+
+    // Item extent is clamped to screen size.
+    final Size logoSize = tester.getSize(find.byType(FlutterLogo));
+    const double itemHorizontalPadding = 8.0; // Default padding.
+    expect(logoSize.width, 800.0 - itemHorizontalPadding);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/163436.
+  testWidgets('Does not crash when initial viewport dimension is zero and itemExtent is fixed', (
+    WidgetTester tester,
+  ) async {
+    await tester.binding.setSurfaceSize(Size.zero);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const double fixedItemExtent = 60.0;
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CarouselView(itemExtent: fixedItemExtent, children: <Widget>[FlutterLogo()]),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/163436.
+  testWidgets('Does not crash when initial viewport dimension is zero and itemExtent is infinite', (
+    WidgetTester tester,
+  ) async {
+    await tester.binding.setSurfaceSize(Size.zero);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CarouselView(itemExtent: double.infinity, children: <Widget>[FlutterLogo()]),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/163436.
+  testWidgets('itemExtent is applied when viewport dimension is updated', (
+    WidgetTester tester,
+  ) async {
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const double itemExtent = 60.0;
+    bool showScrollbars = false;
+
+    Future<void> updateSurfaceSizeAndPump(Size size) async {
+      await tester.binding.setSurfaceSize(size);
+
+      // At startup, a warm-up frame can be produced before the Flutter engine has reported the
+      // initial view metrics. As a result, the first frame can be produced with a size of zero.
+      // This leads to several instances of _CarouselPosition being created and
+      // _CarouselPosition.absorb to be called.
+      // To correctly simulate this behavior in the test environment, one solution is to
+      // update the ScrollConfiguration. For instance by changing the ScrollBehavior.scrollbars
+      // value on each build.
+      showScrollbars = !showScrollbars;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: ScrollConfiguration(
+                behavior: const ScrollBehavior().copyWith(scrollbars: showScrollbars),
+                child: const CarouselView(
+                  itemExtent: itemExtent,
+                  children: <Widget>[FlutterLogo()],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Simulate an initial zero viewport dimension.
+    await updateSurfaceSizeAndPump(Size.zero);
+    await updateSurfaceSizeAndPump(const Size(500, 400));
+
+    final Size logoSize = tester.getSize(find.byType(FlutterLogo));
+    const double itemHorizontalPadding = 8.0; // Default padding.
+    expect(logoSize.width, itemExtent - itemHorizontalPadding);
+  });
+
   group('CarouselController.animateToItem', () {
     testWidgets('CarouselView.weighted horizontal, not reversed, flexWeights [7,1]', (
       WidgetTester tester,


### PR DESCRIPTION
## Description

This PR fixes CarouselView crashes due to viewportDimension being 0.0.
 
At startup, a warm-up frame can be produced before the Flutter engine has reported the
initial view metrics. As a result, the first frame can be produced with a size of zero. In the context of CarouselView this leads to some problems mainly related to division by zero.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/163436
Fixes https://github.com/flutter/flutter/issues/160679

## Tests

Adds 5 tests.

