### PR TITLE
Label platform view modes using the unified naming scheme

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -128,9 +128,9 @@ class PlatformViewsService {
   /// null.
   /// {@endtemplate}
   ///
-  /// This attempts to use the newest and most efficient platform view
-  /// implementation when possible. In cases where that is not supported, it
-  /// falls back to using Virtual Display.
+  /// This attempts to use the TLHC implementation when possible.
+  /// In cases where that is not supported, it falls back to using
+  /// Virtual Display.
   static AndroidViewController initAndroidView({
     required int id,
     required String viewType,
@@ -1221,6 +1221,7 @@ class HybridAndroidViewController extends AndroidViewController {
 /// The platform view is created by calling [create] with an initial size.
 ///
 /// The controller is typically created with [PlatformViewsService.initAndroidView].
+// "TLHC" or "VD"
 class TextureAndroidViewController extends AndroidViewController {
   TextureAndroidViewController._({
     required super.viewId,


### PR DESCRIPTION
Stop referring to TLHC as the newest platform view mode and label the controllers with what modes they are used for. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

