### PR TITLE
Check for duplicate archive paths in the engine build configuration JSON files

### DIFF
--- a/engine/src/flutter/tools/pkg/engine_build_configs/bin/check.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/bin/check.dart
@@ -240,13 +240,13 @@ List<String> checkForDuplicateArchives(Map<String, BuilderConfig> configs) {
   final List<String> errors = <String>[];
   final Set<String> archivePaths = <String>{};
   _forEachBuild(configs, (String name, BuilderConfig config, Build build) {
-    for (BuildArchive archive in build.archives) {
-      for (String path in archive.includePaths) {
-        RegExpMatch? match = zipPathPattern.firstMatch(path);
+    for (final BuildArchive archive in build.archives) {
+      for (final String path in archive.includePaths) {
+        final RegExpMatch? match = zipPathPattern.firstMatch(path);
         if (match == null) {
           continue;
         }
-        String zipPath = match.group(1)!;
+        final String zipPath = match.group(1)!;
         if (!archivePaths.add(zipPath)) {
           errors.add('$zipPath is duplicated in $name\n');
         }

--- a/engine/src/flutter/tools/pkg/engine_build_configs/bin/check.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/bin/check.dart
@@ -137,6 +137,12 @@ void run(
   statusPrint('All build names must have a conforming prefix', success: buildNameErrors.isEmpty);
   indentedPrint(buildNameErrors);
 
+  // Check for duplicate archive paths in order to prevent builders from
+  // overwriting each other's artifacts in cloud storage.
+  final List<String> duplicateArchives = checkForDuplicateArchives(configs);
+  statusPrint('Archive paths must be unique', success: duplicateArchives.isEmpty);
+  indentedPrint(duplicateArchives);
+
   // If we have a successfully parsed .ci.yaml, perform additional checks.
   if (ciConfig == null) {
     return;
@@ -223,6 +229,28 @@ List<String> checkForDuplicateConfigs(Map<String, BuilderConfig> configs) {
       errors.add('${build.name} is duplicated in $name\n');
     } else {
       builds.add(build.name);
+    }
+  });
+  return errors;
+}
+
+// This check ensures that json files do not duplicate archive paths.
+List<String> checkForDuplicateArchives(Map<String, BuilderConfig> configs) {
+  final RegExp zipPathPattern = RegExp(r'zip_archives/(.*\.zip)$');
+  final List<String> errors = <String>[];
+  final Set<String> archivePaths = <String>{};
+  _forEachBuild(configs, (String name, BuilderConfig config, Build build) {
+    for (BuildArchive archive in build.archives) {
+      for (String path in archive.includePaths) {
+        RegExpMatch? match = zipPathPattern.firstMatch(path);
+        if (match == null) {
+          continue;
+        }
+        String zipPath = match.group(1)!;
+        if (!archivePaths.add(zipPath)) {
+          errors.add('$zipPath is duplicated in $name\n');
+        }
+      }
     }
   });
   return errors;

--- a/engine/src/flutter/tools/pkg/engine_build_configs/test/check_integration_test.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/test/check_integration_test.dart
@@ -214,4 +214,31 @@ void main() {
 
     expect(stderr.toString(), contains('❌ All builder files conform to release_build standards'));
   });
+
+  test('fails if archives.include_paths containts duplicates', () {
+    addConfig('android_debug', [
+      {
+        'name': 'ci/android_debug',
+        'archives': <Object?>[
+          {
+            'include_paths': <Object?>['out/android_debug/zip_archives/android-arm/artifacts.zip'],
+          },
+        ],
+      },
+    ]);
+    addConfig('android_debug2', [
+      {
+        'name': 'ci/android_debug2',
+        'archives': <Object?>[
+          {
+            'include_paths': <Object?>['out/android_debug2/zip_archives/android-arm/artifacts.zip'],
+          },
+        ],
+      },
+    ]);
+
+    run(['--engine-src-path=${tmpFlutterEngineSrc.path}'], allowFailure: true);
+
+    expect(stderr.toString(), contains('❌ Archive paths must be unique'));
+  });
 }


### PR DESCRIPTION
The intent is to catch issues like https://github.com/flutter/flutter/issues/168180 where multiple builders are uploading artifacts to the same paths on cloud storage.