### PR TITLE
Fix CarouselView.weighted crashes when initlal viewportDimension is 0.0

### DIFF
--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -844,6 +844,11 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
   // The given `index` is compared with `_firstVisibleItemIndex` to know how
   // many items are placed before the current one in the view.
   double _buildItemExtent(int index, SliverLayoutDimensions currentLayoutDimensions) {
+    // If constraints.viewportMainAxisExtent is 0, firstChildExtent will be 0 and cause division error.
+    if (constraints.viewportMainAxisExtent == 0) {
+      return 0;
+    }
+
     double extent;
     if (index == _firstVisibleItemIndex) {
       extent = math.max(_distanceToLeadingEdge, effectiveShrinkExtent);
@@ -905,6 +910,10 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
   // (with weight 7), we leave some space before item 0 assuming there is another
   // item -1 as the first visible item.
   int get _firstVisibleItemIndex {
+    // If constraints.viewportMainAxisExtent is 0, firstChildExtent will be 0 and cause division error.
+    if (constraints.viewportMainAxisExtent == 0.0) {
+      return 0;
+    }
     int smallerWeightCount = 0;
     for (final int weight in weights) {
       if (weight == weights.max) {
@@ -928,6 +937,10 @@ class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
   // item. It informs them how much the first item has moved off-screen,
   // enabling them to adjust their sizes (grow or shrink) accordingly.
   double get _firstVisibleItemOffscreenExtent {
+    // If constraints.viewportMainAxisExtent is 0, firstChildExtent will be 0 and cause division error.
+    if (constraints.viewportMainAxisExtent == 0.0) {
+      return 0;
+    }
     int index;
     final double actual = constraints.scrollOffset / firstChildExtent;
     final int round = (constraints.scrollOffset / firstChildExtent).round();


### PR DESCRIPTION
## Description

This PR fixes `CarouselView.weigthed` crashes due to given constraints being zero (which happen, for instance, when viewportDimension is 0.0).
 
At startup, a warm-up frame can be produced before the Flutter engine has reported the
initial view metrics. As a result, the first frame can be produced with a size of zero. In the context of CarouselView this leads to some problems mainly related to division by zero.

Similar to https://github.com/flutter/flutter/pull/167271 which addressed the same problem for `CarouselView`.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/167621

## Tests

Adds 3 tests.

