### PR TITLE
Stage the `CHANGELOG` for 3.32 so that a stable publish is 1-step.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ INTERNAL NOTE
 
 <!-- EDIT MADE TO LAND AN EMPTY COMMIT DUE TO https://github.com/flutter/cocoon/pull/4541 -->
 
+## Flutter 3.32 Changes
+
+### [3.32.0](https://github.com/flutter/flutter/releases/tag/3.32.0)
+Initial stable release.
+
 ## Flutter 3.29 Changes
 
 ### [3.29.2](https://github.com/flutter/flutter/releases/tag/3.29.2)


### PR DESCRIPTION
This will not require an `engine.version` revision, so the last step will just be a publish step.