### PR TITLE
Disable a couple of entries in `android_java17_dependency_smoke_tests`

### DIFF
--- a/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
+++ b/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
@@ -29,10 +29,12 @@ List<VersionTuple> versionTuples = <VersionTuple>[
   VersionTuple(agpVersion: '8.4.0', gradleVersion: '8.6', kotlinVersion: '1.8.22'),
   VersionTuple(agpVersion: '8.5.0', gradleVersion: '8.7', kotlinVersion: '1.8.22'),
   VersionTuple(agpVersion: '8.6.0', gradleVersion: '8.7', kotlinVersion: '1.8.22'),
-  VersionTuple(agpVersion: '8.7.0', gradleVersion: '8.9', kotlinVersion: '1.8.22'),
-  VersionTuple(agpVersion: '8.7.0', gradleVersion: '8.9', kotlinVersion: '2.1.0'),
   VersionTuple(agpVersion: '8.7.0', gradleVersion: '8.12', kotlinVersion: '2.1.0'),
 ];
+// TODO(jesswrd): Re enable the following VersionTuples after splitting the test target into multiple.
+//                See https://github.com/flutter/flutter/issues/167495.
+//  VersionTuple(agpVersion: '8.7.0', gradleVersion: '8.9', kotlinVersion: '1.8.22'),
+//  VersionTuple(agpVersion: '8.7.0', gradleVersion: '8.9', kotlinVersion: '2.1.0'),
 
 Future<void> main() async {
   /// The [FileSystem] for the integration test environment.


### PR DESCRIPTION
This target is frequently timing out. We should prioritize tackling https://github.com/flutter/flutter/issues/167495, but in the meantime the flake rate is too high. To avoid disabling the target entirely, disable a couple of entries that are testing the same AGP version (but with different Gradle and Kotlin versions).

Partially fixes https://github.com/flutter/flutter/issues/167263.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
