### PR TITLE
[Impeller] fix playground validation errors in imgui overlay.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/testing/testing.h"
 #include "gtest/gtest.h"
+#include "impeller/core/formats.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
 #include "impeller/renderer/render_target.h"
@@ -27,14 +28,18 @@ TEST_P(RendererTest, CachesRenderPassAndFramebuffer) {
       render_target.GetColorAttachment(0).resolve_texture;
   TextureVK& texture_vk = TextureVK::Cast(*resolve_texture);
 
-  EXPECT_EQ(texture_vk.GetCachedFrameData().framebuffer, nullptr);
-  EXPECT_EQ(texture_vk.GetCachedFrameData().render_pass, nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount4).framebuffer,
+            nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount4).render_pass,
+            nullptr);
 
   auto buffer = GetContext()->CreateCommandBuffer();
   auto render_pass = buffer->CreateRenderPass(render_target);
 
-  EXPECT_NE(texture_vk.GetCachedFrameData().framebuffer, nullptr);
-  EXPECT_NE(texture_vk.GetCachedFrameData().render_pass, nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount4).framebuffer,
+            nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount4).render_pass,
+            nullptr);
 
   render_pass->EncodeCommands();
   EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer}).ok());
@@ -61,14 +66,18 @@ TEST_P(RendererTest, CachesRenderPassAndFramebufferNonMSAA) {
       render_target.GetColorAttachment(0).texture;
   TextureVK& texture_vk = TextureVK::Cast(*color_texture);
 
-  EXPECT_EQ(texture_vk.GetCachedFrameData().framebuffer, nullptr);
-  EXPECT_EQ(texture_vk.GetCachedFrameData().render_pass, nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount1).framebuffer,
+            nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount1).render_pass,
+            nullptr);
 
   auto buffer = GetContext()->CreateCommandBuffer();
   auto render_pass = buffer->CreateRenderPass(render_target);
 
-  EXPECT_NE(texture_vk.GetCachedFrameData().framebuffer, nullptr);
-  EXPECT_NE(texture_vk.GetCachedFrameData().render_pass, nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount1).framebuffer,
+            nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount1).render_pass,
+            nullptr);
 
   render_pass->EncodeCommands();
   EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer}).ok());
@@ -79,6 +88,72 @@ TEST_P(RendererTest, CachesRenderPassAndFramebufferNonMSAA) {
 
   EXPECT_TRUE(render_pass_2->EncodeCommands());
   EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer_2}).ok());
