### PR TITLE
Remove `linux_fuchsia` builds from `release_build: "true"`.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -144,7 +144,6 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:
-      release_build: "false"
       config_name: linux_fuchsia
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -144,7 +144,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:
-      release_build: "true"
+      release_build: "false"
       config_name: linux_fuchsia
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/168089.

These builds are not required in the MQ/part of `beta` or `stable` branches, and are not requested by the Flutter CLI.

Notably, this deletes the line instead of `release_build: "false"`, because that is broken: https://github.com/flutter/flutter/issues/168088.