### PR TITLE
[Android 16] Update mockito to 5.17.0 from 4.7.0, prework for android 36 support

### DIFF
--- a/engine/src/flutter/shell/platform/android/test/io/flutter/FlutterInjectorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/FlutterInjectorTest.java
@@ -25,8 +25,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterInjectorTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/FlutterInjectorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/FlutterInjectorTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterInjectorTest {
   @Mock FlutterLoader mockFlutterLoader;

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/LogTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/LogTest.java
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(RobolectricTestRunner.class)
 public class LogTest {
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/LogTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/LogTest.java
@@ -11,8 +11,6 @@ import java.io.StringWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(RobolectricTestRunner.class)
 public class LogTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/SmokeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/SmokeTest.java
@@ -10,10 +10,8 @@ import android.text.TextUtils;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
 
 /** Basic smoke test verifying that Robolectric is loaded and mocking out Android APIs. */
-
 @RunWith(AndroidJUnit4.class)
 public class SmokeTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/SmokeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/SmokeTest.java
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
 /** Basic smoke test verifying that Robolectric is loaded and mocking out Android APIs. */
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class SmokeTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/AndroidTouchProcessorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/AndroidTouchProcessorTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_28)
 public class AndroidTouchProcessorTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/AndroidTouchProcessorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/AndroidTouchProcessorTest.java
@@ -32,7 +32,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_28)
 public class AndroidTouchProcessorTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -67,7 +67,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterActivityAndFragmentDelegateTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -65,8 +65,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterActivityAndFragmentDelegateTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -60,7 +60,6 @@ import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 public class FlutterActivityTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -60,7 +60,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterActivityTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -48,7 +48,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterAndroidComponentTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -46,8 +46,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterAndroidComponentTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -45,7 +45,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 public class FlutterFragmentActivityTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterFragmentActivityTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -36,7 +36,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterFragmentTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -34,8 +34,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterFragmentTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterSurfaceViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterSurfaceViewTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_30)
 public class FlutterSurfaceViewTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterSurfaceViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterSurfaceViewTest.java
@@ -22,8 +22,6 @@ import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_30)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterTextureViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterTextureViewTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_30)
 public class FlutterTextureViewTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterTextureViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterTextureViewTest.java
@@ -23,8 +23,6 @@ import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_30)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -76,7 +76,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowDisplay;
 import org.robolectric.shadows.ShadowViewGroup;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(30)
 public class FlutterViewTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -76,7 +76,6 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowDisplay;
 import org.robolectric.shadows.ShadowViewGroup;
 
-
 @RunWith(AndroidJUnit4.class)
 @TargetApi(30)
 public class FlutterViewTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyChannelResponderTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyChannelResponderTest.java
@@ -20,8 +20,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_28)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyChannelResponderTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyChannelResponderTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_28)
 public class KeyChannelResponderTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
@@ -43,8 +43,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class KeyboardManagerTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
@@ -45,7 +45,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class KeyboardManagerTest {
   public static final int SCAN_KEY_A = 0x1e;

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineCacheTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineCacheTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineCacheTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineCacheTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineCacheTest.java
@@ -13,8 +13,6 @@ import static org.mockito.Mockito.mock;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineCacheTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
 // Run with Robolectric so that Log calls don't crash.
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineConnectionRegistryTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -25,7 +25,6 @@ import io.flutter.plugin.platform.PlatformViewsController2;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
 
 // Run with Robolectric so that Log calls don't crash.
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupCacheTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupCacheTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(RobolectricTestRunner.class)
 public class FlutterEngineGroupCacheTest {
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupCacheTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupCacheTest.java
@@ -18,8 +18,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(RobolectricTestRunner.class)
 public class FlutterEngineGroupCacheTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupComponentTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.annotation.Config;
 
 // It's a component test because it tests the FlutterEngineGroup its components such as the
 // FlutterEngine and the DartExecutor.

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupComponentTest.java
@@ -40,7 +40,7 @@ import org.robolectric.annotation.Config;
 
 // It's a component test because it tests the FlutterEngineGroup its components such as the
 // FlutterEngine and the DartExecutor.
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineGroupComponentTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -45,9 +45,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
-import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -48,7 +48,7 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -31,8 +31,6 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24) // LocaleList and scriptCode are API 24+.

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24) // LocaleList and scriptCode are API 24+.
 public class FlutterJNITest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterShellArgsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterShellArgsTest.java
