### PR TITLE
[Impeller] libImpeller: Allow setting text decorations.

### DIFF
--- a/engine/src/flutter/impeller/toolkit/interop/formats.h
+++ b/engine/src/flutter/impeller/toolkit/interop/formats.h
@@ -38,6 +38,14 @@ constexpr SkPoint ToSkiaType(const Point& point) {
   return SkPoint::Make(point.x, point.y);
 }
 
+constexpr SkColor ToSkiaType(const ImpellerColor& color) {
+  return SkColorSetARGB(color.alpha * 255,  //
+                        color.red * 255,    //
+                        color.green * 255,  //
+                        color.blue * 255    //
+  );
+}
+
 constexpr SkVector ToSkiaVector(const Size& point) {
   return SkVector::Make(point.width, point.height);
 }
@@ -429,6 +437,23 @@ constexpr flutter::DlColor ToDisplayListType(ImpellerColor color) {
                           color.blue,                           //
                           ToDisplayListType(color.color_space)  //
   );
+}
+
+constexpr txt::TextDecorationStyle ToTxtType(
+    ImpellerTextDecorationStyle style) {
+  switch (style) {
+    case kImpellerTextDecorationStyleSolid:
+      return txt::TextDecorationStyle::kSolid;
+    case kImpellerTextDecorationStyleDouble:
+      return txt::TextDecorationStyle::kDouble;
+    case kImpellerTextDecorationStyleDotted:
+      return txt::TextDecorationStyle::kDotted;
+    case kImpellerTextDecorationStyleDashed:
+      return txt::TextDecorationStyle::kDashed;
+    case kImpellerTextDecorationStyleWavy:
+      return txt::TextDecorationStyle::kWavy;
+  }
+  return txt::TextDecorationStyle::kSolid;
 }
 
 constexpr txt::FontWeight ToTxtType(ImpellerFontWeight weight) {

--- a/engine/src/flutter/impeller/toolkit/interop/impeller.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller.cc
@@ -1136,6 +1136,13 @@ void ImpellerParagraphStyleSetTextDirection(
 }
 
 IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetTextDecoration(
+    ImpellerParagraphStyle paragraph_style,
+    const ImpellerTextDecoration* decoration) {
+  GetPeer(paragraph_style)->SetTextDecoration(*decoration);
+}
+
+IMPELLER_EXTERN_C
 void ImpellerParagraphStyleSetMaxLines(ImpellerParagraphStyle paragraph_style,
                                        uint32_t max_lines) {
   GetPeer(paragraph_style)->SetMaxLines(max_lines);

--- a/engine/src/flutter/impeller/toolkit/interop/impeller.h
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller.h
@@ -472,6 +472,21 @@ typedef enum ImpellerTextDirection {
   kImpellerTextDirectionLTR,
 } ImpellerTextDirection;
 
+typedef enum ImpellerTextDecorationType {
+  kImpellerTextDecorationTypeNone = 0 << 0,
+  kImpellerTextDecorationTypeUnderline = 1 << 0,
+  kImpellerTextDecorationTypeOverline = 1 << 1,
+  kImpellerTextDecorationTypeLineThrough = 1 << 2,
+} ImpellerTextDecorationType;
+
+typedef enum ImpellerTextDecorationStyle {
+  kImpellerTextDecorationStyleSolid,
+  kImpellerTextDecorationStyleDouble,
+  kImpellerTextDecorationStyleDotted,
+  kImpellerTextDecorationStyleDashed,
+  kImpellerTextDecorationStyleWavy,
+} ImpellerTextDecorationStyle;
+
 //------------------------------------------------------------------------------
 // Non-opaque structs
 // -----------------------------------------------------------------------------
@@ -618,6 +633,18 @@ typedef struct ImpellerContextVulkanInfo {
   uint32_t graphics_queue_family_index;
   uint32_t graphics_queue_index;
 } ImpellerContextVulkanInfo;
+
+typedef struct ImpellerTextDecoration {
+  /// A mask of `ImpellerTextDecorationType`s to enable.
+  int types;
+  /// The decoration color.
+  ImpellerColor color;
+  /// The decoration style.
+  ImpellerTextDecorationStyle style;
+  // The multiplier applied to the default thickness of the font to use for the
+  // decoration.
+  float thickness_multiplier;
+} ImpellerTextDecoration;
 
 //------------------------------------------------------------------------------
 // Version
@@ -2395,6 +2422,19 @@ IMPELLER_EXPORT
 void ImpellerParagraphStyleSetTextDirection(
     ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
     ImpellerTextDirection direction);
+
+//------------------------------------------------------------------------------
+/// @brief      Set one of more text decorations on the paragraph. Decorations
+///             can be underlines, overlines, strikethroughs, etc.. The style of
+///             decorations can be set as well (dashed, dotted, wavy, etc..)
+///
+/// @param[in]  ImpellerParagraphStyle  The paragraph style.
+/// @param[in]  decoration              The text decoration.
+///
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetTextDecoration(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    const ImpellerTextDecoration* IMPELLER_NONNULL decoration);
 
 //------------------------------------------------------------------------------
 /// @brief      Set the maximum line count within the paragraph.

--- a/engine/src/flutter/impeller/toolkit/interop/impeller.hpp
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller.hpp
@@ -178,6 +178,7 @@ struct Proc {
   PROC(ImpellerParagraphStyleSetMaxLines)                         \
   PROC(ImpellerParagraphStyleSetTextAlignment)                    \
   PROC(ImpellerParagraphStyleSetTextDirection)                    \
+  PROC(ImpellerParagraphStyleSetTextDecoration)                   \
   PROC(ImpellerPathBuilderAddArc)                                 \
   PROC(ImpellerPathBuilderAddOval)                                \
   PROC(ImpellerPathBuilderAddRect)                                \
@@ -1106,6 +1107,15 @@ class ParagraphStyle final
   ///
   ParagraphStyle& SetTextDirection(ImpellerTextDirection direction) {
     gGlobalProcTable.ImpellerParagraphStyleSetTextDirection(Get(), direction);
+    return *this;
+  }
+
+  //----------------------------------------------------------------------------
+  /// @see      ImpellerParagraphStyleSetTextDecoration
+  ///
+  ParagraphStyle& SetTextDecoration(const ImpellerTextDecoration& decoration) {
+    gGlobalProcTable.ImpellerParagraphStyleSetTextDecoration(Get(),
+                                                             &decoration);
     return *this;
   }
 };

--- a/engine/src/flutter/impeller/toolkit/interop/impeller_unittests.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller_unittests.cc
@@ -289,6 +289,32 @@ TEST_P(InteropPlaygroundTest, CanCreateParagraphs) {
       }));
 }
 
