### PR TITLE
Android home/end keyboard shortcut support

### DIFF
--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -593,6 +593,24 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
       LogicalKeyboardKey.end,
       shift: true,
     ): const ExtendSelectionToLineBreakIntent(forward: true, collapseSelection: false),
+    const SingleActivator(
+      LogicalKeyboardKey.home,
+      control: true,
+    ): const ExtendSelectionToDocumentBoundaryIntent(forward: false, collapseSelection: true),
+    const SingleActivator(
+      LogicalKeyboardKey.end,
+      control: true,
+    ): const ExtendSelectionToDocumentBoundaryIntent(forward: true, collapseSelection: true),
+    const SingleActivator(
+      LogicalKeyboardKey.home,
+      shift: true,
+      control: true,
+    ): const ExtendSelectionToDocumentBoundaryIntent(forward: false, collapseSelection: false),
+    const SingleActivator(
+      LogicalKeyboardKey.end,
+      shift: true,
+      control: true,
+    ): const ExtendSelectionToDocumentBoundaryIntent(forward: true, collapseSelection: false),
     // The following key combinations have no effect on text editing on this
     // platform:
     //   * Control + shift? + end

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -369,7 +369,53 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
   //   * Shift + home
   //   * Meta + shift? + delete
   //   * Meta + shift? + backspace
-  static final Map<ShortcutActivator, Intent> _androidShortcuts = _commonShortcuts;
+  static final Map<ShortcutActivator, Intent> _androidShortcuts = {
+    ..._commonShortcuts,
+    const SingleActivator(LogicalKeyboardKey.home): const ExtendSelectionToLineBreakIntent(
+      forward: false,
+      collapseSelection: true,
+      continuesAtWrap: true,
+    ),
+    const SingleActivator(LogicalKeyboardKey.end): const ExtendSelectionToLineBreakIntent(
+      forward: true,
+      collapseSelection: true,
+      continuesAtWrap: true,
+    ),
+    const SingleActivator(
+      LogicalKeyboardKey.home,
+      shift: true,
+    ): const ExtendSelectionToLineBreakIntent(
+      forward: false,
+      collapseSelection: false,
+      continuesAtWrap: true,
+    ),
+    const SingleActivator(
+      LogicalKeyboardKey.end,
+      shift: true,
+    ): const ExtendSelectionToLineBreakIntent(
+      forward: true,
+      collapseSelection: false,
+      continuesAtWrap: true,
+    ),
+    const SingleActivator(
+      LogicalKeyboardKey.home,
+      control: true,
+    ): const ExtendSelectionToDocumentBoundaryIntent(forward: false, collapseSelection: true),
+    const SingleActivator(
+      LogicalKeyboardKey.end,
+      control: true,
+    ): const ExtendSelectionToDocumentBoundaryIntent(forward: true, collapseSelection: true),
+    const SingleActivator(
+      LogicalKeyboardKey.home,
+      shift: true,
+      control: true,
+    ): const ExtendSelectionToDocumentBoundaryIntent(forward: false, collapseSelection: false),
+    const SingleActivator(
+      LogicalKeyboardKey.end,
+      shift: true,
+      control: true,
+    ): const ExtendSelectionToDocumentBoundaryIntent(forward: true, collapseSelection: false),
+  };
 
   static final Map<ShortcutActivator, Intent> _fuchsiaShortcuts = _androidShortcuts;
 

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -365,7 +365,7 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
   //   * Meta + shift? + arrow up
   //   * Meta + shift? + delete
   //   * Meta + shift? + backspace
-  static final Map<ShortcutActivator, Intent> _androidShortcuts = {
+  static final Map<ShortcutActivator, Intent> _androidShortcuts = <ShortcutActivator, Intent>{
     ..._commonShortcuts,
     const SingleActivator(LogicalKeyboardKey.home): const ExtendSelectionToLineBreakIntent(
       forward: false,

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -354,8 +354,6 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
 
   // The following key combinations have no effect on text editing on this
   // platform:
-  //   * End
-  //   * Home
   //   * Meta + X
   //   * Meta + C
   //   * Meta + V
@@ -365,8 +363,6 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
   //   * Meta + shift? + arrow left
   //   * Meta + shift? + arrow right
   //   * Meta + shift? + arrow up
-  //   * Shift + end
-  //   * Shift + home
   //   * Meta + shift? + delete
   //   * Meta + shift? + backspace
   static final Map<ShortcutActivator, Intent> _androidShortcuts = {

--- a/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
@@ -977,7 +977,7 @@ void main() {
         expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, false);
     }
 
-    // Press home + shift
+    // Press home + shift.
     state.lastIntent = null;
     await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.home, shift: true));
     switch (defaultTargetPlatform) {

--- a/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
@@ -913,104 +913,218 @@ void main() {
     );
   });
 
