### PR TITLE
[Android] add abiFilters to Flutter Gradle Plugin

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -153,7 +153,12 @@ class FlutterPlugin : Plugin<Project> {
             FlutterPluginUtils.getAndroidExtension(project).buildTypes.forEach { buildType ->
                 if (!buildType.isDebuggable) {
                     buildType.ndk.abiFilters.clear()
-                    buildType.ndk.abiFilters.addAll(setOf("arm64-v8a", "x86_64", "armeabi-v7a"))
+                    FlutterPluginConstants.DEFAULT_PLATFORMS.forEach({ platform ->
+                        val abiValue: String =
+                            FlutterPluginConstants.PLATFORM_ARCH_MAP[platform]
+                                ?: throw GradleException("Invalid platform: $platform")
+                        buildType.ndk.abiFilters.add(abiValue)
+                    })
                 }
             }
         }

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -151,15 +151,13 @@ class FlutterPlugin : Plugin<Project> {
             }
         } else {
             FlutterPluginUtils.getAndroidExtension(project).buildTypes.forEach { buildType ->
-                if (!buildType.isDebuggable) {
-                    buildType.ndk.abiFilters.clear()
-                    FlutterPluginConstants.DEFAULT_PLATFORMS.forEach({ platform ->
-                        val abiValue: String =
-                            FlutterPluginConstants.PLATFORM_ARCH_MAP[platform]
-                                ?: throw GradleException("Invalid platform: $platform")
-                        buildType.ndk.abiFilters.add(abiValue)
-                    })
-                }
+                buildType.ndk.abiFilters.clear()
+                FlutterPluginConstants.DEFAULT_PLATFORMS.forEach({ platform ->
+                    val abiValue: String =
+                        FlutterPluginConstants.PLATFORM_ARCH_MAP[platform]
+                            ?: throw GradleException("Invalid platform: $platform")
+                    buildType.ndk.abiFilters.add(abiValue)
+                })
             }
         }
         val propDeferredComponentNames = "deferred-component-names"

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -149,6 +149,13 @@ class FlutterPlugin : Plugin<Project> {
                 reset()
                 isUniversalApk = false
             }
+        } else {
+            FlutterPluginUtils.getAndroidExtension(project).buildTypes.forEach { buildType ->
+                if (!buildType.isDebuggable) {
+                    buildType.ndk.abiFilters.clear()
+                    buildType.ndk.abiFilters.addAll(setOf("arm64-v8a", "x86_64", "armeabi-v7a"))
+                }
+            }
         }
         val propDeferredComponentNames = "deferred-component-names"
         val deferredComponentNamesValue: String? =

--- a/packages/flutter_tools/test/integration.shard/gradle_jni_packaging_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gradle_jni_packaging_test.dart
@@ -1,0 +1,166 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/build_info.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('flutter_app_test.');
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  // Tests the behavior of abiFilters during the build process.
+  // Without abiFilters set, third-party x86 libraries would be packaged into the resulting APK/bundle.
+  // This would force Google Play to add x86 ABI to the list of supported ABIs, leading to crashes on x86 devices.
+  testWithoutContext('3rd-party x86 library is not packaged (default settings)', () async {
+    final Directory projectDir = createProjectWithThirdpartyLib(tempDir);
+    processManager.runSync(<String>[flutterBin, 'build', 'apk'], workingDirectory: projectDir.path);
+
+    // Verify that the library is valid and picked up by Gradle during transform tasks.
+    // Note: Gradle transforms and merges all available native libraries by default;
+    // abiFilters are not applied at this stage.
+    expect(
+      projectDir
+          .childDirectory(
+            'build/app/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib/x86',
+          )
+          .childFile('libflutter.so'),
+      exists,
+    );
+
+    // Verify that libflutter.so is not packaged in the APK for x86 architecture.
+    expect(_checkLibIsInApk(projectDir, 'lib/x86/libflutter.so'), false);
+  });
+
+  testWithoutContext('abiFilters provided by the user take precedence over the default', () async {
+    final Directory projectDir = createProjectWithThirdpartyLib(tempDir);
+    final String buildGradleContents =
+        projectDir.childFile('android/app/build.gradle.kts').readAsStringSync();
+
+    // Modify the project's build.gradle.kts file to include abiFilters for a single ABI only.
+    final String updatedBuildGradleContents = buildGradleContents.replaceFirstMapped(
+      RegExp(r'(buildTypes\s*\{\s*release\s*\{)([^}]*)\}', dotAll: true),
+      (Match match) {
+        final String before = match.group(1)!;
+        final String body = match.group(2)!;
+        const String ndkBlock = '''
+                ndk {
+                    abiFilters.clear()
+                    abiFilters.addAll(listOf("arm64-v8a"))
+                }
+    ''';
+        return '$before$body$ndkBlock        }';
+      },
+    );
+    projectDir
+        .childFile('android/app/build.gradle.kts')
+        .writeAsStringSync(updatedBuildGradleContents);
+
+    processManager.runSync(<String>[flutterBin, 'build', 'apk'], workingDirectory: projectDir.path);
+
+    expect(_checkLibIsInApk(projectDir, 'lib/arm64-v8a/libflutter.so'), true);
+    expect(_checkLibIsInApk(projectDir, 'lib/x86_64/libflutter.so'), false);
+    expect(_checkLibIsInApk(projectDir, 'lib/armeabi-v7a/libflutter.so'), false);
+    expect(_checkLibIsInApk(projectDir, 'lib/x86/libflutter.so'), false);
+  });
+}
+
+Directory createProjectWithThirdpartyLib(Directory workingDir) {
+  final Directory appDir = workingDir.childDirectory('app');
+
+  processManager.runSync(<String>[
+    flutterBin,
+    'create',
+    '--template=app',
+    '--platforms=android',
+    'app',
+  ], workingDirectory: workingDir.path);
+
+  // Generate a prebuilt x86 artifact by building a debug APK and extracting the valid x86 libflutter.so.
+  // This is the most straightforward way to obtain a valid x86 library for testing.
+  processManager.runSync(<String>[
+    flutterBin,
+    'build',
+    'apk',
+    '--debug',
+    '--target-platform',
+    'android-x86',
+  ], workingDirectory: appDir.path);
+
+  final File x86FlutterLib = appDir.childFile(
+    'build/app/intermediates/stripped_native_libs/debug/stripDebugDebugSymbols/out/lib/x86/libflutter.so',
+  );
+
+  // Copies prebuilt x86 debug library to directory from which gradle will pick it up during release build.
+  final Directory x86Dir = appDir.childDirectory('android/app/src/main/jniLibs/x86');
+  x86Dir.createSync(recursive: true);
+  x86FlutterLib.copySync(x86Dir.childFile('libflutter.so').path);
+
+  return appDir;
+}
+
+bool _checkLibIsInApk(
+  Directory appDir,
+  String filename, {
+  BuildMode buildMode = BuildMode.release,
+}) {
+  final File localPropertiesFile = appDir.childDirectory('android').childFile('local.properties');
+  if (!localPropertiesFile.existsSync()) {
+    throw StateError('local.properties file not found at ${localPropertiesFile.path}');
+  }
+
+  final String fileContent = localPropertiesFile.readAsStringSync();
+  final RegExp regex = RegExp(r'sdk\.dir=(.+)');
+  final Match? match = regex.firstMatch(fileContent);
+  final String sdkPath = match?.group(1) ?? '';
+
+  if (sdkPath.isEmpty) {
+    throw StateError('SDK path not found in local.properties');
+  }
+
+  final String apkAnalyzer =
+      fileSystem
+          .directory(sdkPath)
+          .childDirectory('cmdline-tools/latest/bin')
+          .childFile(Platform.isWindows ? 'apkanalyzer.bat' : 'apkanalyzer')
+          .path;
+
+  final File apkFile = appDir
+      .childDirectory('build/app/outputs/apk/${buildMode.cliName}')
+      .childFile('app-${buildMode.cliName}.apk');
+
+  if (!apkFile.existsSync()) {
+    throw StateError('APK file not found at ${apkFile.path}');
+  }
+
+  final ProcessResult result = processManager.runSync(<String>[
+    apkAnalyzer,
+    'files',
+    'list',
+    apkFile.path,
+  ]);
+
+  if (result.exitCode != 0) {
+    throw ProcessException(
+      apkAnalyzer,
+      <String>['files', 'list', apkFile.path],
+      'apkanalyzer failed with exit code ${result.exitCode}\n${result.stderr}',
+      result.exitCode,
+    );
+  }
+
+  return result.stdout.toString().contains(filename);
+}

