### PR TITLE
[Impeller] libImpeller: Expose access to conservative path bounds.

### DIFF
--- a/engine/src/flutter/impeller/toolkit/interop/impeller.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller.cc
@@ -325,6 +325,11 @@ void ImpellerPathRelease(ImpellerPath path) {
 }
 
 IMPELLER_EXTERN_C
+void ImpellerPathGetBounds(ImpellerPath path, ImpellerRect* out_bounds) {
+  *out_bounds = GetPeer(path)->GetBounds();
+}
+
+IMPELLER_EXTERN_C
 ImpellerPathBuilder ImpellerPathBuilderNew() {
   return Create<PathBuilder>().Leak();
 }

--- a/engine/src/flutter/impeller/toolkit/interop/impeller.h
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller.h
@@ -82,7 +82,7 @@ IMPELLER_EXTERN_C_BEGIN
 
 #define IMPELLER_VERSION_VARIANT 1
 #define IMPELLER_VERSION_MAJOR 1
-#define IMPELLER_VERSION_MINOR 3
+#define IMPELLER_VERSION_MINOR 4
 #define IMPELLER_VERSION_PATCH 0
 
 //------------------------------------------------------------------------------
@@ -912,6 +912,20 @@ void ImpellerPathRetain(ImpellerPath IMPELLER_NULLABLE path);
 ///
 IMPELLER_EXPORT
 void ImpellerPathRelease(ImpellerPath IMPELLER_NULLABLE path);
+
+//------------------------------------------------------------------------------
+/// @brief      Get the bounds of the path.
+///
+///             The bounds are conservative. That is, they may be larger than
+///             the actual shape of the path and could include the control
+///             points and isolated calls to move the cursor.
+///
+/// @param[in]  path        The path
+/// @param[out] out_bounds  The conservative bounds of the path.
+///
+IMPELLER_EXPORT
+void ImpellerPathGetBounds(ImpellerPath IMPELLER_NONNULL path,
+                           ImpellerRect* IMPELLER_NONNULL out_bounds);
 
 //------------------------------------------------------------------------------
 // Path Builder

--- a/engine/src/flutter/impeller/toolkit/interop/impeller.hpp
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller.hpp
@@ -25,7 +25,7 @@
 
 // Tripping this assertion means that the C++ wrapper needs to be updated to
 // account for impeller.h changes as necessary.
-static_assert(IMPELLER_VERSION == IMPELLER_MAKE_VERSION(1, 1, 3, 0),
+static_assert(IMPELLER_VERSION == IMPELLER_MAKE_VERSION(1, 1, 4, 0),
               "C++ bindings must be for the same version as the C API.");
 
 namespace IMPELLER_HPP_NAMESPACE {
@@ -120,10 +120,10 @@ struct Proc {
   PROC(ImpellerLineMetricsGetCodeUnitStartIndex)                  \
   PROC(ImpellerLineMetricsGetDescent)                             \
   PROC(ImpellerLineMetricsGetHeight)                              \
-  PROC(ImpellerLineMetricsIsHardbreak)                            \
   PROC(ImpellerLineMetricsGetLeft)                                \
   PROC(ImpellerLineMetricsGetUnscaledAscent)                      \
   PROC(ImpellerLineMetricsGetWidth)                               \
+  PROC(ImpellerLineMetricsIsHardbreak)                            \
   PROC(ImpellerLineMetricsRelease)                                \
   PROC(ImpellerLineMetricsRetain)                                 \
   PROC(ImpellerMaskFilterCreateBlurNew)                           \
@@ -192,6 +192,7 @@ struct Proc {
   PROC(ImpellerPathBuilderRelease)                                \
   PROC(ImpellerPathBuilderRetain)                                 \
   PROC(ImpellerPathBuilderTakePathNew)                            \
+  PROC(ImpellerPathGetBounds)                                     \
   PROC(ImpellerPathRelease)                                       \
   PROC(ImpellerPathRetain)                                        \
   PROC(ImpellerSurfaceCreateWrappedFBONew)                        \
@@ -1211,6 +1212,12 @@ class ParagraphBuilder final
 class Path final : public Object<ImpellerPath, ImpellerPathTraits> {
  public:
   Path(ImpellerPath path, AdoptTag tag) : Object(path, tag) {}
+
+  ImpellerRect GetBounds() const {
+    ImpellerRect bounds = {};
+    gGlobalProcTable.ImpellerPathGetBounds(Get(), &bounds);
+    return bounds;
+  }
 };
 
 //------------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/toolkit/interop/impeller_unittests.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller_unittests.cc
@@ -582,4 +582,14 @@ TEST_P(InteropPlaygroundTest, CanMeasureText) {
       }));
 }
 
+TEST_P(InteropPlaygroundTest, CanGetPathBounds) {
+  const auto path =
+      hpp::PathBuilder{}.MoveTo({100, 100}).LineTo({200, 200}).Build();
+  const auto bounds = path.GetBounds();
+  ASSERT_EQ(bounds.x, 100);
+  ASSERT_EQ(bounds.y, 100);
+  ASSERT_EQ(bounds.width, 100);
+  ASSERT_EQ(bounds.height, 100);
+}
+
 }  // namespace impeller::interop::testing

--- a/engine/src/flutter/impeller/toolkit/interop/path.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/path.cc
@@ -14,4 +14,14 @@ const SkPath& Path::GetPath() const {
   return path_;
 }
 
+ImpellerRect Path::GetBounds() const {
+  const auto bounds = path_.getBounds();
+  return ImpellerRect{
+      .x = bounds.x(),
+      .y = bounds.y(),
+      .width = bounds.width(),
+      .height = bounds.height(),
+  };
+}
+
 }  // namespace impeller::interop

--- a/engine/src/flutter/impeller/toolkit/interop/path.h
+++ b/engine/src/flutter/impeller/toolkit/interop/path.h
@@ -25,6 +25,8 @@ class Path final
 
   const SkPath& GetPath() const;
 
+  ImpellerRect GetBounds() const;
+
  private:
   SkPath path_;
 };


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/165909
