### PR TITLE
iOS: Re-enable iOS unittests

### DIFF
--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -178,11 +178,11 @@ group("unittests") {
     ]
   }
 
-  # Compile all unittests targets if enabled.
+  if (enable_ios_unittests) {
+    public_deps += [ "//flutter/shell/platform/darwin/ios:ios_test_flutter" ]
+  }
+
   if (enable_unittests) {
-    if (is_ios) {
-      public_deps += [ "//flutter/shell/platform/darwin/ios:ios_test_flutter" ]
-    }
     public_deps += [
       "//flutter/assets:assets_unittests",
       "//flutter/display_list:display_list_rendertests",

--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -31,7 +31,7 @@ config("config_swift") {
   lib_dirs = ios_swift_lib_paths
 
   # Allow use of @testable imports in debug builds and when tests are enabled.
-  if (flutter_runtime_mode == "debug" || enable_unittests) {
+  if (enable_ios_unittests) {
     swiftflags = [ "-enable-testing" ]
   }
 }
@@ -209,97 +209,99 @@ source_set("flutter_framework_source") {
   ]
 }
 
-platform_frameworks_path =
-    rebase_path("$ios_sdk_path/../../Library/Frameworks/")
+if (enable_ios_unittests) {
+  platform_frameworks_path =
+      rebase_path("$ios_sdk_path/../../Library/Frameworks/")
 
-source_set("ios_test_flutter_swift") {
-  testonly = true
-  visibility = [ ":*" ]
-  configs += [ ":config_swift" ]
+  source_set("ios_test_flutter_swift") {
+    testonly = true
+    visibility = [ ":*" ]
+    configs += [ ":config_swift" ]
 
-  sources = [ "framework/Source/FakeUIPressProxy.swift" ]
-  deps = [ ":InternalFlutterSwift" ]
-}
+    sources = [ "framework/Source/FakeUIPressProxy.swift" ]
+    deps = [ ":InternalFlutterSwift" ]
+  }
 
-shared_library("ios_test_flutter") {
-  testonly = true
-  visibility = [ "*" ]
+  shared_library("ios_test_flutter") {
+    testonly = true
+    visibility = [ "*" ]
 
-  cflags_objc = flutter_cflags_objc
-  cflags_objcc = flutter_cflags_objcc
-  cflags = [
-    "-fvisibility=default",
-    "-F$platform_frameworks_path",
-    "-mios-simulator-version-min=$ios_testing_deployment_target",
-  ]
+    cflags_objc = flutter_cflags_objc
+    cflags_objcc = flutter_cflags_objcc
+    cflags = [
+      "-fvisibility=default",
+      "-F$platform_frameworks_path",
+      "-mios-simulator-version-min=$ios_testing_deployment_target",
+    ]
 
-  ldflags = [
-    "-F$platform_frameworks_path",
-    "-Wl,-install_name,@rpath/Frameworks/libios_test_flutter.dylib",
-  ]
-  frameworks = [ "XCTest.framework" ]
-  configs += [ ":config_ios" ]
-  configs -= [
-    "//build/config/gcc:symbol_visibility_hidden",
-    "//build/config:symbol_visibility_hidden",
-  ]
-  sources = [
-    "framework/Source/FlutterAppDelegateTest.mm",
-    "framework/Source/FlutterChannelKeyResponderTest.mm",
-    "framework/Source/FlutterDartProjectTest.mm",
-    "framework/Source/FlutterEmbedderKeyResponderTest.mm",
-    "framework/Source/FlutterEngineGroupTest.mm",
-    "framework/Source/FlutterEnginePlatformViewTest.mm",
-    "framework/Source/FlutterEngineTest.mm",
-    "framework/Source/FlutterFakeKeyEvents.h",
-    "framework/Source/FlutterFakeKeyEvents.mm",
-    "framework/Source/FlutterKeyboardManagerTest.mm",
-    "framework/Source/FlutterMetalLayerTest.mm",
-    "framework/Source/FlutterPlatformPluginTest.mm",
-    "framework/Source/FlutterPlatformViewsTest.mm",
-    "framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm",
-    "framework/Source/FlutterRestorationPluginTest.mm",
-    "framework/Source/FlutterSharedApplicationTest.mm",
-    "framework/Source/FlutterSpellCheckPluginTest.mm",
-    "framework/Source/FlutterTextInputPluginTest.mm",
-    "framework/Source/FlutterTextureRegistryRelayTest.mm",
-    "framework/Source/FlutterTouchInterceptingView_Test.h",
-    "framework/Source/FlutterUndoManagerPluginTest.mm",
-    "framework/Source/FlutterViewControllerTest.mm",
-    "framework/Source/FlutterViewTest.mm",
-    "framework/Source/SemanticsObjectTest.mm",
-    "framework/Source/SemanticsObjectTestMocks.h",
-    "framework/Source/UIViewController_FlutterScreenAndSceneIfLoadedTest.mm",
-    "framework/Source/VsyncWaiterIosTest.mm",
-    "framework/Source/accessibility_bridge_test.mm",
-    "framework/Source/availability_version_check_test.mm",
-    "framework/Source/connection_collection_test.mm",
-    "ios_context_noop_unittests.mm",
-    "ios_surface_noop_unittests.mm",
-    "platform_message_handler_ios_test.mm",
-  ]
-  deps = [
-    ":InternalFlutterSwift",
-    ":flutter_framework",
-    ":flutter_framework_source",
-    ":ios_gpu_configuration",
-    ":ios_test_flutter_swift",
-    "//flutter/common:common",
-    "//flutter/lib/ui:ui",
-    "//flutter/shell/platform/darwin/common:framework_common",
-    "//flutter/shell/platform/embedder:embedder_as_internal_library",
-    "//flutter/shell/platform/embedder:embedder_test_utils",
-    "//flutter/third_party/ocmock:ocmock_shared",
-    "//flutter/third_party/rapidjson",
-    "//flutter/third_party/spring_animation",
-    "//flutter/third_party/tonic",
-    "//flutter/txt",
-  ]
-  public_configs = [
-    ":ios_gpu_configuration_config",
-    "//flutter:config",
-  ]
-}
+    ldflags = [
+      "-F$platform_frameworks_path",
+      "-Wl,-install_name,@rpath/Frameworks/libios_test_flutter.dylib",
+    ]
+    frameworks = [ "XCTest.framework" ]
+    configs += [ ":config_ios" ]
+    configs -= [
+      "//build/config/gcc:symbol_visibility_hidden",
+      "//build/config:symbol_visibility_hidden",
+    ]
+    sources = [
+      "framework/Source/FlutterAppDelegateTest.mm",
+      "framework/Source/FlutterChannelKeyResponderTest.mm",
+      "framework/Source/FlutterDartProjectTest.mm",
+      "framework/Source/FlutterEmbedderKeyResponderTest.mm",
+      "framework/Source/FlutterEngineGroupTest.mm",
+      "framework/Source/FlutterEnginePlatformViewTest.mm",
+      "framework/Source/FlutterEngineTest.mm",
+      "framework/Source/FlutterFakeKeyEvents.h",
+      "framework/Source/FlutterFakeKeyEvents.mm",
+      "framework/Source/FlutterKeyboardManagerTest.mm",
+      "framework/Source/FlutterMetalLayerTest.mm",
+      "framework/Source/FlutterPlatformPluginTest.mm",
+      "framework/Source/FlutterPlatformViewsTest.mm",
+      "framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm",
+      "framework/Source/FlutterRestorationPluginTest.mm",
+      "framework/Source/FlutterSharedApplicationTest.mm",
+      "framework/Source/FlutterSpellCheckPluginTest.mm",
+      "framework/Source/FlutterTextInputPluginTest.mm",
+      "framework/Source/FlutterTextureRegistryRelayTest.mm",
+      "framework/Source/FlutterTouchInterceptingView_Test.h",
+      "framework/Source/FlutterUndoManagerPluginTest.mm",
+      "framework/Source/FlutterViewControllerTest.mm",
+      "framework/Source/FlutterViewTest.mm",
+      "framework/Source/SemanticsObjectTest.mm",
+      "framework/Source/SemanticsObjectTestMocks.h",
+      "framework/Source/UIViewController_FlutterScreenAndSceneIfLoadedTest.mm",
+      "framework/Source/VsyncWaiterIosTest.mm",
+      "framework/Source/accessibility_bridge_test.mm",
+      "framework/Source/availability_version_check_test.mm",
+      "framework/Source/connection_collection_test.mm",
+      "ios_context_noop_unittests.mm",
+      "ios_surface_noop_unittests.mm",
+      "platform_message_handler_ios_test.mm",
+    ]
+    deps = [
+      ":InternalFlutterSwift",
+      ":flutter_framework",
+      ":flutter_framework_source",
+      ":ios_gpu_configuration",
+      ":ios_test_flutter_swift",
+      "//flutter/common:common",
+      "//flutter/lib/ui:ui",
+      "//flutter/shell/platform/darwin/common:framework_common",
+      "//flutter/shell/platform/embedder:embedder_as_internal_library",
+      "//flutter/shell/platform/embedder:embedder_test_utils",
+      "//flutter/third_party/ocmock:ocmock_shared",
+      "//flutter/third_party/rapidjson",
+      "//flutter/third_party/spring_animation",
+      "//flutter/third_party/tonic",
+      "//flutter/txt",
+    ]
+    public_configs = [
+      ":ios_gpu_configuration_config",
+      "//flutter:config",
+    ]
+  }
+}  # if (enable_ios_unittests)
 
 shared_library("create_flutter_framework_dylib") {
   visibility = [ ":*" ]

--- a/engine/src/flutter/testing/testing.gni
+++ b/engine/src/flutter/testing/testing.gni
@@ -9,12 +9,19 @@ import("//flutter/common/config.gni")
 is_aot_test =
     flutter_runtime_mode == "profile" || flutter_runtime_mode == "release"
 
-# Build unit tests when any of the following are true:
-# * host_toolchain: non-cross-compile, so we can run tests on the host.
-# * is_mac: arm64 builds can run x64 binaries.
-# * is_fuchsia: build unittests for testing on device.
 declare_args() {
+  # Build portable unit tests. These test a broad swath of generic Flutter
+  # functionality on general-purpose operating systems:
+  # * host_toolchain: non-cross-compile. We can run tests on the host.
+  # * Fuchsia: build unittests for testing on device.
+  # * macOS: arm64 builds can run x64 binaries.
   enable_unittests = current_toolchain == host_toolchain || is_fuchsia || is_mac
+
+  # Build iOS target device unit tests.
+  #
+  # Build unittests for testing on device for non-profile/release builds since
+  # we compile with --enable-tests, which impacts exported symbols.
+  enable_ios_unittests = is_ios && flutter_runtime_mode == "debug"
 }
 
 # Creates a translation unit that defines the flutter::testing::GetFixturesPath


### PR DESCRIPTION
Re-enables iOS unittests, which were inadvertently disabled as part of #167530.

This extracts out `enable_ios_unittests` for readability/re-usability across the build system, and better documents `enable_unittests` as specifically being for platform-portable unit tests that can be run on general-purpose operating systems such as macOS, Fuchsia, Linux, but not specific target OSes such as iOS/Android that require executables to be built against platform SDKs as installable apps.

Issue: https://github.com/flutter/flutter/issues/144791

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
