### PR TITLE
Fix ListTiles theme override

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -841,14 +841,34 @@ class ListTile extends StatelessWidget {
       ).resolve(states);
     }
 
-    final Color? effectiveIconColor = resolveColor(iconColor, selectedColor, iconColor)
-      ?? resolveColor(tileTheme.iconColor, tileTheme.selectedColor, tileTheme.iconColor)
-      ?? resolveColor(theme.listTileTheme.iconColor, theme.listTileTheme.selectedColor, theme.listTileTheme.iconColor)
-      ?? resolveColor(defaults.iconColor, defaults.selectedColor, defaults.iconColor, theme.disabledColor);
-    final Color? effectiveColor = resolveColor(textColor, selectedColor, textColor)
-      ?? resolveColor(tileTheme.textColor, tileTheme.selectedColor, tileTheme.textColor)
-      ?? resolveColor(theme.listTileTheme.textColor, theme.listTileTheme.selectedColor, theme.listTileTheme.textColor)
-      ?? resolveColor(defaults.textColor, defaults.selectedColor, defaults.textColor, theme.disabledColor);
+    final Color? effectiveIconColor =
+        resolveColor(iconColor, selectedColor, iconColor) ??
+        resolveColor(tileTheme.iconColor, tileTheme.selectedColor, tileTheme.iconColor) ??
+        resolveColor(
+          theme.listTileTheme.iconColor,
+          theme.listTileTheme.selectedColor,
+          theme.listTileTheme.iconColor,
+        ) ??
+        resolveColor(
+          defaults.iconColor,
+          defaults.selectedColor,
+          defaults.iconColor,
+          theme.disabledColor,
+        );
+    final Color? effectiveColor =
+        resolveColor(textColor, selectedColor, textColor) ??
+        resolveColor(tileTheme.textColor, tileTheme.selectedColor, tileTheme.textColor) ??
+        resolveColor(
+          theme.listTileTheme.textColor,
+          theme.listTileTheme.selectedColor,
+          theme.listTileTheme.textColor,
+        ) ??
+        resolveColor(
+          defaults.textColor,
+          defaults.selectedColor,
+          defaults.textColor,
+          theme.disabledColor,
+        );
 
     final IconButtonThemeData currentIconTheme = IconButtonTheme.of(context);
     final IconThemeData iconThemeData = IconThemeData(color: effectiveIconColor);

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -873,9 +873,9 @@ class ListTile extends StatelessWidget {
     final IconButtonThemeData currentIconTheme = IconButtonTheme.of(context);
     final IconThemeData iconThemeData = IconThemeData(color: effectiveIconColor);
     final IconButtonThemeData iconButtonThemeData = IconButtonThemeData(
-      style: IconButton.styleFrom(
-        foregroundColor: effectiveIconColor,
-      ).merge(currentIconTheme.style),
+      style: currentIconTheme.style?.copyWith(
+        foregroundColor: MaterialStateProperty.all(effectiveIconColor),
+      ),
     );
 
     TextStyle? leadingAndTrailingStyle;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -873,9 +873,11 @@ class ListTile extends StatelessWidget {
     final IconButtonThemeData currentIconTheme = IconButtonTheme.of(context);
     final IconThemeData iconThemeData = IconThemeData(color: effectiveIconColor);
     final IconButtonThemeData iconButtonThemeData = IconButtonThemeData(
-      style: currentIconTheme.style?.copyWith(
-        foregroundColor: MaterialStateProperty.all(effectiveIconColor),
-      ),
+      style:
+          currentIconTheme.style?.copyWith(
+            foregroundColor: WidgetStateProperty.all(effectiveIconColor),
+          ) ??
+          IconButton.styleFrom(foregroundColor: effectiveIconColor),
     );
 
     TextStyle? leadingAndTrailingStyle;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -841,37 +841,21 @@ class ListTile extends StatelessWidget {
       ).resolve(states);
     }
 
-    final Color? effectiveIconColor =
-        resolveColor(iconColor, selectedColor, iconColor) ??
-        resolveColor(tileTheme.iconColor, tileTheme.selectedColor, tileTheme.iconColor) ??
-        resolveColor(
-          theme.listTileTheme.iconColor,
-          theme.listTileTheme.selectedColor,
-          theme.listTileTheme.iconColor,
-        ) ??
-        resolveColor(
-          defaults.iconColor,
-          defaults.selectedColor,
-          defaults.iconColor,
-          theme.disabledColor,
-        );
-    final Color? effectiveColor =
-        resolveColor(textColor, selectedColor, textColor) ??
-        resolveColor(tileTheme.textColor, tileTheme.selectedColor, tileTheme.textColor) ??
-        resolveColor(
-          theme.listTileTheme.textColor,
-          theme.listTileTheme.selectedColor,
-          theme.listTileTheme.textColor,
-        ) ??
-        resolveColor(
-          defaults.textColor,
-          defaults.selectedColor,
-          defaults.textColor,
-          theme.disabledColor,
-        );
+    final Color? effectiveIconColor = resolveColor(iconColor, selectedColor, iconColor)
+      ?? resolveColor(tileTheme.iconColor, tileTheme.selectedColor, tileTheme.iconColor)
+      ?? resolveColor(theme.listTileTheme.iconColor, theme.listTileTheme.selectedColor, theme.listTileTheme.iconColor)
+      ?? resolveColor(defaults.iconColor, defaults.selectedColor, defaults.iconColor, theme.disabledColor);
+    final Color? effectiveColor = resolveColor(textColor, selectedColor, textColor)
+      ?? resolveColor(tileTheme.textColor, tileTheme.selectedColor, tileTheme.textColor)
+      ?? resolveColor(theme.listTileTheme.textColor, theme.listTileTheme.selectedColor, theme.listTileTheme.textColor)
+      ?? resolveColor(defaults.textColor, defaults.selectedColor, defaults.textColor, theme.disabledColor);
+
+    final IconButtonThemeData currentIconTheme = IconButtonTheme.of(context);
     final IconThemeData iconThemeData = IconThemeData(color: effectiveIconColor);
     final IconButtonThemeData iconButtonThemeData = IconButtonThemeData(
-      style: IconButton.styleFrom(foregroundColor: effectiveIconColor),
+      style: IconButton.styleFrom(
+        foregroundColor: effectiveIconColor,
+      ).merge(currentIconTheme.style),
     );
 
     TextStyle? leadingAndTrailingStyle;

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2300,6 +2300,52 @@ void main() {
     },
   );
 
