### PR TITLE
CupertinoSliverNavigationBar respects accessibility text scaling

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -65,11 +65,32 @@ const double _kNavBarBottomPadding = 8.0;
 
 const double _kNavBarBackButtonTapWidth = 50.0;
 
+// The minimum text scale to apply to contents of the nav bar which can scale to
+// a size less than the default, such as the large title.
+//
+// Eyeballed on an iPhone 15 simulator running iOS 17.5.
+const double _kMinScaleFactor = 0.9;
+
+// The maximum text scale to apply to contents of the nav bar, except the large
+// title which can grow larger but is damped.
+//
+// Calculated on an iPhone 15 simulator running iOS 17.5.
+const double _kMaxScaleFactor = 1.235;
+
+// The damping ratio applied to reduce the rate at which the large title scales.
+//
+// Eyeballed on an iPhone 15 simulator running iOS 17.5.
+const double _kLargeTitleScaleDampingRatio = 3.0;
+
 /// The width of the 'Cancel' button if the search field in a
 /// [CupertinoSliverNavigationBar.search] is active.
 ///
 /// Eyeballed on an iPhone 15 simulator running iOS 17.5.
 const double _kSearchFieldCancelButtonWidth = 67.0;
+
+/// The height of the unscaled search field used in
+/// a [CupertinoSliverNavigationBar.search].
+const double _kSearchFieldHeight = 36.0;
 
 /// The duration of the animation when the search field in
 /// [CupertinoSliverNavigationBar.search] is tapped.
@@ -235,6 +256,13 @@ Widget _wrapWithBackground({
       child: childWithBackground,
     ),
   );
+}
+
+double _dampScaleFactor(double scaledFontSize, double unscaledFontSize, double dampingRatio) {
+  final double scaleFactor = scaledFontSize / unscaledFontSize;
+  return scaleFactor < 1.0
+      ? math.max(_kMinScaleFactor, scaleFactor)
+      : 1.0 + ((scaleFactor - 1.0) / dampingRatio);
 }
 
 // Whether the current route supports nav bar hero transitions from or to.
@@ -776,7 +804,10 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
                     style: CupertinoTheme.of(context).textTheme.navLargeTitleTextStyle,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    child: _LargeTitle(child: components.largeTitle),
+                    child: _LargeTitle(
+                      height: _kNavBarLargeTitleHeightExtension,
+                      child: components.largeTitle,
+                    ),
                   ),
                 ),
               ),
@@ -831,6 +862,7 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
             border: effectiveBorder,
             hasUserMiddle: widget.middle != null,
             largeExpanded: widget.largeTitle != null,
+            searchable: false,
             automaticBackgroundVisibility: widget.automaticBackgroundVisibility,
             child: navBar,
           ),
@@ -881,11 +913,6 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
 /// should be present in each [PageRoute] to support the default transitions.
 /// Use [transitionBetweenRoutes] or [heroTag] to customize the transition
 /// behavior for multiple navigation bars per route.
-///
-/// [CupertinoSliverNavigationBar] by default disables text scaling to match the
-/// native iOS behavior. To override this behavior, wrap each of the
-/// [CupertinoSliverNavigationBar]'s components inside a [MediaQuery] with the
-/// desired [TextScaler].
 ///
 /// The [stretch] parameter determines whether the nav bar should stretch to
 /// fill the over-scroll area. The nav bar can still expand and contract as the
