### PR TITLE
Fix mac_ios_engine_ddm config with missing ci/ios_debug_sim_ddm config

### DIFF
--- a/engine/src/flutter/ci/builders/mac_ios_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/mac_ios_engine_ddm.json
@@ -25,6 +25,53 @@
       },
       "gn": [
         "--target-dir",
+        "ci/ios_debug_sim_ddm",
+        "--ios",
+        "--runtime-mode",
+        "debug",
+        "--simulator",
+        "--no-lto",
+        "--rbe",
+        "--no-goma",
+        "--xcode-symlinks"
+      ],
+      "name": "ci/ios_debug_sim_ddm",
+      "description": "Produces debug mode artifacts to target the x64 iOS simulator.",
+      "ninja": {
+        "config": "ci/ios_debug_sim_ddm"
+      },
+      "postsubmit_overrides": {
+        "gn": [
+          "--target-dir",
+          "ci/ios_debug_sim_ddm",
+          "--ios",
+          "--runtime-mode",
+          "debug",
+          "--simulator",
+          "--no-lto",
+          "--no-rbe",
+          "--no-goma"
+        ]
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "16c5032a"
+        }
+      }
+    },
+    {
+      "drone_dimensions": [
+        "device_type=none",
+        "os=Mac-14",
+        "cpu=arm64"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "download_jdk": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--target-dir",
         "ci/ios_debug_sim_arm64_ddm",
         "--ios",
         "--runtime-mode",


### PR DESCRIPTION
This should fix an error that I got in `Global generators` -> `Debug-ios-Flutter.xcframework`:
https://ci.chromium.org/ui/p/flutter/builders/staging/Mac%20mac_ios_engine_ddm/1/overview

```
Cannot find iOS x64 simulator framework at /Volumes/Work/s/w/ir/cache/builder/engine/src/out/ci/ios_debug_sim_ddm/Flutter.framework`
```

I think what happened here is that I assumed I could skip the x64 simulator build because myself and other 1P developers are using arm64 macs. But I now see that the `Debug-ios-Flutter.xcframework` task and the `flutter/sky/tools/create_ios_framework.py` script assumes both architectures are present.