-  testWidgets(
-    'Home and end keys on Android and Windows',
-    (WidgetTester tester) async {
-      final FocusNode editable = FocusNode();
-      addTearDown(editable.dispose);
-      final FocusNode spy = FocusNode();
-      addTearDown(spy.dispose);
+  testWidgets('Home and end keys on Android and Windows', (WidgetTester tester) async {
+    final FocusNode editable = FocusNode();
+    addTearDown(editable.dispose);
+    final FocusNode spy = FocusNode();
+    addTearDown(spy.dispose);
 
-      await tester.pumpWidget(
-        buildSpyAboveEditableText(editableFocusNode: editable, spyFocusNode: spy),
-      );
-      spy.requestFocus();
-      await tester.pump();
-      final ActionSpyState state = tester.state<ActionSpyState>(find.byType(ActionSpy));
+    await tester.pumpWidget(
+      buildSpyAboveEditableText(editableFocusNode: editable, spyFocusNode: spy),
+    );
+    spy.requestFocus();
+    await tester.pump();
+    final ActionSpyState state = tester.state<ActionSpyState>(find.byType(ActionSpy));
 
-      // Home/end
-      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.home));
-      expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, false);
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, true);
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+    // Press home.
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.home));
+    switch (defaultTargetPlatform) {
+      // These platforms do nothing when home/end are pressed.
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        expect(state.lastIntent, isNull);
 
-      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.end));
-      expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, true);
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, true);
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+      // These platforms go to the line start/end.
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.windows:
+        expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, false);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, true);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
 
-      // Home/end + shift
-      await sendKeyCombination(
-        tester,
-        const SingleActivator(LogicalKeyboardKey.home, shift: true),
-      );
-      expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, false);
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, false);
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+      // Linux goes to the line start/end but does not wrap.
+      case TargetPlatform.linux:
+        expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, false);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, true);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, false);
+    }
 
-      await sendKeyCombination(
-        tester,
-        const SingleActivator(LogicalKeyboardKey.end, shift: true),
-      );
-      expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, true);
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, false);
-      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+    // Press end.
+    state.lastIntent = null;
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.end));
+    switch (defaultTargetPlatform) {
+      // These platforms do nothing when home/end are pressed.
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        expect(state.lastIntent, isNull);
 
-      // Home/end + control
-      await sendKeyCombination(
-        tester,
-        const SingleActivator(LogicalKeyboardKey.home, control: true),
-      );
-      expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
-      expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, false);
-      expect(
-        (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
-        true,
-      );
+      // These platforms go to the line start/end.
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.windows:
+        expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, true);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, true);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
 
-      await sendKeyCombination(
-        tester,
-        const SingleActivator(LogicalKeyboardKey.end, control: true),
-      );
-      expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
-      expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, true);
-      expect(
-        (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
-        true,
-      );
+      // Linux goes to the line start/end but does not wrap.
+      case TargetPlatform.linux:
+        expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, true);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, true);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, false);
+    }
 
