### PR TITLE
[gen-l10n] Add `// dart format off` for generated dart files to disable formatting

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -9,7 +9,8 @@ description: The Flutter application's synthetic package.
 ''';
 
 const String fileTemplate = '''
-@(header)import 'dart:async';
+@(header)// dart format off
+import 'dart:async';
 
 @(requiresFoundationImport)
 import 'package:flutter/widgets.dart';
@@ -173,7 +174,8 @@ const String dateVariableTemplate = '''
     String @(varName) = intl.DateFormat.@(formatType)(localeName).format(@(argument));''';
 
 const String classFileTemplate = '''
-@(header)// ignore: unused_import
+@(header)// dart format off
+// ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import '@(fileName)';
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -829,6 +829,7 @@ flutter:
       expect(fs.file('/lib/l10n/bar_en.dart').readAsStringSync(), '''
 HEADER
 
+// dart format off
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'bar.dart';
@@ -942,6 +943,7 @@ flutter:\r
       );
 
       expect(fs.file('/lib/l10n/app_localizations_en.dart').readAsStringSync(), '''
+// dart format off
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'app_localizations.dart';
@@ -977,6 +979,7 @@ class AppLocalizationsEn extends AppLocalizations {
       expect(fs.file('/lib/l10n/app_localizations_en.dart').readAsStringSync(), '''
 HEADER
 
+// dart format off
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'app_localizations.dart';


### PR DESCRIPTION
This PR adds `// dart format off` to the first line of the template for gen-l10n, in an attempt to turns off formatting of generated dart files by [dart_style](https://github.com/dart-lang/dart_style).