### PR TITLE
iOS,macOS: delete run_command_with_retry

### DIFF
--- a/engine/src/build/config/ios/ios_sdk.py
+++ b/engine/src/build/config/ios/ios_sdk.py
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import argparse
-import errno
 import os
 import shutil
 import subprocess
@@ -20,28 +19,6 @@ SDKs = ['iphoneos', 'iphonesimulator']
 PREBUILTS = os.path.realpath(os.path.join(
   os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, 'flutter', 'prebuilts',
 ))
-
-
-def run_command_with_retry(command, timeout=10, retries=3):
-  """
-  Runs a command using subprocess.check_output with timeout and retry logic.
-
-  Args:
-      command: A list representing the command and its arguments.
-      timeout: The maximum time (in seconds) to wait for each command execution.
-      retries: The number of times to retry the command if it times out.
-
-  Returns:
-      The output of the command as a bytes object if successful, otherwise
-      raises a CalledProcessError.
-  """
-  for attempt in range(1, retries + 1):
-    try:
-      result = subprocess.check_output(command, timeout=timeout)
-      return result.decode('utf-8').strip()
-    except subprocess.TimeoutExpired:
-      if attempt >= retries:
-        raise  # Re-raise the TimeoutExpired error after all retries
 
 
 def main(argv):
@@ -98,7 +75,7 @@ def main(argv):
       sdk,
       '--show-sdk-path',
     ]
-    sdk_output = run_command_with_retry(command, timeout=300)
+    sdk_output = subprocess.check_output(command, timeout=300).decode('utf-8').strip()
     if symlink_path:
       symlink_target = os.path.join(sdks_path, os.path.basename(sdk_output))
       symlink(sdk_output, symlink_target)

--- a/engine/src/build/mac/find_sdk.py
+++ b/engine/src/build/mac/find_sdk.py
@@ -31,28 +31,6 @@ def parse_version(version_str):
   return [int(x) for x in re.findall(r'(\d+)', version_str)]
 
 
-def run_command_with_retry(command, timeout=10, retries=3):
-  """
-  Runs a command using subprocess.check_output with timeout and retry logic.
-
-  Args:
-      command: A list representing the command and its arguments.
-      timeout: The maximum time (in seconds) to wait for each command execution.
-      retries: The number of times to retry the command if it times out.
-
-  Returns:
-      The output of the command as a bytes object if successful, otherwise
-      raises a CalledProcessError.
-  """
-  for attempt in range(1, retries + 1):
-    try:
-      result = subprocess.check_output(command, timeout=timeout)
-      return result.decode('utf-8').strip()
-    except subprocess.TimeoutExpired:
-      if attempt >= retries:
-        raise  # Re-raise the TimeoutExpired error after all retries
-
-
 def main():
   parser = OptionParser()
   parser.add_option("--print_sdk_path",
@@ -91,7 +69,7 @@ def main():
       'if you are using Xcode 4.') % job.returncode)
 
   # Locate the host toolchain.
-  xcode_dir = run_command_with_retry(['xcode-select', '-print-path'], timeout=300)
+  xcode_dir = subprocess.check_output(['xcode-select', '-print-path'], timeout=300).decode('utf-8').strip()
   toolchain_dir = os.path.join(xcode_dir, 'Toolchains/XcodeDefault.xctoolchain')
 
   # Locate the target SDK.
@@ -101,7 +79,7 @@ def main():
     'macosx',
     '--show-sdk-path',
   ]
-  sdk_output = run_command_with_retry(sdk_command, timeout=300)
+  sdk_output = subprocess.check_output(sdk_command, timeout=300).decode('utf-8').strip()
   if symlink_path:
     sdks_path = os.path.join(symlink_path, 'SDKs')
     # Symlink the host toolchain.


### PR DESCRIPTION
`//build/mac/find_sdk.py` and `//build/config/ios/ios_sdk.py` contain a copy-pasted function to run a given command with a specified number of retries and a timeout. This code was added in https://github.com/flutter/buildroot/pull/876 in response to timeouts on the mac bots in relation to https://github.com/flutter/flutter/issues/157636, and is no longer necessary.

This is a pre-factoring patch to reduce the size of the upcoming merge of iOS and macOS SDK config/resolving infrastructure.

No tests, since this is a refactor with no change in functionality.

Issue: https://github.com/flutter/flutter/issues/167592

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
