### PR TITLE
Upload `android-arm64-release` treemap to known location

### DIFF
--- a/engine/src/flutter/ci/builders/linux_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/linux_android_aot_engine.json
@@ -155,7 +155,11 @@
                     "parameters": [
                         "../../src/out/ci/android_release_arm64/libflutter.so",
                         "${FLUTTER_LOGS_DIR}"
-                    ]
+                    ],
+                    "upload_logs": {
+                        "name": "android-arm64-release",
+                        "uuid": "sizes"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
fixes: #136011

Logs should now be locate:
* gs://flutter_logs/flutter/_SHA_/android_release_arm64/sizes/
* https://storage.googleapis.com/flutter_logs/flutter/_SHA_/android_release_arm64/sizes/index.html
