### PR TITLE
refactor the usage of `MediaQuery.sizeOf(context).height` to use the new `.heightOf(context)`

### DIFF
--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -530,7 +530,7 @@ void main() {
       createAppWithButtonThatLaunchesActionSheet(
         Builder(
           builder: (BuildContext context) {
-            screenHeight = MediaQuery.sizeOf(context).height;
+            screenHeight = MediaQuery.heightOf(context);
             return MediaQuery.withClampedTextScaling(
               minScaleFactor: 3.0,
               maxScaleFactor: 3.0,
@@ -706,7 +706,7 @@ void main() {
       createAppWithButtonThatLaunchesActionSheet(
         Builder(
           builder: (BuildContext context) {
-            screenHeight = MediaQuery.sizeOf(context).height;
+            screenHeight = MediaQuery.heightOf(context);
             return CupertinoActionSheet(
               message: Text('content ' * 1000),
               actions: <Widget>[


### PR DESCRIPTION
Replace the usage of MediaQuery.sizeOf(context).height with MediaQuery.hieghtOf(context)

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
