### PR TITLE
[Impeller] Use StrokeParameters anywhere stroke is described

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -175,12 +175,6 @@ static std::unique_ptr<EntityPassTarget> CreateRenderTarget(
   );
 }
 
-struct PaintStrokeParameters : public StrokeParameters {
-  explicit PaintStrokeParameters(const Paint& paint)
-      : StrokeParameters{paint.stroke_width, paint.stroke_miter,
-                         paint.stroke_cap, paint.stroke_join} {}
-};
-
 }  // namespace
 
 Canvas::Canvas(ContentContext& renderer,
@@ -321,8 +315,7 @@ void Canvas::DrawPath(const flutter::DlPath& path, const Paint& paint) {
     FillPathGeometry geom(path);
     AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
   } else {
-    PaintStrokeParameters parameters(paint);
-    StrokePathGeometry geom(path, parameters);
+    StrokePathGeometry geom(path, paint.stroke);
     AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
   }
 }
@@ -553,8 +546,8 @@ void Canvas::DrawLine(const Point& p0,
   entity.SetTransform(GetCurrentTransform());
   entity.SetBlendMode(paint.blend_mode);
 
-  auto geometry = std::make_unique<LineGeometry>(p0, p1, paint.stroke_width,
-                                                 paint.stroke_cap);
+  auto geometry = std::make_unique<LineGeometry>(p0, p1, paint.stroke.width,
+                                                 paint.stroke.cap);
 
   if (renderer_.GetContext()->GetFlags().antialiased_lines &&
       !paint.color_filter && !paint.invert_colors && !paint.image_filter &&
@@ -578,8 +571,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
   entity.SetBlendMode(paint.blend_mode);
 
   if (paint.style == Paint::Style::kStroke) {
-    StrokeRectGeometry geom(rect, paint.stroke_width, paint.stroke_join,
-                            paint.stroke_miter);
+    StrokeRectGeometry geom(rect, paint.stroke);
     AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
   } else {
     FillRectGeometry geom(rect);
@@ -593,7 +585,7 @@ void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
   // assert prevents.
   if (rect.IsSquare() && (paint.style == Paint::Style::kFill ||
                           (paint.style == Paint::Style::kStroke &&
-                           paint.stroke_width < rect.GetWidth()))) {
+                           paint.stroke.width < rect.GetWidth()))) {
     // Circles have slightly less overhead and can do stroking
     DrawCircle(rect.GetCenter(), rect.GetWidth() * 0.5f, paint);
     return;
@@ -608,8 +600,7 @@ void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
   entity.SetBlendMode(paint.blend_mode);
 
   if (paint.style == Paint::Style::kStroke) {
-    PaintStrokeParameters parameters(paint);
-    StrokeEllipseGeometry geom(rect, parameters);
+    StrokeEllipseGeometry geom(rect, paint.stroke);
     AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
   } else {
     EllipseGeometry geom(rect);
@@ -644,8 +635,7 @@ void Canvas::DrawRoundRect(const RoundRect& round_rect, const Paint& paint) {
     FillRoundRectGeometry geom(round_rect);
     AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
   } else {
-    PaintStrokeParameters parameters(paint);
-    StrokeRoundRectGeometry geom(round_rect, parameters);
+    StrokeRoundRectGeometry geom(round_rect, paint.stroke);
     AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
   }
 }
@@ -688,7 +678,7 @@ void Canvas::DrawCircle(const Point& center,
   entity.SetBlendMode(paint.blend_mode);
 
   if (paint.style == Paint::Style::kStroke) {
-    CircleGeometry geom(center, radius, paint.stroke_width);
+    CircleGeometry geom(center, radius, paint.stroke.width);
     AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
   } else {
     CircleGeometry geom(center, radius);
@@ -1556,13 +1546,10 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
   text_contents->SetScale(max_scale);
   text_contents->SetColor(paint.color);
   text_contents->SetOffset(position);
-  text_contents->SetTextProperties(paint.color,                           //
-                                   paint.style == Paint::Style::kStroke,  //
-                                   paint.stroke_width,                    //
-                                   paint.stroke_cap,                      //
-                                   paint.stroke_join,                     //
-                                   paint.stroke_miter                     //
-  );
+  text_contents->SetTextProperties(paint.color,
+                                   paint.style == Paint::Style::kStroke
+                                       ? std::optional(paint.stroke)
+                                       : std::nullopt);
 
   entity.SetTransform(GetCurrentTransform() *
                       Matrix::MakeTranslation(position));

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -546,8 +546,7 @@ void Canvas::DrawLine(const Point& p0,
   entity.SetTransform(GetCurrentTransform());
   entity.SetBlendMode(paint.blend_mode);
 
-  auto geometry = std::make_unique<LineGeometry>(p0, p1, paint.stroke.width,
-                                                 paint.stroke.cap);
+  auto geometry = std::make_unique<LineGeometry>(p0, p1, paint.stroke);
 
   if (renderer_.GetContext()->GetFlags().antialiased_lines &&
       !paint.color_filter && !paint.invert_colors && !paint.image_filter &&

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -183,14 +183,14 @@ void DlDispatcherBase::setColor(flutter::DlColor color) {
 void DlDispatcherBase::setStrokeWidth(DlScalar width) {
   AUTO_DEPTH_WATCHER(0u);
 
-  paint_.stroke_width = width;
+  paint_.stroke.width = width;
 }
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::setStrokeMiter(DlScalar limit) {
   AUTO_DEPTH_WATCHER(0u);
 
-  paint_.stroke_miter = limit;
+  paint_.stroke.miter_limit = limit;
 }
 
 // |flutter::DlOpReceiver|
@@ -199,13 +199,13 @@ void DlDispatcherBase::setStrokeCap(flutter::DlStrokeCap cap) {
 
   switch (cap) {
     case flutter::DlStrokeCap::kButt:
-      paint_.stroke_cap = Cap::kButt;
+      paint_.stroke.cap = Cap::kButt;
       break;
     case flutter::DlStrokeCap::kRound:
-      paint_.stroke_cap = Cap::kRound;
+      paint_.stroke.cap = Cap::kRound;
       break;
     case flutter::DlStrokeCap::kSquare:
-      paint_.stroke_cap = Cap::kSquare;
+      paint_.stroke.cap = Cap::kSquare;
       break;
   }
 }
@@ -216,13 +216,13 @@ void DlDispatcherBase::setStrokeJoin(flutter::DlStrokeJoin join) {
 
   switch (join) {
     case flutter::DlStrokeJoin::kMiter:
-      paint_.stroke_join = Join::kMiter;
+      paint_.stroke.join = Join::kMiter;
       break;
     case flutter::DlStrokeJoin::kRound:
-      paint_.stroke_join = Join::kRound;
+      paint_.stroke.join = Join::kRound;
       break;
     case flutter::DlStrokeJoin::kBevel:
-      paint_.stroke_join = Join::kBevel;
+      paint_.stroke.join = Join::kBevel;
       break;
   }
 }
@@ -684,16 +684,16 @@ void DlDispatcherBase::drawArc(const DlRect& oval_bounds,
                                bool use_center) {
   AUTO_DEPTH_WATCHER(1u);
 
-  if (paint_.stroke_width >
+  if (paint_.stroke.width >
       std::max(oval_bounds.GetWidth(), oval_bounds.GetHeight())) {
     // This is a special case for rendering arcs whose stroke width is so large
     // you are effectively drawing a sector of a circle.
     // https://github.com/flutter/flutter/issues/158567
-    DlRect expanded_rect = oval_bounds.Expand(Size(paint_.stroke_width / 2));
+    DlRect expanded_rect = oval_bounds.Expand(Size(paint_.stroke.width / 2));
     PathBuilder builder;
     Paint fill_paint = paint_;
     fill_paint.style = Paint::Style::kFill;
-    fill_paint.stroke_width = 1;
+    fill_paint.stroke.width = 1;
     builder.AddArc(expanded_rect, Degrees(start_degrees),
                    Degrees(sweep_degrees),
                    /*use_center=*/true);
@@ -717,10 +717,10 @@ void DlDispatcherBase::drawPoints(flutter::DlPointMode mode,
   switch (mode) {
     case flutter::DlPointMode::kPoints: {
       // Cap::kButt is also treated as a square.
-      PointStyle point_style = paint.stroke_cap == Cap::kRound
+      PointStyle point_style = paint.stroke.cap == Cap::kRound
                                    ? PointStyle::kRound
                                    : PointStyle::kSquare;
-      Scalar radius = paint.stroke_width;
+      Scalar radius = paint.stroke.width;
       if (radius > 0) {
         radius /= 2.0;
       }
@@ -1152,11 +1152,7 @@ void FirstPassDispatcher::drawTextFrame(
     DlScalar y) {
   GlyphProperties properties;
   if (paint_.style == Paint::Style::kStroke) {
-    properties.stroke = true;
-    properties.stroke_cap = paint_.stroke_cap;
-    properties.stroke_join = paint_.stroke_join;
-    properties.stroke_miter = paint_.stroke_miter;
-    properties.stroke_width = paint_.stroke_width;
+    properties.stroke = paint_.stroke;
   }
   if (text_frame->HasColor()) {
     // Alpha is always applied when rendering, remove it here so
@@ -1171,9 +1167,9 @@ void FirstPassDispatcher::drawTextFrame(
       scale,        //
       Point(x, y),  //
       matrix_,
-      (properties.stroke || text_frame->HasColor())     //
-          ? std::optional<GlyphProperties>(properties)  //
-          : std::nullopt                                //
+      (properties.stroke.has_value() || text_frame->HasColor())  //
+          ? std::optional<GlyphProperties>(properties)           //
+          : std::nullopt                                         //
   );
 }
 
@@ -1226,25 +1222,25 @@ void FirstPassDispatcher::setColor(flutter::DlColor color) {
 
 // |flutter::DlOpReceiver|
 void FirstPassDispatcher::setStrokeWidth(DlScalar width) {
-  paint_.stroke_width = width;
+  paint_.stroke.width = width;
 }
 
 // |flutter::DlOpReceiver|
 void FirstPassDispatcher::setStrokeMiter(DlScalar limit) {
-  paint_.stroke_miter = limit;
+  paint_.stroke.miter_limit = limit;
 }
 
 // |flutter::DlOpReceiver|
 void FirstPassDispatcher::setStrokeCap(flutter::DlStrokeCap cap) {
   switch (cap) {
     case flutter::DlStrokeCap::kButt:
-      paint_.stroke_cap = Cap::kButt;
+      paint_.stroke.cap = Cap::kButt;
       break;
     case flutter::DlStrokeCap::kRound:
-      paint_.stroke_cap = Cap::kRound;
+      paint_.stroke.cap = Cap::kRound;
       break;
     case flutter::DlStrokeCap::kSquare:
-      paint_.stroke_cap = Cap::kSquare;
+      paint_.stroke.cap = Cap::kSquare;
       break;
   }
 }
@@ -1253,13 +1249,13 @@ void FirstPassDispatcher::setStrokeCap(flutter::DlStrokeCap cap) {
 void FirstPassDispatcher::setStrokeJoin(flutter::DlStrokeJoin join) {
   switch (join) {
     case flutter::DlStrokeJoin::kMiter:
-      paint_.stroke_join = Join::kMiter;
+      paint_.stroke.join = Join::kMiter;
       break;
     case flutter::DlStrokeJoin::kRound:
-      paint_.stroke_join = Join::kRound;
+      paint_.stroke.join = Join::kRound;
       break;
     case flutter::DlStrokeJoin::kBevel:
-      paint_.stroke_join = Join::kBevel;
+      paint_.stroke.join = Join::kBevel;
       break;
   }
 }

--- a/engine/src/flutter/impeller/display_list/paint.h
+++ b/engine/src/flutter/impeller/display_list/paint.h
@@ -20,6 +20,7 @@
 #include "impeller/entity/entity.h"
 #include "impeller/entity/geometry/geometry.h"
 #include "impeller/geometry/color.h"
+#include "impeller/geometry/stroke_parameters.h"
 
 namespace impeller {
 
@@ -76,10 +77,7 @@ struct Paint {
   const flutter::DlColorFilter* color_filter = nullptr;
   const flutter::DlImageFilter* image_filter = nullptr;
 
-  Scalar stroke_width = 0.0;
-  Cap stroke_cap = Cap::kButt;
-  Join stroke_join = Join::kMiter;
-  Scalar stroke_miter = 4.0;
+  StrokeParameters stroke;
   Style style = Style::kFill;
   BlendMode blend_mode = BlendMode::kSrcOver;
   bool invert_colors = false;

--- a/engine/src/flutter/impeller/entity/contents/line_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/line_contents_unittests.cc
@@ -40,8 +40,10 @@ TEST(LineContents, Create) {
   auto geometry = std::make_unique<LineGeometry>(
       /*p0=*/Point{0, 0},      //
       /*p1=*/Point{100, 100},  //
-      /*width=*/width,         //
-      /*cap=*/Cap::kSquare);
+      StrokeParameters{
+          .width = width,
+          .cap = Cap::kSquare,
+      });
   std::unique_ptr<LineContents> contents =
       LineContents::Make(std::move(geometry), Color(1.f, 0.f, 0.f, 1.f));
   EXPECT_TRUE(contents);
@@ -60,8 +62,10 @@ TEST(LineContents, CalculatePerVertex) {
   auto geometry = std::make_unique<LineGeometry>(
       /*p0=*/Point{100, 100},  //
       /*p1=*/Point{200, 100},  //
-      /*width=*/5.f,           //
-      /*cap=*/Cap::kButt);
+      StrokeParameters{
+          .width = 5.f,
+          .cap = Cap::kButt,
+      });
   Matrix transform;
 
   fml::StatusOr<LineContents::EffectiveLineParameters> status =
@@ -125,8 +129,10 @@ TEST(LineContents, CalculatePerVertexLimit) {
   auto geometry = std::make_unique<LineGeometry>(
       /*p0=*/Point{100, 100},  //
       /*p1=*/Point{200, 100},  //
-      /*width=*/10.f,          //
-      /*cap=*/Cap::kButt);
+      StrokeParameters{
+          .width = 10.f,
+          .cap = Cap::kButt,
+      });
   Matrix transform = Matrix::MakeTranslation({100, 100, 1.0}) *
                      Matrix::MakeScale({scale, scale, 1.0}) *
                      Matrix::MakeTranslation({-100, -100, 1.0});

--- a/engine/src/flutter/impeller/entity/contents/text_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.cc
@@ -57,24 +57,15 @@ std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
   return frame_->GetBounds().TransformBounds(entity.GetTransform());
 }
 
-void TextContents::SetTextProperties(Color color,
-                                     bool stroke,
-                                     Scalar stroke_width,
-                                     Cap stroke_cap,
-                                     Join stroke_join,
-                                     Scalar stroke_miter) {
+void TextContents::SetTextProperties(
+    Color color,
+    const std::optional<StrokeParameters>& stroke) {
   if (frame_->HasColor()) {
     // Alpha is always applied when rendering, remove it here so
     // we do not double-apply the alpha.
     properties_.color = color.WithAlpha(1.0);
   }
-  if (stroke) {
-    properties_.stroke = true;
-    properties_.stroke_width = stroke_width;
-    properties_.stroke_cap = stroke_cap;
-    properties_.stroke_join = stroke_join;
-    properties_.stroke_miter = stroke_miter;
-  }
+  properties_.stroke = stroke;
 }
 
 namespace {

--- a/engine/src/flutter/impeller/entity/contents/text_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/text_contents.h
@@ -11,6 +11,7 @@
 #include "impeller/entity/contents/contents.h"
 #include "impeller/entity/contents/pipelines.h"
 #include "impeller/geometry/color.h"
+#include "impeller/geometry/stroke_parameters.h"
 #include "impeller/typographer/font_glyph_pair.h"
 #include "impeller/typographer/text_frame.h"
 
@@ -37,11 +38,7 @@ class TextContents final : public Contents {
 
   /// Must be set after text frame.
   void SetTextProperties(Color color,
-                         bool stroke,
-                         Scalar stroke_width,
-                         Cap stroke_cap,
-                         Join stroke_join,
-                         Scalar stroke_miter);
+                         const std::optional<StrokeParameters>& stroke);
 
   Color GetColor() const;
 

--- a/engine/src/flutter/impeller/entity/geometry/geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.cc
@@ -73,8 +73,8 @@ std::unique_ptr<Geometry> Geometry::MakeStrokePath(const Path& path,
   if (miter_limit < 0) {
     miter_limit = 4.0;
   }
-  StrokeParameters parameters{stroke_width, miter_limit, stroke_cap,
-                              stroke_join};
+  StrokeParameters parameters{stroke_width, stroke_cap, stroke_join,
+                              miter_limit};
   return std::make_unique<StrokePathGeometry>(path, parameters);
 }
 

--- a/engine/src/flutter/impeller/entity/geometry/geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.cc
@@ -92,9 +92,8 @@ std::unique_ptr<Geometry> Geometry::MakeOval(const Rect& rect) {
 
 std::unique_ptr<Geometry> Geometry::MakeLine(const Point& p0,
                                              const Point& p1,
-                                             Scalar width,
-                                             Cap cap) {
-  return std::make_unique<LineGeometry>(p0, p1, width, cap);
+                                             const StrokeParameters& stroke) {
+  return std::make_unique<LineGeometry>(p0, p1, stroke);
 }
 
 std::unique_ptr<Geometry> Geometry::MakeCircle(const Point& center,

--- a/engine/src/flutter/impeller/entity/geometry/geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.h
@@ -71,8 +71,7 @@ class Geometry {
 
   static std::unique_ptr<Geometry> MakeLine(const Point& p0,
                                             const Point& p1,
-                                            Scalar width,
-                                            Cap cap);
+                                            const StrokeParameters& stroke);
 
   static std::unique_ptr<Geometry> MakeCircle(const Point& center,
                                               Scalar radius);

--- a/engine/src/flutter/impeller/entity/geometry/geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.h
@@ -9,6 +9,7 @@
 #include "impeller/core/vertex_buffer.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
+#include "impeller/geometry/stroke_parameters.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/vertex_buffer_builder.h"
 

--- a/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
@@ -57,14 +57,11 @@ namespace impeller {
 
 class ImpellerEntityUnitTestAccessor {
  public:
-  static std::vector<Point> GenerateSolidStrokeVertices(const PathSource& path,
-                                                        Scalar stroke_width,
-                                                        Scalar miter_limit,
-                                                        Join stroke_join,
-                                                        Cap stroke_cap,
-                                                        Scalar scale) {
-    return StrokePathGeometry::GenerateSolidStrokeVertices(
-        path, {stroke_width, miter_limit, stroke_cap, stroke_join}, scale);
+  static std::vector<Point> GenerateSolidStrokeVertices(
+      const PathSource& path,
+      const StrokeParameters& stroke,
+      Scalar scale) {
+    return StrokePathGeometry::GenerateSolidStrokeVertices(path, stroke, scale);
   }
 };
 
@@ -190,7 +187,14 @@ TEST(EntityGeometryTest, SimpleTwoLineStrokeVerticesButtCap) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 10.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+      path,
+      {
+          .width = 10.0f,
+          .cap = Cap::kButt,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   std::vector<Point> expected = {
       // The points for the first segment (20, 20) -> (30, 20)
@@ -224,7 +228,14 @@ TEST(EntityGeometryTest, SimpleTwoLineStrokeVerticesRoundCap) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 10.0f, 4.0f, Join::kBevel, Cap::kRound, 1.0f);
+      path,
+      {
+          .width = 10.0f,
+          .cap = Cap::kRound,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   size_t count = points.size();
   ASSERT_TRUE((count & 0x1) == 0x0);  // Should always be even
@@ -305,7 +316,14 @@ TEST(EntityGeometryTest, SimpleTwoLineStrokeVerticesSquareCap) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 10.0f, 4.0f, Join::kBevel, Cap::kSquare, 1.0f);
+      path,
+      {
+          .width = 10.0f,
+          .cap = Cap::kSquare,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   // clang-format off
   std::vector<Point> expected = {
@@ -348,7 +366,14 @@ TEST(EntityGeometryTest, TwoLineSegmentsRightTurnStrokeVerticesBevelJoin) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 10.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+      path,
+      {
+          .width = 10.0f,
+          .cap = Cap::kButt,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   std::vector<Point> expected = {
       // The points for the first segment (20, 20) -> (30, 20)
@@ -375,7 +400,14 @@ TEST(EntityGeometryTest, TwoLineSegmentsLeftTurnStrokeVerticesBevelJoin) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 10.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+      path,
+      {
+          .width = 10.0f,
+          .cap = Cap::kButt,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   std::vector<Point> expected = {
       // The points for the first segment (20, 20) -> (30, 20)
@@ -402,7 +434,14 @@ TEST(EntityGeometryTest, TwoLineSegmentsRightTurnStrokeVerticesMiterJoin) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 10.0f, 4.0f, Join::kMiter, Cap::kButt, 1.0f);
+      path,
+      {
+          .width = 10.0f,
+          .cap = Cap::kButt,
+          .join = Join::kMiter,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   std::vector<Point> expected = {
       // The points for the first segment (20, 20) -> (30, 20)
@@ -432,7 +471,14 @@ TEST(EntityGeometryTest, TwoLineSegmentsLeftTurnStrokeVerticesMiterJoin) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 10.0f, 4.0f, Join::kMiter, Cap::kButt, 1.0f);
+      path,
+      {
+          .width = 10.0f,
+          .cap = Cap::kButt,
+          .join = Join::kMiter,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   std::vector<Point> expected = {
       // The points for the first segment (20, 20) -> (30, 20)
@@ -461,7 +507,14 @@ TEST(EntityGeometryTest, TinyQuadGeneratesCaps) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 4.0f, 4.0f, Join::kBevel, Cap::kSquare, 1.0f);
+      path,
+      {
+          .width = 4.0f,
+          .cap = Cap::kSquare,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   std::vector<Point> expected = {
       // The points for the opening square cap
@@ -491,7 +544,14 @@ TEST(EntityGeometryTest, TinyConicGeneratesCaps) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 4.0f, 4.0f, Join::kBevel, Cap::kSquare, 1.0f);
+      path,
+      {
+          .width = 4.0f,
+          .cap = Cap::kSquare,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   std::vector<Point> expected = {
       // The points for the opening square cap
@@ -521,7 +581,14 @@ TEST(EntityGeometryTest, TinyCubicGeneratesCaps) {
   flutter::DlPath path(path_builder);
 
   auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-      path, 4.0f, 4.0f, Join::kBevel, Cap::kSquare, 1.0f);
+      path,
+      {
+          .width = 4.0f,
+          .cap = Cap::kSquare,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
 
   std::vector<Point> expected = {
       // The points for the opening square cap
@@ -576,7 +643,14 @@ TEST(EntityGeometryTest, TwoLineSegmentsMiterLimit) {
       // Miter limit too small (99% of required) to allow a miter
       auto points1 =
           ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-              path, width, limit * 0.99f, Join::kMiter, Cap::kButt, 1.0f);
+              path,
+              {
+                  .width = static_cast<Scalar>(width),
+                  .cap = Cap::kButt,
+                  .join = Join::kMiter,
+                  .miter_limit = limit * 0.99f,
+              },
+              1.0f);
       EXPECT_EQ(points1.size(), 8u)
           << "degrees: " << degrees << ", width: " << width << ", "
           << points1[4];
@@ -584,7 +658,14 @@ TEST(EntityGeometryTest, TwoLineSegmentsMiterLimit) {
       // Miter limit large enough (101% of required) to allow a miter
       auto points2 =
           ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-              path, width, limit * 1.01f, Join::kMiter, Cap::kButt, 1.0f);
+              path,
+              {
+                  .width = static_cast<Scalar>(width),
+                  .cap = Cap::kButt,
+                  .join = Join::kMiter,
+                  .miter_limit = limit * 1.01f,
+              },
+              1.0f);
       EXPECT_EQ(points2.size(), 9u)
           << "degrees: " << degrees << ", width: " << width;
       EXPECT_LE(points2[4].GetDistance({30, 20}), width * limit * 1.05f)
@@ -604,19 +685,40 @@ TEST(EntityGeometryTest, TwoLineSegments180DegreeJoins) {
 
   auto points_bevel =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kBevel,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates no join - because it is a bevel join
   EXPECT_EQ(points_bevel.size(), 8u);
 
   auto points_miter =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 400.0f, Join::kMiter, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kMiter,
+              .miter_limit = 400.0f,
+          },
+          1.0f);
   // Generates no join - even with a very large miter limit
   EXPECT_EQ(points_miter.size(), 8u);
 
   auto points_round =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 4.0f, Join::kRound, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kRound,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates lots of join points - to round off the 180 degree bend
   EXPECT_EQ(points_round.size(), 19u);
 }
@@ -631,7 +733,14 @@ TEST(EntityGeometryTest, TightQuadratic180DegreeJoins) {
 
   auto points_bevel_reference =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path_reference, 20.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+          path_reference,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kBevel,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates no joins because the curve is smooth
   EXPECT_EQ(points_bevel_reference.size(), 74u);
 
@@ -643,19 +752,40 @@ TEST(EntityGeometryTest, TightQuadratic180DegreeJoins) {
 
   auto points_bevel =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kBevel,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_bevel.size(), points_bevel_reference.size());
 
   auto points_miter =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 400.0f, Join::kMiter, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kMiter,
+              .miter_limit = 400.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_miter.size(), points_bevel_reference.size());
 
   auto points_round =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 4.0f, Join::kRound, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kRound,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_round.size(), points_bevel_reference.size());
 }
@@ -670,7 +800,14 @@ TEST(EntityGeometryTest, TightConic180DegreeJoins) {
 
   auto points_bevel_reference =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path_reference, 20.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+          path_reference,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kBevel,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates no joins because the curve is smooth
   EXPECT_EQ(points_bevel_reference.size(), 78u);
 
@@ -682,19 +819,40 @@ TEST(EntityGeometryTest, TightConic180DegreeJoins) {
 
   auto points_bevel =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kBevel,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_bevel.size(), points_bevel_reference.size());
 
   auto points_miter =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 400.0f, Join::kMiter, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kMiter,
+              .miter_limit = 400.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_miter.size(), points_bevel_reference.size());
 
   auto points_round =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 4.0f, Join::kRound, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kRound,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_round.size(), points_bevel_reference.size());
 }
@@ -710,7 +868,14 @@ TEST(EntityGeometryTest, TightCubic180DegreeJoins) {
 
   auto points_reference =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path_reference, 20.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+          path_reference,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kBevel,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates no joins because the curve is smooth
   EXPECT_EQ(points_reference.size(), 80u);
 
@@ -722,19 +887,40 @@ TEST(EntityGeometryTest, TightCubic180DegreeJoins) {
 
   auto points_bevel =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 4.0f, Join::kBevel, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kBevel,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_bevel.size(), points_reference.size());
 
   auto points_miter =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 400.0f, Join::kMiter, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kMiter,
+              .miter_limit = 400.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_miter.size(), points_reference.size());
 
   auto points_round =
       ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
-          path, 20.0f, 4.0f, Join::kRound, Cap::kButt, 1.0f);
+          path,
+          {
+              .width = 20.0f,
+              .cap = Cap::kButt,
+              .join = Join::kRound,
+              .miter_limit = 4.0f,
+          },
+          1.0f);
   // Generates round join because it is in the middle of a curved segment
   EXPECT_GT(points_round.size(), points_reference.size());
 }

--- a/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
@@ -122,25 +122,29 @@ TEST(EntityGeometryTest, FillRoundRectGeometryCoversArea) {
 
 TEST(EntityGeometryTest, LineGeometryCoverage) {
   {
-    auto geometry = Geometry::MakeLine({10, 10}, {20, 10}, 2, Cap::kButt);
+    auto geometry = Geometry::MakeLine(  //
+        {10, 10}, {20, 10}, {.width = 2, .cap = Cap::kButt});
     EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(10, 9, 20, 11));
     EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(10, 9, 20, 11)));
   }
 
   {
-    auto geometry = Geometry::MakeLine({10, 10}, {20, 10}, 2, Cap::kSquare);
+    auto geometry = Geometry::MakeLine(  //
+        {10, 10}, {20, 10}, {.width = 2, .cap = Cap::kSquare});
     EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 9, 21, 11));
     EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 9, 21, 11)));
   }
 
   {
-    auto geometry = Geometry::MakeLine({10, 10}, {10, 20}, 2, Cap::kButt);
+    auto geometry = Geometry::MakeLine(  //
+        {10, 10}, {10, 20}, {.width = 2, .cap = Cap::kButt});
     EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 10, 11, 20));
     EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 10, 11, 20)));
   }
 
   {
-    auto geometry = Geometry::MakeLine({10, 10}, {10, 20}, 2, Cap::kSquare);
+    auto geometry = Geometry::MakeLine(  //
+        {10, 10}, {10, 20}, {.width = 2, .cap = Cap::kSquare});
     EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 9, 11, 21));
     EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 9, 11, 21)));
   }

--- a/engine/src/flutter/impeller/entity/geometry/line_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/line_geometry.cc
@@ -8,9 +8,9 @@
 
 namespace impeller {
 
-LineGeometry::LineGeometry(Point p0, Point p1, Scalar width, Cap cap)
-    : p0_(p0), p1_(p1), width_(width), cap_(cap) {
-  FML_DCHECK(width >= 0);
+LineGeometry::LineGeometry(Point p0, Point p1, const StrokeParameters& stroke)
+    : p0_(p0), p1_(p1), width_(stroke.width), cap_(stroke.cap) {
+  FML_DCHECK(width_ >= 0);
 }
 
 LineGeometry::~LineGeometry() = default;

--- a/engine/src/flutter/impeller/entity/geometry/line_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/line_geometry.h
@@ -11,7 +11,7 @@ namespace impeller {
 
 class LineGeometry final : public Geometry {
  public:
-  explicit LineGeometry(Point p0, Point p1, Scalar width, Cap cap);
+  explicit LineGeometry(Point p0, Point p1, const StrokeParameters& stroke);
 
   ~LineGeometry() override;
 

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
@@ -46,13 +46,11 @@ bool FillRectGeometry::IsAxisAlignedRect() const {
   return true;
 }
 
-StrokeRectGeometry::StrokeRectGeometry(Rect rect,
-                                       Scalar stroke_width,
-                                       Join stroke_join,
-                                       Scalar miter_limit)
+StrokeRectGeometry::StrokeRectGeometry(const Rect& rect,
+                                       const StrokeParameters& stroke)
     : rect_(rect),
-      stroke_width_(stroke_width),
-      stroke_join_(AdjustStrokeJoin(stroke_join, miter_limit)) {}
+      stroke_width_(stroke.width),
+      stroke_join_(AdjustStrokeJoin(stroke)) {}
 
 StrokeRectGeometry::~StrokeRectGeometry() = default;
 
@@ -209,8 +207,10 @@ std::optional<Rect> StrokeRectGeometry::GetCoverage(
   return rect_.TransformBounds(transform);
 }
 
-Join StrokeRectGeometry::AdjustStrokeJoin(Join join, Scalar miter_limit) {
-  return (join == Join::kMiter && miter_limit < kSqrt2) ? Join::kBevel : join;
+Join StrokeRectGeometry::AdjustStrokeJoin(const StrokeParameters& stroke) {
+  return (stroke.join == Join::kMiter && stroke.miter_limit < kSqrt2)
+             ? Join::kBevel
+             : stroke.join;
 }
 
 Point* StrokeRectGeometry::AppendRoundCornerJoin(

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_ENTITY_GEOMETRY_RECT_GEOMETRY_H_
 
 #include "impeller/entity/geometry/geometry.h"
+#include "impeller/geometry/stroke_parameters.h"
 
 namespace impeller {
 
@@ -35,10 +36,7 @@ class FillRectGeometry final : public Geometry {
 
 class StrokeRectGeometry final : public Geometry {
  public:
-  explicit StrokeRectGeometry(Rect rect,
-                              Scalar stroke_width,
-                              Join stroke_join,
-                              Scalar miter_limit);
+  explicit StrokeRectGeometry(const Rect& rect, const StrokeParameters& stroke);
 
   ~StrokeRectGeometry() override;
 
@@ -55,7 +53,7 @@ class StrokeRectGeometry final : public Geometry {
   const Scalar stroke_width_;
   const Join stroke_join_;
 
-  static Join AdjustStrokeJoin(Join join, Scalar miter_limit);
+  static Join AdjustStrokeJoin(const StrokeParameters& stroke);
 
   static Point* AppendRoundCornerJoin(Point* buffer,
                                       Point corner,

--- a/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.cc
@@ -297,17 +297,16 @@ class StrokePathSegmentReceiver : public PathTessellator::SegmentReceiver {
   bool contour_needs_cap_ = false;
 
   StrokePathSegmentReceiver(PositionWriter& vtx_builder,
-                            const StrokeParameters& parameters,
+                            const StrokeParameters& stroke,
                             const Scalar scale,
                             const Tessellator::Trigs& trigs)
       : vtx_builder_(vtx_builder),
-        half_stroke_width_(parameters.stroke_width * 0.5f),
+        half_stroke_width_(stroke.width * 0.5f),
         maximum_join_cosine_(
-            ComputeMaximumJoinCosine(scale, parameters.stroke_width * 0.5f)),
-        minimum_miter_cosine_(
-            ComputeMinimumMiterCosine(parameters.miter_limit)),
-        join_(parameters.stroke_join),
-        cap_(parameters.stroke_cap),
+            ComputeMaximumJoinCosine(scale, half_stroke_width_)),
+        minimum_miter_cosine_(ComputeMinimumMiterCosine(stroke.miter_limit)),
+        join_(stroke.join),
+        cap_(stroke.cap),
         scale_(scale),
         trigs_(trigs) {}
 
@@ -669,13 +668,13 @@ class StrokePathSegmentReceiver : public PathTessellator::SegmentReceiver {
 // Private for benchmarking and debugging
 std::vector<Point> StrokePathSourceGeometry::GenerateSolidStrokeVertices(
     const PathSource& source,
-    const StrokeParameters& parameters,
+    const StrokeParameters& stroke,
     Scalar scale) {
   std::vector<Point> points(4096);
   PositionWriter vtx_builder(points);
-  Tessellator::Trigs trigs(scale * parameters.stroke_width * 0.5f);
-  StrokePathSegmentReceiver::GenerateStrokeVertices(vtx_builder, source,
-                                                    parameters, scale, trigs);
+  Tessellator::Trigs trigs(scale * stroke.width * 0.5f);
+  StrokePathSegmentReceiver::GenerateStrokeVertices(vtx_builder, source, stroke,
+                                                    scale, trigs);
   auto [arena, extra] = vtx_builder.GetUsedSize();
   FML_DCHECK(extra == 0u);
   points.resize(arena);
@@ -683,38 +682,37 @@ std::vector<Point> StrokePathSourceGeometry::GenerateSolidStrokeVertices(
 }
 
 StrokePathSourceGeometry::StrokePathSourceGeometry(
-    const StrokeParameters& parameters)
-    : parameters_(parameters) {}
+    const StrokeParameters& stroke)
+    : stroke_(stroke) {}
 
 StrokePathSourceGeometry::~StrokePathSourceGeometry() = default;
 
 Scalar StrokePathSourceGeometry::GetStrokeWidth() const {
-  return parameters_.stroke_width;
+  return stroke_.width;
 }
 
 Scalar StrokePathSourceGeometry::GetMiterLimit() const {
-  return parameters_.miter_limit;
+  return stroke_.miter_limit;
 }
 
 Cap StrokePathSourceGeometry::GetStrokeCap() const {
-  return parameters_.stroke_cap;
+  return stroke_.cap;
 }
 
 Join StrokePathSourceGeometry::GetStrokeJoin() const {
-  return parameters_.stroke_join;
+  return stroke_.join;
 }
 
 Scalar StrokePathSourceGeometry::ComputeAlphaCoverage(
     const Matrix& transform) const {
-  return Geometry::ComputeStrokeAlphaCoverage(transform,
-                                              parameters_.stroke_width);
+  return Geometry::ComputeStrokeAlphaCoverage(transform, stroke_.width);
 }
 
 GeometryResult StrokePathSourceGeometry::GetPositionBuffer(
     const ContentContext& renderer,
     const Entity& entity,
     RenderPass& pass) const {
-  if (parameters_.stroke_width < 0.0) {
+  if (stroke_.width < 0.0) {
     return {};
   }
   Scalar max_basis = entity.GetTransform().GetMaxBasisLengthXY();
@@ -723,9 +721,8 @@ GeometryResult StrokePathSourceGeometry::GetPositionBuffer(
   }
 
   Scalar min_size = kMinStrokeSize / max_basis;
-  StrokeParameters adjusted_parameters = parameters_;
-  adjusted_parameters.stroke_width =
-      std::max(parameters_.stroke_width, min_size);
+  StrokeParameters adjusted_stroke = stroke_;
+  adjusted_stroke.width = std::max(stroke_.width, min_size);
 
   auto& host_buffer = renderer.GetTransientsBuffer();
   auto scale = entity.GetTransform().GetMaxBasisLengthXY();
@@ -733,9 +730,9 @@ GeometryResult StrokePathSourceGeometry::GetPositionBuffer(
   PositionWriter position_writer(
       renderer.GetTessellator().GetStrokePointCache());
   Tessellator::Trigs trigs = renderer.GetTessellator().GetTrigsForDeviceRadius(
-      scale * adjusted_parameters.stroke_width * 0.5f);
+      scale * adjusted_stroke.width * 0.5f);
   StrokePathSegmentReceiver::GenerateStrokeVertices(
-      position_writer, GetSource(), adjusted_parameters, scale, trigs);
+      position_writer, GetSource(), adjusted_stroke, scale, trigs);
 
   const auto [arena_length, oversized_length] = position_writer.GetUsedSize();
   if (!position_writer.HasOversizedBuffer()) {
@@ -795,11 +792,11 @@ std::optional<Rect> StrokePathSourceGeometry::GetCoverage(
   }
 
   Scalar max_radius = 0.5;
-  if (parameters_.stroke_cap == Cap::kSquare) {
+  if (stroke_.cap == Cap::kSquare) {
     max_radius = max_radius * kSqrt2;
   }
-  if (parameters_.stroke_join == Join::kMiter) {
-    max_radius = std::max(max_radius, parameters_.miter_limit * 0.5f);
+  if (stroke_.join == Join::kMiter) {
+    max_radius = std::max(max_radius, stroke_.miter_limit * 0.5f);
   }
   Scalar max_basis = transform.GetMaxBasisLengthXY();
   if (max_basis == 0) {
@@ -807,7 +804,7 @@ std::optional<Rect> StrokePathSourceGeometry::GetCoverage(
   }
   // Use the most conervative coverage setting.
   Scalar min_size = kMinStrokeSize / max_basis;
-  max_radius *= std::max(parameters_.stroke_width, min_size);
+  max_radius *= std::max(stroke_.width, min_size);
   return path_bounds.Expand(max_radius).TransformBounds(transform);
 }
 

--- a/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.h
@@ -8,15 +8,9 @@
 #include "impeller/entity/geometry/geometry.h"
 #include "impeller/geometry/matrix.h"
 #include "impeller/geometry/path_source.h"
+#include "impeller/geometry/stroke_parameters.h"
 
 namespace impeller {
-
-struct StrokeParameters {
-  Scalar stroke_width;
-  Scalar miter_limit;
-  Cap stroke_cap;
-  Join stroke_join;
-};
 
 /// @brief An abstract Geometry base class that produces fillable vertices
 ///        representing the stroked outline from any |PathSource| provided
@@ -57,7 +51,7 @@ class StrokePathSourceGeometry : public Geometry {
   // Private for benchmarking and debugging
   static std::vector<Point> GenerateSolidStrokeVertices(
       const PathSource& source,
-      const StrokeParameters& parameters,
+      const StrokeParameters& stroke,
       Scalar scale);
 
   friend class ImpellerBenchmarkAccessor;
@@ -65,7 +59,7 @@ class StrokePathSourceGeometry : public Geometry {
 
   bool SkipRendering() const;
 
-  const StrokeParameters parameters_;
+  const StrokeParameters stroke_;
 
   StrokePathSourceGeometry(const StrokePathSourceGeometry&) = delete;
 

--- a/engine/src/flutter/impeller/geometry/geometry_benchmarks.cc
+++ b/engine/src/flutter/impeller/geometry/geometry_benchmarks.cc
@@ -14,14 +14,11 @@ namespace impeller {
 
 class ImpellerBenchmarkAccessor {
  public:
-  static std::vector<Point> GenerateSolidStrokeVertices(const PathSource& path,
-                                                        Scalar stroke_width,
-                                                        Scalar miter_limit,
-                                                        Join stroke_join,
-                                                        Cap stroke_cap,
-                                                        Scalar scale) {
-    return StrokePathGeometry::GenerateSolidStrokeVertices(
-        path, {stroke_width, miter_limit, stroke_cap, stroke_join}, scale);
+  static std::vector<Point> GenerateSolidStrokeVertices(
+      const PathSource& path,
+      const StrokeParameters& stroke,
+      Scalar scale) {
+    return StrokePathGeometry::GenerateSolidStrokeVertices(path, stroke, scale);
   }
 };
 
@@ -68,22 +65,26 @@ template <class... Args>
 static void BM_StrokePath(benchmark::State& state, Args&&... args) {
   auto args_tuple = std::make_tuple(std::move(args)...);
   auto raw_path = flutter::DlPath(std::get<Path>(args_tuple));
-  auto cap = std::get<Cap>(args_tuple);
-  auto join = std::get<Join>(args_tuple);
+
+  StrokeParameters stroke{
+      .width = 5.0f,
+      .cap = std::get<Cap>(args_tuple),
+      .join = std::get<Join>(args_tuple),
+      .miter_limit = 10.0f,
+  };
+
   // Production code uses ui.Path which generates a path using an SkPath,
   // so we simulate that work flow by making sure the path used inside the
   // benchmark loop came from an SkPath.
   auto path = flutter::DlPath(raw_path.GetSkPath());
 
-  const Scalar stroke_width = 5.0f;
-  const Scalar miter_limit = 10.0f;
   const Scalar scale = 1.0f;
 
   size_t point_count = 0u;
   size_t single_point_count = 0u;
   while (state.KeepRunning()) {
     auto vertices = ImpellerBenchmarkAccessor::GenerateSolidStrokeVertices(
-        path, stroke_width, miter_limit, join, cap, scale);
+        path, stroke, scale);
     single_point_count = vertices.size();
     point_count += single_point_count;
   }

--- a/engine/src/flutter/impeller/geometry/path.h
+++ b/engine/src/flutter/impeller/geometry/path.h
@@ -17,18 +17,6 @@
 
 namespace impeller {
 
-enum class Cap {
-  kButt,
-  kRound,
-  kSquare,
-};
-
-enum class Join {
-  kMiter,
-  kRound,
-  kBevel,
-};
-
 enum class FillType {
   kNonZero,  // The default winding order.
   kOdd,

--- a/engine/src/flutter/impeller/geometry/stroke_parameters.cc
+++ b/engine/src/flutter/impeller/geometry/stroke_parameters.cc
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/impeller/geometry/stroke_parameters.h"
+
+namespace impeller {
+
+//
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/geometry/stroke_parameters.h
+++ b/engine/src/flutter/impeller/geometry/stroke_parameters.h
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_GEOMETRY_STROKE_PARAMETERS_H_
+#define FLUTTER_IMPELLER_GEOMETRY_STROKE_PARAMETERS_H_
+
+#include "flutter/impeller/geometry/scalar.h"
+
+namespace impeller {
+
+/// @brief An enum that describes ways to decorate the end of a path contour.
+enum class Cap {
+  kButt,
+  kRound,
+  kSquare,
+};
+
+/// @brief An enum that describes ways to join two segments of a path.
+enum class Join {
+  kMiter,
+  kRound,
+  kBevel,
+};
+
+/// @brief A structure to store all of the parameters related to stroking
+///        a path or basic geometry object.
+struct StrokeParameters {
+  Scalar width = 0.0f;
+  Cap cap = Cap::kButt;
+  Join join = Join::kMiter;
+  Scalar miter_limit = 4.0f;
+
+  constexpr bool operator==(const StrokeParameters& parameters) const {
+    return parameters.width == width && parameters.cap == cap &&
+           parameters.join == join && parameters.miter_limit == miter_limit;
+  }
+
+  constexpr bool operator!=(const StrokeParameters& parameters) const {
+    return !(*this == parameters);
+  }
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_GEOMETRY_STROKE_PARAMETERS_H_

--- a/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -232,13 +232,18 @@ static void DrawGlyph(SkCanvas* canvas,
   SkPaint glyph_paint;
   glyph_paint.setColor(glyph_color);
   glyph_paint.setBlendMode(SkBlendMode::kSrc);
-  if (prop.has_value() && prop->stroke) {
-    glyph_paint.setStroke(true);
-    glyph_paint.setStrokeWidth(prop->stroke_width *
-                               static_cast<Scalar>(scaled_font.scale));
-    glyph_paint.setStrokeCap(ToSkiaCap(prop->stroke_cap));
-    glyph_paint.setStrokeJoin(ToSkiaJoin(prop->stroke_join));
-    glyph_paint.setStrokeMiter(prop->stroke_miter);
+  if (prop.has_value()) {
+    auto stroke = prop->stroke;
+    if (stroke.has_value()) {
+      glyph_paint.setStroke(true);
+      glyph_paint.setStrokeWidth(stroke->width *
+                                 static_cast<Scalar>(scaled_font.scale));
+      glyph_paint.setStrokeCap(ToSkiaCap(stroke->cap));
+      glyph_paint.setStrokeJoin(ToSkiaJoin(stroke->join));
+      glyph_paint.setStrokeMiter(stroke->miter_limit);
+    } else {
+      glyph_paint.setStroke(false);
+    }
   }
   canvas->save();
   Point subpixel_offset = SubpixelPositionToPoint(glyph.subpixel_offset);
@@ -396,10 +401,10 @@ static Rect ComputeGlyphSize(const SkFont& font,
   SkPaint glyph_paint;
   if (glyph.properties.has_value() && glyph.properties->stroke) {
     glyph_paint.setStroke(true);
-    glyph_paint.setStrokeWidth(glyph.properties->stroke_width * scale);
-    glyph_paint.setStrokeCap(ToSkiaCap(glyph.properties->stroke_cap));
-    glyph_paint.setStrokeJoin(ToSkiaJoin(glyph.properties->stroke_join));
-    glyph_paint.setStrokeMiter(glyph.properties->stroke_miter);
+    glyph_paint.setStrokeWidth(glyph.properties->stroke->width * scale);
+    glyph_paint.setStrokeCap(ToSkiaCap(glyph.properties->stroke->cap));
+    glyph_paint.setStrokeJoin(ToSkiaJoin(glyph.properties->stroke->join));
+    glyph_paint.setStrokeMiter(glyph.properties->stroke->miter_limit);
   }
   font.getBounds(&glyph.glyph.index, 1, &scaled_bounds, &glyph_paint);
 

--- a/engine/src/flutter/impeller/typographer/font_glyph_pair.h
+++ b/engine/src/flutter/impeller/typographer/font_glyph_pair.h
@@ -6,9 +6,9 @@
 #define FLUTTER_IMPELLER_TYPOGRAPHER_FONT_GLYPH_PAIR_H_
 
 #include "impeller/geometry/color.h"
-#include "impeller/geometry/path.h"
-#include "impeller/geometry/point.h"
 #include "impeller/geometry/rational.h"
+#include "impeller/geometry/scalar.h"
+#include "impeller/geometry/stroke_parameters.h"
 #include "impeller/typographer/font.h"
 #include "impeller/typographer/glyph.h"
 
@@ -16,20 +16,13 @@ namespace impeller {
 
 struct GlyphProperties {
   Color color = Color::Black();
-  Scalar stroke_width = 0.0;
-  Cap stroke_cap = Cap::kButt;
-  Join stroke_join = Join::kMiter;
-  Scalar stroke_miter = 4.0;
-  bool stroke = false;
+  std::optional<StrokeParameters> stroke;
 
   struct Equal {
     constexpr bool operator()(const impeller::GlyphProperties& lhs,
                               const impeller::GlyphProperties& rhs) const {
       return lhs.color.ToARGB() == rhs.color.ToARGB() &&
-             lhs.stroke == rhs.stroke && lhs.stroke_cap == rhs.stroke_cap &&
-             lhs.stroke_join == rhs.stroke_join &&
-             lhs.stroke_miter == rhs.stroke_miter &&
-             lhs.stroke_width == rhs.stroke_width;
+             lhs.stroke == rhs.stroke;
     }
   };
 };
@@ -104,10 +97,14 @@ struct SubpixelGlyph {
     if (!sg.properties.has_value()) {
       return H::combine(std::move(h), sg.glyph.index, sg.subpixel_offset);
     }
+    StrokeParameters stroke;
+    bool has_stroke = sg.properties->stroke.has_value();
+    if (has_stroke) {
+      stroke = sg.properties->stroke.value();
+    }
     return H::combine(std::move(h), sg.glyph.index, sg.subpixel_offset,
-                      sg.properties->color.ToARGB(), sg.properties->stroke,
-                      sg.properties->stroke_cap, sg.properties->stroke_join,
-                      sg.properties->stroke_miter, sg.properties->stroke_width);
+                      sg.properties->color.ToARGB(), has_stroke, stroke.cap,
+                      stroke.join, stroke.miter_limit, stroke.width);
   }
 
   struct Equal {

--- a/engine/src/flutter/impeller/typographer/font_glyph_pair.h
+++ b/engine/src/flutter/impeller/typographer/font_glyph_pair.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_IMPELLER_TYPOGRAPHER_FONT_GLYPH_PAIR_H_
 #define FLUTTER_IMPELLER_TYPOGRAPHER_FONT_GLYPH_PAIR_H_
 
+#include <optional>
+
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/rational.h"
 #include "impeller/geometry/scalar.h"


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/168125 introduced StrokeParameters to hold all of the stroke-related values, but was only used in the rendering code. We now use it across Impeller to describe stroke decorations.