### PR TITLE
Fix `DropDownButton` focus color when using a mouse

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1369,18 +1369,27 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   bool _isTraditionalPointer = false;
 
   void _handlePointerEvent(PointerEvent event) {
+    final bool hasFocus = focusNode != null && (focusNode!.hasPrimaryFocus || focusNode!.hasFocus);
+    if (!hasFocus && _dropdownRoute == null) {
+      return;
+    }
+
     switch (event.kind) {
       case PointerDeviceKind.mouse:
       case PointerDeviceKind.trackpad:
       case PointerDeviceKind.unknown:
         if (!_isTraditionalPointer) {
-          _isTraditionalPointer = true;
+          setState(() {
+            _isTraditionalPointer = true;
+          });
         }
       case PointerDeviceKind.touch:
       case PointerDeviceKind.stylus:
       case PointerDeviceKind.invertedStylus:
         if (_isTraditionalPointer) {
-          _isTraditionalPointer = false;
+          setState(() {
+            _isTraditionalPointer = false;
+          });
         }
     }
   }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1366,6 +1366,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     super.dispose();
   }
 
+  // Whether the current pointer is a mouse or trackpad.
   bool _isTraditionalPointer = false;
 
   void _handlePointerEvent(PointerEvent event) {
@@ -1754,8 +1755,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       );
     } else {
       // Hide focus color when using a mouse.
-      final Color focusColor = (widget.focusColor ?? Theme.of(context).focusColor).withAlpha(
-        _isTraditionalPointer ? 0 : 255,
+      final Color focusColor = widget.focusColor ?? Theme.of(context).focusColor;
+      final int focusAlpha = (focusColor.a * 255.0).round() & 0xff;
+      final Color effectiveFocusColor = focusColor.withAlpha(
+        _isTraditionalPointer ? 0 : focusAlpha,
       );
       result = InkWell(
         mouseCursor: effectiveMouseCursor,
@@ -1764,7 +1767,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         borderRadius: widget.borderRadius,
         focusNode: focusNode,
         autofocus: widget.autofocus,
-        focusColor: focusColor,
+        focusColor: effectiveFocusColor,
         enableFeedback: false,
         child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
       );

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1369,7 +1369,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   bool _isTraditionalPointer = false;
 
   void _handlePointerEvent(PointerEvent event) {
-    final bool hasFocus = focusNode != null && (focusNode!.hasPrimaryFocus || focusNode!.hasFocus);
+    final bool hasFocus = focusNode.hasPrimaryFocus || focusNode.hasFocus;
     if (!hasFocus && _dropdownRoute == null) {
       return;
     }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2549,6 +2549,52 @@ void main() {
     );
   }
 
+  testWidgets('DropdownButton can be focused, and hides the focusColor when using a mouse', (
+    WidgetTester tester,
+  ) async {
+    // Set strategy to alwaysTraditional so InkResponse tries to show the focusColor.
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    final UniqueKey buttonKey = UniqueKey();
+    final FocusNode focusNode = FocusNode(debugLabel: 'DropdownButton');
+    const Color focusColor = Color(0xff00ff00);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      buildFrame(
+        buttonKey: buttonKey,
+        onChanged: onChanged,
+        focusNode: focusNode,
+        focusColor: focusColor,
+        useMaterial3: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Click on button to open options.
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(buttonKey)),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Click on option to 'three', button should have focus after.
+    await gesture.down(tester.getCenter(find.text('three')));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      find.byType(Material),
+      paints..rect(
+        rect: const Rect.fromLTRB(348.0, 276.0, 452.0, 324.0),
+        color: focusColor.withAlpha(0), // Focus color should be transparent to hide it.
+      ),
+    );
+  });
+
   testWidgets('DropdownButton can be focused, and has focusColor', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     final UniqueKey buttonKey = UniqueKey();


### PR DESCRIPTION
Keyboard traversal:

https://github.com/user-attachments/assets/f3b1fe08-7312-4e2d-905b-5d437ea5516d

Using mouse:

https://github.com/user-attachments/assets/806f0858-2bb1-4e02-8454-9e2cd074edbc

This change makes the focus color behavior consistent between mouse and touch pointer devices when using a `DropdownButton`. When using a touch device the underlying `InkResponse` of `DropdownButton` ignores the focus color, but when using a mouse device it shows the focus color. This change updates `DropdownButton`s implementation to ignore the focus color when using a mouse device.

Fixes #168096

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.