### PR TITLE
[flutter_tools] Add --no-codesign support for macOS build

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -25,6 +25,7 @@ class BuildMacosCommand extends BuildSubCommand {
           'This can be used in CI/CD process that create an archive to avoid '
           'performing duplicate work.',
     );
+    argParser.addFlag('codesign', defaultsTo: true, help: 'Codesign the application bundle.');
   }
 
   @override
@@ -45,6 +46,8 @@ class BuildMacosCommand extends BuildSubCommand {
   bool get supported => globals.platform.isMacOS;
 
   bool get configOnly => boolArg('config-only');
+
+  bool get shouldCodesign => boolArg('codesign');
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -70,6 +73,7 @@ class BuildMacosCommand extends BuildSubCommand {
         analytics: analytics,
       ),
       usingCISystem: usingCISystem,
+      codesign: shouldCodesign,
     );
     return FlutterCommandResult.success();
   }

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -60,6 +60,9 @@ class BuildMacosCommand extends BuildSubCommand {
     if (!supported) {
       throwToolExit('"build macos" only supported on macOS hosts.');
     }
+    if (!shouldCodesign) {
+      globals.printStatus('Warning: Building with codesigning disabled.');
+    }
     await buildMacOS(
       flutterProject: project,
       buildInfo: buildInfo,

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -72,6 +72,7 @@ Future<void> buildMacOS({
   bool configOnly = false,
   SizeAnalyzer? sizeAnalyzer,
   bool usingCISystem = false,
+  bool codesign = true,
 }) async {
   final Directory? xcodeWorkspace = flutterProject.macos.xcodeWorkspace;
   if (xcodeWorkspace == null) {
@@ -225,6 +226,11 @@ Future<void> buildMacOS({
         if (disabledSandboxEntitlementFile != null)
           'CODE_SIGN_ENTITLEMENTS=${disabledSandboxEntitlementFile.path}',
         ...environmentVariablesAsXcodeBuildSettings(globals.platform),
+        if (!codesign) ...<String>[
+          'CODE_SIGNING_ALLOWED=NO',
+          'CODE_SIGNING_REQUIRED=NO',
+          'CODE_SIGNING_IDENTITY=""',
+        ],
       ],
       trace: true,
       stdoutErrorMatcher: verboseLogging ? null : _filteredOutput,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -1017,4 +1017,57 @@ STDERR STUFF
       OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
     },
   );
+
+  testUsingContext(
+    'macos build --no-codesign skips codesigning',
+    () async {
+      final BuildCommand command = BuildCommand(
+        androidSdk: FakeAndroidSdk(),
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+        logger: logger,
+        fileSystem: fileSystem,
+        osUtils: FakeOperatingSystemUtils(),
+      );
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            '/usr/bin/env',
+            'xcrun',
+            'xcodebuild',
+            '-workspace',
+            '/macos/Runner.xcworkspace',
+            '-configuration',
+            'Release',
+            '-scheme',
+            'Runner',
+            '-derivedDataPath',
+            '/build/macos',
+            '-destination',
+            'platform=macOS',
+            'OBJROOT=/build/macos/Build/Intermediates.noindex',
+            'SYMROOT=/build/macos/Build/Products',
+            '-quiet',
+            'COMPILER_INDEX_STORE_ENABLE=NO',
+            'CODE_SIGNING_ALLOWED=NO',
+            'CODE_SIGNING_REQUIRED=NO',
+            'CODE_SIGNING_IDENTITY=""',
+          ],
+        ),
+      ]);
+      createMinimalMockProjectFiles();
+
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'macos', '--no-pub', '--no-codesign']);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(logger.statusText, contains('Codesigning disabled with --no-codesign'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      Logger: () => logger,
+      ProcessManager: () => fakeProcessManager,
+      Pub: FakePubWithPrimedDeps.new,
+      Platform: () => macosPlatform,
+    },
+  );
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -1066,7 +1066,7 @@ STDERR STUFF
       FileSystem: () => fileSystem,
       Logger: () => logger,
       ProcessManager: () => fakeProcessManager,
-      Pub: FakePubWithPrimedDeps.new,
+      Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
     },
   );

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -1026,7 +1026,7 @@ STDERR STUFF
         buildSystem: TestBuildSystem.all(BuildResult(success: true)),
         logger: logger,
         fileSystem: fileSystem,
-        osUtils: FakeOperatingSystemUtils(),
+        osUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
       );
       fakeProcessManager.addCommands(<FakeCommand>[
         const FakeCommand(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -1043,7 +1043,7 @@ STDERR STUFF
             '-derivedDataPath',
             '/build/macos',
             '-destination',
-            'platform=macOS',
+            'generic/platform=macOS',
             'OBJROOT=/build/macos/Build/Intermediates.noindex',
             'SYMROOT=/build/macos/Build/Products',
             '-quiet',
@@ -1060,7 +1060,7 @@ STDERR STUFF
         command,
       ).run(const <String>['build', 'macos', '--no-pub', '--no-codesign']);
       expect(fakeProcessManager, hasNoRemainingExpectations);
-      expect(logger.statusText, contains('Codesigning disabled with --no-codesign'));
+      expect(logger.statusText, contains('Warning: Building with codesigning disabled.'));
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -1068,6 +1068,7 @@ STDERR STUFF
       ProcessManager: () => fakeProcessManager,
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
+      OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
     },
   );
 }


### PR DESCRIPTION
Unlike iOS, the macOS build currently does not support `--no-codesign` option to skip signing of application bundle. Having this option is useful for situation where the code-signing step is happens separately after the bundle is built (i.e. on CI).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
