### PR TITLE
Add a `gradle_errors.dart`entry for missing NDK source.properties file

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -297,7 +297,7 @@ final GradleHandledError flavorUndefinedHandler = GradleHandledError(
 );
 
 final RegExp _minSdkVersionPattern = RegExp(
-  r'uses-sdk:minSdkVersion ([0-9]+) cannot be smaller than version ([0-9]+) declared in library \[\:(.+)\]',
+  r'uses-sdk:minSdkVersion ([0-9]+) cannot be smaller than version ([0-9]+) declared in library \[:(.+)\]',
 );
 
 /// Handler when a plugin requires a higher Android API level.

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -731,7 +731,7 @@ https://github.com/flutter/flutter/issues/156304''', title: _boxTitle);
   eventLabel: 'java21-and-source-compatibility',
 );
 
-final RegExp _missingNdkSourcePropertiesRegexp = RegExp(r'NDK at ((?:/|[a-zA-Z]:\\|\\\\).+?) did not have a source\.properties file', multiLine: true);
+final RegExp _missingNdkSourcePropertiesRegexp = RegExp(r'NDK at ((?:/|[a-zA-Z]:\\).+?) did not have a source\.properties file', multiLine: true);
 
 @visibleForTesting
 final GradleHandledError missingNdkSourcePropertiesFile = GradleHandledError(

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -731,7 +731,9 @@ https://github.com/flutter/flutter/issues/156304''', title: _boxTitle);
   eventLabel: 'java21-and-source-compatibility',
 );
 
-final RegExp _missingNdkSourcePropertiesRegexp = RegExp(r'NDK at ((?:/|[a-zA-Z]:\\).+?) did not have a source\.properties file', multiLine: true);
+final RegExp _missingNdkSourcePropertiesRegexp = RegExp(
+    r'NDK at ((?:/|[a-zA-Z]:\\).+?) did not have a source\.properties file',
+    multiLine: true);
 
 @visibleForTesting
 final GradleHandledError missingNdkSourcePropertiesFile = GradleHandledError(

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -748,8 +748,8 @@ final GradleHandledError missingNdkSourcePropertiesFile = GradleHandledError(
         .group(1)!;
     globals.printBox('''
     ${globals.logger.terminal.warningMark} This is likely due to a malformed download of the NDK.
-    This can be fixed by deleting the local NDK copy at $path and allowing the Android Gradle 
-    Plugin to automatically re-download it.
+    This can be fixed by deleting the local NDK copy at: $path
+    and allowing the Android Gradle Plugin to automatically re-download it.
     ''',
         title: _boxTitle
     );

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -750,7 +750,9 @@ final GradleHandledError missingNdkSourcePropertiesFile = GradleHandledError(
     ${globals.logger.terminal.warningMark} This is likely due to a malformed download of the NDK.
     This can be fixed by deleting the local NDK copy at $path and allowing the Android Gradle 
     Plugin to automatically re-download it.
-    ''');
+    ''',
+        title: _boxTitle
+    );
     return GradleBuildStatus.exit;
   },
   eventLabel: 'ndk-missing-source-properties-file',

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -732,27 +732,24 @@ https://github.com/flutter/flutter/issues/156304''', title: _boxTitle);
 );
 
 final RegExp _missingNdkSourcePropertiesRegexp = RegExp(
-    r'NDK at ((?:/|[a-zA-Z]:\\).+?) did not have a source\.properties file',
-    multiLine: true);
+  r'NDK at ((?:/|[a-zA-Z]:\\).+?) did not have a source\.properties file',
+  multiLine: true,
+);
 
 @visibleForTesting
 final GradleHandledError missingNdkSourcePropertiesFile = GradleHandledError(
-  test:
-      (String line) => _missingNdkSourcePropertiesRegexp.hasMatch(line),
+  test: (String line) => _missingNdkSourcePropertiesRegexp.hasMatch(line),
   handler: ({
     required String line,
     required FlutterProject project,
     required bool usesAndroidX,
   }) async {
-    final String path = _missingNdkSourcePropertiesRegexp.firstMatch(line)!
-        .group(1)!;
+    final String path = _missingNdkSourcePropertiesRegexp.firstMatch(line)!.group(1)!;
     globals.printBox('''
     ${globals.logger.terminal.warningMark} This is likely due to a malformed download of the NDK.
     This can be fixed by deleting the local NDK copy at: $path
     and allowing the Android Gradle Plugin to automatically re-download it.
-    ''',
-        title: _boxTitle
-    );
+    ''', title: _boxTitle);
     return GradleBuildStatus.exit;
   },
   eventLabel: 'ndk-missing-source-properties-file',

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -80,6 +80,7 @@ final List<GradleHandledError> gradleErrors = <GradleHandledError>[
   incompatibleCompileSdk35AndAgpVersionHandler,
   usageOfV1EmbeddingReferencesHandler,
   jlinkErrorWithJava21AndSourceCompatibility,
+  missingNdkSourcePropertiesFile,
   incompatibleKotlinVersionHandler, // This handler should always be last, as its key log output is sometimes in error messages with other root causes.
 ];
 
@@ -728,4 +729,27 @@ https://github.com/flutter/flutter/issues/156304''', title: _boxTitle);
     return GradleBuildStatus.exit;
   },
   eventLabel: 'java21-and-source-compatibility',
