### PR TITLE
Add support for hiding widget subtrees from the widget inspector

### DIFF
--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1796,13 +1796,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
           for (int i = 0; i < propertiesJson.length; ++i) {
             final Map<String, Object?> propertyJson = propertiesJson[i]! as Map<String, Object?>;
-            if (propertyJson['inDisableWidgetInspectorScope']! as bool) {
-            } else {
-              expect(
-                service.toObject(propertyJson['valueId']! as String),
-                equals(getFirstVisibleNode(children[i])?.value),
-              );
-            }
+            expect(
+              service.toObject(propertyJson['valueId']! as String),
+              equals(getFirstVisibleNode(children[i])?.value),
+            );
           }
         });
       });

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -89,6 +89,20 @@ class _ClockTextState extends State<ClockText> {
   }
 }
 
+class TestHiddenWidget extends StatelessWidget {
+  const TestHiddenWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) => Container();
+}
+
+class TestVisibleWidget extends StatelessWidget {
+  const TestVisibleWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) => Container();
+}
+
 // End of block of code where widget creation location line numbers and
 // columns will impact whether tests pass.
 
@@ -296,10 +310,43 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
+              DisableWidgetInspectorScope(
+                child: Column(
+                  children: <Widget>[
+                    TestHiddenWidget(),
+                    EnableWidgetInspectorScope(child: TestVisibleWidget()),
+                  ],
+                ),
+              ),
             ],
           ),
         ),
       );
+    }
+
+    /// Returns the first [DiagnosticsNode] that isn't in a [DisableWidgetInspectorScope] and isn't
+    /// an [EnableWidgetInspectorScope].
+    DiagnosticsNode? getFirstVisibleNode(
+      DiagnosticsNode node, [
+      bool inDisableInspectorWidgetScope = false,
+    ]) {
+      final Object? value = node.value;
+      if (value is Element) {
+        if (value.widget is DisableWidgetInspectorScope || inDisableInspectorWidgetScope) {
+          final List<DiagnosticsNode> children = node.getChildren();
+          for (final DiagnosticsNode child in children) {
+            final DiagnosticsNode? result = getFirstVisibleNode(
+              child,
+              value.widget is! EnableWidgetInspectorScope,
+            );
+            if (result != null) {
+              return result;
+            }
+          }
+          return null;
+        }
+      }
+      return node;
     }
 
     Element findElementABC(String letter) {
@@ -1744,11 +1791,18 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           final List<Object?> propertiesJson =
               json.decode(service.getChildren(id, group)) as List<Object?>;
           final List<DiagnosticsNode> children = diagnostic.getChildren();
-          expect(children.length, equals(3));
+          expect(children.length, equals(4));
           expect(propertiesJson.length, equals(children.length));
+
           for (int i = 0; i < propertiesJson.length; ++i) {
             final Map<String, Object?> propertyJson = propertiesJson[i]! as Map<String, Object?>;
-            expect(service.toObject(propertyJson['valueId']! as String), equals(children[i].value));
+            if (propertyJson['inDisableWidgetInspectorScope']! as bool) {
+            } else {
+              expect(
+                service.toObject(propertyJson['valueId']! as String),
+                equals(getFirstVisibleNode(children[i])?.value),
+              );
+            }
           }
         });
       });
@@ -2394,7 +2448,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
               // Verify the first child's first child's children are the same
               // length.
-              expect(children.length, equals(3));
+              expect(children.length, equals(4));
               expect(children.length, equals(childrenFromOtherApi.length));
 
               // Get the first child's first child's third child.
@@ -2491,6 +2545,29 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
               } else {
                 return <String, String>{'objectGroup': groupName};
               }
+            }
+
+            void testWidgetInspectorScopes(Map<String, Object?> rootJson) {
+              expect(
+                oneChildSatisfiesCondition(
+                  rootJson,
+                  condition: (Map<String, Object?> child) {
+                    return hasDescription(child, description: 'TestVisibleWidget') &&
+                        wasCreatedByLocalProject(child);
+                  },
+                ),
+                isTrue,
+              );
+              expect(
+                oneChildSatisfiesCondition(
+                  rootJson,
+                  condition: (Map<String, Object?> child) {
+                    return hasDescription(child, description: 'TestHiddenWidget') &&
+                        wasCreatedByLocalProject(child);
+                  },
+                ),
+                isFalse,
+              );
             }
 
             for (final bool useGetRootWidgetTreeApi in <bool>[true, false]) {
@@ -2656,6 +2733,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
                 ),
                 isTrue,
               );
