### PR TITLE
ColorFilter.saturation

### DIFF
--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4046,9 +4046,9 @@ class ColorFilter implements ImageFilter {
   /// Creates a color filter that applies the given saturation to the RGB
   /// channels.
   factory ColorFilter.saturation(double saturation) {
-    const r = 0.2126;
-    const g = 0.7152;
-    const b = 0.0722;
+    const double r = 0.2126;
+    const double g = 0.7152;
+    const double b = 0.0722;
     final double invSat = 1 - saturation;
 
     // https://github.com/flutter/flutter/issues/166589#issuecomment-2779794114

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4043,6 +4043,25 @@ class ColorFilter implements ImageFilter {
       _matrix = null,
       _type = _kTypeSrgbToLinearGamma;
 
+  /// Creates a color filter that applies the given saturation to the RGB
+  /// channels.
+  factory ColorFilter.saturation(double saturation) {
+    const r = 0.2126;
+    const g = 0.7152;
+    const b = 0.0722;
+    final double invSat = 1 - saturation;
+
+    // https://github.com/flutter/flutter/issues/166589#issuecomment-2779794114
+    return ColorFilter.matrix(<double>[
+      // dart format off
+        invSat * r + saturation, invSat * g,              invSat * b,              0, 0,
+        invSat * r,              invSat * g + saturation, invSat * b,              0, 0,
+        invSat * r,              invSat * g,              invSat * b + saturation, 0, 0,
+        0,                       0,                       0,                       1, 0,
+      // dart format on
+    ]);
+  }
+
   final Color? _color;
   final BlendMode? _blendMode;
   final List<double>? _matrix;

--- a/engine/src/flutter/lib/web_ui/lib/painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/painting.dart
@@ -443,6 +443,7 @@ class ColorFilter implements ImageFilter {
   const factory ColorFilter.matrix(List<double> matrix) = engine.EngineColorFilter.matrix;
   const factory ColorFilter.linearToSrgbGamma() = engine.EngineColorFilter.linearToSrgbGamma;
   const factory ColorFilter.srgbToLinearGamma() = engine.EngineColorFilter.srgbToLinearGamma;
+  const factory ColorFilter.saturation(double saturation) = engine.EngineColorFilter.saturation;
 }
 
 // These enum values must be kept in sync with SkBlurStyle.

--- a/packages/flutter/test/widgets/color_filter_test.dart
+++ b/packages/flutter/test/widgets/color_filter_test.dart
@@ -56,6 +56,46 @@ void main() {
     await expectLater(find.byType(ColorFiltered), matchesGoldenFile('color_filter_sepia.png'));
   });
 
+  testWidgets('Color filter - saturation', (WidgetTester tester) async {
+    Future<void> pumpWithColorFilter(ColorFilter colorFilter) {
+      return tester.pumpWidget(
+        RepaintBoundary(
+          child: Container(
+            color: Colors.red,
+            alignment: Alignment.center,
+            child: ColorFiltered(
+              colorFilter: colorFilter,
+              child: Container(
+                height: 256,
+                width: 256,
+                decoration: BoxDecoration(
+                  color: Colors.blue,
+                  borderRadius: BorderRadius.circular(64),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await pumpWithColorFilter(ColorFilter.saturation(0));
+    await expectLater(
+      find.byType(RepaintBoundary),
+      matchesGoldenFile('color_filter_saturation_none.png'),
+    );
+    await pumpWithColorFilter(ColorFilter.saturation(0.5));
+    await expectLater(
+      find.byType(RepaintBoundary),
+      matchesGoldenFile('color_filter_saturation_partial.png'),
+    );
+    await pumpWithColorFilter(ColorFilter.saturation(1));
+    await expectLater(
+      find.byType(RepaintBoundary),
+      matchesGoldenFile('color_filter_saturation_full.png'),
+    );
+  });
+
   testWidgets('Color filter - reuses its layer', (WidgetTester tester) async {
     Future<void> pumpWithColor(Color color) async {
       await tester.pumpWidget(


### PR DESCRIPTION
Resolves #166589

I'm not sure how to update the Goldens but here are the three I have locally. Test was written to ensure that transparency is preserved.

<details>
<summary> golden files </summary>

`ColorFilter.saturation(1)`

![color_filter_saturation_full](https://github.com/user-attachments/assets/f5b75943-e8ed-48b8-859d-fbf883e7c7a0)

`ColorFilter.saturation(0.5)`

![color_filter_saturation_partial](https://github.com/user-attachments/assets/213146f2-86c4-499c-94bd-697402903510)

`ColorFilter.saturation(0)`

![color_filter_saturation_none](https://github.com/user-attachments/assets/b4515a37-60c9-4306-9046-44951e2a62b5)

</details>

---

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
