### PR TITLE
Forward mnemonics for compiled actions.

### DIFF
--- a/engine/src/build/compiled_action.gni
+++ b/engine/src/build/compiled_action.gni
@@ -88,6 +88,7 @@ template("compiled_action") {
                              "testonly",
                              "pool",
                              "outputs",
+                             "mnemonic",
                            ])
 
     script = "//build/gn_run_binary.py"
@@ -140,6 +141,8 @@ template("compiled_action_foreach") {
   assert(defined(invoker.args), "args must be defined for $target_name")
 
   action_foreach(target_name) {
+    forward_variables_from(invoker, [ "mnemonic" ])
+
     # Otherwise this is a standalone action, define visibility if requested.
     if (defined(invoker.visibility)) {
       visibility = invoker.visibility

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -83,6 +83,7 @@ impeller_shaders("shader_fixtures") {
 }
 
 impellerc("runtime_stages") {
+  mnemonic = "IMPELLERC_IPLR"
   shaders = [
     "ink_sparkle.frag",
     "runtime_stage_example.frag",

--- a/engine/src/flutter/impeller/tools/compiler.gni
+++ b/engine/src/flutter/impeller/tools/compiler.gni
@@ -13,6 +13,9 @@ import("//flutter/impeller/tools/args.gni")
 # * When the `single_invocation` argument is true, `impellerc` is only
 #   invoked once via `compiled_action` or `action`.
 template("_impellerc") {
+  if (!defined(invoker.mnemonic)) {
+    mnemonic = "IMPELLERC"
+  }
   if (invoker.single_invocation) {
     compiled_action(target_name) {
       forward_variables_from(invoker, "*")
@@ -94,6 +97,7 @@ template("impellerc") {
              ])
 
   _impellerc(target_name) {
+    forward_variables_from(invoker, [ "mnemonic" ])
     pool = "//build/toolchain:toolchain_pool"
     shader_bundle = defined(invoker.shader_bundle)
 

--- a/engine/src/flutter/impeller/tools/embed_blob.gni
+++ b/engine/src/flutter/impeller/tools/embed_blob.gni
@@ -30,6 +30,7 @@ template("embed_blob") {
     ]
     script = "//flutter/impeller/tools/xxd.py"
     deps = invoker.deps
+    mnemonic = "XXD"
   }
 
   embed_config = "embed_$target_name"

--- a/engine/src/flutter/impeller/tools/shader_archive.gni
+++ b/engine/src/flutter/impeller/tools/shader_archive.gni
@@ -11,6 +11,7 @@ template("shader_archive") {
 
   output_file = "$target_gen_dir/$target_name.shar"
   compiled_action(target_name) {
+    mnemonic = "SHADER_ARCHIVE"
     tool = "//flutter/impeller/shader_archive:shader_archiver"
     inputs = invoker.shaders
     outputs = [ output_file ]

--- a/engine/src/flutter/impeller/tools/shaders_gles.gni
+++ b/engine/src/flutter/impeller/tools/shaders_gles.gni
@@ -39,8 +39,10 @@ template("impeller_shaders_gles") {
     if (impeller_enable_metal || impeller_enable_vulkan) {
       if (is_300) {
         intermediates_subdir = "gles3"
+        mnemonic = "IMPELLERC_GLES3"
       } else {
         intermediates_subdir = "gles"
+        mnemonic = "IMPELLERC_GLES2"
       }
     }
     shader_target_flags = [ "--opengl-es" ]

--- a/engine/src/flutter/impeller/tools/shaders_mtl.gni
+++ b/engine/src/flutter/impeller/tools/shaders_mtl.gni
@@ -28,6 +28,7 @@ template("impeller_shaders_metal") {
                                   ])
   impellerc_mtl = "impellerc_$target_name"
   impellerc(impellerc_mtl) {
+    mnemonic = "IMPELLERC_METAL"
     shaders = invoker.shaders
     metal_version = metal_version
     sl_file_extension = "metal"

--- a/engine/src/flutter/impeller/tools/shaders_vk.gni
+++ b/engine/src/flutter/impeller/tools/shaders_vk.gni
@@ -20,6 +20,7 @@ template("impeller_shaders_vk") {
                                   ])
   impellerc_vk = "impellerc_$target_name"
   impellerc(impellerc_vk) {
+    mnemonic = "IMPELLERC_VULKAN"
     shaders = invoker.shaders
     sl_file_extension = "vkspv"
 

--- a/engine/src/flutter/lib/ui/fixtures/shaders/general_shaders/BUILD.gn
+++ b/engine/src/flutter/lib/ui/fixtures/shaders/general_shaders/BUILD.gn
@@ -30,6 +30,7 @@ if (enable_unittests) {
   }
 
   impellerc("compile_general_shaders") {
+    mnemonic = "IMPELLERC_SKSL"
     shaders = test_shaders
     shader_target_flags = [ "--sksl" ]
     intermediates_subdir = "iplr"

--- a/engine/src/flutter/lib/ui/fixtures/shaders/supported_glsl_op_shaders/BUILD.gn
+++ b/engine/src/flutter/lib/ui/fixtures/shaders/supported_glsl_op_shaders/BUILD.gn
@@ -49,6 +49,7 @@ if (enable_unittests) {
   }
 
   impellerc("compile_supported_glsl_shaders") {
+    mnemonic = "IMPELLERC_SKSL"
     shaders = test_shaders
     shader_target_flags = [ "--sksl" ]
     intermediates_subdir = "iplr"

--- a/engine/src/flutter/lib/ui/fixtures/shaders/supported_op_shaders/BUILD.gn
+++ b/engine/src/flutter/lib/ui/fixtures/shaders/supported_op_shaders/BUILD.gn
@@ -45,6 +45,7 @@ if (enable_unittests) {
   }
 
   impellerc("compile_supported_op_shaders") {
+    mnemonic = "IMPELLERC_SKSL"
     shaders = test_shaders
     shader_target_flags = [ "--sksl" ]
     intermediates_subdir = "iplr"


### PR DESCRIPTION
Previously, mnemonics specified in templates that used compiled_action and compiled_action_foreach would not be forwarded. This made actions like ImpellerC invocation unable to tag themselves. As Ninja builds progressed, only a mysterious ACTION label would be emitted for all ImpellerC edges. Now, the edges tag themselves.