@@ -1153,12 +1180,13 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
     with TickerProviderStateMixin {
   late _NavigationBarStaticComponentsKeys keys;
   ScrollableState? _scrollableState;
-  _NavigationBarSearchField? preferredSizeSearchField;
   Widget? effectiveMiddle;
   late AnimationController _animationController;
   late CurvedAnimation _searchAnimation;
   late Animation<double> persistentHeightAnimation;
   late Animation<double> largeTitleHeightAnimation;
+  late double scaledSearchFieldHeight;
+  late double scaledLargeTitleHeight;
   bool searchIsActive = false;
   bool isPortrait = true;
 
@@ -1166,24 +1194,17 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
   void initState() {
     super.initState();
     keys = _NavigationBarStaticComponentsKeys();
-    _setupSearchableAnimation();
-    if (widget._searchable) {
-      assert(widget.searchField != null);
-      preferredSizeSearchField = _NavigationBarSearchField(searchField: widget.searchField!);
-    }
+    _animationController = AnimationController(vsync: this, duration: _kNavBarSearchDuration);
+    _searchAnimation = CurvedAnimation(parent: _animationController, curve: _kNavBarSearchCurve);
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     isPortrait = MediaQuery.orientationOf(context) == Orientation.portrait;
-    final Tween<double> largeTitleHeightTween = Tween<double>(
-      begin: isPortrait ? _kNavBarLargeTitleHeightExtension : 0.0,
-      end: 0.0,
-    );
-    largeTitleHeightAnimation = largeTitleHeightTween.animate(_animationController);
     effectiveMiddle = widget.middle ?? (isPortrait ? null : widget.largeTitle);
-
+    _computeScaledHeights();
+    _setupSearchableAnimation();
     _scrollableState?.position.isScrollingNotifier.removeListener(_handleScrollChange);
     _scrollableState = Scrollable.maybeOf(context);
     _scrollableState?.position.isScrollingNotifier.addListener(_handleScrollChange);
@@ -1194,30 +1215,53 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
     if (_scrollableState?.position != null) {
       _scrollableState?.position.isScrollingNotifier.removeListener(_handleScrollChange);
     }
-    _animationController.dispose();
     _searchAnimation.dispose();
+    _animationController.dispose();
     super.dispose();
   }
 
   double get _bottomHeight {
     assert(!widget._searchable || widget.bottom == null);
     if (widget._searchable) {
-      return preferredSizeSearchField!.preferredSize.height;
+      return scaledSearchFieldHeight + _kNavBarBottomPadding;
     } else if (widget.bottom != null) {
       return widget.bottom!.preferredSize.height;
     }
     return 0.0;
   }
 
+  void _computeScaledHeights() {
+    final TextScaler textScaler = MediaQuery.textScalerOf(context);
+    scaledSearchFieldHeight =
+        _kSearchFieldHeight *
+        _dampScaleFactor(
+          textScaler.scale(_kSearchFieldHeight),
+          _kSearchFieldHeight,
+          _kMaxScaleFactor,
+        );
+    scaledLargeTitleHeight =
+        isPortrait
+            ? _kNavBarLargeTitleHeightExtension *
+                _dampScaleFactor(
+                  textScaler.scale(_kNavBarLargeTitleHeightExtension),
+                  _kNavBarLargeTitleHeightExtension,
+                  _kLargeTitleScaleDampingRatio,
+                )
+            : 0.0;
+  }
+
   void _setupSearchableAnimation() {
-    _animationController = AnimationController(vsync: this, duration: _kNavBarSearchDuration);
-    _searchAnimation = CurvedAnimation(parent: _animationController, curve: _kNavBarSearchCurve);
     final Tween<double> persistentHeightTween = Tween<double>(
       begin: _kNavBarPersistentHeight,
       end: 0.0,
     );
     persistentHeightAnimation = persistentHeightTween.animate(_animationController)
       ..addStatusListener(_handleSearchFieldStatusChanged);
+    final Tween<double> largeTitleHeightTween = Tween<double>(
+      begin: scaledLargeTitleHeight,
+      end: 0.0,
+    );
+    largeTitleHeightAnimation = largeTitleHeightTween.animate(_animationController);
   }
 
   void _handleScrollChange() {
@@ -1231,17 +1275,16 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
         widget.bottomMode == NavigationBarBottomMode.always ? 0.0 : _bottomHeight;
     final bool canScrollBottom =
         (widget._searchable || widget.bottom != null) && bottomScrollOffset > 0.0;
-    final double effectiveLargeTitleHeight = isPortrait ? _kNavBarLargeTitleHeightExtension : 0.0;
 
     // Snap the scroll view to a target determined by the navigation bar's
     // position.
     if (canScrollBottom && position.pixels < bottomScrollOffset) {
       target = position.pixels > bottomScrollOffset / 2 ? bottomScrollOffset : 0.0;
     } else if (position.pixels > bottomScrollOffset &&
-        position.pixels < bottomScrollOffset + effectiveLargeTitleHeight) {
+        position.pixels < bottomScrollOffset + scaledLargeTitleHeight) {
       target =
-          position.pixels > bottomScrollOffset + (effectiveLargeTitleHeight / 2)
-              ? bottomScrollOffset + effectiveLargeTitleHeight
+          position.pixels > bottomScrollOffset + (scaledLargeTitleHeight / 2)
+              ? bottomScrollOffset + scaledLargeTitleHeight
               : bottomScrollOffset;
     }
 
@@ -1304,12 +1347,14 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
                     animationController: _animationController,
                     animation: persistentHeightAnimation,
                     searchField: widget.searchField,
+                    searchFieldHeight: scaledSearchFieldHeight,
                     onSearchFieldTap: _onSearchFieldTap,
                   )
                   : _InactiveSearchableBottom(
                     animationController: _animationController,
                     animation: persistentHeightAnimation,
-                    searchField: preferredSizeSearchField,
+                    searchField: widget.searchField,
+                    searchFieldHeight: scaledSearchFieldHeight,
                     onSearchFieldTap: _onSearchFieldTap,
                   )
               : widget.bottom) ??
