### PR TITLE
Android doctor: more robust `canrun`

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -61,11 +61,11 @@ class AndroidWorkflow implements Workflow {
 }
 
 Future<String?> getEmulatorVersion(AndroidSdk androidSdk, ProcessManager processManager) async {
-  if (!processManager.canRun(androidSdk.emulatorPath)) {
-    return null;
-  }
-
   try {
+    if (!processManager.canRun(androidSdk.emulatorPath)) {
+      return null;
+    }
+
     final ProcessResult result = await processManager.run(<Object>[
       androidSdk.emulatorPath!,
       '-version',
@@ -93,6 +93,8 @@ Future<String?> getEmulatorVersion(AndroidSdk androidSdk, ProcessManager process
       return null;
     }
   } on Exception catch (e, _) {
+    return null;
+  } on Error catch (_) {
     return null;
   }
 }

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -455,6 +455,30 @@ Review licenses that have not been accepted (y/N)?
     expect(sdkMessage.message, 'Emulator version 35.2.10.0 (build_id 12414864) (CL:N/A)');
   });
 
+  testUsingContext('includes emulator version - no emulator path', () async {
+    sdk
+      ..licensesAvailable = true
+      ..platformToolsAvailable = false
+      ..cmdlineToolsAvailable = true
+      ..directory = fileSystem.directory('/foo/bar')
+      ..emulatorPath = null;
+    final ValidationResult validationResult =
+        await AndroidValidator(
+          java: FakeJava(),
+          androidSdk: sdk,
+          logger: logger,
+          platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
+          userMessages: UserMessages(),
+          processManager: processManager,
+        ).validate();
+
+    expect(validationResult.type, ValidationType.partial);
+    expect(validationResult.messages.length > 2, isTrue);
+    final ValidationMessage sdkMessage = validationResult.messages[1];
+    expect(sdkMessage.type, ValidationMessageType.information);
+    expect(sdkMessage.message, 'Emulator version unknown');
+  });
+
   testUsingContext('detects license-only SDK installation with cmdline-tools', () async {
     sdk
       ..licensesAvailable = true


### PR DESCRIPTION
Fixes error found in rolling to google.

```
[☠] Android toolchain - develop for Android devices (the doctor check crashed)
    ✗ Due to an error, the doctor check did not complete. If the error message
      below is not helpful, please let us know about this issue at
      https://github.com/flutter/flutter/issues.
    ✗ type 'Null' is not a subtype of type 'String' of 'executable'
    • #0      LocalProcessManager.canRun
      (package:process/src/interface/local_process_manager.dart:124)
      #1      getEmulatorVersion
      (package:flutter_tools/src/android/android_workflow.dart:64)
      #2      AndroidValidator.validateImpl
      (package:flutter_tools/src/android/android_workflow.dart:200)
      #3      DoctorValidator.validate
      (package:flutter_tools/src/doctor_validator.dart:58)
      #4      Doctor.startValidatorTasks.<anonymous closure>
      (package:flutter_tools/src/doctor.dart:244)
      #5      asyncGuard.<anonymous closure>
      (package:flutter_tools/src/base/async_guard.dart:109)
      #6      _rootRun (dart:async/zone.dart:1525)
      #7      _CustomZone.run (dart:async/zone.dart:1422)
      #8      _runZoned (dart:async/zone.dart:2033)
      #9      runZonedGuarded (dart:async/zone.dart:2019)
      #10     runZoned (dart:async/zone.dart:1952)
      #11     asyncGuard (package:flutter_tools/src/base/async_guard.dart:106)
      #12     Doctor.startValidatorTasks
      (package:flutter_tools/src/doctor.dart:234)
      #13     Doctor.diagnose (package:flutter_tools/src/doctor.dart:372)
      #14     DoctorCommand.runCommand
      (package:flutter_tools/src/commands/doctor.dart:59)
      #15     FlutterCommand.verifyThenRunCommand
      (package:flutter_tools/src/runner/flutter_command.dart:1897)
      <asynchronous suspension>
      #16     FlutterCommand.run.<anonymous closure>
      (package:flutter_tools/src/runner/flutter_command.dart:1551)
      <asynchronous suspension>
      #17     AppContext.run.<anonymous closure>
      (package:flutter_tools/src/base/context.dart:154)
      <asynchronous suspension>
      #18     CommandRunner.runCommand (package:args/command_runner.dart:212)
      <asynchronous suspension>
      #19     FlutterCommandRunner.runCommand.<anonymous closure>
      (package:flutter_tools/src/runner/flutter_command_runner.dart:501)
      <asynchronous suspension>
      #20     AppContext.run.<anonymous closure>
      (package:flutter_tools/src/base/context.dart:154)
      <asynchronous suspension>
      #21     FlutterCommandRunner.runCommand
      (package:flutter_tools/src/runner/flutter_command_runner.dart:438)
      <asynchronous suspension>
      #22     run.<anonymous closure>.<anonymous closure>
      (package:flutter_tools/runner.dart:98)
      <asynchronous suspension>
      #23     AppContext.run.<anonymous closure>
      (package:flutter_tools/src/base/context.dart:154)
      <asynchronous suspension>
      #24     AppContext.run.<anonymous closure>
      (package:flutter_tools/src/base/context.dart:154)
      <asynchronous suspension>
      #25     run (package:mobile.flutter.cli/flutter_tools.dart:106)
      <asynchronous suspension>
      #26     main (google3:///mobile/flutter/cli/bin/cli_usage_aot.dart:4)
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
