### PR TITLE
[flutter_tools] Allow passing args in a file, provided as `@filename` as the last argument

### DIFF
--- a/packages/flutter_tools/test/integration.shard/args_test.dart
+++ b/packages/flutter_tools/test/integration.shard/args_test.dart
@@ -1,0 +1,117 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+final Future<Directory> tempDir = fileSystem.systemTempDirectory.createTemp('flutter_args_test');
+
+void main() {
+  tearDownAll(() async {
+    tryToDelete(await tempDir);
+  });
+
+  testWithoutContext('accepts top-level commands in a trailing @file', () async {
+    final File argsFile = await createArgsFile(<String>['help']);
+    await verifyFlutterOutput(
+      <String>['@${argsFile.path}'],
+      exitCode: 0,
+      stdout: startsWith('Manage your Flutter app development.'),
+    );
+  });
+
+  testWithoutContext('accepts top-level args in a trailing @file', () async {
+    final File argsFile = await createArgsFile(<String>['--help']);
+    await verifyFlutterOutput(
+      <String>['@${argsFile.path}'],
+      exitCode: 0,
+      stdout: startsWith('Manage your Flutter app development.'),
+    );
+  });
+
+  testWithoutContext('accepts command-level args in a trailing @file', () async {
+    final File argsFile = await createArgsFile(<String>['--no-pub', '--help']);
+    await verifyFlutterOutput(
+      <String>['test', '@${argsFile.path}'],
+      exitCode: 0,
+      stdout: startsWith('Run Flutter unit tests for the current project.'),
+    );
+  });
+
+  testWithoutContext('accepts command and args in a trailing @file', () async {
+    final File argsFile = await createArgsFile(<String>['test', '--no-pub', '--help']);
+    await verifyFlutterOutput(
+      <String>['@${argsFile.path}'],
+      exitCode: 0,
+      stdout: startsWith('Run Flutter unit tests for the current project.'),
+    );
+  });
+}
+
+/// Create an `args.txt` file in a temporary subdirectory of [tempDir] with
+/// [args] written as lines.
+Future<File> createArgsFile(List<String> args) async {
+  final Directory argsDir = (await tempDir).createTempSync('args');
+  final File file = fileSystem.file(fileSystem.path.join(argsDir.path, 'args.txt'));
+  file.writeAsStringSync(args.join(platform.isWindows ? '\r\n' : '\n'));
+  return file;
+}
+
+/// Runs 'flutter' with [args] and verifies the [exitCode], [stdout] and
+/// [stderr].
+Future<void> verifyFlutterOutput(
+  List<String> args, {
+  int? exitCode,
+  Matcher? stdout,
+  Matcher? stderr,
+}) async {
+  final ProcessResult exec = await _runFlutter(args);
+
+  if (exitCode != null) {
+    expect(
+      exec.exitCode,
+      exitCode,
+      reason:
+          '"flutter $args" returned code ${exec.exitCode}\n\nstdout:\n'
+          '${exec.stdout}\nstderr:\n${exec.stderr}',
+    );
+  }
+
+  if (stdout != null) {
+    expect(
+      exec.stdout.toString(),
+      stdout,
+      reason:
+          '"flutter $args" returned code ${exec.exitCode}\n\nstdout:\n'
+          '${exec.stdout}\nstderr:\n${exec.stderr}',
+    );
+  }
+
+  if (stderr != null) {
+    expect(
+      exec.stderr.toString(),
+      stderr,
+      reason:
+          '"flutter $args" returned code ${exec.exitCode}\n\nstdout:\n'
+          '${exec.stdout}\nstderr:\n${exec.stderr}',
+    );
+  }
+}
+
+Future<ProcessResult> _runFlutter(List<String> args) async {
+  args = <String>['--no-color', '--no-version-check', ...args];
+
+  return Process.run(
+    flutterBin, // Uses the precompiled flutter tool for faster tests,
+    args,
+    stdoutEncoding: utf8,
+    stderrEncoding: utf8,
+  );
+}


### PR DESCRIPTION
On Windows, there is a limit to how long command lines can be. This causes problems if a user selects a large subset of test files to run (which prevents using `flutter test foldername`) - see https://github.com/Dart-Code/Dart-Code/issues/5473

This change allows the last argument to be `@filename` where filename is a text file containing arguments that should be substituted in its place.

This is roughly equivalent to a `dart test` change for the same at https://github.com/dart-lang/test/pull/2485 which is similar to existing functionality elsewhere (such as Bazel - see https://github.com/Dart-Code/Dart-Code/issues/5473#issuecomment-2790187082).

To ensure these args always behave identically to args passed on the command line, the substitution is done as the very first thing in `executable.dart`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above (works towards https://github.com/Dart-Code/Dart-Code/issues/5473, but does not fix it alone, Dart-Code changes will be required).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
