### PR TITLE
Make Cupertino sheet set the systemUIStyle through an AnnotatedRegion

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -274,26 +274,39 @@ class CupertinoSheetTransition extends StatefulWidget {
             )
             : child;
 
-    return SlideTransition(
-      position: slideAnimation,
-      child: ScaleTransition(
-        scale: scaleAnimation,
-        filterQuality: FilterQuality.medium,
-        alignment: Alignment.topCenter,
-        child: AnimatedBuilder(
-          animation: radiusAnimation,
-          child: child,
-          builder: (BuildContext context, Widget? child) {
-            return ClipRRect(
-              borderRadius:
-                  !secondaryAnimation.isDismissed
-                      ? radiusAnimation.value
-                      : BorderRadius.circular(0),
-              child: contrastedChild,
-            );
-          },
+    final double topGapHeight = MediaQuery.sizeOf(context).height * _kTopGapRatio;
+
+    return Stack(
+      children: <Widget>[
+        AnnotatedRegion<SystemUiOverlayStyle>(
+          value: const SystemUiOverlayStyle(
+            statusBarBrightness: Brightness.dark,
+            statusBarIconBrightness: Brightness.light,
+          ),
+          child: SizedBox(height: topGapHeight, width: double.infinity),
         ),
-      ),
+        SlideTransition(
+          position: slideAnimation,
+          child: ScaleTransition(
+            scale: scaleAnimation,
+            filterQuality: FilterQuality.medium,
+            alignment: Alignment.topCenter,
+            child: AnimatedBuilder(
+              animation: radiusAnimation,
+              child: child,
+              builder: (BuildContext context, Widget? child) {
+                return ClipRRect(
+                  borderRadius:
+                      !secondaryAnimation.isDismissed
+                          ? radiusAnimation.value
+                          : BorderRadius.circular(0),
+                  child: contrastedChild,
+                );
+              },
+            ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -348,12 +361,6 @@ class _CupertinoSheetTransitionState extends State<CupertinoSheetTransition> {
   @override
   void initState() {
     super.initState();
-    SystemChrome.setSystemUIOverlayStyle(
-      const SystemUiOverlayStyle(
-        statusBarBrightness: Brightness.dark,
-        statusBarIconBrightness: Brightness.light,
-      ),
-    );
     _setupAnimation();
   }
 

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -1306,20 +1306,17 @@ void main() {
     });
   });
 
-  testWidgets('CupertinoSheet causes SystemUiOverlayStyle changes', (
-    WidgetTester tester,
-  ) async {
-    expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.light);
-    expect(SystemChrome.latestStyle!.statusBarIconBrightness, Brightness.dark);
-
+  testWidgets('CupertinoSheet causes SystemUiOverlayStyle changes', (WidgetTester tester) async {
     final GlobalKey scaffoldKey = GlobalKey();
 
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoPageScaffold(
           key: scaffoldKey,
+          navigationBar: const CupertinoNavigationBar(middle: Text('SystemUiOverlayStyle')),
           child: Center(
             child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 const Text('Page 1'),
                 CupertinoButton(
@@ -1341,6 +1338,9 @@ void main() {
         ),
       ),
     );
+
+    expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.light);
+    expect(SystemChrome.latestStyle!.statusBarIconBrightness, Brightness.dark);
 
     await tester.tap(find.text('Push Page 2'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
#164680 caused a regression where the systemUIStyle would not be set correctly if the previous page has a navbar.

https://github.com/user-attachments/assets/656d171c-d768-4481-bf64-4c93463752a2

This happens because the RenderView is constantly watching for AnnotatedRegions at the top of the bottom of the screen to set the UI style. So the sheet when initialized would set the style, but during the transition the previous pages navbar is still at the top of the screen, so the RenderView immediately sets the style back to where it was.

This PR fixes that by adding an AnnotatedRegion behind the previous page through the delegatedTransition with the style set correctly for the sheet. That way when the previous page drops low enough, the systemUI switches over.

https://github.com/user-attachments/assets/e600e23b-aad3-4059-9009-c3037a15a2bd

The RenderView is watching for right around the midpoint of the systemUI so it switches back and forth at a good point when the transition is manually dragged back and forth.


https://github.com/user-attachments/assets/a299c0fd-0bbe-40f2-b235-a593f8b5a885



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
