### PR TITLE
Adds radio group widget

### DIFF
--- a/examples/api/lib/material/radio/radio.0.dart
+++ b/examples/api/lib/material/radio/radio.0.dart
@@ -36,33 +36,25 @@ class _RadioExampleState extends State<RadioExample> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        ListTile(
-          title: const Text('Lafayette'),
-          leading: Radio<SingingCharacter>(
-            value: SingingCharacter.lafayette,
-            groupValue: _character,
-            onChanged: (SingingCharacter? value) {
-              setState(() {
-                _character = value;
-              });
-            },
+    return RadioGroup<SingingCharacter>(
+      groupValue: _character,
+      onChanged: (SingingCharacter? value) {
+        setState(() {
+          _character = value;
+        });
+      },
+      child: const Column(
+        children: <Widget>[
+          ListTile(
+            title: Text('Lafayette'),
+            leading: Radio<SingingCharacter>(value: SingingCharacter.lafayette),
           ),
-        ),
-        ListTile(
-          title: const Text('Thomas Jefferson'),
-          leading: Radio<SingingCharacter>(
-            value: SingingCharacter.jefferson,
-            groupValue: _character,
-            onChanged: (SingingCharacter? value) {
-              setState(() {
-                _character = value;
-              });
-            },
+          ListTile(
+            title: Text('Thomas Jefferson'),
+            leading: Radio<SingingCharacter>(value: SingingCharacter.jefferson),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/examples/api/lib/material/radio/radio.toggleable.0.dart
+++ b/examples/api/lib/material/radio/radio.toggleable.0.dart
@@ -42,28 +42,30 @@ class _ToggleableExampleState extends State<ToggleableExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: ListView.builder(
-        itemBuilder: (BuildContext context, int index) {
-          return Row(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Radio<int>(
-                value: index,
-                groupValue: groupValue,
-                // TRY THIS: Try setting the toggleable value to false and
-                // see how that changes the behavior of the widget.
-                toggleable: true,
-                onChanged: (int? value) {
-                  setState(() {
-                    groupValue = value;
-                  });
-                },
-              ),
-              Text(selections[index]),
-            ],
-          );
+      body: RadioGroup<int>(
+        groupValue: groupValue,
+        onChanged: (int? value) {
+          setState(() {
+            groupValue = value;
+          });
         },
-        itemCount: selections.length,
+        child: ListView.builder(
+          itemBuilder: (BuildContext context, int index) {
+            return Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Radio<int>(
+                  value: index,
+                  // TRY THIS: Try setting the toggleable value to false and
+                  // see how that changes the behavior of the widget.
+                  toggleable: true,
+                ),
+                Text(selections[index]),
+              ],
+            );
+          },
+          itemCount: selections.length,
+        ),
       ),
     );
   }

--- a/examples/api/lib/material/radio_group/radio_group.0.dart
+++ b/examples/api/lib/material/radio_group/radio_group.0.dart
@@ -1,0 +1,107 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [Radio].
+
+void main() => runApp(const RadioExampleApp());
+
+class RadioExampleApp extends StatelessWidget {
+  const RadioExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Radio Group Sample')),
+        body: const Center(child: RadioExample()),
+      ),
+    );
+  }
+}
+
+enum SingingCharacter { lafayette, jefferson }
+
+enum Genre { metal, jazz }
+
+class RadioExample extends StatelessWidget {
+  const RadioExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(children: <Widget>[SingingCharacterRadioGroup(), GenreRadioGroup()]);
+  }
+}
+
+class SingingCharacterRadioGroup extends StatefulWidget {
+  const SingingCharacterRadioGroup({super.key});
+
+  @override
+  State<SingingCharacterRadioGroup> createState() => SingingCharacterRadioGroupState();
+}
+
+class SingingCharacterRadioGroupState extends State<SingingCharacterRadioGroup> {
+  SingingCharacter? _character = SingingCharacter.lafayette;
+
+  @override
+  Widget build(BuildContext context) {
+    return RadioGroup<SingingCharacter>(
+      groupValue: _character,
+      onChanged: (SingingCharacter? value) {
+        setState(() {
+          _character = value;
+        });
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text('Selected: $_character'),
+          const ListTile(
+            title: Text('Lafayette'),
+            leading: Radio<SingingCharacter>(value: SingingCharacter.lafayette),
+          ),
+          const ListTile(
+            title: Text('Thomas Jefferson'),
+            leading: Radio<SingingCharacter>(value: SingingCharacter.jefferson),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class GenreRadioGroup extends StatefulWidget {
+  const GenreRadioGroup({super.key});
+
+  @override
+  State<GenreRadioGroup> createState() => GenreRadioGroupState();
+}
+
+class GenreRadioGroupState extends State<GenreRadioGroup> {
+  Genre? _genre;
+
+  @override
+  Widget build(BuildContext context) {
+    return RadioGroup<Genre>(
+      groupValue: _genre,
+      onChanged: (Genre? value) {
+        setState(() {
+          _genre = value;
+        });
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text('Selected: $_genre'),
+          const ListTile(
+            title: Text('Metal'),
+            leading: Radio<Genre>(toggleable: true, value: Genre.metal),
+          ),
+          const ListTile(title: Text('Jazz'), leading: Radio<Genre>(value: Genre.jazz)),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/api/test/material/radio/radio.toggleable.0_test.dart
+++ b/examples/api/test/material/radio/radio.toggleable.0_test.dart
@@ -21,8 +21,10 @@ void main() {
       await tester.tap(find.byType(Radio<int>).at(i));
       await tester.pump();
       expect(
-        find.byWidgetPredicate((Widget widget) => widget is Radio<int> && widget.groupValue == i),
-        findsExactly(5),
+        find.byWidgetPredicate(
+          (Widget widget) => widget is RadioGroup<int> && widget.groupValue == i,
+        ),
+        findsOne,
       );
     }
   });

--- a/examples/api/test/material/radio_group/radio_group.0_test.dart
+++ b/examples/api/test/material/radio_group/radio_group.0_test.dart
@@ -3,14 +3,14 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_api_samples/material/radio/radio.0.dart' as example;
+import 'package:flutter_api_samples/material/radio_group/radio_group.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Radio Smoke Test', (WidgetTester tester) async {
+  testWidgets('Radio Smoke Test - character', (WidgetTester tester) async {
     await tester.pumpWidget(const example.RadioExampleApp());
 
-    expect(find.widgetWithText(AppBar, 'Radio Sample'), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Radio Group Sample'), findsOneWidget);
     final Finder listTile1 = find.widgetWithText(ListTile, 'Lafayette');
     expect(listTile1, findsOneWidget);
     final Finder listTile2 = find.widgetWithText(ListTile, 'Thomas Jefferson');
@@ -39,6 +39,41 @@ void main() {
     expect(
       tester.widget<RadioGroup<example.SingingCharacter>>(radioGroup).groupValue,
       tester.widget<Radio<example.SingingCharacter>>(radioButton2).value,
+    );
+  });
+
+  testWidgets('Radio Smoke Test - genre', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.RadioExampleApp());
+
+    expect(find.widgetWithText(AppBar, 'Radio Group Sample'), findsOneWidget);
+    final Finder listTile1 = find.widgetWithText(ListTile, 'Metal');
+    expect(listTile1, findsOneWidget);
+    final Finder listTile2 = find.widgetWithText(ListTile, 'Jazz');
+    expect(listTile2, findsOneWidget);
+
+    final Finder radioButton1 = find.byType(Radio<example.Genre>).first;
+    final Finder radioButton2 = find.byType(Radio<example.Genre>).last;
+    final Finder radioGroup = find.byType(RadioGroup<example.Genre>).last;
+
+    await tester.tap(radioButton1);
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<RadioGroup<example.Genre>>(radioGroup).groupValue,
+      tester.widget<Radio<example.Genre>>(radioButton1).value,
+    );
+    expect(
+      tester.widget<RadioGroup<example.Genre>>(radioGroup).groupValue,
+      isNot(tester.widget<Radio<example.Genre>>(radioButton2).value),
+    );
+    await tester.tap(radioButton2);
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<RadioGroup<example.Genre>>(radioGroup).groupValue,
+      isNot(tester.widget<Radio<example.Genre>>(radioButton1).value),
+    );
+    expect(
+      tester.widget<RadioGroup<example.Genre>>(radioGroup).groupValue,
+      tester.widget<Radio<example.Genre>>(radioButton2).value,
     );
   });
 }

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -160,11 +160,7 @@ enum _RadioType { material, adaptive }
 class RadioListTile<T> extends StatelessWidget {
   /// Creates a combination of a list tile and a radio button.
   ///
-  /// The radio tile itself does not maintain any state. Instead, when the radio
-  /// button is selected, the widget calls the [onChanged] callback. Most
-  /// widgets that use a radio button will listen for the [onChanged] callback
-  /// and rebuild the radio tile with a new [groupValue] to update the visual
-  /// appearance of the radio button.
+  /// {@macro flutter.material.Radio.groupValue}
   ///
   /// The following arguments are required:
   ///
@@ -174,8 +170,8 @@ class RadioListTile<T> extends StatelessWidget {
   const RadioListTile({
     super.key,
     required this.value,
-    required this.groupValue,
-    required this.onChanged,
+    this.groupValue,
+    this.onChanged,
     this.mouseCursor,
     this.toggleable = false,
     this.activeColor,
@@ -215,8 +211,8 @@ class RadioListTile<T> extends StatelessWidget {
   const RadioListTile.adaptive({
     super.key,
     required this.value,
-    required this.groupValue,
-    required this.onChanged,
+    this.groupValue,
+    this.onChanged,
     this.mouseCursor,
     this.toggleable = false,
     this.activeColor,
@@ -254,6 +250,8 @@ class RadioListTile<T> extends StatelessWidget {
   ///
   /// This radio button is considered selected if its [value] matches the
   /// [groupValue].
+  ///
+  /// leave this unassigned or null if building this widget under [RadioGroup].
   final T? groupValue;
 
   /// Called when the user selects this radio button.

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -27,8 +27,7 @@ void main() {
     int? selectedValue;
     // Constructor parameters are required for [RadioListTile], but they are
     // irrelevant when searching with [find.byType].
-    final Type radioListTileType =
-        const RadioListTile<int>(value: 0, groupValue: 0, onChanged: null).runtimeType;
+    final Type radioListTileType = const RadioListTile<int>(value: 0, groupValue: 0).runtimeType;
 
     List<RadioListTile<int>> generatedRadioListTiles;
     List<RadioListTile<int>> findTiles() =>
@@ -126,7 +125,6 @@ void main() {
           key: key,
           value: 1,
           groupValue: 2,
-          onChanged: null,
           title: Text('Title', key: titleKey),
         ),
       ),
@@ -158,7 +156,7 @@ void main() {
     int? selectedValue;
     // Constructor parameters are required for [Radio], but they are irrelevant
     // when searching with [find.byType].
-    final Type radioType = const Radio<int>(value: 0, groupValue: 0, onChanged: null).runtimeType;
+    final Type radioType = const Radio<int>(value: 0, groupValue: 0).runtimeType;
     final List<dynamic> log = <dynamic>[];
 
     Widget buildFrame() {
@@ -223,7 +221,7 @@ void main() {
     int? selectedValue;
     // Constructor parameters are required for [Radio], but they are irrelevant
     // when searching with [find.byType].
-    final Type radioType = const Radio<int>(value: 0, groupValue: 0, onChanged: null).runtimeType;
+    final Type radioType = const Radio<int>(value: 0, groupValue: 0).runtimeType;
     final List<dynamic> log = <dynamic>[];
 
     Widget buildFrame() {
@@ -273,7 +271,7 @@ void main() {
     int? selectedValue;
     // Constructor parameters are required for [Radio], but they are irrelevant
     // when searching with [find.byType].
-    final Type radioType = const Radio<int>(value: 0, groupValue: 0, onChanged: null).runtimeType;
+    final Type radioType = const Radio<int>(value: 0, groupValue: 0).runtimeType;
     final List<dynamic> log = <dynamic>[];
 
     Widget buildFrame() {
@@ -362,15 +360,7 @@ void main() {
 
     await tester.pumpWidget(
       Material(
-        child: Center(
-          child: Radio<int>(
-            key: key,
-            value: 1,
-            groupValue: null,
-            onChanged: log.add,
-            toggleable: true,
-          ),
-        ),
+        child: Center(child: Radio<int>(key: key, value: 1, onChanged: log.add, toggleable: true)),
       ),
     );
 
@@ -466,7 +456,6 @@ void main() {
         child: const RadioListTile<int>(
           value: 1,
           groupValue: 2,
-          onChanged: null,
           title: Text('Title'),
           internalAddSemanticForOnTap: true,
         ),
@@ -504,7 +493,6 @@ void main() {
         child: const RadioListTile<int>(
           value: 2,
           groupValue: 2,
-          onChanged: null,
           title: Text('Title'),
           internalAddSemanticForOnTap: true,
         ),
@@ -607,7 +595,6 @@ void main() {
         child: RadioListTile<int>(
           value: 1,
           groupValue: 2,
-          onChanged: null,
           title: Text('Title', key: childKey),
           autofocus: true,
         ),
@@ -619,8 +606,7 @@ void main() {
   });
 
   testWidgets('RadioListTile contentPadding test', (WidgetTester tester) async {
-    final Type radioType =
-        const Radio<bool>(groupValue: true, value: true, onChanged: null).runtimeType;
+    final Type radioType = const Radio<bool>(groupValue: true, value: true).runtimeType;
 
     await tester.pumpWidget(
       wrap(
@@ -666,7 +652,6 @@ void main() {
           child: RadioListTile<bool>(
             value: true,
             groupValue: true,
-            onChanged: null,
             title: Text('Title'),
             shape: shapeBorder,
           ),
@@ -686,7 +671,6 @@ void main() {
           child: RadioListTile<bool>(
             value: false,
             groupValue: true,
-            onChanged: null,
             title: const Text('Title'),
             tileColor: tileColor,
           ),
@@ -706,7 +690,6 @@ void main() {
           child: RadioListTile<bool>(
             value: false,
             groupValue: true,
-            onChanged: null,
             title: const Text('Title'),
             selected: true,
             selectedTileColor: selectedTileColor,
@@ -887,7 +870,7 @@ void main() {
       wrap(
         child: const MouseRegion(
           cursor: SystemMouseCursors.forbidden,
-          child: RadioListTile<int>(value: 1, onChanged: null, groupValue: 2),
+          child: RadioListTile<int>(value: 1, groupValue: 2),
         ),
       ),
     );
@@ -1610,9 +1593,7 @@ void main() {
   testWidgets('RadioListTile renders with default scale', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
-        home: Material(
-          child: RadioListTile<bool>(value: false, groupValue: false, onChanged: null),
-        ),
+        home: Material(child: RadioListTile<bool>(value: false, groupValue: false)),
       ),
     );
 
@@ -1629,12 +1610,7 @@ void main() {
     await tester.pumpWidget(
       const MaterialApp(
         home: Material(
-          child: RadioListTile<bool>(
-            value: false,
-            groupValue: false,
-            onChanged: null,
-            radioScaleFactor: scale,
-          ),
+          child: RadioListTile<bool>(value: false, groupValue: false, radioScaleFactor: scale),
         ),
       ),
     );

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -63,9 +63,7 @@ void main() {
     await tester.pumpWidget(
       Theme(
         data: theme,
-        child: Material(
-          child: Center(child: Radio<int>(key: key, value: 1, groupValue: 2, onChanged: null)),
-        ),
+        child: Material(child: Center(child: Radio<int>(key: key, value: 1, groupValue: 2))),
       ),
     );
 
@@ -127,13 +125,7 @@ void main() {
         data: theme,
         child: Material(
           child: Center(
-            child: Radio<int>(
-              key: key,
-              value: 1,
-              groupValue: null,
-              onChanged: log.add,
-              toggleable: true,
-            ),
+            child: Radio<int>(key: key, value: 1, onChanged: log.add, toggleable: true),
           ),
         ),
       ),
@@ -291,10 +283,7 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Theme(
-        data: theme,
-        child: const Material(child: Radio<int>(value: 1, groupValue: 2, onChanged: null)),
-      ),
+      Theme(data: theme, child: const Material(child: Radio<int>(value: 1, groupValue: 2))),
     );
 
     expect(
@@ -343,10 +332,7 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Theme(
-        data: theme,
-        child: const Material(child: Radio<int>(value: 2, groupValue: 2, onChanged: null)),
-      ),
+      Theme(data: theme, child: const Material(child: Radio<int>(value: 2, groupValue: 2))),
     );
 
     expect(
@@ -1091,7 +1077,7 @@ void main() {
             child: Material(
               child: MouseRegion(
                 cursor: SystemMouseCursors.forbidden,
-                child: Radio<int>(value: 1, onChanged: null, groupValue: 2),
+                child: Radio<int>(value: 1, groupValue: 2),
               ),
             ),
           ),
@@ -1566,7 +1552,7 @@ void main() {
         home: const Material(
           child: Tooltip(
             message: longPressTooltip,
-            child: Radio<bool>(value: true, groupValue: false, onChanged: null),
+            child: Radio<bool>(value: true, groupValue: false),
           ),
         ),
       ),
@@ -1596,7 +1582,7 @@ void main() {
           child: Tooltip(
             triggerMode: TooltipTriggerMode.tap,
             message: tapTooltip,
-            child: Radio<bool>(value: true, groupValue: false, onChanged: null),
+            child: Radio<bool>(value: true, groupValue: false),
           ),
         ),
       ),


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/113562

This pr introduce a new widget RadioGroup

It does two things:
1. maintain the group value and provide a simpler api to get the group value
2. Provide semantics and keyboard navigation matching https://www.w3.org/WAI/ARIA/apg/patterns/radio/

If for some reason, one only wants to have (2), they can use RadioGroupPolicy.

Before this change developers have to implement
```dart
int? selection;

  @override
  Widget build(BuildContext context) {
    return Column(
      children: <Widget>[
        Radio<int>(
            value: 0,
            groupValue: selection,
            onChanged: (int? value) {
              setState(() {
                selection = value;
              });
            },
          ),
        Radio<int>(
            value: 1,
            groupValue: selection,
            onChanged: (int? value) {
              setState(() {
                selection = value;
              });
            },
          ),
      ],
    );
  }
```

After this change

```dart
  @override
  Widget build(BuildContext context) {
    return RadioGroup<int>(
      onChange: (int? value) => print(value)
      child: Column(
        children: <Widget>[
          Radio<int>(value: 0),
          Radio<int>(value: 1),
        ],
      ),
    );
  }
```
They also get keyboard behaviors match Accessibility standard

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
