### PR TITLE
Increase sub-task timeout for `Mac web_tool_tests`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4702,7 +4702,7 @@ targets:
       subshard: "1_1"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-      test_timeout_secs: "2700" # Allows 45 minutes (up from 30 default)
+      test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
Similar to https://github.com/flutter/flutter/pull/169277 but for Mac.

Also, some recent slow tests have been [disabled](https://github.com/flutter/flutter/pull/169305) and we will find a [better way](https://github.com/flutter/flutter/issues/169304) to re-enable them.