### PR TITLE
delete stale references/includes to classes no longer used

### DIFF
--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -1801,7 +1801,6 @@ bool DisplayListBuilder::AdjustBoundsForPaint(DlRect& bounds,
   if (flags.is_geometric()) {
     bool is_stroked = flags.is_stroked(current_.getDrawStyle());
 
-    // Path effect occurs before stroking...
     DisplayListSpecialGeometryFlags special_flags =
         flags.GeometryFlags(is_stroked);
 

--- a/engine/src/flutter/display_list/effects/dl_image_filter_unittests.cc
+++ b/engine/src/flutter/display_list/effects/dl_image_filter_unittests.cc
@@ -16,7 +16,6 @@
 #include "gtest/gtest.h"
 
 #include "include/core/SkMatrix.h"
-#include "include/core/SkRect.h"
 #include "third_party/skia/include/core/SkBlendMode.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/skia/include/core/SkSamplingOptions.h"
@@ -25,13 +24,13 @@
 namespace flutter {
 namespace testing {
 
-// SkRect::contains treats the rect as a half-open interval which is
+// DlRect::Contains treats the rect as a half-open interval which is
 // appropriate for so many operations. Unfortunately, we are using
 // it here to test containment of the corners of a transformed quad
 // so the corners of the quad that are measured against the right
 // and bottom edges are contained even if they are on the right or
 // bottom edge. This method does the "all sides inclusive" version
-// of SkRect::contains.
+// of DlRect::Contains.
 static bool containsInclusive(const DlRect rect, const DlPoint p) {
   // Test with a slight offset of 1E-9 to "forgive" IEEE bit-rounding
   // Ending up with bounds that are off by 1E-9 (these numbers are all

--- a/engine/src/flutter/impeller/entity/contents/line_contents_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/line_contents_unittests.cc
@@ -35,7 +35,6 @@ float CalculateLine(const LineVertexShader::PerVertexData& per_vertex,
 }  // namespace
 
 TEST(LineContents, Create) {
-  Path path;
   Scalar width = 5.0f;
   auto geometry = std::make_unique<LineGeometry>(
       /*p0=*/Point{0, 0},      //

--- a/engine/src/flutter/impeller/entity/contents/solid_rrect_blur_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/solid_rrect_blur_contents.h
@@ -15,10 +15,6 @@
 
 namespace impeller {
 
-class Path;
-class HostBuffer;
-struct VertexBuffer;
-
 /// @brief  Draws a fast solid color blur of an rounded rectangle. Only supports
 /// RRects with fully symmetrical radii. Also produces correct results for
 /// rectangles (corner_radius=0) and circles (corner_radius=width/2=height/2).


### PR DESCRIPTION
Simple code pruning. While scanning the sources for unused code I found a few stale references to classes that were already no longer being used.