### PR TITLE
Fix Chip delete button semantic bounds

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1299,7 +1299,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     };
     final VisualDensity effectiveVisualDensity = widget.visualDensity ?? theme.visualDensity;
 
-    return _DeleteButtonSemantic(
+    return _EnsureMinSemanticsSize(
       semanticSize: semanticSize + effectiveVisualDensity.baseSizeAdjustment,
       child: _wrapWithTooltip(
         tooltip:
@@ -2433,27 +2433,27 @@ bool _hitIsOnDeleteIcon({
   };
 }
 
-class _DeleteButtonSemantic extends SingleChildRenderObjectWidget {
-  const _DeleteButtonSemantic({super.child, required this.semanticSize});
+class _EnsureMinSemanticsSize extends SingleChildRenderObjectWidget {
+  const _EnsureMinSemanticsSize({super.child, required this.semanticSize});
 
   final Size semanticSize;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    return _RenderDeleteButtonSemantic(semanticSize);
+    return _RenderEnsureMinSemanticsSize(semanticSize);
   }
 
   @override
   void updateRenderObject(
     BuildContext context,
-    covariant _RenderDeleteButtonSemantic renderObject,
+    covariant _RenderEnsureMinSemanticsSize renderObject,
   ) {
     renderObject.semanticSize = semanticSize;
   }
 }
 
-class _RenderDeleteButtonSemantic extends RenderProxyBox {
-  _RenderDeleteButtonSemantic(this._semanticSize, [RenderBox? child]) : super(child);
+class _RenderEnsureMinSemanticsSize extends RenderProxyBox {
+  _RenderEnsureMinSemanticsSize(this._semanticSize, [RenderBox? child]) : super(child);
 
   Size get semanticSize => _semanticSize;
   Size _semanticSize;

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -2462,7 +2462,7 @@ class _RenderEnsureMinSemanticsSize extends RenderProxyBox {
       return;
     }
     _semanticSize = value;
-    markNeedsLayout();
+    markNeedsSemanticsUpdate();
   }
 
   @override

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1290,9 +1290,8 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
         chipTheme.iconTheme?.size ??
         theme.chipTheme.iconTheme?.size ??
         _ChipDefaultsM3(context, widget.isEnabled).iconTheme!.size!;
-    return Semantics(
-      container: true,
-      button: true,
+
+    return _DeleteButtonSemantic(
       child: _wrapWithTooltip(
         tooltip:
             widget.deleteButtonTooltipMessage ??
@@ -2423,6 +2422,31 @@ bool _hitIsOnDeleteIcon({
     TextDirection.ltr => adjustedPosition.dx >= deflatedSize.width - accessibleDeleteButtonWidth,
     TextDirection.rtl => adjustedPosition.dx <= accessibleDeleteButtonWidth,
   };
+}
+
+class _DeleteButtonSemantic extends SingleChildRenderObjectWidget {
+  const _DeleteButtonSemantic({super.child});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderDeleteButtonSemantic();
+  }
+}
+
+class _RenderDeleteButtonSemantic extends RenderProxyBox {
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config.isSemanticBoundary = true;
+    config.isButton = true;
+  }
+
+  @override
+  Rect get semanticBounds => Rect.fromCenter(
+    center: paintBounds.center,
+    width: kMinInteractiveDimension,
+    height: kMinInteractiveDimension,
+  );
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES - Chip

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -6167,6 +6167,37 @@ void main() {
       SystemMouseCursors.forbidden,
     );
   });
+
+  testWidgets('Delete button semantic tap target complies with Material guideline', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final UniqueKey deleteKey = UniqueKey();
+    await tester.pumpWidget(
+      wrapForChip(
+        child: Column(
+          children: <Widget>[
+            Chip(
+              label: const Text('Label'),
+              deleteIcon: Icon(Icons.delete, key: deleteKey),
+              onDeleted: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+
+    final Finder deleteIcon = find.byKey(deleteKey);
+    final Size iconSize = tester.getSize(deleteIcon);
+    final Rect semanticRect = tester.getSemantics(deleteIcon).rect;
+
+    // Semantic rect is centered around the icon.
+    expect(semanticRect.center, Offset(iconSize.width / 2, iconSize.height / 2));
+
+    handle.dispose();
+  });
 }
 
 class _MaterialStateOutlinedBorder extends StadiumBorder implements MaterialStateOutlinedBorder {

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -6198,6 +6198,65 @@ void main() {
 
     handle.dispose();
   });
+
+  testWidgets('Delete button semantic tap target is 32x32 on desktop', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final UniqueKey deleteKey = UniqueKey();
+    await tester.pumpWidget(
+      wrapForChip(
+        child: Column(
+          children: <Widget>[
+            Chip(
+              label: const Text('Label'),
+              deleteIcon: Icon(Icons.delete, key: deleteKey),
+              onDeleted: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final Finder deleteIcon = find.byKey(deleteKey);
+    final Size iconSize = tester.getSize(deleteIcon);
+    final Rect semanticRect = tester.getSemantics(deleteIcon).rect;
+
+    expect(semanticRect.size, const Size(32.0, 32.0));
+
+    // Semantic rect is centered around the icon.
+    expect(semanticRect.center, Offset(iconSize.width / 2, iconSize.height / 2));
+
+    handle.dispose();
+  }, variant: TargetPlatformVariant.desktop());
+
+  testWidgets(
+    'Delete button semantic tap target can be larger than the minimum interactive dimension',
+    (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final UniqueKey deleteKey = UniqueKey();
+      const double iconHeight = 60;
+      await tester.pumpWidget(
+        wrapForChip(
+          child: Column(
+            children: <Widget>[
+              Chip(
+                label: const Text('Label', style: TextStyle(fontSize: iconHeight)),
+                deleteIcon: Icon(Icons.delete, key: deleteKey, size: iconHeight),
+                onDeleted: () {},
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final Finder deleteIcon = find.byKey(deleteKey);
+      final Size iconSize = tester.getSize(deleteIcon);
+      final Rect semanticRect = tester.getSemantics(deleteIcon).rect;
+
+      expect(semanticRect.size, iconSize);
+
+      handle.dispose();
+    },
+  );
 }
 
 class _MaterialStateOutlinedBorder extends StadiumBorder implements MaterialStateOutlinedBorder {


### PR DESCRIPTION
## Description

This PR fixes Chip's delete icon semantic tap target.
Chip implementation extends the hit area of the delete icon but it did not expand the semantic bounds.

### Before

![image](https://github.com/user-attachments/assets/5bcc87dc-6379-456d-a5d6-d3f30c7fda8a)

### After

![image](https://github.com/user-attachments/assets/af9b400c-91b6-4c26-a021-3c812a2b2a78)

## Related Issue

Fixes [Chip delete button tap target does not meet platform recommended tap target size](https://github.com/flutter/flutter/issues/94098)

## Tests

Adds 1 test.