@@ -1352,6 +1397,7 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
                       : widget.bottomMode ?? NavigationBarBottomMode.automatic,
               bottomHeight: _bottomHeight,
               controller: _animationController,
+              searchable: widget._searchable,
             ),
           );
         },
@@ -1382,6 +1428,7 @@ class _LargeTitleNavigationBarSliverDelegate extends SliverPersistentHeaderDeleg
     required this.bottomMode,
     required this.bottomHeight,
     required this.controller,
+    required this.searchable,
   });
 
   final _NavigationBarStaticComponentsKeys keys;
@@ -1402,6 +1449,7 @@ class _LargeTitleNavigationBarSliverDelegate extends SliverPersistentHeaderDeleg
   final NavigationBarBottomMode bottomMode;
   final double bottomHeight;
   final AnimationController controller;
+  final bool searchable;
 
   @override
   double get minExtent =>
@@ -1496,7 +1544,10 @@ class _LargeTitleNavigationBarSliverDelegate extends SliverPersistentHeaderDeleg
                                 style: CupertinoTheme.of(context).textTheme.navLargeTitleTextStyle,
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
-                                child: _LargeTitle(child: components.largeTitle),
+                                child: _LargeTitle(
+                                  height: largeTitleHeight,
+                                  child: components.largeTitle,
+                                ),
                               ),
                             ),
                           ),
@@ -1547,6 +1598,7 @@ class _LargeTitleNavigationBarSliverDelegate extends SliverPersistentHeaderDeleg
         border: effectiveBorder,
         hasUserMiddle: userMiddle != null && (alwaysShowMiddle || !showLargeTitle),
         largeExpanded: showLargeTitle,
+        searchable: searchable,
         automaticBackgroundVisibility: automaticBackgroundVisibility,
         child: navBar,
       ),
@@ -1570,7 +1622,8 @@ class _LargeTitleNavigationBarSliverDelegate extends SliverPersistentHeaderDeleg
         enableBackgroundFilterBlur != oldDelegate.enableBackgroundFilterBlur ||
         bottomMode != oldDelegate.bottomMode ||
         bottomHeight != oldDelegate.bottomHeight ||
-        controller != oldDelegate.controller;
+        controller != oldDelegate.controller ||
+        searchable != oldDelegate.searchable;
   }
 }
 
