### PR TITLE
Update platform views documentation with 4 standard names and abbreviations

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -202,7 +202,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
                     + " parent view.");
           }
 
-          // The newer Texture Layer Hybrid Composition mode isn't suppported if any of the
+          // The Texture Layer Hybrid Composition mode isn't supported if any of the
           // following are true:
           // - The embedded view contains any of the VIEW_TYPES_REQUIRE_VIRTUAL_DISPLAY view types.
           //   These views allow out-of-band graphics operations that aren't notified to the Android

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -6,7 +6,6 @@ package io.flutter.plugin.platform;
 
 import static io.flutter.Build.API_LEVELS;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.PixelFormat;
 import android.util.SparseArray;
@@ -43,6 +42,10 @@ import java.util.List;
  *
  * <p>Each {@link io.flutter.embedding.engine.FlutterEngine} has a single platform views controller.
  * A platform views controller can be attached to at most one Flutter view.
+ * [PlatformViewsController2] is intentionally a different class from [PlatformViewsController] in
+ * order to separate out the complexity of the first 3 platform view implementations (Virtual
+ * Display, Texture Layer, and Hybrid Composition). From the 4th platform view implementation,
+ * Hybrid Composition++.
  */
 public class PlatformViewsController2 implements PlatformViewsAccessibilityDelegate {
   private static final String TAG = "PlatformViewsController2";
@@ -520,7 +523,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     }
   }
 
-  @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)
   public void onEndFrame() {
     SurfaceControl.Transaction tx = new SurfaceControl.Transaction();
@@ -542,7 +544,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   }
 
   // NOT called from UI thread.
-  @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)
   public SurfaceControl.Transaction createTransaction() {
     SurfaceControl.Transaction tx = new SurfaceControl.Transaction();
@@ -551,7 +552,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   }
 
   // NOT called from UI thread.
-  @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)
   public void applyTransactions() {
     SurfaceControl.Transaction tx = new SurfaceControl.Transaction();
@@ -562,7 +562,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     pendingTransactions.clear();
   }
 
-  @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)
   public FlutterOverlaySurface createOverlaySurface() {
     if (overlayerSurface == null) {
@@ -592,7 +591,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     }
   }
 
-  @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)
   public void showOverlaySurface() {
     if (overlaySurfaceControl == null) {
@@ -603,7 +601,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     tx.apply();
   }
 
-  @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)
   public void hideOverlaySurface() {
     if (overlaySurfaceControl == null) {

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -155,10 +155,12 @@ class PlatformViewsService {
 
   /// {@macro flutter.services.PlatformViewsService.initAndroidView}
   ///
-  /// This attempts to use the newest and most efficient platform view
+  /// This attempts to use the "Texture Layer Hybrid Composition (TLHC)" platform view
   /// implementation when possible. In cases where that is not supported, it
-  /// falls back to using Hybrid Composition, which is the mode used by
+  /// falls back to using "Hybrid Composition", which is the mode used by
   /// [initExpensiveAndroidView].
+  // Fallback logic for TLHC or HC lives in
+  // engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
   static SurfaceAndroidViewController initSurfaceAndroidView({
     required int id,
     required String viewType,
@@ -185,9 +187,10 @@ class PlatformViewsService {
   /// When this factory is used, the Android view and Flutter widgets are
   /// composed at the Android view hierarchy level.
   ///
-  /// Using this method has a performance cost on devices running Android 9 or
-  /// earlier, or on underpowered devices. In most situations, you should use
+  /// Using this method has a performance cost on devices running Android 9 (api 28)
+  /// or earlier, or on underpowered devices. In most situations, you should use
   /// [initAndroidView] or [initSurfaceAndroidView] instead.
+  /// Always creates a "Hybrid Composition (HC)" view.
   static ExpensiveAndroidViewController initExpensiveAndroidView({
     required int id,
     required String viewType,
@@ -215,6 +218,7 @@ class PlatformViewsService {
   ///
   /// This functionality is only supported on Android devices running Vulkan on
   /// API 34 or newer.
+  /// Always creates a "Hybrid Composition++ (HCPP)" view.
   static HybridAndroidViewController initHybridAndroidView({
     required int id,
     required String viewType,
@@ -1092,6 +1096,7 @@ class SurfaceAndroidViewController extends AndroidViewController {
 
 /// Controls an Android view that is composed using the Android view hierarchy.
 /// This controller is created from the [PlatformViewsService.initExpensiveAndroidView] factory.
+// "Hybrid Composition" controller.
 class ExpensiveAndroidViewController extends AndroidViewController {
   ExpensiveAndroidViewController._({
     required super.viewId,
@@ -1145,7 +1150,8 @@ class ExpensiveAndroidViewController extends AndroidViewController {
 }
 
 /// Controls an Android view that is composed using the Android view hierarchy.
-/// This controller is created from the [PlatformViewsService.initExpensiveAndroidView] factory.
+/// This controller is created from the [PlatformViewsService.initHybridAndroidView] factory.
+// "HCPP"
 class HybridAndroidViewController extends AndroidViewController {
   HybridAndroidViewController._({
     required super.viewId,
@@ -1337,7 +1343,7 @@ abstract class _AndroidViewControllerInternals {
 // An AndroidViewController implementation for views whose contents are
 // displayed via a texture rather than directly in a native view.
 //
-// This is used for both Virtual Display and Texture Layer Hybrid Composition.
+// This is used for both Virtual Display (VD) and Texture Layer Hybrid Composition (TLHC).
 class _TextureAndroidViewControllerInternals extends _AndroidViewControllerInternals {
   _TextureAndroidViewControllerInternals();
 


### PR DESCRIPTION
After talking with @gmackall we are going to try to standardize on 

Virtual Display (VD) 
Hybrid Composition (HC) 
Texture Layer Hybrid Composition (TLHC)
Hybrid Composition++ (HCPP) 

for our documentation covering android platform views and how we describe the code to each other. 

For example HC++ would be discouraged, so would referring to HC as expensive. 

This pr also removes TargetSdk since that annotation has been deprecated for a number of years and can be wholly replaced by the already used RequiresApi annotations. 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
