### PR TITLE
[Windows] Improve et's error if gclient has never been run

### DIFF
--- a/engine/src/flutter/bin/et.bat
+++ b/engine/src/flutter/bin/et.bat
@@ -31,6 +31,9 @@ IF "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
 )
 
 SET dart=%dart_sdk_path%\bin\dart.exe
+IF NOT EXIST "%dart%" (
+    ECHO Error: You must run 'gclient sync -D' before using this tool && EXIT /B 1
+)
 
 cd "%engine_tool_dir%"
 


### PR DESCRIPTION
Mirrors et's shell error here:

https://github.com/flutter/flutter/blob/69da944f9ec3fa20c3026e9a7d3ccb7c1458851c/engine/src/flutter/bin/et#L55-L58