+);
+
+final RegExp _missingNdkSourcePropertiesRegexp = RegExp(r'NDK at ((?:/|[a-zA-Z]:\\|\\\\).+?) did not have a source\.properties file', multiLine: true);
+
+@visibleForTesting
+final GradleHandledError missingNdkSourcePropertiesFile = GradleHandledError(
+  test:
+      (String line) => _missingNdkSourcePropertiesRegexp.hasMatch(line),
+  handler: ({
+    required String line,
+    required FlutterProject project,
+    required bool usesAndroidX,
+  }) async {
+    final String path = _missingNdkSourcePropertiesRegexp.firstMatch(line)!
+        .group(1)!;
+    globals.printBox('''
+    ${globals.logger.terminal.warningMark} This is likely due to a malformed download of the NDK.
+    This can be fixed by deleting the local NDK copy at $path and allowing the Android Gradle 
+    Plugin to automatically re-download it.
+    ''');
+    return GradleBuildStatus.exit;
+  },
+  eventLabel: 'ndk-missing-source-properties-file',
 );

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -54,6 +54,7 @@ void main() {
           incompatibleCompileSdk35AndAgpVersionHandler,
           usageOfV1EmbeddingReferencesHandler,
           jlinkErrorWithJava21AndSourceCompatibility,
+          missingNdkSourcePropertiesFile,
           incompatibleKotlinVersionHandler,
         ]),
       );
@@ -1560,6 +1561,39 @@ Execution failed for task ':shared_preferences_android:compileReleaseJavaWithJav
       // Links to info.
       expect(testLogger.statusText, contains('https://issuetracker.google.com/issues/294137077'));
       expect(testLogger.statusText, contains('https://github.com/flutter/flutter/issues/156304'));
+    },
+    overrides: <Type, Generator>{
+      GradleUtils: () => FakeGradleUtils(),
+      Platform: () => fakePlatform('android'),
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+    },
+  );
+
+  testUsingContext(
+    'Missing NDK source.properties file',
+        () async {
+      const String errorExample = r'''
+* What went wrong:
+A problem occurred configuring project ':app'.
+> [CXX1101] NDK at /Users/mackall/Library/Android/sdk/ndk/26.3.11579264 did not have a source.properties file
+    ''';
+
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+      await missingNdkSourcePropertiesFile.handler(
+        line: errorExample,
+        project: project,
+        usesAndroidX: true,
+      );
+
+      expect(
+        testLogger.statusText,
+        contains('This can be fixed by deleting the local NDK copy at'),
+      );
+      expect(
+        testLogger.statusText,
+        contains('/Users/mackall/Library/Android/sdk/ndk/26.3.11579264'),
+      );
     },
     overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1573,7 +1573,7 @@ Execution failed for task ':shared_preferences_android:compileReleaseJavaWithJav
   testUsingContext(
     'Missing NDK source.properties file',
         () async {
-      const String errorExample = r'''
+      const String unixErrorExample = r'''
 * What went wrong:
 A problem occurred configuring project ':app'.
 > [CXX1101] NDK at /Users/mackall/Library/Android/sdk/ndk/26.3.11579264 did not have a source.properties file
@@ -1581,7 +1581,7 @@ A problem occurred configuring project ':app'.
 
       final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
       await missingNdkSourcePropertiesFile.handler(
-        line: errorExample,
+        line: unixErrorExample,
         project: project,
         usesAndroidX: true,
       );
@@ -1593,6 +1593,26 @@ A problem occurred configuring project ':app'.
       expect(
         testLogger.statusText,
         contains('/Users/mackall/Library/Android/sdk/ndk/26.3.11579264'),
+      );
+
+      const String windowsErrorExample = r'''
+* What went wrong:
+A problem occurred configuring project ':app'.
+> [CXX1101] NDK at C:\Users\mackall\Library\Android\sdk\ndk\26.3.11579264 did not have a source.properties file
+    ''';
+      await missingNdkSourcePropertiesFile.handler(
+        line: windowsErrorExample,
+        project: project,
+        usesAndroidX: true,
+      );
+
+      expect(
+        testLogger.statusText,
+        contains('This can be fixed by deleting the local NDK copy at'),
+      );
+      expect(
+        testLogger.statusText,
+        contains('C:\\Users\\mackall\\Library\\Android\\sdk\\ndk\\26.3.11579264'),
       );
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1612,7 +1612,7 @@ A problem occurred configuring project ':app'.
       );
       expect(
         testLogger.statusText,
-        contains('C:\\Users\\mackall\\Library\\Android\\sdk\\ndk\\26.3.11579264'),
+        contains(r'C:\Users\mackall\Library\Android\sdk\ndk\26.3.11579264'),
       );
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1572,7 +1572,7 @@ Execution failed for task ':shared_preferences_android:compileReleaseJavaWithJav
 
   testUsingContext(
     'Missing NDK source.properties file',
-        () async {
+    () async {
       const String unixErrorExample = r'''
 * What went wrong:
 A problem occurred configuring project ':app'.


### PR DESCRIPTION
Adds an error handler for https://github.com/flutter/flutter/issues/164085, based on the suggested workaround. 

The only related Android issue I could find is http://issuetracker.google.com/issues/201557284, which suggests it is due to an incorrect path for the NDK within the Android directory, which means that allowing AGP to re-download would fix the issue. Users also suggest that doing that fixes the issue in this comment https://github.com/flutter/flutter/issues/164085#issuecomment-2684252849, so the handler suggests that as the official workaround.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
