### PR TITLE
[a11y] Semanctis flag refactor step 3: framework part

### DIFF
--- a/engine/src/flutter/lib/ui/semantics.dart
+++ b/engine/src/flutter/lib/ui/semantics.dart
@@ -1340,101 +1340,39 @@ class SemanticsFlags {
 
   /// Convert flags to a list of string.
   List<String> toStrings() {
-    final List<String> trueFlags = <String>[];
-    if (hasCheckedState) {
-      trueFlags.add('hasCheckedState');
-    }
-    if (isChecked) {
-      trueFlags.add('isChecked');
-    }
-    if (isSelected) {
-      trueFlags.add('isSelected');
-    }
-    if (isButton) {
-      trueFlags.add('isButton');
-    }
-    if (isTextField) {
-      trueFlags.add('isTextField');
-    }
-    if (isFocused) {
-      trueFlags.add('isFocused');
-    }
-    if (hasEnabledState) {
-      trueFlags.add('hasEnabledState');
-    }
-    if (isEnabled) {
-      trueFlags.add('isEnabled');
-    }
-    if (isInMutuallyExclusiveGroup) {
-      trueFlags.add('isInMutuallyExclusiveGroup');
-    }
-    if (isHeader) {
-      trueFlags.add('isHeader');
-    }
-    if (isObscured) {
-      trueFlags.add('isObscured');
-    }
-    if (scopesRoute) {
-      trueFlags.add('scopesRoute');
-    }
-    if (namesRoute) {
-      trueFlags.add('namesRoute');
-    }
-    if (isHidden) {
-      trueFlags.add('isHidden');
-    }
-    if (isImage) {
-      trueFlags.add('isImage');
-    }
-    if (isLiveRegion) {
-      trueFlags.add('isLiveRegion');
-    }
-    if (hasToggledState) {
-      trueFlags.add('hasToggledState');
-    }
-    if (isToggled) {
-      trueFlags.add('isToggled');
-    }
-    if (hasImplicitScrolling) {
-      trueFlags.add('hasImplicitScrolling');
-    }
-    if (isMultiline) {
-      trueFlags.add('isMultiline');
-    }
-    if (isReadOnly) {
-      trueFlags.add('isReadOnly');
-    }
-    if (isFocusable) {
-      trueFlags.add('isFocusable');
-    }
-    if (isLink) {
-      trueFlags.add('isLink');
-    }
-    if (isSlider) {
-      trueFlags.add('isSlider');
-    }
-    if (isKeyboardKey) {
-      trueFlags.add('isKeyboardKey');
-    }
-    if (isCheckStateMixed) {
-      trueFlags.add('isCheckStateMixed');
-    }
-    if (hasExpandedState) {
-      trueFlags.add('hasExpandedState');
-    }
-    if (isExpanded) {
-      trueFlags.add('isExpanded');
-    }
-    if (hasSelectedState) {
-      trueFlags.add('hasSelectedState');
-    }
-    if (hasRequiredState) {
-      trueFlags.add('hasRequiredState');
-    }
-    if (isRequired) {
-      trueFlags.add('isRequired');
-    }
-    return trueFlags;
+    return <String>[
+      if (hasCheckedState) 'hasCheckedState',
+      if (isChecked) 'isChecked',
+      if (isSelected) 'isSelected',
+      if (isButton) 'isButton',
+      if (isTextField) 'isTextField',
+      if (isFocused) 'isFocused',
+      if (hasEnabledState) 'hasEnabledState',
+      if (isEnabled) 'isEnabled',
+      if (isInMutuallyExclusiveGroup) 'isInMutuallyExclusiveGroup',
+      if (isHeader) 'isHeader',
+      if (isObscured) 'isObscured',
+      if (scopesRoute) 'scopesRoute',
+      if (namesRoute) 'namesRoute',
+      if (isHidden) 'isHidden',
+      if (isImage) 'isImage',
+      if (isLiveRegion) 'isLiveRegion',
+      if (hasToggledState) 'hasToggledState',
+      if (isToggled) 'isToggled',
+      if (hasImplicitScrolling) 'hasImplicitScrolling',
+      if (isMultiline) 'isMultiline',
+      if (isReadOnly) 'isReadOnly',
+      if (isFocusable) 'isFocusable',
+      if (isLink) 'isLink',
+      if (isSlider) 'isSlider',
+      if (isKeyboardKey) 'isKeyboardKey',
+      if (isCheckStateMixed) 'isCheckStateMixed',
+      if (hasExpandedState) 'hasExpandedState',
+      if (isExpanded) 'isExpanded',
+      if (hasSelectedState) 'hasSelectedState',
+      if (hasRequiredState) 'hasRequiredState',
+      if (isRequired) 'isRequired',
+    ];
   }
 
   /// Checks if any of the boolean semantic flags are set to true

--- a/engine/src/flutter/lib/ui/semantics.dart
+++ b/engine/src/flutter/lib/ui/semantics.dart
@@ -1340,7 +1340,7 @@ class SemanticsFlags {
 
   /// Convert flags to a list of string.
   List<String> toStrings() {
-    List<String> trueFlags = [];
+    final List<String> trueFlags = <String>[];
     if (hasCheckedState) {
       trueFlags.add('hasCheckedState');
     }

--- a/engine/src/flutter/lib/ui/semantics.dart
+++ b/engine/src/flutter/lib/ui/semantics.dart
@@ -1436,6 +1436,42 @@ class SemanticsFlags {
     }
     return trueFlags;
   }
+
+  /// Checks if any of the boolean semantic flags are set to true
+  /// in both this instance and the [other] instance.
+  bool hasRepeatedFlags(SemanticsFlags other) {
+    return (hasCheckedState && other.hasCheckedState) ||
+        (isChecked && other.isChecked) ||
+        (isSelected && other.isSelected) ||
+        (isButton && other.isButton) ||
+        (isTextField && other.isTextField) ||
+        (isFocused && other.isFocused) ||
+        (hasEnabledState && other.hasEnabledState) ||
+        (isEnabled && other.isEnabled) ||
+        (isInMutuallyExclusiveGroup && other.isInMutuallyExclusiveGroup) ||
+        (isHeader && other.isHeader) ||
+        (isObscured && other.isObscured) ||
+        (scopesRoute && other.scopesRoute) ||
+        (namesRoute && other.namesRoute) ||
+        (isHidden && other.isHidden) ||
+        (isImage && other.isImage) ||
+        (isLiveRegion && other.isLiveRegion) ||
+        (hasToggledState && other.hasToggledState) ||
+        (isToggled && other.isToggled) ||
+        (hasImplicitScrolling && other.hasImplicitScrolling) ||
+        (isMultiline && other.isMultiline) ||
+        (isReadOnly && other.isReadOnly) ||
+        (isFocusable && other.isFocusable) ||
+        (isLink && other.isLink) ||
+        (isSlider && other.isSlider) ||
+        (isKeyboardKey && other.isKeyboardKey) ||
+        (isCheckStateMixed && other.isCheckStateMixed) ||
+        (hasExpandedState && other.hasExpandedState) ||
+        (isExpanded && other.isExpanded) ||
+        (hasSelectedState && other.hasSelectedState) ||
+        (hasRequiredState && other.hasRequiredState) ||
+        (isRequired && other.isRequired);
+  }
 }
 
 /// The validation result of a form field.

--- a/engine/src/flutter/lib/ui/semantics.dart
+++ b/engine/src/flutter/lib/ui/semantics.dart
@@ -1337,6 +1337,105 @@ class SemanticsFlags {
     hasRequiredState,
     isRequired,
   ]);
+
+  /// Convert flags to a list of string.
+  List<String> toStrings() {
+    List<String> trueFlags = [];
+    if (hasCheckedState) {
+      trueFlags.add('hasCheckedState');
+    }
+    if (isChecked) {
+      trueFlags.add('isChecked');
+    }
+    if (isSelected) {
+      trueFlags.add('isSelected');
+    }
+    if (isButton) {
+      trueFlags.add('isButton');
+    }
+    if (isTextField) {
+      trueFlags.add('isTextField');
+    }
+    if (isFocused) {
+      trueFlags.add('isFocused');
+    }
+    if (hasEnabledState) {
+      trueFlags.add('hasEnabledState');
+    }
+    if (isEnabled) {
+      trueFlags.add('isEnabled');
+    }
+    if (isInMutuallyExclusiveGroup) {
+      trueFlags.add('isInMutuallyExclusiveGroup');
+    }
+    if (isHeader) {
+      trueFlags.add('isHeader');
+    }
+    if (isObscured) {
+      trueFlags.add('isObscured');
+    }
+    if (scopesRoute) {
+      trueFlags.add('scopesRoute');
+    }
+    if (namesRoute) {
+      trueFlags.add('namesRoute');
+    }
+    if (isHidden) {
+      trueFlags.add('isHidden');
+    }
+    if (isImage) {
+      trueFlags.add('isImage');
+    }
+    if (isLiveRegion) {
+      trueFlags.add('isLiveRegion');
+    }
+    if (hasToggledState) {
+      trueFlags.add('hasToggledState');
+    }
+    if (isToggled) {
+      trueFlags.add('isToggled');
+    }
+    if (hasImplicitScrolling) {
+      trueFlags.add('hasImplicitScrolling');
+    }
+    if (isMultiline) {
+      trueFlags.add('isMultiline');
+    }
+    if (isReadOnly) {
+      trueFlags.add('isReadOnly');
+    }
+    if (isFocusable) {
+      trueFlags.add('isFocusable');
+    }
+    if (isLink) {
+      trueFlags.add('isLink');
+    }
+    if (isSlider) {
+      trueFlags.add('isSlider');
+    }
+    if (isKeyboardKey) {
+      trueFlags.add('isKeyboardKey');
+    }
+    if (isCheckStateMixed) {
+      trueFlags.add('isCheckStateMixed');
+    }
+    if (hasExpandedState) {
+      trueFlags.add('hasExpandedState');
+    }
+    if (isExpanded) {
+      trueFlags.add('isExpanded');
+    }
+    if (hasSelectedState) {
+      trueFlags.add('hasSelectedState');
+    }
+    if (hasRequiredState) {
+      trueFlags.add('hasRequiredState');
+    }
+    if (isRequired) {
+      trueFlags.add('isRequired');
+    }
+    return trueFlags;
+  }
 }
 
 /// The validation result of a form field.

