### PR TITLE
Fix WidgetStatesController

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -1144,10 +1144,19 @@ class WidgetStatesController extends ValueNotifier<Set<WidgetState>> {
   /// Creates a WidgetStatesController.
   WidgetStatesController([Set<WidgetState>? value]) : super(<WidgetState>{...?value});
 
+  @override
+    Set<WidgetState> get value => <WidgetState>{...super.value};
+
+    @override
+    set value(Set<WidgetState> newValue) {
+      super.value = <WidgetState>{...newValue};
+    }
+
   /// Adds [state] to [value] if [add] is true, and removes it otherwise,
   /// and notifies listeners if [value] has changed.
   void update(WidgetState state, bool add) {
-    final bool valueChanged = add ? value.add(state) : value.remove(state);
+  final Set<WidgetState> mutable = super.value;
+    final bool valueChanged = add ? mutable.add(state) : mutable.remove(state);
     if (valueChanged) {
       notifyListeners();
     }

--- a/packages/flutter/test/widgets/widget_states_controller_test.dart
+++ b/packages/flutter/test/widgets/widget_states_controller_test.dart
@@ -99,4 +99,20 @@ void main() {
     expect(controller.value, <WidgetState>{});
     expect(count, 1);
   });
+
+  test('WidgetStatesController original reference', () {
+    final WidgetStatesController controller = WidgetStatesController();
+    final Set<WidgetState> original = controller.value;
+
+    expect(original.isEmpty, true);
+
+    controller.update(WidgetState.pressed, true);
+
+
+   expect(controller.value.contains(WidgetState.pressed), true);
+
+   expect(original, isEmpty, reason: 'Original reference should remain empty after update.');
+
+  });
+
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR fixes an unexpected behavior in WidgetStatesController, where updating the controller would unintentionally mutate any previously saved reference to its value.

Fixes #167916 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.(There was one test that was failing even before i made any change so the changes i made were not related to the test failed, related test: flutter/packages/flutter/test/cupertino/popup_surface_test.dart -p vm --plain-name 'Saturation is applied before blur'
 
If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