+}
+
+TEST_P(RendererTest, CachesRenderPassAndFramebufferMixed) {
+  if (GetBackend() != PlaygroundBackend::kVulkan) {
+    GTEST_SKIP() << "Test only applies to Vulkan";
+  }
+
+  auto allocator = std::make_shared<RenderTargetAllocator>(
+      GetContext()->GetResourceAllocator());
+
+  RenderTarget render_target =
+      allocator->CreateOffscreenMSAA(*GetContext(), {100, 100}, 1);
+  std::shared_ptr<Texture> resolve_texture =
+      render_target.GetColorAttachment(0).resolve_texture;
+  TextureVK& texture_vk = TextureVK::Cast(*resolve_texture);
+
+  EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount4).framebuffer,
+            nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount4).render_pass,
+            nullptr);
+
+  auto buffer = GetContext()->CreateCommandBuffer();
+  auto render_pass = buffer->CreateRenderPass(render_target);
+
+  EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount4).framebuffer,
+            nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount4).render_pass,
+            nullptr);
+
+  render_pass->EncodeCommands();
+  EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer}).ok());
+
+  // Can be reused without error.
+  auto buffer_2 = GetContext()->CreateCommandBuffer();
+  auto render_pass_2 = buffer_2->CreateRenderPass(render_target);
+
+  EXPECT_TRUE(render_pass_2->EncodeCommands());
+  EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer_2}).ok());
+
+  // Now switch to single sample count and demonstrate no validation errors.
+  {
+    RenderTarget other_target;
+    ColorAttachment color0;
+    color0.load_action = LoadAction::kLoad;
+    color0.store_action = StoreAction::kStore;
+    color0.texture = resolve_texture;
+    other_target.SetColorAttachment(color0, 0);
+    other_target.SetDepthAttachment(std::nullopt);
+    other_target.SetStencilAttachment(std::nullopt);
+
+    EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount1).framebuffer,
+              nullptr);
+    EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount1).render_pass,
+              nullptr);
+
+    auto buffer_3 = GetContext()->CreateCommandBuffer();
+    auto render_pass_3 = buffer_3->CreateRenderPass(other_target);
+
+    EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount1).framebuffer,
+              nullptr);
+    EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount1).render_pass,
+              nullptr);
+
+    EXPECT_TRUE(render_pass_3->EncodeCommands());
+    EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer_3}).ok());
+  }
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
@@ -27,14 +27,14 @@ TEST_P(RendererTest, CachesRenderPassAndFramebuffer) {
       render_target.GetColorAttachment(0).resolve_texture;
   TextureVK& texture_vk = TextureVK::Cast(*resolve_texture);
 
-  EXPECT_EQ(texture_vk.GetCachedFramebuffer(), nullptr);
-  EXPECT_EQ(texture_vk.GetCachedRenderPass(), nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData().framebuffer, nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData().render_pass, nullptr);
 
   auto buffer = GetContext()->CreateCommandBuffer();
   auto render_pass = buffer->CreateRenderPass(render_target);
 
-  EXPECT_NE(texture_vk.GetCachedFramebuffer(), nullptr);
-  EXPECT_NE(texture_vk.GetCachedRenderPass(), nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData().framebuffer, nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData().render_pass, nullptr);
 
   render_pass->EncodeCommands();
   EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer}).ok());
@@ -61,14 +61,14 @@ TEST_P(RendererTest, CachesRenderPassAndFramebufferNonMSAA) {
       render_target.GetColorAttachment(0).texture;
   TextureVK& texture_vk = TextureVK::Cast(*color_texture);
 
-  EXPECT_EQ(texture_vk.GetCachedFramebuffer(), nullptr);
-  EXPECT_EQ(texture_vk.GetCachedRenderPass(), nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData().framebuffer, nullptr);
+  EXPECT_EQ(texture_vk.GetCachedFrameData().render_pass, nullptr);
 
   auto buffer = GetContext()->CreateCommandBuffer();
   auto render_pass = buffer->CreateRenderPass(render_target);
 
-  EXPECT_NE(texture_vk.GetCachedFramebuffer(), nullptr);
-  EXPECT_NE(texture_vk.GetCachedRenderPass(), nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData().framebuffer, nullptr);
+  EXPECT_NE(texture_vk.GetCachedFrameData().render_pass, nullptr);
 
   render_pass->EncodeCommands();
   EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer}).ok());

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -81,8 +81,11 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     const SharedHandleVK<vk::RenderPass>& recycled_renderpass,
     const std::shared_ptr<CommandBufferVK>& command_buffer,
     bool is_swapchain) const {
-  RenderPassBuilderVK builder;
+  if (recycled_renderpass != nullptr) {
+    return recycled_renderpass;
+  }
 
+  RenderPassBuilderVK builder;
   render_target_.IterateAllColorAttachments([&](size_t bind_point,
                                                 const ColorAttachment&
                                                     attachment) -> bool {
@@ -114,10 +117,6 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     );
   }
 
-  if (recycled_renderpass != nullptr) {
-    return recycled_renderpass;
-  }
-
   auto pass = builder.Build(context.GetDevice());
 
   if (!pass) {
@@ -146,30 +145,27 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
     return true;
   });
 
