### PR TITLE
Fix ListTile overwriting parent IconButtonTheme for its children (#167727)

### DIFF
--- a/packages/flutter/lib/src/material/icon_button_theme.dart
+++ b/packages/flutter/lib/src/material/icon_button_theme.dart
@@ -72,6 +72,16 @@ class IconButtonThemeData with Diagnosticable {
     return other is IconButtonThemeData && other.style == style;
   }
 
+  /// icon button theme is null, returns this IconButtonThemeData.
+  /// The [style] of this theme will be merged with [other.style]
+  /// via [ButtonStyle.merge].
+  IconButtonThemeData merge(IconButtonThemeData? other) {
+    if (other == null) {
+      return this;
+    }
+    return IconButtonThemeData(style: style?.merge(other.style));
+  }
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
@@ -91,6 +101,26 @@ class IconButtonThemeData with Diagnosticable {
 class IconButtonTheme extends InheritedTheme {
   /// Create a [IconButtonTheme].
   const IconButtonTheme({super.key, required this.data, required super.child});
+
+  /// Creates an icon button theme that controls the properties of
+  /// descendant widgets, and merges in the current icon button theme, if any.
+  static Widget merge({Key? key, required IconButtonThemeData data, required Widget child}) {
+    return Builder(
+      builder: (BuildContext context) {
+        return IconButtonTheme(
+          key: key,
+          data: _getInheritedIconButtonThemeData(context).merge(data),
+          child: child,
+        );
+      },
+    );
+  }
+
+  static IconButtonThemeData _getInheritedIconButtonThemeData(BuildContext context) {
+    final IconButtonTheme? iconButtonTheme =
+        context.dependOnInheritedWidgetOfExactType<IconButtonTheme>();
+    return iconButtonTheme?.data ?? Theme.of(context).iconButtonTheme;
+  }
 
   /// The configuration of this theme.
   final IconButtonThemeData data;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -18,8 +18,23 @@ library;
 
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+import 'color_scheme.dart';
+import 'colors.dart';
+import 'constants.dart';
+import 'debug.dart';
+import 'divider.dart';
+import 'icon_button.dart';
+import 'icon_button_theme.dart';
+import 'ink_decoration.dart';
+import 'ink_well.dart';
+import 'list_tile_theme.dart';
+import 'material_state.dart';
+import 'text_theme.dart';
+import 'theme.dart';
+import 'theme_data.dart';
 
 // Examples can assume:
 // int _act = 1;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -18,23 +18,8 @@ library;
 
 import 'dart:math' as math;
 
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
-
-import 'color_scheme.dart';
-import 'colors.dart';
-import 'constants.dart';
-import 'debug.dart';
-import 'divider.dart';
-import 'icon_button.dart';
-import 'icon_button_theme.dart';
-import 'ink_decoration.dart';
-import 'ink_well.dart';
-import 'list_tile_theme.dart';
-import 'material_state.dart';
-import 'text_theme.dart';
-import 'theme.dart';
-import 'theme_data.dart';
 
 // Examples can assume:
 // int _act = 1;
@@ -983,7 +968,7 @@ class ListTile extends StatelessWidget {
             minimum: resolvedContentPadding,
             child: IconTheme.merge(
               data: iconThemeData,
-              child: IconButtonTheme(
+              child: IconButtonTheme.merge(
                 data: iconButtonThemeData,
                 child: _ListTile(
                   leading: leadingIcon,


### PR DESCRIPTION
### Description

ListTile was recreating its own IconButtonThemeData—discarding any styles inherited from an existing IconButtonTheme above it. This change makes ListTile merge its theme data with the inherited one instead of replacing it, so child IconButtons now correctly pick up parent styling 

issue: https://github.com/flutter/flutter/issues/167727


