### PR TITLE
[Impeller] report application version info as 2.0

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -205,7 +205,18 @@ void ContextVK::Setup(Settings settings) {
   }
 
   vk::ApplicationInfo application_info;
-  application_info.setApplicationVersion(VK_API_VERSION_1_0);
+
+  // Use the same encoding macro as vulkan versions, but otherwise application
+  // version is intended to be the version of the Impeller engine. This version
+  // information, along with the application name below is provided to allow
+  // IHVs to make optimizations and/or disable functionality based on knowledge
+  // of the engine version (for example, to work around bugs). We don't tie this
+  // to the overall Flutter version as that version is not yet defined when the
+  // engine is compiled. Instead we can manually bump it occassionally.
+  //
+  // variant, major, minor, patch
+  application_info.setApplicationVersion(
+      VK_MAKE_API_VERSION(0, 2, 0, 0) /*version 2.0.0*/);
   application_info.setApiVersion(VK_API_VERSION_1_1);
   application_info.setEngineVersion(VK_API_VERSION_1_0);
   application_info.setPEngineName("Impeller");


### PR DESCRIPTION
Update the reported engine so we can distinguish 3.27 engines from (eventually) newer engines.
