### PR TITLE
Increase sub-task timeout for Mac web_tool_tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4702,7 +4702,7 @@ targets:
       subshard: "1_1"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-      test_timeout_secs: "2700" # Allows 45 minutes (up from 30 default)
+      test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
In my PR https://github.com/flutter/flutter/pull/169198 the Mac web_tool_tests are timing out after around 45 minutes. The global timeout has been set to 60 minutes but the sub-task timeout was lower.

This increases the sub-task timeout to match the global timeout (see https://github.com/flutter/flutter/pull/169277 and https://github.com/flutter/flutter/issues/169168).

