### PR TITLE
[framework] remove flaky goldens.

### DIFF
--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -1379,10 +1379,6 @@ void main() {
 
       expect(find.byIcon(CupertinoIcons.mic_solid), findsNWidgets(4));
       expect(find.byIcon(CupertinoIcons.search), findsNWidgets(4));
-      await expectLater(
-        find.byType(CupertinoApp),
-        matchesGoldenFile('nav_bar_transition.search_to_search.bottom.png'),
-      );
       await tester.pumpAndSettle();
 
       expect(find.byIcon(CupertinoIcons.mic_solid), findsOneWidget);
@@ -1424,10 +1420,6 @@ void main() {
 
       expect(find.byIcon(CupertinoIcons.mic_solid), findsNWidgets(4));
       expect(find.byIcon(CupertinoIcons.search), findsNWidgets(4));
-      await expectLater(
-        find.byType(CupertinoApp),
-        matchesGoldenFile('nav_bar_transition.search_to_search.top.png'),
-      );
       await tester.pumpAndSettle();
     },
   );


### PR DESCRIPTION
These goldens may not be stable as they are executed during an animation and will capture different frames. These flaked several times today and 1-2 weeks ago.