### PR TITLE
[flutter_tools] Enable hot reload on the web

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -17,6 +17,7 @@ import 'base/os.dart';
 import 'base/utils.dart';
 import 'convert.dart';
 import 'globals.dart' as globals;
+import 'runner/flutter_command.dart' show FlutterOptions;
 
 /// Whether icon font subsetting is enabled by default.
 const bool kIconTreeShakerEnabledDefault = true;
@@ -263,13 +264,36 @@ class BuildInfo {
   /// The module system DDC is targeting, or null if not using DDC or the
   /// associated flag isn't present.
   // TODO(markzipan): delete this when DDC's AMD module system is deprecated, https://github.com/flutter/flutter/issues/142060.
-  DdcModuleFormat? get ddcModuleFormat =>
-      _ddcModuleFormatAndCanaryFeaturesFromFrontEndArgs(extraFrontEndOptions).ddcModuleFormat;
+  DdcModuleFormat get ddcModuleFormat {
+    final DdcModuleFormat moduleFormat =
+        webEnableHotReload ? DdcModuleFormat.ddc : DdcModuleFormat.amd;
+    final DdcModuleFormat? parsedFormat =
+        _ddcModuleFormatAndCanaryFeaturesFromFrontEndArgs(extraFrontEndOptions).ddcModuleFormat;
+    if (parsedFormat != null && moduleFormat != parsedFormat) {
+      throw Exception(
+        'Unsupported option combination:\n'
+        '${FlutterOptions.kWebExperimentalHotReload}: $webEnableHotReload\n'
+        '${FlutterOptions.kExtraFrontEndOptions}: --dartdevc-module-format=${parsedFormat.name}',
+      );
+    }
+    return moduleFormat;
+  }
 
   /// Whether to enable canary features when using DDC, or null if not using
   /// DDC or the associated flag isn't present.
-  bool? get canaryFeatures =>
-      _ddcModuleFormatAndCanaryFeaturesFromFrontEndArgs(extraFrontEndOptions).canaryFeatures;
+  bool get canaryFeatures {
+    final bool canaryEnabled = webEnableHotReload;
+    final bool? parsedCanary =
+        _ddcModuleFormatAndCanaryFeaturesFromFrontEndArgs(extraFrontEndOptions).canaryFeatures;
+    if (parsedCanary != null && canaryEnabled != parsedCanary) {
+      throw Exception(
+        'Unsupported option combination:\n'
+        '${FlutterOptions.kWebExperimentalHotReload}: $webEnableHotReload\n'
+        '${FlutterOptions.kExtraFrontEndOptions}: --dartdevc-canary=$parsedCanary',
+      );
+    }
+    return canaryEnabled;
+  }
 
   /// Convert to a structured string encoded structure appropriate for usage
   /// in build system [Environment.defines].

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -50,6 +50,7 @@ class BuildInfo {
     this.assumeInitializeFromDillUpToDate = false,
     this.buildNativeAssets = true,
     this.useLocalCanvasKit = false,
+    this.webEnableHotReload = false,
   }) : extraFrontEndOptions = extraFrontEndOptions ?? const <String>[],
        extraGenSnapshotOptions = extraGenSnapshotOptions ?? const <String>[],
        fileSystemRoots = fileSystemRoots ?? const <String>[],
