### PR TITLE
Correct documentation regarding dispose() for a TextEditingController

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -198,8 +198,9 @@ class _RenderCompositionCallback extends RenderProxyBox {
 /// controller's [value] instead. Setting [text] will clear the selection
 /// and composing range.
 ///
-/// Remember to [dispose] of the [TextEditingController] when it is no longer
-/// needed. This will ensure we discard any resources used by the object.
+/// If the [TextEditingController] is instantiated in [initState], then [dispose] must
+/// be overridden to dispose of the object when it is no longer needed.
+/// This will ensure we discard any resources used by the object.
 ///
 /// {@tool dartpad}
 /// This example creates a [TextField] with a [TextEditingController] whose


### PR DESCRIPTION
I believe the documentation for TextEditingController is incorrect. The documentation stated that dispose() must be called to discard a TextEditingController. This commit changes the documentation to indicate that dispose only needs to be called if the TextEditingController was instantiated in initState().