### PR TITLE
Fixes tab semantics gets dropped if the child produce a semantics node

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1961,16 +1961,22 @@ class _TabBarState extends State<TabBar> {
             widget.splashBorderRadius ??
             tabBarTheme.splashBorderRadius ??
             _defaults.splashBorderRadius,
-        child: Semantics(
-          role: SemanticsRole.tab,
-          selected: index == _currentIndex,
-          label: kIsWeb ? null : localizations.tabLabel(tabIndex: index + 1, tabCount: tabCount),
-          child: Padding(
-            padding: EdgeInsets.only(bottom: widget.indicatorWeight),
-            child: wrappedTabs[index],
+        child: Padding(
+          padding: EdgeInsets.only(bottom: widget.indicatorWeight),
+          child: Stack(
+            children: <Widget>[
+              wrappedTabs[index],
+              Semantics(
+                role: SemanticsRole.tab,
+                selected: index == _currentIndex,
+                label:
+                    kIsWeb ? null : localizations.tabLabel(tabIndex: index + 1, tabCount: tabCount),
+              ),
+            ],
           ),
         ),
       );
+      wrappedTabs[index] = MergeSemantics(child: wrappedTabs[index]);
       if (!widget.isScrollable && effectiveTabAlignment == TabAlignment.fill) {
         wrappedTabs[index] = Expanded(child: wrappedTabs[index]);
       }

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1961,18 +1961,13 @@ class _TabBarState extends State<TabBar> {
             widget.splashBorderRadius ??
             tabBarTheme.splashBorderRadius ??
             _defaults.splashBorderRadius,
-        child: Padding(
-          padding: EdgeInsets.only(bottom: widget.indicatorWeight),
-          child: Stack(
-            children: <Widget>[
-              wrappedTabs[index],
-              Semantics(
-                role: SemanticsRole.tab,
-                selected: index == _currentIndex,
-                label:
-                    kIsWeb ? null : localizations.tabLabel(tabIndex: index + 1, tabCount: tabCount),
-              ),
-            ],
+        child: Semantics(
+          role: SemanticsRole.tab,
+          selected: index == _currentIndex,
+          label: kIsWeb ? null : localizations.tabLabel(tabIndex: index + 1, tabCount: tabCount),
+          child: Padding(
+            padding: EdgeInsets.only(bottom: widget.indicatorWeight),
+            child: wrappedTabs[index],
           ),
         ),
       );

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4312,6 +4312,9 @@ class SemanticsOwner extends ChangeNotifier {
       return null;
     }
     if (node.mergeAllDescendantsIntoThisNode) {
+      if (node._canPerformAction(action)) {
+        return node._actions[action];
+      }
       SemanticsNode? result;
       node._visitDescendants((SemanticsNode child) {
         if (child._canPerformAction(action)) {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -158,13 +158,14 @@ void main() {
 
   testWidgets('tab semantics role test', (WidgetTester tester) async {
     // Regressing test for https://github.com/flutter/flutter/issues/169175
-    final _TestImageProvider imageProvider2 = _TestImageProvider();
+    final _TestImageProvider imageProvider = _TestImageProvider();
+    addTearDown(() => imageProvider.fail(Object(), null));
     // Creates an image widget that never complete, which will have zero size.
     await tester.pumpWidget(
       boilerplate(
         child: DefaultTabController(
           length: 1,
-          child: TabBar(tabs: <Widget>[Tab(icon: Image(image: imageProvider2))]),
+          child: TabBar(tabs: <Widget>[Tab(icon: Image(image: imageProvider))]),
         ),
       ),
     );
@@ -9167,5 +9168,9 @@ class _TestImageProvider extends ImageProvider<Object> {
   @override
   ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) {
     return _streamCompleter;
+  }
+
+  void fail(Object exception, StackTrace? stackTrace) {
+    _completer.completeError(exception, stackTrace);
   }
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -168,8 +168,6 @@ void main() {
         ),
       ),
     );
-    debugDumpSemanticsTree();
-
     expect(find.byType(Tab), findsOneWidget);
   });
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -156,10 +156,10 @@ void main() {
     expect(tester.renderObject(find.byType(CustomPaint)).debugNeedsPaint, true);
   });
 
-  testWidgets('tab semanitcs role test', (WidgetTester tester) async {
+  testWidgets('tab semantics role test', (WidgetTester tester) async {
     // Regressing test for https://github.com/flutter/flutter/issues/169175
     final _TestImageProvider imageProvider2 = _TestImageProvider();
-
+    // Creates an image widget that never complete, which will have zero size.
     await tester.pumpWidget(
       boilerplate(
         child: DefaultTabController(

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/feedback_tester.dart';
 import '../widgets/semantics_tester.dart';

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
+import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -154,6 +154,23 @@ void main() {
     );
 
     expect(tester.renderObject(find.byType(CustomPaint)).debugNeedsPaint, true);
+  });
+
+  testWidgets('tab semanitcs role test', (WidgetTester tester) async {
+    // Regressing test for https://github.com/flutter/flutter/issues/169175
+    final _TestImageProvider imageProvider2 = _TestImageProvider();
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: DefaultTabController(
+          length: 1,
+          child: TabBar(tabs: <Widget>[Tab(icon: Image(image: imageProvider2))]),
+        ),
+      ),
+    );
+    debugDumpSemanticsTree();
+
+    expect(find.byType(Tab), findsOneWidget);
   });
 
   testWidgets('Tab sizing - icon', (WidgetTester tester) async {
@@ -9134,4 +9151,23 @@ void main() {
       (focus: false, index: 2), // Third tab loses focus
     ]);
   });
+}
+
+class _TestImageProvider extends ImageProvider<Object> {
+  _TestImageProvider({ImageStreamCompleter? streamCompleter}) {
+    _streamCompleter = streamCompleter ?? OneFrameImageStreamCompleter(_completer.future);
+  }
+
+  final Completer<ImageInfo> _completer = Completer<ImageInfo>();
+  late ImageStreamCompleter _streamCompleter;
+
+  @override
+  Future<Object> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<_TestImageProvider>(this);
+  }
+
+  @override
+  ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) {
+    return _streamCompleter;
+  }
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/feedback_tester.dart';
 import '../widgets/semantics_tester.dart';
@@ -158,14 +157,14 @@ void main() {
 
   testWidgets('tab semantics role test', (WidgetTester tester) async {
     // Regressing test for https://github.com/flutter/flutter/issues/169175
-    final _TestImageProvider imageProvider = _TestImageProvider();
-    addTearDown(() => imageProvider.fail(Object(), null));
-    // Creates an image widget that never complete, which will have zero size.
+    // Creates an image semantics node with zero size.
     await tester.pumpWidget(
       boilerplate(
         child: DefaultTabController(
           length: 1,
-          child: TabBar(tabs: <Widget>[Tab(icon: Image(image: imageProvider))]),
+          child: TabBar(
+            tabs: <Widget>[Tab(icon: Semantics(image: true, child: const SizedBox.shrink()))],
+          ),
         ),
       ),
     );
@@ -9150,27 +9149,4 @@ void main() {
       (focus: false, index: 2), // Third tab loses focus
     ]);
   });
-}
-
-class _TestImageProvider extends ImageProvider<Object> {
-  _TestImageProvider({ImageStreamCompleter? streamCompleter}) {
-    _streamCompleter = streamCompleter ?? OneFrameImageStreamCompleter(_completer.future);
-  }
-
-  final Completer<ImageInfo> _completer = Completer<ImageInfo>();
-  late ImageStreamCompleter _streamCompleter;
-
-  @override
-  Future<Object> obtainKey(ImageConfiguration configuration) {
-    return SynchronousFuture<_TestImageProvider>(this);
-  }
-
-  @override
-  ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) {
-    return _streamCompleter;
-  }
-
-  void fail(Object exception, StackTrace? stackTrace) {
-    _completer.completeError(exception, stackTrace);
-  }
 }

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -918,6 +918,26 @@ void main() {
     expect(newNode.id, expectId);
   });
 
+  test('performActionAt can hit test on merged semantics node', () {
+    bool tapped = false;
+    final SemanticsOwner owner = SemanticsOwner(onSemanticsUpdate: (SemanticsUpdate update) {});
+    final SemanticsNode root = SemanticsNode.root(owner: owner)
+      ..rect = const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0);
+    final SemanticsNode merged = SemanticsNode()..rect = const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0);
+    final SemanticsConfiguration mergeConfig =
+        SemanticsConfiguration()
+          ..isSemanticBoundary = true
+          ..isMergingSemanticsOfDescendants = true
+          ..onTap = () => tapped = true;
+    final SemanticsConfiguration rootConfig = SemanticsConfiguration()..isSemanticBoundary = true;
+
+    merged.updateWith(config: mergeConfig, childrenInInversePaintOrder: <SemanticsNode>[]);
+    root.updateWith(config: rootConfig, childrenInInversePaintOrder: <SemanticsNode>[merged]);
+
+    owner.performActionAt(const Offset(5, 5), SemanticsAction.tap);
+    expect(tapped, isTrue);
+  });
+
   test('Tags show up in debug properties', () {
     final SemanticsNode actionNode =
         SemanticsNode()..tags = <SemanticsTag>{RenderViewport.useTwoPaneSemantics};


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/169175

the bug is due to the image widget will create it own semanitc node and force the semantics widget in the stack to form its own node instead of merge up. Modify the code so that it works correctly.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
