### PR TITLE
[Impeller] Make incremental builds faster when tinkering on the compiler.

### DIFF
--- a/engine/src/flutter/impeller/compiler/BUILD.gn
+++ b/engine/src/flutter/impeller/compiler/BUILD.gn
@@ -38,6 +38,8 @@ impeller_component("compiler_lib") {
     "compiler_backend.h",
     "constants.cc",
     "constants.h",
+    "filesystem.cc",
+    "filesystem.h",
     "include_dir.h",
     "includer.cc",
     "includer.h",

--- a/engine/src/flutter/impeller/compiler/compiler_test.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_test.cc
@@ -121,9 +121,9 @@ bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
     return false;
   }
 
-  if (!WriteToFilesystem(intermediates_directory_,
-                         SPIRVFileName(fixture_name).c_str(),
-                         *spirv_assembly)) {
+  if (!WriteAtomicallyIfChanged(intermediates_directory_,
+                                SPIRVFileName(fixture_name).c_str(),
+                                *spirv_assembly)) {
     VALIDATION_LOG << "Could not write SPIRV intermediates.";
     return false;
   }
@@ -134,9 +134,9 @@ bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
     return false;
   }
 
-  if (!WriteToFilesystem(intermediates_directory_,
-                         SLFileName(fixture_name, GetParam()).c_str(),
-                         *sl_source)) {
+  if (!WriteAtomicallyIfChanged(intermediates_directory_,
+                                SLFileName(fixture_name, GetParam()).c_str(),
+                                *sl_source)) {
     VALIDATION_LOG << "Could not write SL intermediates.";
     return false;
   }
@@ -168,23 +168,23 @@ bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
       return false;
     }
 
