### PR TITLE
Add `Navigator.popUntilWithResult`

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2787,7 +2787,15 @@ class Navigator extends StatefulWidget {
   /// To pop until a route with a certain name, use the [RoutePredicate]
   /// returned from [ModalRoute.withName].
   ///
-  /// The routes are closed with null as their `return` value.
+  /// If `result` is not specified, then all routes are closed
+  /// with null as their `return` value.
+  /// If `result` is specified, then the last popped route will be closed with
+  /// `result` as its return value.
+  ///
+  /// The `T` type argument is the type of the return value of the last popped route.
+  ///
+  /// The type of `result`, if provided, must match the type argument of the
+  /// class of the last popped route (`T`).
   ///
   /// See [pop] for more details of the semantics of popping a route.
   /// {@endtemplate}

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2811,7 +2811,11 @@ class Navigator extends StatefulWidget {
   /// ```
   /// {@end-tool}
   @optionalTypeArgs
-  static void popUntil<T extends Object?>(BuildContext context, RoutePredicate predicate, [T? result]) {
+  static void popUntil<T extends Object?>(
+    BuildContext context,
+    RoutePredicate predicate, [
+    T? result,
+  ]) {
     Navigator.of(context).popUntil<T>(predicate, result);
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5634,10 +5634,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @optionalTypeArgs
   void popUntil<T extends Object?>(RoutePredicate predicate, [T? result]) {
     _RouteEntry? candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
-    if (candidate == null || predicate(candidate.route)) {
-      return;
-    }
+
     while (candidate != null) {
+      if (predicate(candidate.route)) {
+        return;
+      }
       // Check what would be next if we pop this route
       final _RouteEntry? next = _lastRouteEntryWhereOrNull(
         (_RouteEntry e) => _RouteEntry.isPresentPredicate(e) && e != candidate,
@@ -5650,7 +5651,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
         pop();
       }
 
-      candidate = next;
+      candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5644,9 +5644,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
         (_RouteEntry e) => _RouteEntry.isPresentPredicate(e) && e != candidate,
       );
 
-      if (next != null && predicate(next.route)) {
+      if (next != null && !next.route.willHandlePopInternally && predicate(next.route)) {
         pop<T>(result);
-        return;
       } else {
         pop();
       }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5633,7 +5633,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @optionalTypeArgs
   void popUntil<T extends Object?>(RoutePredicate predicate, [T? result]) {
     _RouteEntry? candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
-
     while (candidate != null) {
       if (predicate(candidate.route)) {
         return;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5652,7 +5652,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// [result] to the last popped route.
   ///
   /// {@macro flutter.widgets.navigator.popUntil}
-  ///
   @optionalTypeArgs
   void popUntilWithResult<T extends Object?>(RoutePredicate predicate, T? result) {
     _RouteEntry? candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2787,6 +2787,36 @@ class Navigator extends StatefulWidget {
   /// To pop until a route with a certain name, use the [RoutePredicate]
   /// returned from [ModalRoute.withName].
   ///
+  /// The routes are closed with null as their `return` value.
+  ///
+  /// See [pop] for more details of the semantics of popping a route.
+  /// {@endtemplate}
+  ///
+  /// {@tool snippet}
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// void _logout() {
+  ///   Navigator.popUntil(context, ModalRoute.withName('/login'));
+  /// }
+  /// ```
+  /// {@end-tool}
+  static void popUntil(BuildContext context, RoutePredicate predicate) {
+    Navigator.of(context).popUntil(predicate);
+  }
+
+  /// Calls [pop] repeatedly on the navigator that most tightly encloses the
+  /// given context until the predicate returns true, returning the [result] to
+  /// the last popped route.
+  ///
+  /// {@template flutter.widgets.navigator.popUntil}
+  /// The predicate may be applied to the same route more than once if
+  /// [Route.willHandlePopInternally] is true.
+  ///
+  /// To pop until a route with a certain name, use the [RoutePredicate]
+  /// returned from [ModalRoute.withName].
+  ///
   /// If `result` is not specified, then all routes are closed
   /// with null as their `return` value.
   /// If `result` is specified, then the last popped route will be closed with
@@ -2808,12 +2838,12 @@ class Navigator extends StatefulWidget {
   /// ```
   /// {@end-tool}
   @optionalTypeArgs
-  static void popUntil<T extends Object?>(
+  static void popUntilWithResult<T extends Object?>(
     BuildContext context,
-    RoutePredicate predicate, [
+    RoutePredicate predicate,
     T? result,
-  ]) {
-    Navigator.of(context).popUntil<T>(predicate, result);
+  ) {
+    Navigator.of(context).popUntilWithResult<T>(predicate, result);
   }
 
   /// Immediately remove `route` from the navigator that most tightly encloses
@@ -5631,8 +5661,34 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// }
   /// ```
   /// {@end-tool}
+  void popUntil(RoutePredicate predicate) {
+    _RouteEntry? candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
+    while (candidate != null) {
+      if (predicate(candidate.route)) {
+        return;
+      }
+      pop();
+      candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
+    }
+  }
+
+  /// Calls [pop] repeatedly until the predicate returns true, returning the
+  /// [result] to the last popped route.
+  ///
+  /// {@macro flutter.widgets.navigator.popUntil}
+  ///
+  /// {@tool snippet}
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// void _doLogout() {
+  ///   navigator.popUntil(ModalRoute.withName('/login'));
+  /// }
+  /// ```
+  /// {@end-tool}
   @optionalTypeArgs
-  void popUntil<T extends Object?>(RoutePredicate predicate, [T? result]) {
+  void popUntilWithResult<T extends Object?>(RoutePredicate predicate, T? result) {
     _RouteEntry? candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
 
     while (candidate != null) {

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2817,11 +2817,6 @@ class Navigator extends StatefulWidget {
   /// To pop until a route with a certain name, use the [RoutePredicate]
   /// returned from [ModalRoute.withName].
   ///
-  /// If `result` is not specified, then all routes are closed
-  /// with null as their `return` value.
-  /// If `result` is specified, then the last popped route will be closed with
-  /// `result` as its return value.
-  ///
   /// The `T` type argument is the type of the return value of the last popped route.
   ///
   /// See [pop] for more details of the semantics of popping a route.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2810,28 +2810,9 @@ class Navigator extends StatefulWidget {
   /// given context until the predicate returns true, returning the [result] to
   /// the last popped route.
   ///
-  /// {@template flutter.widgets.navigator.popUntil}
-  /// The predicate may be applied to the same route more than once if
-  /// [Route.willHandlePopInternally] is true.
-  ///
-  /// To pop until a route with a certain name, use the [RoutePredicate]
-  /// returned from [ModalRoute.withName].
-  ///
   /// The `T` type argument is the type of the return value of the last popped route.
   ///
-  /// See [pop] for more details of the semantics of popping a route.
-  /// {@endtemplate}
-  ///
-  /// {@tool snippet}
-  ///
-  /// Typical usage is as follows:
-  ///
-  /// ```dart
-  /// void _logout() {
-  ///   Navigator.popUntil(context, ModalRoute.withName('/login'));
-  /// }
-  /// ```
-  /// {@end-tool}
+  /// {@macro flutter.widgets.navigator.popUntil}
   @optionalTypeArgs
   static void popUntilWithResult<T extends Object?>(
     BuildContext context,
@@ -5672,16 +5653,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.popUntil}
   ///
-  /// {@tool snippet}
-  ///
-  /// Typical usage is as follows:
-  ///
-  /// ```dart
-  /// void _doLogout() {
-  ///   navigator.popUntil(ModalRoute.withName('/login'));
-  /// }
-  /// ```
-  /// {@end-tool}
   @optionalTypeArgs
   void popUntilWithResult<T extends Object?>(RoutePredicate predicate, T? result) {
     _RouteEntry? candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -79,9 +79,6 @@ typedef RestorableRouteBuilder<T> = Route<T> Function(BuildContext context, Obje
 /// Signature for the [Navigator.popUntil] predicate argument.
 typedef RoutePredicate = bool Function(Route<dynamic> route);
 
-/// Signature for the [Navigator.popUntil] return value predicate argument.
-typedef RouteResultPredicate = Object? Function(Route<dynamic> route);
-
 /// Signature for a callback that verifies that it's OK to call [Navigator.pop].
 ///
 /// Used by [Form.onWillPop], [ModalRoute.addScopedWillPopCallback],
@@ -2810,6 +2807,7 @@ class Navigator extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
+  @optionalTypeArgs
   static void popUntil<T extends Object?>(
     BuildContext context,
     RoutePredicate predicate, [

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5639,7 +5639,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
       if (predicate(candidate.route)) {
         return;
       }
-      // Check what would be next if we pop this route
+      // Check what would be next if we pop this route.
       final _RouteEntry? next = _lastRouteEntryWhereOrNull(
         (_RouteEntry e) => _RouteEntry.isPresentPredicate(e) && e != candidate,
       );

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2802,8 +2802,9 @@ class Navigator extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
-  static void popUntil(BuildContext context, RoutePredicate predicate) {
-    Navigator.of(context).popUntil(predicate);
+  @optionalTypeArgs
+  static void popUntil<T extends Object?>(BuildContext context, RoutePredicate predicate, [T? result]) {
+    Navigator.of(context).popUntil<T>(predicate, result);
   }
 
   /// Immediately remove `route` from the navigator that most tightly encloses
@@ -5621,15 +5622,26 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// }
   /// ```
   /// {@end-tool}
-  void popUntil(RoutePredicate predicate) {
-    _RouteEntry? candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
-    while (candidate != null) {
-      if (predicate(candidate.route)) {
-        return;
+  @optionalTypeArgs
+  void popUntil<T extends Object?>(RoutePredicate predicate, [T? result]) {
+    final List<_RouteEntry> present = _history.where(_RouteEntry.isPresentPredicate).toList();
+
+    int toPop = 0;
+    for (final _RouteEntry entry in present.reversed) {
+      if (predicate(entry.route)) {
+        break;
       }
-      pop();
-      candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
+      toPop++;
     }
+
+    if (toPop == 0) {
+      return;
+    }
+
+    for (int i = 0; i < toPop - 1; i++) {
+      pop();
+    }
+    pop<T>(result);
   }
 
   /// Immediately remove `route` from the navigator, and [Route.dispose] it.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5632,24 +5632,26 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// {@end-tool}
   @optionalTypeArgs
   void popUntil<T extends Object?>(RoutePredicate predicate, [T? result]) {
-    final List<_RouteEntry> present = _history.where(_RouteEntry.isPresentPredicate).toList();
+    _RouteEntry? candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
 
-    int toPop = 0;
-    for (final _RouteEntry entry in present.reversed) {
-      if (predicate(entry.route)) {
-        break;
+    while (candidate != null) {
+      if (predicate(candidate.route)) {
+        return;
       }
-      toPop++;
-    }
 
-    if (toPop == 0) {
-      return;
-    }
+      // Check what would be next if we pop this route
+      final _RouteEntry? next = _lastRouteEntryWhereOrNull(
+        (_RouteEntry e) => _RouteEntry.isPresentPredicate(e) && e != candidate,
+      );
 
-    for (int i = 0; i < toPop - 1; i++) {
-      pop();
+      if (next != null && predicate(next.route)) {
+        pop<T>(result);
+      } else {
+        pop();
+      }
+
+      candidate = _lastRouteEntryWhereOrNull(_RouteEntry.isPresentPredicate);
     }
-    pop<T>(result);
   }
 
   /// Immediately remove `route` from the navigator, and [Route.dispose] it.

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1312,7 +1312,9 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('popUntil with a return value', (WidgetTester tester) async {
+  testWidgets('popUntilWithResult return value to the last popped route', (
+    WidgetTester tester,
+  ) async {
     bool? firstReturnValue;
     bool? secondReturnValue;
 
@@ -1348,7 +1350,7 @@ void main() {
                 builder: (BuildContext context) => OnTapPage(
                   id: 'B',
                   onTap: () async {
-                    Navigator.popUntil<bool>(
+                    Navigator.popUntilWithResult<bool>(
                       context,
                       (Route<dynamic> route) => route.isFirst,
                       true,

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1340,7 +1340,7 @@ void main() {
                     (BuildContext context) => OnTapPage(
                       id: 'A',
                       onTap: () async {
-                        firstReturnValue = await Navigator.pushNamed(context, '/B');
+                        secondReturnValue = await Navigator.pushNamed(context, '/B');
                       },
                     ),
                 settings: settings,

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1325,39 +1325,36 @@ void main() {
           switch (routeName) {
             case '/':
               return MaterialPageRoute<bool>(
-                builder:
-                    (BuildContext context) => OnTapPage(
-                      id: '/',
-                      onTap: () async {
-                        firstReturnValue = await Navigator.pushNamed(context, '/A');
-                      },
-                    ),
+                builder: (BuildContext context) => OnTapPage(
+                  id: '/',
+                  onTap: () async {
+                    firstReturnValue = await Navigator.pushNamed(context, '/A');
+                  },
+                ),
                 settings: settings,
               );
             case '/A':
               return MaterialPageRoute<bool>(
-                builder:
-                    (BuildContext context) => OnTapPage(
-                      id: 'A',
-                      onTap: () async {
-                        secondReturnValue = await Navigator.pushNamed(context, '/B');
-                      },
-                    ),
+                builder: (BuildContext context) => OnTapPage(
+                  id: 'A',
+                  onTap: () async {
+                    secondReturnValue = await Navigator.pushNamed(context, '/B');
+                  },
+                ),
                 settings: settings,
               );
             case '/B':
               return MaterialPageRoute<bool>(
-                builder:
-                    (BuildContext context) => OnTapPage(
-                      id: 'B',
-                      onTap: () async {
-                        Navigator.popUntil<bool>(
-                          context,
-                          (Route<dynamic> route) => route.isFirst,
-                          true,
-                        );
-                      },
-                    ),
+                builder: (BuildContext context) => OnTapPage(
+                  id: 'B',
+                  onTap: () async {
+                    Navigator.popUntil<bool>(
+                      context,
+                      (Route<dynamic> route) => route.isFirst,
+                      true,
+                    );
+                  },
+                ),
                 settings: settings,
               );
             default:

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1315,7 +1315,6 @@ void main() {
   testWidgets('popUntil with a return value', (WidgetTester tester) async {
     bool? firstReturnValue;
     bool? secondReturnValue;
-    bool? thirdReturnValue;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1341,7 +1340,7 @@ void main() {
                     (BuildContext context) => OnTapPage(
                       id: 'A',
                       onTap: () async {
-                        secondReturnValue = await Navigator.pushNamed(context, '/B');
+                        firstReturnValue = await Navigator.pushNamed(context, '/B');
                       },
                     ),
                 settings: settings,
@@ -1352,27 +1351,11 @@ void main() {
                     (BuildContext context) => OnTapPage(
                       id: 'B',
                       onTap: () async {
-                        thirdReturnValue = await Navigator.pushNamed(context, '/C');
-                      },
-                    ),
-                settings: settings,
-              );
-            case '/C':
-              return MaterialPageRoute<bool>(
-                builder:
-                    (BuildContext context) => OnTapPage(
-                      id: 'C',
-                      onTap: () async {
-                        Navigator.popUntil(context, (Route<dynamic> route) => route.isFirst, (
-                          Route<dynamic> route,
-                        ) {
-                          if (route.settings.name == '/B') {
-                            return true;
-                          } else if (route.settings.name == '/A') {
-                            return false;
-                          }
-                          return null;
-                        });
+                        Navigator.popUntil<bool>(
+                          context,
+                          (Route<dynamic> route) => route.isFirst,
+                          true,
+                        );
                       },
                     ),
                 settings: settings,
@@ -1394,14 +1377,11 @@ void main() {
 
     await tester.tap(find.text('B'));
     await tester.pumpAndSettle();
-
-    await tester.tap(find.text('C'));
-    await tester.pumpAndSettle();
     expect(find.text('/'), findsOneWidget);
 
-    expect(firstReturnValue, isNull);
-    expect(secondReturnValue, isFalse);
-    expect(thirdReturnValue, isTrue);
+    // Only the first return value should be set.
+    expect(firstReturnValue, isTrue);
+    expect(secondReturnValue, isNull);
   });
 
   testWidgets('pushAndRemoveUntil triggers secondaryAnimation', (WidgetTester tester) async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR adds a new `Navigator.popUntilWithResult` method that allows to pass a value to the last `pop` call.

Fixes https://github.com/flutter/flutter/issues/30112

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
