### PR TITLE
Fix remaining iconbuttontheme overrides in listtile

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -692,10 +692,13 @@ class IconButton extends StatelessWidget {
       iconSize: ButtonStyleButton.allOrNull<double>(iconSize),
       side: ButtonStyleButton.allOrNull<BorderSide>(side),
       shape: ButtonStyleButton.allOrNull<OutlinedBorder>(shape),
-      mouseCursor: WidgetStateProperty<MouseCursor?>.fromMap(<WidgetStatesConstraint, MouseCursor?>{
-        WidgetState.disabled: disabledMouseCursor,
-        WidgetState.any: enabledMouseCursor,
-      }),
+      mouseCursor:
+          disabledMouseCursor == null && enabledMouseCursor == null
+              ? null
+              : WidgetStateProperty<MouseCursor?>.fromMap(<WidgetStatesConstraint, MouseCursor?>{
+                WidgetState.disabled: disabledMouseCursor,
+                WidgetState.any: enabledMouseCursor,
+              }),
       visualDensity: visualDensity,
       tapTargetSize: tapTargetSize,
       animationDuration: animationDuration,

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -815,6 +815,7 @@ class ListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData theme = Theme.of(context);
+    final IconButtonThemeData iconButtonTheme = IconButtonTheme.of(context);
     final ListTileThemeData tileTheme = ListTileTheme.of(context);
     final ListTileStyle listTileStyle =
         style ?? tileTheme.style ?? theme.listTileTheme.style ?? ListTileStyle.list;
@@ -841,20 +842,29 @@ class ListTile extends StatelessWidget {
       ).resolve(states);
     }
 
-    final Color? effectiveIconColor =
+    Color? effectiveIconColor =
         resolveColor(iconColor, selectedColor, iconColor) ??
         resolveColor(tileTheme.iconColor, tileTheme.selectedColor, tileTheme.iconColor) ??
         resolveColor(
           theme.listTileTheme.iconColor,
           theme.listTileTheme.selectedColor,
           theme.listTileTheme.iconColor,
-        ) ??
-        resolveColor(
-          defaults.iconColor,
-          defaults.selectedColor,
-          defaults.iconColor,
-          theme.disabledColor,
         );
+
+    final Color? defaultEffectiveIconColor = resolveColor(
+      defaults.iconColor,
+      defaults.selectedColor,
+      defaults.iconColor,
+      theme.disabledColor,
+    );
+
+    final Color? effectiveIconButtonColor =
+        effectiveIconColor ??
+        iconButtonTheme.style?.foregroundColor?.resolve(states) ??
+        defaultEffectiveIconColor;
+
+    effectiveIconColor ??= defaultEffectiveIconColor;
+
     final Color? effectiveColor =
         resolveColor(textColor, selectedColor, textColor) ??
         resolveColor(tileTheme.textColor, tileTheme.selectedColor, tileTheme.textColor) ??
@@ -872,10 +882,10 @@ class ListTile extends StatelessWidget {
     final IconThemeData iconThemeData = IconThemeData(color: effectiveIconColor);
     final IconButtonThemeData iconButtonThemeData = IconButtonThemeData(
       style:
-          IconButtonTheme.of(
-            context,
-          ).style?.copyWith(foregroundColor: WidgetStatePropertyAll<Color?>(effectiveIconColor)) ??
-          IconButton.styleFrom(foregroundColor: effectiveIconColor),
+          IconButtonTheme.of(context).style?.copyWith(
+            foregroundColor: WidgetStatePropertyAll<Color?>(effectiveIconButtonColor),
+          ) ??
+          IconButton.styleFrom(foregroundColor: effectiveIconButtonColor),
     );
 
     TextStyle? leadingAndTrailingStyle;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -871,9 +871,11 @@ class ListTile extends StatelessWidget {
         );
     final IconThemeData iconThemeData = IconThemeData(color: effectiveIconColor);
     final IconButtonThemeData iconButtonThemeData = IconButtonThemeData(
-      style: IconButton.styleFrom(
-        foregroundColor: effectiveIconColor,
-      ).merge(IconButtonTheme.of(context).style),
+      style:
+          IconButtonTheme.of(
+            context,
+          ).style?.copyWith(foregroundColor: WidgetStatePropertyAll<Color?>(effectiveIconColor)) ??
+          IconButton.styleFrom(foregroundColor: effectiveIconColor),
     );
 
     TextStyle? leadingAndTrailingStyle;

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2303,7 +2303,7 @@ void main() {
 
   testWidgets(
     'IconButtonTheme.style.foregroundColor is preserved in ListTile in non-overriding scenario',
-        (WidgetTester tester) async {
+    (WidgetTester tester) async {
       const Color iconButtonThemeColor = Colors.blue;
       const Icon leadingIcon = Icon(Icons.favorite);
       const Icon trailingIcon = Icon(Icons.close);
@@ -2333,8 +2333,8 @@ void main() {
       TextStyle? getIconStyle(WidgetTester tester, IconData icon) =>
           tester
               .widget<RichText>(
-            find.descendant(of: find.byIcon(icon), matching: find.byType(RichText)),
-          )
+                find.descendant(of: find.byIcon(icon), matching: find.byType(RichText)),
+              )
               .text
               .style;
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2301,6 +2301,49 @@ void main() {
     },
   );
 
+  testWidgets(
+    'IconButtonTheme.style.foregroundColor is preserved in ListTile in non-overriding scenario',
+        (WidgetTester tester) async {
+      const Color iconButtonThemeColor = Colors.blue;
+      const Icon leadingIcon = Icon(Icons.favorite);
+      const Icon trailingIcon = Icon(Icons.close);
+
+      Widget buildFrame() {
+        return MaterialApp(
+          theme: ThemeData(
+            iconButtonTheme: IconButtonThemeData(
+              style: IconButton.styleFrom(foregroundColor: iconButtonThemeColor),
+            ),
+          ),
+          home: Material(
+            child: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ListTile(
+                    leading: IconButton(icon: leadingIcon, onPressed: () {}),
+                    trailing: IconButton(icon: trailingIcon, onPressed: () {}),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      }
+
+      TextStyle? getIconStyle(WidgetTester tester, IconData icon) =>
+          tester
+              .widget<RichText>(
+            find.descendant(of: find.byIcon(icon), matching: find.byType(RichText)),
+          )
+              .text
+              .style;
+
+      await tester.pumpWidget(buildFrame());
+      expect(getIconStyle(tester, leadingIcon.icon!)?.color, iconButtonThemeColor);
+      expect(getIconStyle(tester, trailingIcon.icon!)?.color, iconButtonThemeColor);
+    },
+  );
+
   testWidgets('ListTile respects and combines parent IconButtonThemeData style', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Fix remaining outstanding IconButtonTheme overrides: overlayColor and mouseCursor. 

Issue: #167727


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
