### PR TITLE
Update goldens.dart error to point to moved file

### DIFF
--- a/dev/tools/android_driver_extensions/lib/src/goldens.dart
+++ b/dev/tools/android_driver_extensions/lib/src/goldens.dart
@@ -111,7 +111,7 @@ final class NaiveLocalFileComparator extends GoldenFileComparator {
         'when running "flutter drive" to establish a baseline, and then subequent '
         '"flutter drive" instances will be tested against that (local) golden.\n'
         '\n'
-        'See the documentation at dev/tools/android_engine_test/README.md for '
+        'See the documentation at dev/integration_tests/android_engine_test/README.md for '
         'details.',
       );
     }


### PR DESCRIPTION
No issue, found while debugging goldens. 

The file path referenced does not exist. I think the replacement file is the correct one because it referenced the image that appear related. 

https://github.com/search?q=repo%3Aflutter%2Fflutter%20dev%2Ftools%2Fandroid_engine_test%2FREADME.md&type=code

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
