### PR TITLE
Homogenize themes documentation

### DIFF
--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -134,10 +134,10 @@ class CupertinoTheme extends StatelessWidget {
   }
 }
 
-/// Provides a [CupertinoTheme] to all descendents.
+/// Provides a [CupertinoTheme] to all descendants.
 class InheritedCupertinoTheme extends InheritedTheme {
   /// Creates an [InheritedTheme] that provides a [CupertinoTheme] to all
-  /// descendents.
+  /// descendants.
   const InheritedCupertinoTheme({super.key, required this.theme, required super.child});
 
   /// The [CupertinoTheme] that is provided to widgets lower in the tree.

--- a/packages/flutter/lib/src/material/action_icons_theme.dart
+++ b/packages/flutter/lib/src/material/action_icons_theme.dart
@@ -161,7 +161,8 @@ class ActionIconTheme extends InheritedTheme {
   /// [CloseButtonIcon], [DrawerButtonIcon], and [EndDrawerButtonIcon] widgets.
   final ActionIconThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [ActionIconThemeData] from the closest ancestor [ActionIconTheme]
+  /// widget.
   ///
   /// If there is no enclosing [ActionIconTheme] widget, then
   /// [ThemeData.actionIconTheme] is used.

--- a/packages/flutter/lib/src/material/badge_theme.dart
+++ b/packages/flutter/lib/src/material/badge_theme.dart
@@ -18,7 +18,7 @@ import 'theme.dart';
 /// Overrides the default properties values for descendant [Badge] widgets.
 ///
 /// Descendant widgets obtain the current [BadgeThemeData] object
-/// using `BadgeTheme.of(context)`. Instances of [BadgeThemeData] can
+/// using [BadgeTheme.of]. Instances of [BadgeThemeData] can
 /// be customized with [BadgeThemeData.copyWith].
 ///
 /// Typically a [BadgeThemeData] is specified as part of the
@@ -171,7 +171,7 @@ class BadgeTheme extends InheritedTheme {
   /// Specifies the default color and size overrides for descendant [Badge] widgets.
   final BadgeThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [BadgeThemeData] from the closest ancestor [BadgeTheme].
   ///
   /// If there is no enclosing [BadgeTheme] widget, then
   /// [ThemeData.badgeTheme] is used.

--- a/packages/flutter/lib/src/material/banner_theme.dart
+++ b/packages/flutter/lib/src/material/banner_theme.dart
@@ -18,7 +18,7 @@ import 'theme.dart';
 /// Defines the visual properties of [MaterialBanner] widgets.
 ///
 /// Descendant widgets obtain the current [MaterialBannerThemeData] object using
-/// `MaterialBannerTheme.of(context)`. Instances of [MaterialBannerThemeData]
+/// [MaterialBannerTheme.of]. Instances of [MaterialBannerThemeData]
 /// can be customized with [MaterialBannerThemeData.copyWith].
 ///
 /// Typically a [MaterialBannerThemeData] is specified as part of the overall

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -123,7 +123,8 @@ class ButtonTheme extends InheritedTheme {
   /// Specifies the color and geometry of buttons.
   final ButtonThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [ButtonThemeData] from the closest ancestor [ButtonTheme]
+  /// widget.
   ///
   /// Typical usage is as follows:
   ///

--- a/packages/flutter/lib/src/material/carousel_theme.dart
+++ b/packages/flutter/lib/src/material/carousel_theme.dart
@@ -11,10 +11,13 @@ import 'carousel.dart';
 import 'material.dart';
 import 'theme.dart';
 
+// Examples can assume:
+// late BuildContext context;
+
 /// Defines default property values for descendant [CarouselView] widgets.
 ///
 /// Descendant widgets obtain the current [CarouselViewThemeData] object using
-/// `CarouselViewTheme.of(context)`. Instances of [CarouselViewThemeData] can be
+/// [CarouselViewTheme.of]. Instances of [CarouselViewThemeData] can be
 /// customized with [CarouselViewThemeData.copyWith].
 ///
 /// Typically a [CarouselViewThemeData] is specified as part of the overall [Theme]
@@ -165,6 +168,12 @@ class CarouselViewTheme extends InheritedTheme {
   /// Returns the configuration [data] from the closest [CarouselViewTheme] ancestor.
   ///
   /// If there is no ancestor, it returns [ThemeData.carouselViewTheme].
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// CarouselViewThemeData theme = CarouselViewTheme.of(context);
+  /// ```
   static CarouselViewThemeData of(BuildContext context) {
     final CarouselViewTheme? inheritedTheme =
         context.dependOnInheritedWidgetOfExactType<CarouselViewTheme>();

--- a/packages/flutter/lib/src/material/date_picker_theme.dart
+++ b/packages/flutter/lib/src/material/date_picker_theme.dart
@@ -1019,8 +1019,8 @@ class DatePickerTheme extends InheritedTheme {
   ///
   /// See also:
   ///
-  ///  * [of], which will return [ThemeData.datePickerTheme] if it doesn't
-  ///    find a [DatePickerTheme] ancestor, instead of returning null.
+  ///  * [of], which will return the data from [ThemeData.datePickerTheme] if
+  ///    it doesn't find a [DatePickerTheme] ancestor, instead of returning null.
   ///  * [defaults], which will return the default properties used when no
   ///    other [DatePickerTheme] has been provided.
   static DatePickerThemeData? maybeOf(BuildContext context) {
@@ -1034,8 +1034,8 @@ class DatePickerTheme extends InheritedTheme {
   ///
   /// See also:
   ///
-  ///  * [of], which will return [ThemeData.datePickerTheme] if it doesn't
-  ///    find a [DatePickerTheme] ancestor, instead of returning null.
+  ///  * [of], which will return the data from [ThemeData.datePickerTheme] if
+  ///    it doesn't find a [DatePickerTheme] ancestor, instead of returning null.
   ///  * [maybeOf], which returns null if it doesn't find a
   ///    [DatePickerTheme] ancestor.
   static DatePickerThemeData defaults(BuildContext context) {

--- a/packages/flutter/lib/src/material/divider_theme.dart
+++ b/packages/flutter/lib/src/material/divider_theme.dart
@@ -21,8 +21,8 @@ import 'theme.dart';
 /// between [ListTile]s, and dividers between rows in [DataTable]s.
 ///
 /// Descendant widgets obtain the current [DividerThemeData] object using
-/// `DividerTheme.of(context)`. Instances of [DividerThemeData]
-/// can be customized with [DividerThemeData.copyWith].
+/// [DividerTheme.of]. Instances of [DividerThemeData] can be customized with
+/// [DividerThemeData.copyWith].
 ///
 /// Typically a [DividerThemeData] is specified as part of the overall
 /// [Theme] with [ThemeData.dividerTheme].

--- a/packages/flutter/lib/src/material/drawer_theme.dart
+++ b/packages/flutter/lib/src/material/drawer_theme.dart
@@ -19,7 +19,7 @@ import 'theme.dart';
 /// Defines default property values for descendant [Drawer] widgets.
 ///
 /// Descendant widgets obtain the current [DrawerThemeData] object
-/// using `DrawerTheme.of(context)`. Instances of [DrawerThemeData] can be
+/// using [DrawerTheme.of]. Instances of [DrawerThemeData] can be
 /// customized with [DrawerThemeData.copyWith].
 ///
 /// Typically a [DrawerThemeData] is specified as part of the
@@ -188,7 +188,7 @@ class DrawerTheme extends InheritedTheme {
   /// descendant [Drawer] widgets.
   final DrawerThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [DrawerThemeData] from the closest ancestor [DrawerTheme].
   ///
   /// If there is no enclosing [DrawerTheme] widget, then
   /// [ThemeData.drawerTheme] is used.

--- a/packages/flutter/lib/src/material/dropdown_menu_theme.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_theme.dart
@@ -119,7 +119,7 @@ class DropdownMenuTheme extends InheritedTheme {
   /// widgets.
   final DropdownMenuThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [DropdownMenuThemeData] from the closest ancestor [DropdownMenuTheme].
   ///
   /// If there is no enclosing [DropdownMenuTheme] widget, then
   /// [ThemeData.dropdownMenuTheme] is used.

--- a/packages/flutter/lib/src/material/elevated_button_theme.dart
+++ b/packages/flutter/lib/src/material/elevated_button_theme.dart
@@ -101,7 +101,7 @@ class ElevatedButtonTheme extends InheritedTheme {
   /// The configuration of this theme.
   final ElevatedButtonThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [ElevatedButtonThemeData] from the closest ancestor [ElevatedButtonTheme].
   ///
   /// If there is no enclosing [ElevatedButtonTheme] widget, then
   /// [ThemeData.elevatedButtonTheme] is used.

--- a/packages/flutter/lib/src/material/expansion_tile_theme.dart
+++ b/packages/flutter/lib/src/material/expansion_tile_theme.dart
@@ -17,9 +17,8 @@ import 'theme.dart';
 /// descendant [ExpansionTile] widgets.
 ///
 /// Descendant widgets obtain the current [ExpansionTileThemeData] object
-/// using `ExpansionTileTheme.of(context)`. Instances of
-/// [ExpansionTileThemeData] can be customized with
-/// [ExpansionTileThemeData.copyWith].
+/// using [ExpansionTileTheme.of]. Instances of [ExpansionTileThemeData] can
+/// be customized with [ExpansionTileThemeData.copyWith].
 ///
 /// A [ExpansionTileThemeData] is often specified as part of the
 /// overall [Theme] with [ThemeData.expansionTileTheme].
@@ -262,7 +261,7 @@ class ExpansionTileTheme extends InheritedTheme {
   /// descendant [ExpansionTile] widgets.
   final ExpansionTileThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [ExpansionTileThemeData] from the closest ancestor [ExpansionTileTheme].
   ///
   /// If there is no enclosing [ExpansionTileTheme] widget, then
   /// [ThemeData.expansionTileTheme] is used.

--- a/packages/flutter/lib/src/material/filled_button_theme.dart
+++ b/packages/flutter/lib/src/material/filled_button_theme.dart
@@ -97,7 +97,7 @@ class FilledButtonTheme extends InheritedTheme {
   /// The configuration of this theme.
   final FilledButtonThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [FilledButtonThemeData] from the closest ancestor [FilledButtonTheme].
   ///
   /// If there is no enclosing [FilledButtonTheme] widget, then
   /// [ThemeData.filledButtonTheme] is used.

--- a/packages/flutter/lib/src/material/icon_button_theme.dart
+++ b/packages/flutter/lib/src/material/icon_button_theme.dart
@@ -95,7 +95,7 @@ class IconButtonTheme extends InheritedTheme {
   /// The configuration of this theme.
   final IconButtonThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [IconButtonThemeData] from the closest ancestor [IconButtonTheme].
   ///
   /// If there is no enclosing [IconButtonTheme] widget, then
   /// [ThemeData.iconButtonTheme] is used.

--- a/packages/flutter/lib/src/material/list_tile_theme.dart
+++ b/packages/flutter/lib/src/material/list_tile_theme.dart
@@ -29,9 +29,8 @@ import 'theme_data.dart';
 /// [SwitchListTile].
 ///
 /// Descendant widgets obtain the current [ListTileThemeData] object
-/// using `ListTileTheme.of(context)`. Instances of
-/// [ListTileThemeData] can be customized with
-/// [ListTileThemeData.copyWith].
+/// using [ListTileTheme.of]. Instances of [ListTileThemeData] can be
+/// customized with [ListTileThemeData.copyWith].
 ///
 /// A [ListTileThemeData] is often specified as part of the
 /// overall [Theme] with [ThemeData.listTileTheme].

--- a/packages/flutter/lib/src/material/menu_bar_theme.dart
+++ b/packages/flutter/lib/src/material/menu_bar_theme.dart
@@ -14,6 +14,7 @@ import 'theme.dart';
 
 // Examples can assume:
 // late Widget child;
+// late BuildContext context;
 
 /// A data class that [MenuBarTheme] uses to define the visual properties of
 /// [MenuBar] widgets.
@@ -23,7 +24,7 @@ import 'theme.dart';
 /// [MenuButtonThemeData] instead.
 ///
 /// Descendant widgets obtain the current [MenuBarThemeData] object using
-/// `MenuBarTheme.of(context)`.
+/// [MenuBarTheme.of].
 ///
 /// Typically, a [MenuBarThemeData] is specified as part of the overall [Theme]
 /// with [ThemeData.menuBarTheme]. Otherwise, [MenuTheme] can be used to
@@ -88,16 +89,7 @@ class MenuBarTheme extends InheritedTheme {
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// Widget build(BuildContext context) {
-  ///   return MenuTheme(
-  ///     data: const MenuThemeData(
-  ///       style: MenuStyle(
-  ///         backgroundColor: WidgetStatePropertyAll<Color?>(Colors.red),
-  ///       ),
-  ///     ),
-  ///     child: child,
-  ///   );
-  /// }
+  /// MenuBarThemeData theme = MenuBarTheme.of(context);
   /// ```
   static MenuBarThemeData of(BuildContext context) {
     final MenuBarTheme? menuBarTheme = context.dependOnInheritedWidgetOfExactType<MenuBarTheme>();

--- a/packages/flutter/lib/src/material/menu_theme.dart
+++ b/packages/flutter/lib/src/material/menu_theme.dart
@@ -15,12 +15,13 @@ import 'theme.dart';
 
 // Examples can assume:
 // late Widget child;
+// late BuildContext context;
 
 /// Defines the configuration of the submenus created by the [SubmenuButton],
 /// [MenuBar], or [MenuAnchor] widgets.
 ///
 /// Descendant widgets obtain the current [MenuThemeData] object using
-/// `MenuTheme.of(context)`.
+/// [MenuTheme.of].
 ///
 /// Typically, a [MenuThemeData] is specified as part of the overall [Theme]
 /// with [ThemeData.menuTheme]. Otherwise, [MenuTheme] can be used to configure
@@ -125,16 +126,7 @@ class MenuTheme extends InheritedTheme {
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// Widget build(BuildContext context) {
-  ///   return MenuTheme(
-  ///     data: const MenuThemeData(
-  ///       style: MenuStyle(
-  ///         backgroundColor: WidgetStatePropertyAll<Color>(Colors.red),
-  ///       ),
-  ///     ),
-  ///     child: child,
-  ///   );
-  /// }
+  /// MenuThemeData theme = MenuTheme.of(context);
   /// ```
   static MenuThemeData of(BuildContext context) {
     final MenuTheme? menuTheme = context.dependOnInheritedWidgetOfExactType<MenuTheme>();

--- a/packages/flutter/lib/src/material/navigation_bar_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_bar_theme.dart
@@ -19,9 +19,8 @@ import 'theme.dart';
 /// widgets.
 ///
 /// Descendant widgets obtain the current [NavigationBarThemeData] object
-/// using `NavigationBarTheme.of(context)`. Instances of
-/// [NavigationBarThemeData] can be customized with
-/// [NavigationBarThemeData.copyWith].
+/// using [NavigationBarTheme.of]. Instances of [NavigationBarThemeData] can be
+/// customized with [NavigationBarThemeData.copyWith].
 ///
 /// Typically a [NavigationBarThemeData] is specified as part of the
 /// overall [Theme] with [ThemeData.navigationBarTheme]. Alternatively, a
@@ -279,7 +278,7 @@ class NavigationBarTheme extends InheritedTheme {
   /// type values for descendant [NavigationBar] widgets.
   final NavigationBarThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [NavigationBarThemeData] from the closest ancestor [NavigationBarTheme].
   ///
   /// If there is no enclosing [NavigationBarTheme] widget, then
   /// [ThemeData.navigationBarTheme] is used.

--- a/packages/flutter/lib/src/material/navigation_drawer_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer_theme.dart
@@ -22,9 +22,8 @@ import 'theme.dart';
 /// widgets.
 ///
 /// Descendant widgets obtain the current [NavigationDrawerThemeData] object
-/// using `NavigationDrawerTheme.of(context)`. Instances of
-/// [NavigationDrawerThemeData] can be customized with
-/// [NavigationDrawerThemeData.copyWith].
+/// using [NavigationDrawerTheme.of]. Instances of [NavigationDrawerThemeData]
+/// can be customized with [NavigationDrawerThemeData.copyWith].
 ///
 /// Typically a [NavigationDrawerThemeData] is specified as part of the
 /// overall [Theme] with [ThemeData.navigationDrawerTheme]. Alternatively, a
@@ -243,10 +242,17 @@ class NavigationDrawerTheme extends InheritedTheme {
   /// type values for descendant [NavigationDrawer] widgets.
   final NavigationDrawerThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [NavigationDrawerThemeData] from the closest
+  /// ancestor [NavigationDrawerTheme].
   ///
   /// If there is no enclosing [NavigationDrawerTheme] widget, then
   /// [ThemeData.navigationDrawerTheme] is used.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// NavigationDrawerThemeData theme = NavigationDrawerTheme.of(context);
+  /// ```
   static NavigationDrawerThemeData of(BuildContext context) {
     final NavigationDrawerTheme? navigationDrawerTheme =
         context.dependOnInheritedWidgetOfExactType<NavigationDrawerTheme>();

--- a/packages/flutter/lib/src/material/navigation_rail_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_rail_theme.dart
@@ -21,9 +21,8 @@ import 'theme.dart';
 /// widgets.
 ///
 /// Descendant widgets obtain the current [NavigationRailThemeData] object
-/// using `NavigationRailTheme.of(context)`. Instances of
-/// [NavigationRailThemeData] can be customized with
-/// [NavigationRailThemeData.copyWith].
+/// using [NavigationRailTheme.of]. Instances of [NavigationRailThemeData]
+/// can be customized with [NavigationRailThemeData.copyWith].
 ///
 /// Typically a [NavigationRailThemeData] is specified as part of the
 /// overall [Theme] with [ThemeData.navigationRailTheme].
@@ -311,7 +310,7 @@ class NavigationRailTheme extends InheritedTheme {
   /// [NavigationRail] widgets.
   final NavigationRailThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [NavigationRailThemeData] from the closest ancestor [NavigationRailTheme].
   ///
   /// If there is no enclosing [NavigationRailTheme] widget, then
   /// [ThemeData.navigationRailTheme] is used.

--- a/packages/flutter/lib/src/material/outlined_button_theme.dart
+++ b/packages/flutter/lib/src/material/outlined_button_theme.dart
@@ -101,7 +101,7 @@ class OutlinedButtonTheme extends InheritedTheme {
   /// The configuration of this theme.
   final OutlinedButtonThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [OutlinedButtonThemeData] from the closest ancestor [OutlinedButtonTheme].
   ///
   /// If there is no enclosing [OutlinedButtonTheme] widget, then
   /// [ThemeData.outlinedButtonTheme] is used.

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -29,9 +29,8 @@ enum PopupMenuPosition {
 /// as well as [PopupMenuItem] and [PopupMenuDivider] widgets.
 ///
 /// Descendant widgets obtain the current [PopupMenuThemeData] object
-/// using `PopupMenuTheme.of(context)`. Instances of
-/// [PopupMenuThemeData] can be customized with
-/// [PopupMenuThemeData.copyWith].
+/// using [PopupMenuTheme.of]. Instances of [PopupMenuThemeData] can be
+/// customized with [PopupMenuThemeData.copyWith].
 ///
 /// Typically, a [PopupMenuThemeData] is specified as part of the
 /// overall [Theme] with [ThemeData.popupMenuTheme]. Otherwise,

--- a/packages/flutter/lib/src/material/search_view_theme.dart
+++ b/packages/flutter/lib/src/material/search_view_theme.dart
@@ -21,7 +21,7 @@ import 'theme.dart';
 /// widget.
 ///
 /// Descendant widgets obtain the current [SearchViewThemeData] object using
-/// `SearchViewTheme.of(context)`.
+/// [SearchViewTheme.of].
 ///
 /// Typically, a [SearchViewThemeData] is specified as part of the overall [Theme]
 /// with [ThemeData.searchViewTheme]. Otherwise, [SearchViewTheme] can be used

--- a/packages/flutter/lib/src/material/text_button_theme.dart
+++ b/packages/flutter/lib/src/material/text_button_theme.dart
@@ -97,7 +97,7 @@ class TextButtonTheme extends InheritedTheme {
   /// The configuration of this theme.
   final TextButtonThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [TextButtonThemeData] from the closest ancestor [TextButtonTheme].
   ///
   /// If there is no enclosing [TextButtonTheme] widget, then
   /// [ThemeData.textButtonTheme] is used.

--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -27,8 +27,8 @@ import 'theme.dart';
 /// Defines the visual properties of the widget displayed with [showTimePicker].
 ///
 /// Descendant widgets obtain the current [TimePickerThemeData] object using
-/// `TimePickerTheme.of(context)`. Instances of [TimePickerThemeData]
-/// can be customized with [TimePickerThemeData.copyWith].
+/// [TimePickerTheme.of]. Instances of [TimePickerThemeData] can be customized
+/// with [TimePickerThemeData.copyWith].
 ///
 /// Typically a [TimePickerThemeData] is specified as part of the overall
 /// [Theme] with [ThemeData.timePickerTheme].

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -263,7 +263,7 @@ class ToggleButtonsTheme extends InheritedTheme {
   /// Specifies the color and border values for descendant [ToggleButtons] widgets.
   final ToggleButtonsThemeData data;
 
-  /// The closest instance of this class that encloses the given context.
+  /// Retrieves the [ToggleButtonsThemeData] from the closest ancestor [ToggleButtonsTheme].
   ///
   /// If there is no enclosing [ToggleButtonsTheme] widget, then
   /// [ThemeData.toggleButtonsTheme] is used.

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -338,7 +338,7 @@ class TooltipTheme extends InheritedTheme {
   /// The properties for descendant [Tooltip] widgets.
   final TooltipThemeData data;
 
-  /// Returns the ambient tooltip theme.
+  /// Retrieves the [TooltipThemeData] from the closest ancestor [TooltipTheme].
   ///
   /// The result comes from the closest [TooltipTheme] ancestor if any,
   /// and otherwise from [Theme.of] and [ThemeData.tooltipTheme].


### PR DESCRIPTION
## Description

This PR homogenizes `xxxTheme` and `xxxThemeData` classes documentation.
Mainly:
- Points to `xxxTheme.of` from `xxxThemeData` documentation instead of using pseudo code (and add a code block in `xxxTheme.of` documentation when it was missing.
- Fix `xxxTheme.of` documentation when the comment did not specify the correct return type.

## Tests

Documentation only