### PR TITLE
[ Widget Preview ] Improve widget inspector support for widget previews

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1817,20 +1817,22 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     }
 
     assert(() {
-      result = ValueListenableBuilder<bool>(
-        valueListenable: WidgetsBinding.instance.debugShowWidgetInspectorOverrideNotifier,
-        builder: (BuildContext context, bool debugShowWidgetInspectorOverride, Widget? child) {
-          if (widget.debugShowWidgetInspector || debugShowWidgetInspectorOverride) {
-            return WidgetInspector(
-              exitWidgetSelectionButtonBuilder: widget.exitWidgetSelectionButtonBuilder,
-              moveExitWidgetSelectionButtonBuilder: widget.moveExitWidgetSelectionButtonBuilder,
-              child: child!,
-            );
-          }
-          return child!;
-        },
-        child: result,
-      );
+      if (!WidgetsBinding.instance.debugWillManuallyInjectWidgetInspector) {
+        result = ValueListenableBuilder<bool>(
+          valueListenable: WidgetsBinding.instance.debugShowWidgetInspectorOverrideNotifier,
+          builder: (BuildContext context, bool debugShowWidgetInspectorOverride, Widget? child) {
+            if (widget.debugShowWidgetInspector || debugShowWidgetInspectorOverride) {
+              return WidgetInspector(
+                exitWidgetSelectionButtonBuilder: widget.exitWidgetSelectionButtonBuilder,
+                moveExitWidgetSelectionButtonBuilder: widget.moveExitWidgetSelectionButtonBuilder,
+                child: child!,
+              );
+            }
+            return child!;
+          },
+          child: result,
+        );
+      }
       if (widget.debugShowCheckedModeBanner && WidgetsApp.debugAllowBannerOverride) {
         result = CheckedModeBanner(child: result);
       }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1817,7 +1817,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     }
 
     assert(() {
-      if (!WidgetsBinding.instance.debugWillManuallyInjectWidgetInspector) {
+      if (!WidgetsBinding.instance.debugExcludeRootWidgetInspector) {
         result = ValueListenableBuilder<bool>(
           valueListenable: WidgetsBinding.instance.debugShowWidgetInspectorOverrideNotifier,
           builder: (BuildContext context, bool debugShowWidgetInspectorOverride, Widget? child) {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -501,15 +501,15 @@ mixin WidgetsBinding
   /// to true.
   ///
   /// Used by tools that want more control over which widgets can be selected
-  /// and highlighted by the widget inspector by manually injecting instance of
+  /// and highlighted by the widget inspector by manually injecting instances of
   /// [WidgetInspector].
-  bool get debugWillManuallyInjectWidgetInspector => _debugWillManuallyInjectWidgetInspector;
+  bool get debugExcludeRootWidgetInspector => _debugExcludeRootWidgetInspector;
 
-  set debugWillManuallyInjectWidgetInspector(bool value) {
-    _debugWillManuallyInjectWidgetInspector = value;
+  set debugExcludeRootWidgetInspector(bool value) {
+    _debugExcludeRootWidgetInspector = value;
   }
 
-  bool _debugWillManuallyInjectWidgetInspector = false;
+  bool _debugExcludeRootWidgetInspector = false;
 
   @visibleForTesting
   @override

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -492,6 +492,25 @@ mixin WidgetsBinding
       _debugShowWidgetInspectorOverrideNotifierObject ??= ValueNotifier<bool>(false);
   ValueNotifier<bool>? _debugShowWidgetInspectorOverrideNotifierObject;
 
+  /// If true, [WidgetInspector] will not be automatically injected into the
+  /// widget tree.
+  ///
+  /// This overrides the behavior where [WidgetInspector] is added to the
+  /// widget tree created by [WidgetsApp] when the `debugShowWidgetInspector`
+  /// value is set in [WidgetsApp] or [debugShowWidgetInspectorOverride] is set
+  /// to true.
+  ///
+  /// Used by tools that want more control over which widgets can be selected
+  /// and highlighted by the widget inspector by manually injecting instance of
+  /// [WidgetInspector].
+  bool get debugWillManuallyInjectWidgetInspector => _debugWillManuallyInjectWidgetInspector;
+
+  set debugWillManuallyInjectWidgetInspector(bool value) {
+    _debugWillManuallyInjectWidgetInspector = value;
+  }
+
+  bool _debugWillManuallyInjectWidgetInspector = false;
+
   @visibleForTesting
   @override
   void resetInternalState() {

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2977,7 +2977,7 @@ class _WidgetInspectorState extends State<WidgetInspector> with WidgetsBindingOb
           excludeFromSemantics: true,
           child: IgnorePointer(ignoring: isSelectMode, key: _ignorePointerKey, child: widget.child),
         ),
-        _InspectorOverlay(selection: selection),
+        Positioned.fill(child: _InspectorOverlay(selection: selection)),
         if (isSelectMode && widget.exitWidgetSelectionButtonBuilder != null)
           _ExitWidgetSelectionButtonGroup(
             exitWidgetSelectionButtonBuilder: widget.exitWidgetSelectionButtonBuilder!,

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -275,6 +275,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     tearDown(() async {
       service.resetAllState();
 
+      final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.instance;
+      binding.debugShowWidgetInspectorOverride = false;
+      binding.debugWillManuallyInjectWidgetInspector = false;
+
       if (WidgetInspectorService.instance.isWidgetCreationTracked()) {
         await service.testBoolExtension(
           WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -277,7 +277,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
       final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.instance;
       binding.debugShowWidgetInspectorOverride = false;
-      binding.debugWillManuallyInjectWidgetInspector = false;
+      binding.debugExcludeRootWidgetInspector = false;
 
       if (WidgetInspectorService.instance.isWidgetCreationTracked()) {
         await service.testBoolExtension(
@@ -854,7 +854,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         'debugWillManuallyInjectWidgetInspector is set', (WidgetTester tester) async {
       final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
       // Disable automatic insertion of WidgetInspector into the widget tree by WidgetsApp.
-      binding.debugWillManuallyInjectWidgetInspector = true;
+      binding.debugExcludeRootWidgetInspector = true;
 
       await tester.pumpWidget(WidgetsApp(color: Colors.red, builder: (_, _) => const Text('Foo')));
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -846,6 +846,26 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       );
     });
 
+    testWidgets("WidgetInspector isn't inserted into the widget tree when "
+        'debugWillManuallyInjectWidgetInspector is set', (WidgetTester tester) async {
+      final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+      // Disable automatic insertion of WidgetInspector into the widget tree by WidgetsApp.
+      binding.debugWillManuallyInjectWidgetInspector = true;
+
+      await tester.pumpWidget(WidgetsApp(color: Colors.red, builder: (_, _) => const Text('Foo')));
+
+      // Verify that the widget inspector is disabled and there's no instances of WidgetInspector
+      // in the tree.
+      final Finder widgetInspectorFinder = find.byType(WidgetInspector);
+      expect(binding.debugShowWidgetInspectorOverride, false);
+      expect(widgetInspectorFinder, findsNothing);
+
+      // Enable the widget inspector and verify WidgetInspector hasn't been inserted into the tree.
+      binding.debugShowWidgetInspectorOverride = true;
+      await tester.pump();
+      expect(widgetInspectorFinder, findsNothing);
+    });
+
     testWidgets(
       'WidgetInspector Exit Selection Mode button',
       (WidgetTester tester) async {

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -5,7 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart' show kIsWeb, ValueListenable;
+import 'package:flutter/foundation.dart' show ValueListenable, kIsWeb;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -91,11 +91,10 @@ class _WidgetPreviewErrorWidget extends StatelessWidget {
           TextSpan(
             text: frame.location,
             style: linkTextStyle,
-            recognizer:
-                TapGestureRecognizer()
-                  ..onTap = () {
-                    // TODO(bkonyi): notify IDEs to navigate to the source location via DTD.
-                  },
+            recognizer: TapGestureRecognizer()
+              ..onTap = () {
+                // TODO(bkonyi): notify IDEs to navigate to the source location via DTD.
+              },
           ),
           TextSpan(text: ' ' * (longest - frame.location.length)),
           const TextSpan(text: '  '),
@@ -136,11 +135,10 @@ class NoPreviewsDetectedWidget extends StatelessWidget {
             TextSpan(
               text: documentationUrl.toString(),
               style: linkTextStyle,
-              recognizer:
-                  TapGestureRecognizer()
-                    ..onTap = () {
-                      launchUrl(documentationUrl);
-                    },
+              recognizer: TapGestureRecognizer()
+                ..onTap = () {
+                  launchUrl(documentationUrl);
+                },
             ),
             style: style,
           ),
@@ -252,12 +250,34 @@ class WidgetPreviewWidgetState extends State<WidgetPreviewWidget> {
       },
     );
 
-    preview = _WidgetPreviewWrapper(
-      previewerConstraints: maxSizeConstraints,
-      child: SizedBox(
-        width: widget.preview.width,
-        height: widget.preview.height,
-        child: preview,
+    // Add support for selecting only previewed widgets via the widget
+    // inspector.
+    preview = ValueListenableBuilder(
+      valueListenable:
+          WidgetsBinding.instance.debugShowWidgetInspectorOverrideNotifier,
+      builder: (context, enableWidgetInspector, child) {
+        if (enableWidgetInspector) {
+          return WidgetInspector(
+            // TODO(bkonyi): wire up inspector controls for individual previews or
+            // the entire preview environment. This currently requires users to
+            // to enable widget selection via the Widget Inspector tool in DevTools.
+
+            // These buttons would be rendered on top of the previewed widget, so
+            // don't display them.
+            exitWidgetSelectionButtonBuilder: null,
+            moveExitWidgetSelectionButtonBuilder: null,
+            child: child!,
+          );
+        }
+        return child!;
+      },
+      child: _WidgetPreviewWrapper(
+        previewerConstraints: maxSizeConstraints,
+        child: SizedBox(
+          width: widget.preview.width,
+          height: widget.preview.height,
+          child: preview,
+        ),
       ),
     );
 
@@ -432,11 +452,8 @@ class WidgetPreviewerWindowConstraints extends InheritedWidget {
   final BoxConstraints constraints;
 
   static BoxConstraints getRootConstraints(BuildContext context) {
-    final result =
-        context
-            .dependOnInheritedWidgetOfExactType<
-              WidgetPreviewerWindowConstraints
-            >();
+    final result = context
+        .dependOnInheritedWidgetOfExactType<WidgetPreviewerWindowConstraints>();
     assert(
       result != null,
       'No WidgetPreviewerWindowConstraints founds in context',
@@ -536,10 +553,9 @@ class _WidgetPreviewWrapperBox extends RenderShiftedBox {
       // the previewer. In this case, apply finite constraints (e.g., the
       // constraints for the root of the previewer). Otherwise, use the
       // widget's actual constraints.
-      _constraintOverride =
-          minInstrinsicHeight == 0
-              ? _previewerConstraints
-              : const BoxConstraints();
+      _constraintOverride = minInstrinsicHeight == 0
+          ? _previewerConstraints
+          : const BoxConstraints();
     }
     super.layout(constraints, parentUsesSize: parentUsesSize);
   }
@@ -598,6 +614,12 @@ class PreviewAssetBundle extends PlatformAssetBundle {
 /// the preview scaffold project which prevents us from being able to use hot
 /// restart to iterate on this file.
 Future<void> mainImpl() async {
+  final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
+  // Disable the injection of [WidgetInspector] into the widget tree built by
+  // [WidgetsApp]. [WidgetInspector] instances will be created for each
+  // individual preview so the widget inspector won't allow for users to select
+  // widgets that make up the widget preview scaffolding.
+  binding.debugWillManuallyInjectWidgetInspector = true;
   // TODO(bkonyi): store somewhere.
   await WidgetPreviewScaffoldDtdServices().connect();
   runApp(WidgetPreviewScaffold(previews: previews));
@@ -677,18 +699,16 @@ class WidgetPreviewScaffold extends StatelessWidget {
                     IconButton(
                       onPressed: () => _toggleLayout(LayoutType.gridView),
                       icon: Icon(Icons.grid_on),
-                      color:
-                          selectedLayout == LayoutType.gridView
-                              ? Colors.blue
-                              : Colors.black,
+                      color: selectedLayout == LayoutType.gridView
+                          ? Colors.blue
+                          : Colors.black,
                     ),
                     IconButton(
                       onPressed: () => _toggleLayout(LayoutType.listView),
                       icon: Icon(Icons.view_list),
-                      color:
-                          selectedLayout == LayoutType.listView
-                              ? Colors.blue
-                              : Colors.black,
+                      color: selectedLayout == LayoutType.listView
+                          ? Colors.blue
+                          : Colors.black,
                     ),
                   ],
                 );

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -619,7 +619,7 @@ Future<void> mainImpl() async {
   // [WidgetsApp]. [WidgetInspector] instances will be created for each
   // individual preview so the widget inspector won't allow for users to select
   // widgets that make up the widget preview scaffolding.
-  binding.debugWillManuallyInjectWidgetInspector = true;
+  binding.debugExcludeRootWidgetInspector = true;
   // TODO(bkonyi): store somewhere.
   await WidgetPreviewScaffoldDtdServices().connect();
   runApp(WidgetPreviewScaffold(previews: previews));

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -5,7 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart' show kIsWeb, ValueListenable;
+import 'package:flutter/foundation.dart' show ValueListenable, kIsWeb;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -91,11 +91,10 @@ class _WidgetPreviewErrorWidget extends StatelessWidget {
           TextSpan(
             text: frame.location,
             style: linkTextStyle,
-            recognizer:
-                TapGestureRecognizer()
-                  ..onTap = () {
-                    // TODO(bkonyi): notify IDEs to navigate to the source location via DTD.
-                  },
+            recognizer: TapGestureRecognizer()
+              ..onTap = () {
+                // TODO(bkonyi): notify IDEs to navigate to the source location via DTD.
+              },
           ),
           TextSpan(text: ' ' * (longest - frame.location.length)),
           const TextSpan(text: '  '),
@@ -136,11 +135,10 @@ class NoPreviewsDetectedWidget extends StatelessWidget {
             TextSpan(
               text: documentationUrl.toString(),
               style: linkTextStyle,
-              recognizer:
-                  TapGestureRecognizer()
-                    ..onTap = () {
-                      launchUrl(documentationUrl);
-                    },
+              recognizer: TapGestureRecognizer()
+                ..onTap = () {
+                  launchUrl(documentationUrl);
+                },
             ),
             style: style,
           ),
@@ -252,12 +250,34 @@ class WidgetPreviewWidgetState extends State<WidgetPreviewWidget> {
       },
     );
 
-    preview = _WidgetPreviewWrapper(
-      previewerConstraints: maxSizeConstraints,
-      child: SizedBox(
-        width: widget.preview.width,
-        height: widget.preview.height,
-        child: preview,
+    // Add support for selecting only previewed widgets via the widget
+    // inspector.
+    preview = ValueListenableBuilder(
+      valueListenable:
+          WidgetsBinding.instance.debugShowWidgetInspectorOverrideNotifier,
+      builder: (context, enableWidgetInspector, child) {
+        if (enableWidgetInspector) {
+          return WidgetInspector(
+            // TODO(bkonyi): wire up inspector controls for individual previews or
+            // the entire preview environment. This currently requires users to
+            // to enable widget selection via the Widget Inspector tool in DevTools.
+
+            // These buttons would be rendered on top of the previewed widget, so
+            // don't display them.
+            exitWidgetSelectionButtonBuilder: null,
+            moveExitWidgetSelectionButtonBuilder: null,
+            child: child!,
+          );
+        }
+        return child!;
+      },
+      child: _WidgetPreviewWrapper(
+        previewerConstraints: maxSizeConstraints,
+        child: SizedBox(
+          width: widget.preview.width,
+          height: widget.preview.height,
+          child: preview,
+        ),
       ),
     );
 
@@ -432,11 +452,8 @@ class WidgetPreviewerWindowConstraints extends InheritedWidget {
   final BoxConstraints constraints;
 
   static BoxConstraints getRootConstraints(BuildContext context) {
-    final result =
-        context
-            .dependOnInheritedWidgetOfExactType<
-              WidgetPreviewerWindowConstraints
-            >();
+    final result = context
+        .dependOnInheritedWidgetOfExactType<WidgetPreviewerWindowConstraints>();
     assert(
       result != null,
       'No WidgetPreviewerWindowConstraints founds in context',
@@ -536,10 +553,9 @@ class _WidgetPreviewWrapperBox extends RenderShiftedBox {
       // the previewer. In this case, apply finite constraints (e.g., the
       // constraints for the root of the previewer). Otherwise, use the
       // widget's actual constraints.
-      _constraintOverride =
-          minInstrinsicHeight == 0
-              ? _previewerConstraints
-              : const BoxConstraints();
+      _constraintOverride = minInstrinsicHeight == 0
+          ? _previewerConstraints
+          : const BoxConstraints();
     }
     super.layout(constraints, parentUsesSize: parentUsesSize);
   }
@@ -598,6 +614,12 @@ class PreviewAssetBundle extends PlatformAssetBundle {
 /// the preview scaffold project which prevents us from being able to use hot
 /// restart to iterate on this file.
 Future<void> mainImpl() async {
+  final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
+  // Disable the injection of [WidgetInspector] into the widget tree built by
+  // [WidgetsApp]. [WidgetInspector] instances will be created for each
+  // individual preview so the widget inspector won't allow for users to select
+  // widgets that make up the widget preview scaffolding.
+  binding.debugWillManuallyInjectWidgetInspector = true;
   // TODO(bkonyi): store somewhere.
   await WidgetPreviewScaffoldDtdServices().connect();
   runApp(WidgetPreviewScaffold(previews: previews));
@@ -677,18 +699,16 @@ class WidgetPreviewScaffold extends StatelessWidget {
                     IconButton(
                       onPressed: () => _toggleLayout(LayoutType.gridView),
                       icon: Icon(Icons.grid_on),
-                      color:
-                          selectedLayout == LayoutType.gridView
-                              ? Colors.blue
-                              : Colors.black,
+                      color: selectedLayout == LayoutType.gridView
+                          ? Colors.blue
+                          : Colors.black,
                     ),
                     IconButton(
                       onPressed: () => _toggleLayout(LayoutType.listView),
                       icon: Icon(Icons.view_list),
-                      color:
-                          selectedLayout == LayoutType.listView
-                              ? Colors.blue
-                              : Colors.black,
+                      color: selectedLayout == LayoutType.listView
+                          ? Colors.blue
+                          : Colors.black,
                     ),
                   ],
                 );

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -619,7 +619,7 @@ Future<void> mainImpl() async {
   // [WidgetsApp]. [WidgetInspector] instances will be created for each
   // individual preview so the widget inspector won't allow for users to select
   // widgets that make up the widget preview scaffolding.
-  binding.debugWillManuallyInjectWidgetInspector = true;
+  binding.debugExcludeRootWidgetInspector = true;
   // TODO(bkonyi): store somewhere.
   await WidgetPreviewScaffoldDtdServices().connect();
   runApp(WidgetPreviewScaffold(previews: previews));

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_inspector_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_inspector_test.dart
@@ -31,7 +31,7 @@ void main() {
       await tester.pumpWidget(widgetPreview);
 
       // By default, the widget preview scaffold sets
-      // WidgetsBinding.debugWillManuallyInjectWidgetInspector = true (we copy
+      // WidgetsBinding.debugExcludeRootWidgetInspector = true (we copy
       // this behavior in the WidgetPreviewerWidgetScaffolding utility class),
       // which prevents WidgetInspector from being injected into the widget
       // tree by WidgetApp.
@@ -62,7 +62,7 @@ void main() {
     await tester.pumpWidget(widgetPreview);
 
     // By default, the widget preview scaffold sets
-    // WidgetsBinding.debugWillManuallyInjectWidgetInspector = true (we copy
+    // WidgetsBinding.debugExcludeRootWidgetInspector = true (we copy
     // this behavior in the WidgetPreviewerWidgetScaffolding utility class),
     // which prevents WidgetInspector from being injected into the widget
     // tree by WidgetApp.

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_inspector_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_inspector_test.dart
@@ -1,0 +1,83 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widget_preview_scaffold/src/widget_preview.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_rendering.dart';
+
+import 'widget_preview_scaffold_test_utils.dart';
+
+void main() {
+  testWidgets(
+    'WidgetInspector is manually injected into each WidgetPreviewWidget',
+    (tester) async {
+      final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
+      const int kNumPreviewedWidgets = 3;
+      const String kTestText = 'Foo';
+      final WidgetPreviewerWidgetScaffolding widgetPreview =
+          WidgetPreviewerWidgetScaffolding(
+            child: Column(
+              children: <Widget>[
+                for (int i = 0; i < kNumPreviewedWidgets; ++i)
+                  WidgetPreviewWidget(
+                    preview: WidgetPreview(builder: () => Text('$kTestText$i')),
+                  ),
+              ],
+            ),
+          );
+
+      await tester.pumpWidget(widgetPreview);
+
+      // By default, the widget preview scaffold sets
+      // WidgetsBinding.debugWillManuallyInjectWidgetInspector = true (we copy
+      // this behavior in the WidgetPreviewerWidgetScaffolding utility class),
+      // which prevents WidgetInspector from being injected into the widget
+      // tree by WidgetApp.
+      //
+      // While debugShowWidgetInspectorOverride is false, we expect for there
+      // to be no instances of WidgetInspector in the tree.
+      final Finder widgetInspectorFinder = find.byType(WidgetInspector);
+      expect(binding.debugShowWidgetInspectorOverride, false);
+      expect(widgetInspectorFinder, findsNothing);
+
+      // When debugShowWidgetInspectorOverride is set to true, instances of
+      // WidgetInspector are inserted into each preview instance, allowing for
+      // the widget inspector to only highlight widgets selected within widget
+      // previews and not the actual scaffolding.
+      binding.debugShowWidgetInspectorOverride = true;
+      await tester.pump();
+      expect(widgetInspectorFinder, findsExactly(kNumPreviewedWidgets));
+    },
+  );
+
+  testWidgets('WidgetInspector is not injected with no previews defined', (
+    tester,
+  ) async {
+    final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
+    final WidgetPreviewerWidgetScaffolding widgetPreview =
+        WidgetPreviewerWidgetScaffolding(child: SizedBox());
+
+    await tester.pumpWidget(widgetPreview);
+
+    // By default, the widget preview scaffold sets
+    // WidgetsBinding.debugWillManuallyInjectWidgetInspector = true (we copy
+    // this behavior in the WidgetPreviewerWidgetScaffolding utility class),
+    // which prevents WidgetInspector from being injected into the widget
+    // tree by WidgetApp.
+    //
+    // While debugShowWidgetInspectorOverride is false, we expect for there
+    // to be no instances of WidgetInspector in the tree.
+    final Finder widgetInspectorFinder = find.byType(WidgetInspector);
+    expect(binding.debugShowWidgetInspectorOverride, false);
+    expect(widgetInspectorFinder, findsNothing);
+
+    // When debugShowWidgetInspectorOverride is set to true, we still shouldn't
+    // find an instance of WidgetInspector since there's no previews being
+    // rendered.
+    binding.debugShowWidgetInspectorOverride = true;
+    await tester.pump();
+    expect(widgetInspectorFinder, findsNothing);
+  });
+}

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_preview_scaffold_test_utils.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_preview_scaffold_test_utils.dart
@@ -12,7 +12,7 @@ class WidgetPreviewerWidgetScaffolding extends StatelessWidget {
     required this.child,
   }) {
     // This is set unconditionally by the preview scaffolding.
-    WidgetsBinding.instance.debugWillManuallyInjectWidgetInspector = true;
+    WidgetsBinding.instance.debugExcludeRootWidgetInspector = true;
   }
 
   /// Sets the root platform brightness. Defaults to light.

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_preview_scaffold_test_utils.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_preview_scaffold_test_utils.dart
@@ -6,11 +6,14 @@ import 'package:flutter/material.dart';
 import 'package:widget_preview_scaffold/src/widget_preview_rendering.dart';
 
 class WidgetPreviewerWidgetScaffolding extends StatelessWidget {
-  const WidgetPreviewerWidgetScaffolding({
+  WidgetPreviewerWidgetScaffolding({
     super.key,
     this.platformBrightness = Brightness.light,
     required this.child,
-  });
+  }) {
+    // This is set unconditionally by the preview scaffolding.
+    WidgetsBinding.instance.debugWillManuallyInjectWidgetInspector = true;
+  }
 
   /// Sets the root platform brightness. Defaults to light.
   final Brightness platformBrightness;
@@ -33,17 +36,16 @@ class WidgetPreviewerWidgetScaffolding extends StatelessWidget {
             );
           },
         ),
-        pageRouteBuilder:
-            <T>(RouteSettings settings, WidgetBuilder builder) =>
-                PageRouteBuilder<T>(
-                  settings: settings,
-                  pageBuilder:
-                      (
-                        BuildContext context,
-                        Animation<double> animation,
-                        Animation<double> secondaryAnimation,
-                      ) => builder(context),
-                ),
+        pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) =>
+            PageRouteBuilder<T>(
+              settings: settings,
+              pageBuilder:
+                  (
+                    BuildContext context,
+                    Animation<double> animation,
+                    Animation<double> secondaryAnimation,
+                  ) => builder(context),
+            ),
       ),
     );
   }


### PR DESCRIPTION
In order to prevent the widget inspector from being able to select and inspect elements of the widget previewer's scaffolding, this commit consists of two notable changes:

1) A `debugWillManuallyInjectWidgetInspector` property has been added to `WidgetsBinding`. Setting this property to true before running the application will prevent `WidgetsApp` from injecting a `WidgetInspector` instance into the widget tree, even if the widget inspector is enabled. This means that the widget inspector will not be able to select and highlight widgets by default, requiring `WidgetInspector` to be manually wrapped around widget trees that should be inspectable.

2) The widget_preview_scaffold template has been updated to set `debugWillManuallyInjectWidgetInspector` to true by default, and to wrap individual previews provided by the developer with an instance of `WidgetInspector` to restrict widget inspection to the contents of the preview.

This change also includes a minor bug fix for situations where `WidgetInspector` is inserted into an unconstrained context. Previously, the `WidgetInspector`'s `_InspectorOverlay` would attempt to take up as much space as possible, causing an overflow. To fix this, the `_InspectorOverlay` is wrapped with `Positioned.fill(...)` to force it to take on the same size as its parent `Stack`.

Work towards https://github.com/flutter/flutter/issues/166423

**Demo:**

https://github.com/user-attachments/assets/6d9d384c-5470-4828-983d-a6d9051a2282

