### PR TITLE
Slimpeller can stomp on gcs binary bits ☠️

### DIFF
--- a/engine/src/flutter/ci/builders/linux_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/linux_android_aot_engine.json
@@ -162,64 +162,6 @@
         {
             "archives": [
                 {
-                    "name": "ci/android_release_slimpeller_arm64",
-                    "type": "gcs",
-                    "base_path": "out/ci/android_release_slimpeller_arm64/zip_archives/",
-                    "include_paths": [
-                        "out/ci/android_release_slimpeller_arm64/zip_archives/android-arm64-release/artifacts.zip",
-                        "out/ci/android_release_slimpeller_arm64/zip_archives/android-arm64-release/linux-x64.zip",
-                        "out/ci/android_release_slimpeller_arm64/zip_archives/android-arm64-release/symbols.zip",
-                        "out/ci/android_release_slimpeller_arm64/zip_archives/android-arm64-release/analyze-snapshot-linux-x64.zip",
-                        "out/ci/android_release_slimpeller_arm64/zip_archives/download.flutter.io"
-                    ],
-                    "realm": "production"
-                }
-            ],
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/android_release_slimpeller_arm64",
-                "--runtime-mode",
-                "release",
-                "--android",
-                "--android-cpu",
-                "arm64",
-                "--rbe",
-                "--no-goma",
-                "--slimpeller"
-            ],
-            "name": "ci/android_release_slimpeller_arm64",
-            "description": "Produces release mode artifacts to target 64-bit arm Android from a Linux host without Skia.",
-            "ninja": {
-                "config": "ci/android_release_slimpeller_arm64",
-                "targets": [
-                    "default",
-                    "clang_x64/gen_snapshot",
-                    "flutter/shell/platform/android:abi_jars",
-                    "flutter/shell/platform/android:analyze_snapshot"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "Generate treemap for android_release_slimpeller_arm64",
-                    "language": "bash",
-                    "script": "flutter/ci/binary_size_treemap.sh",
-                    "parameters": [
-                        "../../src/out/ci/android_release_slimpeller_arm64/libflutter.so",
-                        "${FLUTTER_LOGS_DIR}"
-                    ]
-                }
-            ]
-        },
-        {
-            "archives": [
-                {
                     "name": "ci/android_profile_arm64",
                     "type": "gcs",
                     "base_path": "out/ci/android_profile_arm64/zip_archives/",


### PR DESCRIPTION
Binaries for the Android Slimpeller build were being uploaded to the same paths as regular Android builds. This race condition leads to artifacts.zip being incorrect.

fyi: @jonahwilliams 