### PR TITLE
Fix support for back gestures in CupertinoPageTransition delegatedTransition

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -459,15 +459,26 @@ class CupertinoPageTransition extends StatefulWidget {
     bool allowSnapshotting,
     Widget? child,
   ) {
-    final CurvedAnimation animation = CurvedAnimation(
-      parent: secondaryAnimation,
-      curve: Curves.linearToEaseOut,
-      reverseCurve: Curves.easeInToLinear,
-    );
-    final Animation<Offset> delegatedPositionAnimation = animation.drive(_kMiddleLeftTween);
-    animation.dispose();
+    final bool? linearTransition = ModalRoute.of(context)?.popGestureInProgress;
+
+    final Animation<Offset> delegatedPositionAnimation;
+
+    if (linearTransition ?? false) {
+      delegatedPositionAnimation = secondaryAnimation.drive(_kMiddleLeftTween);
+    } else {
+      final CurvedAnimation animation = CurvedAnimation(
+        parent: secondaryAnimation,
+        curve: Curves.linearToEaseOut,
+        reverseCurve: Curves.easeInToLinear,
+      );
+
+      delegatedPositionAnimation = animation.drive(_kMiddleLeftTween);
+
+      animation.dispose();
+    }
 
     assert(debugCheckHasDirectionality(context));
+
     final TextDirection textDirection = Directionality.of(context);
     return SlideTransition(
       position: delegatedPositionAnimation,


### PR DESCRIPTION
The current delegatedTransition did not account for the fact that the original builder uses a linear animation if the pop transition is initiated by a user gesture.

| Before | After |
| --- | --- |
| <video src='https://github.com/user-attachments/assets/a359d3dd-1822-49f3-8206-db0d2f139a17'></video> | <video src='https://github.com/user-attachments/assets/de2413ee-eca9-4f41-b39b-dcfe5d3d0024'></video> |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

