### PR TITLE
runtime/dart: fuchsia::io::MODE_TYPE_FILE -> V_TYPE_FILE

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
@@ -6,6 +6,7 @@
 
 #include <dirent.h>
 #include <fuchsia/io/cpp/fidl.h>
+#include <lib/fdio/vfs.h>
 #include <zircon/status.h>
 
 #include <cerrno>
@@ -47,8 +48,8 @@ void VMServiceObject::GetContents(LazyEntryVector* out_vector) const {
     if ((file == ".") || (file == "..")) {
       continue;
     }
-    out_vector->push_back({std::stoul(file) + GetStartingId(), file,
-                           fuchsia::io::MODE_TYPE_FILE});
+    out_vector->push_back(
+        {std::stoul(file) + GetStartingId(), file, V_TYPE_FILE});
   }
 }
 


### PR DESCRIPTION
fuchsia::io::MODE_TYPE_FILE is deprecated and V_TYPE_FILE is the correct constant anyway.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

An upcoming change to the Fuchsia SDK will remove the `fuchsia::io::MODE_TYPE_…` constants. This PR changes `fuchsia::io::MODE_TYPE_FILE` to `V_TYPE_FILE` (which is actually the correct constant to use in this case anyway). The constant has the same value.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA]. *n/a: I am a Googler*
- [x] I listed at least one issue that this PR fixes in the description above. *trivial change*
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
