### PR TITLE
macOS: remove unused mac_sdk_min

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -100,10 +100,6 @@ vars = {
   # Checkout Linux dependencies only when building on Linux.
   'download_linux_deps': 'host_os == "linux"',
 
-  # The minimum macOS SDK version. This must match the setting in
-  # //flutter/tools/gn.
-  'mac_sdk_min': '10.14',
-
   # Checkout Fuchsia dependencies only on Linux. This is the umbrella flag which
   # controls the behavior of all fuchsia related flags. I.e. any fuchsia related
   # logic or condition may not work if this flag is False.
@@ -1011,7 +1007,6 @@ hooks = [
       'python3',
       'engine/src/build/mac/find_sdk.py',
       '--as-gclient-hook',
-      Var('mac_sdk_min')
     ]
   },
   {

--- a/engine/src/build/config/mac/mac_sdk.gni
+++ b/engine/src/build/config/mac/mac_sdk.gni
@@ -6,20 +6,15 @@ import("//build/config/apple/apple_sdk.gni")
 import("//build/toolchain/rbe.gni")
 
 declare_args() {
-  # Minimum supported version of the Mac SDK.
-  mac_sdk_min = ""
-
   # The MACOSX_DEPLOYMENT_TARGET variable used when compiling.
   # Must be of the form x.x.x for Info.plist files.
   mac_deployment_target = ""
 
   # Path to a specific version of the Mac SDK, not including a backslash at
-  # the end. If empty, the path to the lowest version greater than or equal to
-  # mac_sdk_min is used.
+  # the end.
   mac_sdk_path = ""
 }
 
-assert(mac_sdk_min != "")
 assert(mac_deployment_target != "")
 
 if (mac_sdk_path == "") {
@@ -31,10 +26,7 @@ if (mac_sdk_path == "") {
       rebase_path("//flutter/prebuilts"),
     ]
   }
-  find_sdk_args += [
-    "--print_sdk_path",
-    mac_sdk_min,
-  ]
+  find_sdk_args += [ "--print_sdk_path" ]
 
   # Outputs the SDK path on the first line, and the host toolchain path on the
   # second.

--- a/engine/src/build/mac/find_sdk.py
+++ b/engine/src/build/mac/find_sdk.py
@@ -65,7 +65,6 @@ def main():
                     action="store", type="string", dest="symlink",
                     help="Whether to create a symlink in the buildroot to the SDK.")
   (options, args) = parser.parse_args()
-  min_sdk_version = args[0]
 
   # On CI, Xcode is not yet installed when gclient hooks are being run.
   # This is because the version of Xcode that CI installs might depend on the

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -264,10 +264,6 @@ def setup_rbe(args):
 def setup_apple_sdks():
   sdks_gn_args = {}
 
-  # These are needed on a macOS host regardless of target.
-  # This value should agree with the 'mac_sdk_min' value in the DEPS file.
-  sdks_gn_args['mac_sdk_min'] = '10.14'
-
   # The MACOSX_DEPLOYMENT_TARGET variable used when compiling.
   # Must be of the form x.x.x for Info.plist files.
   sdks_gn_args['mac_deployment_target'] = '10.14.0'


### PR DESCRIPTION
This variable is no longer used in //build/mac/find_sdk.py or in our build. It was removed in flutter/buildroot#912. Previously, we worked out the SDK path from a list of available SDKs, and used mac_sdk_min as a filter. We now use `xcrun --sdk macosx --show-sdk-path` to get the SDK path and no longer need this variable.

This is a pre-factoring patch to reduce the size of the upcoming merge of iOS and macOS SDK config/resolving infrastructure.

No test changes since this is dead code elimination.

Issue: https://github.com/flutter/flutter/issues/167592

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
