### PR TITLE
Ignore pointer on the outgoing route

### DIFF
--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -571,11 +571,14 @@ class _FadeForwardsPageTransition extends StatelessWidget {
         );
       },
       reverseBuilder: (BuildContext context, Animation<double> animation, Widget? child) {
-        return FadeTransition(
-          opacity: FadeForwardsPageTransitionsBuilder._fadeOutTransition.animate(animation),
-          child: SlideTransition(
-            position: _backwardTranslationTween.animate(animation),
-            child: child,
+        return IgnorePointer(
+          ignoring: animation.status == AnimationStatus.forward,
+          child: FadeTransition(
+            opacity: FadeForwardsPageTransitionsBuilder._fadeOutTransition.animate(animation),
+            child: SlideTransition(
+              position: _backwardTranslationTween.animate(animation),
+              child: child,
+            ),
           ),
         );
       },


### PR DESCRIPTION
When going back with FadeForwardsPageTransition, this PR makes it possible to interact with the incoming page before the transition has finished.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/fc2b18cf-b0a3-4be8-9360-361bcfe4a7e0" /> |<video src="https://github.com/user-attachments/assets/faaa42fb-9d7a-48df-9012-e99569244db3" /> |


Fixes https://github.com/flutter/flutter/issues/168424