### PR TITLE
Note when `--enable-vmservice` is required and skip otherwise.

### DIFF
--- a/packages/integration_test/test/_requires_vm_service.dart
+++ b/packages/integration_test/test/_requires_vm_service.dart
@@ -1,0 +1,12 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter_test/flutter_test.dart';
+
+Future<bool> hasVmServiceEnabled() async {
+  final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
+  final bool result = info.serverUri != null;
+  if (!result) {
+    print('Run test suite with --enable-vmservice to enable this test.');
+  }
+  return result;
+}

--- a/packages/integration_test/test/_requires_vm_service.dart
+++ b/packages/integration_test/test/_requires_vm_service.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:developer' as developer;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/integration_test/test/_requires_vm_service.dart
+++ b/packages/integration_test/test/_requires_vm_service.dart
@@ -6,6 +6,7 @@ Future<bool> hasVmServiceEnabled() async {
   final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
   final bool result = info.serverUri != null;
   if (!result) {
+    // ignore: avoid_print
     print('Run test suite with --enable-vmservice to enable this test.');
   }
   return result;

--- a/packages/integration_test/test/socket_fail_test.dart
+++ b/packages/integration_test/test/socket_fail_test.dart
@@ -31,5 +31,5 @@ Future<void> main() async {
       fail('Did not expect a socket exception.');
     }
     expect(gotStateError, true);
-  }, skip: !(await hasVmServiceEnabled()));
+  }, skip: !(await hasVmServiceEnabled())); // [intended] avoid local failures
 }

--- a/packages/integration_test/test/socket_fail_test.dart
+++ b/packages/integration_test/test/socket_fail_test.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '_requires_vm_service.dart';
+
 class SocketExceptionHttpClient extends Fake implements HttpClient {
   @override
   Future<HttpClientRequest> openUrl(String method, Uri url) {
@@ -29,5 +31,5 @@ Future<void> main() async {
       fail('Did not expect a socket exception.');
     }
     expect(gotStateError, true);
-  });
+  }, skip: !(await hasVmServiceEnabled()));
 }


### PR DESCRIPTION
Our CI system runs with `--enable-vmservice`, but the default (i.e. for `flutter test`) does not.

Closes https://github.com/flutter/flutter/issues/136079.