### PR TITLE
Stop using `isExplicitPackageDeps*` to guard Darwin devDependencies.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -486,12 +486,6 @@ end
     const String appFrameworkName = 'App.framework';
     final Status status = globals.logger.startProgress(' ├─Building App.xcframework...');
     final List<Directory> frameworks = <Directory>[];
-
-    // Dev dependencies are removed from release builds if the explicit package
-    // dependencies flag is on.
-    final bool devDependenciesEnabled =
-        !featureFlags.isExplicitPackageDependenciesEnabled || !buildInfo.mode.isRelease;
-
     try {
       for (final EnvironmentType sdkType in EnvironmentType.values) {
         final Directory outputBuildDirectory = switch (sdkType) {
@@ -514,7 +508,7 @@ end
               globals.artifacts!,
             ).map((DarwinArch e) => e.name).join(' '),
             kSdkRoot: await globals.xcode!.sdkLocation(sdkType),
-            kDevDependenciesEnabled: devDependenciesEnabled.toString(),
+            kDevDependenciesEnabled: '${!buildInfo.mode.isRelease}',
             ...buildInfo.toBuildSystemEnvironment(),
           },
           artifacts: globals.artifacts!,

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -17,7 +17,6 @@ import '../build_info.dart';
 import '../build_system/build_system.dart';
 import '../build_system/targets/ios.dart';
 import '../cache.dart';
-import '../features.dart';
 import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -15,7 +15,6 @@ import '../build_info.dart';
 import '../build_system/build_system.dart';
 import '../build_system/targets/macos.dart';
 import '../cache.dart';
-import '../features.dart';
 import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -234,10 +234,6 @@ end
   ) async {
     final Status status = globals.logger.startProgress(' ├─Building App.xcframework...');
     try {
-      // Dev dependencies are removed from release builds if the explicit package
-      // dependencies flag is on.
-      final bool devDependenciesEnabled =
-          !featureFlags.isExplicitPackageDependenciesEnabled || !buildInfo.mode.isRelease;
       final Environment environment = Environment(
         projectDir: globals.fs.currentDirectory,
         packageConfigPath: packageConfigPath(),
@@ -251,7 +247,7 @@ end
           kDarwinArchs: defaultMacOSArchsForEnvironment(
             globals.artifacts!,
           ).map((DarwinArch e) => e.name).join(' '),
-          kDevDependenciesEnabled: devDependenciesEnabled.toString(),
+          kDevDependenciesEnabled: '${!buildInfo.mode.isRelease}',
           ...buildInfo.toBuildSystemEnvironment(),
         },
         artifacts: globals.artifacts!,

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -37,15 +37,10 @@ Future<void> updateGeneratedXcodeProperties({
   String? buildDirOverride,
   String? configurationBuildDir,
 }) async {
-  // Dev dependencies are removed from release builds if the explicit package
-  // dependencies flag is on.
-  final bool devDependenciesEnabled =
-      !featureFlags.isExplicitPackageDependenciesEnabled || !buildInfo.mode.isRelease;
-
   final List<String> xcodeBuildSettings = await _xcodeBuildSettingsLines(
     project: project,
     buildInfo: buildInfo,
-    devDependenciesEnabled: devDependenciesEnabled,
+    devDependenciesEnabled: !buildInfo.mode.isRelease,
     targetOverride: targetOverride,
     useMacOSConfig: useMacOSConfig,
     buildDirOverride: buildDirOverride,


### PR DESCRIPTION
This PR removes the flag `isExplicitPackageDependenciesEnabled` from guarding Darwin `devDependencies` removal.

The flag was added opt-in 3.29 and opt-out 3.32 and is now being removed with the logic "always enabled":

- https://docs.flutter.dev/release/breaking-changes/flutter-generate-i10n-source
- https://github.com/flutter/flutter/pull/169283

Tests already assumed this flag was always on, which is why no tests changes are made in this PR.