### PR TITLE
Fix uninitalized fields in FlutterWindowMetricsEvent

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -776,7 +776,7 @@ FlutterViewId fl_engine_add_view(FlEngine* self,
   // will be updated in a following FlutterWindowMetricsEvent
   FlutterEngineDisplayId display_id = 0;
 
-  FlutterWindowMetricsEvent metrics;
+  FlutterWindowMetricsEvent metrics = {};
   metrics.struct_size = sizeof(FlutterWindowMetricsEvent);
   metrics.width = width;
   metrics.height = height;


### PR DESCRIPTION
Specifically physical_view_* were not set and thus had random values. When they were negative this would cause Flutter to reject the event.
