### PR TITLE
docs: fix broken MaterialTapTargetSize links (#167808)

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -993,6 +993,11 @@ class ThemeData with Diagnosticable {
   /// Defaults to a [platform]-appropriate size: [MaterialTapTargetSize.padded]
   /// on mobile platforms, [MaterialTapTargetSize.shrinkWrap] on desktop
   /// platforms.
+  /// Defaults to a [platform]-appropriate size:
+  /// [MaterialTapTargetSize.padded](https://api.flutter.dev/flutter/material/MaterialTapTargetSize.html#MaterialTapTargetSize.padded)
+  /// on mobile platforms,
+  /// [MaterialTapTargetSize.shrinkWrap](https://api.flutter.dev/flutter/material/MaterialTapTargetSize.html#MaterialTapTargetSize.shrinkWrap)
+  /// on desktop platforms.
   final MaterialTapTargetSize materialTapTargetSize;
 
   /// Default [MaterialPageRoute] transitions per [TargetPlatform].


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## What this PR does

This PR fixes the broken API documentation links for `MaterialTapTargetSize.padded` and `MaterialTapTargetSize.shrinkWrap` in the `ThemeData` docs. Previously, those entries pointed to:

https://api.flutter.dev/flutter/src_material_theme_data/MaterialTapTargetSize.html

which resulted in 404 errors. Now they explicitly link to the correct URLs with anchors:

- `https://api.flutter.dev/flutter/material/MaterialTapTargetSize.html#MaterialTapTargetSize.padded`  
- `https://api.flutter.dev/flutter/material/MaterialTapTargetSize.html#MaterialTapTargetSize.shrinkWrap`

## Issues fixed

- Fixes flutter/flutter#167808

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there.
- [x] I read the [Tree Hygiene] wiki page.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I did not need to change anything in the [flutter/tests] repo.
- [x] I followed the [breaking change policy].
- [x] This PR is [test-exempt]—no changes to code behavior or tests.
- [x] All existing and new tests are passing.  