@@ -14,8 +14,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterShellArgsTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterShellArgsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterShellArgsTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterShellArgsTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/PluginComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/PluginComponentTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class PluginComponentTest {
   boolean jniAttached;

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/PluginComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/PluginComponentTest.java
@@ -18,8 +18,6 @@ import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class PluginComponentTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/RenderingComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/RenderingComponentTest.java
@@ -16,8 +16,6 @@ import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class RenderingComponentTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/RenderingComponentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/RenderingComponentTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class RenderingComponentTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
@@ -26,8 +26,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class DartExecutorTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
@@ -28,7 +28,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class DartExecutorTest {
   @Mock FlutterLoader mockFlutterLoader;

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
@@ -33,8 +33,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class DartMessengerTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
@@ -35,7 +35,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class DartMessengerTest {
   SynchronousTaskQueue synchronousTaskQueue = new SynchronousTaskQueue();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class PlayStoreDeferredComponentManagerTest {
   private class TestFlutterJNI extends FlutterJNI {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -28,8 +28,6 @@ import io.flutter.embedding.engine.loader.ApplicationInfoLoader;
 import java.io.File;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class PlayStoreDeferredComponentManagerTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
@@ -27,10 +27,8 @@ import java.io.StringReader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
-import org.robolectric.annotation.Config;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
-
 
 @RunWith(AndroidJUnit4.class)
 public class ApplicationInfoLoaderTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
@@ -31,7 +31,7 @@ import org.robolectric.annotation.Config;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class ApplicationInfoLoaderTest {
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -38,7 +38,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterLoaderTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -38,7 +38,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 public class FlutterLoaderTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -26,7 +26,6 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-
 @RunWith(AndroidJUnit4.class)
 public class FlutterMutatorViewTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -26,7 +26,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterMutatorViewTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -44,8 +44,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterRendererTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterRendererTest {
   @Rule(order = 1)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
@@ -20,8 +20,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@Config(
-    shadows = {})
+@Config(shadows = {})
 @RunWith(RobolectricTestRunner.class)
 @TargetApi(API_LEVELS.API_24)
 public class AccessibilityChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
@@ -21,7 +21,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @Config(
-    manifest = Config.NONE,
     shadows = {})
 @RunWith(RobolectricTestRunner.class)
 @TargetApi(API_LEVELS.API_24)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/DeferredComponentChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/DeferredComponentChannelTest.java
@@ -53,7 +53,7 @@ class TestDeferredComponentManager implements DeferredComponentManager {
   public void destroy() {}
 }
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class DeferredComponentChannelTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/DeferredComponentChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/DeferredComponentChannelTest.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
 
 class TestDeferredComponentManager implements DeferredComponentManager {
   DeferredComponentChannel channel;
@@ -52,7 +51,6 @@ class TestDeferredComponentManager implements DeferredComponentManager {
 
   public void destroy() {}
 }
-
 
 @RunWith(AndroidJUnit4.class)
 public class DeferredComponentChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyEventChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyEventChannelTest.java
@@ -29,7 +29,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_35)
 public class KeyEventChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyEventChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyEventChannelTest.java
@@ -27,8 +27,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_35)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyboardChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyboardChannelTest.java
@@ -21,8 +21,6 @@ import java.util.HashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class KeyboardChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyboardChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyboardChannelTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class KeyboardChannelTest {
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/LifecycleChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/LifecycleChannelTest.java
@@ -16,8 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class LifecycleChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/LifecycleChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/LifecycleChannelTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class LifecycleChannelTest {
   LifecycleChannel lifecycleChannel;

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class PlatformChannelTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
@@ -22,8 +22,6 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class PlatformChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
@@ -25,8 +25,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
-@Config(
-    shadows = {})
+@Config(shadows = {})
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24)
 public class RestorationChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
@@ -26,7 +26,6 @@ import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
 @Config(
-    manifest = Config.NONE,
     shadows = {})
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/SettingsChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/SettingsChannelTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class SettingsChannelTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/SettingsChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/SettingsChannelTest.java
@@ -22,7 +22,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 public class SettingsChannelTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java
@@ -23,7 +23,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
 @Config(
-    manifest = Config.NONE,
     shadows = {})
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java
@@ -22,8 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(
-    shadows = {})
+@Config(shadows = {})
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24)
 public class TextInputChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/external/FlutterLaunchTests.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/external/FlutterLaunchTests.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class FlutterLaunchTests {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/external/FlutterLaunchTests.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/external/FlutterLaunchTests.java
@@ -15,8 +15,6 @@ import io.flutter.embedding.android.RobolectricFlutterActivity;
 import io.flutter.embedding.android.TransparencyMode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class FlutterLaunchTests {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/BinaryCodecTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/BinaryCodecTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class BinaryCodecTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/BinaryCodecTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/BinaryCodecTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class BinaryCodecTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class MethodChannelTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
@@ -15,8 +15,6 @@ import java.nio.ByteBuffer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class MethodChannelTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
@@ -11,8 +11,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class StandardMessageCodecTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class StandardMessageCodecTest {
   // Data types defined as per StandardMessageCodec.Java

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/StandardMethodCodecTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/StandardMethodCodecTest.java
@@ -13,8 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class StandardMethodCodecTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/StandardMethodCodecTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/common/StandardMethodCodecTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class StandardMethodCodecTest {
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -68,7 +68,6 @@ import org.robolectric.shadows.ShadowContentResolver;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
 @Config(
-    manifest = Config.NONE,
     shadows = {InputConnectionAdaptorTest.TestImm.class})
 @RunWith(AndroidJUnit4.class)
 public class InputConnectionAdaptorTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -67,8 +67,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowContentResolver;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
-@Config(
-    shadows = {InputConnectionAdaptorTest.TestImm.class})
+@Config(shadows = {InputConnectionAdaptorTest.TestImm.class})
 @RunWith(AndroidJUnit4.class)
 public class InputConnectionAdaptorTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
@@ -22,8 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class ListenableEditingStateTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
@@ -24,7 +24,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class ListenableEditingStateTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextEditingDeltaTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextEditingDeltaTest.java
@@ -7,8 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class TextEditingDeltaTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextEditingDeltaTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextEditingDeltaTest.java
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class TextEditingDeltaTest {
   @Before

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -89,7 +89,6 @@ import org.robolectric.shadows.ShadowBuild;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
 @Config(
-    manifest = Config.NONE,
     shadows = {TextInputPluginTest.TestImm.class, TextInputPluginTest.TestAfm.class})
 @RunWith(AndroidJUnit4.class)
 public class TextInputPluginTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -88,8 +88,7 @@ import org.robolectric.shadows.ShadowAutofillManager;
 import org.robolectric.shadows.ShadowBuild;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
-@Config(
-    shadows = {TextInputPluginTest.TestImm.class, TextInputPluginTest.TestAfm.class})
+@Config(shadows = {TextInputPluginTest.TestImm.class, TextInputPluginTest.TestAfm.class})
 @RunWith(AndroidJUnit4.class)
 public class TextInputPluginTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24) // LocaleList and scriptCode are API 24+.
 public class LocalizationPluginTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24) // LocaleList and scriptCode are API 24+.
 public class LocalizationPluginTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/mouse/MouseCursorPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/mouse/MouseCursorPluginTest.java
@@ -25,7 +25,6 @@ import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
 @Config(
-    manifest = Config.NONE,
     minSdk = API_LEVELS.API_24,
     shadows = {})
 @RunWith(AndroidJUnit4.class)

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -57,7 +57,6 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 
-
 @RunWith(RobolectricTestRunner.class)
 public class PlatformPluginTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -57,7 +57,7 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(RobolectricTestRunner.class)
 public class PlatformPluginTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -53,7 +53,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.shadows.ShadowSurfaceView;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class PlatformViewsController2Test {
   // An implementation of PlatformView that counts invocations of its lifecycle callbacks.

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -53,7 +53,6 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.shadows.ShadowSurfaceView;
 
-
 @RunWith(AndroidJUnit4.class)
 public class PlatformViewsController2Test {
   // An implementation of PlatformView that counts invocations of its lifecycle callbacks.

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -67,7 +67,6 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.shadows.ShadowSurfaceView;
 
-
 @RunWith(AndroidJUnit4.class)
 public class PlatformViewsControllerTest {
   // An implementation of PlatformView that counts invocations of its lifecycle callbacks.

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -67,7 +67,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.shadows.ShadowSurfaceView;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class PlatformViewsControllerTest {
   // An implementation of PlatformView that counts invocations of its lifecycle callbacks.

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_28)
 public class SingleViewPresentationTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_28)
 public class SingleViewPresentationTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/WindowManagerHandlerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/WindowManagerHandlerTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_28)
 public class WindowManagerHandlerTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/WindowManagerHandlerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/WindowManagerHandlerTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_28)
 public class WindowManagerHandlerTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/util/PathUtilsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/util/PathUtilsTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(RobolectricTestRunner.class)
 public class PathUtilsTest {
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/util/PathUtilsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/util/PathUtilsTest.java
@@ -16,8 +16,6 @@ import java.io.File;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(RobolectricTestRunner.class)
 public class PathUtilsTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/util/PreconditionsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/util/PreconditionsTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class PreconditionsTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/util/PreconditionsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/util/PreconditionsTest.java
@@ -10,8 +10,6 @@ import static org.junit.Assert.assertThrows;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class PreconditionsTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/util/ViewUtilsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/util/ViewUtilsTest.java
@@ -18,8 +18,6 @@ import android.view.ViewGroup;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class ViewUtilsTest {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/util/ViewUtilsTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/util/ViewUtilsTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class ViewUtilsTest {
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -63,7 +63,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.robolectric.annotation.Config;
 
-
 @RunWith(AndroidJUnit4.class)
 public class AccessibilityBridgeTest {
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -63,7 +63,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class AccessibilityBridgeTest {
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+
 @RunWith(AndroidJUnit4.class)
 public class VsyncWaiterTest {
   @Before

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
@@ -23,8 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.annotation.Config;
-
 
 @RunWith(AndroidJUnit4.class)
 public class VsyncWaiterTest {

--- a/engine/src/flutter/shell/platform/android/test_runner/build.gradle
+++ b/engine/src/flutter/shell/platform/android/test_runner/build.gradle
@@ -40,8 +40,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
 
   testOptions {
@@ -75,9 +75,8 @@ android {
     testImplementation "junit:junit:4.13.2"
     testImplementation "androidx.test.ext:junit:1.1.4-alpha07"
 
-    def mockitoVersion = "4.7.0"
+    def mockitoVersion = "5.17.0"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "org.mockito:mockito-inline:$mockitoVersion"
     testImplementation "org.mockito:mockito-android:$mockitoVersion"
   }
 

--- a/engine/src/flutter/shell/platform/android/test_runner/build.gradle
+++ b/engine/src/flutter/shell/platform/android/test_runner/build.gradle
@@ -68,20 +68,19 @@ android {
     // Only add test dependencies.
 
     implementation files(project.property("flutter_jar"))
-    testImplementation "androidx.test:core:1.4.0"
+    testImplementation "androidx.test:core:1.6.1"
+    //noinspection RiskyLibrary,PlaySdkIndexDeprecated
     testImplementation "com.google.android.play:core:1.8.0"
-    testImplementation "com.ibm.icu:icu4j:69.1"
+    testImplementation "com.ibm.icu:icu4j:75.1"
     testImplementation "org.robolectric:robolectric:4.14.1"
     testImplementation "junit:junit:4.13.2"
-    testImplementation "androidx.test.ext:junit:1.1.4-alpha07"
+    testImplementation "androidx.test.ext:junit:1.2.1"
 
-    def mockitoVersion = "5.17.0"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "org.mockito:mockito-android:$mockitoVersion"
+    testImplementation "org.mockito:mockito-core:5.17.0"
   }
 
   // Configure the embedding dependencies.
-  apply from: new File(rootDir, '../../../../tools/androidx/configure.gradle').absolutePath;
+  apply from: new File(rootDir, '../../../../tools/androidx/configure.gradle').absolutePath
   configureDependencies(new File(rootDir, '../../../..')) { dependency ->
     dependencies {
       testImplementation "$dependency"


### PR DESCRIPTION
This updates all the dependencies in engine/src/flutter/shell/platform/android/test_runner/build.gradle and ignores the play store deprecration so I could get android studio to give me other lint help. 

This work is required to unblock @jesswrd's work to update the engine to use android 36. 
Deleted mockito-inline because it is automatically used after 5.2.0 according to Maven docs: https://mvnrepository.com/artifact/org.mockito/mockito-inline/5.2.0"

- **Remove config none annotations that have been deprecrated since roboletrics 4.0.1**
- **Update all dependencies used in test runner, passes for spellcheckplugintest**

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

