### PR TITLE
Make flutter_test depend on the packages needed for --experimental-faster-testing

### DIFF
--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -23,6 +23,11 @@ dependencies:
 
   # Testing utilities for dealing with async calls and time.
   fake_async: 1.3.3
+
+  # Used by the `--experimental-faster-testing` generated test runner stub.
+  ffi: 2.1.4
+  test_core: 0.6.8
+
   clock: 1.1.2
 
   # We import stack_trace because the test packages uses it and we

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -421,14 +421,12 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       testTimeRecorder = TestTimeRecorder(globals.logger);
     }
 
-    if (buildInfo.packageConfig['test_api'] == null) {
+    if (buildInfo.packageConfig['flutter_test'] == null) {
       throwToolExit(
-        'Error: cannot run without a dependency on either "package:flutter_test" or "package:test". '
-        'Ensure the following lines are present in your pubspec.yaml:'
+        'Error: cannot run without a dependency on either "package:flutter_test". '
+        'Run the following command to add it to pubspec.yaml:'
         '\n\n'
-        'dev_dependencies:\n'
-        '  flutter_test:\n'
-        '    sdk: flutter\n',
+        '> flutter pub add dev:flutter_test',
       );
     }
 
@@ -641,6 +639,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     if (experimentalFasterTesting) {
       assert(!isWeb && !_isIntegrationTest && _testFileUris.length > 1);
       result = await testRunner.runTestsBySpawningLightweightEngines(
+        buildInfo: buildInfo,
         _testFileUris.toList(),
         debuggingOptions: debuggingOptions,
         names: names,

--- a/packages/flutter_tools/test/integration.shard/flutter_test_dependencies_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_test_dependencies_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:package_config/package_config.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+// This test depends on some files in ///dev/automated_tests/flutter_test/*
+
+final String automatedTestsDirectory = fileSystem.path.join('..', '..', 'dev', 'automated_tests');
+final String missingDependencyDirectory = fileSystem.path.join(
+  '..',
+  '..',
+  'dev',
+  'missing_dependency_tests',
+);
+final String flutterTestDirectory = fileSystem.path.join(automatedTestsDirectory, 'flutter_test');
+final String integrationTestDirectory = fileSystem.path.join(
+  automatedTestsDirectory,
+  'integration_test',
+);
+
+// Running Integration Tests in the Flutter Tester will still exercise the same
+// flows specific to Integration Tests.
+final List<String> integrationTestExtraArgs = <String>['-d', 'flutter-tester'];
+
+void main() {
+  testWithoutContext(
+    'flutter_test should have all the transitive dependencies for the --experimental-faster-testing isolate spawner code',
+    () async {
+      final Directory dir = fileSystem.systemTempDirectory.createTempSync('test_dir');
+      dir.childFile('pubspec.yaml').writeAsStringSync('''
+name: app
+environment:
+  sdk: ^3.7.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+''');
+      expect(
+        await processManager.run(<String>[flutterBin, 'pub', 'get'], workingDirectory: dir.path),
+        const ProcessResultMatcher(),
+      );
+
+      final File packageConfigFile = dir
+          .childDirectory('.dart_tool')
+          .childFile('package_config.json');
+      final PackageConfig packageConfig = PackageConfig.parseString(
+        packageConfigFile.readAsStringSync(),
+        packageConfigFile.uri,
+      );
+      expect(packageConfig['test_api'], isNotNull);
+      expect(packageConfig['ffi'], isNotNull);
+      expect(packageConfig['stream_channel'], isNotNull);
+      expect(packageConfig['test_core'], isNotNull);
+    },
+  );
+}


### PR DESCRIPTION
This avoids having to manually create an extended package_config.json file.