### PR TITLE
Remove now disabled code that would generate `.flutter-plugins`.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -387,33 +387,6 @@ List<Object?> _createPluginLegacyDependencyGraph(List<Plugin> plugins) {
   return directAppDependencies;
 }
 
-// The .flutter-plugins file will be DEPRECATED in favor of .flutter-plugins-dependencies.
-// TODO(franciscojma): Remove this method once deprecated.
-// https://github.com/flutter/flutter/issues/48918
-//
-/// Writes the `.flutter-plugins` files based on the list of plugins.
-/// If there aren't any plugins, then the files aren't written to disk.
-///
-/// Finally, returns `true` if `.flutter-plugins` has changed, otherwise returns `false`.
-bool _writeFlutterPluginsListLegacy(FlutterProject project, List<Plugin> plugins) {
-  final File pluginsFile = project.flutterPluginsFile;
-  if (plugins.isEmpty) {
-    return ErrorHandlingFileSystem.deleteIfExists(pluginsFile);
-  }
-
-  const String info = 'This is a generated file; do not edit or check into version control.';
-  final StringBuffer flutterPluginsBuffer = StringBuffer('# $info\n');
-
-  for (final Plugin plugin in plugins) {
-    flutterPluginsBuffer.write('${plugin.name}=${globals.fsUtils.escapePath(plugin.path)}\n');
-  }
-  final String? oldPluginFileContent = _readFileContent(pluginsFile);
-  final String pluginFileContent = flutterPluginsBuffer.toString();
-  pluginsFile.writeAsStringSync(pluginFileContent, flush: true);
-
-  return oldPluginFileContent != _readFileContent(pluginsFile);
-}
-
 /// Returns the contents of [File] or `null` if that file does not exist.
 String? _readFileContent(File file) {
   return file.existsSync() ? file.readAsStringSync() : null;
@@ -1195,16 +1168,10 @@ Future<void> refreshPluginsList(
   bool iosPlatform = false,
   bool macOSPlatform = false,
   bool forceCocoaPodsOnly = false,
-  bool? generateLegacyPlugins,
 }) async {
   final List<Plugin> plugins = await findPlugins(project);
   // Sort the plugins by name to keep ordering stable in generated files.
   plugins.sort((Plugin left, Plugin right) => left.name.compareTo(right.name));
-  // TODO(matanlurey): Remove once migration is complete.
-  // Write the legacy plugin files to avoid breaking existing apps.
-  generateLegacyPlugins ??= !featureFlags.isExplicitPackageDependenciesEnabled;
-  final bool legacyChanged =
-      generateLegacyPlugins && _writeFlutterPluginsListLegacy(project, plugins);
 
   bool swiftPackageManagerEnabledIos = false;
   bool swiftPackageManagerEnabledMacos = false;
@@ -1223,7 +1190,7 @@ Future<void> refreshPluginsList(
     swiftPackageManagerEnabledIos: swiftPackageManagerEnabledIos,
     swiftPackageManagerEnabledMacos: swiftPackageManagerEnabledMacos,
   );
-  if (changed || legacyChanged || forceCocoaPodsOnly) {
+  if (changed || forceCocoaPodsOnly) {
     createPluginSymlinks(project, force: true);
     if (iosPlatform) {
       globals.cocoaPods?.invalidatePodInstallOutput(project.ios);

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -34,13 +34,6 @@ Future<void> processPodsIfNeeded(
     iosPlatform: project.ios.existsSync(),
     macOSPlatform: project.macos.existsSync(),
     forceCocoaPodsOnly: forceCocoaPodsOnly,
-
-    // TODO(matanlurey): As-per discussion on https://github.com/flutter/flutter/pull/157393
-    //  we'll assume that iOS/MacOS builds do not use or rely on the `.flutter-plugins` legacy
-    //  file being generated. A better long-term fix would be not to have a call to refreshPluginsList
-    //  at all, and instead have it implicitly run by the FlutterCommand instead. See
-    //  https://github.com/flutter/flutter/issues/157391 for details.
-    generateLegacyPlugins: false,
   );
 
   // If there are no plugins and if the project is a not module with an existing


### PR DESCRIPTION
As of https://github.com/flutter/flutter/pull/169283 it's impossible for the `.flutter-plugins` file to exist outside of unit tests.

This removes the unit tests too :)