### PR TITLE
integration_tests: Check if BuildContext is mounted in display_cutout_test

### DIFF
--- a/dev/integration_tests/display_cutout_rotation/integration_test/display_cutout_test.dart
+++ b/dev/integration_tests/display_cutout_rotation/integration_test/display_cutout_test.dart
@@ -22,6 +22,9 @@ void main() {
       // Load app widget.
       await tester.pumpWidget(const MyApp());
       final BuildContext context = tester.element(find.byType(Text));
+      if (!context.mounted) {
+        fail('BuildContext not mounted');
+      }
       final Iterable<DisplayFeature> displayFeatures = getCutouts(tester, context);
       // Test is expecting one cutout setup in the test harness.
       expect(displayFeatures.length, 1, reason: 'Single cutout display feature expected');
@@ -40,6 +43,9 @@ void main() {
       // Load app widget.
       await tester.pumpWidget(const MyApp());
       final BuildContext context = tester.element(find.byType(Text));
+      if (!context.mounted) {
+        fail('BuildContext not mounted');
+      }
       // Verify that app code thinks there is a left cutout.
       final Iterable<DisplayFeature> displayFeatures = getCutouts(tester, context);
 
@@ -60,6 +66,9 @@ void main() {
       // Load app widget.
       await tester.pumpWidget(widgetUnderTest);
       BuildContext context = tester.element(find.byType(Text));
+      if (!context.mounted) {
+        fail('BuildContext not mounted');
+      }
       Iterable<DisplayFeature> displayFeatures = getCutouts(tester, context);
       // Test is expecting one cutout setup in the test harness.
       expect(displayFeatures.length, 1, reason: 'Single cutout display feature expected');
@@ -76,6 +85,9 @@ void main() {
 
       // Requery for display features after rotation.
       context = tester.element(find.byType(Text));
+      if (!context.mounted) {
+        fail('BuildContext not mounted');
+      }
       displayFeatures = getCutouts(tester, context);
       // Test is expecting one cutout setup in the test harness.
       expect(displayFeatures.length, 1, reason: 'Single cutout display feature expected');
@@ -116,7 +128,7 @@ Future<void> setOrientationAndWaitUntilRotation(
   }
   while (true) {
     final BuildContext context = tester.element(find.byType(Text));
-    if (expectedOrientation == MediaQuery.of(context).orientation) {
+    if (context.mounted && expectedOrientation == MediaQuery.of(context).orientation) {
       break;
     }
     await tester.pumpAndSettle();


### PR DESCRIPTION
These changes highlight where code was not safely checking whether the BuildContext was mounted before using it.

The `use_build_context_synchronously` lint rule is changing to catch these cases.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
