### PR TITLE
Resolve Cupertino textstyle in MaterialBasedCupertinoThemeData

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -2983,16 +2983,6 @@ class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
       ),
     );
   }
-
-  @override
-  CupertinoThemeData resolveFrom(BuildContext context) {
-    // Only the cupertino override theme part will be resolved.
-    // If the color comes from the material theme it's not resolved.
-    return MaterialBasedCupertinoThemeData._(
-      _materialTheme,
-      _cupertinoOverrideTheme.resolveFrom(context),
-    );
-  }
 }
 
 /// A class for creating a Material theme with a color scheme based off of the

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -2986,8 +2986,8 @@ class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
 
   @override
   CupertinoThemeData resolveFrom(BuildContext context) {
-    // Only the cupertino override theme part will be resolved, except for the
-    // text theme.
+    // Only the cupertino override theme part will be resolved, as well as the
+    // default text theme.
     // If the color comes from the material theme it's not resolved.
     final NoDefaultCupertinoThemeData cupertinoOverrideThemeWithTextTheme = _cupertinoOverrideTheme
         .copyWith(textTheme: textTheme);

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -2983,6 +2983,17 @@ class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
       ),
     );
   }
+
+  @override
+  CupertinoThemeData resolveFrom(BuildContext context) {
+    // Only the cupertino override theme part will be resolved, except for the
+    // text theme.
+    // If the color comes from the material theme it's not resolved.
+    return MaterialBasedCupertinoThemeData._(
+      _materialTheme,
+      _cupertinoOverrideTheme.copyWith(textTheme: super.textTheme).resolveFrom(context),
+    );
+  }
 }
 
 /// A class for creating a Material theme with a color scheme based off of the

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -2989,10 +2989,11 @@ class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
     // Only the cupertino override theme part will be resolved, except for the
     // text theme.
     // If the color comes from the material theme it's not resolved.
-    final CupertinoTextThemeData resolvedTextTheme = super.textTheme.resolveFrom(context);
+    final NoDefaultCupertinoThemeData cupertinoOverrideThemeWithTextTheme = _cupertinoOverrideTheme
+        .copyWith(textTheme: textTheme);
     return MaterialBasedCupertinoThemeData._(
       _materialTheme,
-      _cupertinoOverrideTheme.resolveFrom(context).copyWith(textTheme: resolvedTextTheme),
+      cupertinoOverrideThemeWithTextTheme.resolveFrom(context),
     );
   }
 }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -2989,9 +2989,10 @@ class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
     // Only the cupertino override theme part will be resolved, except for the
     // text theme.
     // If the color comes from the material theme it's not resolved.
+    final CupertinoTextThemeData resolvedTextTheme = super.textTheme.resolveFrom(context);
     return MaterialBasedCupertinoThemeData._(
       _materialTheme,
-      _cupertinoOverrideTheme.copyWith(textTheme: super.textTheme).resolveFrom(context),
+      _cupertinoOverrideTheme.resolveFrom(context).copyWith(textTheme: resolvedTextTheme),
     );
   }
 }

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -758,6 +758,30 @@ void main() {
       expect(CupertinoTheme.brightnessOf(context!), Brightness.light);
     });
 
+    testWidgets('Cupertino widgets correctly get the right text theme in dark mode', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey textFieldKey = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(),
+          home: Scaffold(body: CupertinoTextField(key: textFieldKey)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+
+      // Default CupertinoTextStyle color is a CupertinoDynamicColor.
+      final CupertinoThemeData cupertinoThemeData = CupertinoTheme.of(textFieldKey.currentContext!);
+      expect(cupertinoThemeData.textTheme.textStyle.color, isA<CupertinoDynamicColor>());
+      final CupertinoDynamicColor themeTextStyleColor =
+          cupertinoThemeData.textTheme.textStyle.color! as CupertinoDynamicColor;
+
+      // The value of the textfield's color should resolve to the theme's dark color.
+      expect(state.widget.style.color?.value, equals(themeTextStyleColor.darkColor.value));
+    });
+
     testWidgets('Material2 - Can override material theme', (WidgetTester tester) async {
       final CupertinoThemeData themeM2 = await testTheme(
         tester,


### PR DESCRIPTION
Fixes #146864. The overridden resolve was keeping the Cupertino text styles from resolving their dynamic colors depending on the theme brightness when in a MaterialApp in most cases. I *believe* that this was to keep values from the Material theme from changing, but as far as I can tell that shouldn't affect anything in the current state and that is 6 year old code. Waiting to see if tests make me a liar.

Update: tests made me a liar.

Before (text should be showing):
<img width="423" alt="Screenshot 2025-04-22 at 1 58 53 PM" src="https://github.com/user-attachments/assets/0aabf6cf-2c25-4446-8d12-69e745f26be0" />

After:
<img width="418" alt="Screenshot 2025-04-22 at 1 59 16 PM" src="https://github.com/user-attachments/assets/ea9958bb-4470-4f16-b5ca-f149be1301b1" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
