### PR TITLE
added removeSnackBar function for removing arbitrary queued items

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -480,6 +480,23 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
     hideCurrentSnackBar();
   }
 
+/// Removes the given [SnackBar] from the queue, or dismisses it
+/// immediately if it’s currently visible.
+void removeSnackBar(
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> controller,
+) {
+  // 1. If it’s queued, drop it before showing:
+  if (_snackBars.remove(controller)) {
+    controller._completer.complete(SnackBarClosedReason.remove);
+    return;
+  }
+  // 2. If it’s the active one, delegate to existing logic:
+  if (_snackBars.isNotEmpty && _snackBars.first == controller) {
+    removeCurrentSnackBar(reason: SnackBarClosedReason.remove);
+  }
+}
+
+
   // MATERIAL BANNER API
 
   /// Shows a [MaterialBanner] across all registered [Scaffold]s. Scaffolds register


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

There is no way to remove a specific queued SnackBar once it’s been enqueued but not yet displayed (or after it has already dismissed itself). Calling .close() only works on the currently visible SnackBar; attempts to close one further back in the queue throw:

dart
final sb1 = ScaffoldMessenger.of(context).showSnackBar(...);
final sb2 = ScaffoldMessenger.of(context).showSnackBar(...);
final sb3 = ScaffoldMessenger.of(context).showSnackBar(...);
sb2.close(); // throws because sb2 is not the active SnackBar


*Technical Impact*:  
- Uncaught exceptions when trying to close a non-active snack bar.
- Poor UX: Unable to cancel outdated or no-longer-relevant messages before they appear.
- Workarounds required (try/catch, flush entire queue) that are clumsy and break user expectations.
- Inconsistent API: removeCurrentSnackBar exists for the active item, but nothing for arbitrary queued items.


Fixes #168211 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
