### PR TITLE
Mark web_tool_tests_1_2 as bringup.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6553,6 +6553,7 @@ targets:
 
   - name: Windows web_tool_tests_1_2
     recipe: flutter/flutter_drone
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/168863
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
Unblocks the tree (>10% failure rate in prod): https://github.com/flutter/flutter/issues/168863.