### PR TITLE
Run `{Platform} flutter_packaging` builders on release candidates.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6939,6 +6939,7 @@ targets:
     scheduler: release
     bringup: true # https://github.com/flutter/flutter/issues/126286
     enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6953,6 +6954,7 @@ targets:
     timeout: 60
     scheduler: release
     enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6969,6 +6971,7 @@ targets:
     timeout: 60
     scheduler: release
     enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6985,6 +6988,7 @@ targets:
     scheduler: release
     bringup: true
     enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/168745.