### PR TITLE
Fix DDC library bundle format test files to correctly pass flags

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_errors_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_errors_common.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/tester/flutter_tester.dart';
 import 'package:flutter_tools/src/web/web_device.dart' show GoogleChromeDevice;
 
 import '../../src/common.dart';
@@ -36,7 +37,11 @@ void testAll({
     testWithoutContext(
       'hot reload displays a formatted error message when removing a field from a const class',
       () async {
-        await flutter.run();
+        await flutter.run(
+          device:
+              chrome ? GoogleChromeDevice.kChromeDeviceId : FlutterTesterDevices.kTesterDeviceId,
+          additionalCommandArgs: additionalCommandArgs,
+        );
         project.removeFieldFromConstClass();
 
         expect(
@@ -54,7 +59,7 @@ void testAll({
 
     testWithoutContext('hot restart succeeds when removing a field from a const class', () async {
       await flutter.run(
-        device: GoogleChromeDevice.kChromeDeviceId,
+        device: chrome ? GoogleChromeDevice.kChromeDeviceId : FlutterTesterDevices.kTesterDeviceId,
         additionalCommandArgs: additionalCommandArgs,
       );
       project.removeFieldFromConstClass();

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_test_common.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/tester/flutter_tester.dart';
 import 'package:flutter_tools/src/web/web_device.dart' show GoogleChromeDevice;
 import 'package:vm_service/vm_service.dart';
 
@@ -275,21 +276,10 @@ Future<void> runFlutterWithDevice(
   bool withDebugger = false,
   bool startPaused = false,
   List<String> additionalCommandArgs = const <String>[],
-}) async {
-  if (chrome) {
-    await flutter.run(
-      verbose: verbose,
-      withDebugger: withDebugger,
-      startPaused: startPaused,
-      device: GoogleChromeDevice.kChromeDeviceId,
-      additionalCommandArgs: additionalCommandArgs,
-    );
-  } else {
-    await flutter.run(
-      verbose: verbose,
-      withDebugger: withDebugger,
-      startPaused: startPaused,
-      additionalCommandArgs: additionalCommandArgs,
-    );
-  }
-}
+}) => flutter.run(
+  verbose: verbose,
+  withDebugger: withDebugger,
+  startPaused: startPaused,
+  device: chrome ? GoogleChromeDevice.kChromeDeviceId : FlutterTesterDevices.kTesterDeviceId,
+  additionalCommandArgs: additionalCommandArgs,
+);

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset_test_common.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/tester/flutter_tester.dart';
 import 'package:flutter_tools/src/web/web_device.dart' show GoogleChromeDevice;
 
 import '../../src/common.dart';
@@ -50,7 +51,7 @@ void testAll({bool chrome = false, List<String> additionalCommandArgs = const <S
       });
       flutter.stdout.listen(printOnFailure);
       await flutter.run(
-        device: GoogleChromeDevice.kChromeDeviceId,
+        device: chrome ? GoogleChromeDevice.kChromeDeviceId : FlutterTesterDevices.kTesterDeviceId,
         additionalCommandArgs: additionalCommandArgs,
       );
       await onFirstLoad.future;
@@ -80,7 +81,7 @@ void testAll({bool chrome = false, List<String> additionalCommandArgs = const <S
       });
       flutter.stdout.listen(printOnFailure);
       await flutter.run(
-        device: GoogleChromeDevice.kChromeDeviceId,
+        device: chrome ? GoogleChromeDevice.kChromeDeviceId : FlutterTesterDevices.kTesterDeviceId,
         additionalCommandArgs: additionalCommandArgs,
       );
       await onFirstLoad.future;

--- a/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_hot_reload_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_hot_reload_test_common.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/tester/flutter_tester.dart';
 import 'package:flutter_tools/src/web/web_device.dart' show GoogleChromeDevice;
 
 import '../../src/common.dart';
@@ -39,14 +40,10 @@ void testAll({bool chrome = false, List<String> additionalCommandArgs = const <S
           completer.complete();
         }
       });
-      if (chrome) {
-        await flutter.run(
-          device: GoogleChromeDevice.kChromeDeviceId,
-          additionalCommandArgs: additionalCommandArgs,
-        );
-      } else {
-        await flutter.run(additionalCommandArgs: additionalCommandArgs);
-      }
+      await flutter.run(
+        device: chrome ? GoogleChromeDevice.kChromeDeviceId : FlutterTesterDevices.kTesterDeviceId,
+        additionalCommandArgs: additionalCommandArgs,
+      );
       // Wait for run to finish.
       await completer.future;
       await subscription.cancel();

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -10,7 +10,8 @@ import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/utils.dart';
-import 'package:flutter_tools/src/web/web_device.dart' show GoogleChromeDevice, WebServerDevice;
+import 'package:flutter_tools/src/tester/flutter_tester.dart';
+import 'package:flutter_tools/src/web/web_device.dart' show GoogleChromeDevice;
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart';
@@ -530,7 +531,7 @@ final class FlutterRunTestDriver extends FlutterTestDriver {
     bool withDebugger = false,
     bool startPaused = false,
     bool pauseOnExceptions = false,
-    String device = 'flutter-tester',
+    String device = FlutterTesterDevices.kTesterDeviceId,
     bool expressionEvaluation = true,
     bool structuredErrors = false,
     bool serveObservatory = false,
@@ -547,10 +548,8 @@ final class FlutterRunTestDriver extends FlutterTestDriver {
           '--web-run-headless',
           if (!expressionEvaluation) '--no-web-enable-expression-evaluation',
         ];
-      case WebServerDevice.kWebServerDeviceId:
-        deviceArgs = <String>[WebServerDevice.kWebServerDeviceId];
       default:
-        deviceArgs = <String>['flutter-tester'];
+        deviceArgs = <String>[device];
     }
 
     await _setupProcess(

--- a/packages/flutter_tools/test/web.shard/test_data/expression_evaluation_web_common.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/expression_evaluation_web_common.dart
@@ -45,7 +45,10 @@ Future<void> testAll({required bool useDDCLibraryBundleFormat}) async {
         expressionEvaluation: expressionEvaluation,
         additionalCommandArgs: <String>[
           '--verbose',
-          if (useDDCLibraryBundleFormat) '--web-experimental-hot-reload',
+          if (useDDCLibraryBundleFormat)
+            '--web-experimental-hot-reload'
+          else
+            '--no-web-experimental-hot-reload',
         ],
       );
     }
@@ -173,7 +176,10 @@ Future<void> testAll({required bool useDDCLibraryBundleFormat}) async {
         script: project.testFilePath,
         additionalCommandArgs: <String>[
           '--verbose',
-          if (useDDCLibraryBundleFormat) '--web-experimental-hot-reload',
+          if (useDDCLibraryBundleFormat)
+            '--web-experimental-hot-reload'
+          else
+            '--no-web-experimental-hot-reload',
         ],
       );
     }

--- a/packages/flutter_tools/test/web.shard/test_data/expression_evaluation_web_common.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/expression_evaluation_web_common.dart
@@ -16,7 +16,7 @@ import '../../src/common.dart';
 final RegExp stackTraceCurrentRegexp = RegExp(r'\.dart\s+[0-9]+:[0-9]+\s+get current');
 
 Future<void> testAll({required bool useDDCLibraryBundleFormat}) async {
-  group('Flutter run for web', () {
+  group('Flutter run for web, DDC library bundle format: $useDDCLibraryBundleFormat', () {
     final BasicProject project = BasicProject();
     late Directory tempDir;
     late FlutterRunTestDriver flutter;
@@ -140,7 +140,7 @@ Future<void> testAll({required bool useDDCLibraryBundleFormat}) async {
     });
   });
 
-  group('Flutter test for web', () {
+  group('Flutter test for web, DDC library bundle format: $useDDCLibraryBundleFormat', () {
     final TestsProject project = TestsProject();
     late Directory tempDir;
     late FlutterRunTestDriver flutter;
@@ -171,7 +171,10 @@ Future<void> testAll({required bool useDDCLibraryBundleFormat}) async {
         expressionEvaluation: expressionEvaluation,
         startPaused: true,
         script: project.testFilePath,
-        additionalCommandArgs: <String>['--verbose'],
+        additionalCommandArgs: <String>[
+          '--verbose',
+          if (useDDCLibraryBundleFormat) '--web-experimental-hot-reload',
+        ],
       );
     }
 

--- a/packages/flutter_tools/test/web.shard/test_data/hot_restart_web_test_common.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/hot_restart_web_test_common.dart
@@ -90,7 +90,10 @@ Future<void> _testProject(
       device: GoogleChromeDevice.kChromeDeviceId,
       additionalCommandArgs: <String>[
         '--verbose',
-        if (useDDCLibraryBundleFormat) '--web-experimental-hot-reload',
+        if (useDDCLibraryBundleFormat)
+          '--web-experimental-hot-reload'
+        else
+          '--no-web-experimental-hot-reload',
       ],
     );
     await flutter.hotRestart();
@@ -110,7 +113,10 @@ Future<void> _testProject(
         device: GoogleChromeDevice.kChromeDeviceId,
         additionalCommandArgs: <String>[
           '--verbose',
-          if (useDDCLibraryBundleFormat) '--web-experimental-hot-reload',
+          if (useDDCLibraryBundleFormat)
+            '--web-experimental-hot-reload'
+          else
+            '--no-web-experimental-hot-reload',
         ],
       );
       project.uncommentHotReloadPrint();

--- a/packages/flutter_tools/test/web.shard/test_data/hot_restart_web_test_common.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/hot_restart_web_test_common.dart
@@ -69,11 +69,8 @@ Future<void> _testProject(
   late Directory tempDir;
   late FlutterRunTestDriver flutter;
 
-  final List<String> additionalCommandArgs =
-      useDDCLibraryBundleFormat ? <String>['--web-experimental-hot-reload'] : <String>[];
   final String testName =
-      'Hot restart (index.html: $name)'
-      '${additionalCommandArgs.isEmpty ? '' : ' with args: $additionalCommandArgs'}';
+      'Hot restart (index.html: $name), DDC library bundle format: $useDDCLibraryBundleFormat';
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('hot_restart_test.');
@@ -91,7 +88,10 @@ Future<void> _testProject(
     flutter.stdout.listen(printOnFailure);
     await flutter.run(
       device: GoogleChromeDevice.kChromeDeviceId,
-      additionalCommandArgs: <String>['--verbose', ...additionalCommandArgs],
+      additionalCommandArgs: <String>[
+        '--verbose',
+        if (useDDCLibraryBundleFormat) '--web-experimental-hot-reload',
+      ],
     );
     await flutter.hotRestart();
   });
@@ -108,7 +108,10 @@ Future<void> _testProject(
       });
       await flutter.run(
         device: GoogleChromeDevice.kChromeDeviceId,
-        additionalCommandArgs: <String>['--verbose', ...additionalCommandArgs],
+        additionalCommandArgs: <String>[
+          '--verbose',
+          if (useDDCLibraryBundleFormat) '--web-experimental-hot-reload',
+        ],
       );
       project.uncommentHotReloadPrint();
       try {


### PR DESCRIPTION
Fixes a couple issues:
- Passes --web-experimental-hot-reload when library bundle format is enabled.
- Passes chrome id only if chrome is enabled.
- Makes sure common code is run with VM and chrome.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