+              testWidgetInspectorScopes(rootJson);
             });
 
             testWidgets('tree without full details using ext.flutter.inspector.getRootWidgetTree', (
@@ -2721,6 +2799,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
                 ),
                 isTrue,
               );
+              testWidgetInspectorScopes(rootJson);
             });
 
             testWidgets('full tree with previews using ext.flutter.inspector.getRootWidgetTree', (
@@ -2785,6 +2864,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
                 ),
                 isTrue,
               );
+              testWidgetInspectorScopes(rootJson);
             });
 
             testWidgets(
@@ -2852,6 +2932,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
                   ),
                   isTrue,
                 );
+                testWidgetInspectorScopes(rootJson);
               },
             );
           });
@@ -3179,11 +3260,14 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
               ))!
               as List<Object?>;
       final List<DiagnosticsNode> children = diagnostic.getChildren();
-      expect(children.length, equals(3));
+      expect(children.length, equals(4));
       expect(propertiesJson.length, equals(children.length));
       for (int i = 0; i < propertiesJson.length; ++i) {
         final Map<String, Object?> propertyJson = propertiesJson[i]! as Map<String, Object?>;
-        expect(service.toObject(propertyJson['valueId']! as String), equals(children[i].value));
+        expect(
+          service.toObject(propertyJson['valueId']! as String),
+          equals(getFirstVisibleNode(children[i])?.value),
+        );
       }
     });
 
@@ -3199,11 +3283,14 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
               ))!
               as List<Object?>;
       final List<DiagnosticsNode> children = diagnosticable.toDiagnosticsNode().getChildren();
-      expect(children.length, equals(3));
+      expect(children.length, equals(4));
       expect(childrenJson.length, equals(children.length));
       for (int i = 0; i < childrenJson.length; ++i) {
         final Map<String, Object?> childJson = childrenJson[i]! as Map<String, Object?>;
-        expect(service.toObject(childJson['valueId']! as String), equals(children[i].value));
+        expect(
+          service.toObject(childJson['valueId']! as String),
+          equals(getFirstVisibleNode(children[i])?.value),
+        );
         final List<Object?> propertiesJson = childJson['properties']! as List<Object?>;
         final Element element = service.toObject(childJson['valueId']! as String)! as Element;
         final List<DiagnosticsNode> expectedProperties =
@@ -3235,11 +3322,14 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(subtreeJson['valueId'], equals(id));
       final List<Object?> childrenJson = subtreeJson['children']! as List<Object?>;
       final List<DiagnosticsNode> children = diagnosticable.toDiagnosticsNode().getChildren();
-      expect(children.length, equals(3));
+      expect(children.length, equals(4));
       expect(childrenJson.length, equals(children.length));
       for (int i = 0; i < childrenJson.length; ++i) {
         final Map<String, Object?> childJson = childrenJson[i]! as Map<String, Object?>;
-        expect(service.toObject(childJson['valueId']! as String), equals(children[i].value));
+        expect(
+          service.toObject(childJson['valueId']! as String),
+          equals(getFirstVisibleNode(children[i])?.value),
+        );
         final List<Object?> propertiesJson = childJson['properties']! as List<Object?>;
         for (final Map<String, Object?> propertyJson
             in propertiesJson.cast<Map<String, Object?>>()) {

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -530,6 +530,9 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
         trackWidgetCreation: true,
         projectRootPath: widgetPreviewScaffoldProject.directory.path,
       );
+      app.runner.residentDevtoolsHandler!.launchDevToolsInBrowser(
+        flutterDevices: app.runner.flutterDevices,
+      );
     } on Exception catch (error) {
       throwToolExit(error.toString());
     }

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview.dart.tmpl
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widget_previews.dart';
 import 'package:flutter/widgets.dart';
 
@@ -61,4 +62,13 @@ class WidgetPreview {
   ///
   /// If not provided, the current system default brightness will be used.
   final Brightness? brightness;
+
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty<String>('name', name, ifNull: 'not set'))
+      ..add(DiagnosticsProperty<Size>('size', size))
+      ..add(DiagnosticsProperty<double>('textScaleFactor', textScaleFactor))
+      ..add(DiagnosticsProperty<PreviewThemeData>('theme', theme))
+      ..add(DiagnosticsProperty<Brightness>('brightness', brightness));
+  }
 }

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -5,7 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart' show ValueListenable, kIsWeb;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -148,6 +148,33 @@ class NoPreviewsDetectedWidget extends StatelessWidget {
   }
 }
 