-      // Home/end + control + shift
-      await sendKeyCombination(
-        tester,
-        const SingleActivator(LogicalKeyboardKey.home, control: true, shift: true),
-      );
-      expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
-      expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, false);
-      expect(
-        (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
-        false,
-      );
+    // Press home + shift
+    state.lastIntent = null;
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.home, shift: true));
+    switch (defaultTargetPlatform) {
+      // These platforms select to the start of the document.
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        expect(state.lastIntent, isA<ExpandSelectionToDocumentBoundaryIntent>());
+        expect((state.lastIntent! as ExpandSelectionToDocumentBoundaryIntent).forward, false);
 
-      await sendKeyCombination(
-        tester,
-        const SingleActivator(LogicalKeyboardKey.end, control: true, shift: true),
-      );
-      expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
-      expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, true);
-      expect(
-        (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
-        false,
-      );
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.android,
-      TargetPlatform.windows,
-    }),
-  );
+      // These platforms select to the line start.
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.windows:
+        expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, false);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, false);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+
+      // Linux selects to the start but does not wrap.
+      case TargetPlatform.linux:
+        expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, false);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, false);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, false);
+    }
+
+    // Press end + shift.
+    state.lastIntent = null;
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.end, shift: true));
+    switch (defaultTargetPlatform) {
+      // These platforms select to the end of the document.
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        expect(state.lastIntent, isA<ExpandSelectionToDocumentBoundaryIntent>());
+        expect((state.lastIntent! as ExpandSelectionToDocumentBoundaryIntent).forward, true);
+
+      // These platforms select to the line end.
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.windows:
+        expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, true);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, false);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+
+      // Linux selects to the end but does not wrap.
+      case TargetPlatform.linux:
+        expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, true);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, false);
+        expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, false);
+    }
+
+    // Press home + control.
+    state.lastIntent = null;
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.home, control: true));
+    switch (defaultTargetPlatform) {
+      // These platforms do nothing.
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        expect(state.lastIntent, isNull);
+
+      // These platforms go to the line start/end.
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
+        expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, false);
+        expect(
+          (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
+          true,
+        );
+    }
+
+    // Press end + control.
+    state.lastIntent = null;
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.end, control: true));
+    switch (defaultTargetPlatform) {
+      // These platforms do nothing.
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        expect(state.lastIntent, isNull);
+
+      // These platforms go to the line start/end.
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
+        expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, true);
+        expect(
+          (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
+          true,
+        );
+    }
+
+    // Press home + control + shift.
+    state.lastIntent = null;
+    await sendKeyCombination(
+      tester,
+      const SingleActivator(LogicalKeyboardKey.home, control: true, shift: true),
+    );
+    switch (defaultTargetPlatform) {
+      // These platforms do nothing.
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        expect(state.lastIntent, isNull);
+
+      // These platforms go to the line start/end.
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
+        expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, false);
+        expect(
+          (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
+          false,
+        );
+    }
+
+    // Press end + control + shift.
+    state.lastIntent = null;
+    await sendKeyCombination(
+      tester,
+      const SingleActivator(LogicalKeyboardKey.end, control: true, shift: true),
+    );
+    switch (defaultTargetPlatform) {
+      // These platforms do nothing.
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        expect(state.lastIntent, isNull);
+
+      // These platforms go to the line start/end.
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
+        expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, true);
+        expect(
+          (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
+          false,
+        );
+    }
+  }, variant: TargetPlatformVariant.all());
 }
 
 class ActionSpy extends StatefulWidget {

--- a/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
@@ -912,6 +912,105 @@ void main() {
       skip: !kIsWeb, // [intended] Web only.
     );
   });
