### PR TITLE
Remove `isExplicitPackageDependenciesEnabled: true`, it is the default.

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
@@ -10,14 +10,12 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/localizations.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/generate_localizations.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/localizations/gen_l10n_types.dart';
 
 import '../../integration.shard/test_data/basic_project.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
-import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -25,12 +23,6 @@ void main() {
   late BufferLogger logger;
   late Artifacts artifacts;
   late FakeProcessManager processManager;
-
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
 
   setUpAll(() {
     Cache.disableLocking();
@@ -71,7 +63,6 @@ void main() {
       expect(outputDirectory.childFile('app_localizations.dart').existsSync(), true);
     },
     overrides: <Type, Generator>{
-      FeatureFlags: enableExplicitPackageDependencies,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     },
@@ -144,7 +135,6 @@ flutter:
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      FeatureFlags: enableExplicitPackageDependencies,
     },
   );
 
@@ -216,7 +206,6 @@ flutter:
       expect(outputDirectory.childFile('app_localizations.dart').existsSync(), true);
     },
     overrides: <Type, Generator>{
-      FeatureFlags: enableExplicitPackageDependencies,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     },
@@ -293,7 +282,6 @@ flutter:
       expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{
-      FeatureFlags: enableExplicitPackageDependencies,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     },
@@ -330,7 +318,6 @@ flutter:
       expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{
-      FeatureFlags: enableExplicitPackageDependencies,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     },
@@ -379,7 +366,6 @@ format: true
       expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{
-      FeatureFlags: enableExplicitPackageDependencies,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     },
@@ -418,7 +404,6 @@ format: false
       expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{
-      FeatureFlags: enableExplicitPackageDependencies,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     },
@@ -479,7 +464,6 @@ untranslated-messages-file: lib/l10n/untranslated.json
       expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{
-      FeatureFlags: enableExplicitPackageDependencies,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     },
@@ -530,7 +514,6 @@ format: true
       expect(outputDirectory.childFile('app_localizations.dart').existsSync(), true);
       expect(processManager, hasNoRemainingExpectations);
     },
-    overrides: <Type, Generator>{FeatureFlags: enableExplicitPackageDependencies},
   );
 
   testUsingContext(
@@ -564,7 +547,6 @@ format: true
       );
     },
     overrides: <Type, Generator>{
-      FeatureFlags: enableExplicitPackageDependencies,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     },
@@ -706,7 +688,6 @@ format: true
         expect(outputDirectory.childFile('app_localizations.dart').existsSync(), true);
       },
       overrides: <Type, Generator>{
-        FeatureFlags: enableExplicitPackageDependencies,
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.any(),
       },

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -55,11 +55,6 @@ void main() {
     return command;
   }
 
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   group('Usage', () {
     late Directory tempDir;
     late FakeAnalytics analytics;
@@ -153,7 +148,6 @@ void main() {
       overrides: <Type, Generator>{
         AndroidBuilder: () => _CapturingFakeAndroidBuilder(),
         Analytics: () => analytics,
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: FakePub.new,
       },
     );

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -30,12 +30,6 @@ import '../../src/test_flutter_command_runner.dart';
 void main() {
   late FakeStdio mockStdio;
 
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   // TODO(matanlurey): Remove after `flutter_gen` is removed.
   // See https://github.com/flutter/flutter/issues/102983 for details.
   FeatureFlags disableExplicitPackageDependencies() {
@@ -701,7 +695,6 @@ flutter:
               platform: globals.platform,
               stdio: mockStdio,
             ),
-        FeatureFlags: enableExplicitPackageDependencies,
       },
     );
 
@@ -736,7 +729,6 @@ flutter:
               platform: globals.platform,
               stdio: mockStdio,
             ),
-        FeatureFlags: enableExplicitPackageDependencies,
       },
     );
 
