### PR TITLE
Set pause_isolates_on_start flag if --start-paused

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -508,10 +508,9 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         } else {
           final DateTime reloadStart = _systemClock.now();
           final vmservice.VM vm = await _vmService.service.getVM();
-          final vmservice.Isolate isolate = await _vmService.service.getIsolate(
-            vm.isolates!.first.id!,
+          final vmservice.ReloadReport report = await _vmService.service.reloadSources(
+            vm.isolates?.firstOrNull?.id ?? '',
           );
-          final vmservice.ReloadReport report = await _vmService.service.reloadSources(isolate.id!);
           reloadDuration = _systemClock.now().difference(reloadStart);
           final ReloadReportContents contents = ReloadReportContents.fromReloadReport(report);
           final bool success = contents.success ?? false;

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -506,10 +506,12 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
               _registeredMethodsForService['hotRestart'] ?? 'hotRestart';
           await _vmService.service.callMethod(hotRestartMethod);
         } else {
-          // Isolates don't work on web. For lack of a better value, pass an
-          // empty string for the isolate id.
           final DateTime reloadStart = _systemClock.now();
-          final vmservice.ReloadReport report = await _vmService.service.reloadSources('');
+          final vmservice.VM vm = await _vmService.service.getVM();
+          final vmservice.Isolate isolate = await _vmService.service.getIsolate(
+            vm.isolates!.first.id!,
+          );
+          final vmservice.ReloadReport report = await _vmService.service.reloadSources(isolate.id!);
           reloadDuration = _systemClock.now().difference(reloadStart);
           final ReloadReportContents contents = ReloadReportContents.fromReloadReport(report);
           final bool success = contents.success ?? false;
@@ -786,6 +788,24 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       void onLogEvent(vmservice.Event event) {
         final String message = processVmServiceMessage(event);
         _logger.printStatus(message);
+      }
+
+      // This flag is needed to manage breakpoints properly.
+      if (debuggingOptions.startPaused && debuggingOptions.debuggingEnabled) {
+        try {
+          final vmservice.Response result = await _vmService.service.setFlag(
+            'pause_isolates_on_start',
+            'true',
+          );
+          if (result.type != 'Success') {
+            _logger.printError('setFlag failure: $result');
+          }
+        } on Exception catch (e) {
+          _logger.printError(
+            'Failed to set pause_isolates_on_start=true, proceeding. '
+            'Error: $e',
+          );
+        }
       }
 
       _stdOutSub = _vmService.service.onStdoutEvent.listen(onLogEvent);

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -509,7 +509,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           final DateTime reloadStart = _systemClock.now();
           final vmservice.VM vm = await _vmService.service.getVM();
           final vmservice.ReloadReport report = await _vmService.service.reloadSources(
-            vm.isolates?.firstOrNull?.id ?? '',
+            vm.isolates!.first.id!,
           );
           reloadDuration = _systemClock.now().difference(reloadStart);
           final ReloadReportContents contents = ReloadReportContents.fromReloadReport(report);
@@ -796,7 +796,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
             'pause_isolates_on_start',
             'true',
           );
-          if (result.type != 'Success') {
+          if (result is! vmservice.Success) {
             _logger.printError('setFlag failure: $result');
           }
         } on Exception catch (e) {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -35,7 +35,6 @@ const String kReloadAssetFonts = '_flutter.reloadAssetFonts';
 
 const String kFlutterToolAlias = 'Flutter Tools';
 
-const String kGetVMServiceName = 'getVM';
 const String kReloadSourcesServiceName = 'reloadSources';
 const String kHotRestartServiceName = 'hotRestart';
 const String kFlutterVersionServiceName = 'flutterVersion';

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -35,6 +35,7 @@ const String kReloadAssetFonts = '_flutter.reloadAssetFonts';
 
 const String kFlutterToolAlias = 'Flutter Tools';
 
+const String kGetVMServiceName = 'getVM';
 const String kReloadSourcesServiceName = 'reloadSources';
 const String kHotRestartServiceName = 'hotRestart';
 const String kFlutterVersionServiceName = 'flutterVersion';

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -47,6 +47,7 @@ import '../src/fakes.dart' as test_fakes;
 import '../src/package_config.dart';
 import '../src/test_build_system.dart';
 import '../src/throwing_pub.dart';
+import 'resident_runner_helpers.dart';
 
 const List<VmServiceExpectation> kSetPauseIsolatesOnStartExpectations = <VmServiceExpectation>[
   FakeVmServiceRequest(
@@ -742,13 +743,10 @@ name: my_app
       fakeVmServiceHost = FakeVmServiceHost(
         requests: <VmServiceExpectation>[
           ...kAttachExpectations,
-          const FakeVmServiceRequest(
-            method: kGetVMServiceName,
-            jsonResponse: <String, Object>{'type': 'VM', 'success': true},
-          ),
+          FakeVmServiceRequest(method: 'getVM', jsonResponse: fakeVM.toJson()),
           const FakeVmServiceRequest(
             method: kReloadSourcesServiceName,
-            args: <String, Object>{'isolateId': ''},
+            args: <String, Object>{'isolateId': '1'},
             jsonResponse: <String, Object>{'type': 'ReloadReport', 'success': true},
           ),
           const FakeVmServiceRequest(


### PR DESCRIPTION
This enables breakpoint management for hot restart and hot reload. --start-paused is passed by VS code.

Also fixes a small issue where we're not passing the isolate ID when hot reloading. It doesn't matter what we pass as there's only one isolate, but we should keep consistent and use the isolate ID that already exists.

https://github.com/dart-lang/sdk/issues/60186

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