+class Preview extends StatelessWidget {
+  const Preview({super.key, required this.preview, required this.child});
+
+  final WidgetPreview preview;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+
+  @override
+  String toStringShort() {
+    final StringBuffer buffer = StringBuffer('@Preview');
+    if (preview.name != null) {
+      buffer.write('(name: "${preview.name}")');
+    }
+    return buffer.toString();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    preview.debugFillProperties(properties);
+  }
+}
+
 class WidgetPreviewWidget extends StatefulWidget {
   const WidgetPreviewWidget({super.key, required this.preview});
 
@@ -226,7 +253,12 @@ class WidgetPreviewWidgetState extends State<WidgetPreviewWidget> {
             key: key,
             child: WidgetPreviewTheming(
               theme: widget.preview.theme,
-              child: widget.preview.builder(),
+              child: EnableWidgetInspectorScope(
+                child: Preview(
+                  preview: widget.preview,
+                  child: widget.preview.builder(),
+                ),
+              ),
             ),
           );
           if (performRestart) {
@@ -625,7 +657,13 @@ Future<void> mainImpl() async {
   binding.debugExcludeRootWidgetInspector = true;
   // TODO(bkonyi): store somewhere.
   await WidgetPreviewScaffoldDtdServices().connect();
-  runApp(WidgetPreviewScaffold(previews: previews));
+  runWidget(
+    DisableWidgetInspectorScope(
+      child: binding.wrapWithDefaultView(
+        WidgetPreviewScaffold(previews: previews),
+      ),
+    ),
+  );
 }
 
 /// Define the Enum for Layout Types

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widget_previews.dart';
 import 'package:flutter/widgets.dart';
 
@@ -61,4 +62,13 @@ class WidgetPreview {
   ///
   /// If not provided, the current system default brightness will be used.
   final Brightness? brightness;
+
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty<String>('name', name, ifNull: 'not set'))
+      ..add(DiagnosticsProperty<Size>('size', size))
+      ..add(DiagnosticsProperty<double>('textScaleFactor', textScaleFactor))
+      ..add(DiagnosticsProperty<PreviewThemeData>('theme', theme))
+      ..add(DiagnosticsProperty<Brightness>('brightness', brightness));
+  }
 }

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -5,7 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart' show ValueListenable, kIsWeb;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -148,6 +148,33 @@ class NoPreviewsDetectedWidget extends StatelessWidget {
   }
 }
 
+class Preview extends StatelessWidget {
+  const Preview({super.key, required this.preview, required this.child});
+
+  final WidgetPreview preview;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+
+  @override
+  String toStringShort() {
+    final StringBuffer buffer = StringBuffer('@Preview');
+    if (preview.name != null) {
+      buffer.write('(name: "${preview.name}")');
+    }
+    return buffer.toString();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    preview.debugFillProperties(properties);
+  }
+}
+
 class WidgetPreviewWidget extends StatefulWidget {
   const WidgetPreviewWidget({super.key, required this.preview});
 
@@ -226,7 +253,12 @@ class WidgetPreviewWidgetState extends State<WidgetPreviewWidget> {
             key: key,
             child: WidgetPreviewTheming(
               theme: widget.preview.theme,
-              child: widget.preview.builder(),
+              child: EnableWidgetInspectorScope(
+                child: Preview(
+                  preview: widget.preview,
+                  child: widget.preview.builder(),
+                ),
+              ),
             ),
           );
           if (performRestart) {
@@ -625,7 +657,13 @@ Future<void> mainImpl() async {
   binding.debugExcludeRootWidgetInspector = true;
   // TODO(bkonyi): store somewhere.
   await WidgetPreviewScaffoldDtdServices().connect();
-  runApp(WidgetPreviewScaffold(previews: previews));
+  runWidget(
+    DisableWidgetInspectorScope(
+      child: binding.wrapWithDefaultView(
+        WidgetPreviewScaffold(previews: previews),
+      ),
+    ),
+  );
 }
 
 /// Define the Enum for Layout Types


### PR DESCRIPTION
This PR introduces two new widgets:

- `DisableWidgetInspectorScope`, which hides its children from the widget inspector
- `EnableWidgetInspectorScope`, which makes its children available to the widget inspector

These widgets are used to inform the `WidgetInspectorService`'s `InspectorSerializationDelegate` when it should be omitting `DiagnosticableNodes` from the response when building the root widget tree for the inspector.

This functionality is meant to be used by developer tooling and packages that want to prevent unnecessary implementation details from polluting the inspector and possibly confusing end users.

This change also includes some minor updates to the Widget Preview scaffolding template to hide the scaffold's implementation details and only show details for the previews defined by the user.

Part of https://github.com/flutter/flutter/issues/166423

**Widget Previewer Demo**
<img width="1606" alt="image" src="https://github.com/user-attachments/assets/eb23160e-01c5-413f-b1d2-97985ced9ef9" />
