### PR TITLE
Fix date picker calendar tap targets (portrait mode)

### DIFF
--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -41,7 +41,7 @@ const double _maxDayPickerHeightM2 = _dayPickerRowHeightM2 * (_maxDayPickerRowCo
 const double _maxDayPickerHeightM3 = _dayPickerRowHeightM3 * (_maxDayPickerRowCount + 1);
 
 const double _monthPickerHorizontalPaddingPortraitM3 = 12.0;
-const double _monthPickerHorizontalPaddingM2 = 8.0;
+const double _monthPickerHorizontalPaddingOther = 8.0;
 
 const int _yearPickerColumnCount = 3;
 const double _yearPickerPadding = 16.0;
@@ -1102,7 +1102,7 @@ class _DayPickerState extends State<_DayPicker> {
     final double monthPickerHorizontalPadding =
         Theme.of(context).useMaterial3 && !isLandscapeOrientation
             ? _monthPickerHorizontalPaddingPortraitM3
-            : _monthPickerHorizontalPaddingM2;
+            : _monthPickerHorizontalPaddingOther;
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: monthPickerHorizontalPadding),
       child: MediaQuery.withClampedTextScaling(

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -40,7 +40,8 @@ const int _maxDayPickerRowCount = 6; // A 31 day month that starts on Saturday.
 const double _maxDayPickerHeightM2 = _dayPickerRowHeightM2 * (_maxDayPickerRowCount + 1);
 const double _maxDayPickerHeightM3 = _dayPickerRowHeightM3 * (_maxDayPickerRowCount + 1);
 
-const double _monthPickerHorizontalPadding = 12.0;
+const double _monthPickerHorizontalPaddingPortraitM3 = 12.0;
+const double _monthPickerHorizontalPaddingM2 = 8.0;
 
 const int _yearPickerColumnCount = 3;
 const double _yearPickerPadding = 16.0;
@@ -1098,8 +1099,12 @@ class _DayPickerState extends State<_DayPicker> {
       }
     }
 
+    final double monthPickerHorizontalPadding =
+        Theme.of(context).useMaterial3 && !isLandscapeOrientation
+            ? _monthPickerHorizontalPaddingPortraitM3
+            : _monthPickerHorizontalPaddingM2;
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: _monthPickerHorizontalPadding),
+      padding: EdgeInsets.symmetric(horizontal: monthPickerHorizontalPadding),
       child: MediaQuery.withClampedTextScaling(
         maxScaleFactor:
             isLandscapeOrientation

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -27,8 +27,14 @@ import 'theme.dart';
 
 const Duration _monthScrollDuration = Duration(milliseconds: 200);
 
+// Current M2 implementation is not compliant with the M2 specification.
+// Instead of a 42 pixels row height it should be 40 with a 2 pixels inner padding.
+// See: https://m2.material.io/components/date-pickers#specs.
 const double _dayPickerRowHeightM2 = 42.0;
+// For M3, row height is 48 pxiels with 4 pixels inner padding.
+// See: https://m3.material.io/components/date-pickers/specs#2d53890e-a08f-4c63-a0d9-abd9e95b4245.
 const double _dayPickerRowHeightM3 = 48.0;
+
 const int _maxDayPickerRowCount = 6; // A 31 day month that starts on Saturday.
 // One extra row for the day-of-week header.
 const double _maxDayPickerHeightM2 = _dayPickerRowHeightM2 * (_maxDayPickerRowCount + 1);

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -27,11 +27,14 @@ import 'theme.dart';
 
 const Duration _monthScrollDuration = Duration(milliseconds: 200);
 
-const double _dayPickerRowHeight = 42.0;
+const double _dayPickerRowHeightM2 = 42.0;
+const double _dayPickerRowHeightM3 = 48.0;
 const int _maxDayPickerRowCount = 6; // A 31 day month that starts on Saturday.
 // One extra row for the day-of-week header.
-const double _maxDayPickerHeight = _dayPickerRowHeight * (_maxDayPickerRowCount + 1);
-const double _monthPickerHorizontalPadding = 8.0;
+const double _maxDayPickerHeightM2 = _dayPickerRowHeightM2 * (_maxDayPickerRowCount + 1);
+const double _maxDayPickerHeightM3 = _dayPickerRowHeightM3 * (_maxDayPickerRowCount + 1);
+
+const double _monthPickerHorizontalPadding = 12.0;
 
 const int _yearPickerColumnCount = 3;
 const double _yearPickerPadding = 16.0;
@@ -361,14 +364,22 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
           context,
         ).clamp(maxScaleFactor: _kMaxTextScaleFactor).scale(_fontSizeToScale) /
         _fontSizeToScale;
+
+    // Conform to M3 spec in portrait mode (landscape mode is not specified).
+    final Orientation orientation = MediaQuery.orientationOf(context);
+    final double maxDayPickerHeight =
+        Theme.of(context).useMaterial3 && orientation == Orientation.portrait
+            ? _maxDayPickerHeightM3
+            : _maxDayPickerHeightM2;
+
     // Scale the height of the picker area up with larger text. The size of the
-    // picker has room for larger text, up until a scale facotr of 1.3. After
+    // picker has room for larger text, up until a scale factor of 1.3. After
     // after which, we increase the height to add room for content to continue
     // to scale the text size.
     final double scaledMaxDayPickerHeight =
         textScaleFactor > 1.3
