### PR TITLE
Fix crash on two finger selection gesture

### DIFF
--- a/packages/flutter/lib/src/gestures/drag_details.dart
+++ b/packages/flutter/lib/src/gestures/drag_details.dart
@@ -124,6 +124,7 @@ class DragUpdateDetails with Diagnosticable implements PositionedGestureDetails 
     this.sourceTimeStamp,
     this.delta = Offset.zero,
     this.primaryDelta,
+    this.kind,
   }) : assert(
          primaryDelta == null ||
              (primaryDelta == delta.dx && delta.dy == 0.0) ||
@@ -167,6 +168,9 @@ class DragUpdateDetails with Diagnosticable implements PositionedGestureDetails 
   ///
   /// Defaults to null if not specified in the constructor.
   final double? primaryDelta;
+
+  /// The kind of the device that initiated the event.
+  final PointerDeviceKind? kind;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -717,6 +717,7 @@ sealed class DragGestureRecognizer extends OneSequenceGestureRecognizer {
             primaryDelta: _getPrimaryValueFromOffset(resolvedDelta),
             globalPosition: position,
             localPosition: localPosition,
+            pointer: event.pointer,
           );
       }
       _recordMoveDeltaForMultitouch(event.pointer, localDelta);
@@ -830,6 +831,7 @@ sealed class DragGestureRecognizer extends OneSequenceGestureRecognizer {
         primaryDelta: _getPrimaryValueFromOffset(localUpdateDelta),
         globalPosition: correctedPosition.global,
         localPosition: correctedPosition.local,
+        pointer: pointer,
       );
     }
     // This acceptGesture might have been called only for one pointer, instead
@@ -856,6 +858,7 @@ sealed class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     double? primaryDelta,
     required Offset globalPosition,
     Offset? localPosition,
+    required int pointer,
   }) {
     if (onUpdate != null) {
       final DragUpdateDetails details = DragUpdateDetails(
@@ -864,6 +867,7 @@ sealed class DragGestureRecognizer extends OneSequenceGestureRecognizer {
         primaryDelta: primaryDelta,
         globalPosition: globalPosition,
         localPosition: localPosition,
+        kind: getKindForPointer(pointer),
       );
       invokeCallback<void>('onUpdate', () => onUpdate!(details));
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5011,10 +5011,10 @@ class EditableTextState extends State<EditableText>
   }
 
   /// Shows the magnifier at the position given by `positionToShow`,
-  /// if there is no magnifier visible.
+  /// if no magnifier exists.
   ///
   /// Updates the magnifier to the position given by `positionToShow`,
-  /// if there is a magnifier visible.
+  /// if a magnifier exits.
   ///
   /// Does nothing if a magnifier couldn't be shown, such as when the selection
   /// overlay does not currently exist.
@@ -5023,22 +5023,20 @@ class EditableTextState extends State<EditableText>
       return;
     }
 
-    if (_selectionOverlay!.magnifierIsVisible) {
+    if (_selectionOverlay!.magnifierExists) {
       _selectionOverlay!.updateMagnifier(positionToShow);
     } else {
       _selectionOverlay!.showMagnifier(positionToShow);
     }
   }
 
-  /// Hides the magnifier if it is visible.
+  /// Hides the magnifier.
   void hideMagnifier() {
     if (_selectionOverlay == null) {
       return;
     }
 
-    if (_selectionOverlay!.magnifierIsVisible) {
-      _selectionOverlay!.hideMagnifier();
-    }
+    _selectionOverlay!.hideMagnifier();
   }
 
   // Tracks the location a [_ScribblePlaceholder] should be rendered in the

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1204,14 +1204,9 @@ class SelectableRegionState extends State<SelectableRegion>
     final Matrix4 globalTransform = _selectable!.getTransformTo(null);
     _selectionStartHandleDragPosition = MatrixUtils.transformPoint(globalTransform, localPosition);
 
-    if (_selectionOverlay != null && !_selectionOverlay!.magnifierIsVisible) {
-      _selectionOverlay!.showMagnifier(
-        _buildInfoForMagnifier(
-          details.globalPosition,
-          _selectionDelegate.value.startSelectionPoint!,
-        ),
-      );
-    }
+    _selectionOverlay!.showMagnifier(
+      _buildInfoForMagnifier(details.globalPosition, _selectionDelegate.value.startSelectionPoint!),
+    );
     _updateSelectedContentIfNeeded();
   }
 
@@ -1237,11 +1232,9 @@ class SelectableRegionState extends State<SelectableRegion>
     final Matrix4 globalTransform = _selectable!.getTransformTo(null);
     _selectionEndHandleDragPosition = MatrixUtils.transformPoint(globalTransform, localPosition);
 