-  SharedHandleVK<vk::RenderPass> recycled_render_pass;
-  SharedHandleVK<vk::Framebuffer> recycled_framebuffer;
+  FramebufferAndRenderPass frame_data;
+  bool is_swapchain = false;
+  SampleCount sample_count =
+      color_image_vk_->GetTextureDescriptor().sample_count;
   if (resolve_image_vk_) {
-    recycled_render_pass =
-        TextureVK::Cast(*resolve_image_vk_).GetCachedRenderPass();
-    recycled_framebuffer =
-        TextureVK::Cast(*resolve_image_vk_).GetCachedFramebuffer();
+    frame_data = TextureVK::Cast(*resolve_image_vk_).GetCachedFrameData();
+    is_swapchain = TextureVK::Cast(*resolve_image_vk_).IsSwapchainImage();
   } else {
-    recycled_render_pass =
-        TextureVK::Cast(*color_image_vk_).GetCachedRenderPass();
-    recycled_framebuffer =
-        TextureVK::Cast(*color_image_vk_).GetCachedFramebuffer();
+    frame_data = TextureVK::Cast(*color_image_vk_).GetCachedFrameData();
+    is_swapchain = TextureVK::Cast(*color_image_vk_).IsSwapchainImage();
+  }
+  // If the sample count changed from the last cache usage, clear the
+  // cached framebuffer and render pass.
+  if (sample_count != frame_data.sample_count) {
+    frame_data.framebuffer = nullptr;
+    frame_data.render_pass = nullptr;
   }
 
   const auto& target_size = render_target_.GetRenderTargetSize();
 
-  bool is_swapchain = false;
-  if (resolve_image_vk_) {
-    is_swapchain = TextureVK::Cast(*resolve_image_vk_).IsSwapchainImage();
-  } else {
-    is_swapchain = TextureVK::Cast(*color_image_vk_).IsSwapchainImage();
-  }
-
-  render_pass_ = CreateVKRenderPass(vk_context, recycled_render_pass,
+  render_pass_ = CreateVKRenderPass(vk_context, frame_data.render_pass,
                                     command_buffer_, is_swapchain);
   if (!render_pass_) {
     VALIDATION_LOG << "Could not create renderpass.";
@@ -177,9 +173,9 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
     return;
   }
 
-  auto framebuffer = (recycled_framebuffer == nullptr)
+  auto framebuffer = (frame_data.framebuffer == nullptr)
                          ? CreateVKFramebuffer(vk_context, *render_pass_)
-                         : recycled_framebuffer;
+                         : frame_data.framebuffer;
   if (!framebuffer) {
     VALIDATION_LOG << "Could not create framebuffer.";
     is_valid_ = false;
@@ -191,12 +187,15 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
     is_valid_ = false;
     return;
   }
+
+  frame_data.framebuffer = framebuffer;
+  frame_data.render_pass = render_pass_;
+  frame_data.sample_count = sample_count;
+
   if (resolve_image_vk_) {
-    TextureVK::Cast(*resolve_image_vk_).SetCachedFramebuffer(framebuffer);
-    TextureVK::Cast(*resolve_image_vk_).SetCachedRenderPass(render_pass_);
+    TextureVK::Cast(*resolve_image_vk_).SetCachedFrameData(frame_data);
   } else {
-    TextureVK::Cast(*color_image_vk_).SetCachedFramebuffer(framebuffer);
-    TextureVK::Cast(*color_image_vk_).SetCachedRenderPass(render_pass_);
+    TextureVK::Cast(*color_image_vk_).SetCachedFrameData(frame_data);
   }
 
   // If the resolve image exists and has mipmaps, transition mip levels besides

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -150,17 +150,13 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   SampleCount sample_count =
       color_image_vk_->GetTextureDescriptor().sample_count;
   if (resolve_image_vk_) {
-    frame_data = TextureVK::Cast(*resolve_image_vk_).GetCachedFrameData();
+    frame_data =
+        TextureVK::Cast(*resolve_image_vk_).GetCachedFrameData(sample_count);
     is_swapchain = TextureVK::Cast(*resolve_image_vk_).IsSwapchainImage();
   } else {
-    frame_data = TextureVK::Cast(*color_image_vk_).GetCachedFrameData();
+    frame_data =
+        TextureVK::Cast(*color_image_vk_).GetCachedFrameData(sample_count);
     is_swapchain = TextureVK::Cast(*color_image_vk_).IsSwapchainImage();
-  }
-  // If the sample count changed from the last cache usage, clear the
-  // cached framebuffer and render pass.
-  if (sample_count != frame_data.sample_count) {
-    frame_data.framebuffer = nullptr;
-    frame_data.render_pass = nullptr;
   }
 
   const auto& target_size = render_target_.GetRenderTargetSize();
@@ -190,12 +186,13 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
 
   frame_data.framebuffer = framebuffer;
   frame_data.render_pass = render_pass_;
-  frame_data.sample_count = sample_count;
 
   if (resolve_image_vk_) {
-    TextureVK::Cast(*resolve_image_vk_).SetCachedFrameData(frame_data);
+    TextureVK::Cast(*resolve_image_vk_)
+        .SetCachedFrameData(frame_data, sample_count);
   } else {
-    TextureVK::Cast(*color_image_vk_).SetCachedFrameData(frame_data);
+    TextureVK::Cast(*color_image_vk_)
+        .SetCachedFrameData(frame_data, sample_count);
   }
 
   // If the resolve image exists and has mipmaps, transition mip levels besides

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
@@ -76,8 +76,8 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
 
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);
-    EXPECT_EQ(texture_vk.GetCachedFramebuffer(), nullptr);
-    EXPECT_EQ(texture_vk.GetCachedRenderPass(), nullptr);
+    EXPECT_EQ(texture_vk.GetCachedFrameData().framebuffer, nullptr);
+    EXPECT_EQ(texture_vk.GetCachedFrameData().render_pass, nullptr);
 
     auto command_buffer = context->CreateCommandBuffer();
     auto render_pass = command_buffer->CreateRenderPass(render_target);