-            ? _maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * 8))
-            : _maxDayPickerHeight;
+            ? maxDayPickerHeight + ((_maxDayPickerRowCount + 1) * ((textScaleFactor - 1) * 8))
+            : maxDayPickerHeight;
     return Stack(
       children: <Widget>[
         SizedBox(height: _subHeaderHeight + scaledMaxDayPickerHeight, child: _buildPicker()),
@@ -1191,6 +1202,12 @@ class _DayState extends State<_Day> {
       ),
     );
 
+    // Conform to M3 spec in portrait mode (landscape mode is not specified).
+    final Orientation orientation = MediaQuery.orientationOf(context);
+    if (Theme.of(context).useMaterial3 && orientation == Orientation.portrait) {
+      dayWidget = Padding(padding: const EdgeInsets.all(4.0), child: dayWidget);
+    }
+
     if (widget.isDisabled) {
       dayWidget = ExcludeSemantics(child: dayWidget);
     } else {
@@ -1239,10 +1256,16 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
     final double textScaleFactor =
         MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 3.0).scale(_fontSizeToScale) /
         _fontSizeToScale;
+    // Conform to M3 spec in portrait mode (landscape mode is not specified).
+    final Orientation orientation = MediaQuery.orientationOf(context);
+    final double dayPickerRowHeight =
+        Theme.of(context).useMaterial3 && orientation == Orientation.portrait
+            ? _dayPickerRowHeightM3
+            : _dayPickerRowHeightM2;
     final double scaledRowHeight =
         textScaleFactor > 1.3
-            ? ((textScaleFactor - 1) * 30) + _dayPickerRowHeight
-            : _dayPickerRowHeight;
+            ? ((textScaleFactor - 1) * 30) + dayPickerRowHeight
+            : dayPickerRowHeight;
     const int columnCount = DateTime.daysPerWeek;
     final double tileWidth = constraints.crossAxisExtent / columnCount;
     final double tileHeight = math.min(

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -1208,7 +1208,8 @@ class _DayState extends State<_Day> {
       ),
     );
 
-    // Conform to M3 spec in portrait mode (landscape mode is not specified).
+    // Adds padding as per M3 guidelines for portrait mode. Not applied in landscape
+    // mode currently due to unclear specifications.
     final Orientation orientation = MediaQuery.orientationOf(context);
     if (Theme.of(context).useMaterial3 && orientation == Orientation.portrait) {
       dayWidget = Padding(padding: const EdgeInsets.all(4.0), child: dayWidget);

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -42,7 +42,7 @@ import 'theme.dart';
 // The M3 sizes are coming from the tokens, but are hand coded,
 // as the current token DB does not contain landscape versions.
 const Size _calendarPortraitDialogSizeM2 = Size(330.0, 518.0);
-const Size _calendarPortraitDialogSizeM3 = Size(328.0, 512.0);
+const Size _calendarPortraitDialogSizeM3 = Size(360.0, 568.0);
 const Size _calendarLandscapeDialogSize = Size(496.0, 346.0);
 const Size _inputPortraitDialogSizeM2 = Size(330.0, 270.0);
 const Size _inputPortraitDialogSizeM3 = Size(328.0, 270.0);

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -157,7 +157,7 @@ void main() {
       }
 
       const Size calendarLandscapeDialogSize = Size(496.0, 346.0);
-      const Size calendarPortraitDialogSizeM3 = Size(328.0, 512.0);
+      const Size calendarPortraitDialogSizeM3 = Size(360.0, 568.0);
 
       // Test landscape layout.
       await showPicker(tester, wideWindowSize);
@@ -1788,6 +1788,20 @@ void main() {
         );
       });
       semantics.dispose();
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/158325.
+    testWidgets('Calendar mode respects tap target guidelines in portrait orientation', (
+      WidgetTester tester,
+    ) async {
+      addTearDown(tester.view.reset);
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+
+      await prepareDatePicker(tester, useMaterial3: true, (Future<DateTime?> date) async {
+        expect(find.byType(DatePickerDialog), findsOneWidget);
+        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      });
     });
 
     testWidgets('input mode', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR fixes the touch target (and Semantic bounds) for day buttons shown in the date picker calendar mode.
To do so it changes the dialog size and buttons padding to conform to the M3 spec, see https://m3.material.io/components/date-pickers/specs#2d53890e-a08f-4c63-a0d9-abd9e95b4245

### Before

![image](https://github.com/user-attachments/assets/22f906b9-bd95-4996-852e-bc2df4247364)

### After

![image](https://github.com/user-attachments/assets/83fd37e2-2cd1-454d-a13d-f2dcc3220e3b)

## Related Issue

Fixes [DateTimePicker date buttons fail touch target size accessibility checks](https://github.com/flutter/flutter/issues/158325)

## Tests

Adds 1 test.

## Implementation choice

This PR targets only M3 and portrait mode:
- M3 because M2 dialog picker was not designed to be accessible (day buttons are 40 pixels).
- Portrait mode only, because there are no specification for the landscape mode and existing implementations (Google Calendar, Compose) vary. I will open a separate issue to discuss a possible solution for landscape mode.