### PR TITLE
Fix casing of error when Dart compiler is interrupted

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -891,7 +891,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
             // process has died unexpectedly.
             if (_stdoutHandler.compilerOutput?.isCompleted == false) {
               _stdoutHandler.compilerOutput?.complete();
-              throwToolExit('the Dart compiler exited unexpectedly.');
+              throwToolExit('The Dart compiler exited unexpectedly.');
             }
           },
         );
@@ -904,7 +904,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     unawaited(
       _server?.exitCode.then((int code) {
         if (code != 0) {
-          throwToolExit('the Dart compiler exited unexpectedly.');
+          throwToolExit('The Dart compiler exited unexpectedly.');
         }
       }),
     );

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -612,7 +612,7 @@ resolution: workspace
         onError: (Object error) async {
           expect(error, isA<ToolExit>());
           // We expect this message because we are using a fake ProcessManager.
-          expect((error as ToolExit).message, contains('the Dart compiler exited unexpectedly.'));
+          expect((error as ToolExit).message, contains('The Dart compiler exited unexpectedly.'));
           caughtToolExit = true;
 
           final File isolateSpawningTesterPackageConfigFile = fs
@@ -694,7 +694,7 @@ resolution: workspace
         onError: (Object error) async {
           expect(error, isA<ToolExit>());
           // We expect this message because we are using a fake ProcessManager.
-          expect((error as ToolExit).message, contains('the Dart compiler exited unexpectedly.'));
+          expect((error as ToolExit).message, contains('The Dart compiler exited unexpectedly.'));
           caughtToolExit = true;
 
           final File childTestIsolateSpawnerSourceFile = fs
@@ -761,7 +761,7 @@ const List<String> packageTestArgs = <String>[
         onError: (Object error) async {
           expect(error, isA<ToolExit>());
           // We expect this message because we are using a fake ProcessManager.
-          expect((error as ToolExit).message, contains('the Dart compiler exited unexpectedly.'));
+          expect((error as ToolExit).message, contains('The Dart compiler exited unexpectedly.'));
           caughtToolExit = true;
 
           final File childTestIsolateSpawnerSourceFile = fs

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -191,7 +191,7 @@ void main() {
             projectRootPath: '',
           ),
         ),
-        throwsToolExit(message: 'the Dart compiler exited unexpectedly.'),
+        throwsToolExit(message: 'The Dart compiler exited unexpectedly.'),
       );
     },
   );


### PR DESCRIPTION
You see this error if you do a well timed `Ctrl+C` during a `flutter run`