### PR TITLE
[native assets] Graduate to preview

### DIFF
--- a/dev/devicelab/bin/tasks/build_android_host_app_with_module_aar.dart
+++ b/dev/devicelab/bin/tasks/build_android_host_app_with_module_aar.dart
@@ -72,13 +72,6 @@ class ModuleTest {
 
       section('Create package with native assets');
 
-      await flutter(
-        'config',
-        options: <String>['--enable-native-assets'],
-        output: stdout,
-        stderr: stderr,
-      );
-
       const String ffiPackageName = 'ffi_package';
       await createFfiPackage(ffiPackageName, tempDir);
 

--- a/dev/devicelab/bin/tasks/build_android_host_app_with_module_source.dart
+++ b/dev/devicelab/bin/tasks/build_android_host_app_with_module_source.dart
@@ -66,13 +66,6 @@ class ModuleTest {
 
       section('Create package with native assets');
 
-      await flutter(
-        'config',
-        options: <String>['--enable-native-assets'],
-        output: stdout,
-        stderr: stderr,
-      );
-
       const String ffiPackageName = 'ffi_package';
       await createFfiPackage(ffiPackageName, tempDir);
 

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -68,8 +68,6 @@ Future<void> main() async {
 
       section('Create package with native assets');
 
-      await flutter('config', options: <String>['--enable-native-assets']);
-
       const String ffiPackageName = 'ffi_package';
       await createFfiPackage(ffiPackageName, tempDir);
 

--- a/dev/devicelab/lib/tasks/native_assets_test.dart
+++ b/dev/devicelab/lib/tasks/native_assets_test.dart
@@ -29,8 +29,6 @@ TaskFunction createNativeAssetsTest({
       deviceIdOverride = device.deviceId;
     }
 
-    await enableNativeAssets();
-
     for (final String buildMode in _buildModes) {
       if (buildMode != 'debug' && isIosSimulator) {
         continue;
@@ -148,18 +146,6 @@ Future<int> runFlutter({
 }
 
 final String _flutterBin = path.join(flutterDirectory.path, 'bin', 'flutter');
-
-Future<void> enableNativeAssets() async {
-  print('Enabling configs for native assets...');
-  final int configResult = await exec(_flutterBin, <String>[
-    'config',
-    '-v',
-    '--enable-native-assets',
-  ], canFail: true);
-  if (configResult != 0) {
-    print('Failed to enable configuration, tasks may not run.');
-  }
-}
 
 Future<Directory> createTestProject(String packageName, Directory tempDirectory) async {
   await exec(_flutterBin, <String>[

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -48,7 +48,7 @@ abstract class FeatureFlags {
   bool get isCliAnimationEnabled => true;
 
   /// Whether native assets compilation and bundling is enabled.
-  bool get isNativeAssetsEnabled => false;
+  bool get isNativeAssetsEnabled => true;
 
   /// Whether Swift Package Manager dependency management is enabled.
   bool get isSwiftPackageManagerEnabled => false;
@@ -154,7 +154,8 @@ const Feature nativeAssets = Feature(
   name: 'native assets compilation and bundling',
   configSetting: 'enable-native-assets',
   environmentOverride: 'FLUTTER_NATIVE_ASSETS',
-  master: FeatureChannelSetting(available: true),
+  master: FeatureChannelSetting(available: true, enabledByDefault: true),
+  beta: FeatureChannelSetting(available: true, enabledByDefault: true),
 );
 
 /// Enable Swift Package Manager as a darwin dependency manager.

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -661,7 +661,7 @@ Future<DartBuildResult> _runDartBuild({
     globals.logger.printTrace(
       'Note: You are using the dart build hooks feature which is currently '
       'in preview. Please see '
-      'https://github.com/flutter/flutter/issues/129757 for more details.',
+      'https://dart.dev/interop/c-interop#native-assets for more details.',
     );
   }
   globals.logger.printTrace('Building native assets for $targetOS $architectureString done.');

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -657,7 +657,13 @@ Future<DartBuildResult> _runDartBuild({
       dependencies.addAll(linkResult.dependencies);
     }
   }
-
+  if (codeAssets.isNotEmpty) {
+    globals.logger.printTrace(
+      'Note: You are using the dart build hooks feature which is currently '
+      'in preview. Please see '
+      'https://github.com/flutter/flutter/issues/129757 for more details.',
+    );
+  }
   globals.logger.printTrace('Building native assets for $targetOS $architectureString done.');
   return DartBuildResult(codeAssets, dependencies.toList());
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
@@ -178,7 +178,6 @@ void main() {
         },
         overrides: <Type, Generator>{
           DoctorValidatorsProvider: () => FakeDoctorValidatorsProvider(),
-          FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
         },
       );
     });

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -4326,61 +4326,49 @@ void main() {
   );
 
   for (final String template in <String>['package_ffi', 'plugin_ffi']) {
-    testUsingContext(
-      '$template error android language',
-      () async {
-        final CreateCommand command = CreateCommand();
-        final CommandRunner<void> runner = createTestCommandRunner(command);
-        final List<String> args = <String>[
-          'create',
-          '--no-pub',
-          '--template=$template',
-          '-a',
-          'kotlin',
-          if (template == 'plugin_ffi') '--platforms=android',
-          projectDir.path,
-        ];
+    testWithoutContext('$template error android language', () async {
+      final CreateCommand command = CreateCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+      final List<String> args = <String>[
+        'create',
+        '--no-pub',
+        '--template=$template',
+        '-a',
+        'kotlin',
+        if (template == 'plugin_ffi') '--platforms=android',
+        projectDir.path,
+      ];
 
-        await expectLater(
-          runner.run(args),
-          throwsToolExit(
-            message:
-                'The "android-language" option is not supported with the $template template: the language will always be C or C++.',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{
-        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-      },
-    );
+      await expectLater(
+        runner.run(args),
+        throwsToolExit(
+          message:
+              'The "android-language" option is not supported with the $template template: the language will always be C or C++.',
+        ),
+      );
+    });
 
-    testUsingContext(
-      '$template error ios language',
-      () async {
-        final CreateCommand command = CreateCommand();
-        final CommandRunner<void> runner = createTestCommandRunner(command);
-        final List<String> args = <String>[
-          'create',
-          '--no-pub',
-          '--template=$template',
-          '--ios-language',
-          'swift',
-          if (template == 'plugin_ffi') '--platforms=ios',
-          projectDir.path,
-        ];
+    testWithoutContext('$template error ios language', () async {
+      final CreateCommand command = CreateCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+      final List<String> args = <String>[
+        'create',
+        '--no-pub',
+        '--template=$template',
+        '--ios-language',
+        'swift',
+        if (template == 'plugin_ffi') '--platforms=ios',
+        projectDir.path,
+      ];
 
-        await expectLater(
-          runner.run(args),
-          throwsToolExit(
-            message:
-                'The "ios-language" option is not supported with the $template template: the language will always be C or C++.',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{
-        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-      },
-    );
+      await expectLater(
+        runner.run(args),
+        throwsToolExit(
+          message:
+              'The "ios-language" option is not supported with the $template template: the language will always be C or C++.',
+        ),
+      );
+    });
   }
 
   testUsingContext('FFI plugins error web platform', () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -4326,7 +4326,7 @@ void main() {
   );
 
   for (final String template in <String>['package_ffi', 'plugin_ffi']) {
-    testWithoutContext('$template error android language', () async {
+    testUsingContext('$template error android language', () async {
       final CreateCommand command = CreateCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
       final List<String> args = <String>[
@@ -4348,7 +4348,7 @@ void main() {
       );
     });
 
-    testWithoutContext('$template error ios language', () async {
+    testUsingContext('$template error ios language', () async {
       final CreateCommand command = CreateCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
       final List<String> args = <String>[

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -4326,49 +4326,61 @@ void main() {
   );
 
   for (final String template in <String>['package_ffi', 'plugin_ffi']) {
-    testUsingContext('$template error android language', () async {
-      final CreateCommand command = CreateCommand();
-      final CommandRunner<void> runner = createTestCommandRunner(command);
-      final List<String> args = <String>[
-        'create',
-        '--no-pub',
-        '--template=$template',
-        '-a',
-        'kotlin',
-        if (template == 'plugin_ffi') '--platforms=android',
-        projectDir.path,
-      ];
+    testUsingContext(
+      '$template error android language',
+      () async {
+        final CreateCommand command = CreateCommand();
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        final List<String> args = <String>[
+          'create',
+          '--no-pub',
+          '--template=$template',
+          '-a',
+          'kotlin',
+          if (template == 'plugin_ffi') '--platforms=android',
+          projectDir.path,
+        ];
 
-      await expectLater(
-        runner.run(args),
-        throwsToolExit(
-          message:
-              'The "android-language" option is not supported with the $template template: the language will always be C or C++.',
-        ),
-      );
-    });
+        await expectLater(
+          runner.run(args),
+          throwsToolExit(
+            message:
+                'The "android-language" option is not supported with the $template template: the language will always be C or C++.',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
+      },
+    );
 
-    testUsingContext('$template error ios language', () async {
-      final CreateCommand command = CreateCommand();
-      final CommandRunner<void> runner = createTestCommandRunner(command);
-      final List<String> args = <String>[
-        'create',
-        '--no-pub',
-        '--template=$template',
-        '--ios-language',
-        'swift',
-        if (template == 'plugin_ffi') '--platforms=ios',
-        projectDir.path,
-      ];
+    testUsingContext(
+      '$template error ios language',
+      () async {
+        final CreateCommand command = CreateCommand();
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        final List<String> args = <String>[
+          'create',
+          '--no-pub',
+          '--template=$template',
+          '--ios-language',
+          'swift',
+          if (template == 'plugin_ffi') '--platforms=ios',
+          projectDir.path,
+        ];
 
-      await expectLater(
-        runner.run(args),
-        throwsToolExit(
-          message:
-              'The "ios-language" option is not supported with the $template template: the language will always be C or C++.',
-        ),
-      );
-    });
+        await expectLater(
+          runner.run(args),
+          throwsToolExit(
+            message:
+                'The "ios-language" option is not supported with the $template template: the language will always be C or C++.',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
+      },
+    );
   }
 
   testUsingContext('FFI plugins error web platform', () async {

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -312,9 +312,9 @@ void main() {
       expect(
         nativeAssets,
         allOf(<Matcher>[
-          _onChannelIs('master', available: true, enabledByDefault: false),
+          _onChannelIs('master', available: true, enabledByDefault: true),
           _onChannelIs('stable', available: false, enabledByDefault: false),
-          _onChannelIs('beta', available: false, enabledByDefault: false),
+          _onChannelIs('beta', available: true, enabledByDefault: true),
         ]),
       );
     });

--- a/packages/flutter_tools/test/general.shard/flutter_project_metadata_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_project_metadata_test.dart
@@ -239,29 +239,32 @@ migration:
     expect(logger.traceText, contains('The key `create_revision` was not found'));
   });
 
-  testUsingContext('enabledValues does not contain packageFfi if native-assets not enabled', () {
-    expect(
-      ParsedFlutterTemplateType.enabledValues(featureFlags),
-      isNot(contains(FlutterTemplateType.packageFfi)),
-    );
-    expect(
-      ParsedFlutterTemplateType.enabledValues(featureFlags),
-      contains(FlutterTemplateType.plugin),
-    );
-  });
-
   testUsingContext(
-    'enabledValues contains packageFfi if natives-assets enabled',
+    'enabledValues does not contain packageFfi if native-assets not enabled',
     () {
       expect(
         ParsedFlutterTemplateType.enabledValues(featureFlags),
-        contains(FlutterTemplateType.packageFfi),
+        isNot(contains(FlutterTemplateType.packageFfi)),
       );
       expect(
         ParsedFlutterTemplateType.enabledValues(featureFlags),
         contains(FlutterTemplateType.plugin),
       );
     },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true)},
+    overrides: <Type, Generator>{
+      // ignore: avoid_redundant_argument_values
+      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: false),
+    },
   );
+
+  testUsingContext('enabledValues contains packageFfi if natives-assets enabled', () {
+    expect(
+      ParsedFlutterTemplateType.enabledValues(featureFlags),
+      contains(FlutterTemplateType.packageFfi),
+    );
+    expect(
+      ParsedFlutterTemplateType.enabledValues(featureFlags),
+      contains(FlutterTemplateType.plugin),
+    );
+  });
 }

--- a/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
@@ -54,10 +54,7 @@ void main() {
       'build with assets $buildMode',
       // [intended] Backslashes in commands, but we will never run these commands on Windows.
       skip: const LocalPlatform().isWindows,
-      overrides: <Type, Generator>{
-        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-        ProcessManager: () => FakeProcessManager.empty(),
-      },
+      overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
       () async {
         final File packageConfig = environment.projectDir.childFile(
           '.dart_tool/package_config.json',
@@ -121,10 +118,7 @@ void main() {
   // assets have to be build.
   testUsingContext(
     'does not throw if NDK not present but no native assets present',
-    overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-      ProcessManager: () => FakeProcessManager.empty(),
-    },
+    overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
     () async {
       final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
       await packageConfig.create(recursive: true);

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -189,7 +189,6 @@ void main() {
               ],
             ),
           ]),
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
     },
     () async {
       writePackageConfigFiles(directory: iosEnvironment.projectDir, mainLibName: 'my_app');
@@ -252,7 +251,6 @@ void main() {
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => processManager,
-        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
       },
       () async {
         writePackageConfigFiles(directory: androidEnvironment.projectDir, mainLibName: 'my_app');

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -13,14 +13,12 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
 import 'package:hooks/hooks.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
-import '../../../src/fakes.dart';
 import '../fake_native_assets_build_runner.dart';
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -52,7 +52,6 @@ void main() {
     testUsingContext(
       'build with assets $buildMode',
       overrides: <Type, Generator>{
-        FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
         ProcessManager:
             () => FakeProcessManager.list(<FakeCommand>[
               const FakeCommand(

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -53,10 +53,7 @@ void main() {
 
   testUsingContext(
     'does not throw if clang not present but no native assets present',
-    overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-      ProcessManager: () => FakeProcessManager.empty(),
-    },
+    overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
     () async {
       final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
       await packageConfig.create(recursive: true);
@@ -81,7 +78,6 @@ void main() {
   testUsingContext(
     'NativeAssetsBuildRunnerImpl.cCompilerConfig',
     overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
       ProcessManager:
           () => FakeProcessManager.list(<FakeCommand>[
             const FakeCommand(

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -13,14 +13,12 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
 import 'package:package_config/package_config_types.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
-import '../../../src/fakes.dart';
 import '../../../src/package_config.dart';
 import '../fake_native_assets_build_runner.dart';
 

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
 import 'package:hooks/hooks.dart';
@@ -21,7 +20,6 @@ import 'package:package_config/package_config_types.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
-import '../../../src/fakes.dart';
 import '../../../src/package_config.dart';
 import '../fake_native_assets_build_runner.dart';
 

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -84,7 +84,6 @@ void main() {
       testUsingContext(
         'build with assets $buildMode$testName',
         overrides: <Type, Generator>{
-          FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
           ProcessManager:
               () => FakeProcessManager.list(<FakeCommand>[
                 if (flutterTester) ...<FakeCommand>[
@@ -371,7 +370,6 @@ void main() {
   testUsingContext(
     'NativeAssetsBuildRunnerImpl.cCompilerConfig',
     overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
       ProcessManager:
           () => FakeProcessManager.list(<FakeCommand>[
             const FakeCommand(

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
@@ -47,10 +47,7 @@ void main() {
 
   testUsingContext(
     'Native assets: non-bundled libraries require no copying',
-    overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-      ProcessManager: () => FakeProcessManager.empty(),
-    },
+    overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
     () async {
       final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
       final Uri nonFlutterTesterAssetUri = environment.buildDir.childFile('native_assets.json').uri;
@@ -96,7 +93,11 @@ void main() {
 
   testUsingContext(
     'build with assets but not enabled',
-    overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
+    overrides: <Type, Generator>{
+      // ignore: avoid_redundant_argument_values
+      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: false),
+      ProcessManager: () => FakeProcessManager.empty(),
+    },
     () async {
       final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
       await packageConfig.parent.create();
@@ -122,10 +123,7 @@ void main() {
 
   testUsingContext(
     'build no assets',
-    overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-      ProcessManager: () => FakeProcessManager.empty(),
-    },
+    overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
     () async {
       final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
       final Uri nonFlutterTesterAssetUri =
@@ -169,10 +167,7 @@ void main() {
 
   testUsingContext(
     'Native assets build error',
-    overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-      ProcessManager: () => FakeProcessManager.empty(),
-    },
+    overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
     () async {
       final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
       await packageConfig.parent.create();
@@ -195,10 +190,7 @@ void main() {
 
   testUsingContext(
     'Native assets: no duplicate assets with linking',
-    overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-      ProcessManager: () => FakeProcessManager.empty(),
-    },
+    overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
     () async {
       final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
       await packageConfig.parent.create();

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -72,10 +72,7 @@ void main() {
 
       testUsingContext(
         'build with assets $buildMode$testName',
-        overrides: <Type, Generator>{
-          FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
-          ProcessManager: () => FakeProcessManager.empty(),
-        },
+        overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
         () async {
           writePackageConfigFiles(directory: environment.projectDir, mainLibName: 'my_app');
           final Uri nonFlutterTesterAssetUri =
@@ -165,7 +162,6 @@ void main() {
   testUsingContext(
     'NativeAssetsBuildRunnerImpl.cCompilerConfig',
     overrides: <Type, Generator>{
-      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
       ProcessManager:
           () => FakeProcessManager.list(<FakeCommand>[
             FakeCommand(

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -14,14 +14,12 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
-import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
 import 'package:package_config/package_config_types.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
-import '../../../src/fakes.dart';
 import '../../../src/package_config.dart';
 import '../fake_native_assets_build_runner.dart';
 

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_agp_version_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_agp_version_test.dart
@@ -30,10 +30,6 @@ void main() {
     return;
   }
 
-  setUpAll(() {
-    processManager.runSync(<String>[flutterBin, 'config', '--enable-native-assets']);
-  });
-
   for (final String agpVersion in agpVersions) {
     for (final String buildMode in buildModes) {
       testWithoutContext(

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -53,10 +53,6 @@ void main() {
     return;
   }
 
-  setUpAll(() {
-    processManager.runSync(<String>[flutterBin, 'config', '--enable-native-assets']);
-  });
-
   for (final String device in devices) {
     for (final String buildMode in buildModes) {
       if (device == 'flutter-tester' && buildMode != 'debug') {

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
@@ -36,10 +36,6 @@ void main() {
   const ProcessManager processManager = LocalProcessManager();
   final String constraint = _getPackageFfiTemplatePubspecVersion();
 
-  setUpAll(() {
-    processManager.runSync(<String>[flutterBin, 'config', '--enable-native-assets']);
-  });
-
   // Test building a host, iOS, and APK (Android) target where possible.
   for (final String buildCommand in <String>[
     // Current (Host) OS.


### PR DESCRIPTION
This PR enables native assets on the main and dev channel by default, and make native assets available on the beta channel.

This PR removes the flag from invocations.

The helper packages (`package:hooks` and `package:code_assets`) will stay 0.x for now, until the SDK constraint can be bumped to a beta release and we're happy with the Dart API.

Corresponding Dart CL: https://dart-review.googlesource.com/c/sdk/+/429920

Issue:

* https://github.com/flutter/flutter/issues/129757

Project: https://github.com/orgs/dart-lang/projects/99/