--- a/packages/flutter_tools/test/integration.shard/gradle_jni_packaging_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gradle_jni_packaging_test.dart
@@ -89,25 +89,26 @@ Directory createProjectWithThirdpartyLib(Directory workingDir) {
     'app',
   ], workingDirectory: workingDir.path);
 
-  // Generate a prebuilt x86 artifact by building a debug APK and extracting the valid x86 libflutter.so.
-  // This is the most straightforward way to obtain a valid x86 library for testing.
+  // Generate a prebuilt x86_64 artifact by building a debug APK and extracting the valid libflutter.so.
+  // This is the most straightforward way to obtain a valid library (*.so) for testing.
+  // Any architecture can be used, because gradle does not check the architecture of the library – it only checks that it is a valid shared object file.
   processManager.runSync(<String>[
     flutterBin,
     'build',
     'apk',
     '--debug',
     '--target-platform',
-    'android-x86',
+    'android-x64',
   ], workingDirectory: appDir.path);
 
-  final File x86FlutterLib = appDir.childFile(
-    'build/app/intermediates/stripped_native_libs/debug/stripDebugDebugSymbols/out/lib/x86/libflutter.so',
+  final File prebuiltFlutterLib = appDir.childFile(
+    'build/app/intermediates/stripped_native_libs/debug/stripDebugDebugSymbols/out/lib/x86_64/libflutter.so',
   );
 
-  // Copies prebuilt x86 debug library to directory from which gradle will pick it up during release build.
+  // Copies prebuilt debug library to directory from which gradle will pick it up during release build.
   final Directory x86Dir = appDir.childDirectory('android/app/src/main/jniLibs/x86');
   x86Dir.createSync(recursive: true);
-  x86FlutterLib.copySync(x86Dir.childFile('libflutter.so').path);
+  prebuiltFlutterLib.copySync(x86Dir.childFile('libflutter.so').path);
 
   return appDir;
 }


### PR DESCRIPTION
fixes #153476 

More context in https://github.com/flutter/flutter/issues/153476#issuecomment-2849311523 and https://github.com/flutter/flutter/issues/153476#issuecomment-2866416786

TLDR: `abiFilters` cannot be added to templates (the original issue proposes that) because it will break the Gradle build if the `--splits-per-abi` option is provided:

```
Conflicting configuration : 'armeabi-v7a,arm64-v8a,x86_64' in ndk abiFilters cannot be present when splits abi filters are set : armeabi-v7a,arm64-v8a
```

In this PR, `abiFilters` is added programmatically in the Flutter Gradle Plugin when the `splits-per-abi` option is not provided and only for non-debuggable builds.

As stated in https://github.com/flutter/flutter/issues/153476#issuecomment-2866416786, `abiFilters` are actually useful in cases when a third-party dependency is used with the `x86` variant. In other cases (such as a fresh Flutter app project), `abiFilters` are a bit excessive, but they do no harm.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
