### PR TITLE
Unbreak https://github.com/flutter/flutter/pull/164034

### DIFF
--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -347,7 +347,8 @@ mixin RenderAbstractLayoutBuilderMixin<LayoutInfoType, ChildType extends RenderO
 /// the the same `LayoutInfoType`.
 ///
 /// Use [RenderAbstractLayoutBuilderMixin] instead, which replaces this mixin.
-typedef RenderConstrainedLayoutBuilder<LayoutInfoType, ChildType extends RenderObject> = RenderAbstractLayoutBuilderMixin<LayoutInfoType, ChildType>;
+typedef RenderConstrainedLayoutBuilder<LayoutInfoType, ChildType extends RenderObject> =
+    RenderAbstractLayoutBuilderMixin<LayoutInfoType, ChildType>;
 
 /// Builds a widget tree that can depend on the parent widget's size.
 ///

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -302,8 +302,12 @@ class _LayoutBuilderElement<LayoutInfoType> extends RenderObjectElement {
 /// Provides a [layoutCallback] implementation which, if needed, invokes
 /// [AbstractLayoutBuilder]'s builder callback.
 ///
-/// Implementers must provide a [layoutInfo] implementation that is safe to
-/// access in [layoutCallback], which is called in [performLayout].
+/// Implementers can override the [layoutInfo] implementation with a value
+/// that is safe to access in [layoutCallback], which is called in
+/// [performLayout]. The default [layoutInfo] returns the incoming
+/// [Constraints].
+///
+/// This mixin replaces [RenderConstrainedLayoutBuilder].
 mixin RenderAbstractLayoutBuilderMixin<LayoutInfoType, ChildType extends RenderObject>
     on RenderObjectWithChildMixin<ChildType>, RenderObjectWithLayoutCallbackMixin {
   LayoutCallback<Constraints>? _callback;
@@ -334,10 +338,16 @@ mixin RenderAbstractLayoutBuilderMixin<LayoutInfoType, ChildType extends RenderO
   ///
   /// This is typically the information that are only made available in
   /// [performLayout], which is inaccessible for regular [Builder] widget,
-  /// such as the incoming [Constraints].
+  /// such as the incoming [Constraints], which are the default value.
   @protected
-  LayoutInfoType get layoutInfo;
+  LayoutInfoType get layoutInfo => constraints as LayoutInfoType;
 }
+
+/// Generic mixin for [RenderObject]s created by an [AbstractLayoutBuilder] with
+/// the the same `LayoutInfoType`.
+///
+/// Use [RenderAbstractLayoutBuilderMixin] instead, which replaces this mixin.
+typedef RenderConstrainedLayoutBuilder<LayoutInfoType, ChildType extends RenderObject> = RenderAbstractLayoutBuilderMixin<LayoutInfoType, ChildType>;
 
 /// Builds a widget tree that can depend on the parent widget's size.
 ///
@@ -476,10 +486,6 @@ class _RenderLayoutBuilder extends RenderBox
 
     return true;
   }
-
-  @protected
-  @override
-  BoxConstraints get layoutInfo => constraints;
 }
 
 FlutterErrorDetails _reportException(

--- a/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
@@ -29,7 +29,7 @@ class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
   const SliverLayoutBuilder({super.key, required super.builder});
 
   @override
-  RenderAbstractLayoutBuilderMixin<SliverConstraints, RenderSliver> createRenderObject(
+  RenderConstrainedLayoutBuilder<SliverConstraints, RenderSliver> createRenderObject(
     BuildContext context,
   ) => _RenderSliverLayoutBuilder();
 }
@@ -38,16 +38,12 @@ class _RenderSliverLayoutBuilder extends RenderSliver
     with
         RenderObjectWithChildMixin<RenderSliver>,
         RenderObjectWithLayoutCallbackMixin,
-        RenderAbstractLayoutBuilderMixin<SliverConstraints, RenderSliver> {
+        RenderConstrainedLayoutBuilder<SliverConstraints, RenderSliver> {
   @override
   double childMainAxisPosition(RenderObject child) {
     assert(child == this.child);
     return 0;
   }
-
-  @protected
-  @override
-  SliverConstraints get layoutInfo => constraints;
 
   @override
   void performLayout() {

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -1067,10 +1067,6 @@ class _RenderSmartLayoutBuilder extends RenderProxyBox
       onChildWasPainted(extraOffset);
     }
   }
-
-  @protected
-  @override
-  BoxConstraints get layoutInfo => constraints;
 }
 
 class _LayoutSpy extends LeafRenderObjectWidget {


### PR DESCRIPTION
This remedies a breaking change from https://github.com/flutter/flutter/pull/164034 by restoring RenderConstrainedLayoutBuilder as a typedef of RenderAbstractLayoutBuilderMixin and providing a default implementation for `layoutInfo`.

Fixes https://github.com/flutter/flutter/issues/167247

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