+  testWidgets('ListTile merge its iconButtonThemeData with the parent iconButtonThemeData', (
+    WidgetTester tester,
+  ) async {
+    const Color listTileIconColor = Colors.green;
+    const Icon leadingIcon = Icon(Icons.favorite);
+    const Icon trailingIcon = Icon(Icons.close);
+    const OutlinedBorder shape = RoundedRectangleBorder(side: BorderSide());
+
+    Widget buildFrame() {
+      return MaterialApp(
+        theme: ThemeData(
+          iconButtonTheme: IconButtonThemeData(style: IconButton.styleFrom(shape: shape)),
+        ),
+        home: Material(
+          child: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ListTile(
+                  iconColor: listTileIconColor,
+                  leading: IconButton(icon: leadingIcon, onPressed: () {}),
+                  trailing: IconButton(icon: trailingIcon, onPressed: () {}),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    TextStyle? getIconStyle(WidgetTester tester, IconData icon) =>
+        tester
+            .widget<RichText>(
+              find.descendant(of: find.byIcon(icon), matching: find.byType(RichText)),
+            )
+            .text
+            .style;
+    await tester.pumpWidget(buildFrame());
+
+    final BuildContext listTileContext = tester.element(find.byType(ListTile));
+    final IconButtonThemeData iconButtonThemeData = IconButtonTheme.of(listTileContext);
+
+    expect(iconButtonThemeData.style?.shape?.resolve(<MaterialState>{}), shape);
+    expect(getIconStyle(tester, leadingIcon.icon!)?.color, listTileIconColor);
+    expect(getIconStyle(tester, trailingIcon.icon!)?.color, listTileIconColor);
+  });
+
   testWidgets('ListTile.dense does not throw assertion', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/pull/116908
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2300,7 +2300,7 @@ void main() {
     },
   );
 
-  testWidgets('ListTile merge its iconButtonThemeData with the parent iconButtonThemeData', (
+  testWidgets('ListTile merges its IconButtonThemeData with parent IconButtonThemeData', (
     WidgetTester tester,
   ) async {
     const Color listTileIconColor = Colors.green;


### PR DESCRIPTION
Fix issue with the IconButtonThemeData being overrided by the ListTile IconButtonThemeData



issue: #167727

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X ] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
