### PR TITLE
iOS,macOS: Support using public API in Swift

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -125,8 +125,14 @@ config("framework_relative_headers") {
 }
 
 source_set("InternalFlutterSwiftCommon") {
+  # Targets should only ever depend on the framework target.
+  # This allows code in this target to use types declared in the bridging
+  # header, but defined in the framework, while avoiding linking errors.
+  visibility = [ ":framework_common" ]
   configs += [ ":config" ]
+  bridge_header = "InternalFlutterSwiftCommon-Bridging-Header.h"
   sources = [ "framework/Source/Logger.swift" ]
+  public = framework_common_headers
 }
 
 # Framework code shared between iOS and macOS.
@@ -157,10 +163,8 @@ source_set("framework_common") {
     ":framework_relative_headers",
   ]
 
-  deps = [
-    ":InternalFlutterSwiftCommon",
-    "//flutter/fml",
-  ]
+  deps = [ "//flutter/fml" ]
+  public_deps = [ ":InternalFlutterSwiftCommon" ]
 }
 
 test_fixtures("framework_common_fixtures") {
@@ -175,7 +179,7 @@ source_set("test_utils_swift") {
     ":test_config",
   ]
   sources = [ "framework/Source/LoggerTestUtils.swift" ]
-  deps = [ ":InternalFlutterSwiftCommon" ]
+  deps = [ ":framework_common" ]
 }
 
 # Implements a main entry point for Swift Testing tests.
@@ -202,7 +206,7 @@ executable("framework_common_swift_unittests") {
   ]
   sources = [ "framework/Source/LoggerTest.swift" ]
   deps = [
-    ":InternalFlutterSwiftCommon",
+    ":framework_common",
     ":swift_testing_main",
     ":test_utils_swift",
   ]

