### PR TITLE
[Impeller] Add a CommandPoolVK to the global map of thread-local pools only if it is a newly created pool that was not recycled

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -140,6 +140,9 @@ class CommandPoolRecyclerVK final
   /// @brief      Clears all recycled command pools to let them be reclaimed.
   void Dispose();
 
+  // Visible for testing.
+  static int GetGlobalPoolCount(const ContextVK* context);
+
  private:
   std::weak_ptr<ContextVK> context_;
 


### PR DESCRIPTION
CommandPoolRecyclerVK uses a thread-local map that stores the currently active command pool for each ContextVK.  CommandPoolRecyclerVK also needs to maintain a global map of these pools so that context shutdown can destroy all pools associated with the context in the thread-local maps.

Prior to this change CommandPoolRecyclerVK::Get was appending to the context's pool list in the global map each time CommandPoolRecyclerVK::Create was called. CommandPoolRecyclerVK::Create will reuse a reclaimed pool if one is available. However, the reused pool was already added to the global map when it was created.  So adding it again causes a memory leak.

This PR changes CommandPoolRecyclerVK to only add the pool to the global map if the pool was not reused.

Fixes https://github.com/flutter/flutter/issues/169208