### PR TITLE
Improve log output of keyboard_hot_restart_ios

### DIFF
--- a/dev/devicelab/lib/tasks/keyboard_hot_restart_test.dart
+++ b/dev/devicelab/lib/tasks/keyboard_hot_restart_test.dart
@@ -133,8 +133,8 @@ Future<int> runApp({
   final Completer<void> stderrDone = Completer<void>();
 
   void onStdout(String line) {
-    onLine(line, process);
     print('stdout: $line');
+    onLine(line, process);
   }
 
   process.stdout


### PR DESCRIPTION
The keyboard hot restart test listens to `flutter run` logs and then does an action. However, the test prints the `flutter run` log after the action. This results in confusing logs.

For example: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8716606099574306145/+/u/run_keyboard_hot_restart_ios/stdout

```
═══════════╡ ••• Launch app and wait for keyboard to be visible ••• ╞═══════════
...
stdout: Installing and launching...                                        37.2s
stdout: Syncing files to device swarming’s iPhone...                    


════╡ ••• Update the app to no longer force the keyboard to be visible ••• ╞════



════════════════════════╡ ••• Hot restart the app ••• ╞═════════════════════════



════════════╡ ••• Wait until the keyboard is no longer visible ••• ╞════════════

stdout: flutter: Keyboard is open
```

Here, the test waits until the keyboard is visible before moving onto the test's next step. However, the log that triggers this action (`flutter: Keyboard is open`) is printed after the action was taken (`Update the app to no longer force the keyboard to be visible` and `Wait until the keyboard is no longer visible`). This is confusing.

Follow-up to: https://github.com/flutter/flutter/pull/167013
Part of: https://github.com/flutter/flutter/issues/10713