### PR TITLE
Reverts caching render passes for non-msaa passes

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
@@ -47,39 +47,5 @@ TEST_P(RendererTest, CachesRenderPassAndFramebuffer) {
   EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer_2}).ok());
 }
 
-TEST_P(RendererTest, CachesRenderPassAndFramebufferNonMSAA) {
-  if (GetBackend() != PlaygroundBackend::kVulkan) {
-    GTEST_SKIP() << "Test only applies to Vulkan";
-  }
-
-  auto allocator = std::make_shared<RenderTargetAllocator>(
-      GetContext()->GetResourceAllocator());
-
-  RenderTarget render_target =
-      allocator->CreateOffscreen(*GetContext(), {100, 100}, 1);
-  std::shared_ptr<Texture> color_texture =
-      render_target.GetColorAttachment(0).texture;
-  TextureVK& texture_vk = TextureVK::Cast(*color_texture);
-
-  EXPECT_EQ(texture_vk.GetCachedFramebuffer(), nullptr);
-  EXPECT_EQ(texture_vk.GetCachedRenderPass(), nullptr);
-
-  auto buffer = GetContext()->CreateCommandBuffer();
-  auto render_pass = buffer->CreateRenderPass(render_target);
-
-  EXPECT_NE(texture_vk.GetCachedFramebuffer(), nullptr);
-  EXPECT_NE(texture_vk.GetCachedRenderPass(), nullptr);
-
-  render_pass->EncodeCommands();
-  EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer}).ok());
-
-  // Can be reused without error.
-  auto buffer_2 = GetContext()->CreateCommandBuffer();
-  auto render_pass_2 = buffer_2->CreateRenderPass(render_target);
-
-  EXPECT_TRUE(render_pass_2->EncodeCommands());
-  EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer_2}).ok());
-}
-
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -153,11 +153,6 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
         TextureVK::Cast(*resolve_image_vk_).GetCachedRenderPass();
     recycled_framebuffer =
         TextureVK::Cast(*resolve_image_vk_).GetCachedFramebuffer();
-  } else {
-    recycled_render_pass =
-        TextureVK::Cast(*color_image_vk_).GetCachedRenderPass();
-    recycled_framebuffer =
-        TextureVK::Cast(*color_image_vk_).GetCachedFramebuffer();
   }
 
   const auto& target_size = render_target_.GetRenderTargetSize();
@@ -194,9 +189,6 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   if (resolve_image_vk_) {
     TextureVK::Cast(*resolve_image_vk_).SetCachedFramebuffer(framebuffer);
     TextureVK::Cast(*resolve_image_vk_).SetCachedRenderPass(render_pass_);
-  } else {
-    TextureVK::Cast(*color_image_vk_).SetCachedFramebuffer(framebuffer);
-    TextureVK::Cast(*color_image_vk_).SetCachedRenderPass(render_pass_);
   }
 
   // If the resolve image exists and has mipmaps, transition mip levels besides


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/167316
partial revert of https://github.com/flutter/flutter/pull/165497

This disables the render pass caching of non-msaa passes.  This seems to have broken vulkan playgrounds locally.  I believe this is because of the imgui pass that is present locally but not on CI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