--- a/engine/src/flutter/lib/web_ui/lib/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/semantics.dart
@@ -512,7 +512,7 @@ class SemanticsFlags {
   ]);
 
   List<String> toStrings() {
-    List<String> trueFlags = [];
+    final List<String> trueFlags = <String>[];
     if (hasCheckedState) {
       trueFlags.add('hasCheckedState');
     }

--- a/engine/src/flutter/lib/web_ui/lib/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/semantics.dart
@@ -512,101 +512,39 @@ class SemanticsFlags {
   ]);
 
   List<String> toStrings() {
-    final List<String> trueFlags = <String>[];
-    if (hasCheckedState) {
-      trueFlags.add('hasCheckedState');
-    }
-    if (isChecked) {
-      trueFlags.add('isChecked');
-    }
-    if (isSelected) {
-      trueFlags.add('isSelected');
-    }
-    if (isButton) {
-      trueFlags.add('isButton');
-    }
-    if (isTextField) {
-      trueFlags.add('isTextField');
-    }
-    if (isFocused) {
-      trueFlags.add('isFocused');
-    }
-    if (hasEnabledState) {
-      trueFlags.add('hasEnabledState');
-    }
-    if (isEnabled) {
-      trueFlags.add('isEnabled');
-    }
-    if (isInMutuallyExclusiveGroup) {
-      trueFlags.add('isInMutuallyExclusiveGroup');
-    }
-    if (isHeader) {
-      trueFlags.add('isHeader');
-    }
-    if (isObscured) {
-      trueFlags.add('isObscured');
-    }
-    if (scopesRoute) {
-      trueFlags.add('scopesRoute');
-    }
-    if (namesRoute) {
-      trueFlags.add('namesRoute');
-    }
-    if (isHidden) {
-      trueFlags.add('isHidden');
-    }
-    if (isImage) {
-      trueFlags.add('isImage');
-    }
-    if (isLiveRegion) {
-      trueFlags.add('isLiveRegion');
-    }
-    if (hasToggledState) {
-      trueFlags.add('hasToggledState');
-    }
-    if (isToggled) {
-      trueFlags.add('isToggled');
-    }
-    if (hasImplicitScrolling) {
-      trueFlags.add('hasImplicitScrolling');
-    }
-    if (isMultiline) {
-      trueFlags.add('isMultiline');
-    }
-    if (isReadOnly) {
-      trueFlags.add('isReadOnly');
-    }
-    if (isFocusable) {
-      trueFlags.add('isFocusable');
-    }
-    if (isLink) {
-      trueFlags.add('isLink');
-    }
-    if (isSlider) {
-      trueFlags.add('isSlider');
-    }
-    if (isKeyboardKey) {
-      trueFlags.add('isKeyboardKey');
-    }
-    if (isCheckStateMixed) {
-      trueFlags.add('isCheckStateMixed');
-    }
-    if (hasExpandedState) {
-      trueFlags.add('hasExpandedState');
-    }
-    if (isExpanded) {
-      trueFlags.add('isExpanded');
-    }
-    if (hasSelectedState) {
-      trueFlags.add('hasSelectedState');
-    }
-    if (hasRequiredState) {
-      trueFlags.add('hasRequiredState');
-    }
-    if (isRequired) {
-      trueFlags.add('isRequired');
-    }
-    return trueFlags;
+    return <String>[
+      if (hasCheckedState) 'hasCheckedState',
+      if (isChecked) 'isChecked',
+      if (isSelected) 'isSelected',
+      if (isButton) 'isButton',
+      if (isTextField) 'isTextField',
+      if (isFocused) 'isFocused',
+      if (hasEnabledState) 'hasEnabledState',
+      if (isEnabled) 'isEnabled',
+      if (isInMutuallyExclusiveGroup) 'isInMutuallyExclusiveGroup',
+      if (isHeader) 'isHeader',
+      if (isObscured) 'isObscured',
+      if (scopesRoute) 'scopesRoute',
+      if (namesRoute) 'namesRoute',
+      if (isHidden) 'isHidden',
+      if (isImage) 'isImage',
+      if (isLiveRegion) 'isLiveRegion',
+      if (hasToggledState) 'hasToggledState',
+      if (isToggled) 'isToggled',
+      if (hasImplicitScrolling) 'hasImplicitScrolling',
+      if (isMultiline) 'isMultiline',
+      if (isReadOnly) 'isReadOnly',
+      if (isFocusable) 'isFocusable',
+      if (isLink) 'isLink',
+      if (isSlider) 'isSlider',
+      if (isKeyboardKey) 'isKeyboardKey',
+      if (isCheckStateMixed) 'isCheckStateMixed',
+      if (hasExpandedState) 'hasExpandedState',
+      if (isExpanded) 'isExpanded',
+      if (hasSelectedState) 'hasSelectedState',
+      if (hasRequiredState) 'hasRequiredState',
+      if (isRequired) 'isRequired',
+    ];
   }
 
   bool hasRepeatedFlags(SemanticsFlags other) {

--- a/engine/src/flutter/lib/web_ui/lib/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/semantics.dart
@@ -510,6 +510,104 @@ class SemanticsFlags {
     hasRequiredState,
     isRequired,
   ]);
+
+  List<String> toStrings() {
+    List<String> trueFlags = [];
+    if (hasCheckedState) {
+      trueFlags.add('hasCheckedState');
+    }
+    if (isChecked) {
+      trueFlags.add('isChecked');
+    }
+    if (isSelected) {
+      trueFlags.add('isSelected');
+    }
+    if (isButton) {
+      trueFlags.add('isButton');
+    }
+    if (isTextField) {
+      trueFlags.add('isTextField');
+    }
+    if (isFocused) {
+      trueFlags.add('isFocused');
+    }
+    if (hasEnabledState) {
+      trueFlags.add('hasEnabledState');
+    }
+    if (isEnabled) {
+      trueFlags.add('isEnabled');
+    }
+    if (isInMutuallyExclusiveGroup) {
+      trueFlags.add('isInMutuallyExclusiveGroup');
+    }
+    if (isHeader) {
+      trueFlags.add('isHeader');
+    }
+    if (isObscured) {
+      trueFlags.add('isObscured');
+    }
+    if (scopesRoute) {
+      trueFlags.add('scopesRoute');
+    }
+    if (namesRoute) {
+      trueFlags.add('namesRoute');
+    }
+    if (isHidden) {
+      trueFlags.add('isHidden');
+    }
+    if (isImage) {
+      trueFlags.add('isImage');
+    }
+    if (isLiveRegion) {
+      trueFlags.add('isLiveRegion');
+    }
+    if (hasToggledState) {
+      trueFlags.add('hasToggledState');
+    }
+    if (isToggled) {
+      trueFlags.add('isToggled');
+    }
+    if (hasImplicitScrolling) {
+      trueFlags.add('hasImplicitScrolling');
+    }
+    if (isMultiline) {
+      trueFlags.add('isMultiline');
+    }
+    if (isReadOnly) {
+      trueFlags.add('isReadOnly');
+    }
+    if (isFocusable) {
+      trueFlags.add('isFocusable');
+    }
+    if (isLink) {
+      trueFlags.add('isLink');
+    }
+    if (isSlider) {
+      trueFlags.add('isSlider');
+    }
+    if (isKeyboardKey) {
+      trueFlags.add('isKeyboardKey');
+    }
+    if (isCheckStateMixed) {
+      trueFlags.add('isCheckStateMixed');
+    }
+    if (hasExpandedState) {
+      trueFlags.add('hasExpandedState');
+    }
+    if (isExpanded) {
+      trueFlags.add('isExpanded');
+    }
+    if (hasSelectedState) {
+      trueFlags.add('hasSelectedState');
+    }
+    if (hasRequiredState) {
+      trueFlags.add('hasRequiredState');
+    }
+    if (isRequired) {
+      trueFlags.add('isRequired');
+    }
+    return trueFlags;
+  }
 }
 
 // Mirrors engine/src/flutter/lib/ui/semantics.dart

--- a/engine/src/flutter/lib/web_ui/lib/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/semantics.dart
@@ -608,6 +608,40 @@ class SemanticsFlags {
     }
     return trueFlags;
   }