@@ -759,7 +751,6 @@ flutter:
         expectPluginInjected(exampleProjectPath, includeLegacyPluginsList: false);
       },
       overrides: <Type, Generator>{
-        FeatureFlags: () => TestFeatureFlags(isExplicitPackageDependenciesEnabled: true),
         Stdio: () => mockStdio,
         Pub:
             () => Pub.test(

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -20,7 +20,6 @@ import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -42,11 +41,6 @@ const String minimalV2EmbeddingManifest = r'''
 ''';
 
 void main() {
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   group('gradle build', () {
     late BufferLogger logger;
     late FakeAnalytics fakeAnalytics;
@@ -1593,139 +1587,135 @@ Gradle Crashed
     );
 
     // Regression test for https://github.com/flutter/flutter/issues/162649.
-    testUsingContext(
-      'buildAar generates tooling for each sub-build for AARs',
-      () async {
-        addTearDown(() {
-          printOnFailure(logger.statusText);
-          printOnFailure(logger.errorText);
-        });
-        final AndroidGradleBuilder builder = AndroidGradleBuilder(
-          java: FakeJava(),
-          logger: logger,
-          processManager: processManager,
-          fileSystem: fileSystem,
-          artifacts: Artifacts.test(),
-          analytics: fakeAnalytics,
-          gradleUtils: FakeGradleUtils(),
-          platform: FakePlatform(),
-          androidStudio: FakeAndroidStudio(),
-        );
-        processManager.addCommands(const <FakeCommand>[
-          FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
-              '-Pflutter-root=/',
-              '-Poutput-dir=/build/host',
-              '-Pis-plugin=false',
-              '-PbuildNumber=1.0',
-              '-q',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              'assembleAarDebug',
-            ],
-          ),
-          FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
-              '-Pflutter-root=/',
-              '-Poutput-dir=/build/host',
-              '-Pis-plugin=false',
-              '-PbuildNumber=1.0',
-              '-q',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              'assembleAarProfile',
-            ],
-          ),
-          FakeCommand(
-            command: <String>[
-              'gradlew',
-              '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
-              '-Pflutter-root=/',
-              '-Poutput-dir=/build/host',
-              '-Pis-plugin=false',
-              '-PbuildNumber=1.0',
-              '-q',
-              '-Pdart-obfuscation=false',
-              '-Ptrack-widget-creation=false',
-              '-Ptree-shake-icons=false',
-              '-Ptarget-platform=android-arm,android-arm64,android-x64',
-              'assembleAarRelease',
-            ],
-          ),
-        ]);
+    testUsingContext('buildAar generates tooling for each sub-build for AARs', () async {
+      addTearDown(() {
+        printOnFailure(logger.statusText);
+        printOnFailure(logger.errorText);
+      });
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        java: FakeJava(),
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        analytics: fakeAnalytics,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+      );
+      processManager.addCommands(const <FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+            '-Pflutter-root=/',
+            '-Poutput-dir=/build/host',
+            '-Pis-plugin=false',
+            '-PbuildNumber=1.0',
+            '-q',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            'assembleAarDebug',
+          ],
+        ),
+        FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+            '-Pflutter-root=/',
+            '-Poutput-dir=/build/host',
+            '-Pis-plugin=false',
+            '-PbuildNumber=1.0',
+            '-q',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            'assembleAarProfile',
+          ],
+        ),
+        FakeCommand(
+          command: <String>[
+            'gradlew',
+            '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+            '-Pflutter-root=/',
+            '-Poutput-dir=/build/host',
+            '-Pis-plugin=false',
+            '-PbuildNumber=1.0',
+            '-q',
+            '-Pdart-obfuscation=false',
+            '-Ptrack-widget-creation=false',
+            '-Ptree-shake-icons=false',
+            '-Ptarget-platform=android-arm,android-arm64,android-x64',
+            'assembleAarRelease',
+          ],
+        ),
+      ]);
 
