### PR TITLE
Remove `release_build: "false"` which is interpreted as` true` due to a recipes bug.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -284,7 +284,6 @@ targets:
     backfill: false
     properties:
       config_name: linux_android_aot_engine_ddm
-      release_build: "false"
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform
     drone_dimensions:
@@ -321,7 +320,6 @@ targets:
     timeout: 120
     backfill: false
     properties:
-      release_build: "false"
       config_name: linux_android_debug_engine_ddm
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform


### PR DESCRIPTION
Mitigates https://github.com/flutter/flutter/issues/168088.

The non-existence of `properties: release_build: "true"` is the same thing as `false`.

I'll fix the recipe, but this is better for now.

/cc @sigmundch for FYI.