### PR TITLE
Update documentation for `Size` and `Rect` classes

### DIFF
--- a/engine/src/flutter/lib/ui/geometry.dart
+++ b/engine/src/flutter/lib/ui/geometry.dart
@@ -533,7 +533,7 @@ class Size extends OffsetBase {
   /// The offset to the center of the right edge of the rectangle described by the
   /// given offset (which is interpreted as the top-left corner) and this size.
   ///
-  /// See also [Rect.centerLeft].
+  /// See also [Rect.centerRight].
   Offset centerRight(Offset origin) => Offset(origin.dx + width, origin.dy + height / 2.0);
 
   /// The offset to the intersection of the bottom and left edges of the
@@ -547,7 +547,7 @@ class Size extends OffsetBase {
   /// the given offset (which is interpreted as the top-left corner) and this
   /// size.
   ///
-  /// See also [Rect.bottomLeft].
+  /// See also [Rect.bottomCenter].
   Offset bottomCenter(Offset origin) => Offset(origin.dx + width / 2.0, origin.dy + height);
 
   /// The offset to the intersection of the bottom and right edges of the
@@ -845,7 +845,7 @@ class Rect {
 
   /// The offset to the center of the right edge of this rectangle.
   ///
-  /// See also [Size.centerLeft].
+  /// See also [Size.centerRight].
   Offset get centerRight => Offset(right, top + height / 2.0);
 
   /// The offset to the intersection of the bottom and left edges of this rectangle.
@@ -855,7 +855,7 @@ class Rect {
 
   /// The offset to the center of the bottom edge of this rectangle.
   ///
-  /// See also [Size.bottomLeft].
+  /// See also [Size.bottomCenter].
   Offset get bottomCenter => Offset(left + width / 2.0, bottom);
 
   /// The offset to the intersection of the bottom and right edges of this rectangle.


### PR DESCRIPTION
Update documentation for `Size` and `Rect` classes in geometry.dart to correct references for `centerRight` and `bottomCenter` methods.
