### PR TITLE
Fix keyboard_hot_restart_ios flakes

### DIFF
--- a/dev/integration_tests/keyboard_hot_restart/lib/main.dart
+++ b/dev/integration_tests/keyboard_hot_restart/lib/main.dart
@@ -13,7 +13,7 @@ import 'package:flutter/material.dart';
 // //dev/devicelab/lib/tasks/keyboard_hot_restart_test.dart
 const bool forceKeyboard = true;
 
-bool? keyboardVisible = null;
+bool? keyboardVisible;
 
 void main() {
   runApp(const MyApp());
@@ -54,8 +54,6 @@ class MyHomePage extends StatelessWidget {
 
     keyboardVisible = insets.bottom > 0;
 
-    return const Scaffold(
-      body: Center(child: TextField(autofocus: forceKeyboard)),
-    );
+    return const Scaffold(body: Center(child: TextField(autofocus: forceKeyboard)));
   }
 }

--- a/dev/integration_tests/keyboard_hot_restart/lib/main.dart
+++ b/dev/integration_tests/keyboard_hot_restart/lib/main.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 // If true, the app autofocuses a text field, making the software keyboard visible.
@@ -11,8 +13,27 @@ import 'package:flutter/material.dart';
 // //dev/devicelab/lib/tasks/keyboard_hot_restart_test.dart
 const bool forceKeyboard = true;
 
+bool? keyboardVisible = null;
+
 void main() {
   runApp(const MyApp());
+  unawaited(printKeyboardState());
+}
+
+Future<void> printKeyboardState() async {
+  while (true) {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    if (keyboardVisible == null) {
+      continue;
+    }
+
+    // Print whether the keyboard is visible or not.
+    // If you change this line, update the test as well.
+    // See:
+    // //dev/devicelab/lib/tasks/keyboard_hot_restart_test.dart
+    // ignore: avoid_print
+    print('Keyboard is ${keyboardVisible! ? 'open' : 'closed'}');
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -31,13 +52,10 @@ class MyHomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     final EdgeInsets insets = MediaQuery.of(context).viewInsets;
 
-    // Print whether the keyboard is visible or not.
-    // If you change this line, update the test as well.
-    // See:
-    // //dev/devicelab/lib/tasks/keyboard_hot_restart_test.dart
-    // ignore: avoid_print
-    print('Keyboard is ${insets.bottom > 0 ? 'open' : 'closed'}');
+    keyboardVisible = insets.bottom > 0;
 
-    return const Scaffold(body: Center(child: TextField(autofocus: forceKeyboard)));
+    return const Scaffold(
+      body: Center(child: TextField(autofocus: forceKeyboard)),
+    );
   }
 }


### PR DESCRIPTION
The keyboard hot restart test does these steps:

1. It launches an app that forces the keyboard to be visible
2. It checks that the keyboard is visible by examining the app's logs
3. It updates the app to no longer force the keyboard to be visible and hot restarts the app
4. It checks that the keyboard is no longer visible by examining the app's logs

Previously, the test app printed the keyboard status whenever the app rebuilt. The test would move on as soon as it saw a log that indicates the keyboard was in the expected state. However, since the app could log the keyboard's visibility _before_ the Dart VM was available, hot restart commands could be ignored (or at least, that's my theory from the DeviceLab logs).

Now, the test app prints the keyboard status non-stop. The test now waits until the Dart VM is available before checking if the logs indicate the keyboard is open. Also, the test now waits until the hot restart has completed before checking if the keyboard is closed. In theory, this should ensure that hot restart does not happen until after the Dart VM is available.

Follow-up to: https://github.com/flutter/flutter/pull/167013
Part of: https://github.com/flutter/flutter/issues/10713

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
