### PR TITLE
Increase sub-task timeout for `web_tool_tests_1_2`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6566,7 +6566,7 @@ targets:
       subshard: "1_2"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      test_timeout_secs: "2700"
+      test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
For more details, @flar did a great job explaining it in https://github.com/flutter/flutter/issues/169168.

This PR is a one-off fix for the `web_tool_tests_1_2` shard that has been timing out and bringing the tree down with it. The shard was marked `bringup` [here](https://github.com/flutter/flutter/pull/168871). After increasing the sub-task timeout, let's watch it and if it becomes consistently green, we will remove the `bringup` status.

Partial fix for https://github.com/flutter/flutter/issues/168863
(partial because I still want to remove `bringup` before I consider the issue fixed)