### PR TITLE
Add a callback for when the menu opens or closes.

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -192,6 +192,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.maxLines = 1,
     this.textInputAction,
     this.restorationId,
+    this.onMenuOpen,
   }) : assert(filterCallback == null || enableFilter);
 
   /// Determine if the [DropdownMenu] is enabled.
@@ -335,6 +336,8 @@ class DropdownMenu<T> extends StatefulWidget {
   ///
   /// Defaults to null. If null, only the text field is updated.
   final ValueChanged<T?>? onSelected;
+
+  final ValueChanged<bool>? onMenuOpen;
 
   /// Defines the keyboard focus for this widget.
   ///
@@ -904,6 +907,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         _internalFocudeNode.requestFocus();
       }
     }
+    widget.onMenuOpen?.call(controller.isOpen);
     setState(() {});
   }
 


### PR DESCRIPTION
This PR adds support for a callback that notifies when the `DropdownMenu` is opened or closed. By exposing this callback, developers can now listen to changes in the menu’s visibility state and react accordingly.

```
DropdownMenu<IconLabel>(
              onMenuOpen: (value) {
              print(value);
        },
```

This is just a first idea and open to feedback or refinement.



https://github.com/flutter/flutter/issues/168464

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