@@ -106,10 +106,10 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);
 
-    EXPECT_NE(texture_vk.GetCachedFramebuffer(), nullptr);
-    EXPECT_NE(texture_vk.GetCachedRenderPass(), nullptr);
-    framebuffers.push_back(texture_vk.GetCachedFramebuffer());
-    render_passes.push_back(texture_vk.GetCachedRenderPass());
+    EXPECT_NE(texture_vk.GetCachedFrameData().framebuffer, nullptr);
+    EXPECT_NE(texture_vk.GetCachedFrameData().render_pass, nullptr);
+    framebuffers.push_back(texture_vk.GetCachedFrameData().framebuffer);
+    render_passes.push_back(texture_vk.GetCachedFrameData().render_pass);
   }
 
   // Iterate through once more to verify render passes and framebuffers are
@@ -121,8 +121,8 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);
 
-    EXPECT_EQ(texture_vk.GetCachedFramebuffer(), framebuffers[i]);
-    EXPECT_EQ(texture_vk.GetCachedRenderPass(), render_passes[i]);
+    EXPECT_EQ(texture_vk.GetCachedFrameData().framebuffer, framebuffers[i]);
+    EXPECT_EQ(texture_vk.GetCachedFrameData().render_pass, render_passes[i]);
   }
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
@@ -4,12 +4,11 @@
 
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
+#include "impeller/core/formats.h"
 #include "impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
 #include "impeller/renderer/render_pass.h"
-#include "vulkan/vulkan_enums.hpp"
-#include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
 namespace testing {
@@ -76,8 +75,10 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
 
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);
-    EXPECT_EQ(texture_vk.GetCachedFrameData().framebuffer, nullptr);
-    EXPECT_EQ(texture_vk.GetCachedFrameData().render_pass, nullptr);
+    EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount4).framebuffer,
+              nullptr);
+    EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount4).render_pass,
+              nullptr);
 
     auto command_buffer = context->CreateCommandBuffer();
     auto render_pass = command_buffer->CreateRenderPass(render_target);
@@ -106,10 +107,14 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);
 
-    EXPECT_NE(texture_vk.GetCachedFrameData().framebuffer, nullptr);
-    EXPECT_NE(texture_vk.GetCachedFrameData().render_pass, nullptr);
-    framebuffers.push_back(texture_vk.GetCachedFrameData().framebuffer);
-    render_passes.push_back(texture_vk.GetCachedFrameData().render_pass);
+    EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount4).framebuffer,
+              nullptr);
+    EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount4).render_pass,
+              nullptr);
+    framebuffers.push_back(
+        texture_vk.GetCachedFrameData(SampleCount::kCount4).framebuffer);
+    render_passes.push_back(
+        texture_vk.GetCachedFrameData(SampleCount::kCount4).render_pass);
   }
 
   // Iterate through once more to verify render passes and framebuffers are