@@ -176,6 +177,9 @@ class BuildInfo {
 
   /// If set, web builds will use the locally built CanvasKit instead of using the CDN
   final bool useLocalCanvasKit;
+
+  /// If set, web builds with DDC will run with support for hot reload.
+  final bool webEnableHotReload;
 
   /// Can be used when the actual information is not needed.
   static const BuildInfo dummy = BuildInfo(

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -321,7 +321,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           chromiumLauncher: _chromiumLauncher,
           nativeNullAssertions: debuggingOptions.nativeNullAssertions,
           ddcModuleSystem: debuggingOptions.buildInfo.ddcModuleFormat == DdcModuleFormat.ddc,
-          canaryFeatures: debuggingOptions.buildInfo.canaryFeatures ?? false,
+          canaryFeatures: debuggingOptions.buildInfo.canaryFeatures,
           webRenderer: debuggingOptions.webRenderer,
           isWasm: debuggingOptions.webUseWasm,
           useLocalCanvasKit: debuggingOptions.buildInfo.useLocalCanvasKit,
@@ -420,7 +420,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
     final DateTime start = _systemClock.now();
     final Status status;
     if (debuggingOptions.buildInfo.ddcModuleFormat != DdcModuleFormat.ddc ||
-        debuggingOptions.buildInfo.canaryFeatures == false) {
+        !debuggingOptions.buildInfo.canaryFeatures) {
       // Triggering hot reload performed hot restart for the old module formats
       // historically. Keep that behavior and only perform hot reload when the
       // new module format is used.

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -172,7 +172,7 @@ class ResidentWebRunner extends ResidentRunner {
       // since we still want a reload command to succeed, but to do a hot
       // restart.
       debuggingOptions.buildInfo.ddcModuleFormat != DdcModuleFormat.ddc ||
-      debuggingOptions.buildInfo.canaryFeatures != true;
+      !debuggingOptions.buildInfo.canaryFeatures;
 
   @override
   bool get supportsDetach => stopAppDuringCleanup;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -114,6 +114,11 @@ class FlutterDevice {
         globals.artifacts!.getHostArtifact(HostArtifact.webPlatformKernelFolder).path,
         platformDillName,
       );
+      final List<String> extraFrontEndOptions = buildInfo.extraFrontEndOptions;
+      if (buildInfo.webEnableHotReload) {
+        // These flags are only valid to be passed when we are compiling with DDC.
+        extraFrontEndOptions.addAll(<String>['--dartdevc-canary', '--dartdevc-module-format=ddc']);
+      }
 
       generator = ResidentCompiler(
         globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path,
@@ -133,7 +138,7 @@ class FlutterDevice {
         assumeInitializeFromDillUpToDate: buildInfo.assumeInitializeFromDillUpToDate,
         targetModel: TargetModel.dartdevc,
         frontendServerStarterPath: buildInfo.frontendServerStarterPath,
-        extraFrontEndOptions: buildInfo.extraFrontEndOptions,
+        extraFrontEndOptions: extraFrontEndOptions,
         platformDill: globals.fs.file(platformDillPath).absolute.uri.toString(),
         dartDefines: buildInfo.dartDefines,
         librariesSpec:

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -114,11 +114,12 @@ class FlutterDevice {
         globals.artifacts!.getHostArtifact(HostArtifact.webPlatformKernelFolder).path,
         platformDillName,
       );
-      final List<String> extraFrontEndOptions = buildInfo.extraFrontEndOptions;
-      if (buildInfo.webEnableHotReload) {
-        // These flags are only valid to be passed when we are compiling with DDC.
-        extraFrontEndOptions.addAll(<String>['--dartdevc-canary', '--dartdevc-module-format=ddc']);
-      }
+      final List<String> extraFrontEndOptions = <String>[
+        ...buildInfo.extraFrontEndOptions,
+        if (buildInfo.webEnableHotReload)
+        // These flags are only valid to be passed when compiling with DDC.
+        ...<String>['--dartdevc-canary', '--dartdevc-module-format=ddc'],
+      ];
 
       generator = ResidentCompiler(
         globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -374,6 +374,7 @@ abstract class FlutterCommand extends Command<void> {
     argParser.addFlag(
       FlutterOptions.kWebExperimentalHotReload,
       help: 'Enables new module format that supports hot reload.',
+      defaultsTo: true,
       hide: !verboseHelp,
     );
     argParser.addOption(

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1352,16 +1352,9 @@ abstract class FlutterCommand extends Command<void> {
     }
 
     // TODO(natebiggs): Delete this when new DDC module system is the default.
-    if (argParser.options.containsKey(FlutterOptions.kWebExperimentalHotReload) &&
-        boolArg(FlutterOptions.kWebExperimentalHotReload) &&
-        getBuildMode() == BuildMode.debug &&
-        !(argParser.options.containsKey(FlutterOptions.kAnalyzeSize) &&
-            boolArg(FlutterOptions.kWebWasmFlag))) {
-      // These flags are only valid to be passed when we are compiling with DDC.
-      // There isn't a direct flag for this compiler so we try to deduce it from
-      // the debug mode, and not WASM.
-      extraFrontEndOptions.addAll(<String>['--dartdevc-canary', '--dartdevc-module-format=ddc']);
-    }
+    final bool webEnableHotReload =
+        argParser.options.containsKey(FlutterOptions.kWebExperimentalHotReload) &&
+        boolArg(FlutterOptions.kWebExperimentalHotReload);
 
     String? codeSizeDirectory;
     if (argParser.options.containsKey(FlutterOptions.kAnalyzeSize) &&
@@ -1478,6 +1471,7 @@ abstract class FlutterCommand extends Command<void> {
           argParser.options.containsKey(FlutterOptions.kAssumeInitializeFromDillUpToDate) &&
           boolArg(FlutterOptions.kAssumeInitializeFromDillUpToDate),
       useLocalCanvasKit: useLocalCanvasKit,
+      webEnableHotReload: webEnableHotReload,
     );
   }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1353,7 +1353,8 @@ abstract class FlutterCommand extends Command<void> {
 
     // TODO(natebiggs): Delete this when new DDC module system is the default.
     if (argParser.options.containsKey(FlutterOptions.kWebExperimentalHotReload) &&
-        boolArg(FlutterOptions.kWebExperimentalHotReload)) {
+        boolArg(FlutterOptions.kWebExperimentalHotReload) &&
+        getBuildMode() == BuildMode.debug) {
       extraFrontEndOptions.addAll(<String>['--dartdevc-canary', '--dartdevc-module-format=ddc']);
     }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1354,7 +1354,12 @@ abstract class FlutterCommand extends Command<void> {
     // TODO(natebiggs): Delete this when new DDC module system is the default.
     if (argParser.options.containsKey(FlutterOptions.kWebExperimentalHotReload) &&
         boolArg(FlutterOptions.kWebExperimentalHotReload) &&
-        getBuildMode() == BuildMode.debug) {
+        getBuildMode() == BuildMode.debug &&
+        !(argParser.options.containsKey(FlutterOptions.kAnalyzeSize) &&
+            boolArg(FlutterOptions.kWebWasmFlag))) {
+      // These flags are only valid to be passed when we are compiling with DDC.
+      // There isn't a direct flag for this compiler so we try to deduce it from
+      // the debug mode, and not WASM.
       extraFrontEndOptions.addAll(<String>['--dartdevc-canary', '--dartdevc-module-format=ddc']);
     }
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -283,7 +283,7 @@ class FlutterWebPlatform extends PlatformPlugin {
     // TODO(srujzs): Remove this assertion when the library bundle format is
     // supported without canary mode.
     if (buildInfo.ddcModuleFormat == DdcModuleFormat.ddc) {
-      assert(buildInfo.canaryFeatures ?? true);
+      assert(buildInfo.canaryFeatures);
     }
     final Map<WebRendererMode, HostArtifact> dartSdkArtifactMap =
         buildInfo.ddcModuleFormat == DdcModuleFormat.ddc
@@ -296,7 +296,7 @@ class FlutterWebPlatform extends PlatformPlugin {
     // TODO(srujzs): Remove this assertion when the library bundle format is
     // supported without canary mode.
     if (buildInfo.ddcModuleFormat == DdcModuleFormat.ddc) {
-      assert(buildInfo.canaryFeatures ?? true);
+      assert(buildInfo.canaryFeatures);
     }
     final Map<WebRendererMode, HostArtifact> dartSdkArtifactMap =
         buildInfo.ddcModuleFormat == DdcModuleFormat.ddc

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -739,7 +739,8 @@ name: my_app
             trackWidgetCreation: true,
             treeShakeIcons: false,
             packageConfigPath: '.dart_tool/package_config.json',
-            // Hot reload only supported with these flags for now.
+            // TODO(nshahan): Remove when hot reload can no longer be disabled.
+            webEnableHotReload: true,
             extraFrontEndOptions: kDdcLibraryBundleFlags,
           ),
         ),


### PR DESCRIPTION
Update the defaults so hot reload is enabled on web development builds by default. This enables the use of a new module representation in the compiled JavaScript. Passing `--no-web-experimental-hot-reload` will disable the ability to hot reload and return to the AMD JavaScript module representation.