-        final File manifestFile = fileSystem.file('pubspec.yaml');
-        manifestFile.createSync(recursive: true);
-        manifestFile.writeAsStringSync('''
+      final File manifestFile = fileSystem.file('pubspec.yaml');
+      manifestFile.createSync(recursive: true);
+      manifestFile.writeAsStringSync('''
         flutter:
           module:
             androidPackage: com.example.test
         ''');
 
-        fileSystem.file('.android/gradlew').createSync(recursive: true);
-        fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
-        fileSystem.file('.android/build.gradle').createSync(recursive: true);
-        fileSystem.directory('build/host/outputs/repo').createSync(recursive: true);
+      fileSystem.file('.android/gradlew').createSync(recursive: true);
+      fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
+      fileSystem.file('.android/build.gradle').createSync(recursive: true);
+      fileSystem.directory('build/host/outputs/repo').createSync(recursive: true);
 
-        final List<(FlutterProject, bool)> generateToolingCalls = <(FlutterProject, bool)>[];
-        await builder.buildAar(
-          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          androidBuildInfo: const <AndroidBuildInfo>{
-            AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.debug,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
+      final List<(FlutterProject, bool)> generateToolingCalls = <(FlutterProject, bool)>[];
+      await builder.buildAar(
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        androidBuildInfo: const <AndroidBuildInfo>{
+          AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.debug,
+              null,
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
             ),
-            AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.profile,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
+          ),
+          AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.profile,
+              null,
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
             ),
-            AndroidBuildInfo(
-              BuildInfo(
-                BuildMode.release,
-                null,
-                treeShakeIcons: false,
-                packageConfigPath: '.dart_tool/package_config.json',
-              ),
+          ),
+          AndroidBuildInfo(
+            BuildInfo(
+              BuildMode.release,
+              null,
+              treeShakeIcons: false,
+              packageConfigPath: '.dart_tool/package_config.json',
             ),
-          },
-          target: '',
-          buildNumber: '1.0',
-          generateTooling: (FlutterProject project, {required bool releaseMode}) async {
-            generateToolingCalls.add((project, releaseMode));
-          },
-        );
-        expect(processManager, hasNoRemainingExpectations);
+          ),
+        },
+        target: '',
+        buildNumber: '1.0',
+        generateTooling: (FlutterProject project, {required bool releaseMode}) async {
+          generateToolingCalls.add((project, releaseMode));
+        },
+      );
+      expect(processManager, hasNoRemainingExpectations);
 
-        // Ideally, this should be checked before each invocation to the process,
-        // but instead we'll assume it was invoked in the same order as the calls
-        // to gradle to keep the scope of this test light.
-        expect(generateToolingCalls, hasLength(3));
-        expect(
-          generateToolingCalls.map(((FlutterProject, bool) call) {
-            return call.$2;
-          }),
-          <bool>[false, false, true],
-          reason: 'generateTooling should omit debug metadata for release builds',
-        );
-      },
-      overrides: <Type, Generator>{FeatureFlags: enableExplicitPackageDependencies},
-    );
+      // Ideally, this should be checked before each invocation to the process,
+      // but instead we'll assume it was invoked in the same order as the calls
+      // to gradle to keep the scope of this test light.
+      expect(generateToolingCalls, hasLength(3));
+      expect(
+        generateToolingCalls.map(((FlutterProject, bool) call) {
+          return call.$2;
+        }),
+        <bool>[false, false, true],
+        reason: 'generateTooling should omit debug metadata for release builds',
+      );
+    });
 
     testUsingContext(
       'Verbose mode for AARs includes Gradle stacktrace and sets debug log level',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
@@ -10,12 +10,10 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/dart_plugin_registrant.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
-import '../../../src/fakes.dart';
 import '../../../src/package_config.dart';
 import '../../../src/throwing_pub.dart';
 
@@ -57,12 +55,6 @@ environment:
 ''';
 
 void main() {
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   group('Dart plugin registrant', () {
     late FileSystem fileSystem;
 
@@ -162,7 +154,6 @@ name: path_provider_example
       },
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );
@@ -249,7 +240,6 @@ name: path_provider_example
       },
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );
@@ -303,7 +293,6 @@ name: path_provider_example
       },
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );
@@ -390,7 +379,6 @@ name: path_provider_example
       },
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/web/compile.dart';
@@ -21,7 +20,6 @@ import 'package:flutter_tools/src/web_template.dart';
 
 import '../../../src/common.dart';
 import '../../../src/fake_process_manager.dart';
-import '../../../src/fakes.dart';
 import '../../../src/package_config.dart';
 import '../../../src/testbed.dart';
 import '../../../src/throwing_pub.dart';
@@ -46,12 +44,6 @@ void main() {
   late TestBed testbed;
   late Environment environment;
   late FakeProcessManager processManager;
-
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
 
   final Platform linux = FakePlatform(environment: <String, String>{});
   final Platform windows = FakePlatform(
@@ -124,7 +116,6 @@ name: foo
       },
       overrides: <Type, Generator>{
         TemplateRenderer: () => const MustacheTemplateRenderer(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     ),
@@ -344,7 +335,6 @@ name: foo
       },
       overrides: <Type, Generator>{
         TemplateRenderer: () => const MustacheTemplateRenderer(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     ),
@@ -370,7 +360,6 @@ name: foo
       },
       overrides: <Type, Generator>{
         TemplateRenderer: () => const MustacheTemplateRenderer(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     ),
@@ -405,7 +394,6 @@ name: foo
       overrides: <Type, Generator>{
         Platform: () => windows,
         TemplateRenderer: () => const MustacheTemplateRenderer(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     ),
@@ -438,7 +426,6 @@ name: foo
       },
       overrides: <Type, Generator>{
         TemplateRenderer: () => const MustacheTemplateRenderer(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     ),
@@ -462,7 +449,6 @@ name: foo
       },
       overrides: <Type, Generator>{
         TemplateRenderer: () => const MustacheTemplateRenderer(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     ),
@@ -487,7 +473,6 @@ name: foo
       },
       overrides: <Type, Generator>{
         TemplateRenderer: () => const MustacheTemplateRenderer(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     ),
@@ -520,7 +505,6 @@ name: foo
       },
       overrides: <Type, Generator>{
         TemplateRenderer: () => const MustacheTemplateRenderer(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     ),

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -28,12 +28,6 @@ void main() {
     return TestFeatureFlags(isExplicitPackageDependenciesEnabled: false);
   }
 
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   testUsingContext(
     'calls buildSystem.build with blank l10n.yaml file',
     () async {
@@ -481,7 +475,6 @@ void main() {
         isNot(contains('https://flutter.dev/to/flutter-gen-deprecation')),
       );
     },
-    overrides: <Type, Generator>{FeatureFlags: enableExplicitPackageDependencies},
   );
 
   testUsingContext(
@@ -524,9 +517,6 @@ void main() {
         ),
       );
     },
-    overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isExplicitPackageDependenciesEnabled: true),
-    },
   );
 
   testUsingContext(
@@ -565,9 +555,6 @@ void main() {
         ),
         returnsNormally,
       );
