### PR TITLE
use `minSdk` instead of deprecated `minSdkVersion`

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
@@ -185,7 +185,7 @@ object DependencyVersionChecker {
         return if (agpVersion != null && agpVersion.major >= 8 && agpVersion.minor >= 1) {
             MinSdkVersion(it.name, it.minSdk.apiLevel)
         } else {
-            MinSdkVersion(it.name, it.minSdkVersion.apiLevel)
+            MinSdkVersion(it.name, it.minSdk.apiLevel)
         }
     }
 


### PR DESCRIPTION
according to android studio :

![minSdk](https://github.com/user-attachments/assets/b49e5c3c-42a1-4db2-883f-edfb85749e5c)

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