@@ -1579,23 +1632,31 @@ class _LargeTitleNavigationBarSliverDelegate extends SliverPersistentHeaderDeleg
 /// Magnifies on over-scroll when [CupertinoSliverNavigationBar.stretch]
 /// parameter is true.
 class _LargeTitle extends SingleChildRenderObjectWidget {
-  const _LargeTitle({super.child});
+  const _LargeTitle({super.child, required this.height});
+
+  final double height;
 
   @override
   _RenderLargeTitle createRenderObject(BuildContext context) {
     return _RenderLargeTitle(
       alignment: AlignmentDirectional.bottomStart.resolve(Directionality.of(context)),
+      height: height,
     );
   }
 
   @override
   void updateRenderObject(BuildContext context, _RenderLargeTitle renderObject) {
-    renderObject.alignment = AlignmentDirectional.bottomStart.resolve(Directionality.of(context));
+    renderObject
+      ..alignment = AlignmentDirectional.bottomStart.resolve(Directionality.of(context))
+      ..height = height;
   }
 }
 
 class _RenderLargeTitle extends RenderShiftedBox {
-  _RenderLargeTitle({required Alignment alignment}) : _alignment = alignment, super(null);
+  _RenderLargeTitle({required Alignment alignment, required double height})
+    : _alignment = alignment,
+      _height = height,
+      super(null);
 
   Alignment get alignment => _alignment;
   Alignment _alignment;
@@ -1608,10 +1669,21 @@ class _RenderLargeTitle extends RenderShiftedBox {
     markNeedsLayout();
   }
 
+  double get height => _height;
+  double _height;
+  set height(double value) {
+    if (_height == value) {
+      return;
+    }
+    _height = value;
+
+    markNeedsLayout();
+  }
+
   double _scale = 1.0;
 
-  static double _computeTitleScale(Size childSize, BoxConstraints constraints) {
-    const double maxHeight = _kNavBarLargeTitleHeightExtension - _kNavBarBottomPadding;
+  static double _computeTitleScale(Size childSize, BoxConstraints constraints, double height) {
+    final double maxHeight = height - _kNavBarBottomPadding;
     final double scale = 1.0 + 0.03 * (constraints.maxHeight - maxHeight) / maxHeight;
     final double maxScale =
         childSize.width != 0.0
@@ -1642,7 +1714,7 @@ class _RenderLargeTitle extends RenderShiftedBox {
       return null;
     }
     final Size childSize = child.getDryLayout(childConstraints);
-    final double scale = _computeTitleScale(childSize, constraints);
+    final double scale = _computeTitleScale(childSize, constraints, height);
     final Size scaledChildSize = childSize * scale;
     return result * scale +
         alignment.alongOffset(constraints.biggest - scaledChildSize as Offset).dy;
@@ -1659,7 +1731,7 @@ class _RenderLargeTitle extends RenderShiftedBox {
 
     final BoxConstraints childConstraints = constraints.widthConstraints().loosen();
     child.layout(childConstraints, parentUsesSize: true);
-    _scale = _computeTitleScale(child.size, constraints);
+    _scale = _computeTitleScale(child.size, constraints, height);
     final BoxParentData childParentData = child.parentData! as BoxParentData;
     childParentData.offset = alignment.alongOffset(size - (child.size * _scale) as Offset);
   }
@@ -1852,6 +1924,7 @@ class _NavigationBarStaticComponents {
          userLeading: userLeading,
          route: route,
          automaticallyImplyLeading: automaticallyImplyLeading,
+         context: context,
        ),
        backLabel = createBackLabel(
          backLabelKey: keys.backLabelKey,
@@ -1859,6 +1932,7 @@ class _NavigationBarStaticComponents {
          route: route,
          previousPageTitle: previousPageTitle,
          automaticallyImplyLeading: automaticallyImplyLeading,
+         context: context,
        ),
        middle = createMiddle(
          middleKey: keys.middleKey,
@@ -1868,11 +1942,13 @@ class _NavigationBarStaticComponents {
          automaticallyImplyTitle: automaticallyImplyTitle,
          large: large,
          staticBar: staticBar,
+         context: context,
        ),
        trailing = createTrailing(
          trailingKey: keys.trailingKey,
          userTrailing: userTrailing,
          padding: padding,
+         context: context,
        ),
        largeTitle = createLargeTitle(
          largeTitleKey: keys.largeTitleKey,
@@ -1880,10 +1956,12 @@ class _NavigationBarStaticComponents {
          route: route,
          automaticImplyTitle: automaticallyImplyTitle,
          large: large,
+         context: context,
        ),
        navBarBottom = createNavBarBottom(
          navBarBottomKey: keys.navBarBottomKey,
          userBottom: userBottom,
+         context: context,
        );
 
   static Widget? _derivedTitle({
@@ -1934,7 +2012,14 @@ class _NavigationBarStaticComponents {
       key: leadingKey,
       child: Padding(
         padding: EdgeInsetsDirectional.only(start: padding?.start ?? _kNavBarEdgePadding),
-        child: IconTheme.merge(data: const IconThemeData(size: 32.0), child: leadingContent),
+        child: MediaQuery(
+          data: MediaQueryData(
+            textScaler: MediaQuery.textScalerOf(
+              context,
+            ).clamp(minScaleFactor: 1.0, maxScaleFactor: _kMaxScaleFactor),
+          ),
+          child: IconTheme.merge(data: const IconThemeData(size: 32.0), child: leadingContent),
+        ),
       ),
     );
   }
@@ -1945,6 +2030,7 @@ class _NavigationBarStaticComponents {
     required Widget? userLeading,
     required ModalRoute<dynamic>? route,
     required bool automaticallyImplyLeading,
+    required BuildContext context,
   }) {
     if (userLeading != null ||
         !automaticallyImplyLeading ||
@@ -1954,7 +2040,17 @@ class _NavigationBarStaticComponents {
       return null;
     }
 
-    return KeyedSubtree(key: backChevronKey, child: const _BackChevron());
+    return KeyedSubtree(
+      key: backChevronKey,
+      child: MediaQuery(
+        data: MediaQueryData(
+          textScaler: MediaQuery.textScalerOf(
+            context,
+          ).clamp(minScaleFactor: 1.0, maxScaleFactor: _kMaxScaleFactor),
+        ),
+        child: const _BackChevron(),
+      ),
+    );
   }
 
   /// This widget is not decorated with a font since the font style could
@@ -1966,6 +2062,7 @@ class _NavigationBarStaticComponents {
     required ModalRoute<dynamic>? route,
     required bool automaticallyImplyLeading,
     required String? previousPageTitle,
+    required BuildContext context,
   }) {
     if (userLeading != null ||
         !automaticallyImplyLeading ||
@@ -1977,7 +2074,14 @@ class _NavigationBarStaticComponents {
 
     return KeyedSubtree(
       key: backLabelKey,
-      child: _BackLabel(specifiedPreviousTitle: previousPageTitle, route: route),
+      child: MediaQuery(
+        data: MediaQueryData(
+          textScaler: MediaQuery.textScalerOf(
+            context,
+          ).clamp(minScaleFactor: 1.0, maxScaleFactor: _kMaxScaleFactor),
+        ),
+        child: _BackLabel(specifiedPreviousTitle: previousPageTitle, route: route),
+      ),
     );
   }
 
@@ -1992,6 +2096,7 @@ class _NavigationBarStaticComponents {
     required bool staticBar,
     required bool automaticallyImplyTitle,
     required ModalRoute<dynamic>? route,
+    required BuildContext context,
   }) {
     Widget? middleContent = userMiddle;
 
@@ -2014,7 +2119,17 @@ class _NavigationBarStaticComponents {
       return null;
     }
 
-    return KeyedSubtree(key: middleKey, child: middleContent);
+    return KeyedSubtree(
+      key: middleKey,
+      child: MediaQuery(
+        data: MediaQueryData(
+          textScaler: MediaQuery.textScalerOf(
+            context,
+          ).clamp(minScaleFactor: 1.0, maxScaleFactor: _kMaxScaleFactor),
+        ),
+        child: middleContent,
+      ),
+    );
   }
 
   final KeyedSubtree? trailing;
@@ -2022,6 +2137,7 @@ class _NavigationBarStaticComponents {
     required GlobalKey trailingKey,
     required Widget? userTrailing,
     required EdgeInsetsDirectional? padding,
+    required BuildContext context,
   }) {
     if (userTrailing == null) {
       return null;
@@ -2031,7 +2147,14 @@ class _NavigationBarStaticComponents {
       key: trailingKey,
       child: Padding(
         padding: EdgeInsetsDirectional.only(end: padding?.end ?? _kNavBarEdgePadding),
-        child: IconTheme.merge(data: const IconThemeData(size: 32.0), child: userTrailing),
+        child: MediaQuery(
+          data: MediaQueryData(
+            textScaler: MediaQuery.textScalerOf(
+              context,
+            ).clamp(minScaleFactor: 1.0, maxScaleFactor: _kMaxScaleFactor),
+          ),
+          child: IconTheme.merge(data: const IconThemeData(size: 32.0), child: userTrailing),
+        ),
       ),
     );
   }
@@ -2045,6 +2168,7 @@ class _NavigationBarStaticComponents {
     required bool large,
     required bool automaticImplyTitle,
     required ModalRoute<dynamic>? route,
+    required BuildContext context,
   }) {
     if (!large) {
       return null;
@@ -2059,15 +2183,36 @@ class _NavigationBarStaticComponents {
       'largeTitle was not provided and there was no title from the route.',
     );
 
-    return KeyedSubtree(key: largeTitleKey, child: largeTitleContent!);
+    return KeyedSubtree(
+      key: largeTitleKey,
+      child: MediaQuery(
+        data: MediaQueryData(
+          textScaler: TextScaler.linear(
+            _dampScaleFactor(
+              MediaQuery.textScalerOf(context).scale(_kNavBarLargeTitleHeightExtension),
+              _kNavBarLargeTitleHeightExtension,
+              _kLargeTitleScaleDampingRatio,
+            ),
+          ),
+        ),
+        child: largeTitleContent!,
+      ),
+    );
   }
 
   final KeyedSubtree? navBarBottom;
   static KeyedSubtree? createNavBarBottom({
     required GlobalKey navBarBottomKey,
     required Widget? userBottom,
+    required BuildContext context,
   }) {
-    return KeyedSubtree(key: navBarBottomKey, child: userBottom ?? const SizedBox.shrink());
+    return KeyedSubtree(
+      key: navBarBottomKey,
+      child: MediaQuery(
+        data: MediaQueryData(textScaler: MediaQuery.textScalerOf(context)),
+        child: userBottom ?? const SizedBox.shrink(),
+      ),
+    );
   }
 }
 
@@ -2280,14 +2425,16 @@ class _CancelButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final CupertinoLocalizations localizations = CupertinoLocalizations.of(context);
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: Opacity(
-        opacity: opacity,
-        child: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: onPressed,
-          child: Text(localizations.cancelButtonLabel, maxLines: 1, overflow: TextOverflow.clip),
+    return MediaQuery.withNoTextScaling(
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Opacity(
+          opacity: opacity,
+          child: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: onPressed,
+            child: Text(localizations.cancelButtonLabel, maxLines: 1, overflow: TextOverflow.clip),
+          ),
         ),
       ),
     );
@@ -2300,20 +2447,37 @@ class _InactiveSearchableBottom extends StatelessWidget {
   const _InactiveSearchableBottom({
     required this.animationController,
     required this.searchField,
-    required this.onSearchFieldTap,
     required this.animation,
+    required this.searchFieldHeight,
+    required this.onSearchFieldTap,
   });
 
   final AnimationController animationController;
-  final _NavigationBarSearchField? searchField;
+  final Widget? searchField;
   final Animation<double> animation;
+  final double searchFieldHeight;
   final void Function()? onSearchFieldTap;
 
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
       animation: animation,
-      child: GestureDetector(onTap: onSearchFieldTap, child: searchField),
+      child: GestureDetector(
+        onTap: onSearchFieldTap,
+        child: AbsorbPointer(
+          child: FocusableActionDetector(
+            descendantsAreFocusable: false,
+            child: Padding(
+              padding: const EdgeInsetsDirectional.only(
+                start: _kNavBarEdgePadding,
+                end: _kNavBarEdgePadding,
+                bottom: _kNavBarBottomPadding,
+              ),
+              child: SizedBox(height: searchFieldHeight, child: searchField),
+            ),
+          ),
+        ),
+      ),
       builder: (BuildContext context, Widget? child) {
         return LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
@@ -2349,12 +2513,14 @@ class _ActiveSearchableBottom extends StatelessWidget {
     required this.animationController,
     required this.searchField,
     required this.animation,
+    required this.searchFieldHeight,
     required this.onSearchFieldTap,
   });
 
   final AnimationController animationController;
   final Widget? searchField;
   final Animation<double> animation;
+  final double searchFieldHeight;
   final void Function()? onSearchFieldTap;
 
   @override
@@ -2367,7 +2533,12 @@ class _ActiveSearchableBottom extends StatelessWidget {
       child: Row(
         spacing: 12.0, // Eyeballed on an iPhone 15 simulator running iOS 17.5.
         children: <Widget>[
-          Expanded(child: searchField ?? const SizedBox.shrink()),
+          Expanded(
+            child: SizedBox(
+              height: searchFieldHeight,
+              child: searchField ?? const SizedBox.shrink(),
+            ),
+          ),
           AnimatedBuilder(
             animation: animation,
             child: FadeTransition(
@@ -2385,36 +2556,6 @@ class _ActiveSearchableBottom extends StatelessWidget {
       ),
     );
   }
-}
-
-/// The search field used in the expanded state of a
-/// [CupertinoSliverNavigationBar.search].
-class _NavigationBarSearchField extends StatelessWidget implements PreferredSizeWidget {
-  const _NavigationBarSearchField({required this.searchField});
-
-  static const double verticalPadding = 8.0;
-  static const double searchFieldHeight = 36.0;
-  final Widget searchField;
-
-  @override
-  Widget build(BuildContext context) {
-    return AbsorbPointer(
-      child: FocusableActionDetector(
-        descendantsAreFocusable: false,
-        child: Padding(
-          padding: const EdgeInsetsDirectional.only(
-            start: _kNavBarEdgePadding,
-            end: _kNavBarEdgePadding,
-            bottom: verticalPadding,
-          ),
-          child: SizedBox(height: searchFieldHeight, child: searchField),
-        ),
-      ),
-    );
-  }
-
-  @override
-  Size get preferredSize => const Size.fromHeight(searchFieldHeight + verticalPadding);
 }
 
 /// This should always be the first child of Hero widgets.
@@ -2435,6 +2576,7 @@ class _TransitionableNavigationBar extends StatelessWidget {
     required this.border,
     required this.hasUserMiddle,
     required this.largeExpanded,
+    required this.searchable,
     required this.automaticBackgroundVisibility,
     required this.child,
   }) : assert(!largeExpanded || largeTitleTextStyle != null),
@@ -2448,6 +2590,7 @@ class _TransitionableNavigationBar extends StatelessWidget {
   final Border? border;
   final bool hasUserMiddle;
   final bool largeExpanded;
+  final bool searchable;
   final bool automaticBackgroundVisibility;
   final Widget child;
 
@@ -2621,6 +2764,7 @@ class _NavigationBarComponentsTransition {
        bottomAutomaticBackgroundVisibility = bottomNavBar.automaticBackgroundVisibility,
        userGestureInProgress =
            topNavBar.userGestureInProgress || bottomNavBar.userGestureInProgress,
+       searchable = topNavBar.searchable && bottomNavBar.searchable,
        transitionBox =
        // paintBounds are based on offset zero so it's ok to expand the Rects.
        bottomNavBar.renderBox.paintBounds.expandToInclude(topNavBar.renderBox.paintBounds),
@@ -2651,6 +2795,7 @@ class _NavigationBarComponentsTransition {
   final bool bottomLargeExpanded;
   final bool topLargeExpanded;
   final bool userGestureInProgress;
+  final bool searchable;
   final bool bottomAutomaticBackgroundVisibility;
 
   final Color? bottomBackgroundColor;
@@ -2993,8 +3138,6 @@ class _NavigationBarComponentsTransition {
   Widget? get bottomNavBarBottom {
     final KeyedSubtree? bottomNavBarBottom =
         bottomComponents.navBarBottomKey.currentWidget as KeyedSubtree?;
-    final KeyedSubtree? topNavBarBottom =
-        topComponents.navBarBottomKey.currentWidget as KeyedSubtree?;
 
     if (bottomNavBarBottom == null) {
       return null;
@@ -3018,13 +3161,8 @@ class _NavigationBarComponentsTransition {
 
     // Fade out only if this is not a CupertinoSliverNavigationBar.search to
     // CupertinoSliverNavigationBar.search transition.
-    if (topNavBarBottom == null ||
-        topNavBarBottom.child is! _InactiveSearchableBottom ||
-        bottomNavBarBottom.child is! _InactiveSearchableBottom) {
-      child = FadeTransition(
-        opacity: fadeOutBy(0.8, curve: animationCurve),
-        child: ClipRect(child: child),
-      );
+    if (!searchable) {
+      child = FadeTransition(opacity: fadeOutBy(0.8, curve: animationCurve), child: child);
     }
 
     return PositionedTransition(
@@ -3034,7 +3172,7 @@ class _NavigationBarComponentsTransition {
               ? routeAnimation.drive(CurveTween(curve: Curves.linear)).drive(positionTween)
               : animation.drive(CurveTween(curve: animationCurve)).drive(positionTween),
 
-      child: child,
+      child: ClipRect(child: child),
     );
   }
 
@@ -3320,8 +3458,6 @@ class _NavigationBarComponentsTransition {
   Widget? get topNavBarBottom {
     final KeyedSubtree? topNavBarBottom =
         topComponents.navBarBottomKey.currentWidget as KeyedSubtree?;
-    final KeyedSubtree? bottomNavBarBottom =
-        bottomComponents.navBarBottomKey.currentWidget as KeyedSubtree?;
 
     if (topNavBarBottom == null) {
       return null;
@@ -3346,13 +3482,8 @@ class _NavigationBarComponentsTransition {
 
     // Fade in only if this is not a CupertinoSliverNavigationBar.search to
     // CupertinoSliverNavigationBar.search transition.
-    if (bottomNavBarBottom == null ||
-        bottomNavBarBottom.child is! _InactiveSearchableBottom ||
-        topNavBarBottom.child is! _InactiveSearchableBottom) {
-      child = FadeTransition(
-        opacity: fadeInFrom(0.0, curve: animationCurve),
-        child: ClipRect(child: child),
-      );
+    if (!searchable) {
+      child = FadeTransition(opacity: fadeInFrom(0.0, curve: animationCurve), child: child);
     }
 
     return PositionedTransition(
@@ -3361,7 +3492,7 @@ class _NavigationBarComponentsTransition {
           userGestureInProgress
               ? routeAnimation.drive(CurveTween(curve: Curves.linear)).drive(positionTween)
               : animation.drive(CurveTween(curve: animationCurve)).drive(positionTween),
-      child: child,
+      child: ClipRect(child: child),
     );
   }
 }


### PR DESCRIPTION
Dupe of https://github.com/flutter/flutter/pull/167313 (closed because of issues with Google testing)

Fixes [Cupertino nav bars should respect accessibility text scaling](https://github.com/flutter/flutter/issues/167248)
Fixes [Title jumps during a CupertinoNavigationBar -> CupertinoNavigationBar hero transition](https://github.com/flutter/flutter/issues/90589)

## Before

| Regular | Scaled | 
| --- | --- |
| <img width="378" alt="Image" src="https://github.com/user-attachments/assets/0e010c06-253f-41a5-9b23-18c6d1f75046" /> | <img width="378" alt="Image" src="https://github.com/user-attachments/assets/7033f879-3e68-4e5e-94d1-cc84383d6d5d" /> |

## After

| Regular | Scaled | 
| --- | --- |
| <img width="375" alt="flutter nav bar unscaled" src="https://github.com/user-attachments/assets/ff761339-358e-4fa5-a0c2-b0f43f6cea2e" /> | <img width="376" alt="flutter after 2 textscale" src="https://github.com/user-attachments/assets/11d46451-bd46-4c65-9f3a-fb2b0da0d77c" /> |

## Native

| Regular | Scaled | 
| --- | --- |
| <img width="376" alt="Image" src="https://github.com/user-attachments/assets/5775f9f1-d1f9-446b-9ec8-e77073a8887e" /> | <img width="376" alt="Image" src="https://github.com/user-attachments/assets/76bf6263-d94c-4136-bd53-d91bb0d88437" /> |