### PR TITLE
Add `/coverage/` to `.gitignore.tmp`

### DIFF
--- a/packages/flutter_tools/templates/app/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/app/.gitignore.tmpl
@@ -32,6 +32,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+/coverage/
 
 # Symbolication related
 app.*.symbols

--- a/packages/flutter_tools/templates/package/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package/.gitignore.tmpl
@@ -28,4 +28,5 @@ migrate_working_dir/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies
-build/
+/build/
+/coverage/

--- a/packages/flutter_tools/templates/package_ffi/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/.gitignore.tmpl
@@ -29,4 +29,5 @@ migrate_working_dir/
 .flutter-plugins
 .flutter-plugins-dependencies
 .packages
-build/
+/build/
+/coverage/

--- a/packages/flutter_tools/templates/plugin_shared/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/.gitignore.tmpl
@@ -30,4 +30,5 @@ migrate_working_dir/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies
-build/
+/build/
+/coverage/


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/166909.

Made `/build/` consistent while I was here.