+
+  testWidgets(
+    'Home and end keys on Android and Windows',
+    (WidgetTester tester) async {
+      final FocusNode editable = FocusNode();
+      addTearDown(editable.dispose);
+      final FocusNode spy = FocusNode();
+      addTearDown(spy.dispose);
+
+      await tester.pumpWidget(
+        buildSpyAboveEditableText(editableFocusNode: editable, spyFocusNode: spy),
+      );
+      spy.requestFocus();
+      await tester.pump();
+      final ActionSpyState state = tester.state<ActionSpyState>(find.byType(ActionSpy));
+
+      // Home/end
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.home));
+      expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, false);
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, true);
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.end));
+      expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, true);
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, true);
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+
+      // Home/end + shift
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.home, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, false);
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, false);
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.end, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToLineBreakIntent>());
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).forward, true);
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).collapseSelection, false);
+      expect((state.lastIntent! as ExtendSelectionToLineBreakIntent).continuesAtWrap, true);
+
+      // Home/end + control
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.home, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
+        true,
+      );
+
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.end, control: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
+        true,
+      );
+
+      // Home/end + control + shift
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.home, control: true, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, false);
+      expect(
+        (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
+        false,
+      );
+
+      await sendKeyCombination(
+        tester,
+        const SingleActivator(LogicalKeyboardKey.end, control: true, shift: true),
+      );
+      expect(state.lastIntent, isA<ExtendSelectionToDocumentBoundaryIntent>());
+      expect((state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).forward, true);
+      expect(
+        (state.lastIntent! as ExtendSelectionToDocumentBoundaryIntent).collapseSelection,
+        false,
+      );
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.windows,
+    }),
+  );
 }
 
 class ActionSpy extends StatefulWidget {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -7395,9 +7395,7 @@ void main() {
 
       switch (defaultTargetPlatform) {
         // These platforms don't move the selection with home/end at all.
-        case TargetPlatform.android:
         case TargetPlatform.iOS:
-        case TargetPlatform.fuchsia:
         case TargetPlatform.macOS:
           expect(
             selection,
@@ -7406,6 +7404,8 @@ void main() {
           );
 
         // These platforms go to the line start/end.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(
@@ -7423,9 +7423,7 @@ void main() {
 
       switch (defaultTargetPlatform) {
         // These platforms don't move the selection with home/end at all.
-        case TargetPlatform.android:
         case TargetPlatform.iOS:
-        case TargetPlatform.fuchsia:
         case TargetPlatform.macOS:
           expect(
             selection,
@@ -7434,6 +7432,8 @@ void main() {
           );
 
         // These platforms go to the line start/end.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(
@@ -7511,9 +7511,7 @@ void main() {
 
       switch (defaultTargetPlatform) {
         // These platforms don't move the selection with home/end at all.
-        case TargetPlatform.android:
         case TargetPlatform.iOS:
-        case TargetPlatform.fuchsia:
         case TargetPlatform.macOS:
           expect(
             selection,
@@ -7522,6 +7520,8 @@ void main() {
           );
 
         // These platforms go to the line start/end.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(
@@ -7539,9 +7539,7 @@ void main() {
 
       switch (defaultTargetPlatform) {
         // These platforms don't move the selection with home/end at all still.
-        case TargetPlatform.android:
         case TargetPlatform.iOS:
-        case TargetPlatform.fuchsia:
         case TargetPlatform.macOS:
           expect(
             selection,
@@ -7557,7 +7555,9 @@ void main() {
             reason: 'on $platform',
           );
 
-        // Windows jumps to the previous wordwrapped line.
+        // Windows, Android, and Fuchsia jump to the previous wordwrapped line.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.windows:
           expect(
             selection,
@@ -7633,9 +7633,7 @@ void main() {
 
       switch (defaultTargetPlatform) {
         // These platforms don't move the selection with home/end at all.
-        case TargetPlatform.android:
         case TargetPlatform.iOS:
-        case TargetPlatform.fuchsia:
         case TargetPlatform.macOS:
           expect(
             selection,
@@ -7644,6 +7642,8 @@ void main() {
           );
 
         // These platforms go to the line start/end.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(
@@ -7660,9 +7660,7 @@ void main() {
 
       switch (defaultTargetPlatform) {
         // These platforms don't move the selection with home/end at all still.
-        case TargetPlatform.android:
         case TargetPlatform.iOS:
-        case TargetPlatform.fuchsia:
         case TargetPlatform.macOS:
           expect(
             selection,
@@ -7678,7 +7676,9 @@ void main() {
             reason: 'on $platform',
           );
 
-        // Windows jumps to the next wordwrapped line.
+        // Windows, Android, and Fuchsia jump to the next wordwrapped line.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.windows:
           expect(
             selection,
@@ -7771,20 +7771,6 @@ void main() {
       final TextSelection selectionAfterEnd = selection;
 
       switch (defaultTargetPlatform) {
-        // These platforms don't handle shift + home/end at all.
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-          expect(
-            selectionAfterHome,
-            equals(const TextSelection(baseOffset: 23, extentOffset: 23)),
-            reason: 'on $platform',
-          );
-          expect(
-            selectionAfterEnd,
-            equals(const TextSelection(baseOffset: 23, extentOffset: 23)),
-            reason: 'on $platform',
-          );
-
         // Linux extends to the line start/end.
         case TargetPlatform.linux:
           expect(
@@ -7805,6 +7791,8 @@ void main() {
           );
 
         // Windows expands to the line start/end.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.windows:
           expect(
             selectionAfterHome,
@@ -8047,15 +8035,6 @@ void main() {
       );
 
       switch (defaultTargetPlatform) {
-        // These platforms don't move the selection with shift + home/end at all.
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-          expect(
-            selection,
-            equals(const TextSelection.collapsed(offset: 32)),
-            reason: 'on $platform',
-          );
-
         // Mac and iOS select to the start of the document.
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
@@ -8066,6 +8045,8 @@ void main() {
           );
 
         // These platforms select to the line start.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(
@@ -8085,15 +8066,6 @@ void main() {
       );
 
       switch (defaultTargetPlatform) {
-        // These platforms don't move the selection with home/end at all still.
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-          expect(
-            selection,
-            equals(const TextSelection.collapsed(offset: 32)),
-            reason: 'on $platform',
-          );
-
         // Mac and iOS select to the start of the document.
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
@@ -8112,6 +8084,8 @@ void main() {
           );
 
         // Windows jumps to the previous wordwrapped line.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.windows:
           expect(
             selection,
@@ -8189,15 +8163,6 @@ void main() {
       );
 
       switch (defaultTargetPlatform) {
-        // These platforms don't move the selection with home/end at all.
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-          expect(
-            selection,
-            equals(const TextSelection.collapsed(offset: 32)),
-            reason: 'on $platform',
-          );
-
         // Mac and iOS select to the end of the document.
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
@@ -8208,6 +8173,8 @@ void main() {
           );
 
         // These platforms select to the line end.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(
@@ -8232,15 +8199,6 @@ void main() {
       );
 
       switch (defaultTargetPlatform) {
-        // These platforms don't move the selection with home/end at all still.
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-          expect(
-            selection,
-            equals(const TextSelection.collapsed(offset: 32)),
-            reason: 'on $platform',
-          );
-
         // Mac and iOS stay at the end of the document.
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
@@ -8265,6 +8223,8 @@ void main() {
           );
 
         // Windows jumps to the previous wordwrapped line.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
         case TargetPlatform.windows:
           expect(
             selection,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -8322,7 +8322,7 @@ void main() {
   );
 
   testWidgets(
-    'control + home/end keys (Windows only)',
+    'control + home/end keys',
     (WidgetTester tester) async {
       controller.text = testText;
       controller.selection = const TextSelection(
@@ -8363,7 +8363,22 @@ void main() {
         targetPlatform: defaultTargetPlatform,
       );
       await tester.pump();
-      expect(controller.selection, equals(const TextSelection.collapsed(offset: testText.length)));
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          expect(
+            controller.selection,
+            equals(const TextSelection.collapsed(offset: 0, affinity: TextAffinity.upstream)),
+          );
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          expect(
+            controller.selection,
+            equals(const TextSelection.collapsed(offset: testText.length)),
+          );
+      }
 
       await sendKeys(
         tester,
@@ -8372,14 +8387,26 @@ void main() {
         targetPlatform: defaultTargetPlatform,
       );
       await tester.pump();
-      expect(controller.selection, equals(const TextSelection.collapsed(offset: 0)));
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          expect(
+            controller.selection,
+            equals(const TextSelection.collapsed(offset: 0, affinity: TextAffinity.upstream)),
+          );
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          expect(controller.selection, equals(const TextSelection.collapsed(offset: 0)));
+      }
     },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.windows}),
+    variant: TargetPlatformVariant.all(),
   );
 
   testWidgets(
-    'control + shift + home/end keys (Windows only)',
+    'control + shift + home/end keys',
     (WidgetTester tester) async {
       controller.text = testText;
       controller.selection = const TextSelection(
@@ -8421,17 +8448,29 @@ void main() {
         targetPlatform: defaultTargetPlatform,
       );
       await tester.pump();
-      expect(
-        controller.selection,
-        equals(const TextSelection(baseOffset: 0, extentOffset: testText.length)),
-      );
+      switch (defaultTargetPlatform) {
+        // Apple platforms don't handle this shortcut and do nothing.
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          expect(
+            controller.selection,
+            equals(const TextSelection.collapsed(offset: 0, affinity: TextAffinity.upstream)),
+          );
 
-      // Collapse the selection at the end.
-      await sendKeys(tester, <LogicalKeyboardKey>[
-        LogicalKeyboardKey.arrowRight,
-      ], targetPlatform: defaultTargetPlatform);
+        // These platforms select to the endof the text.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          expect(
+            controller.selection,
+            equals(const TextSelection(baseOffset: 0, extentOffset: testText.length)),
+          );
+      }
+
+      // Set the selection to collapsed at the end to test the home key.
+      controller.selection = const TextSelection.collapsed(offset: testText.length);
       await tester.pump();
-      expect(controller.selection, equals(const TextSelection.collapsed(offset: testText.length)));
 
       await sendKeys(
         tester,
@@ -8441,13 +8480,28 @@ void main() {
         targetPlatform: defaultTargetPlatform,
       );
       await tester.pump();
-      expect(
-        controller.selection,
-        equals(const TextSelection(baseOffset: testText.length, extentOffset: 0)),
-      );
+      switch (defaultTargetPlatform) {
+        // Apple platforms don't handle this shortcut and do nothing.
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          expect(
+            controller.selection,
+            equals(const TextSelection.collapsed(offset: testText.length)),
+          );
+
+        // These platforms select to the beginning of the text.
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          expect(
+            controller.selection,
+            equals(const TextSelection(baseOffset: testText.length, extentOffset: 0)),
+          );
+      }
     },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.windows}),
+    variant: TargetPlatformVariant.all(),
   );
 
   testWidgets(


### PR DESCRIPTION
This PR adds support for Home and End keyboard shortcuts on Android. It seems like we had mistakenly purposely disabled them on Android before (or maybe native Android recently added support for them?).

In the process I also noticed that Linux was missing home/end+control shortcuts, so I added them. I confirmed that these are supported natively using my Linux machine.

Fixes https://github.com/flutter/flutter/issues/168183