### PR TITLE
iOS: extract config_ios_test

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -24,16 +24,27 @@ shell_gpu_configuration("ios_gpu_configuration") {
 
 config("config_ios") {
   include_dirs = [ target_gen_dir ]
-}
-
-config("config_swift") {
-  configs = [ ":config_ios" ]
   lib_dirs = ios_swift_lib_paths
 
   # Allow use of @testable imports in debug builds and when tests are enabled.
   if (enable_ios_unittests) {
     swiftflags = [ "-enable-testing" ]
   }
+}
+
+config("config_ios_test") {
+  configs = [ ":config_ios" ]
+
+  # Add platform frameworks directory to search path for test frameworks.
+  # Add platform lib to search path for test libraries/Swift modules.
+  cflags = [
+    "-fvisibility=default",
+    "-F$ios_platform_path/Developer/Library/Frameworks",
+  ]
+  swiftflags = [ "-F$ios_platform_path/Developer/Library/Frameworks" ]
+  include_dirs = [ "$ios_platform_path/Developer/usr/lib" ]
+  framework_dirs = [ "$ios_platform_path/Developer/Library/Frameworks" ]
+  lib_dirs = [ "$ios_platform_path/Developer/usr/lib" ]
 }
 
 # The headers that will be copied to the Flutter.framework and be accessed
@@ -55,7 +66,7 @@ _flutter_framework_headers_copy_dir = "$_flutter_framework_dir/Headers"
 
 source_set("InternalFlutterSwift") {
   visibility = [ ":*" ]
-  configs += [ ":config_swift" ]
+  configs += [ ":config_ios" ]
 
   sources = [ "framework/Source/UIPressProxy.swift" ]
 }
@@ -70,7 +81,6 @@ source_set("flutter_framework_source") {
     ":ios_gpu_configuration_config",
     "//flutter:config",
   ]
-
   configs += [
     ":config_ios",
     "//build/config/ios:ios_application_extension",
@@ -213,9 +223,9 @@ if (enable_ios_unittests) {
   source_set("ios_test_flutter_swift") {
     testonly = true
     visibility = [ ":*" ]
-    configs += [ ":config_swift" ]
-
+    configs += [ ":config_ios_test" ]
     sources = [ "framework/Source/FakeUIPressProxy.swift" ]
+    frameworks = [ "XCTest.framework" ]
     deps = [ ":InternalFlutterSwift" ]
   }
 
@@ -227,16 +237,13 @@ if (enable_ios_unittests) {
     cflags_objcc = flutter_cflags_objcc
     cflags = [
       "-fvisibility=default",
-      "-F$ios_platform_path/Developer/Library/Frameworks",
       "-mios-simulator-version-min=$ios_testing_deployment_target",
     ]
 
-    ldflags = [
-      "-F$ios_platform_path/Developer/Library/Frameworks",
-      "-Wl,-install_name,@rpath/Frameworks/libios_test_flutter.dylib",
-    ]
+    ldflags =
+        [ "-Wl,-install_name,@rpath/Frameworks/libios_test_flutter.dylib" ]
     frameworks = [ "XCTest.framework" ]
-    configs += [ ":config_ios" ]
+    configs += [ ":config_ios_test" ]
     configs -= [
       "//build/config/gcc:symbol_visibility_hidden",
       "//build/config:symbol_visibility_hidden",


### PR DESCRIPTION
Creates a config for iOS test targets, which includes framework, library, and swiftmodule paths for for XCTest and other SDK testing libraries.

This patch:
* Merges `config_ios` and `config_swift`. `config_swift` was equivalent to `config_ios` but just with additional `swiftargs`. Since `swiftargs` is ignored in Obj-C targets, we can just merge the two for simplicity.
* Adds a `config_ios_test` which adds:
  * `$ios_platform_path/Developer/Library/Frameworks` to the framework search path, used for XCTest.framework in Obj-C/Swift builds.
  * `$ios_platform_path/Developer/usr/lib` to the include path, use for XCTest.swiftmodule in Swift builds.
  * `$ios_platform_path/Developer/usr/lib` to the lib dirs used by the linker when building Swift code.

Note that we manually pass the `-F` flag via `cflags` (Obj-C) and `swiftflags` (Swift) for the framework search path _as well as_ via the more general `framework_dirs` param. This is because our macOS/iOS compiler toolchain doesn't correctly translate `framework_dirs` into the compiler invocation for either Obj-C or Swift builds, _but_ it's correctly passed to linker invocations in our toolchain.

As a followup, I'll update our toolchain to translate the contents of `framework_dirs` to the appropriate `-F` flags passed to the compilers.

Issue: https://github.com/flutter/flutter/issues/144791
Issue: https://github.com/flutter/flutter/issues/167592

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
