### PR TITLE
Revert "Mark web_tool_tests_1_2 as bringup."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6552,7 +6552,6 @@ targets:
 
   - name: Windows web_tool_tests_1_2
     recipe: flutter/flutter_drone
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/168863
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
Reverts flutter/flutter#168871

The timeout was [fixed](https://github.com/flutter/flutter/pull/169277) and some slow tests have been [disabled](https://github.com/flutter/flutter/pull/169305). The builder has been consistently green for the past 20+ runs: https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.staging/Windows%20web_tool_tests_1_2

Closes https://github.com/flutter/flutter/issues/168863