### PR TITLE
Fix framebuffer leak rendering to secondary views.

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -384,7 +384,7 @@ static gboolean present_layers(FlCompositorOpenGL* self,
 
     // Write into a texture in the views context.
     fl_renderable_make_current(renderable);
-    FlFramebuffer* view_framebuffer =
+    g_autoptr(FlFramebuffer) view_framebuffer =
         fl_framebuffer_new(self->general_format, width, height);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
                       fl_framebuffer_get_id(view_framebuffer));


### PR DESCRIPTION
Each frame would be leaked. This doesn't occur for single window.

