### PR TITLE
Tab bar theme and dialog theme documentation cleanup

### DIFF
--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -14,8 +14,8 @@ import 'theme.dart';
 
 /// Defines a theme for [Dialog] widgets.
 ///
-/// Descendant widgets obtain the current [DialogTheme] object using
-/// `DialogTheme.of(context)`. Instances of [DialogTheme] can be customized with
+/// Descendant widgets obtain the current [DialogThemeData] object using
+/// [DialogTheme.of]. Instances of [DialogTheme] can be customized with
 /// [DialogTheme.copyWith].
 ///
 /// [titleTextStyle] and [contentTextStyle] are used in [AlertDialog]s and [SimpleDialog]s.
@@ -302,7 +302,7 @@ class DialogTheme extends InheritedTheme with Diagnosticable {
 /// Defines default property values for descendant [Dialog] widgets.
 ///
 /// Descendant widgets obtain the current [DialogThemeData] object using
-/// `CardTheme.of(context).data`. Instances of [DialogThemeData] can be
+/// [DialogTheme.of]. Instances of [DialogThemeData] can be
 /// customized with [DialogThemeData.copyWith].
 ///
 /// Typically a [DialogThemeData] is specified as part of the overall [Theme]

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -12,13 +12,13 @@ import 'theme.dart';
 
 /// Defines a theme for [TabBar] widgets.
 ///
-/// Descendant widgets obtain the current [TabBarTheme] object using
-/// `TabBarTheme.of(context)`.
+/// Descendant widgets obtain the current [TabBarThemeData] object using
+/// [TabBarTheme.of].
 ///
 /// See also:
 ///
-///  * [TabBarThemeData], which describes the actual configuration of a switch
-///    theme.
+///  * [TabBarThemeData], which describes the actual configuration of a tab
+///    bar theme.
 @immutable
 class TabBarTheme extends InheritedTheme with Diagnosticable {
   /// Creates a tab bar theme that can be used with [ThemeData.tabBarTheme].
@@ -266,7 +266,7 @@ class TabBarTheme extends InheritedTheme with Diagnosticable {
     );
   }
 
-  /// Returns the closest [TabBarTheme] instance given the build context.
+  /// Returns the closest [TabBarThemeData] instance given the build context.
   static TabBarThemeData of(BuildContext context) {
     final TabBarTheme? tabBarTheme = context.dependOnInheritedWidgetOfExactType<TabBarTheme>();
     return tabBarTheme?.data ?? Theme.of(context).tabBarTheme;
@@ -319,8 +319,8 @@ class TabBarTheme extends InheritedTheme with Diagnosticable {
 /// Defines default property values for descendant [TabBar] widgets.
 ///
 /// Descendant widgets obtain the current [TabBarThemeData] object using
-/// `TabBarTheme.of(context).data`. Instances of [TabBarThemeData] can be
-/// customized with [TabBarThemeData.copyWith].
+/// [TabBarTheme.of]. Instances of [TabBarThemeData] can be customized
+/// with [TabBarThemeData.copyWith].
 ///
 /// Typically a [TabBarThemeData] is specified as part of the overall [Theme]
 /// with [ThemeData.tabBarTheme].


### PR DESCRIPTION
## Description

While preparing a PR to normalize `InputDecorationTheme` (part of https://github.com/flutter/flutter/issues/91772), I spotted some typos in tab bar theme and dialog theme documentation:

## Tests

Documentation only