-    },
-    overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isExplicitPackageDependenciesEnabled: true),
     },
   );
 }

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -1130,10 +1130,6 @@ exit code: 66
         completes,
       );
     },
-    overrides: <Type, Generator>{
-      // ignore: avoid_redundant_argument_values
-      FeatureFlags: () => TestFeatureFlags(isExplicitPackageDependenciesEnabled: true),
-    },
   );
 
   testWithoutContext('Pub error handling', () async {

--- a/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
@@ -6,7 +6,6 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/flutter_plugins.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -19,17 +18,10 @@ import 'package:yaml/yaml.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/fakes.dart';
 import '../src/package_config.dart';
 import '../src/throwing_pub.dart';
 
 void main() {
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   group('Dart plugin registrant', () {
     late FileSystem fs;
     late FakeFlutterProject flutterProject;
@@ -1267,7 +1259,6 @@ void main() {
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1314,7 +1305,6 @@ void main() {
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1360,7 +1350,6 @@ void main() {
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1391,7 +1380,6 @@ void main() {
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1443,7 +1431,6 @@ void main() {
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -28,12 +28,6 @@ import '../src/throwing_pub.dart';
 import 'hot_shared.dart';
 
 void main() {
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   group('validateReloadReport', () {
     testUsingContext('invalid', () async {
       expect(
@@ -206,7 +200,6 @@ name: my_app
           FileSystem: () => fileSystem,
           Platform: () => FakePlatform(),
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -250,7 +243,6 @@ name: my_app
           FileSystem: () => fileSystem,
           Platform: () => FakePlatform(),
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_devtools_handler.dart';
 import 'package:flutter_tools/src/resident_runner.dart';

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/ios/code_signing.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
@@ -31,12 +30,6 @@ import '../../src/throwing_pub.dart';
 
 void main() {
   late BufferLogger logger;
-
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
 
   setUp(() {
     logger = BufferLogger.test();
@@ -685,7 +678,6 @@ duplicate symbol '_$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_S
       },
       overrides: <Type, Generator>{
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -34,12 +34,6 @@ void main() {
   late BufferLogger logger;
   late FakeAnalytics fakeAnalytics;
 
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   void pretendPodVersionFails() {
     fakeProcessManager.addCommand(
       const FakeCommand(command: <String>['pod', '--version'], exitCode: 1),
@@ -439,7 +433,6 @@ environement:
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -77,12 +77,6 @@ class _PluginPlatformInfo {
 }
 
 void main() {
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   // TODO(matanlurey): Remove after `explicit-package-dependencies` is removed.
   // See https://github.com/flutter/flutter/issues/48918 for details.
   FeatureFlags disableExplicitPackageDependencies() {
@@ -439,7 +433,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -456,7 +449,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -496,7 +488,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -519,7 +510,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: FakeProcessManager.empty,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -684,7 +674,6 @@ dependencies:
           // Not necessary, you can observe this bug by calling `generateLegacyPlugins: false`,
           // but since this flag is about to be enabled, and enabling it implicitly sets that
           // argument to false, this is a more "honest" test.
-          FeatureFlags: enableExplicitPackageDependencies,
         },
       );
 
@@ -756,7 +745,6 @@ dependencies:
           // Not necessary, you can observe this bug by calling `generateLegacyPlugins: false`,
           // but since this flag is about to be enabled, and enabling it implicitly sets that
           // argument to false, this is a more "honest" test.
-          FeatureFlags: enableExplicitPackageDependencies,
         },
       );
 
@@ -842,7 +830,6 @@ dependencies:
           ProcessManager: () => FakeProcessManager.any(),
           SystemClock: () => systemClock,
           FlutterVersion: () => flutterVersion,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -894,7 +881,6 @@ dependencies:
           ProcessManager: () => FakeProcessManager.any(),
           SystemClock: () => systemClock,
           FlutterVersion: () => flutterVersion,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -946,7 +932,6 @@ dependencies:
           ProcessManager: () => FakeProcessManager.any(),
           SystemClock: () => systemClock,
           FlutterVersion: () => flutterVersion,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -998,7 +983,6 @@ dependencies:
           ProcessManager: () => FakeProcessManager.any(),
           SystemClock: () => systemClock,
           FlutterVersion: () => flutterVersion,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1021,7 +1005,6 @@ dependencies:
           ProcessManager: () => FakeProcessManager.any(),
           SystemClock: () => systemClock,
           FlutterVersion: () => flutterVersion,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1050,7 +1033,6 @@ dependencies:
           ProcessManager: () => FakeProcessManager.any(),
           SystemClock: () => systemClock,
           FlutterVersion: () => flutterVersion,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1087,7 +1069,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1119,7 +1100,6 @@ dependencies:
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
           XcodeProjectInterpreter: () => xcodeProjectInterpreter,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1151,7 +1131,6 @@ dependencies:
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
           XcodeProjectInterpreter: () => xcodeProjectInterpreter,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1181,7 +1160,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1212,7 +1190,6 @@ dependencies:
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
           XcodeProjectInterpreter: () => xcodeProjectInterpreter,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1243,7 +1220,6 @@ dependencies:
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
           XcodeProjectInterpreter: () => xcodeProjectInterpreter,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1274,7 +1250,6 @@ dependencies:
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
           XcodeProjectInterpreter: () => xcodeProjectInterpreter,
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1289,7 +1264,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1337,7 +1311,6 @@ dependencies:
           overrides: <Type, Generator>{
             FileSystem: () => fs,
             ProcessManager: () => FakeProcessManager.any(),
-            FeatureFlags: enableExplicitPackageDependencies,
             Pub: ThrowingPub.new,
           },
         );
@@ -1408,7 +1381,6 @@ dependencies:
           overrides: <Type, Generator>{
             FileSystem: () => fs,
             ProcessManager: () => FakeProcessManager.any(),
-            FeatureFlags: enableExplicitPackageDependencies,
             Pub: ThrowingPub.new,
           },
         );
@@ -1439,7 +1411,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1474,7 +1445,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1499,7 +1469,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1536,7 +1505,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1575,7 +1543,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1607,7 +1574,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1636,7 +1602,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1699,7 +1664,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1772,7 +1736,6 @@ dependencies:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1803,7 +1766,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1835,7 +1797,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1868,7 +1829,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1899,7 +1859,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1925,7 +1884,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1955,7 +1913,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -1987,7 +1944,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -2018,7 +1974,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -2051,7 +2006,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fsWindows,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -2076,7 +2030,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -2096,7 +2049,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: ThrowingPub.new,
         },
       );
@@ -2690,7 +2642,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: () => const ThrowingPub(),
         },
       );
@@ -2735,7 +2686,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: () => const ThrowingPub(),
         },
       );
@@ -2772,7 +2722,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: () => const ThrowingPub(),
         },
       );
@@ -2823,7 +2772,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: () => const ThrowingPub(),
         },
       );
@@ -2868,7 +2816,6 @@ flutter:
         overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
-          FeatureFlags: enableExplicitPackageDependencies,
           Pub: () => const ThrowingPub(),
         },
       );

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -35,12 +35,6 @@ import '../src/package_config.dart';
 import '../src/throwing_pub.dart';
 
 void main() {
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   FeatureFlags disableExplicitPackageDependencies() {
     // ignore: avoid_redundant_argument_values
     return TestFeatureFlags(isExplicitPackageDependenciesEnabled: false);
@@ -328,7 +322,6 @@ void main() {
           );
         },
         overrides: <Type, Generator>{
-          FeatureFlags: enableExplicitPackageDependencies,
           FileSystem: () => MemoryFileSystem.test(),
           ProcessManager: () => FakeProcessManager.any(),
           Pub: ThrowingPub.new,
@@ -352,7 +345,6 @@ void main() {
           );
         },
         overrides: <Type, Generator>{
-          FeatureFlags: enableExplicitPackageDependencies,
           FileSystem: () => MemoryFileSystem.test(),
           ProcessManager: () => FakeProcessManager.any(),
           Pub: ThrowingPub.new,
@@ -376,7 +368,6 @@ void main() {
           );
         },
         overrides: <Type, Generator>{
-          FeatureFlags: enableExplicitPackageDependencies,
           FileSystem: () => MemoryFileSystem.test(),
           ProcessManager: () => FakeProcessManager.any(),
           Pub: ThrowingPub.new,
@@ -2147,9 +2138,6 @@ void _testInMemory(
           ),
       FlutterProjectFactory:
           () => FlutterProjectFactory(fileSystem: testFileSystem, logger: globals.logger),
-      // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-      // See https://github.com/flutter/flutter/issues/160257 for details.
-      FeatureFlags: () => TestFeatureFlags(isExplicitPackageDependenciesEnabled: true),
       Pub: ThrowingPub.new,
     },
   );

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -50,12 +50,6 @@ void main() {
   late FakeDevice device;
   FakeVmServiceHost? fakeVmServiceHost;
 
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
-
   setUp(() {
     testbed = TestBed(
       setup: () {
@@ -1126,64 +1120,57 @@ void main() {
 
   testUsingContext(
     'ResidentRunner can run source generation',
-    () => testbed.run(
-      () async {
-        final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-          ..createSync(recursive: true);
-        arbFile.writeAsStringSync('''
+    () => testbed.run(() async {
+      final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+        ..createSync(recursive: true);
+      arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-        globals.fs.file('l10n.yaml').createSync();
-        globals.fs.file('pubspec.yaml').writeAsStringSync('''
+      globals.fs.file('l10n.yaml').createSync();
+      globals.fs.file('pubspec.yaml').writeAsStringSync('''
 name: my_app
 flutter:
   generate: true''');
 
-        // Create necessary files for [DartPluginRegistrantTarget]
-        writePackageConfigFiles(
-          directory: globals.fs.currentDirectory,
-          mainLibName: 'my_app',
-          packages: <String, String>{'path_provider_linux': 'path_provider_linux'},
-        );
+      // Create necessary files for [DartPluginRegistrantTarget]
+      writePackageConfigFiles(
+        directory: globals.fs.currentDirectory,
+        mainLibName: 'my_app',
+        packages: <String, String>{'path_provider_linux': 'path_provider_linux'},
+      );
 
-        // Start from an empty dart_plugin_registrant.dart file.
-        globals.fs
-            .directory('.dart_tool')
-            .childDirectory('flutter_build')
-            .childFile('dart_plugin_registrant.dart')
-            .createSync(recursive: true);
+      // Start from an empty dart_plugin_registrant.dart file.
+      globals.fs
+          .directory('.dart_tool')
+          .childDirectory('flutter_build')
+          .childFile('dart_plugin_registrant.dart')
+          .createSync(recursive: true);
 
-        await residentRunner.runSourceGenerators();
+      await residentRunner.runSourceGenerators();
 
-        expect(testLogger.errorText, isEmpty);
-        expect(testLogger.statusText, isEmpty);
-      },
-      overrides: <Type, Generator>{
-        FeatureFlags: enableExplicitPackageDependencies,
-        Pub: ThrowingPub.new,
-      },
-    ),
+      expect(testLogger.errorText, isEmpty);
+      expect(testLogger.statusText, isEmpty);
+    }, overrides: <Type, Generator>{Pub: ThrowingPub.new}),
   );
 
   testUsingContext(
     'generated main uses correct target',
-    () => testbed.run(
-      () async {
-        final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
-          ..createSync(recursive: true);
-        arbFile.writeAsStringSync('''
+    () => testbed.run(() async {
+      final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+        ..createSync(recursive: true);
+      arbFile.writeAsStringSync('''
 {
   "helloWorld": "Hello, World!",
   "@helloWorld": {
     "description": "Sample description"
   }
 }''');
-        globals.fs.file('l10n.yaml').createSync();
-        globals.fs.file('pubspec.yaml').writeAsStringSync('''
+      globals.fs.file('l10n.yaml').createSync();
+      globals.fs.file('pubspec.yaml').writeAsStringSync('''
 name: my_app
 flutter:
   generate: true
@@ -1194,18 +1181,18 @@ dependencies:
   path_provider_linux: 1.0.0
 ''');
 
-        // Create necessary files for [DartPluginRegistrantTarget], including a
-        // plugin that will trigger generation.
-        writePackageConfigFiles(
-          directory: globals.fs.currentDirectory,
-          mainLibName: 'my_app',
-          packages: <String, String>{'path_provider_linux': 'path_provider_linux'},
-        );
+      // Create necessary files for [DartPluginRegistrantTarget], including a
+      // plugin that will trigger generation.
+      writePackageConfigFiles(
+        directory: globals.fs.currentDirectory,
+        mainLibName: 'my_app',
+        packages: <String, String>{'path_provider_linux': 'path_provider_linux'},
+      );
 
-        final Directory fakePluginDir = globals.fs.directory('path_provider_linux');
-        final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
-        pluginPubspec.createSync(recursive: true);
-        pluginPubspec.writeAsStringSync('''
+      final Directory fakePluginDir = globals.fs.directory('path_provider_linux');
+      final File pluginPubspec = fakePluginDir.childFile('pubspec.yaml');
+      pluginPubspec.createSync(recursive: true);
+      pluginPubspec.writeAsStringSync('''
 name: path_provider_linux
 
 flutter:
@@ -1216,30 +1203,25 @@ flutter:
         dartPluginClass: PathProviderLinux
 ''');
 
-        residentRunner = HotRunner(
-          <FlutterDevice>[flutterDevice],
-          stayResident: false,
-          debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-          target: 'custom_main.dart',
-          devtoolsHandler: createNoOpHandler,
-          analytics: fakeAnalytics,
-        );
-        await residentRunner.runSourceGenerators();
+      residentRunner = HotRunner(
+        <FlutterDevice>[flutterDevice],
+        stayResident: false,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'custom_main.dart',
+        devtoolsHandler: createNoOpHandler,
+        analytics: fakeAnalytics,
+      );
+      await residentRunner.runSourceGenerators();
 
-        final File generatedMain = globals.fs
-            .directory('.dart_tool')
-            .childDirectory('flutter_build')
-            .childFile('dart_plugin_registrant.dart');
+      final File generatedMain = globals.fs
+          .directory('.dart_tool')
+          .childDirectory('flutter_build')
+          .childFile('dart_plugin_registrant.dart');
 
-        expect(generatedMain.existsSync(), isTrue);
-        expect(testLogger.errorText, isEmpty);
-        expect(testLogger.statusText, isEmpty);
-      },
-      overrides: <Type, Generator>{
-        FeatureFlags: enableExplicitPackageDependencies,
-        Pub: ThrowingPub.new,
-      },
-    ),
+      expect(generatedMain.existsSync(), isTrue);
+      expect(testLogger.errorText, isEmpty);
+      expect(testLogger.statusText, isEmpty);
+    }, overrides: <Type, Generator>{Pub: ThrowingPub.new}),
   );
 
   testUsingContext(
@@ -1306,7 +1288,6 @@ flutter:
       // Completing this future ensures that the daemon can exit correctly.
       expect(await residentRunner.waitForAppToFinish(), 1);
     }),
-    overrides: <Type, Generator>{FeatureFlags: enableExplicitPackageDependencies},
   );
 
   testUsingContext(

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -16,7 +16,6 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/isolated/devfs_web.dart';
 import 'package:flutter_tools/src/isolated/resident_web_runner.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -35,12 +34,6 @@ void main() {
   late FakeFlutterDevice mockFlutterDevice;
   late FakeWebDevFS mockWebDevFS;
   late MemoryFileSystem fileSystem;
-
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -89,7 +82,6 @@ name: my_app
       BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -122,7 +114,6 @@ name: my_app
       BuildSystem: () => TestBuildSystem.all(BuildResult(success: false)),
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -155,7 +146,6 @@ name: my_app
       BuildSystem: () => TestBuildSystem.error(Exception('foo')),
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -191,7 +181,6 @@ name: my_app
       BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -232,7 +221,6 @@ name: my_app
           ]),
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -23,7 +23,6 @@ import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/devfs_web.dart';
 import 'package:flutter_tools/src/isolated/resident_web_runner.dart';
@@ -97,12 +96,6 @@ void main() {
   late MemoryFileSystem fileSystem;
   late ProcessManager processManager;
   late FakeAnalytics fakeAnalytics;
-
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return test_fakes.TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -260,7 +253,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -297,7 +289,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -325,7 +316,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -347,7 +337,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -380,7 +369,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -410,7 +398,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -453,7 +440,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -494,7 +480,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -538,7 +523,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -685,7 +669,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -719,7 +702,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -826,7 +808,6 @@ name: my_app
       Analytics: () => fakeAnalytics,
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -911,7 +892,6 @@ name: my_app
       Analytics: () => fakeAnalytics,
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -993,7 +973,6 @@ name: my_app
       BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1106,7 +1085,6 @@ name: my_app
         Analytics: () => fakeAnalytics,
         FileSystem: () => fileSystem,
         ProcessManager: () => processManager,
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );
@@ -1142,7 +1120,6 @@ name: my_app
       Analytics: () => fakeAnalytics,
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1180,7 +1157,6 @@ name: my_app
       Analytics: () => fakeAnalytics,
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1221,7 +1197,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1248,7 +1223,6 @@ name: my_app
       Analytics: () => fakeAnalytics,
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1279,7 +1253,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1311,7 +1284,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1388,7 +1360,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1415,7 +1386,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1447,7 +1417,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1518,7 +1487,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1566,7 +1534,6 @@ name: my_app
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1625,7 +1592,6 @@ flutter:
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1682,7 +1648,6 @@ flutter:
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1736,7 +1701,6 @@ flutter:
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1755,7 +1719,6 @@ flutter:
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1775,7 +1738,6 @@ flutter:
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1794,7 +1756,6 @@ flutter:
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -1814,7 +1775,6 @@ flutter:
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );

--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/test/test_compiler.dart';
 import 'package:flutter_tools/src/test/test_time_recorder.dart';
@@ -19,7 +18,6 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/fakes.dart';
 import '../../src/logging_logger.dart';
 import '../../src/package_config.dart';
 import '../../src/throwing_pub.dart';
@@ -38,12 +36,6 @@ void main() {
   late FakeResidentCompiler residentCompiler;
   late FileSystem fileSystem;
   late LoggingLogger logger;
-
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(isExplicitPackageDependenciesEnabled: true);
-  }
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -79,7 +71,6 @@ name: foo
       Platform: () => linuxPlatform,
       ProcessManager: () => FakeProcessManager.any(),
       Logger: () => BufferLogger.test(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -106,7 +97,6 @@ name: foo
       Platform: () => linuxPlatform,
       ProcessManager: () => FakeProcessManager.any(),
       Logger: () => BufferLogger.test(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -138,7 +128,6 @@ name: foo
       Platform: () => linuxPlatform,
       ProcessManager: () => FakeProcessManager.any(),
       Logger: () => BufferLogger.test(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -178,7 +167,6 @@ name: foo
       Platform: () => linuxPlatform,
       ProcessManager: () => FakeProcessManager.any(),
       Logger: () => logger,
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -205,7 +193,6 @@ name: foo
       Platform: () => linuxPlatform,
       ProcessManager: () => FakeProcessManager.any(),
       Logger: () => BufferLogger.test(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -263,7 +250,6 @@ environment:
       Platform: () => linuxPlatform,
       ProcessManager: () => FakeProcessManager.any(),
       Logger: () => BufferLogger.test(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );

--- a/packages/flutter_tools/test/general.shard/web/compile_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/compile_web_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/web/compile.dart';
@@ -29,16 +28,6 @@ void main() {
   late BufferLogger logger;
   late FakeFlutterVersion flutterVersion;
   late FlutterProject flutterProject;
-
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(
-      isExplicitPackageDependenciesEnabled: true,
-      // Assumed to be true below.
-      isWebEnabled: true,
-    );
-  }
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -132,7 +121,6 @@ environement:
     },
     overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.any(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );
@@ -186,7 +174,6 @@ environement:
     },
     overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.any(),
-      FeatureFlags: enableExplicitPackageDependencies,
       Pub: ThrowingPub.new,
     },
   );

--- a/packages/flutter_tools/test/general.shard/web/migrations/scrub_generated_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/migrations/scrub_generated_plugin_registrant_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
-import 'package:flutter_tools/src/features.dart';
 
 import '../../../src/context.dart'; // legacy
 import '../../../src/fakes.dart';
@@ -19,16 +18,6 @@ import '../../../src/test_flutter_command_runner.dart';
 import '../../../src/throwing_pub.dart'; // legacy
 
 void main() {
-  // TODO(matanlurey): Remove after `explicit-package-dependencies` is enabled by default.
-  // See https://github.com/flutter/flutter/issues/160257 for details.
-  FeatureFlags enableExplicitPackageDependencies() {
-    return TestFeatureFlags(
-      isExplicitPackageDependenciesEnabled: true,
-      // Assumed to be true below.
-      isWebEnabled: true,
-    );
-  }
-
   setUpAll(() {
     Cache.flutterRoot = '';
     Cache.disableLocking();
@@ -82,7 +71,6 @@ void main() {
         FileSystem: () => fileSystem,
         ProcessManager: () => processManager,
         BuildSystem: () => buildSystem,
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );
@@ -111,7 +99,6 @@ void main() {
         FileSystem: () => fileSystem,
         ProcessManager: () => processManager,
         BuildSystem: () => buildSystem,
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );
@@ -143,7 +130,6 @@ void main() {
         FileSystem: () => fileSystem,
         ProcessManager: () => processManager,
         BuildSystem: () => buildSystem,
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );
@@ -171,7 +157,6 @@ void main() {
         FileSystem: () => fileSystem,
         ProcessManager: () => processManager,
         BuildSystem: () => buildSystem,
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );
@@ -205,7 +190,6 @@ void main() {
         FileSystem: () => fileSystem,
         ProcessManager: () => processManager,
         BuildSystem: () => buildSystem,
-        FeatureFlags: enableExplicitPackageDependencies,
         Pub: ThrowingPub.new,
       },
     );


### PR DESCRIPTION
This flag has been enabled by default for quite some time in `master`, and in the current `stable`.

This is the first of many PRs to get rid of the flag and the deprecated code it is guarding.