### PR TITLE
Fix stencil buffer leak

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -75,6 +75,7 @@ FlFramebuffer* fl_framebuffer_new(GLint format, size_t width, size_t height) {
                             GL_RENDERBUFFER, depth_stencil);
   glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
                             GL_RENDERBUFFER, depth_stencil);
+  glDeleteRenderbuffers(1, &depth_stencil);
 
   return provider;
 }


### PR DESCRIPTION
Most noticable when rendering to secondary views, one leak per frame.

Introduced for Impeller in 3af706d1887a26410cb82a9aa61da6c773d132f2

