### PR TITLE
Add `bringup: true` Linux orchestrators that schedule Windows engine builds

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -499,6 +499,24 @@ targets:
       - os=Mac-14
       - cpu=x86
 
+  - name: Linux windows_android_aot_engine
+    recipe: engine_v2/engine_v2
+    timeout: 120
+    # TODO(matanlurey): Remove bringup: true and add release_build: true.
+    # https://github.com/flutter/flutter/issues/168934
+    bringup: true
+    properties:
+      add_recipes_cq: "true"
+      # TODO(matanlurey): Remove bringup: true and add release_build: true.
+      # release_build: "true"
+      config_name: windows_host_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
+
+  # TODO(matanlurey): Remove and use Linux windows_host_engine.
+  # https://github.com/flutter/flutter/issues/168934
   - name: Windows windows_android_aot_engine
     recipe: engine_v2/engine_v2
     timeout: 120
@@ -511,6 +529,24 @@ targets:
     drone_dimensions:
       - os=Windows
 
+  - name: Linux windows_host_engine
+    recipe: engine_v2/engine_v2
+    timeout: 120
+    # TODO(matanlurey): Remove bringup: true and add release_build: true.
+    # https://github.com/flutter/flutter/issues/168934
+    bringup: true
+    properties:
+      add_recipes_cq: "true"
+      # TODO(matanlurey): Remove bringup: true and add release_build: true.
+      # release_build: "true"
+      config_name: windows_host_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
+
+  # TODO(matanlurey): Remove and use Linux windows_host_engine.
+  # https://github.com/flutter/flutter/issues/168934
   - name: Windows windows_host_engine
     recipe: engine_v2/engine_v2
     timeout: 120


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/168934.

/cc @reidbaker as release engineer.