### PR TITLE
[CP: 3.33] [Widget Inspector] Update on-device inspector button to generic unicode icon

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -568,9 +568,9 @@ class _CupertinoAppState extends State<CupertinoApp> {
     return _CupertinoInspectorButton.toggle(
       onPressed: onPressed,
       semanticLabel: semanticLabel,
-      // This icon is also used for the Material-styled button and for DevTools.
-      // It should be updated in all 3 places if changed.
-      icon: CupertinoIcons.cursor_rays,
+      // This unicode icon is also used for the Material-styled button and for
+      // DevTools. It should be updated in all 3 places if changed.
+      icon: const IconData(0x1F74A),
       toggledOn: selectionOnTapEnabled,
     );
   }

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -971,9 +971,9 @@ class _MaterialAppState extends State<MaterialApp> {
     return _MaterialInspectorButton.toggle(
       onPressed: onPressed,
       semanticLabel: semanticLabel,
-      // This icon is also used for the Cupertino-styled button and for DevTools.
-      // It should be updated in all 3 places if changed.
-      icon: CupertinoIcons.cursor_rays,
+      // This unicode icon is also used for the Cupertino-styled button and for
+      // DevTools. It should be updated in all 3 places if changed.
+      icon: const IconData(0x1F74A),
       isDarkTheme: _isDarkTheme(context),
       toggledOn: selectionOnTapEnabled,
     );


### PR DESCRIPTION
### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/168846

### Changelog Description:
Explain this cherry pick in one line that is accessible to most Flutter developers. See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples

This cherry pick fixes an issue where some users would see a question mark instead of the appropriate icon in the widget inspector button which toggles select-mode on/off.

### Impact Description:
Users who don't have `cupertino_icons` as a dependency in their pubspec will see a question mark in one of the widget inspector buttons. 
<img width="169" alt="Screenshot 2025-05-19 at 12 50 15 PM" src="https://github.com/user-attachments/assets/40cd01c9-f8a6-407d-9d1b-303bc1516d62" />

### Workaround:
Is there a workaround for this issue?

Yes, add `cupertino_icons` package to user's pubspec.

### Risk:
What is the risk level of this cherry-pick?

Low

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

This was tested manually, there are no screenshot tests for this. However, this is only a UI change and not a behavior change.

### Validation Steps:
What are the steps to validate that this fix works?

1. Run an app that doesn't have `cupertino_icons` in its pubspec
2. Open Flutter DevTools > Inspector
3. Enable select widget mode
4. Should not see a ? on any of the buttons