### PR TITLE
Move from getByName to getByType in gradle when fetching androidApp extension. 

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -403,10 +403,8 @@ object FlutterPluginUtils {
         return project.extensions.findByType(BaseExtension::class.java)!!
     }
 
-    // TODO: Use find by type and AbstractAppExtension instead. Or delete in favor of getAndroidExtension.
-    //       see https://github.com/flutter/flutter/issues/165882
     private fun getAndroidAppExtensionOrNull(project: Project): AbstractAppExtension? =
-        project.extensions.findByName("android") as? AbstractAppExtension
+        project.extensions.findByType(AbstractAppExtension::class.java)
 
     /**
      * Expected format of getAndroidExtension(project).compileSdkVersion is a string of the form

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
@@ -1108,7 +1108,7 @@ class FlutterPluginUtilsTest {
                         every { info(any()) } returns Unit
                         every { warn(any()) } returns Unit
                     }
-                every { extensions.findByName("android") } returns
+                every { extensions.findByType(AbstractAppExtension::class.java) } returns
                     mockk<AbstractAppExtension> {
                         val variant1 =
                             mockk<ApplicationVariant> {
@@ -1237,7 +1237,7 @@ class FlutterPluginUtilsTest {
         val mockLogger = mockk<Logger>()
         every { mockProject.logger } returns mockLogger
         every { mockLogger.info(any()) } returns Unit
-        every { mockProject.extensions.findByName("android") } returns null
+        every { mockProject.extensions.findByType(AbstractAppExtension::class.java) } returns null
 
         FlutterPluginUtils.addTasksForOutputsAppLinkSettings(mockProject)
         verify(exactly = 1) { mockLogger.info("addTasksForOutputsAppLinkSettings called on project without android extension.") }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/165882

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