+TEST_P(InteropPlaygroundTest, CanCreateDecorations) {
+  hpp::TypographyContext context;
+  auto para =
+      hpp::ParagraphBuilder(context)
+          .PushStyle(
+              hpp::ParagraphStyle{}
+                  .SetForeground(hpp::Paint{}.SetColor({1.0, 0.0, 0.0, 1.0}))
+                  .SetFontSize(150.0f)
+                  .SetTextDecoration(ImpellerTextDecoration{
+                      .types = kImpellerTextDecorationTypeLineThrough |
+                               kImpellerTextDecorationTypeUnderline,
+                      .color = ImpellerColor{0.0, 1.0, 0.0, 0.75},
+                      .style = kImpellerTextDecorationStyleWavy,
+                      .thickness_multiplier = 1.5,
+                  }))
+          .AddText(std::string{"Holy text decorations Batman!"})
+          .Build(900);
+  auto dl = hpp::DisplayListBuilder{}.DrawParagraph(para, {100, 100}).Build();
+  ASSERT_TRUE(
+      OpenPlaygroundHere([&](const auto& context, const auto& surface) -> bool {
+        hpp::Surface window(surface.GetC());
+        window.Draw(dl);
+        return true;
+      }));
+}
+
 TEST_P(InteropPlaygroundTest, CanCreateShapes) {
   hpp::DisplayListBuilder builder;
 

--- a/engine/src/flutter/impeller/toolkit/interop/paragraph_style.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/paragraph_style.cc
@@ -64,11 +64,24 @@ txt::TextStyle ParagraphStyle::CreateTextStyle() const {
   if (background_) {
     style.background = background_->GetPaint();
   }
+  if (decoration_.has_value()) {
+    const auto& decoration = decoration_.value();
+    style.decoration = decoration.types;
+    style.decoration_color = ToSkiaType(decoration.color);
+    style.decoration_style = ToTxtType(decoration.style);
+    style.decoration_thickness_multiplier = decoration.thickness_multiplier;
+  }
+
   return style;
 }
 
 const txt::ParagraphStyle& ParagraphStyle::GetParagraphStyle() const {
   return style_;
+}
+
+void ParagraphStyle::SetTextDecoration(
+    const ImpellerTextDecoration& decoration) {
+  decoration_ = decoration;
 }
 
 }  // namespace impeller::interop

--- a/engine/src/flutter/impeller/toolkit/interop/paragraph_style.h
+++ b/engine/src/flutter/impeller/toolkit/interop/paragraph_style.h
@@ -42,6 +42,8 @@ class ParagraphStyle final
 
   void SetTextDirection(txt::TextDirection direction);
 
+  void SetTextDecoration(const ImpellerTextDecoration& decoration);
+
   void SetMaxLines(size_t max_lines);
 
   void SetLocale(std::string locale);
@@ -54,6 +56,7 @@ class ParagraphStyle final
   txt::ParagraphStyle style_;
   ScopedObject<Paint> foreground_;
   ScopedObject<Paint> background_;
+  std::optional<ImpellerTextDecoration> decoration_;
 };
 
 }  // namespace impeller::interop


### PR DESCRIPTION
Underlines, overlines, strikethroughs (with dashed, wavy, dotted... styles) etc..

Fixes https://github.com/flutter/flutter/issues/157796

<img width="1136" alt="Screenshot 2025-05-06 at 1 04 30 PM" src="https://github.com/user-attachments/assets/f2233ebd-87b2-42ca-ac2a-c71e40ceb953" />
