### PR TITLE
iOS/macOS: Consistent Flutter copyright headers

### DIFF
--- a/engine/src/build/config/ios/BUILD.gn
+++ b/engine/src/build/config/ios/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright 2014 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/config/mac/BUILD.gn
+++ b/engine/src/build/config/mac/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/config/mac/mac_app.py
+++ b/engine/src/build/config/mac/mac_app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2015 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/config/mac/package_framework.py
+++ b/engine/src/build/config/mac/package_framework.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/config/mac/rules.gni
+++ b/engine/src/build/config/mac/rules.gni
@@ -1,4 +1,4 @@
-# Copyright 2015 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/change_mach_o_flags.py
+++ b/engine/src/build/mac/change_mach_o_flags.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2011 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/change_mach_o_flags_from_xcode.sh
+++ b/engine/src/build/mac/change_mach_o_flags_from_xcode.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2011 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/copy_asan_runtime_dylib.sh
+++ b/engine/src/build/mac/copy_asan_runtime_dylib.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/copy_framework_unversioned.sh
+++ b/engine/src/build/mac/copy_framework_unversioned.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/edit_xibs.sh
+++ b/engine/src/build/mac/edit_xibs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/make_more_helpers.sh
+++ b/engine/src/build/mac/make_more_helpers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/strip_from_xcode
+++ b/engine/src/build/mac/strip_from_xcode
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2008 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/strip_save_dsym
+++ b/engine/src/build/mac/strip_save_dsym
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2011 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/tweak_info_plist.py
+++ b/engine/src/build/mac/tweak_info_plist.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/mac/verify_no_objc.sh
+++ b/engine/src/build/mac/verify_no_objc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2011 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/build/toolchain/mac/BUILD.gn
+++ b/engine/src/build/toolchain/mac/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRunLoop.swift
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRunLoop.swift
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import Foundation
 
 /// Interface for scheduling tasks on the run loop.

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/AppDelegate.h
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/AppDelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/ContinuousTexture.h
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/ContinuousTexture.h
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/ContinuousTexture.m
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/ContinuousTexture.m
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/FlutterEngine+ScenariosTest.h
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/FlutterEngine+ScenariosTest.h
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/FlutterEngine+ScenariosTest.m
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/FlutterEngine+ScenariosTest.m
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/ScreenBeforeFlutter.h
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/ScreenBeforeFlutter.h
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/ScreenBeforeFlutter.m
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/ScreenBeforeFlutter.m
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/TextPlatformView.h
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/TextPlatformView.h
@@ -1,4 +1,4 @@
-// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/TextPlatformView.m
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/Scenarios/TextPlatformView.m
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosTests/ScenariosTests.m
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosTests/ScenariosTests.m
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/integration_test/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/integration_test/example/ios/Runner.xcodeproj/project.pbxproj
@@ -234,7 +234,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1510;
-				ORGANIZATIONNAME = "The Chromium Authors";
+				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					769541C723A0351900E5C350 = {
 						CreatedOnToolsVersion = 11.0;


### PR DESCRIPTION
A long time ago, back after the fork from Chromium, we updated all Chromium BSD copyright notices to Flutter. We did this in the engine, but not in the buildroot. After the monorepo merge, we've now got a mix. This corrects Chromium copyright notices for iOS/macOS files only, and adds a missing copyright header.

No test changes since this touches only comments, and introduces no functional changes.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