-    if (!WriteToFilesystem(intermediates_directory_,
-                           ReflectionHeaderName(fixture_name).c_str(),
-                           *reflection_header)) {
+    if (!WriteAtomicallyIfChanged(intermediates_directory_,
+                                  ReflectionHeaderName(fixture_name).c_str(),
+                                  *reflection_header)) {
       VALIDATION_LOG << "Could not write reflection header intermediates.";
       return false;
     }
 
-    if (!WriteToFilesystem(intermediates_directory_,
-                           ReflectionCCName(fixture_name).c_str(),
-                           *reflection_source)) {
+    if (!WriteAtomicallyIfChanged(intermediates_directory_,
+                                  ReflectionCCName(fixture_name).c_str(),
+                                  *reflection_source)) {
       VALIDATION_LOG << "Could not write reflection CC intermediates.";
       return false;
     }
 
-    if (!WriteToFilesystem(intermediates_directory_,
-                           ReflectionJSONName(fixture_name).c_str(),
-                           *reflection_json)) {
+    if (!WriteAtomicallyIfChanged(intermediates_directory_,
+                                  ReflectionJSONName(fixture_name).c_str(),
+                                  *reflection_json)) {
       VALIDATION_LOG << "Could not write reflection json intermediates.";
       return false;
     }

--- a/engine/src/flutter/impeller/compiler/compiler_test.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_test.cc
@@ -3,11 +3,13 @@
 // found in the LICENSE file.
 
 #include "impeller/compiler/compiler_test.h"
-#include "flutter/fml/paths.h"
-#include "flutter/fml/process.h"
 
 #include <algorithm>
 #include <filesystem>
+
+#include "flutter/fml/paths.h"
+#include "flutter/fml/process.h"
+#include "impeller/compiler/filesystem.h"
 
 namespace impeller {
 namespace compiler {
@@ -119,9 +121,9 @@ bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
     return false;
   }
 
-  if (!fml::WriteAtomically(intermediates_directory_,
-                            SPIRVFileName(fixture_name).c_str(),
-                            *spirv_assembly)) {
+  if (!WriteToFilesystem(intermediates_directory_,
+                         SPIRVFileName(fixture_name).c_str(),
+                         *spirv_assembly)) {
     VALIDATION_LOG << "Could not write SPIRV intermediates.";
     return false;
   }
@@ -132,9 +134,9 @@ bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
     return false;
   }
 
-  if (!fml::WriteAtomically(intermediates_directory_,
-                            SLFileName(fixture_name, GetParam()).c_str(),
-                            *sl_source)) {
+  if (!WriteToFilesystem(intermediates_directory_,
+                         SLFileName(fixture_name, GetParam()).c_str(),
+                         *sl_source)) {
     VALIDATION_LOG << "Could not write SL intermediates.";
     return false;
   }
@@ -166,23 +168,23 @@ bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
       return false;
     }
 
-    if (!fml::WriteAtomically(intermediates_directory_,
-                              ReflectionHeaderName(fixture_name).c_str(),
-                              *reflection_header)) {
+    if (!WriteToFilesystem(intermediates_directory_,
+                           ReflectionHeaderName(fixture_name).c_str(),
+                           *reflection_header)) {
       VALIDATION_LOG << "Could not write reflection header intermediates.";
       return false;
     }
 
-    if (!fml::WriteAtomically(intermediates_directory_,
-                              ReflectionCCName(fixture_name).c_str(),
-                              *reflection_source)) {
+    if (!WriteToFilesystem(intermediates_directory_,
+                           ReflectionCCName(fixture_name).c_str(),
+                           *reflection_source)) {
       VALIDATION_LOG << "Could not write reflection CC intermediates.";
       return false;
     }
 
-    if (!fml::WriteAtomically(intermediates_directory_,
-                              ReflectionJSONName(fixture_name).c_str(),
-                              *reflection_json)) {
+    if (!WriteToFilesystem(intermediates_directory_,
+                           ReflectionJSONName(fixture_name).c_str(),
+                           *reflection_json)) {
       VALIDATION_LOG << "Could not write reflection json intermediates.";
       return false;
     }

--- a/engine/src/flutter/impeller/compiler/filesystem.cc
+++ b/engine/src/flutter/impeller/compiler/filesystem.cc
@@ -1,0 +1,29 @@
+#include "impeller/compiler/filesystem.h"
+
+namespace impeller {
+
+static bool MappingsAreSame(const fml::Mapping* lhs, const fml::Mapping* rhs) {
+  if (lhs == rhs) {
+    return true;
+  }
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+  if (lhs->GetSize() != rhs->GetSize()) {
+    return false;
+  }
+  return std::memcmp(lhs->GetMapping(), rhs->GetMapping(), lhs->GetSize()) == 0;
+}
+
+bool WriteToFilesystem(const fml::UniqueFD& base_directory,
+                       const char* file_name,
+                       const fml::Mapping& data) {
+  if (auto existing = fml::FileMapping::CreateReadOnly(file_name)) {
+    if (MappingsAreSame(&data, existing.get())) {
+      return true;
+    }
+  }
+  return fml::WriteAtomically(base_directory, file_name, data);
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/compiler/filesystem.cc
+++ b/engine/src/flutter/impeller/compiler/filesystem.cc
@@ -19,9 +19,9 @@ static bool MappingsAreSame(const fml::Mapping* lhs, const fml::Mapping* rhs) {
   return std::memcmp(lhs->GetMapping(), rhs->GetMapping(), lhs->GetSize()) == 0;
 }
 
-bool WriteToFilesystem(const fml::UniqueFD& base_directory,
-                       const char* file_name,
-                       const fml::Mapping& data) {
+bool WriteAtomicallyIfChanged(const fml::UniqueFD& base_directory,
+                              const char* file_name,
+                              const fml::Mapping& data) {
   if (auto existing = fml::FileMapping::CreateReadOnly(file_name)) {
     if (MappingsAreSame(&data, existing.get())) {
       return true;

--- a/engine/src/flutter/impeller/compiler/filesystem.cc
+++ b/engine/src/flutter/impeller/compiler/filesystem.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "impeller/compiler/filesystem.h"
 
 namespace impeller {

--- a/engine/src/flutter/impeller/compiler/filesystem.h
+++ b/engine/src/flutter/impeller/compiler/filesystem.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef IMPELLER_COMPILER_FILESYSTEM_H_
-#define IMPELLER_COMPILER_FILESYSTEM_H_
+#ifndef FLUTTER_IMPELLER_COMPILER_FILESYSTEM_H_
+#define FLUTTER_IMPELLER_COMPILER_FILESYSTEM_H_
 
 #include "flutter/fml/mapping.h"
 
@@ -17,7 +17,7 @@ namespace impeller {
 ///             and its contents are identical to the ones about to be written.
 ///             If both conditions hold, this function becomes a no-op.
 ///
-///             The side-effect of skipping the updated is that the modification
+///             The side-effect of skipping the update is that the modification
 ///             timestamp of the file will not be affected. Build systems such
 ///             as ninja and GN (using the `restat` argument) that check the
 ///             timestamp for modification will then be able to cull edges
@@ -28,12 +28,13 @@ namespace impeller {
 /// @param[in]  data            The data
 ///
 /// @return     If the file at the specified location contains the data
-///             provided.
+///             provided. This is regardless of whether there was already a file
+///             with the specified contents at that location.
 ///
-bool WriteToFilesystem(const fml::UniqueFD& base_directory,
-                       const char* file_name,
-                       const fml::Mapping& data);
+bool WriteAtomicallyIfChanged(const fml::UniqueFD& base_directory,
+                              const char* file_name,
+                              const fml::Mapping& data);
 
 }  // namespace impeller
 
-#endif  // IMPELLER_COMPILER_FILESYSTEM_H_
+#endif  // FLUTTER_IMPELLER_COMPILER_FILESYSTEM_H_

--- a/engine/src/flutter/impeller/compiler/filesystem.h
+++ b/engine/src/flutter/impeller/compiler/filesystem.h
@@ -1,0 +1,39 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef IMPELLER_COMPILER_FILESYSTEM_H_
+#define IMPELLER_COMPILER_FILESYSTEM_H_
+
+#include "flutter/fml/mapping.h"
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// @brief      Write the specified mapping to the filesystem.
+///
+///             Conceptually, this is identical to `fml::WriteAtomically`.
+///             Except, it will first check if a file exists at the given path
+///             and its contents are identical to the ones about to be written.
+///             If both conditions hold, this function becomes a no-op.
+///
+///             The side-effect of skipping the updated is that the modification
+///             timestamp of the file will not be affected. Build systems such
+///             as ninja and GN (using the `restat` argument) that check the
+///             timestamp for modification will then be able to cull edges
+///             leading to faster incremental builds.
+///
+/// @param[in]  base_directory  The base directory
+/// @param[in]  file_name       The file name
+/// @param[in]  data            The data
+///
+/// @return     If the file at the specified location contains the data
+///             provided.
+///
+bool WriteToFilesystem(const fml::UniqueFD& base_directory,
+                       const char* file_name,
+                       const fml::Mapping& data);
+
+}  // namespace impeller
+
+#endif  // IMPELLER_COMPILER_FILESYSTEM_H_

--- a/engine/src/flutter/impeller/compiler/impellerc_main.cc
+++ b/engine/src/flutter/impeller/compiler/impellerc_main.cc
@@ -108,10 +108,10 @@ static bool OutputIPLR(
     std::cerr << "Runtime stage data could not be created." << std::endl;
     return false;
   }
-  if (!WriteToFilesystem(*switches.working_directory,                  //
-                         Utf8FromPath(switches.sl_file_name).c_str(),  //
-                         *stage_data_mapping                           //
-                         )) {
+  if (!WriteAtomicallyIfChanged(*switches.working_directory,                  //
+                                Utf8FromPath(switches.sl_file_name).c_str(),  //
+                                *stage_data_mapping                           //
+                                )) {
     std::cerr << "Could not write file to " << switches.sl_file_name
               << std::endl;
     return false;
@@ -132,9 +132,9 @@ static bool OutputSLFile(const Compiler& compiler, const Switches& switches) {
 
   auto sl_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.sl_file_name);
-  if (!WriteToFilesystem(*switches.working_directory,
-                         Utf8FromPath(sl_file_name).c_str(),
-                         *compiler.GetSLShaderSource())) {
+  if (!WriteAtomicallyIfChanged(*switches.working_directory,
+                                Utf8FromPath(sl_file_name).c_str(),
+                                *compiler.GetSLShaderSource())) {
     std::cerr << "Could not write file to " << switches.sl_file_name
               << std::endl;
     return false;
@@ -154,9 +154,10 @@ static bool OutputReflectionData(const Compiler& compiler,
     if (!switches.reflection_json_name.empty()) {
       auto reflection_json_name = std::filesystem::absolute(
           std::filesystem::current_path() / switches.reflection_json_name);
-      if (!WriteToFilesystem(*switches.working_directory,
-                             Utf8FromPath(reflection_json_name).c_str(),
-                             *compiler.GetReflector()->GetReflectionJSON())) {
+      if (!WriteAtomicallyIfChanged(
+              *switches.working_directory,
+              Utf8FromPath(reflection_json_name).c_str(),
+              *compiler.GetReflector()->GetReflectionJSON())) {
         std::cerr << "Could not write reflection json to "
                   << switches.reflection_json_name << std::endl;
         return false;
@@ -167,9 +168,10 @@ static bool OutputReflectionData(const Compiler& compiler,
       auto reflection_header_name =
           std::filesystem::absolute(std::filesystem::current_path() /
                                     switches.reflection_header_name.c_str());
-      if (!WriteToFilesystem(*switches.working_directory,
-                             Utf8FromPath(reflection_header_name).c_str(),
-                             *compiler.GetReflector()->GetReflectionHeader())) {
+      if (!WriteAtomicallyIfChanged(
+              *switches.working_directory,
+              Utf8FromPath(reflection_header_name).c_str(),
+              *compiler.GetReflector()->GetReflectionHeader())) {
         std::cerr << "Could not write reflection header to "
                   << switches.reflection_header_name << std::endl;
         return false;
@@ -180,9 +182,10 @@ static bool OutputReflectionData(const Compiler& compiler,
       auto reflection_cc_name =
           std::filesystem::absolute(std::filesystem::current_path() /
                                     switches.reflection_cc_name.c_str());
-      if (!WriteToFilesystem(*switches.working_directory,
-                             Utf8FromPath(reflection_cc_name).c_str(),
-                             *compiler.GetReflector()->GetReflectionCC())) {
+      if (!WriteAtomicallyIfChanged(
+              *switches.working_directory,
+              Utf8FromPath(reflection_cc_name).c_str(),
+              *compiler.GetReflector()->GetReflectionCC())) {
         std::cerr << "Could not write reflection CC to "
                   << switches.reflection_cc_name << std::endl;
         return false;
@@ -218,9 +221,9 @@ static bool OutputDepfile(const Compiler& compiler, const Switches& switches) {
     }
     auto depfile_path = std::filesystem::absolute(
         std::filesystem::current_path() / switches.depfile_path.c_str());
-    if (!WriteToFilesystem(*switches.working_directory,
-                           Utf8FromPath(depfile_path).c_str(),
-                           *compiler.CreateDepfileContents({result_file}))) {
+    if (!WriteAtomicallyIfChanged(
+            *switches.working_directory, Utf8FromPath(depfile_path).c_str(),
+            *compiler.CreateDepfileContents({result_file}))) {
       std::cerr << "Could not write depfile to " << switches.depfile_path
                 << std::endl;
       return false;
@@ -280,9 +283,9 @@ bool Main(const fml::CommandLine& command_line) {
 
   auto spriv_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.spirv_file_name);
-  if (!WriteToFilesystem(*switches.working_directory,
-                         Utf8FromPath(spriv_file_name).c_str(),
-                         *compiler.GetSPIRVAssembly())) {
+  if (!WriteAtomicallyIfChanged(*switches.working_directory,
+                                Utf8FromPath(spriv_file_name).c_str(),
+                                *compiler.GetSPIRVAssembly())) {
     std::cerr << "Could not write file to " << switches.spirv_file_name
               << std::endl;
     return false;

--- a/engine/src/flutter/impeller/compiler/impellerc_main.cc
+++ b/engine/src/flutter/impeller/compiler/impellerc_main.cc
@@ -10,6 +10,7 @@
 #include "flutter/fml/file.h"
 #include "flutter/fml/mapping.h"
 #include "impeller/compiler/compiler.h"
+#include "impeller/compiler/filesystem.h"
 #include "impeller/compiler/runtime_stage_data.h"
 #include "impeller/compiler/shader_bundle.h"
 #include "impeller/compiler/source_options.h"
@@ -107,10 +108,10 @@ static bool OutputIPLR(
     std::cerr << "Runtime stage data could not be created." << std::endl;
     return false;
   }
-  if (!fml::WriteAtomically(*switches.working_directory,                  //
-                            Utf8FromPath(switches.sl_file_name).c_str(),  //
-                            *stage_data_mapping                           //
-                            )) {
+  if (!WriteToFilesystem(*switches.working_directory,                  //
+                         Utf8FromPath(switches.sl_file_name).c_str(),  //
+                         *stage_data_mapping                           //
+                         )) {
     std::cerr << "Could not write file to " << switches.sl_file_name
               << std::endl;
     return false;
@@ -131,9 +132,9 @@ static bool OutputSLFile(const Compiler& compiler, const Switches& switches) {
 
   auto sl_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.sl_file_name);
-  if (!fml::WriteAtomically(*switches.working_directory,
-                            Utf8FromPath(sl_file_name).c_str(),
-                            *compiler.GetSLShaderSource())) {
+  if (!WriteToFilesystem(*switches.working_directory,
+                         Utf8FromPath(sl_file_name).c_str(),
+                         *compiler.GetSLShaderSource())) {
     std::cerr << "Could not write file to " << switches.sl_file_name
               << std::endl;
     return false;
@@ -153,10 +154,9 @@ static bool OutputReflectionData(const Compiler& compiler,
     if (!switches.reflection_json_name.empty()) {
       auto reflection_json_name = std::filesystem::absolute(
           std::filesystem::current_path() / switches.reflection_json_name);
-      if (!fml::WriteAtomically(
-              *switches.working_directory,
-              Utf8FromPath(reflection_json_name).c_str(),
-              *compiler.GetReflector()->GetReflectionJSON())) {
+      if (!WriteToFilesystem(*switches.working_directory,
+                             Utf8FromPath(reflection_json_name).c_str(),
+                             *compiler.GetReflector()->GetReflectionJSON())) {
         std::cerr << "Could not write reflection json to "
                   << switches.reflection_json_name << std::endl;
         return false;
@@ -167,10 +167,9 @@ static bool OutputReflectionData(const Compiler& compiler,
       auto reflection_header_name =
           std::filesystem::absolute(std::filesystem::current_path() /
                                     switches.reflection_header_name.c_str());
-      if (!fml::WriteAtomically(
-              *switches.working_directory,
-              Utf8FromPath(reflection_header_name).c_str(),
-              *compiler.GetReflector()->GetReflectionHeader())) {
+      if (!WriteToFilesystem(*switches.working_directory,
+                             Utf8FromPath(reflection_header_name).c_str(),
+                             *compiler.GetReflector()->GetReflectionHeader())) {
         std::cerr << "Could not write reflection header to "
                   << switches.reflection_header_name << std::endl;
         return false;
@@ -181,9 +180,9 @@ static bool OutputReflectionData(const Compiler& compiler,
       auto reflection_cc_name =
           std::filesystem::absolute(std::filesystem::current_path() /
                                     switches.reflection_cc_name.c_str());
-      if (!fml::WriteAtomically(*switches.working_directory,
-                                Utf8FromPath(reflection_cc_name).c_str(),
-                                *compiler.GetReflector()->GetReflectionCC())) {
+      if (!WriteToFilesystem(*switches.working_directory,
+                             Utf8FromPath(reflection_cc_name).c_str(),
+                             *compiler.GetReflector()->GetReflectionCC())) {
         std::cerr << "Could not write reflection CC to "
                   << switches.reflection_cc_name << std::endl;
         return false;
@@ -219,9 +218,9 @@ static bool OutputDepfile(const Compiler& compiler, const Switches& switches) {
     }
     auto depfile_path = std::filesystem::absolute(
         std::filesystem::current_path() / switches.depfile_path.c_str());
-    if (!fml::WriteAtomically(*switches.working_directory,
-                              Utf8FromPath(depfile_path).c_str(),
-                              *compiler.CreateDepfileContents({result_file}))) {
+    if (!WriteToFilesystem(*switches.working_directory,
+                           Utf8FromPath(depfile_path).c_str(),
+                           *compiler.CreateDepfileContents({result_file}))) {
       std::cerr << "Could not write depfile to " << switches.depfile_path
                 << std::endl;
       return false;
@@ -281,9 +280,9 @@ bool Main(const fml::CommandLine& command_line) {
 
   auto spriv_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.spirv_file_name);
-  if (!fml::WriteAtomically(*switches.working_directory,
-                            Utf8FromPath(spriv_file_name).c_str(),
-                            *compiler.GetSPIRVAssembly())) {
+  if (!WriteToFilesystem(*switches.working_directory,
+                         Utf8FromPath(spriv_file_name).c_str(),
+                         *compiler.GetSPIRVAssembly())) {
     std::cerr << "Could not write file to " << switches.spirv_file_name
               << std::endl;
     return false;

--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -235,10 +235,10 @@ bool GenerateShaderBundle(Switches& switches) {
   auto sl_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.sl_file_name);
 
-  if (!WriteToFilesystem(*switches.working_directory,         //
-                         Utf8FromPath(sl_file_name).c_str(),  //
-                         *mapping                             //
-                         )) {
+  if (!WriteAtomicallyIfChanged(*switches.working_directory,         //
+                                Utf8FromPath(sl_file_name).c_str(),  //
+                                *mapping                             //
+                                )) {
     std::cerr << "Could not write file to " << switches.sl_file_name
               << std::endl;
     return false;

--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -8,8 +8,8 @@
 #include "impeller/compiler/source_options.h"
 #include "impeller/compiler/types.h"
 
+#include "impeller/compiler/filesystem.h"
 #include "impeller/compiler/utilities.h"
-#include "impeller/runtime_stage/runtime_stage.h"
 #include "impeller/shader_bundle/shader_bundle_flatbuffers.h"
 #include "third_party/json/include/nlohmann/json.hpp"
 
@@ -235,10 +235,10 @@ bool GenerateShaderBundle(Switches& switches) {
   auto sl_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.sl_file_name);
 
-  if (!fml::WriteAtomically(*switches.working_directory,         //
-                            Utf8FromPath(sl_file_name).c_str(),  //
-                            *mapping                             //
-                            )) {
+  if (!WriteToFilesystem(*switches.working_directory,         //
+                         Utf8FromPath(sl_file_name).c_str(),  //
+                         *mapping                             //
+                         )) {
     std::cerr << "Could not write file to " << switches.sl_file_name
               << std::endl;
     return false;


### PR DESCRIPTION
GN set the Ninja `restat` argument to 1 by default. Which means that it notes the modification timestamp when writing the contents. Its man page states "Scripts can improve build performance by taking care not to change the timstamp of the output file(s) if the contents have not changed.".

Modifying the compiler will now still re-compile shaders. But if the shaders have not changed, downstream edges will be culled.

This can be observed in the Ninja progress update after this change. After editing any file in the compiler, Ninja start out with `(2/866) LINK ./impellerc`. But as it culls edges, it skips tasks and ends with `(454/455) ACTION //flutter/...`. Around half the edges are culled. More importantly, the unit-tests edges are culled as well. For workflows where only the changed tests are run, this saves a ton of test time in addition to build time.
