### PR TITLE
Update ButtonStyle documentation

### DIFF
--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -249,12 +249,23 @@ class ButtonStyle with Diagnosticable {
   /// See [ThemeData.visualDensity] for more details.
   final MaterialStateProperty<EdgeInsetsGeometry?>? padding;
 
-  /// The minimum size of the button itself.
+  /// The minimum size of the button itself before applying [visualDensity].
   ///
   /// The size of the rectangle the button lies within may be larger
   /// per [tapTargetSize].
   ///
   /// This value must be less than or equal to [maximumSize].
+  ///
+  /// The minimum size is adjusted automatically based on [visualDensity].
+  ///
+  /// When visual density is [VisualDensity.compact], the minimum size is
+  /// reduced by 8 pixels on both dimensions.
+  ///
+  /// When visual density is [VisualDensity.comfortable], the minimum size is
+  /// [minimumSize] reduced by 4 pixels on both dimensions..
+  ///
+  /// When visual density is [VisualDensity.standard], the minimum size is
+  /// [minimumSize].
   final MaterialStateProperty<Size?>? minimumSize;
 
   /// The button's size.
@@ -262,6 +273,9 @@ class ButtonStyle with Diagnosticable {
   /// This size is still constrained by the style's [minimumSize]
   /// and [maximumSize]. Fixed size dimensions whose value is
   /// [double.infinity] are ignored.
+  ///
+  /// The size of the rectangle the button lies within may be larger
+  /// per [tapTargetSize].
   ///
   /// To specify buttons with a fixed width and the default height use
   /// `fixedSize: Size.fromWidth(320)`. Similarly, to specify a fixed

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -262,7 +262,7 @@ class ButtonStyle with Diagnosticable {
   /// reduced by 8 pixels on both dimensions.
   ///
   /// When visual density is [VisualDensity.comfortable], the minimum size is
-  /// [minimumSize] reduced by 4 pixels on both dimensions..
+  /// [minimumSize] reduced by 4 pixels on both dimensions.
   ///
   /// When visual density is [VisualDensity.standard], the minimum size is
   /// [minimumSize].


### PR DESCRIPTION
## Description

This PR updates `ButtonStyle.minimumSize` and `ButtonStyle.fixedSize` documentation.

It updates the documentation in order to describe the current behavior as it might be surprising.
I have considered changing the behavior related to `ButtonStyle.minimumSize` but while experimenting I noticed that several widgets in the framework (and several tests) use `ButtonStyle.minimumSize` with the expectation that the given size is adjusted based on the ambient visual density (and there are probably several similar usages outside of the framework in Google and non-Google apps).

## Related Issue

ButtonStyle.minimumSize : Fixes [minimumSize not respected properly when visual density is not standard](https://github.com/flutter/flutter/issues/123528)
ButtonStyle.fixedSize : Fixes [Button behaves differently in Web/Desktop and Mobile](https://github.com/flutter/flutter/issues/85729)

## Tests

Documentation only