### PR TITLE
[3.33] Revert: "Run `flutter_packaging` builders on release candidates

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6945,7 +6945,6 @@ targets:
     scheduler: release
     bringup: true # https://github.com/flutter/flutter/issues/126286
     enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6960,7 +6959,6 @@ targets:
     timeout: 60
     scheduler: release
     enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6977,7 +6975,6 @@ targets:
     timeout: 60
     scheduler: release
     enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:
@@ -6994,7 +6991,6 @@ targets:
     scheduler: release
     bringup: true
     enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
       - beta
       - stable
     properties:


### PR DESCRIPTION
This reverts commit 2491dcefcfaaf3652b2ac2a217a0040df1b6b1e5.

`flutter_packaging` builders only should run on `stable` or `beta`, the original definition was correct.