--- a/engine/src/flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon-Bridging-Header.h
+++ b/engine/src/flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon-Bridging-Header.h
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_COMMON_INTERNALFLUTTERSWIFTCOMMON_BRIDGING_HEADER_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_COMMON_INTERNALFLUTTERSWIFTCOMMON_BRIDGING_HEADER_H_
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterDartProject.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterHourFormat.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h"
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_COMMON_INTERNALFLUTTERSWIFTCOMMON_BRIDGING_HEADER_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -40,13 +40,22 @@ _flutter_framework_headers = [
 _flutter_framework_headers_copy_dir = "$_flutter_framework_dir/Headers"
 
 source_set("InternalFlutterSwift") {
-  visibility = [ ":*" ]
+  # Targets should only ever depend on the framework target.
+  # This allows code in this target to use types declared in the bridging
+  # header, but defined in the framework, while avoiding linking errors.
+  visibility = [ ":flutter_framework_source" ]
   configs += [ "//flutter/shell/platform/darwin/common:config" ]
-
+  include_dirs = [
+    "//flutter/shell/platform/darwin/common/framework/Headers",
+    "//flutter/shell/platform/darwin/ios/framework/Headers",
+    "//flutter/shell/platform/darwin/ios/framework",  # For module.modulemap
+  ]
+  bridge_header = "InternalFlutterSwift-Bridging-Header.h"
   sources = [
     "framework/Source/ConnectionCollection.swift",
     "framework/Source/UIPressProxy.swift",
   ]
+  public = _flutter_framework_headers + framework_common_headers
 }
 
 source_set("flutter_framework_source") {
@@ -176,7 +185,6 @@ source_set("flutter_framework_source") {
   }
 
   deps = [
-    ":InternalFlutterSwift",
     ":ios_gpu_configuration",
     "//flutter/common:common",
     "//flutter/common/graphics",
@@ -186,7 +194,6 @@ source_set("flutter_framework_source") {
     "//flutter/shell/common",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/darwin/common",
-    "//flutter/shell/platform/darwin/common:InternalFlutterSwiftCommon",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
@@ -194,6 +201,7 @@ source_set("flutter_framework_source") {
     "//flutter/third_party/icu",
     "//flutter/third_party/spring_animation",
   ]
+  public_deps = [ ":InternalFlutterSwift" ]
 }
 
 if (enable_ios_unittests) {
@@ -206,7 +214,7 @@ if (enable_ios_unittests) {
       "framework/Source/FakeUIPressProxy.swift",
     ]
     frameworks = [ "XCTest.framework" ]
-    deps = [ ":InternalFlutterSwift" ]
+    deps = [ ":flutter_framework_source" ]
   }
 
   shared_library("ios_test_flutter") {
@@ -266,14 +274,12 @@ if (enable_ios_unittests) {
       "platform_message_handler_ios_test.mm",
     ]
     deps = [
-      ":InternalFlutterSwift",
       ":flutter_framework",
       ":flutter_framework_source",
       ":ios_gpu_configuration",
       ":ios_test_flutter_swift",
       "//flutter/common:common",
       "//flutter/lib/ui:ui",
-      "//flutter/shell/platform/darwin/common:InternalFlutterSwiftCommon",
       "//flutter/shell/platform/darwin/common:framework_common",
       "//flutter/shell/platform/embedder:embedder_as_internal_library",
       "//flutter/shell/platform/embedder:embedder_test_utils",
@@ -299,10 +305,7 @@ shared_library("create_flutter_framework_dylib") {
 
   public = _flutter_framework_headers
 
-  deps = [
-    ":InternalFlutterSwift",
-    ":flutter_framework_source",
-  ]
+  deps = [ ":flutter_framework_source" ]
 
   public_configs = [ "//flutter:config" ]
   configs += [ "//build/config/ios:ios_application_extension" ]

--- a/engine/src/flutter/shell/platform/darwin/ios/InternalFlutterSwift-Bridging-Header.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/InternalFlutterSwift-Bridging-Header.h
@@ -1,0 +1,10 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_
+
+#import "flutter/shell/platform/darwin/ios/framework/Headers/Flutter.h"
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_

--- a/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
@@ -51,11 +51,20 @@ _flutter_framework_headers_copy_dir =
     "$_flutter_framework_dir/Versions/A/Headers"
 
 source_set("InternalFlutterSwift") {
-  visibility = [ ":*" ]
+  # Targets should only ever depend on the framework target.
+  # This allows code in this target to use types declared in the bridging
+  # header, but defined in the framework, while avoiding linking errors.
+  visibility = [ ":flutter_framework_source" ]
   configs += [ "//flutter/shell/platform/darwin/common:config" ]
-
+  include_dirs = [
+    "//flutter/shell/platform/darwin/common/framework/Headers",
+    "//flutter/shell/platform/darwin/macos/framework/Headers",
+    "//flutter/shell/platform/darwin/macos/framework",  # For module.modulemap
+  ]
+  bridge_header = "InternalFlutterSwift-Bridging-Header.h"
   sources = [ "framework/Source/FlutterRunLoop.swift" ]
-  deps = [ "//flutter/shell/platform/darwin/common:InternalFlutterSwiftCommon" ]
+  deps = [ "//flutter/shell/platform/darwin/common:framework_common" ]
+  public = _flutter_framework_headers + framework_common_headers
 }
 
 source_set("flutter_framework_source") {
@@ -129,7 +138,6 @@ source_set("flutter_framework_source") {
   sources += _flutter_framework_headers
 
   deps = [
-    ":InternalFlutterSwift",
     ":macos_gpu_configuration",
     "//flutter/flow:flow",
     "//flutter/fml",
@@ -137,13 +145,13 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",
-    "//flutter/shell/platform/darwin/common:InternalFlutterSwiftCommon",
     "//flutter/shell/platform/darwin/common:availability_version_check",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/graphics:graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/skia",
   ]
+  public_deps = [ ":InternalFlutterSwift" ]
 
   public_configs = [ "//flutter:config" ]
 
@@ -218,13 +226,11 @@ executable("flutter_desktop_darwin_unittests") {
   ]
 
   deps = [
-    ":InternalFlutterSwift",
     ":flutter_desktop_darwin_fixtures",
     ":flutter_framework_source",
     "//flutter/fml",
     "//flutter/shell/platform/common:common_cpp_accessibility",
     "//flutter/shell/platform/common:common_cpp_enums",
-    "//flutter/shell/platform/darwin/common:InternalFlutterSwiftCommon",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/common:test_utils_swift",
     "//flutter/shell/platform/darwin/graphics",

--- a/engine/src/flutter/shell/platform/darwin/macos/InternalFlutterSwift-Bridging-Header.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/InternalFlutterSwift-Bridging-Header.h
@@ -1,0 +1,10 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_
+
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterMacOS.h"
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_INTERNALFLUTTERSWIFT_BRIDGING_HEADER_H_


### PR DESCRIPTION
This adds Obj-C/Swift bridging headers to Swift targets, which allows us
to use public Flutter framework API from Swift code in the framework.

This also restricts visibility of the Swift framework targets to the
corresponding framework target. The addition of a bridging header allows
us to use public framework types declared in those headers from Swift,
but those types are defined in the framework target, and thus using the
Swift target directly may result in linking errors in the user. Instead,
all usage of the Swift target should be transitive via the framework
target.

Issue: https://github.com/flutter/flutter/issues/144791

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
