### PR TITLE
[cp][Impeller] separate immutable sampler descriptors. (#169011)

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -582,8 +582,10 @@ std::shared_ptr<PipelineVK> PipelineVK::CreateVariantForImmutableSamplers(
   if (!device_holder) {
     return nullptr;
   }
+  // Note: immutable sampler variant of a pipeline is the negation of the
+  // existing pipeline key. This keeps the descriptors separate.
   return (immutable_sampler_variants_[cache_key] =
-              Create(desc_, device_holder, library_, pipeline_key_,
+              Create(desc_, device_holder, library_, -1 * pipeline_key_,
                      immutable_sampler));
 }
 

--- a/engine/src/flutter/impeller/renderer/pipeline.h
+++ b/engine/src/flutter/impeller/renderer/pipeline.h
@@ -18,7 +18,7 @@
 
 namespace impeller {
 
-using PipelineKey = uint64_t;
+using PipelineKey = int64_t;
 
 class PipelineLibrary;
 template <typename PipelineDescriptor_>


### PR DESCRIPTION
Manual cherry-pick into flutter-3.33-candidate.0

The descriptor set for the immutable sampler may need to be different than the non-immutable sampler variant. Make the pipeline key signed and use the sign bit to indicate immutable sampler.

Fixes https://github.com/flutter/flutter/issues/168114

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