+
+  bool hasRepeatedFlags(SemanticsFlags other) {
+    return (hasCheckedState && other.hasCheckedState) ||
+        (isChecked && other.isChecked) ||
+        (isSelected && other.isSelected) ||
+        (isButton && other.isButton) ||
+        (isTextField && other.isTextField) ||
+        (isFocused && other.isFocused) ||
+        (hasEnabledState && other.hasEnabledState) ||
+        (isEnabled && other.isEnabled) ||
+        (isInMutuallyExclusiveGroup && other.isInMutuallyExclusiveGroup) ||
+        (isHeader && other.isHeader) ||
+        (isObscured && other.isObscured) ||
+        (scopesRoute && other.scopesRoute) ||
+        (namesRoute && other.namesRoute) ||
+        (isHidden && other.isHidden) ||
+        (isImage && other.isImage) ||
+        (isLiveRegion && other.isLiveRegion) ||
+        (hasToggledState && other.hasToggledState) ||
+        (isToggled && other.isToggled) ||
+        (hasImplicitScrolling && other.hasImplicitScrolling) ||
+        (isMultiline && other.isMultiline) ||
+        (isReadOnly && other.isReadOnly) ||
+        (isFocusable && other.isFocusable) ||
+        (isLink && other.isLink) ||
+        (isSlider && other.isSlider) ||
+        (isKeyboardKey && other.isKeyboardKey) ||
+        (isCheckStateMixed && other.isCheckStateMixed) ||
+        (hasExpandedState && other.hasExpandedState) ||
+        (isExpanded && other.isExpanded) ||
+        (hasSelectedState && other.hasSelectedState) ||
+        (hasRequiredState && other.hasRequiredState) ||
+        (isRequired && other.isRequired);
+  }
 }
 
 // Mirrors engine/src/flutter/lib/ui/semantics.dart

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -776,7 +776,7 @@ class SemanticsData with Diagnosticable {
 
   /// A bit field of [SemanticsFlag]s that apply to this node.
   @Deprecated(
-    'Use flagsCollection instead.'
+    'Use flagsCollection instead. '
     'This feature was deprecated after v3.29.0-0.3.pre.',
   )
   int get flags => _toBitMask(flagsCollection);
@@ -2847,7 +2847,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
   /// Whether this node is tagged with `tag`.
   bool isTagged(SemanticsTag tag) => tags != null && tags!.contains(tag);
 
-  SemanticsFlags _flags = SemanticsFlags();
+  SemanticsFlags _flags = SemanticsFlags.kNone;
 
   /// Semantics flags.
   SemanticsFlags get flagsCollection => _flags;
@@ -2856,7 +2856,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
 
   /// Whether this node currently has a given [SemanticsFlag].
   @Deprecated(
-    'Use flagsCollection instead.'
+    'Use flagsCollection instead. '
     'This feature was deprecated after v3.32.0-0.0.pre.',
   )
   bool hasFlag(SemanticsFlag flag) => (_flagsBitMask & flag.index) != 0;
@@ -5469,7 +5469,7 @@ class SemanticsConfiguration {
   bool? get isCheckStateMixed => _flags.hasCheckedState ? _flags.isCheckStateMixed : null;
   set isCheckStateMixed(bool? value) {
     assert(value != true || isChecked != true);
-    _flags = _flags.copyWith(hasCheckedState: true, isCheckStateMixed: value!);
+    _flags = _flags.copyWith(hasCheckedState: true, isCheckStateMixed: value);
     _hasBeenAnnotated = true;
   }
 
@@ -6169,73 +6169,98 @@ int _mergeHeadingLevels({required int sourceLevel, required int targetLevel}) {
 /// This is just to support flag 0-30, new flags don't need to be in the bitmask.
 int _toBitMask(SemanticsFlags flags) {
   int bitmask = 0;
-  if (flags.hasCheckedState) bitmask |= (1 << 0);
-  if (flags.isChecked) bitmask |= (1 << 1);
-  if (flags.isSelected) bitmask |= (1 << 2);
-  if (flags.isButton) bitmask |= (1 << 3);
-  if (flags.isTextField) bitmask |= (1 << 4);
-  if (flags.isFocused) bitmask |= (1 << 5);
-  if (flags.hasEnabledState) bitmask |= (1 << 6);
-  if (flags.isEnabled) bitmask |= (1 << 7);
-  if (flags.isInMutuallyExclusiveGroup) bitmask |= (1 << 8);
-  if (flags.isHeader) bitmask |= (1 << 9);
-  if (flags.isObscured) bitmask |= (1 << 10);
-  if (flags.scopesRoute) bitmask |= (1 << 11);
-  if (flags.namesRoute) bitmask |= (1 << 12);
-  if (flags.isHidden) bitmask |= (1 << 13);
-  if (flags.isImage) bitmask |= (1 << 14);
-  if (flags.isLiveRegion) bitmask |= (1 << 15);
-  if (flags.hasToggledState) bitmask |= (1 << 16);
-  if (flags.isToggled) bitmask |= (1 << 17);
-  if (flags.hasImplicitScrolling) bitmask |= (1 << 18);
-  if (flags.isMultiline) bitmask |= (1 << 19);
-  if (flags.isReadOnly) bitmask |= (1 << 20);
-  if (flags.isFocusable) bitmask |= (1 << 21);
-  if (flags.isLink) bitmask |= (1 << 22);
-  if (flags.isSlider) bitmask |= (1 << 23);
-  if (flags.isKeyboardKey) bitmask |= (1 << 24);
-  if (flags.isCheckStateMixed) bitmask |= (1 << 25);
-  if (flags.hasExpandedState) bitmask |= (1 << 26);
-  if (flags.isExpanded) bitmask |= (1 << 27);
-  if (flags.hasSelectedState) bitmask |= (1 << 28);
-  if (flags.hasRequiredState) bitmask |= (1 << 29);
-  if (flags.isRequired) bitmask |= (1 << 30);
+  if (flags.hasCheckedState) {
+    bitmask |= 1 << 0;
+  }
+  if (flags.isChecked) {
+    bitmask |= 1 << 1;
+  }
+  if (flags.isSelected) {
+    bitmask |= 1 << 2;
+  }
+  if (flags.isButton) {
+    bitmask |= 1 << 3;
+  }
+  if (flags.isTextField) {
+    bitmask |= 1 << 4;
+  }
+  if (flags.isFocused) {
+    bitmask |= 1 << 5;
+  }
+  if (flags.hasEnabledState) {
+    bitmask |= 1 << 6;
+  }
+  if (flags.isEnabled) {
+    bitmask |= 1 << 7;
+  }
+  if (flags.isInMutuallyExclusiveGroup) {
+    bitmask |= 1 << 8;
+  }
+  if (flags.isHeader) {
+    bitmask |= 1 << 9;
+  }
+  if (flags.isObscured) {
+    bitmask |= 1 << 10;
+  }
+  if (flags.scopesRoute) {
+    bitmask |= 1 << 11;
+  }
+  if (flags.namesRoute) {
+    bitmask |= 1 << 12;
+  }
+  if (flags.isHidden) {
+    bitmask |= 1 << 13;
+  }
+  if (flags.isImage) {
+    bitmask |= 1 << 14;
+  }
+  if (flags.isLiveRegion) {
+    bitmask |= 1 << 15;
+  }
+  if (flags.hasToggledState) {
+    bitmask |= 1 << 16;
+  }
+  if (flags.isToggled) {
+    bitmask |= 1 << 17;
+  }
+  if (flags.hasImplicitScrolling) {
+    bitmask |= 1 << 18;
+  }
+  if (flags.isMultiline) {
+    bitmask |= 1 << 19;
+  }
+  if (flags.isReadOnly) {
+    bitmask |= 1 << 20;
+  }
+  if (flags.isFocusable) {
+    bitmask |= 1 << 21;
+  }
+  if (flags.isLink) {
+    bitmask |= 1 << 22;
+  }
+  if (flags.isSlider) {
+    bitmask |= 1 << 23;
+  }
+  if (flags.isKeyboardKey) {
+    bitmask |= 1 << 24;
+  }
+  if (flags.isCheckStateMixed) {
+    bitmask |= 1 << 25;
+  }
+  if (flags.hasExpandedState) {
+    bitmask |= 1 << 26;
+  }
+  if (flags.isExpanded) {
+    bitmask |= 1 << 27;
+  }
+  if (flags.hasSelectedState) {
+    bitmask |= 1 << 28;
+  }
+  if (flags.hasRequiredState) {
+    bitmask |= 1 << 29;
+  }
+  if (flags.isRequired) {
+    bitmask |= 1 << 30;
+  }
   return bitmask;
-}
-
-/// This is just to support flag 0-30, new flags don't need to be in the bitmask.
-SemanticsFlags _fromBitMask(int bitmask) {
-  return SemanticsFlags(
-    hasCheckedState: (bitmask & (1 << 0)) != 0,
-    isChecked: (bitmask & (1 << 1)) != 0,
-    isSelected: (bitmask & (1 << 2)) != 0,
-    isButton: (bitmask & (1 << 3)) != 0,
-    isTextField: (bitmask & (1 << 4)) != 0,
-    isFocused: (bitmask & (1 << 5)) != 0,
-    hasEnabledState: (bitmask & (1 << 6)) != 0,
-    isEnabled: (bitmask & (1 << 7)) != 0,
-    isInMutuallyExclusiveGroup: (bitmask & (1 << 8)) != 0,
-    isHeader: (bitmask & (1 << 9)) != 0,
-    isObscured: (bitmask & (1 << 10)) != 0,
-    scopesRoute: (bitmask & (1 << 11)) != 0,
-    namesRoute: (bitmask & (1 << 12)) != 0,
-    isHidden: (bitmask & (1 << 13)) != 0,
-    isImage: (bitmask & (1 << 14)) != 0,
-    isLiveRegion: (bitmask & (1 << 15)) != 0,
-    hasToggledState: (bitmask & (1 << 16)) != 0,
-    isToggled: (bitmask & (1 << 17)) != 0,
-    hasImplicitScrolling: (bitmask & (1 << 18)) != 0,
-    isMultiline: (bitmask & (1 << 19)) != 0,
-    isReadOnly: (bitmask & (1 << 20)) != 0,
-    isFocusable: (bitmask & (1 << 21)) != 0,
-    isLink: (bitmask & (1 << 22)) != 0,
-    isSlider: (bitmask & (1 << 23)) != 0,
-    isKeyboardKey: (bitmask & (1 << 24)) != 0,
-    isCheckStateMixed: (bitmask & (1 << 25)) != 0,
-    hasExpandedState: (bitmask & (1 << 26)) != 0,
-    isExpanded: (bitmask & (1 << 27)) != 0,
-    hasSelectedState: (bitmask & (1 << 28)) != 0,
-    hasRequiredState: (bitmask & (1 << 29)) != 0,
-    isRequired: (bitmask & (1 << 30)) != 0,
-  );
 }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -9,6 +9,7 @@
 /// @docImport 'package:flutter_test/flutter_test.dart';
 library;
 
+import 'dart:core';
 import 'dart:math' as math;
 import 'dart:ui'
     show
@@ -16,6 +17,7 @@ import 'dart:ui'
         Rect,
         SemanticsAction,
         SemanticsFlag,
+        SemanticsFlags,
         SemanticsInputType,
         SemanticsRole,
         SemanticsUpdate,
@@ -39,6 +41,7 @@ export 'dart:ui'
         Rect,
         SemanticsAction,
         SemanticsFlag,
+        SemanticsFlags,
         SemanticsRole,
         SemanticsValidationResult,
         StringAttribute,
@@ -154,7 +157,7 @@ sealed class _DebugSemanticsRoleChecks {
 
   static FlutterError? _semanticsTab(SemanticsNode node) {
     final SemanticsData data = node.getSemanticsData();
-    if (!data.hasFlag(SemanticsFlag.hasSelectedState)) {
+    if (!data.flagsCollection.hasSelectedState) {
       return FlutterError('A tab needs selected states');
     }
 
@@ -162,11 +165,11 @@ sealed class _DebugSemanticsRoleChecks {
       return null;
     }
 
-    if (!data.hasFlag(SemanticsFlag.hasEnabledState)) {
+    if (!data.flagsCollection.hasEnabledState) {
       if (!data.hasAction(SemanticsAction.tap)) {
         return FlutterError('A tab must have a tap action');
       }
-    } else if (data.hasFlag(SemanticsFlag.isEnabled) && !data.hasAction(SemanticsAction.tap)) {
+    } else if (data.flagsCollection.isEnabled && !data.hasAction(SemanticsAction.tap)) {
       return FlutterError('A tab must have a tap action');
     }
     return null;
@@ -231,19 +234,19 @@ sealed class _DebugSemanticsRoleChecks {
     bool hasCheckedChild = false;
     bool validateRadioGroupChildren(SemanticsNode node) {
       final SemanticsData data = node.getSemanticsData();
-      if (!data.hasFlag(SemanticsFlag.hasCheckedState)) {
+      if (!data.flagsCollection.hasCheckedState) {
         node.visitChildren(validateRadioGroupChildren);
         return error == null;
       }
 
-      if (!data.hasFlag(SemanticsFlag.isInMutuallyExclusiveGroup)) {
+      if (!data.flagsCollection.isInMutuallyExclusiveGroup) {
         error = FlutterError(
           'Radio buttons in a radio group must be in a mutually exclusive group',
         );
         return false;
       }
 
-      if (data.hasFlag(SemanticsFlag.isChecked)) {
+      if (data.flagsCollection.isChecked) {
         if (hasCheckedChild) {
           error = FlutterError('Radio groups must not have multiple checked children');
           return false;
@@ -289,7 +292,7 @@ sealed class _DebugSemanticsRoleChecks {
 
   static FlutterError? _semanticsMenuItemCheckbox(SemanticsNode node) {
     final SemanticsData data = node.getSemanticsData();
-    if (!data.hasFlag(SemanticsFlag.hasCheckedState)) {
+    if (!data.flagsCollection.hasCheckedState) {
       return FlutterError('a menu item checkbox must be checkable');
     }
 
@@ -306,7 +309,7 @@ sealed class _DebugSemanticsRoleChecks {
 
   static FlutterError? _semanticsMenuItemRadio(SemanticsNode node) {
     final SemanticsData data = node.getSemanticsData();
-    if (!data.hasFlag(SemanticsFlag.hasCheckedState)) {
+    if (!data.flagsCollection.hasCheckedState) {
       return FlutterError('a menu item radio must be checkable');
     }
 
@@ -323,7 +326,7 @@ sealed class _DebugSemanticsRoleChecks {
 
   static FlutterError? _noLiveRegion(SemanticsNode node) {
     final SemanticsData data = node.getSemanticsData();
-    if (data.hasFlag(SemanticsFlag.isLiveRegion)) {
+    if (data.flagsCollection.isLiveRegion) {
       return FlutterError(
         'Node ${node.id} has role ${data.role} but is also a live region. '
         'A node can not have ${data.role} and be live region at the same time. '
@@ -710,7 +713,8 @@ class SemanticsData with Diagnosticable {
   ///
   /// If [label] is not empty, then [textDirection] must also not be null.
   SemanticsData({
-    required this.flags,
+    int? flags,
+    SemanticsFlags? flagsCollection,
     required this.actions,
     required this.identifier,
     required this.attributedLabel,
@@ -766,13 +770,23 @@ class SemanticsData with Diagnosticable {
          'A SemanticsData object with hint "${attributedHint.string}" had a null textDirection.',
        ),
        assert(headingLevel >= 0 && headingLevel <= 6, 'Heading level must be between 0 and 6'),
+       assert(flags != null || flagsCollection != null),
+       this.flagsCollection = flagsCollection ?? _fromBitMask(flags!),
        assert(
-         linkUrl == null || (flags & SemanticsFlag.isLink.index) != 0,
+         linkUrl == null ||
+             (flagsCollection?.isLink ?? ((flags! & SemanticsFlag.isLink.index) != 0)),
          'A SemanticsData object with a linkUrl must have the isLink flag set to true',
        );
 
   /// A bit field of [SemanticsFlag]s that apply to this node.
-  final int flags;
+  @Deprecated(
+    'Use flagsCollection instead.'
+    'This feature was deprecated after v3.29.0-0.3.pre.',
+  )
+  int get flags => _toBitMask(flagsCollection);
+
+  /// Semantics flags.
+  final SemanticsFlags flagsCollection;
 
   /// A bit field of [SemanticsAction]s that apply to this node.
   final int actions;
@@ -1010,6 +1024,10 @@ class SemanticsData with Diagnosticable {
   final SemanticsInputType inputType;
 
   /// Whether [flags] contains the given flag.
+  @Deprecated(
+    'Use flagsCollection instead.'
+    'This feature was deprecated after v3.32.0-0.0.pre.',
+  )
   bool hasFlag(SemanticsFlag flag) => (flags & flag.index) != 0;
 
   /// Whether [actions] contains the given action.
@@ -1038,10 +1056,7 @@ class SemanticsData with Diagnosticable {
       IterableProperty<String?>('customActions', customSemanticsActionSummary, ifEmpty: null),
     );
 
-    final List<String> flagSummary = <String>[
-      for (final SemanticsFlag flag in SemanticsFlag.values)
-        if ((flags & flag.index) != 0) flag.name,
-    ];
+    final List<String> flagSummary = flagsCollection.toStrings();
     properties.add(IterableProperty<String>('flags', flagSummary, ifEmpty: null));
     properties.add(StringProperty('identifier', identifier, defaultValue: ''));
     properties.add(AttributedStringProperty('label', attributedLabel));
@@ -2836,10 +2851,19 @@ class SemanticsNode with DiagnosticableTreeMixin {
   /// Whether this node is tagged with `tag`.
   bool isTagged(SemanticsTag tag) => tags != null && tags!.contains(tag);
 
-  int _flags = _kEmptyConfig._flags;
+  SemanticsFlags _flags = SemanticsFlags();
+
+  /// Semantics flags.
+  SemanticsFlags get flagsCollection => _flags;
+
+  int get _flagsBitMask => _toBitMask(flagsCollection);
 
   /// Whether this node currently has a given [SemanticsFlag].
-  bool hasFlag(SemanticsFlag flag) => _flags & flag.index != 0;
+  @Deprecated(
+    'Use flagsCollection instead.'
+    'This feature was deprecated after v3.32.0-0.0.pre.',
+  )
+  bool hasFlag(SemanticsFlag flag) => (_flagsBitMask & flag.index) != 0;
 
   /// {@macro flutter.semantics.SemanticsProperties.identifier}
   String get identifier => _identifier;
@@ -3261,7 +3285,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
   /// includes the information from this node's descendants. Otherwise, the
   /// returned data matches the data on this node.
   SemanticsData getSemanticsData() {
-    int flags = _flags;
+    SemanticsFlags flags = _flags;
     // Can't use _effectiveActionsAsBits here. The filtering of action bits
     // must be done after the merging the its descendants.
     int actions = _actionsAsBits;
@@ -3315,9 +3339,8 @@ class SemanticsNode with DiagnosticableTreeMixin {
     if (mergeAllDescendantsIntoThisNode) {
       _visitDescendants((SemanticsNode node) {
         assert(node.isMergedIntoParent);
-        flags |= node._flags;
+        flags = flags.merge(node._flags);
         actions |= node._effectiveActionsAsBits;
-
         textDirection ??= node._textDirection;
         textSelection ??= node._textSelection;
         scrollChildCount ??= node._scrollChildCount;
@@ -3415,7 +3438,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     }
 
     return SemanticsData(
-      flags: flags,
+      flagsCollection: flags,
       actions: _areUserActionsBlocked ? actions & _kUnblockedUserActions : actions,
       identifier: identifier,
       attributedLabel: attributedLabel,
@@ -3690,16 +3713,10 @@ class SemanticsNode with DiagnosticableTreeMixin {
     properties.add(
       IterableProperty<String?>('customActions', customSemanticsActions, ifEmpty: null),
     );
-    final List<String> flags =
-        SemanticsFlag.values
-            .where((SemanticsFlag flag) => hasFlag(flag))
-            .map((SemanticsFlag flag) => flag.name)
-            .toList();
-    properties.add(IterableProperty<String>('flags', flags, ifEmpty: null));
+
+    properties.add(IterableProperty<String>('flags', flagsCollection.toStrings(), ifEmpty: null));
     properties.add(FlagProperty('isInvisible', value: isInvisible, ifTrue: 'invisible'));
-    properties.add(
-      FlagProperty('isHidden', value: hasFlag(SemanticsFlag.isHidden), ifTrue: 'HIDDEN'),
-    );
+    properties.add(FlagProperty('isHidden', value: flagsCollection.isHidden, ifTrue: 'HIDDEN'));
     properties.add(StringProperty('identifier', _identifier, defaultValue: ''));
     properties.add(AttributedStringProperty('label', _attributedLabel));
     properties.add(AttributedStringProperty('value', _attributedValue));
@@ -5326,9 +5343,10 @@ class SemanticsConfiguration {
   /// See also:
   ///
   ///  * [SemanticsFlag.scopesRoute], for a full description of route scoping.
-  bool get scopesRoute => _hasFlag(SemanticsFlag.scopesRoute);
+  bool get scopesRoute => _flags.scopesRoute;
   set scopesRoute(bool value) {
-    _setFlag(SemanticsFlag.scopesRoute, value);
+    _flags = _flags.copyWith(scopesRoute: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the semantics node contains the label of a route.
@@ -5336,15 +5354,17 @@ class SemanticsConfiguration {
   /// See also:
   ///
   ///  * [SemanticsFlag.namesRoute], for a full description of route naming.
-  bool get namesRoute => _hasFlag(SemanticsFlag.namesRoute);
+  bool get namesRoute => _flags.namesRoute;
   set namesRoute(bool value) {
-    _setFlag(SemanticsFlag.namesRoute, value);
+    _flags = _flags.copyWith(namesRoute: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the semantics node represents an image.
-  bool get isImage => _hasFlag(SemanticsFlag.isImage);
+  bool get isImage => _flags.isImage;
   set isImage(bool value) {
-    _setFlag(SemanticsFlag.isImage, value);
+    _flags = _flags.copyWith(isImage: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the semantics node is a live region.
@@ -5363,9 +5383,10 @@ class SemanticsConfiguration {
   /// See also:
   ///
   ///  * [SemanticsFlag.isLiveRegion], the semantics flag that this setting controls.
-  bool get liveRegion => _hasFlag(SemanticsFlag.isLiveRegion);
+  bool get liveRegion => _flags.isLiveRegion;
   set liveRegion(bool value) {
-    _setFlag(SemanticsFlag.isLiveRegion, value);
+    _flags = _flags.copyWith(isLiveRegion: value);
+    _hasBeenAnnotated = true;
   }
 
   /// The reading direction for the text in [label], [value], [hint],
@@ -5383,10 +5404,10 @@ class SemanticsConfiguration {
   /// accessibility focused may or may not be selected; e.g. a [ListTile] can have
   /// accessibility focus but have its [ListTile.selected] property set to false,
   /// in which case it will not be flagged as selected.
-  bool get isSelected => _hasFlag(SemanticsFlag.isSelected);
+  bool get isSelected => _flags.isSelected;
   set isSelected(bool value) {
-    _setFlag(SemanticsFlag.hasSelectedState, true);
-    _setFlag(SemanticsFlag.isSelected, value);
+    _flags = _flags.copyWith(hasSelectedState: true, isSelected: value);
+    _hasBeenAnnotated = true;
   }
 
   /// If this node has Boolean state that can be controlled by the user, whether
@@ -5397,11 +5418,10 @@ class SemanticsConfiguration {
   ///
   /// The getter returns null if the owning [RenderObject] does not have
   /// expanded/collapsed state.
-  bool? get isExpanded =>
-      _hasFlag(SemanticsFlag.hasExpandedState) ? _hasFlag(SemanticsFlag.isExpanded) : null;
+  bool? get isExpanded => _flags.hasExpandedState ? _flags.isExpanded : null;
   set isExpanded(bool? value) {
-    _setFlag(SemanticsFlag.hasExpandedState, true);
-    _setFlag(SemanticsFlag.isExpanded, value!);
+    _flags = _flags.copyWith(hasExpandedState: true, isExpanded: value!);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] is currently enabled.
@@ -5419,11 +5439,11 @@ class SemanticsConfiguration {
   /// This property does not control whether semantics are enabled. If you wish to
   /// disable semantics for a particular widget, you should use an [ExcludeSemantics]
   /// widget.
-  bool? get isEnabled =>
-      _hasFlag(SemanticsFlag.hasEnabledState) ? _hasFlag(SemanticsFlag.isEnabled) : null;
+  bool? get isEnabled => _flags.hasEnabledState ? _flags.isEnabled : null;
   set isEnabled(bool? value) {
-    _setFlag(SemanticsFlag.hasEnabledState, true);
-    _setFlag(SemanticsFlag.isEnabled, value!);
+    _flags = _flags.copyWith(hasEnabledState: true, isEnabled: value!);
+
+    _hasBeenAnnotated = true;
   }
 
   /// If this node has Boolean state that can be controlled by the user, whether
@@ -5435,12 +5455,11 @@ class SemanticsConfiguration {
   ///
   /// The getter returns null if the owning [RenderObject] does not have
   /// checked/unchecked state.
-  bool? get isChecked =>
-      _hasFlag(SemanticsFlag.hasCheckedState) ? _hasFlag(SemanticsFlag.isChecked) : null;
+  bool? get isChecked => _flags.hasCheckedState ? _flags.isChecked : null;
   set isChecked(bool? value) {
     assert(value != true || isCheckStateMixed != true);
-    _setFlag(SemanticsFlag.hasCheckedState, true);
-    _setFlag(SemanticsFlag.isChecked, value!);
+    _flags = _flags.copyWith(hasCheckedState: true, isChecked: value!);
+    _hasBeenAnnotated = true;
   }
 
   /// If this node has tristate that can be controlled by the user, whether
@@ -5451,12 +5470,11 @@ class SemanticsConfiguration {
   ///
   /// The getter returns null if the owning [RenderObject] does not have
   /// mixed checked state.
-  bool? get isCheckStateMixed =>
-      _hasFlag(SemanticsFlag.hasCheckedState) ? _hasFlag(SemanticsFlag.isCheckStateMixed) : null;
+  bool? get isCheckStateMixed => _flags.hasCheckedState ? _flags.isCheckStateMixed : null;
   set isCheckStateMixed(bool? value) {
     assert(value != true || isChecked != true);
-    _setFlag(SemanticsFlag.hasCheckedState, true);
-    _setFlag(SemanticsFlag.isCheckStateMixed, value!);
+    _flags = _flags.copyWith(hasCheckedState: true, isCheckStateMixed: value!);
+    _hasBeenAnnotated = true;
   }
 
   /// If this node has Boolean state that can be controlled by the user, whether
@@ -5467,11 +5485,11 @@ class SemanticsConfiguration {
   ///
   /// The getter returns null if the owning [RenderObject] does not have
   /// on/off state.
-  bool? get isToggled =>
-      _hasFlag(SemanticsFlag.hasToggledState) ? _hasFlag(SemanticsFlag.isToggled) : null;
+  bool? get isToggled => _flags.hasToggledState ? _flags.isToggled : null;
   set isToggled(bool? value) {
-    _setFlag(SemanticsFlag.hasToggledState, true);
-    _setFlag(SemanticsFlag.isToggled, value!);
+    _flags = _flags.copyWith(hasToggledState: true);
+    _flags = _flags.copyWith(isToggled: value!);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning RenderObject corresponds to UI that allows the user to
@@ -5479,33 +5497,38 @@ class SemanticsConfiguration {
   ///
   /// For example, a [Radio] button is in a mutually exclusive group because
   /// only one radio button in that group can be marked as [isChecked].
-  bool get isInMutuallyExclusiveGroup => _hasFlag(SemanticsFlag.isInMutuallyExclusiveGroup);
+  bool get isInMutuallyExclusiveGroup => _flags.isInMutuallyExclusiveGroup;
   set isInMutuallyExclusiveGroup(bool value) {
-    _setFlag(SemanticsFlag.isInMutuallyExclusiveGroup, value);
+    _flags = _flags.copyWith(isInMutuallyExclusiveGroup: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] can hold the input focus.
-  bool get isFocusable => _hasFlag(SemanticsFlag.isFocusable);
+  bool get isFocusable => _flags.isFocusable;
   set isFocusable(bool value) {
-    _setFlag(SemanticsFlag.isFocusable, value);
+    _flags = _flags.copyWith(isFocusable: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] currently holds the input focus.
-  bool get isFocused => _hasFlag(SemanticsFlag.isFocused);
+  bool get isFocused => _flags.isFocused;
   set isFocused(bool value) {
-    _setFlag(SemanticsFlag.isFocused, value);
+    _flags = _flags.copyWith(isFocused: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] is a button (true) or not (false).
-  bool get isButton => _hasFlag(SemanticsFlag.isButton);
+  bool get isButton => _flags.isButton;
   set isButton(bool value) {
-    _setFlag(SemanticsFlag.isButton, value);
+    _flags = _flags.copyWith(isButton: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] is a link (true) or not (false).
-  bool get isLink => _hasFlag(SemanticsFlag.isLink);
+  bool get isLink => _flags.isLink;
   set isLink(bool value) {
-    _setFlag(SemanticsFlag.isLink, value);
+    _flags = _flags.copyWith(isLink: value);
+    _hasBeenAnnotated = true;
   }
 
   /// The URL that the owning [RenderObject] links to.
@@ -5521,9 +5544,10 @@ class SemanticsConfiguration {
   }
 
   /// Whether the owning [RenderObject] is a header (true) or not (false).
-  bool get isHeader => _hasFlag(SemanticsFlag.isHeader);
+  bool get isHeader => _flags.isHeader;
   set isHeader(bool value) {
-    _setFlag(SemanticsFlag.isHeader, value);
+    _flags = _flags.copyWith(isHeader: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Indicates the heading level in the document structure.
@@ -5542,16 +5566,18 @@ class SemanticsConfiguration {
   }
 
   /// Whether the owning [RenderObject] is a slider (true) or not (false).
-  bool get isSlider => _hasFlag(SemanticsFlag.isSlider);
+  bool get isSlider => _flags.isSlider;
   set isSlider(bool value) {
-    _setFlag(SemanticsFlag.isSlider, value);
+    _flags = _flags.copyWith(isSlider: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] is a keyboard key (true) or not
   /// (false).
-  bool get isKeyboardKey => _hasFlag(SemanticsFlag.isKeyboardKey);
+  bool get isKeyboardKey => _flags.isKeyboardKey;
   set isKeyboardKey(bool value) {
-    _setFlag(SemanticsFlag.isKeyboardKey, value);
+    _flags = _flags.copyWith(isKeyboardKey: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] is considered hidden.
@@ -5570,23 +5596,26 @@ class SemanticsConfiguration {
   /// the semantics tree altogether. Hidden elements are only included in the
   /// semantics tree to work around platform limitations and they are mainly
   /// used to implement accessibility scrolling on iOS.
-  bool get isHidden => _hasFlag(SemanticsFlag.isHidden);
+  bool get isHidden => _flags.isHidden;
   set isHidden(bool value) {
-    _setFlag(SemanticsFlag.isHidden, value);
+    _flags = _flags.copyWith(isHidden: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] is a text field.
-  bool get isTextField => _hasFlag(SemanticsFlag.isTextField);
+  bool get isTextField => _flags.isTextField;
   set isTextField(bool value) {
-    _setFlag(SemanticsFlag.isTextField, value);
+    _flags = _flags.copyWith(isTextField: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the owning [RenderObject] is read only.
   ///
   /// Only applicable when [isTextField] is true.
-  bool get isReadOnly => _hasFlag(SemanticsFlag.isReadOnly);
+  bool get isReadOnly => _flags.isReadOnly;
   set isReadOnly(bool value) {
-    _setFlag(SemanticsFlag.isReadOnly, value);
+    _flags = _flags.copyWith(isReadOnly: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether [value] should be obscured.
@@ -5594,18 +5623,20 @@ class SemanticsConfiguration {
   /// This option is usually set in combination with [isTextField] to indicate
   /// that the text field contains a password (or other sensitive information).
   /// Doing so instructs screen readers to not read out [value].
-  bool get isObscured => _hasFlag(SemanticsFlag.isObscured);
+  bool get isObscured => _flags.isObscured;
   set isObscured(bool value) {
-    _setFlag(SemanticsFlag.isObscured, value);
+    _flags = _flags.copyWith(isObscured: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the text field is multiline.
   ///
   /// This option is usually set in combination with [isTextField] to indicate
   /// that the text field is configured to be multiline.
-  bool get isMultiline => _hasFlag(SemanticsFlag.isMultiline);
+  bool get isMultiline => _flags.isMultiline;
   set isMultiline(bool value) {
-    _setFlag(SemanticsFlag.isMultiline, value);
+    _flags = _flags.copyWith(isMultiline: value);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the semantics node has a required state.
@@ -5619,11 +5650,11 @@ class SemanticsConfiguration {
   /// See also:
   ///
   ///  * [SemanticsFlag.isRequired], for a full description of required nodes.
-  bool? get isRequired =>
-      _hasFlag(SemanticsFlag.hasRequiredState) ? _hasFlag(SemanticsFlag.isRequired) : null;
+  bool? get isRequired => _flags.hasRequiredState ? _flags.isRequired : null;
   set isRequired(bool? value) {
-    _setFlag(SemanticsFlag.hasRequiredState, true);
-    _setFlag(SemanticsFlag.isRequired, value!);
+    _flags = _flags.copyWith(hasRequiredState: true);
+    _flags = _flags.copyWith(isRequired: value!);
+    _hasBeenAnnotated = true;
   }
 
   /// Whether the platform can scroll the semantics node when the user attempts
@@ -5633,9 +5664,10 @@ class SemanticsConfiguration {
   /// easily move to the next visible set of children. A [TabBar] widget does
   /// not have implicit scrolling, so that users can navigate into the tab
   /// body when reaching the end of the tab bar.
-  bool get hasImplicitScrolling => _hasFlag(SemanticsFlag.hasImplicitScrolling);
+  bool get hasImplicitScrolling => _flags.hasImplicitScrolling;
   set hasImplicitScrolling(bool value) {
-    _setFlag(SemanticsFlag.hasImplicitScrolling, value);
+    _flags = _flags.copyWith(hasImplicitScrolling: value);
+    _hasBeenAnnotated = true;
   }
 
   /// The currently selected text (or the position of the cursor) within
@@ -5762,30 +5794,20 @@ class SemanticsConfiguration {
 
   // INTERNAL FLAG MANAGEMENT
 
-  int _flags = 0;
-  void _setFlag(SemanticsFlag flag, bool value) {
-    if (value) {
-      _flags |= flag.index;
-    } else {
-      _flags &= ~flag.index;
-    }
-    _hasBeenAnnotated = true;
-  }
-
-  bool _hasFlag(SemanticsFlag flag) => (_flags & flag.index) != 0;
+  SemanticsFlags _flags = SemanticsFlags();
 
   bool get _hasExplicitRole {
     if (_role != SemanticsRole.none) {
       return true;
     }
-    if (_hasFlag(SemanticsFlag.isTextField) ||
+    if (_flags.isTextField ||
         // In non web platforms, the header is a trait.
-        (_hasFlag(SemanticsFlag.isHeader) && kIsWeb) ||
-        _hasFlag(SemanticsFlag.isSlider) ||
-        _hasFlag(SemanticsFlag.isLink) ||
-        _hasFlag(SemanticsFlag.scopesRoute) ||
-        _hasFlag(SemanticsFlag.isImage) ||
-        _hasFlag(SemanticsFlag.isKeyboardKey)) {
+        (_flags.isHeader && kIsWeb) ||
+        _flags.isSlider ||
+        _flags.isLink ||
+        _flags.scopesRoute ||
+        _flags.isImage ||
+        _flags.isKeyboardKey) {
       return true;
     }
     return false;
@@ -5805,7 +5827,7 @@ class SemanticsConfiguration {
     if (_actionsAsBits & other._actionsAsBits != 0) {
       return false;
     }
-    if ((_flags & other._flags) != 0) {
+    if (_flags == other._flags) {
       return false;
     }
     if (_platformViewId != null && other._platformViewId != null) {
@@ -5854,7 +5876,7 @@ class SemanticsConfiguration {
     }
     _actionsAsBits |= child._effectiveActionsAsBits;
     _customSemanticsActions.addAll(child._customSemanticsActions);
-    _flags |= child._flags;
+    _flags.merge(child._flags);
     _textSelection ??= child._textSelection;
     _scrollPosition ??= child._scrollPosition;
     _scrollExtentMax ??= child._scrollExtentMax;
@@ -6148,4 +6170,77 @@ class OrdinalSortKey extends SemanticsSortKey {
 /// heading level.
 int _mergeHeadingLevels({required int sourceLevel, required int targetLevel}) {
   return targetLevel == 0 ? sourceLevel : targetLevel;
+}
+
+/// This is just to support flag 0-30, new flags don't need to be in the bitmask.
+int _toBitMask(SemanticsFlags flags) {
+  int bitmask = 0;
+  if (flags.hasCheckedState) bitmask |= (1 << 0);
+  if (flags.isChecked) bitmask |= (1 << 1);
+  if (flags.isSelected) bitmask |= (1 << 2);
+  if (flags.isButton) bitmask |= (1 << 3);
+  if (flags.isTextField) bitmask |= (1 << 4);
+  if (flags.isFocused) bitmask |= (1 << 5);
+  if (flags.hasEnabledState) bitmask |= (1 << 6);
+  if (flags.isEnabled) bitmask |= (1 << 7);
+  if (flags.isInMutuallyExclusiveGroup) bitmask |= (1 << 8);
+  if (flags.isHeader) bitmask |= (1 << 9);
+  if (flags.isObscured) bitmask |= (1 << 10);
+  if (flags.scopesRoute) bitmask |= (1 << 11);
+  if (flags.namesRoute) bitmask |= (1 << 12);
+  if (flags.isHidden) bitmask |= (1 << 13);
+  if (flags.isImage) bitmask |= (1 << 14);
+  if (flags.isLiveRegion) bitmask |= (1 << 15);
+  if (flags.hasToggledState) bitmask |= (1 << 16);
+  if (flags.isToggled) bitmask |= (1 << 17);
+  if (flags.hasImplicitScrolling) bitmask |= (1 << 18);
+  if (flags.isMultiline) bitmask |= (1 << 19);
+  if (flags.isReadOnly) bitmask |= (1 << 20);
+  if (flags.isFocusable) bitmask |= (1 << 21);
+  if (flags.isLink) bitmask |= (1 << 22);
+  if (flags.isSlider) bitmask |= (1 << 23);
+  if (flags.isKeyboardKey) bitmask |= (1 << 24);
+  if (flags.isCheckStateMixed) bitmask |= (1 << 25);
+  if (flags.hasExpandedState) bitmask |= (1 << 26);
+  if (flags.isExpanded) bitmask |= (1 << 27);
+  if (flags.hasSelectedState) bitmask |= (1 << 28);
+  if (flags.hasRequiredState) bitmask |= (1 << 29);
+  if (flags.isRequired) bitmask |= (1 << 30);
+  return bitmask;
+}
+
+SemanticsFlags _fromBitMask(int bitmask) {
+  return SemanticsFlags(
+    hasCheckedState: (bitmask & (1 << 0)) != 0,
+    isChecked: (bitmask & (1 << 1)) != 0,
+    isSelected: (bitmask & (1 << 2)) != 0,
+    isButton: (bitmask & (1 << 3)) != 0,
+    isTextField: (bitmask & (1 << 4)) != 0,
+    isFocused: (bitmask & (1 << 5)) != 0,
+    hasEnabledState: (bitmask & (1 << 6)) != 0,
+    isEnabled: (bitmask & (1 << 7)) != 0,
+    isInMutuallyExclusiveGroup: (bitmask & (1 << 8)) != 0,
+    isHeader: (bitmask & (1 << 9)) != 0,
+    isObscured: (bitmask & (1 << 10)) != 0,
+    scopesRoute: (bitmask & (1 << 11)) != 0,
+    namesRoute: (bitmask & (1 << 12)) != 0,
+    isHidden: (bitmask & (1 << 13)) != 0,
+    isImage: (bitmask & (1 << 14)) != 0,
+    isLiveRegion: (bitmask & (1 << 15)) != 0,
+    hasToggledState: (bitmask & (1 << 16)) != 0,
+    isToggled: (bitmask & (1 << 17)) != 0,
+    hasImplicitScrolling: (bitmask & (1 << 18)) != 0,
+    isMultiline: (bitmask & (1 << 19)) != 0,
+    isReadOnly: (bitmask & (1 << 20)) != 0,
+    isFocusable: (bitmask & (1 << 21)) != 0,
+    isLink: (bitmask & (1 << 22)) != 0,
+    isSlider: (bitmask & (1 << 23)) != 0,
+    isKeyboardKey: (bitmask & (1 << 24)) != 0,
+    isCheckStateMixed: (bitmask & (1 << 25)) != 0,
+    hasExpandedState: (bitmask & (1 << 26)) != 0,
+    isExpanded: (bitmask & (1 << 27)) != 0,
+    hasSelectedState: (bitmask & (1 << 28)) != 0,
+    hasRequiredState: (bitmask & (1 << 29)) != 0,
+    isRequired: (bitmask & (1 << 30)) != 0,
+  );
 }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -713,8 +713,7 @@ class SemanticsData with Diagnosticable {
   ///
   /// If [label] is not empty, then [textDirection] must also not be null.
   SemanticsData({
-    int? flags,
-    SemanticsFlags? flagsCollection,
+    required this.flagsCollection,
     required this.actions,
     required this.identifier,
     required this.attributedLabel,
@@ -770,11 +769,8 @@ class SemanticsData with Diagnosticable {
          'A SemanticsData object with hint "${attributedHint.string}" had a null textDirection.',
        ),
        assert(headingLevel >= 0 && headingLevel <= 6, 'Heading level must be between 0 and 6'),
-       assert(flags != null || flagsCollection != null),
-       this.flagsCollection = flagsCollection ?? _fromBitMask(flags!),
        assert(
-         linkUrl == null ||
-             (flagsCollection?.isLink ?? ((flags! & SemanticsFlag.isLink.index) != 0)),
+         linkUrl == null || flagsCollection.isLink,
          'A SemanticsData object with a linkUrl must have the isLink flag set to true',
        );
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1021,7 +1021,7 @@ class SemanticsData with Diagnosticable {
 
   /// Whether [flags] contains the given flag.
   @Deprecated(
-    'Use flagsCollection instead.'
+    'Use flagsCollection instead. '
     'This feature was deprecated after v3.32.0-0.0.pre.',
   )
   bool hasFlag(SemanticsFlag flag) => (flags & flag.index) != 0;
@@ -5788,7 +5788,7 @@ class SemanticsConfiguration {
 
   // INTERNAL FLAG MANAGEMENT
 
-  SemanticsFlags _flags = SemanticsFlags();
+  SemanticsFlags _flags = SemanticsFlags.kNone;
 
   bool get _hasExplicitRole {
     if (_role != SemanticsRole.none) {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5420,7 +5420,7 @@ class SemanticsConfiguration {
   /// expanded/collapsed state.
   bool? get isExpanded => _flags.hasExpandedState ? _flags.isExpanded : null;
   set isExpanded(bool? value) {
-    _flags = _flags.copyWith(hasExpandedState: true, isExpanded: value!);
+    _flags = _flags.copyWith(hasExpandedState: true, isExpanded: value);
     _hasBeenAnnotated = true;
   }
 
@@ -5441,7 +5441,7 @@ class SemanticsConfiguration {
   /// widget.
   bool? get isEnabled => _flags.hasEnabledState ? _flags.isEnabled : null;
   set isEnabled(bool? value) {
-    _flags = _flags.copyWith(hasEnabledState: true, isEnabled: value!);
+    _flags = _flags.copyWith(hasEnabledState: true, isEnabled: value);
 
     _hasBeenAnnotated = true;
   }
@@ -5458,7 +5458,7 @@ class SemanticsConfiguration {
   bool? get isChecked => _flags.hasCheckedState ? _flags.isChecked : null;
   set isChecked(bool? value) {
     assert(value != true || isCheckStateMixed != true);
-    _flags = _flags.copyWith(hasCheckedState: true, isChecked: value!);
+    _flags = _flags.copyWith(hasCheckedState: true, isChecked: value);
     _hasBeenAnnotated = true;
   }
 
@@ -5487,8 +5487,7 @@ class SemanticsConfiguration {
   /// on/off state.
   bool? get isToggled => _flags.hasToggledState ? _flags.isToggled : null;
   set isToggled(bool? value) {
-    _flags = _flags.copyWith(hasToggledState: true);
-    _flags = _flags.copyWith(isToggled: value!);
+    _flags = _flags.copyWith(hasToggledState: true, isToggled: value);
     _hasBeenAnnotated = true;
   }
 
@@ -5652,8 +5651,7 @@ class SemanticsConfiguration {
   ///  * [SemanticsFlag.isRequired], for a full description of required nodes.
   bool? get isRequired => _flags.hasRequiredState ? _flags.isRequired : null;
   set isRequired(bool? value) {
-    _flags = _flags.copyWith(hasRequiredState: true);
-    _flags = _flags.copyWith(isRequired: value!);
+    _flags = _flags.copyWith(hasRequiredState: true, isRequired: value);
     _hasBeenAnnotated = true;
   }
 
@@ -5827,7 +5825,9 @@ class SemanticsConfiguration {
     if (_actionsAsBits & other._actionsAsBits != 0) {
       return false;
     }
-    if (_flags == other._flags) {
+    if (
+      _flags.hasRepeatedFlags (other._flags)
+    ) {
       return false;
     }
     if (_platformViewId != null && other._platformViewId != null) {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -5825,9 +5825,7 @@ class SemanticsConfiguration {
     if (_actionsAsBits & other._actionsAsBits != 0) {
       return false;
     }
-    if (
-      _flags.hasRepeatedFlags (other._flags)
-    ) {
+    if (_flags.hasRepeatedFlags(other._flags)) {
       return false;
     }
     if (_platformViewId != null && other._platformViewId != null) {
@@ -5876,7 +5874,7 @@ class SemanticsConfiguration {
     }
     _actionsAsBits |= child._effectiveActionsAsBits;
     _customSemanticsActions.addAll(child._customSemanticsActions);
-    _flags.merge(child._flags);
+    _flags = _flags.merge(child._flags);
     _textSelection ??= child._textSelection;
     _scrollPosition ??= child._scrollPosition;
     _scrollExtentMax ??= child._scrollExtentMax;
@@ -6209,6 +6207,7 @@ int _toBitMask(SemanticsFlags flags) {
   return bitmask;
 }
 
+/// This is just to support flag 0-30, new flags don't need to be in the bitmask.
 SemanticsFlags _fromBitMask(int bitmask) {
   return SemanticsFlags(
     hasCheckedState: (bitmask & (1 << 0)) != 0,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1749,7 +1749,7 @@ class _RenderScrollSemantics extends RenderProxyBox {
       if (child.isTagged(RenderViewport.excludeFromScrolling)) {
         excluded.add(child);
       } else {
-        if (!child.hasFlag(SemanticsFlag.isHidden)) {
+        if (!child.flagsCollection.isHidden) {
           firstVisibleIndex ??= child.indexInParent;
         }
         included.add(child);

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -226,11 +226,11 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     final List<String> annotations = <String>[];
 
     bool wantsTap = false;
-    if (data.hasFlag(SemanticsFlag.hasCheckedState)) {
-      annotations.add(data.hasFlag(SemanticsFlag.isChecked) ? 'checked' : 'unchecked');
+    if (data.flagsCollection.hasCheckedState) {
+      annotations.add(data.flagsCollection.isChecked ? 'checked' : 'unchecked');
       wantsTap = true;
     }
-    if (data.hasFlag(SemanticsFlag.isTextField)) {
+    if (data.flagsCollection.isTextField) {
       annotations.add('textfield');
       wantsTap = true;
     }

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1897,7 +1897,7 @@ void main() {
 
       final SemanticsNode node = tester.semantics.find(find.byType(DatePickerDialog));
       final SemanticsData semanticsData = node.getSemanticsData();
-      expect(semanticsData.hasFlag(SemanticsFlag.isFocusable), false);
+      expect(semanticsData.flagsCollection.isFocusable, false);
     });
   });
 

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -775,7 +775,7 @@ void main() {
       'Rect.fromLTRB(50.0, 10.0, 70.0, 40.0), '
       '[1.0,0.0,0.0,10.0; 0.0,1.0,0.0,10.0; 0.0,0.0,1.0,0.0; 0.0,0.0,0.0,1.0], '
       'actions: [longPress, scrollUp, showOnScreen], '
-      'flags: [hasCheckedState, hasSelectedState, isSelected, isButton], '
+      'flags: [hasCheckedState, isSelected, isButton, hasSelectedState], '
       'label: "Use all the properties", textDirection: rtl)',
     );
 

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -763,7 +763,7 @@ void main() {
         '   merge boundary ⛔️\n'
         '   Rect.fromLTRB(60.0, 20.0, 80.0, 50.0)\n'
         '   actions: longPress, scrollUp, showOnScreen\n'
-        '   flags: hasCheckedState, hasSelectedState, isSelected, isButton\n'
+        '   flags: hasCheckedState, isSelected, isButton, hasSelectedState\n'
         '   label: "Use all the properties"\n'
         '   textDirection: rtl\n'
         '   sortKey: OrdinalSortKey#19df5(order: 1.0)\n',

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -424,7 +424,7 @@ void main() {
       final SemanticsNode node2 = tester.getSemantics(find.byKey(key2));
       expect(node1 != node2, isTrue);
       expect(node1.role, SemanticsRole.dialog);
-      expect(node2.hasFlag(SemanticsFlag.isTextField), isTrue);
+      expect(node2.flagsCollection.isTextField, isTrue);
     });
 
     testWidgets('Semantics does not merge role - link', (WidgetTester tester) async {
@@ -445,7 +445,7 @@ void main() {
       final SemanticsNode node2 = tester.getSemantics(find.byKey(key2));
       expect(node1 != node2, isTrue);
       expect(node1.role, SemanticsRole.dialog);
-      expect(node2.hasFlag(SemanticsFlag.isLink), isTrue);
+      expect(node2.flagsCollection.isLink, isTrue);
     });
 
     testWidgets('Semantics does not merge role - scopes route', (WidgetTester tester) async {
@@ -471,7 +471,7 @@ void main() {
       final SemanticsNode node2 = tester.getSemantics(find.byKey(key2));
       expect(node1 != node2, isTrue);
       expect(node1.role, SemanticsRole.dialog);
-      expect(node2.hasFlag(SemanticsFlag.scopesRoute), isTrue);
+      expect(node2.flagsCollection.scopesRoute, isTrue);
     });
 
     testWidgets('Semantics does not merge role - header on web', (WidgetTester tester) async {
@@ -493,7 +493,7 @@ void main() {
       if (kIsWeb) {
         expect(node1 != node2, isTrue);
         expect(node1.role, SemanticsRole.dialog);
-        expect(node2.hasFlag(SemanticsFlag.isHeader), isTrue);
+        expect(node2.flagsCollection.isHeader, isTrue);
       } else {
         expect(node1 == node2, isTrue);
       }
@@ -517,7 +517,7 @@ void main() {
       final SemanticsNode node2 = tester.getSemantics(find.byKey(key2));
       expect(node1 != node2, isTrue);
       expect(node1.role, SemanticsRole.dialog);
-      expect(node2.hasFlag(SemanticsFlag.isImage), isTrue);
+      expect(node2.flagsCollection.isImage, isTrue);
     });
 
     testWidgets('Semantics does not merge role - slider', (WidgetTester tester) async {
@@ -538,7 +538,7 @@ void main() {
       final SemanticsNode node2 = tester.getSemantics(find.byKey(key2));
       expect(node1 != node2, isTrue);
       expect(node1.role, SemanticsRole.dialog);
-      expect(node2.hasFlag(SemanticsFlag.isSlider), isTrue);
+      expect(node2.flagsCollection.isSlider, isTrue);
     });
 
     testWidgets('Semantics does not merge role - keyboard key', (WidgetTester tester) async {
@@ -559,7 +559,7 @@ void main() {
       final SemanticsNode node2 = tester.getSemantics(find.byKey(key2));
       expect(node1 != node2, isTrue);
       expect(node1.role, SemanticsRole.dialog);
-      expect(node2.hasFlag(SemanticsFlag.isKeyboardKey), isTrue);
+      expect(node2.flagsCollection.isKeyboardKey, isTrue);
     });
 
     testWidgets('Semantics does not merge role - scopes route', (WidgetTester tester) async {
@@ -580,7 +580,7 @@ void main() {
       final SemanticsNode node2 = tester.getSemantics(find.byKey(key2));
       expect(node1 != node2, isTrue);
       expect(node1.role, SemanticsRole.dialog);
-      expect(node2.hasFlag(SemanticsFlag.isSlider), isTrue);
+      expect(node2.flagsCollection.isSlider, isTrue);
     });
 
     testWidgets('Semantics can set controls visibility of nodes', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1289,23 +1289,23 @@ void main() {
       final SemanticsNode semantics = tester.getSemantics(find.byKey(key));
 
       expect(key.currentState!.focusNode.hasFocus, isFalse);
-      expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
-      expect(semantics.hasFlag(SemanticsFlag.isFocusable), isTrue);
+      expect(semantics.flagsCollection.isFocused, isFalse);
+      expect(semantics.flagsCollection.isFocusable, isTrue);
 
       FocusScope.of(key.currentContext!).requestFocus(key.currentState!.focusNode);
       await tester.pumpAndSettle();
 
       expect(key.currentState!.focusNode.hasFocus, isTrue);
-      expect(semantics.hasFlag(SemanticsFlag.isFocused), isTrue);
-      expect(semantics.hasFlag(SemanticsFlag.isFocusable), isTrue);
+      expect(semantics.flagsCollection.isFocused, isTrue);
+      expect(semantics.flagsCollection.isFocusable, isTrue);
 
       key.currentState!.focusNode.canRequestFocus = false;
       await tester.pumpAndSettle();
 
       expect(key.currentState!.focusNode.hasFocus, isFalse);
       expect(key.currentState!.focusNode.canRequestFocus, isFalse);
-      expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
-      expect(semantics.hasFlag(SemanticsFlag.isFocusable), isFalse);
+      expect(semantics.flagsCollection.isFocused, isFalse);
+      expect(semantics.flagsCollection.isFocusable, isFalse);
     });
 
     testWidgets('Setting canRequestFocus on focus node causes update.', (

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -13,6 +13,40 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart' show Matrix3;
 
+const allFlags = SemanticsFlags(
+  hasCheckedState: true,
+  isChecked: true,
+  isSelected: true,
+  isButton: true,
+  isTextField: true,
+  isFocused: true,
+  hasEnabledState: true,
+  isEnabled: true,
+  isInMutuallyExclusiveGroup: true,
+  isHeader: true,
+  isObscured: true,
+  scopesRoute: true,
+  namesRoute: true,
+  isHidden: true,
+  isImage: true,
+  isLiveRegion: true,
+  hasToggledState: true,
+  isToggled: true,
+  hasImplicitScrolling: true,
+  isMultiline: true,
+  isReadOnly: true,
+  isFocusable: true,
+  isLink: true,
+  isSlider: true,
+  isKeyboardKey: true,
+  isCheckStateMixed: true,
+  hasExpandedState: true,
+  isExpanded: true,
+  hasSelectedState: true,
+  hasRequiredState: true,
+  isRequired: true,
+);
+
 /// Class that makes it easy to mock common toStringDeep behavior.
 class _MockToStringDeep {
   _MockToStringDeep(String str) : _lines = <String>[] {
@@ -431,13 +465,12 @@ void main() {
 
     test('differently constructed rects match', () {
       final Path rectPath = Path()..addRect(const Rect.fromLTRB(5.0, 5.0, 6.0, 6.0));
-      final Path linePath =
-          Path()
-            ..moveTo(5.0, 5.0)
-            ..lineTo(5.0, 6.0)
-            ..lineTo(6.0, 6.0)
-            ..lineTo(6.0, 5.0)
-            ..close();
+      final Path linePath = Path()
+        ..moveTo(5.0, 5.0)
+        ..lineTo(5.0, 6.0)
+        ..lineTo(6.0, 6.0)
+        ..lineTo(6.0, 5.0)
+        ..close();
       expect(
         linePath,
         coversSameAreaAs(rectPath, areaToCompare: const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0)),
@@ -446,13 +479,12 @@ void main() {
 
     test('partially overlapping paths', () {
       final Path rectPath = Path()..addRect(const Rect.fromLTRB(5.0, 5.0, 6.0, 6.0));
-      final Path linePath =
-          Path()
-            ..moveTo(5.0, 5.0)
-            ..lineTo(5.0, 6.0)
-            ..lineTo(6.0, 6.0)
-            ..lineTo(6.0, 5.5)
-            ..close();
+      final Path linePath = Path()
+        ..moveTo(5.0, 5.0)
+        ..lineTo(5.0, 6.0)
+        ..lineTo(6.0, 6.0)
+        ..lineTo(6.0, 5.5)
+        ..close();
       expect(
         linePath,
         isNot(coversSameAreaAs(rectPath, areaToCompare: const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0))),
@@ -695,16 +727,13 @@ void main() {
 
     testWidgets('Can match all semantics flags and actions', (WidgetTester tester) async {
       int actions = 0;
-      int flags = 0;
       const CustomSemanticsAction action = CustomSemanticsAction(label: 'test');
       for (final SemanticsAction action in SemanticsAction.values) {
         actions |= action.index;
       }
-      for (final SemanticsFlag flag in SemanticsFlag.values) {
-        flags |= flag.index;
-      }
+
       final SemanticsData data = SemanticsData(
-        flags: flags,
+        flagsCollection: allFlags,
         actions: actions,
         identifier: 'i',
         attributedLabel: AttributedString('a'),
@@ -863,30 +892,30 @@ void main() {
 
       // This should fail due to the mis-match between the `namesRoute` value.
       void failedExpectation() => expect(
-        tester.getSemantics(find.byKey(key)),
-        matchesSemantics(
-          // Adding the explicit `false` for test readability
-          // ignore: avoid_redundant_argument_values
-          namesRoute: false,
-          label: 'foo',
-          hint: 'bar',
-          value: 'baz',
-          increasedValue: 'a',
-          decreasedValue: 'b',
-          textDirection: TextDirection.rtl,
-          hasTapAction: true,
-          hasLongPressAction: true,
-          isButton: true,
-          isLink: true,
-          isHeader: true,
-          onTapHint: 'scan',
-          onLongPressHint: 'fill',
-          customActions: <CustomSemanticsAction>[
-            const CustomSemanticsAction(label: 'foo'),
-            const CustomSemanticsAction(label: 'bar'),
-          ],
-        ),
-      );
+            tester.getSemantics(find.byKey(key)),
+            matchesSemantics(
+              // Adding the explicit `false` for test readability
+              // ignore: avoid_redundant_argument_values
+              namesRoute: false,
+              label: 'foo',
+              hint: 'bar',
+              value: 'baz',
+              increasedValue: 'a',
+              decreasedValue: 'b',
+              textDirection: TextDirection.rtl,
+              hasTapAction: true,
+              hasLongPressAction: true,
+              isButton: true,
+              isLink: true,
+              isHeader: true,
+              onTapHint: 'scan',
+              onLongPressHint: 'fill',
+              customActions: <CustomSemanticsAction>[
+                const CustomSemanticsAction(label: 'foo'),
+                const CustomSemanticsAction(label: 'bar'),
+              ],
+            ),
+          );
 
       expect(failedExpectation, throwsA(isA<TestFailure>()));
       handle.dispose();
@@ -1000,16 +1029,13 @@ void main() {
 
     testWidgets('can match all semantics flags and actions enabled', (WidgetTester tester) async {
       int actions = 0;
-      int flags = 0;
       const CustomSemanticsAction action = CustomSemanticsAction(label: 'test');
       for (final SemanticsAction action in SemanticsAction.values) {
         actions |= action.index;
       }
-      for (final SemanticsFlag flag in SemanticsFlag.values) {
-        flags |= flag.index;
-      }
+
       final SemanticsData data = SemanticsData(
-        flags: flags,
+        flagsCollection: allFlags,
         actions: actions,
         identifier: 'i',
         attributedLabel: AttributedString('a'),
@@ -1111,7 +1137,7 @@ void main() {
 
     testWidgets('can match all flags and actions disabled', (WidgetTester tester) async {
       final SemanticsData data = SemanticsData(
-        flags: 0,
+        flagsCollection: SemanticsFlags.kNone,
         actions: 0,
         identifier: 'i',
         attributedLabel: AttributedString('a'),
@@ -1211,15 +1237,13 @@ void main() {
 
     testWidgets('only matches given flags and actions', (WidgetTester tester) async {
       int allActions = 0;
-      int allFlags = 0;
+
       for (final SemanticsAction action in SemanticsAction.values) {
         allActions |= action.index;
       }
-      for (final SemanticsFlag flag in SemanticsFlag.values) {
-        allFlags |= flag.index;
-      }
+
       final SemanticsData emptyData = SemanticsData(
-        flags: 0,
+        flagsCollection: SemanticsFlags.kNone,
         actions: 0,
         identifier: 'i',
         attributedLabel: AttributedString('a'),
@@ -1252,7 +1276,7 @@ void main() {
 
       const CustomSemanticsAction action = CustomSemanticsAction(label: 'test');
       final SemanticsData fullData = SemanticsData(
-        flags: allFlags,
+        flagsCollection: allFlags,
         actions: allActions,
         identifier: 'i',
         attributedLabel: AttributedString('a'),
@@ -1342,7 +1366,7 @@ void main() {
     testWidgets('can match only custom actions', (WidgetTester tester) async {
       const CustomSemanticsAction action = CustomSemanticsAction(label: 'test');
       final SemanticsData data = SemanticsData(
-        flags: 0,
+        flagsCollection: SemanticsFlags.kNone,
         actions: SemanticsAction.customAction.index,
         identifier: 'i',
         attributedLabel: AttributedString('a'),
@@ -1407,28 +1431,28 @@ void main() {
 
       // This should fail due to the mis-match between the `namesRoute` value.
       void failedExpectation() => expect(
-        tester.getSemantics(find.byKey(key)),
-        containsSemantics(
-          label: 'foo',
-          hint: 'bar',
-          value: 'baz',
-          increasedValue: 'a',
-          decreasedValue: 'b',
-          textDirection: TextDirection.rtl,
-          hasTapAction: true,
-          hasLongPressAction: true,
-          isButton: true,
-          isLink: true,
-          isHeader: true,
-          namesRoute: false,
-          onTapHint: 'scan',
-          onLongPressHint: 'fill',
-          customActions: <CustomSemanticsAction>[
-            const CustomSemanticsAction(label: 'foo'),
-            const CustomSemanticsAction(label: 'bar'),
-          ],
-        ),
-      );
+            tester.getSemantics(find.byKey(key)),
+            containsSemantics(
+              label: 'foo',
+              hint: 'bar',
+              value: 'baz',
+              increasedValue: 'a',
+              decreasedValue: 'b',
+              textDirection: TextDirection.rtl,
+              hasTapAction: true,
+              hasLongPressAction: true,
+              isButton: true,
+              isLink: true,
+              isHeader: true,
+              namesRoute: false,
+              onTapHint: 'scan',
+              onLongPressHint: 'fill',
+              customActions: <CustomSemanticsAction>[
+                const CustomSemanticsAction(label: 'foo'),
+                const CustomSemanticsAction(label: 'bar'),
+              ],
+            ),
+          );
 
       expect(failedExpectation, throwsA(isA<TestFailure>()));
       handle.dispose();

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart' show Matrix3;
 
-const allFlags = SemanticsFlags(
+const SemanticsFlags allFlags = SemanticsFlags(
   hasCheckedState: true,
   isChecked: true,
   isSelected: true,

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -465,12 +465,13 @@ void main() {
 
     test('differently constructed rects match', () {
       final Path rectPath = Path()..addRect(const Rect.fromLTRB(5.0, 5.0, 6.0, 6.0));
-      final Path linePath = Path()
-        ..moveTo(5.0, 5.0)
-        ..lineTo(5.0, 6.0)
-        ..lineTo(6.0, 6.0)
-        ..lineTo(6.0, 5.0)
-        ..close();
+      final Path linePath =
+          Path()
+            ..moveTo(5.0, 5.0)
+            ..lineTo(5.0, 6.0)
+            ..lineTo(6.0, 6.0)
+            ..lineTo(6.0, 5.0)
+            ..close();
       expect(
         linePath,
         coversSameAreaAs(rectPath, areaToCompare: const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0)),
@@ -479,12 +480,13 @@ void main() {
 
     test('partially overlapping paths', () {
       final Path rectPath = Path()..addRect(const Rect.fromLTRB(5.0, 5.0, 6.0, 6.0));
-      final Path linePath = Path()
-        ..moveTo(5.0, 5.0)
-        ..lineTo(5.0, 6.0)
-        ..lineTo(6.0, 6.0)
-        ..lineTo(6.0, 5.5)
-        ..close();
+      final Path linePath =
+          Path()
+            ..moveTo(5.0, 5.0)
+            ..lineTo(5.0, 6.0)
+            ..lineTo(6.0, 6.0)
+            ..lineTo(6.0, 5.5)
+            ..close();
       expect(
         linePath,
         isNot(coversSameAreaAs(rectPath, areaToCompare: const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0))),
@@ -892,30 +894,30 @@ void main() {
 
       // This should fail due to the mis-match between the `namesRoute` value.
       void failedExpectation() => expect(
-            tester.getSemantics(find.byKey(key)),
-            matchesSemantics(
-              // Adding the explicit `false` for test readability
-              // ignore: avoid_redundant_argument_values
-              namesRoute: false,
-              label: 'foo',
-              hint: 'bar',
-              value: 'baz',
-              increasedValue: 'a',
-              decreasedValue: 'b',
-              textDirection: TextDirection.rtl,
-              hasTapAction: true,
-              hasLongPressAction: true,
-              isButton: true,
-              isLink: true,
-              isHeader: true,
-              onTapHint: 'scan',
-              onLongPressHint: 'fill',
-              customActions: <CustomSemanticsAction>[
-                const CustomSemanticsAction(label: 'foo'),
-                const CustomSemanticsAction(label: 'bar'),
-              ],
-            ),
-          );
+        tester.getSemantics(find.byKey(key)),
+        matchesSemantics(
+          // Adding the explicit `false` for test readability
+          // ignore: avoid_redundant_argument_values
+          namesRoute: false,
+          label: 'foo',
+          hint: 'bar',
+          value: 'baz',
+          increasedValue: 'a',
+          decreasedValue: 'b',
+          textDirection: TextDirection.rtl,
+          hasTapAction: true,
+          hasLongPressAction: true,
+          isButton: true,
+          isLink: true,
+          isHeader: true,
+          onTapHint: 'scan',
+          onLongPressHint: 'fill',
+          customActions: <CustomSemanticsAction>[
+            const CustomSemanticsAction(label: 'foo'),
+            const CustomSemanticsAction(label: 'bar'),
+          ],
+        ),
+      );
 
       expect(failedExpectation, throwsA(isA<TestFailure>()));
       handle.dispose();
@@ -1431,28 +1433,28 @@ void main() {
 
       // This should fail due to the mis-match between the `namesRoute` value.
       void failedExpectation() => expect(
-            tester.getSemantics(find.byKey(key)),
-            containsSemantics(
-              label: 'foo',
-              hint: 'bar',
-              value: 'baz',
-              increasedValue: 'a',
-              decreasedValue: 'b',
-              textDirection: TextDirection.rtl,
-              hasTapAction: true,
-              hasLongPressAction: true,
-              isButton: true,
-              isLink: true,
-              isHeader: true,
-              namesRoute: false,
-              onTapHint: 'scan',
-              onLongPressHint: 'fill',
-              customActions: <CustomSemanticsAction>[
-                const CustomSemanticsAction(label: 'foo'),
-                const CustomSemanticsAction(label: 'bar'),
-              ],
-            ),
-          );
+        tester.getSemantics(find.byKey(key)),
+        containsSemantics(
+          label: 'foo',
+          hint: 'bar',
+          value: 'baz',
+          increasedValue: 'a',
+          decreasedValue: 'b',
+          textDirection: TextDirection.rtl,
+          hasTapAction: true,
+          hasLongPressAction: true,
+          isButton: true,
+          isLink: true,
+          isHeader: true,
+          namesRoute: false,
+          onTapHint: 'scan',
+          onLongPressHint: 'fill',
+          customActions: <CustomSemanticsAction>[
+            const CustomSemanticsAction(label: 'foo'),
+            const CustomSemanticsAction(label: 'bar'),
+          ],
+        ),
+      );
 
       expect(failedExpectation, throwsA(isA<TestFailure>()));
       handle.dispose();


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/166101, overall goal is to update semantics flag to be a struct/class to support more than 32 flags.

step 1: https://github.com/flutter/flutter/pull/167421 Update semantics_node.h and dart:ui
step 2: https://github.com/flutter/flutter/pull/167738  Update Embedder part to use a struct instead of a int bit mask.
step 3:(this PR) Update Framework use the SemanticsFlags class instead of bitmask

TODO:
web engine
use the new class

SemanticsUpdateBuilder.updateNode
pass a list of bools instead of bitmask

flutter_tester
use the SemanticsFlags class instead of bitmask

[apicheck_test.dart](https://github.com/flutter/flutter/pull/167421/files#diff-69aefaacf1041f639974044962123bfae0756ce86032ac1f26256099425d7a5a)
Add this test back