### PR TITLE
[WIP] Action based menu handling

### DIFF
--- a/examples/api/lib/widgets/raw_menu_anchor/raw_menu_anchor_animation.0.dart
+++ b/examples/api/lib/widgets/raw_menu_anchor/raw_menu_anchor_animation.0.dart
@@ -1,0 +1,247 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
+
+/// Flutter code sample for a [RawMenuAnchorAnimationApp] that animates a
+/// [RawMenuAnchor] with a [SpringSimulation].
+void main() {
+  runApp(const RawMenuAnchorAnimationApp());
+}
+
+class AnimatedMenu extends StatefulWidget {
+  const AnimatedMenu({super.key, required this.menuController});
+
+  final MenuController menuController;
+
+  @override
+  State<AnimatedMenu> createState() => _AnimatedMenuState();
+}
+
+class _AnimatedMenuState extends State<AnimatedMenu>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _animationController;
+  final MenuController _internalController = MenuController();
+
+  SpringSimulation get forwardSpring => SpringSimulation(
+    SpringDescription.withDampingRatio(mass: 1.0, stiffness: 150, ratio: 0.7),
+    _animationController.value,
+    1.0,
+    0.0,
+  );
+  SpringSimulation get reverseSpring => SpringSimulation(
+    SpringDescription.withDampingRatio(mass: 1.0, stiffness: 200, ratio: 0.7),
+    _animationController.value,
+    0.0,
+    0.0,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    // Use an unbounded animation controller so that simulations are not clamped.
+    _animationController = AnimationController.unbounded(vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  void _open(_) {
+    // Call whenComplete() rather than whenCompleteOrCancel() to avoid marking
+    // the menu as opened when the [AnimationStatus] moves from forward to
+    // reverse.
+    _internalController.open();
+    setState(() {
+      widget.menuController.animationStatus = AnimationStatus.forward;
+    });
+    _animationController.animateWith(forwardSpring).whenComplete(() {
+      setState(() {
+        widget.menuController.animationStatus = AnimationStatus.completed;
+      });
+    });
+  }
+
+  void _close([_]) {
+    // Call whenComplete() rather than whenCompleteOrCancel() to avoid marking
+    // the menu as closed when the [AnimationStatus] moves from reverse to
+    // forward.
+    setState(() {
+      widget.menuController.animationStatus = AnimationStatus.reverse;
+    });
+    _animationController.animateBackWith(reverseSpring).whenComplete(() {
+      _internalController.close();
+      setState(() {
+        widget.menuController.animationStatus = AnimationStatus.dismissed;
+      });
+    });
+  }
+
+  void _dismiss(_) {
+    _close();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        OpenMenuIntent: CallbackAction<OpenMenuIntent>(onInvoke: _open),
+        CloseMenuIntent: CallbackAction<CloseMenuIntent>(onInvoke: _close),
+        // Handle DismissIntent for dismiss requests dispathed from between
+        // AnimatedMenu and its RawMenuAnchor.
+        if (widget.menuController.isOpen)
+          DismissIntent: CallbackAction<DismissIntent>(onInvoke: _dismiss),
+        // Handle DismissMenuIntent for dismiss requests dispathed from within
+        // the RawMenuAnchor.
+        DismissMenuIntent: CallbackAction<DismissMenuIntent>(onInvoke: _dismiss),
+      },
+      child: _AttachMenuController(
+        controller: widget.menuController,
+        child: Builder(builder: _buildAnchor),
+      )
+    );
+  }
+
+  Widget _buildAnchor(BuildContext context) {
+    return RawMenuAnchor(
+      controller: _internalController,
+      overlayBuilder: (BuildContext context, RawMenuOverlayInfo info) {
+        // Center the menu below the anchor.
+        final ui.Offset position = info.anchorRect.bottomCenter.translate(-75, 4);
+        final ColorScheme colorScheme = ColorScheme.of(context);
+        return Positioned(
+          top: position.dy,
+          left: position.dx,
+          child: Semantics(
+            explicitChildNodes: true,
+            scopesRoute: true,
+            child: ExcludeFocus(
+              excluding: widget.menuController.animationStatus == AnimationStatus.reverse,
+              child: TapRegion(
+                groupId: info.tapRegionGroupId,
+                onTapOutside: (PointerDownEvent event) {
+                  widget.menuController.close();
+                },
+                child: ScaleTransition(
+                  scale: _animationController.view,
+                  child: FadeTransition(
+                    opacity: _animationController.drive(
+                      Animatable<double>.fromCallback(
+                        (double value) => ui.clampDouble(value, 0, 1),
+                      ),
+                    ),
+                    child: Material(
+                      elevation: 8,
+                      clipBehavior: Clip.antiAlias,
+                      borderRadius: BorderRadius.circular(16),
+                      color: colorScheme.primary,
+                      child: SizeTransition(
+                        axisAlignment: -1,
+                        sizeFactor: _animationController.view,
+                        fixedCrossAxisSizeFactor: 1.0,
+                        child: SizedBox(
+                          height: 200,
+                          width: 150,
+                          child: Text(
+                            'ANIMATION STATUS:\n${_animationController.status.name}',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(color: colorScheme.onPrimary, fontSize: 12),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+      child: FilledButton(
+        onPressed: () {
+          if (widget.menuController.animationStatus.isForwardOrCompleted) {
+            widget.menuController.close();
+          } else {
+            widget.menuController.open();
+          }
+        },
+        child: Text(widget.menuController.animationStatus.isForwardOrCompleted ? 'Close' : 'Open'),
+      ),
+    );
+  }
+}
+
+// Attach the controller to the state.
+//
+// This widget ensures that the controller's attached context is within the
+// scope of `Actions`.
+class _AttachMenuController extends StatefulWidget {
+  _AttachMenuController({required this.controller, required this.child});
+
+  final MenuController controller;
+  final Widget child;
+
+  @override
+  _AttachMenuControllerState createState() => _AttachMenuControllerState();
+}
+
+class _AttachMenuControllerState extends State<_AttachMenuController> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.attach(context);
+  }
+
+  @override
+  void didUpdateWidget(_AttachMenuController oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.detach(context);
+      widget.controller.attach(context);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.detach(context);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
+class RawMenuAnchorAnimationApp extends StatefulWidget {
+  const RawMenuAnchorAnimationApp({super.key});
+
+  @override
+  State<RawMenuAnchorAnimationApp> createState() => _RawMenuAnchorAnimationAppState();
+}
+
+class _RawMenuAnchorAnimationAppState extends State<RawMenuAnchorAnimationApp> {
+  final MenuController controller = MenuController();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData.from(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.blue,
+          dynamicSchemeVariant: DynamicSchemeVariant.vibrant,
+        ),
+      ),
+      home: Scaffold(body: Center(child: AnimatedMenu(menuController: controller))),
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2302,7 +2302,6 @@ class _MenuBarAnchor extends MenuAnchor {
 
 class _MenuBarAnchorState extends _MenuAnchorState {
   late final Map<Type, Action<Intent>> actions = <Type, Action<Intent>>{
-    DismissIntent: DismissMenuAction(controller: _menuController),
   };
 
   @override
@@ -3352,7 +3351,10 @@ class _Submenu extends StatelessWidget {
       groupId: menuPosition.tapRegionGroupId,
       consumeOutsideTaps: anchor._root._menuController.isOpen && anchor.widget.consumeOutsideTap,
       onTapOutside: (PointerDownEvent event) {
-        anchor._menuController.close();
+        // This context is outside of the scope of this menu's RawMenuAnchor,
+        // and the intent dispatched here is meant for the parent menu, hence
+        // CloseChildrenMenuIntent.
+        Actions.invoke(context, const CloseChildrenMenuIntent());
       },
       child: MouseRegion(
         cursor: mouseCursor,
@@ -3360,19 +3362,14 @@ class _Submenu extends StatelessWidget {
         child: FocusScope(
           node: anchor._menuScopeNode,
           skipTraversal: true,
-          child: Actions(
-            actions: <Type, Action<Intent>>{
-              DismissIntent: DismissMenuAction(controller: anchor._menuController),
-            },
-            child: Shortcuts(
-              shortcuts: _kMenuTraversalShortcuts,
-              child: _MenuPanel(
-                menuStyle: menuStyle,
-                clipBehavior: clipBehavior,
-                orientation: anchor._orientation,
-                crossAxisUnconstrained: crossAxisUnconstrained,
-                children: menuChildren,
-              ),
+          child: Shortcuts(
+            shortcuts: _kMenuTraversalShortcuts,
+            child: _MenuPanel(
+              menuStyle: menuStyle,
+              clipBehavior: clipBehavior,
+              orientation: anchor._orientation,
+              crossAxisUnconstrained: crossAxisUnconstrained,
+              children: menuChildren,
             ),
           ),
         ),

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2301,23 +2301,18 @@ class _MenuBarAnchor extends MenuAnchor {
 }
 
 class _MenuBarAnchorState extends _MenuAnchorState {
-  late final Map<Type, Action<Intent>> actions = <Type, Action<Intent>>{};
-
   @override
   Axis get _orientation => Axis.horizontal;
 
   @override
   Widget build(BuildContext context) {
-    final Actions child = Actions(
-      actions: actions,
-      child: Shortcuts(
-        shortcuts: _kMenuTraversalShortcuts,
-        child: _MenuPanel(
-          menuStyle: widget.style,
-          clipBehavior: widget.clipBehavior,
-          orientation: _orientation,
-          children: widget.menuChildren,
-        ),
+    final Widget child = Shortcuts(
+      shortcuts: _kMenuTraversalShortcuts,
+      child: _MenuPanel(
+        menuStyle: widget.style,
+        clipBehavior: widget.clipBehavior,
+        orientation: _orientation,
+        children: widget.menuChildren,
       ),
     );
     return _MenuAnchorScope(

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2301,8 +2301,7 @@ class _MenuBarAnchor extends MenuAnchor {
 }
 
 class _MenuBarAnchorState extends _MenuAnchorState {
-  late final Map<Type, Action<Intent>> actions = <Type, Action<Intent>>{
-  };
+  late final Map<Type, Action<Intent>> actions = <Type, Action<Intent>>{};
 
   @override
   Axis get _orientation => Axis.horizontal;
@@ -3351,10 +3350,7 @@ class _Submenu extends StatelessWidget {
       groupId: menuPosition.tapRegionGroupId,
       consumeOutsideTaps: anchor._root._menuController.isOpen && anchor.widget.consumeOutsideTap,
       onTapOutside: (PointerDownEvent event) {
-        // This context is outside of the scope of this menu's RawMenuAnchor,
-        // and the intent dispatched here is meant for the parent menu, hence
-        // CloseChildrenMenuIntent.
-        Actions.invoke(context, const CloseChildrenMenuIntent());
+        anchor._menuController.close();
       },
       child: MouseRegion(
         cursor: mouseCursor,

--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -875,7 +875,7 @@ class MenuController {
   /// This method will establish a dependency relationship, so the calling
   /// widget will rebuild when the menu opens and closes.
   static bool? maybeIsOpenOf(BuildContext context) {
-    return context.getInheritedWidgetOfExactType<_MenuControllerScope>()?.isOpen;
+    return context.dependOnInheritedWidgetOfExactType<_MenuControllerScope>()?.isOpen;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -403,6 +403,12 @@ mixin _RawMenuAnchorBaseMixin<T extends StatefulWidget> on State<T> {
   void close({bool inDispose = false});
 
   @protected
+  void dismiss() {
+    assert(_parent == null);
+    Actions.invoke(menuController._context!, const DismissMenuIntent());
+  }
+
+  @protected
   void closeChildren({bool inDispose = false}) {
     assert(_debugMenuInfo('Closing children of $this${inDispose ? ' (dispose)' : ''}'));
     for (final _RawMenuAnchorBaseMixin child in List<_RawMenuAnchorBaseMixin>.from(
@@ -467,7 +473,7 @@ mixin _RawMenuAnchorBaseMixin<T extends StatefulWidget> on State<T> {
           if (isOpen)
             DismissIntent: CallbackAction<DismissIntent>(
               onInvoke: (DismissIntent intent) {
-                Actions.invoke(menuController._context!, const DismissMenuIntent());
+                root.dismiss();
                 return null;
               },
             ),

--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -120,11 +120,7 @@ typedef RawMenuAnchorChildBuilder =
 // An [InheritedWidget] used to notify anchor descendants when a menu opens
 // and closes, and to pass the anchor's controller to descendants.
 class _MenuControllerScope extends InheritedWidget {
-  const _MenuControllerScope({
-    required this.isOpen,
-    required this.menuBase,
-    required super.child,
-  });
+  const _MenuControllerScope({required this.isOpen, required this.menuBase, required super.child});
 
   final bool isOpen;
   final _RawMenuAnchorBaseMixin menuBase;

--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -399,12 +399,6 @@ mixin _RawMenuAnchorBaseMixin<T extends StatefulWidget> on State<T> {
   void close({bool inDispose = false});
 
   @protected
-  void dismiss() {
-    assert(_parent == null);
-    Actions.invoke(menuController._context!, const DismissMenuIntent());
-  }
-
-  @protected
   void closeChildren({bool inDispose = false}) {
     assert(_debugMenuInfo('Closing children of $this${inDispose ? ' (dispose)' : ''}'));
     for (final _RawMenuAnchorBaseMixin child in List<_RawMenuAnchorBaseMixin>.from(
@@ -469,8 +463,7 @@ mixin _RawMenuAnchorBaseMixin<T extends StatefulWidget> on State<T> {
           if (isOpen)
             DismissIntent: CallbackAction<DismissIntent>(
               onInvoke: (DismissIntent intent) {
-                root.dismiss();
-                return null;
+                menuController.dismiss();
               },
             ),
           DismissMenuIntent: Action<DismissMenuIntent>.overridable(
@@ -842,16 +835,23 @@ class MenuController {
     Actions.invoke(_context!, const CloseChildrenMenuIntent());
   }
 
-  // ignore: use_setters_to_change_properties
-  void _attach(BuildContext context) {
+  void dismiss() {
+    if (_context != null) {
+      Actions.invoke(_context!, const DismissMenuIntent());
+    }
+  }
+
+  void attach(BuildContext context) {
     _context = context;
   }
 
-  void _detach(BuildContext context) {
+  void detach(BuildContext context) {
     if (_context == context) {
       _context = null;
     }
   }
+
+  AnimationStatus animationStatus = AnimationStatus.dismissed;
 
   /// Returns the [MenuController] of the ancestor [RawMenuAnchor] or
   /// [RawMenuAnchorGroup] nearest to the given `context`, if one exists.
@@ -945,21 +945,21 @@ class _AttachMenuControllerState extends State<_AttachMenuController> {
   @override
   void initState() {
     super.initState();
-    widget.controller._attach(context);
+    widget.controller.attach(context);
   }
 
   @override
   void didUpdateWidget(_AttachMenuController oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.controller != widget.controller) {
-      oldWidget.controller._detach(context);
-      widget.controller._attach(context);
+      oldWidget.controller.detach(context);
+      widget.controller.attach(context);
     }
   }
 
   @override
   void dispose() {
-    widget.controller._detach(context);
+    widget.controller.detach(context);
     super.dispose();
   }
 

--- a/packages/flutter/test/widgets/raw_menu_anchor_test.dart
+++ b/packages/flutter/test/widgets/raw_menu_anchor_test.dart
@@ -739,7 +739,7 @@ void main() {
       serializedException = exception.toString();
     });
 
-    expect(serializedException, contains('_anchor != null'));
+    expect(serializedException, contains('_context != null'));
   });
 
   testWidgets('[Group] MenuController is detached on update', (WidgetTester tester) async {
@@ -759,7 +759,7 @@ void main() {
       serializedException = exception.toString();
     });
 
-    expect(serializedException, contains('_anchor != null'));
+    expect(serializedException, contains('_context != null'));
   });
 
   testWidgets('[Default] MenuController is detached on dispose', (WidgetTester tester) async {
@@ -777,7 +777,7 @@ void main() {
       serializedException = exception.toString();
     });
 
-    expect(serializedException, contains('_anchor != null'));
+    expect(serializedException, contains('_context != null'));
   });
 
   testWidgets('[Group] MenuController is detached on dispose', (WidgetTester tester) async {
@@ -795,7 +795,7 @@ void main() {
       serializedException = exception.toString();
     });
 
-    expect(serializedException, contains('_anchor != null'));
+    expect(serializedException, contains('_context != null'));
   });
 
   testWidgets('[Default] MenuOverlayPosition.anchorRect applies transformations to panel', (
@@ -1140,7 +1140,7 @@ void main() {
     expect(invokedOverlay, isTrue);
   });
 
-  testWidgets('DismissMenuAction closes menus', (WidgetTester tester) async {
+  testWidgets('DismissMenuIntent closes menus', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();
     addTearDown(focusNode.dispose);
     await tester.pumpWidget(
@@ -1181,11 +1181,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pump();
 
-    const ActionDispatcher().invokeAction(
-      DismissMenuAction(controller: controller),
-      const DismissIntent(),
-      focusNode.context,
-    );
+    Actions.invoke(focusNode.context!, DismissIntent());
 
     await tester.pump();
 


### PR DESCRIPTION
This is a refactor that manipulates menus via intents and actions. The goal is to incorporate with the design for animated menus that uses dual menu controllers and no decorators or delegates, as described in [this comment](https://github.com/flutter/flutter/pull/165556#issuecomment-2792268796).

Key points:
* First, let's only look at `RawMenuAnchor`s:
  * The `MenuController` no longer directly calls `_RawMenuAnchorBaseMixin`'s methods. Instead, it dispatches `OpenMenuIntent`, `CloseMenuIntent`, etc.
    * The intents will be dispatched to a context that is assigned when the controller is attached, which is the context within the `Actions` widget of the raw menu anchor.
  * The raw menu anchor builds an `Actions` widget, which handles the intents with callback actions that call private methods, such as `open()` and `close()`.
  * This solves the problem of how the `MenuController`'s methods affect the raw menu anchor.
* As for themed menus:
  * As said above, the themed menu is given an external menu controller, which builds another (internal) menu controller for its raw menu anchor.
  * The themed menu will build its own `Actions` widget and handles opening and closing.
    * Opening will making the internal menu controller open and play animations, while closing will play animations before making the internal menu controller close.
    * Dismissing will be discussed later.
    * Similarly, the context just within _this_ `Actions` widget is assigned to the external menu controller. Therefore when calling the methods of the _external_ menu controller will eventually call private methods of the themed menu.
* How dismissing works:
  * The goal is that `DismissIntent`, the standard way of dismissing, such as pressing Esc, must be handled by the root themed menu.
  * This consists of two steps:
    * The `DismissIntent` is handled by any raw menu anchor, which finds its root raw menu anchor and call its `_dismiss()`.
    * The `_dismiss()` actually dispatches a `DismissMenuIntent`, which is by default handled by the raw menu anchor in an overridable way. The themed menu also handles it in its `Actions` by calling the animated `close()`.
    * We can't let `DismissIntent` be handled overridable because it would leak to the next widget surrounding it (such as a dialog barrier).

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
