### PR TITLE
[3.32] Revert: "Run `flutter_packaging` builders on release candidates

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6866,7 +6866,6 @@ targets:
     scheduler: release
     bringup: true # https://github.com/flutter/flutter/issues/126286
     enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6881,7 +6880,6 @@ targets:
     timeout: 60
     scheduler: release
     enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6898,7 +6896,6 @@ targets:
     timeout: 60
     scheduler: release
     enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6915,7 +6912,6 @@ targets:
     scheduler: release
     bringup: true
     enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:


### PR DESCRIPTION
This reverts commit aed4bfd318f189d648e595b89442fc19e3147b47.

`flutter_packaging` builders only should run on `stable` or `beta`, the original definition was correct.