-    if (_selectionOverlay != null && !_selectionOverlay!.magnifierIsVisible) {
-      _selectionOverlay!.showMagnifier(
-        _buildInfoForMagnifier(details.globalPosition, _selectionDelegate.value.endSelectionPoint!),
-      );
-    }
+    _selectionOverlay!.showMagnifier(
+      _buildInfoForMagnifier(details.globalPosition, _selectionDelegate.value.endSelectionPoint!),
+    );
     _updateSelectedContentIfNeeded();
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1126,13 +1126,13 @@ class SelectableRegionState extends State<SelectableRegion>
         _selectionOverlay != null &&
         (_selectionOverlay!.isDraggingStartHandle || _selectionOverlay!.isDraggingEndHandle);
     if (widget.selectionControls is! TextSelectionHandleControls) {
-      _selectionOverlay!.hideMagnifier();
       if (!draggingHandles) {
+        _selectionOverlay!.hideMagnifier();
         _selectionOverlay!.showToolbar();
       }
     } else {
-      _selectionOverlay!.hideMagnifier();
       if (!draggingHandles) {
+        _selectionOverlay!.hideMagnifier();
         _selectionOverlay!.showToolbar(
           context: context,
           contextMenuBuilder: (BuildContext context) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1122,17 +1122,24 @@ class SelectableRegionState extends State<SelectableRegion>
   }
 
   void _onAnyDragEnd(DragEndDetails details) {
+    final bool draggingHandles =
+        _selectionOverlay != null &&
+        (_selectionOverlay!.isDraggingStartHandle || _selectionOverlay!.isDraggingEndHandle);
     if (widget.selectionControls is! TextSelectionHandleControls) {
       _selectionOverlay!.hideMagnifier();
-      _selectionOverlay!.showToolbar();
+      if (!draggingHandles) {
+        _selectionOverlay!.showToolbar();
+      }
     } else {
       _selectionOverlay!.hideMagnifier();
-      _selectionOverlay!.showToolbar(
-        context: context,
-        contextMenuBuilder: (BuildContext context) {
-          return widget.contextMenuBuilder!(context, this);
-        },
-      );
+      if (!draggingHandles) {
+        _selectionOverlay!.showToolbar(
+          context: context,
+          contextMenuBuilder: (BuildContext context) {
+            return widget.contextMenuBuilder!(context, this);
+          },
+        );
+      }
     }
     _finalizeSelection();
     _updateSelectedContentIfNeeded();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1204,9 +1204,14 @@ class SelectableRegionState extends State<SelectableRegion>
     final Matrix4 globalTransform = _selectable!.getTransformTo(null);
     _selectionStartHandleDragPosition = MatrixUtils.transformPoint(globalTransform, localPosition);
 
-    _selectionOverlay!.showMagnifier(
-      _buildInfoForMagnifier(details.globalPosition, _selectionDelegate.value.startSelectionPoint!),
-    );
+    if (_selectionOverlay != null && !_selectionOverlay!.magnifierIsVisible) {
+      _selectionOverlay!.showMagnifier(
+        _buildInfoForMagnifier(
+          details.globalPosition,
+          _selectionDelegate.value.startSelectionPoint!,
+        ),
+      );
+    }
     _updateSelectedContentIfNeeded();
   }
 
@@ -1232,9 +1237,11 @@ class SelectableRegionState extends State<SelectableRegion>
     final Matrix4 globalTransform = _selectable!.getTransformTo(null);
     _selectionEndHandleDragPosition = MatrixUtils.transformPoint(globalTransform, localPosition);
 
-    _selectionOverlay!.showMagnifier(
-      _buildInfoForMagnifier(details.globalPosition, _selectionDelegate.value.endSelectionPoint!),
-    );
+    if (_selectionOverlay != null && !_selectionOverlay!.magnifierIsVisible) {
+      _selectionOverlay!.showMagnifier(
+        _buildInfoForMagnifier(details.globalPosition, _selectionDelegate.value.endSelectionPoint!),
+      );
+    }
     _updateSelectedContentIfNeeded();
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -727,6 +727,7 @@ class TextSelectionOverlay {
       Offset(details.globalPosition.dx, centerOfLineGlobal),
     );
 
+    // The drag start selection is only utilized on Apple platforms.
     if (defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS) {
       _dragStartSelection ??= _selection;
@@ -885,6 +886,7 @@ class TextSelectionOverlay {
       Offset(details.globalPosition.dx, centerOfLineGlobal),
     );
 
+    // The drag start selection is only utilized on Apple platforms.
     if (defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS) {
       _dragStartSelection ??= _selection;
@@ -1205,7 +1207,9 @@ class SelectionOverlay {
 
   // Whether the start handle can be dragged.
   //
-  // On Apple and web platforms only one selection handle can be dragged at a time.
+  // On Apple and web platforms only one selection handle can be dragged
+  // at a time, so when the end handle is being dragged on these platforms
+  // the the start handle cannot be dragged.
   bool get _canDragStartHandle =>
       !_isDraggingEndHandle ||
       (defaultTargetPlatform != TargetPlatform.iOS ||
@@ -1305,7 +1309,9 @@ class SelectionOverlay {
 
   // Whether the end handle can be dragged.
   //
-  // On Apple and web platforms only one selection handle can be dragged at a time.
+  // On Apple and web platforms only one selection handle can be dragged
+  // at a time, so when the start handle is being dragged on these platforms
+  // the the end handle cannot be dragged.
   bool get _canDragEndHandle =>
       !_isDraggingStartHandle ||
       (defaultTargetPlatform != TargetPlatform.iOS ||

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -584,6 +584,9 @@ class TextSelectionOverlay {
   /// {@macro flutter.widgets.SelectionOverlay.magnifierIsVisible}
   bool get magnifierIsVisible => _selectionOverlay.magnifierIsVisible;
 
+  /// {@macro flutter.widgets.SelectionOverlay.magnifierExists}
+  bool get magnifierExists => _selectionOverlay.magnifierExists;
+
   /// Whether the spell check menu is currently visible.
   ///
   /// See also:
@@ -1123,10 +1126,18 @@ class SelectionOverlay {
         : _toolbar != null || _spellCheckToolbarController.isShown;
   }
 
-  /// {@template flutter.widgets.SelectionOverlay.toolbarIsVisible}
+  /// {@template flutter.widgets.SelectionOverlay.magnifierIsVisible}
   /// Whether the magnifier is currently visible.
   /// {@endtemplate}
   bool get magnifierIsVisible => _magnifierController.shown;
+
+  /// {@template flutter.widgets.SelectionOverlay.magnifierExists}
+  /// Whether the magnifier currently exists.
+  ///
+  /// This differs from [magnifierIsVisible] in that the magnifier may exist
+  /// in the overlay, but not be shown.
+  /// {@endtemplate}
+  bool get magnifierExists => _magnifierController.overlayEntry != null;
 
   /// {@template flutter.widgets.SelectionOverlay.showMagnifier}
   /// Shows the magnifier, and hides the toolbar if it was showing when [showMagnifier]

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -581,8 +581,8 @@ class TextSelectionOverlay {
   ///     specifically is visible.
   bool get toolbarIsVisible => _selectionOverlay.toolbarIsVisible;
 
-  /// Whether the magnifier is currently visible.
-  bool get magnifierIsVisible => _selectionOverlay._magnifierController.shown;
+  /// {@macro flutter.widgets.SelectionOverlay.magnifierIsVisible}
+  bool get magnifierIsVisible => _selectionOverlay.magnifierIsVisible;
 
   /// Whether the spell check menu is currently visible.
   ///
@@ -1126,6 +1126,11 @@ class SelectionOverlay {
         ? _contextMenuController.isShown || _spellCheckToolbarController.isShown
         : _toolbar != null || _spellCheckToolbarController.isShown;
   }
+
+  /// {@template flutter.widgets.SelectionOverlay.toolbarIsVisible}
+  /// Whether the magnifier is currently visible.
+  /// {@endtemplate}
+  bool get magnifierIsVisible => _magnifierController.shown;
 
   /// {@template flutter.widgets.SelectionOverlay.showMagnifier}
   /// Shows the magnifier, and hides the toolbar if it was showing when [showMagnifier]

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1212,8 +1212,8 @@ class SelectionOverlay {
   // the the start handle cannot be dragged.
   bool get _canDragStartHandle =>
       !_isDraggingEndHandle ||
-      (defaultTargetPlatform != TargetPlatform.iOS ||
-          defaultTargetPlatform != TargetPlatform.macOS ||
+      (defaultTargetPlatform != TargetPlatform.iOS &&
+          defaultTargetPlatform != TargetPlatform.macOS &&
           !kIsWeb);
 
   /// Whether the start handle is visible.
@@ -1314,8 +1314,8 @@ class SelectionOverlay {
   // the the end handle cannot be dragged.
   bool get _canDragEndHandle =>
       !_isDraggingStartHandle ||
-      (defaultTargetPlatform != TargetPlatform.iOS ||
-          defaultTargetPlatform != TargetPlatform.macOS ||
+      (defaultTargetPlatform != TargetPlatform.iOS &&
+          defaultTargetPlatform != TargetPlatform.macOS &&
           !kIsWeb);
 
   /// Whether the end handle is visible.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -733,13 +733,15 @@ class TextSelectionOverlay {
       _dragStartSelection ??= _selection;
     }
 
-    _selectionOverlay.showMagnifier(
-      _buildMagnifier(
-        currentTextPosition: position,
-        globalGesturePosition: details.globalPosition,
-        renderEditable: renderObject,
-      ),
-    );
+    if (!_selectionOverlay._magnifierController.shown) {
+      _selectionOverlay.showMagnifier(
+        _buildMagnifier(
+          currentTextPosition: position,
+          globalGesturePosition: details.globalPosition,
+          renderEditable: renderObject,
+        ),
+      );
+    }
   }
 
   /// Given a handle position and drag position, returns the position of handle
@@ -892,13 +894,15 @@ class TextSelectionOverlay {
       _dragStartSelection ??= _selection;
     }
 
-    _selectionOverlay.showMagnifier(
-      _buildMagnifier(
-        currentTextPosition: position,
-        globalGesturePosition: details.globalPosition,
-        renderEditable: renderObject,
-      ),
-    );
+    if (!_selectionOverlay._magnifierController.shown) {
+      _selectionOverlay.showMagnifier(
+        _buildMagnifier(
+          currentTextPosition: position,
+          globalGesturePosition: details.globalPosition,
+          renderEditable: renderObject,
+        ),
+      );
+    }
   }
 
   void _handleSelectionStartHandleDragUpdate(DragUpdateDetails details) {
@@ -999,15 +1003,19 @@ class TextSelectionOverlay {
     final bool draggingHandles =
         _selectionOverlay.isDraggingStartHandle || _selectionOverlay.isDraggingEndHandle;
     if (selectionControls is! TextSelectionHandleControls) {
-      _selectionOverlay.hideMagnifier();
-      if (!_selection.isCollapsed && !draggingHandles) {
-        _selectionOverlay.showToolbar();
+      if (!draggingHandles) {
+        _selectionOverlay.hideMagnifier();
+        if (!_selection.isCollapsed) {
+          _selectionOverlay.showToolbar();
+        }
       }
       return;
     }
-    _selectionOverlay.hideMagnifier();
-    if (!_selection.isCollapsed && !draggingHandles) {
-      _selectionOverlay.showToolbar(context: context, contextMenuBuilder: contextMenuBuilder);
+    if (!draggingHandles) {
+      _selectionOverlay.hideMagnifier();
+      if (!_selection.isCollapsed) {
+        _selectionOverlay.showToolbar(context: context, contextMenuBuilder: contextMenuBuilder);
+      }
     }
   }
 
@@ -1201,8 +1209,12 @@ class SelectionOverlay {
     markNeedsBuild();
   }
 
+  // Whether a drag is in progress on the start handle. This differs from
+  // `_isDraggingStartHandle` in that it is not blocked by `_canDragStartHandle`.
+  bool _startHandleDragInProgress = false;
+
   /// Whether the selection start handle is currently being dragged.
-  bool get isDraggingStartHandle => _isDraggingStartHandle;
+  bool get isDraggingStartHandle => _isDraggingStartHandle || _startHandleDragInProgress;
   bool _isDraggingStartHandle = false;
 
   // Whether the start handle can be dragged.
@@ -1235,6 +1247,7 @@ class SelectionOverlay {
       _isDraggingStartHandle = false;
       return;
     }
+    _startHandleDragInProgress = true;
     if (!_canDragStartHandle) {
       return;
     }
@@ -1282,6 +1295,7 @@ class SelectionOverlay {
     if (_handles == null) {
       return;
     }
+    _startHandleDragInProgress = false;
     if (!_canDragStartHandle) {
       return;
     }
@@ -1316,8 +1330,12 @@ class SelectionOverlay {
     markNeedsBuild();
   }
 
+  // Whether a drag is in progress on the start handle. This differs from
+  // `_isDraggingEndHandle` in that it is not blocked by `_canDragEndHandle`.
+  bool _endHandleDragInProgress = false;
+
   /// Whether the selection end handle is currently being dragged.
-  bool get isDraggingEndHandle => _isDraggingEndHandle;
+  bool get isDraggingEndHandle => _isDraggingEndHandle || _endHandleDragInProgress;
   bool _isDraggingEndHandle = false;
 
   // Whether the end handle can be dragged.
@@ -1350,6 +1368,7 @@ class SelectionOverlay {
       _isDraggingEndHandle = false;
       return;
     }
+    _endHandleDragInProgress = true;
     if (!_canDragEndHandle) {
       return;
     }
@@ -1397,6 +1416,7 @@ class SelectionOverlay {
     if (_handles == null) {
       return;
     }
+    _endHandleDragInProgress = false;
     if (!_canDragEndHandle) {
       return;
     }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -983,7 +983,7 @@ class TextSelectionOverlay {
     }
     _dragStartSelection = null;
     final bool draggingHandles =
-        _selectionOverlay._isDraggingStartHandle || _selectionOverlay._isDraggingEndHandle;
+        _selectionOverlay.isDraggingStartHandle || _selectionOverlay.isDraggingEndHandle;
     if (selectionControls is! TextSelectionHandleControls) {
       _selectionOverlay.hideMagnifier();
       if (!_selection.isCollapsed && !draggingHandles) {
@@ -1187,7 +1187,10 @@ class SelectionOverlay {
     markNeedsBuild();
   }
 
+  /// Whether the selection start handle is currently being dragged.
+  bool get isDraggingStartHandle => _isDraggingStartHandle;
   bool _isDraggingStartHandle = false;
+
   bool _blockStartHandleDrag = false;
 
   /// Whether the start handle is visible.
@@ -1283,7 +1286,10 @@ class SelectionOverlay {
     markNeedsBuild();
   }
 
+  /// Whether the selection end handle is currently being dragged.
+  bool get isDraggingEndHandle => _isDraggingEndHandle;
   bool _isDraggingEndHandle = false;
+
   bool _blockEndHandleDrag = false;
 
   /// Whether the end handle is visible.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -733,15 +733,13 @@ class TextSelectionOverlay {
       _dragStartSelection ??= _selection;
     }
 
-    if (!_selectionOverlay._magnifierController.shown) {
-      _selectionOverlay.showMagnifier(
-        _buildMagnifier(
-          currentTextPosition: position,
-          globalGesturePosition: details.globalPosition,
-          renderEditable: renderObject,
-        ),
-      );
-    }
+    _selectionOverlay.showMagnifier(
+      _buildMagnifier(
+        currentTextPosition: position,
+        globalGesturePosition: details.globalPosition,
+        renderEditable: renderObject,
+      ),
+    );
   }
 
   /// Given a handle position and drag position, returns the position of handle
@@ -894,15 +892,13 @@ class TextSelectionOverlay {
       _dragStartSelection ??= _selection;
     }
 
-    if (!_selectionOverlay._magnifierController.shown) {
-      _selectionOverlay.showMagnifier(
-        _buildMagnifier(
-          currentTextPosition: position,
-          globalGesturePosition: details.globalPosition,
-          renderEditable: renderObject,
-        ),
-      );
-    }
+    _selectionOverlay.showMagnifier(
+      _buildMagnifier(
+        currentTextPosition: position,
+        globalGesturePosition: details.globalPosition,
+        renderEditable: renderObject,
+      ),
+    );
   }
 
   void _handleSelectionStartHandleDragUpdate(DragUpdateDetails details) {
@@ -1143,6 +1139,10 @@ class SelectionOverlay {
   /// [MagnifierController.shown].
   /// {@endtemplate}
   void showMagnifier(MagnifierInfo initialMagnifierInfo) {
+    // Do not show the magnifier if one already exists.
+    if (_magnifierController.overlayEntry != null) {
+      return;
+    }
     if (toolbarIsVisible) {
       hideToolbar();
     }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -696,8 +696,16 @@ class TextSelectionOverlay {
   // The initial selection when a selection handle drag has started.
   TextSelection? _dragStartSelection;
 
+  bool _blockEndHandleDrag = false;
+  bool _blockStartHandleDrag = false;
+
   void _handleSelectionEndHandleDragStart(DragStartDetails details) {
     if (!renderObject.attached) {
+      return;
+    }
+    if (_selectionOverlay._isDraggingStartHandle && (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS)) {
+      _blockEndHandleDrag = true;
       return;
     }
 
@@ -716,7 +724,10 @@ class TextSelectionOverlay {
     final TextPosition position = renderObject.getPositionForPoint(
       Offset(details.globalPosition.dx, centerOfLineGlobal),
     );
-    _dragStartSelection ??= _selection;
+    _dragStartSelection =
+        defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.macOS
+            ? _selection
+            : null;
 
     _selectionOverlay.showMagnifier(
       _buildMagnifier(
@@ -753,10 +764,9 @@ class TextSelectionOverlay {
   }
 
   void _handleSelectionEndHandleDragUpdate(DragUpdateDetails details) {
-    if (!renderObject.attached) {
+    if (!renderObject.attached || _blockEndHandleDrag) {
       return;
     }
-    assert(_dragStartSelection != null);
 
     // This is NOT the same as details.localPosition. That is relative to the
     // selection handle, whereas this is relative to the RenderEditable.
@@ -776,25 +786,25 @@ class TextSelectionOverlay {
 
     final TextPosition position = renderObject.getPositionForPoint(handleTargetGlobal);
 
-    if (_dragStartSelection!.isCollapsed) {
-      _selectionOverlay.updateMagnifier(
-        _buildMagnifier(
-          currentTextPosition: position,
-          globalGesturePosition: details.globalPosition,
-          renderEditable: renderObject,
-        ),
-      );
-
-      final TextSelection currentSelection = TextSelection.fromPosition(position);
-      _handleSelectionHandleChanged(currentSelection);
-      return;
-    }
-
     final TextSelection newSelection;
     switch (defaultTargetPlatform) {
       // On Apple platforms, dragging the base handle makes it the extent.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
+        assert(_dragStartSelection != null);
+        if (_dragStartSelection!.isCollapsed) {
+          _selectionOverlay.updateMagnifier(
+            _buildMagnifier(
+              currentTextPosition: position,
+              globalGesturePosition: details.globalPosition,
+              renderEditable: renderObject,
+            ),
+          );
+
+          final TextSelection currentSelection = TextSelection.fromPosition(position);
+          _handleSelectionHandleChanged(currentSelection);
+          return;
+        }
         // Use this instead of _dragStartSelection.isNormalized because TextRange.isNormalized
         // always returns true for a TextSelection.
         final bool dragStartSelectionNormalized =
@@ -810,6 +820,19 @@ class TextSelectionOverlay {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
+        if (_selection.isCollapsed) {
+          _selectionOverlay.updateMagnifier(
+            _buildMagnifier(
+              currentTextPosition: position,
+              globalGesturePosition: details.globalPosition,
+              renderEditable: renderObject,
+            ),
+          );
+
+          final TextSelection currentSelection = TextSelection.fromPosition(position);
+          _handleSelectionHandleChanged(currentSelection);
+          return;
+        }
         newSelection = TextSelection(
           baseOffset: _selection.baseOffset,
           extentOffset: position.offset,
@@ -842,6 +865,11 @@ class TextSelectionOverlay {
     if (!renderObject.attached) {
       return;
     }
+    if (_selectionOverlay._isDraggingStartHandle && (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS)) {
+      _blockStartHandleDrag = true;
+      return;
+    }
 
     _startHandleDragPosition = details.globalPosition.dy;
 
@@ -858,7 +886,10 @@ class TextSelectionOverlay {
     final TextPosition position = renderObject.getPositionForPoint(
       Offset(details.globalPosition.dx, centerOfLineGlobal),
     );
-    _dragStartSelection ??= _selection;
+    _dragStartSelection =
+        defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.macOS
+            ? _selection
+            : null;
 
     _selectionOverlay.showMagnifier(
       _buildMagnifier(
@@ -870,10 +901,9 @@ class TextSelectionOverlay {
   }
 
   void _handleSelectionStartHandleDragUpdate(DragUpdateDetails details) {
-    if (!renderObject.attached) {
+    if (!renderObject.attached || _blockStartHandleDrag) {
       return;
     }
-    assert(_dragStartSelection != null);
 
     // This is NOT the same as details.localPosition. That is relative to the
     // selection handle, whereas this is relative to the RenderEditable.
@@ -890,25 +920,25 @@ class TextSelectionOverlay {
     );
     final TextPosition position = renderObject.getPositionForPoint(handleTargetGlobal);
 
-    if (_dragStartSelection!.isCollapsed) {
-      _selectionOverlay.updateMagnifier(
-        _buildMagnifier(
-          currentTextPosition: position,
-          globalGesturePosition: details.globalPosition,
-          renderEditable: renderObject,
-        ),
-      );
-
-      final TextSelection currentSelection = TextSelection.fromPosition(position);
-      _handleSelectionHandleChanged(currentSelection);
-      return;
-    }
-
     final TextSelection newSelection;
     switch (defaultTargetPlatform) {
       // On Apple platforms, dragging the base handle makes it the extent.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
+        assert(_dragStartSelection != null);
+        if (_dragStartSelection!.isCollapsed) {
+          _selectionOverlay.updateMagnifier(
+            _buildMagnifier(
+              currentTextPosition: position,
+              globalGesturePosition: details.globalPosition,
+              renderEditable: renderObject,
+            ),
+          );
+
+          final TextSelection currentSelection = TextSelection.fromPosition(position);
+          _handleSelectionHandleChanged(currentSelection);
+          return;
+        }
         // Use this instead of _dragStartSelection.isNormalized because TextRange.isNormalized
         // always returns true for a TextSelection.
         final bool dragStartSelectionNormalized =
@@ -924,6 +954,19 @@ class TextSelectionOverlay {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
+        if (_selection.isCollapsed) {
+          _selectionOverlay.updateMagnifier(
+            _buildMagnifier(
+              currentTextPosition: position,
+              globalGesturePosition: details.globalPosition,
+              renderEditable: renderObject,
+            ),
+          );
+
+          final TextSelection currentSelection = TextSelection.fromPosition(position);
+          _handleSelectionHandleChanged(currentSelection);
+          return;
+        }
         newSelection = TextSelection(
           baseOffset: position.offset,
           extentOffset: _selection.extentOffset,
@@ -951,16 +994,23 @@ class TextSelectionOverlay {
     if (!context.mounted) {
       return;
     }
+    if (_blockStartHandleDrag || _blockEndHandleDrag) {
+      _blockStartHandleDrag = false;
+      _blockEndHandleDrag = false;
+      return;
+    }
     _dragStartSelection = null;
+    final bool draggingHandles =
+        _selectionOverlay._isDraggingStartHandle || _selectionOverlay._isDraggingEndHandle;
     if (selectionControls is! TextSelectionHandleControls) {
       _selectionOverlay.hideMagnifier();
-      if (!_selection.isCollapsed) {
+      if (!_selection.isCollapsed && !draggingHandles) {
         _selectionOverlay.showToolbar();
       }
       return;
     }
     _selectionOverlay.hideMagnifier();
-    if (!_selection.isCollapsed) {
+    if (!_selection.isCollapsed && !draggingHandles) {
       _selectionOverlay.showToolbar(context: context, contextMenuBuilder: contextMenuBuilder);
     }
   }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1252,6 +1252,19 @@ class SelectionOverlay {
     if (!_canDragStartHandle) {
       return;
     }
+    // The handle drag may have been blocked before on Apple platforms and the web
+    // while the opposite handle was being dragged. Ensure that any logic that was
+    // meant to be run in onStartHandleDragStart is still run.
+    if (!_isDraggingStartHandle) {
+      _isDraggingStartHandle = details.kind == PointerDeviceKind.touch;
+      final DragStartDetails startDetails = DragStartDetails(
+        globalPosition: details.globalPosition,
+        localPosition: details.localPosition,
+        sourceTimeStamp: details.sourceTimeStamp,
+        kind: details.kind,
+      );
+      onStartHandleDragStart?.call(startDetails);
+    }
     onStartHandleDragUpdate?.call(details);
   }
 
@@ -1353,6 +1366,19 @@ class SelectionOverlay {
     }
     if (!_canDragEndHandle) {
       return;
+    }
+    // The handle drag may have been blocked before on Apple platforms and the web
+    // while the opposite handle was being dragged. Ensure that any logic that was
+    // meant to be run in onStartHandleDragStart is still run.
+    if (!_isDraggingEndHandle) {
+      _isDraggingEndHandle = details.kind == PointerDeviceKind.touch;
+      final DragStartDetails startDetails = DragStartDetails(
+        globalPosition: details.globalPosition,
+        localPosition: details.localPosition,
+        sourceTimeStamp: details.sourceTimeStamp,
+        kind: details.kind,
+      );
+      onEndHandleDragStart?.call(startDetails);
     }
     onEndHandleDragUpdate?.call(details);
   }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1211,8 +1211,9 @@ class SelectionOverlay {
     }
     if (_isDraggingEndHandle &&
         (defaultTargetPlatform == TargetPlatform.iOS ||
-            defaultTargetPlatform == TargetPlatform.macOS)) {
-      // On Apple platforms only one selection handle can be dragged at a time.
+            defaultTargetPlatform == TargetPlatform.macOS ||
+            kIsWeb)) {
+      // On Apple and web platforms only one selection handle can be dragged at a time.
       _blockStartHandleDrag = true;
       return;
     }
@@ -1306,8 +1307,9 @@ class SelectionOverlay {
     }
     if (_isDraggingStartHandle &&
         (defaultTargetPlatform == TargetPlatform.iOS ||
-            defaultTargetPlatform == TargetPlatform.macOS)) {
-      // On Apple platforms only one selection handle can be dragged at a time.
+            defaultTargetPlatform == TargetPlatform.macOS ||
+            kIsWeb)) {
+      // On Apple and web platforms only one selection handle can be dragged at a time.
       _blockEndHandleDrag = true;
       return;
     }

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter/gestures.dart'
     show
         DragStartBehavior,
         PointerDeviceKind,
+        debugPrintGestureArenaDiagnostics,
         kDoubleTapTimeout,
         kLongPressTimeout,
         kSecondaryMouseButton;
@@ -4880,6 +4881,134 @@ void main() {
       expect(controller.selection.extentOffset, 2);
     },
     variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'Can only drag one handle at a time on iOS',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              style: const TextStyle(fontSize: 10.0),
+            ),
+          ),
+        ),
+      );
+
+      // Double tap on 'e' to select 'def'.
+      final Offset ePos = textOffsetToPosition(tester, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, 7);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(controller.selection),
+        renderEditable,
+      );
+      expect(endpoints.length, 2);
+
+      // Drag the end handle to the end of the text.
+      final Offset endHandlePos = endpoints[1].point;
+      Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+
+      // Attempt to drag the start handle to the start of the text.
+      final Offset startHandlePos = endpoints[0].point;
+      newHandlePos = textOffsetToPosition(tester, 0);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+      await tester.pump();
+      await startHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await startHandleGesture.up();
+      await endHandleGesture.up();
+      await tester.pump();
+
+      // The start handle does not cause the selection to change.
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'Can drag both selection handles at a time on Android',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              style: const TextStyle(fontSize: 10.0),
+            ),
+          ),
+        ),
+      );
+
+      // Double tap on 'e' to select 'def'.
+      final Offset ePos = textOffsetToPosition(tester, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(controller.selection),
+        renderEditable,
+      );
+      expect(endpoints.length, 2);
+
+      // Drag the end handle to the end of the text.
+      final Offset endHandlePos = endpoints[1].point;
+      Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+
+      // Attempt to drag the start handle to the start of the text.
+      final Offset startHandlePos = endpoints[0].point;
+      newHandlePos = textOffsetToPosition(tester, 0);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+      await tester.pump();
+      await startHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await startHandleGesture.up();
+      await endHandleGesture.up();
+      await tester.pump();
+
+      // Moving the start handle changes the selection.
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 11);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
   );
 
   testWidgets(

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -16,7 +16,6 @@ import 'package:flutter/gestures.dart'
     show
         DragStartBehavior,
         PointerDeviceKind,
-        debugPrintGestureArenaDiagnostics,
         kDoubleTapTimeout,
         kLongPressTimeout,
         kSecondaryMouseButton;
@@ -4879,6 +4878,78 @@ void main() {
       // The selection inverts moving beyond the left handle.
       expect(controller.selection.baseOffset, 4);
       expect(controller.selection.extentOffset, 2);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'assertion error is not thrown when attempting to drag both selection handles',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/168578.
+      final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              style: const TextStyle(fontSize: 10.0),
+            ),
+          ),
+        ),
+      );
+
+      // Double tap on 'e' to select 'def'.
+      final Offset ePos = textOffsetToPosition(tester, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, 7);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(controller.selection),
+        renderEditable,
+      );
+      expect(endpoints.length, 2);
+
+      // Drag the end handle to 'g'.
+      final Offset endHandlePos = endpoints[1].point;
+      Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
+      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 9);
+
+      // Attempt to drag the start handle to the start of the text.
+      final Offset startHandlePos = endpoints[0].point;
+      newHandlePos = textOffsetToPosition(tester, 0);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+      await tester.pump();
+      await startHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await startHandleGesture.up();
+      await tester.pump();
+
+      // Drag the end handle to the end of the text after releasing the start handle.
+      newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await endHandleGesture.up();
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
     },
     variant: TargetPlatformVariant.only(TargetPlatform.iOS),
   );

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -393,7 +393,7 @@ void main() {
       );
       final TestGesture gesture = await tester.startGesture(
         textOffsetToPosition(paragraph, 11),
-      ); // at the 'a'
+      ); // at the 'e'.
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();
@@ -464,7 +464,7 @@ void main() {
       );
       final TestGesture gesture = await tester.startGesture(
         textOffsetToPosition(paragraph, 11),
-      ); // at the 'a'
+      ); // at the 'e'.
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();
@@ -535,7 +535,7 @@ void main() {
       );
       final TestGesture gesture = await tester.startGesture(
         textOffsetToPosition(paragraph, 11),
-      ); // at the 'a'
+      ); // at the 'e'.
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -364,4 +364,217 @@ void main() {
     variant: TargetPlatformVariant.mobile(),
     skip: kIsWeb, // [intended]
   );
+
+  testWidgets(
+    'Can only drag one selection handle at a time on iOS',
+    (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.only(top: 64),
+              child: Center(
+                child: SelectionArea(
+                  focusNode: focusNode,
+                  child: const Text('one two three four five'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(of: find.text('one two three four five'), matching: find.byType(RichText)),
+      );
+      final TestGesture gesture = await tester.startGesture(
+        textOffsetToPosition(paragraph, 11),
+      ); // at the 'a'
+      addTearDown(gesture.removePointer);
+      await tester.pump(const Duration(milliseconds: 500));
+      await gesture.up();
+      await tester.pumpAndSettle();
+      final List<TextBox> boxes = paragraph.getBoxesForSelection(paragraph.selections[0]);
+      expect(boxes.length, 1);
+      await tester.pumpAndSettle();
+      // There is a selection now.
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 13));
+
+      // This is the position of the selection handle displayed at the end.
+      final Offset endHandlePos = paragraph.localToGlobal(boxes[0].toRect().bottomRight);
+      await gesture.down(endHandlePos);
+      await gesture.moveTo(
+        textOffsetToPosition(paragraph, 22) + Offset(0, paragraph.size.height / 2),
+      );
+      await tester.pumpAndSettle();
+
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 22));
+
+      // Attempt to move the start handle while still touching the end handle.
+      final Offset startHandlePos = paragraph.localToGlobal(boxes[0].toRect().bottomLeft);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos);
+      addTearDown(startHandleGesture.removePointer);
+      await tester.pump();
+      await startHandleGesture.moveTo(
+        textOffsetToPosition(paragraph, 0) + Offset(0, paragraph.size.height / 2),
+      );
+      await tester.pump();
+      await gesture.up();
+      await startHandleGesture.up();
+      await tester.pumpAndSettle();
+      // Selection should not change when dragging start handle.
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 22));
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    skip: kIsWeb, // [intended]
+  );
+
+  testWidgets(
+    'Can only drag one selection handle at a time on Android web',
+    (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.only(top: 64),
+              child: Center(
+                child: SelectionArea(
+                  focusNode: focusNode,
+                  child: const Text('one two three four five'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(of: find.text('one two three four five'), matching: find.byType(RichText)),
+      );
+      final TestGesture gesture = await tester.startGesture(
+        textOffsetToPosition(paragraph, 11),
+      ); // at the 'a'
+      addTearDown(gesture.removePointer);
+      await tester.pump(const Duration(milliseconds: 500));
+      await gesture.up();
+      await tester.pumpAndSettle();
+      final List<TextBox> boxes = paragraph.getBoxesForSelection(paragraph.selections[0]);
+      expect(boxes.length, 1);
+      await tester.pumpAndSettle();
+      // There is a selection now.
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 13));
+
+      // This is the position of the selection handle displayed at the end.
+      final Offset endHandlePos = paragraph.localToGlobal(boxes[0].toRect().bottomRight);
+      await gesture.down(endHandlePos);
+      await gesture.moveTo(
+        textOffsetToPosition(paragraph, 22) + Offset(0, paragraph.size.height / 2),
+      );
+      await tester.pumpAndSettle();
+
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 22));
+
+      // Attempt to move the start handle while still touching the end handle.
+      final Offset startHandlePos = paragraph.localToGlobal(boxes[0].toRect().bottomLeft);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos);
+      addTearDown(startHandleGesture.removePointer);
+      await tester.pump();
+      await startHandleGesture.moveTo(
+        textOffsetToPosition(paragraph, 0) + Offset(0, paragraph.size.height / 2),
+      );
+      await tester.pump();
+      await gesture.up();
+      await startHandleGesture.up();
+      await tester.pumpAndSettle();
+      // Selection should not change when dragging start handle.
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 22));
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+    skip: !kIsWeb, // [intended] on native both selection handles can be dragged at a time.
+  );
+
+  testWidgets(
+    'Can drag both selection handles at a time on Android',
+    (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.only(top: 64),
+              child: Center(
+                child: SelectionArea(
+                  focusNode: focusNode,
+                  child: const Text('one two three four five'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(of: find.text('one two three four five'), matching: find.byType(RichText)),
+      );
+      final TestGesture gesture = await tester.startGesture(
+        textOffsetToPosition(paragraph, 11),
+      ); // at the 'a'
+      addTearDown(gesture.removePointer);
+      await tester.pump(const Duration(milliseconds: 500));
+      await gesture.up();
+      await tester.pumpAndSettle();
+      final List<TextBox> boxes = paragraph.getBoxesForSelection(paragraph.selections[0]);
+      expect(boxes.length, 1);
+      await tester.pumpAndSettle();
+      // There is a selection now.
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 13));
+
+      // This is the position of the selection handle displayed at the end.
+      final Offset endHandlePos = paragraph.localToGlobal(boxes[0].toRect().bottomRight);
+      await gesture.down(endHandlePos);
+      await gesture.moveTo(
+        textOffsetToPosition(paragraph, 22) + Offset(0, paragraph.size.height / 2),
+      );
+      await tester.pumpAndSettle();
+
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 22));
+
+      // Attempt to move the start handle while still touching the end handle.
+      final Offset startHandlePos = paragraph.localToGlobal(boxes[0].toRect().bottomLeft);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos);
+      addTearDown(startHandleGesture.removePointer);
+      await tester.pump();
+      await startHandleGesture.moveTo(
+        textOffsetToPosition(paragraph, 0) + Offset(0, paragraph.size.height / 2),
+      );
+      await tester.pump();
+      await gesture.up();
+      await startHandleGesture.up();
+      await tester.pumpAndSettle();
+      // Selection changes when dragging start handle.
+      expect(paragraph.selections.length, 1);
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 22));
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+    skip: kIsWeb, // [intended] on web only one selection handle can be dragged at a time.
+  );
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -16763,7 +16763,7 @@ void main() {
       );
 
       testWidgets(
-        'should build nothing on Android and iOS',
+        'should build nothing on all platforms but iOS and Android',
         (WidgetTester tester) async {
           await tester.pumpWidget(const MaterialApp(home: Scaffold(body: TextField())));
 
@@ -17036,6 +17036,110 @@ void main() {
         TargetPlatform.android,
         TargetPlatform.iOS,
       }),
+    );
+
+    testWidgets(
+      'Can double tap and drag to show, unshow, and update magnifier',
+      (WidgetTester tester) async {
+        final TextEditingController controller = _textEditingController();
+        MagnifierController? magnifierController;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: Center(
+                child: TextField(
+                  dragStartBehavior: DragStartBehavior.down,
+                  controller: controller,
+                  magnifierConfiguration: TextMagnifierConfiguration(
+                    magnifierBuilder: (
+                      BuildContext context,
+                      MagnifierController controller,
+                      ValueNotifier<MagnifierInfo> localMagnifierInfo,
+                    ) {
+                      magnifierController = controller;
+                      return TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
+                        context,
+                        controller,
+                        localMagnifierInfo,
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        const String testValue = 'one two three four five six seven';
+        await tester.enterText(find.byType(TextField), testValue);
+        await skipPastScrollingAnimation(tester);
+
+        // Tap at 'e' to set the selection to the closest word edge, which is position 3 on iOS.
+        final Offset initialPosition = textOffsetToPosition(tester, testValue.indexOf('e'));
+        await tester.tapAt(initialPosition);
+        await tester.pumpAndSettle(const Duration(milliseconds: 300));
+        expect(controller.selection.isCollapsed, true);
+        expect(controller.selection.baseOffset, 3);
+        expect(magnifierController, isNull);
+
+        // Double tap the 'e' to select 'one'.
+        final TestGesture gesture = await tester.startGesture(initialPosition);
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+        await gesture.down(initialPosition);
+        await tester.pumpAndSettle();
+        expect(controller.selection.isCollapsed, false);
+        expect(controller.selection.baseOffset, 0);
+        expect(controller.selection.extentOffset, 3);
+        expect(magnifierController, isNull);
+
+        // Drag immediately after the double tap to select 'one two three four' and show the magnifier.
+        await gesture.moveTo(textOffsetToPosition(tester, 16));
+        await tester.pumpAndSettle();
+
+        expect(controller.selection.isCollapsed, false);
+        expect(controller.selection.baseOffset, 0);
+        expect(controller.selection.extentOffset, 18);
+        expect(magnifierController, isNotNull);
+        expect(magnifierController!.shown, true);
+
+        // Dragging down at the same position should hide the cupertino magnifier when it
+        // exceeds its `hideBelowThreshold`.
+        await gesture.moveTo(textOffsetToPosition(tester, 16) + const Offset(0.0, 50.0));
+        await tester.pumpAndSettle();
+        expect(controller.selection.isCollapsed, false);
+        expect(controller.selection.baseOffset, 0);
+        expect(controller.selection.extentOffset, 18);
+        expect(magnifierController, isNotNull);
+        expect(magnifierController!.shown, false);
+
+        // Keep draging to select 'one two three four five' while the position continues to
+        // exceed the `hideBelowThreshold` keeping the magnifier hidden.
+        await gesture.moveTo(textOffsetToPosition(tester, 20) + const Offset(0.0, 50.0));
+        await tester.pumpAndSettle();
+        expect(controller.selection.isCollapsed, false);
+        expect(controller.selection.baseOffset, 0);
+        expect(controller.selection.extentOffset, 23);
+        expect(magnifierController, isNotNull);
+        expect(magnifierController!.shown, false);
+
+        // Remove offset that is used to exceed threshold, this should reveal the magnifier.
+        await gesture.moveTo(textOffsetToPosition(tester, 20));
+        await tester.pumpAndSettle();
+        expect(controller.selection.isCollapsed, false);
+        expect(controller.selection.baseOffset, 0);
+        expect(controller.selection.extentOffset, 23);
+        expect(magnifierController, isNotNull);
+        expect(magnifierController!.shown, true);
+
+        // End the drag to hide the magnifier.
+        await gesture.up();
+        await tester.pumpAndSettle();
+        expect(magnifierController, isNotNull);
+        expect(magnifierController!.shown, false);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );
 
     testWidgets(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3443,8 +3443,6 @@ void main() {
       expect(endpoints.length, 2);
 
       // Drag the end handle to the end of the text.
-      // We use a small offset because the endpoint is on the very corner
-      // of the handle.
       final Offset endHandlePos = endpoints[1].point;
       Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
       final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
@@ -3455,8 +3453,6 @@ void main() {
       expect(controller.selection.extentOffset, 11);
 
       // Attempt to drag the start handle to the start of the text.
-      // We use a small offset because the endpoint is on the very corner
-      // of the handle.
       final Offset startHandlePos = endpoints[0].point;
       newHandlePos = textOffsetToPosition(tester, 0);
       final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
@@ -3472,6 +3468,71 @@ void main() {
       expect(controller.selection.extentOffset, 11);
     },
     variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'Can only drag one selection handle at a time on Android web',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        overlay(
+          child: Center(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              style: const TextStyle(fontSize: 10.0),
+            ),
+          ),
+        ),
+      );
+
+      // Double tap on 'e' to select 'def'.
+      final Offset ePos = textOffsetToPosition(tester, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(controller.selection),
+        renderEditable,
+      );
+      expect(endpoints.length, 2);
+
+      // Drag the end handle to the end of the text.
+      final Offset endHandlePos = endpoints[1].point + const Offset(1.0, 1.0);
+      Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+
+      // Attempt to drag the start handle to the start of the text.
+      final Offset startHandlePos = endpoints[0].point + const Offset(1.0, 1.0);
+      newHandlePos = textOffsetToPosition(tester, 0);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+      await tester.pump();
+      await startHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await startHandleGesture.up();
+      await endHandleGesture.up();
+      await tester.pump();
+
+      // Moving the start handle does not change the selection.
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+    },
+    skip: !kIsWeb, // [intended] on web only one selection handle can be dragged at a time.
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
   );
 
   testWidgets(
@@ -3535,6 +3596,7 @@ void main() {
       expect(controller.selection.baseOffset, 0);
       expect(controller.selection.extentOffset, 11);
     },
+    skip: kIsWeb, // [intended] on web only one selection handle can be dragged at a time.
     variant: TargetPlatformVariant.only(TargetPlatform.android),
   );
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3334,6 +3334,138 @@ void main() {
     ),
   );
 
+  testWidgets(
+    'Can only drag one selection handle at a time on iOS',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        overlay(
+          child: Center(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              style: const TextStyle(fontSize: 10.0),
+            ),
+          ),
+        ),
+      );
+
+      // Double tap on 'e' to select 'def'.
+      final Offset ePos = textOffsetToPosition(tester, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, 7);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(controller.selection),
+        renderEditable,
+      );
+      expect(endpoints.length, 2);
+
+      // Drag the end handle to the end of the text.
+      // We use a small offset because the endpoint is on the very corner
+      // of the handle.
+      final Offset endHandlePos = endpoints[1].point;
+      Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+
+      // Attempt to drag the start handle to the start of the text.
+      // We use a small offset because the endpoint is on the very corner
+      // of the handle.
+      final Offset startHandlePos = endpoints[0].point;
+      newHandlePos = textOffsetToPosition(tester, 0);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+      await tester.pump();
+      await startHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await startHandleGesture.up();
+      await endHandleGesture.up();
+      await tester.pump();
+
+      // The start handle does not cause the selection to change.
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'Can drag both selection handles at a time on Android',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        overlay(
+          child: Center(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              style: const TextStyle(fontSize: 10.0),
+            ),
+          ),
+        ),
+      );
+
+      // Double tap on 'e' to select 'def'.
+      final Offset ePos = textOffsetToPosition(tester, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(controller.selection),
+        renderEditable,
+      );
+      expect(endpoints.length, 2);
+
+      // Drag the end handle to the end of the text.
+      final Offset endHandlePos = endpoints[1].point + const Offset(1.0, 1.0);
+      Offset newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 11);
+
+      // Attempt to drag the start handle to the start of the text.
+      final Offset startHandlePos = endpoints[0].point + const Offset(1.0, 1.0);
+      newHandlePos = textOffsetToPosition(tester, 0);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+      await tester.pump();
+      await startHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await startHandleGesture.up();
+      await endHandleGesture.up();
+      await tester.pump();
+
+      // Moving the start handle changes the selection.
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 11);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
   testWidgets('Can drag the left handle while the right handle remains off-screen', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
This change blocks two selection handles from being able to be dragged simultaneously on iOS and the web, this matches the native behavior. On native Android both handles can still be dragged simultaneously this is the behavior observed on Google Keep/ Google Messages and Android's EditText.

Also fixes an issue on iOS where the magnifier would not return after hiding when double tapping and dragging to select and then dragging outside the TextField area. The cause of this issue was because editableText.showMagnifier decides whether to update the magnifier position or show a new one based on whether it was visible, so when it was hidden and we attempt to update it's position, it would try to show a new magnifier which left the magnifier in a broken state. This change makes editableText.showMagnifier depend on whether a magnifier exists instead of just checking it's visibility. Similarly editableText.hideMagnifier now does not depend on the magnifier visibility, instead it internally (selectionOverlay.hideMagnifier) checks if the magnifier exists.

Fixes #168578

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.