@@ -121,8 +126,14 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);
 
-    EXPECT_EQ(texture_vk.GetCachedFrameData().framebuffer, framebuffers[i]);
-    EXPECT_EQ(texture_vk.GetCachedFrameData().render_pass, render_passes[i]);
+    EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount4).framebuffer,
+              framebuffers[i]);
+    EXPECT_EQ(texture_vk.GetCachedFrameData(SampleCount::kCount4).render_pass,
+              render_passes[i]);
+    EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount1).framebuffer,
+              framebuffers[i]);
+    EXPECT_NE(texture_vk.GetCachedFrameData(SampleCount::kCount1).render_pass,
+              render_passes[i]);
   }
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -58,22 +58,12 @@ fml::Status TextureSourceVK::SetLayout(const BarrierVK& barrier) const {
   return {};
 }
 
-void TextureSourceVK::SetCachedFramebuffer(
-    const SharedHandleVK<vk::Framebuffer>& framebuffer) {
-  framebuffer_ = framebuffer;
+void TextureSourceVK::SetCachedFrameData(const FramebufferAndRenderPass& data) {
+  frame_data_ = data;
 }
 
-void TextureSourceVK::SetCachedRenderPass(
-    const SharedHandleVK<vk::RenderPass>& render_pass) {
-  render_pass_ = render_pass;
-}
-
-SharedHandleVK<vk::Framebuffer> TextureSourceVK::GetCachedFramebuffer() const {
-  return framebuffer_;
-}
-
-SharedHandleVK<vk::RenderPass> TextureSourceVK::GetCachedRenderPass() const {
-  return render_pass_;
+const FramebufferAndRenderPass& TextureSourceVK::GetCachedFrameData() const {
+  return frame_data_;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -58,12 +58,14 @@ fml::Status TextureSourceVK::SetLayout(const BarrierVK& barrier) const {
   return {};
 }
 
-void TextureSourceVK::SetCachedFrameData(const FramebufferAndRenderPass& data) {
-  frame_data_ = data;
+void TextureSourceVK::SetCachedFrameData(const FramebufferAndRenderPass& data,
+                                         SampleCount sample_count) {
+  frame_data_[static_cast<int>(sample_count) / 4] = data;
 }
 
-const FramebufferAndRenderPass& TextureSourceVK::GetCachedFrameData() const {
-  return frame_data_;
+const FramebufferAndRenderPass& TextureSourceVK::GetCachedFrameData(
+    SampleCount sample_count) const {
+  return frame_data_[static_cast<int>(sample_count) / 4];
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_TEXTURE_SOURCE_VK_H_
 
 #include "flutter/fml/status.h"
+#include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/backend/vulkan/barrier_vk.h"
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
@@ -19,7 +20,6 @@ namespace impeller {
 struct FramebufferAndRenderPass {
   SharedHandleVK<vk::Framebuffer> framebuffer = nullptr;
   SharedHandleVK<vk::RenderPass> render_pass = nullptr;
-  SampleCount sample_count = SampleCount::kCount1;
 };
 
 //------------------------------------------------------------------------------
@@ -132,17 +132,21 @@ class TextureSourceVK {
 
   // These methods should only be used by render_pass_vk.h
 
-  /// Store the last framebuffer object used with this texture.
+  /// Store the last framebuffer and render pass object used with this texture.
   ///
-  /// This field is only set if this texture is used as the resolve texture
+  /// This method is only called if this texture is used as the resolve texture
   /// of a render pass. By construction, this framebuffer should be compatible
   /// with any future render passes.
-  void SetCachedFrameData(const FramebufferAndRenderPass& data);
+  void SetCachedFrameData(const FramebufferAndRenderPass& data,
+                          SampleCount sample_count);
 
-  /// Retrieve the last framebuffer object used with this texture.
+  /// Retrieve the last framebuffer and render pass object used with this
+  /// texture for a given sample count.
   ///
-  /// May be nullptr if no previous framebuffer existed.
-  const FramebufferAndRenderPass& GetCachedFrameData() const;
+  /// An empty FramebufferAndRenderPass is returned if there is no cached data
+  /// for a particular sample count.
+  const FramebufferAndRenderPass& GetCachedFrameData(
+      SampleCount sample_count) const;
 
  protected:
   const TextureDescriptor desc_;
@@ -150,7 +154,7 @@ class TextureSourceVK {
   explicit TextureSourceVK(TextureDescriptor desc);
 
  private:
-  FramebufferAndRenderPass frame_data_ = {};
+  std::array<FramebufferAndRenderPass, 2> frame_data_;
   mutable vk::ImageLayout layout_ = vk::ImageLayout::eUndefined;
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -15,6 +15,13 @@
 
 namespace impeller {
 
+// These methods should only be used by render_pass_vk.h
+struct FramebufferAndRenderPass {
+  SharedHandleVK<vk::Framebuffer> framebuffer = nullptr;
+  SharedHandleVK<vk::RenderPass> render_pass = nullptr;
+  SampleCount sample_count = SampleCount::kCount1;
+};
+
 //------------------------------------------------------------------------------
 /// @brief      Abstract base class that represents a vkImage and an
 ///             vkImageView.
@@ -130,24 +137,12 @@ class TextureSourceVK {
   /// This field is only set if this texture is used as the resolve texture
   /// of a render pass. By construction, this framebuffer should be compatible
   /// with any future render passes.
-  void SetCachedFramebuffer(const SharedHandleVK<vk::Framebuffer>& framebuffer);
-
-  /// Store the last render pass object used with this texture.
-  ///
-  /// This field is only set if this texture is used as the resolve texture
-  /// of a render pass. By construction, this framebuffer should be compatible
-  /// with any future render passes.
-  void SetCachedRenderPass(const SharedHandleVK<vk::RenderPass>& render_pass);
+  void SetCachedFrameData(const FramebufferAndRenderPass& data);
 
   /// Retrieve the last framebuffer object used with this texture.
   ///
   /// May be nullptr if no previous framebuffer existed.
-  SharedHandleVK<vk::Framebuffer> GetCachedFramebuffer() const;
-
-  /// Retrieve the last render pass object used with this texture.
-  ///
-  /// May be nullptr if no previous render pass existed.
-  SharedHandleVK<vk::RenderPass> GetCachedRenderPass() const;
+  const FramebufferAndRenderPass& GetCachedFrameData() const;
 
  protected:
   const TextureDescriptor desc_;
@@ -155,8 +150,7 @@ class TextureSourceVK {
   explicit TextureSourceVK(TextureDescriptor desc);
 
  private:
-  SharedHandleVK<vk::Framebuffer> framebuffer_;
-  SharedHandleVK<vk::RenderPass> render_pass_;
+  FramebufferAndRenderPass frame_data_ = {};
   mutable vk::ImageLayout layout_ = vk::ImageLayout::eUndefined;
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -196,22 +196,12 @@ vk::ImageView TextureVK::GetRenderTargetView() const {
   return source_->GetRenderTargetView();
 }
 
-void TextureVK::SetCachedFramebuffer(
-    const SharedHandleVK<vk::Framebuffer>& framebuffer) {
-  source_->SetCachedFramebuffer(framebuffer);
+void TextureVK::SetCachedFrameData(const FramebufferAndRenderPass& data) {
+  source_->SetCachedFrameData(data);
 }
 
-void TextureVK::SetCachedRenderPass(
-    const SharedHandleVK<vk::RenderPass>& render_pass) {
-  source_->SetCachedRenderPass(render_pass);
-}
-
-SharedHandleVK<vk::Framebuffer> TextureVK::GetCachedFramebuffer() const {
-  return source_->GetCachedFramebuffer();
-}
-
-SharedHandleVK<vk::RenderPass> TextureVK::GetCachedRenderPass() const {
-  return source_->GetCachedRenderPass();
+const FramebufferAndRenderPass& TextureVK::GetCachedFrameData() const {
+  return source_->GetCachedFrameData();
 }
 
 void TextureVK::SetMipMapGenerated() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
 
+#include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
@@ -196,12 +197,14 @@ vk::ImageView TextureVK::GetRenderTargetView() const {
   return source_->GetRenderTargetView();
 }
 
-void TextureVK::SetCachedFrameData(const FramebufferAndRenderPass& data) {
-  source_->SetCachedFrameData(data);
+void TextureVK::SetCachedFrameData(const FramebufferAndRenderPass& data,
+                                   SampleCount sample_count) {
+  source_->SetCachedFrameData(data, sample_count);
 }
 
-const FramebufferAndRenderPass& TextureVK::GetCachedFrameData() const {
-  return source_->GetCachedFrameData();
+const FramebufferAndRenderPass& TextureVK::GetCachedFrameData(
+    SampleCount sample_count) const {
+  return source_->GetCachedFrameData(sample_count);
 }
 
 void TextureVK::SetMipMapGenerated() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
@@ -49,17 +49,21 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
   std::shared_ptr<SamplerVK> GetImmutableSamplerVariant(
       const SamplerVK& sampler) const;
 
-  /// Store the last framebuffer object used with this texture.
+  /// Store the last framebuffer and render pass object used with this texture.
   ///
-  /// This field is only set if this texture is used as the resolve texture
+  /// This method is only called if this texture is used as the resolve texture
   /// of a render pass. By construction, this framebuffer should be compatible
   /// with any future render passes.
-  void SetCachedFrameData(const FramebufferAndRenderPass& data);
+  void SetCachedFrameData(const FramebufferAndRenderPass& data,
+                          SampleCount sample_count);
 
-  /// Retrieve the last framebuffer object used with this texture.
+  /// Retrieve the last framebuffer and render pass object used with this
+  /// texture.
   ///
-  /// May be nullptr if no previous framebuffer existed.
-  const FramebufferAndRenderPass& GetCachedFrameData() const;
+  /// An empty FramebufferAndRenderPass is returned if there is no cached data
+  /// for a particular sample count.
+  const FramebufferAndRenderPass& GetCachedFrameData(
+      SampleCount sample_count) const;
 
  private:
   std::weak_ptr<Context> context_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_TEXTURE_VK_H_
 
 #include "impeller/base/backend_cast.h"
+#include "impeller/core/formats.h"
 #include "impeller/core/texture.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/device_buffer_vk.h"
@@ -48,31 +49,17 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
   std::shared_ptr<SamplerVK> GetImmutableSamplerVariant(
       const SamplerVK& sampler) const;
 
-  // These methods should only be used by render_pass_vk.h
-
   /// Store the last framebuffer object used with this texture.
   ///
   /// This field is only set if this texture is used as the resolve texture
   /// of a render pass. By construction, this framebuffer should be compatible
   /// with any future render passes.
-  void SetCachedFramebuffer(const SharedHandleVK<vk::Framebuffer>& framebuffer);
-
-  /// Store the last render pass object used with this texture.
-  ///
-  /// This field is only set if this texture is used as the resolve texture
-  /// of a render pass. By construction, this framebuffer should be compatible
-  /// with any future render passes.
-  void SetCachedRenderPass(const SharedHandleVK<vk::RenderPass>& render_pass);
+  void SetCachedFrameData(const FramebufferAndRenderPass& data);
 
   /// Retrieve the last framebuffer object used with this texture.
   ///
   /// May be nullptr if no previous framebuffer existed.
-  SharedHandleVK<vk::Framebuffer> GetCachedFramebuffer() const;
-
-  /// Retrieve the last render pass object used with this texture.
-  ///
-  /// May be nullptr if no previous render pass existed.
-  SharedHandleVK<vk::RenderPass> GetCachedRenderPass() const;
+  const FramebufferAndRenderPass& GetCachedFrameData() const;
 
  private:
   std::weak_ptr<Context> context_;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/167316

Recycling the render passes didn't account for a render pass changing from MSAA to non-MSAA.
