### PR TITLE
TreeSliver collapse animation jump bug

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver_tree.dart
+++ b/packages/flutter/lib/src/widgets/sliver_tree.dart
@@ -828,6 +828,15 @@ class _TreeSliverState<T> extends State<TreeSliver<T>>
     }
   }
 
+  int _activeChildrenCount(TreeSliverNode<T> node) {
+    int activeChildrenCountRecursive = 0;
+    for (final TreeSliverNode<T> childNode in node.children) {
+      activeChildrenCountRecursive +=
+        _activeNodes.contains(childNode) ? 1 + _activeChildrenCount(childNode) : 0;
+    }
+    return activeChildrenCountRecursive;
+  }
+
   void _updateActiveAnimations() {
     // The indexes of various child node animations can change constantly based
     // on more nodes being expanded or collapsed. Compile the indexes and their
@@ -838,7 +847,7 @@ class _TreeSliverState<T> extends State<TreeSliver<T>>
       final int leadingChildIndex = _activeNodes.indexOf(node) + 1;
       final TreeSliverNodesAnimation animatingChildren = (
         fromIndex: leadingChildIndex,
-        toIndex: leadingChildIndex + node.children.length - 1,
+        toIndex: leadingChildIndex + _activeChildrenCount(node) - 1,
         value: animationRecord.animation.value,
       );
       _activeAnimations[animationRecord.key] = animatingChildren;

--- a/packages/flutter/lib/src/widgets/sliver_tree.dart
+++ b/packages/flutter/lib/src/widgets/sliver_tree.dart
@@ -832,7 +832,7 @@ class _TreeSliverState<T> extends State<TreeSliver<T>>
     int activeChildrenCountRecursive = 0;
     for (final TreeSliverNode<T> childNode in node.children) {
       activeChildrenCountRecursive +=
-        _activeNodes.contains(childNode) ? 1 + _activeChildrenCount(childNode) : 0;
+          _activeNodes.contains(childNode) ? 1 + _activeChildrenCount(childNode) : 0;
     }
     return activeChildrenCountRecursive;
   }


### PR DESCRIPTION
Hello!

I recorded the problem in the video so I don't think it will help much to repeat it in written form. In short, there is a little animation bug when collapsing multilevel TreeSliver's, there is a visual jump that gives bad user experience. This is because when counting active children nodes only direct children are considered while child nodes should be considered recursively. I solved the problem and I am sure it is a good and simple solution. In my case it worked smoothly.

Here is the video: https://drive.google.com/file/d/1lQIx_l48O6PGszz_Oi8F6lxUE8eEvLSb/view?usp=sharing