### PR TITLE
Skip hot reload breakpoints test when running with web

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_test_common.dart
@@ -123,77 +123,83 @@ void testAll({bool chrome = false, List<String> additionalCommandArgs = const <S
       await flutter.hotRestart();
     });
 
-    testWithoutContext('breakpoints are hit after hot reload', () async {
-      Isolate isolate;
-      final Completer<void> sawTick1 = Completer<void>();
-      final Completer<void> sawDebuggerPausedMessage = Completer<void>();
-      final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
-        if (line.contains('((((TICK 1))))')) {
-          expect(sawTick1.isCompleted, isFalse);
-          sawTick1.complete();
+    testWithoutContext(
+      'breakpoints are hit after hot reload',
+      () async {
+        Isolate isolate;
+        final Completer<void> sawTick1 = Completer<void>();
+        final Completer<void> sawDebuggerPausedMessage = Completer<void>();
+        final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
+          if (line.contains('((((TICK 1))))')) {
+            expect(sawTick1.isCompleted, isFalse);
+            sawTick1.complete();
+          }
+          if (line.contains('The application is paused in the debugger on a breakpoint.')) {
+            expect(sawDebuggerPausedMessage.isCompleted, isFalse);
+            sawDebuggerPausedMessage.complete();
+          }
+        });
+        await runFlutterWithDevice(
+          flutter,
+          chrome: chrome,
+          withDebugger: true,
+          startPaused: true,
+          additionalCommandArgs: additionalCommandArgs,
+        );
+        await flutter
+            .resume(); // we start paused so we can set up our TICK 1 listener before the app starts
+        unawaited(
+          sawTick1.future.timeout(
+            const Duration(seconds: 5),
+            onTimeout: () {
+              // This print is useful for people debugging this test. Normally we would avoid printing
+              // in a test but this is an exception because it's useful ambient information.
+              // ignore: avoid_print
+              print(
+                'The test app is taking longer than expected to print its synchronization line...',
+              );
+            },
+          ),
+        );
+        printOnFailure('waiting for synchronization line...');
+        await sawTick1.future; // after this, app is in steady state
+        await flutter.addBreakpoint(
+          project.scheduledBreakpointUri,
+          project.scheduledBreakpointLine,
+        );
+        await Future<void>.delayed(const Duration(seconds: 2));
+        await flutter.hotReload(); // reload triggers code which eventually hits the breakpoint
+        isolate = await flutter.waitForPause();
+        expect(isolate.pauseEvent?.kind, equals(EventKind.kPauseBreakpoint));
+        await flutter.resume();
+        await flutter.addBreakpoint(project.buildBreakpointUri, project.buildBreakpointLine);
+        bool reloaded = false;
+        final Future<void> reloadFuture = flutter.hotReload().then((void value) {
+          reloaded = true;
+        });
+        printOnFailure('waiting for pause...');
+        isolate = await flutter.waitForPause();
+        expect(isolate.pauseEvent?.kind, equals(EventKind.kPauseBreakpoint));
+        if (!chrome) {
+          // TODO(srujzs): Implement paused event messages for the web.
+          // https://github.com/flutter/flutter/issues/162500
+          printOnFailure('waiting for debugger message...');
+          await sawDebuggerPausedMessage.future;
         }
-        if (line.contains('The application is paused in the debugger on a breakpoint.')) {
-          expect(sawDebuggerPausedMessage.isCompleted, isFalse);
-          sawDebuggerPausedMessage.complete();
-        }
-      });
-      await runFlutterWithDevice(
-        flutter,
-        chrome: chrome,
-        withDebugger: true,
-        startPaused: true,
-        additionalCommandArgs: additionalCommandArgs,
-      );
-      await flutter
-          .resume(); // we start paused so we can set up our TICK 1 listener before the app starts
-      unawaited(
-        sawTick1.future.timeout(
-          const Duration(seconds: 5),
-          onTimeout: () {
-            // This print is useful for people debugging this test. Normally we would avoid printing
-            // in a test but this is an exception because it's useful ambient information.
-            // ignore: avoid_print
-            print(
-              'The test app is taking longer than expected to print its synchronization line...',
-            );
-          },
-        ),
-      );
-      printOnFailure('waiting for synchronization line...');
-      await sawTick1.future; // after this, app is in steady state
-      await flutter.addBreakpoint(project.scheduledBreakpointUri, project.scheduledBreakpointLine);
-      await Future<void>.delayed(const Duration(seconds: 2));
-      await flutter.hotReload(); // reload triggers code which eventually hits the breakpoint
-      isolate = await flutter.waitForPause();
-      expect(isolate.pauseEvent?.kind, equals(EventKind.kPauseBreakpoint));
-      await flutter.resume();
-      await flutter.addBreakpoint(project.buildBreakpointUri, project.buildBreakpointLine);
-      bool reloaded = false;
-      final Future<void> reloadFuture = flutter.hotReload().then((void value) {
-        reloaded = true;
-      });
-      printOnFailure('waiting for pause...');
-      isolate = await flutter.waitForPause();
-      expect(isolate.pauseEvent?.kind, equals(EventKind.kPauseBreakpoint));
-      if (!chrome) {
-        // TODO(srujzs): Implement paused event messages for the web.
-        // https://github.com/flutter/flutter/issues/162500
-        printOnFailure('waiting for debugger message...');
-        await sawDebuggerPausedMessage.future;
-      }
-      expect(reloaded, isFalse);
-      printOnFailure('waiting for resume...');
-      await flutter.resume();
-      printOnFailure('waiting for reload future...');
-      await reloadFuture;
-      expect(reloaded, isTrue);
-      reloaded = false;
-      printOnFailure('subscription cancel...');
-      await subscription.cancel();
-    },
-    // Hot reload on web does not reregister breakpoints correctly yet.
-    // https://github.com/dart-lang/sdk/issues/60186
-    skip: chrome);
+        expect(reloaded, isFalse);
+        printOnFailure('waiting for resume...');
+        await flutter.resume();
+        printOnFailure('waiting for reload future...');
+        await reloadFuture;
+        expect(reloaded, isTrue);
+        reloaded = false;
+        printOnFailure('subscription cancel...');
+        await subscription.cancel();
+      },
+      // Hot reload on web does not reregister breakpoints correctly yet.
+      // https://github.com/dart-lang/sdk/issues/60186
+      skip: chrome,
+    );
 
     testWithoutContext(
       "hot reload doesn't reassemble if paused",

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_test_common.dart
@@ -190,7 +190,10 @@ void testAll({bool chrome = false, List<String> additionalCommandArgs = const <S
       reloaded = false;
       printOnFailure('subscription cancel...');
       await subscription.cancel();
-    });
+    },
+    // Hot reload on web does not reregister breakpoints correctly yet.
+    // https://github.com/dart-lang/sdk/issues/60186
+    skip: chrome);
 
     testWithoutContext(
       "hot reload doesn't reassemble if paused",


### PR DESCRIPTION
This worked before accidentally, presumably by using stale
source maps. Now that invocations in closures are transformed
by the compiler, the stale source maps are now invalid, leading
to timeouts in tests when running against the latest Dart SDK.
Skip this test instead until breakpoints work.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
