### PR TITLE
[Impeller] Directly tessellate arc operations

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -36,6 +36,7 @@
 #include "impeller/entity/contents/text_shadow_cache.h"
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/contents/vertices_contents.h"
+#include "impeller/entity/geometry/arc_geometry.h"
 #include "impeller/entity/geometry/circle_geometry.h"
 #include "impeller/entity/geometry/cover_geometry.h"
 #include "impeller/entity/geometry/ellipse_geometry.h"
@@ -643,43 +644,63 @@ void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
 }
 
 void Canvas::DrawArc(const Rect& oval_bounds,
-                     Scalar start_degrees,
-                     Scalar sweep_degrees,
+                     Degrees start,
+                     Degrees sweep,
                      bool use_center,
                      const Paint& paint) {
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
   entity.SetBlendMode(paint.blend_mode);
 
-  if (paint.style == Paint::Style::kStroke &&
-      paint.stroke.width > oval_bounds.GetSize().MaxDimension()) {
+  if (paint.style == Paint::Style::kFill) {
+    ArcGeometry geom(oval_bounds, start, sweep, use_center);
+    AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
+    return;
+  }
+
+  if (paint.stroke.width > oval_bounds.GetSize().MaxDimension()) {
     // This is a special case for rendering arcs whose stroke width is so large
     // you are effectively drawing a sector of a circle.
     // https://github.com/flutter/flutter/issues/158567
     Rect expanded_rect = oval_bounds.Expand(Size(paint.stroke.width * 0.5f));
 
-    flutter::DlPathBuilder builder;
-    builder.AddArc(expanded_rect, Degrees(start_degrees),
-                   Degrees(sweep_degrees), /*use_center=*/true);
-
-    Paint fill_paint = paint;
-    fill_paint.style = Paint::Style::kFill;
-
-    ArcFillPathGeometry geom(builder.TakePath(), expanded_rect);
+    ArcGeometry geom(expanded_rect, start, sweep, /*include_center=*/true);
     AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
-  } else {
-    flutter::DlPathBuilder builder;
-    builder.AddArc(oval_bounds, Degrees(start_degrees), Degrees(sweep_degrees),
-                   use_center);
+    return;
+  }
 
-    if (paint.style == Paint::Style::kFill) {
-      ArcFillPathGeometry geom(builder.TakePath(), oval_bounds);
+  // Use_center incurs lots of extra work for stroking an arc, including:
+  // - It introduces segments to/from the center point (not too hard).
+  // - It introduces joins on those segments (a bit more complicated).
+  // - Even if the sweep is >=360 degrees, we still draw the segment to
+  //   the center and it basically looks like a pie cut into the complete
+  //   boundary circle, as if the slice were cut, but not extracted
+  //   (hard to express as a continuous kTriangleStrip).
+  if (!use_center) {
+    if (std::abs(sweep.degrees) >= 360.0f) {
+      return DrawOval(oval_bounds, paint);
+    }
+
+    // Our fast stroking code only works for circular bounds as it assumes
+    // that the inner and outer radii can be scaled along each angular step
+    // of the arc - which is not true for elliptical arcs where the inner
+    // and outer samples are perpendicular to the traveling direction of the
+    // elliptical curve which may not line up with the center of the bounds.
+    //
+    // TODO(flar): It also only supports Butt and Square caps for now.
+    // See https://github.com/flutter/flutter/issues/169400
+    if (oval_bounds.IsSquare() && paint.stroke.cap != Cap::kRound) {
+      ArcGeometry geom(oval_bounds, start, sweep, paint.stroke);
       AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
-    } else {
-      ArcStrokePathGeometry geom(builder.TakePath(), oval_bounds, paint.stroke);
-      AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
+      return;
     }
   }
+
+  flutter::DlPathBuilder builder;
+  builder.AddArc(oval_bounds, start, sweep, use_center);
+
+  ArcStrokePathGeometry geom(builder.TakePath(), oval_bounds, paint.stroke);
+  AddRenderEntityWithFiltersToCurrentPass(entity, &geom, paint);
 }
 
 void Canvas::DrawRoundRect(const RoundRect& round_rect, const Paint& paint) {

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -204,8 +204,8 @@ class Canvas {
   void DrawOval(const Rect& rect, const Paint& paint);
 
   void DrawArc(const Rect& oval_bounds,
-               Scalar start_degrees,
-               Scalar sweep_degrees,
+               Degrees start,
+               Degrees sweep,
                bool use_center,
                const Paint& paint);
 

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -679,8 +679,8 @@ void DlDispatcherBase::drawArc(const DlRect& oval_bounds,
                                bool use_center) {
   AUTO_DEPTH_WATCHER(1u);
 
-  GetCanvas().DrawArc(oval_bounds, start_degrees, sweep_degrees, use_center,
-                      paint_);
+  GetCanvas().DrawArc(oval_bounds, Degrees(start_degrees),
+                      Degrees(sweep_degrees), use_center, paint_);
 }
 
 // |flutter::DlOpReceiver|

--- a/engine/src/flutter/impeller/entity/BUILD.gn
+++ b/engine/src/flutter/impeller/entity/BUILD.gn
@@ -200,6 +200,8 @@ impeller_component("entity") {
     "entity_pass_clip_stack.h",
     "entity_pass_target.cc",
     "entity_pass_target.h",
+    "geometry/arc_geometry.cc",
+    "geometry/arc_geometry.h",
     "geometry/circle_geometry.cc",
     "geometry/circle_geometry.h",
     "geometry/cover_geometry.cc",

--- a/engine/src/flutter/impeller/entity/geometry/arc_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/arc_geometry.cc
@@ -1,0 +1,135 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/impeller/entity/geometry/arc_geometry.h"
+
+#include "flutter/impeller/entity/geometry/line_geometry.h"
+
+namespace impeller {
+
+ArcGeometry::ArcGeometry(const Rect& oval_bounds,
+                         Degrees start,
+                         Degrees sweep,
+                         bool include_center)
+    : oval_bounds_(oval_bounds),
+      start_(start),
+      sweep_(sweep),
+      include_center_(include_center),
+      stroke_width_(-1.0f),
+      cap_(Cap::kButt) {}
+
+ArcGeometry::ArcGeometry(const Rect& oval_bounds,
+                         Degrees start,
+                         Degrees sweep,
+                         const StrokeParameters& stroke)
+    : oval_bounds_(oval_bounds),
+      start_(start),
+      sweep_(sweep),
+      include_center_(false),
+      stroke_width_(stroke.width),
+      cap_(stroke.cap) {
+  FML_DCHECK(oval_bounds_.IsSquare());
+}
+
+ArcGeometry::~ArcGeometry() = default;
+
+// |Geometry|
+Scalar ArcGeometry::ComputeAlphaCoverage(const Matrix& transform) const {
+  if (stroke_width_ < 0) {
+    return 1;
+  }
+  return Geometry::ComputeStrokeAlphaCoverage(transform, stroke_width_);
+}
+
+GeometryResult ArcGeometry::GetPositionBuffer(const ContentContext& renderer,
+                                              const Entity& entity,
+                                              RenderPass& pass) const {
+  auto& transform = entity.GetTransform();
+
+  if (stroke_width_ < 0) {
+    auto generator = renderer.GetTessellator().FilledArc(
+        transform, oval_bounds_, start_, sweep_, include_center_,
+        renderer.GetDeviceCapabilities().SupportsTriangleFan());
+
+    return ComputePositionGeometry(renderer, generator, entity, pass);
+  } else {
+    FML_DCHECK(oval_bounds_.IsSquare());
+    Scalar half_width =
+        LineGeometry::ComputePixelHalfWidth(transform, stroke_width_);
+
+    auto generator = renderer.GetTessellator().StrokedArc(
+        transform, oval_bounds_, start_, sweep_, cap_, half_width);
+
+    return ComputePositionGeometry(renderer, generator, entity, pass);
+  }
+}
+
+std::optional<Rect> ArcGeometry::GetCoverage(const Matrix& transform) const {
+  Scalar half_width =  //
+      stroke_width_ < 0
+          ? 0.0
+          : LineGeometry::ComputePixelHalfWidth(transform, stroke_width_);
+
+  if (sweep_.degrees <= -360 || sweep_.degrees >= 360) {
+    return oval_bounds_.Expand(half_width).TransformAndClipBounds(transform);
+  }
+
+  Point center = oval_bounds_.GetCenter();
+  Size size = oval_bounds_.GetSize();
+
+  Degrees start = start_.GetPositive();
+  Degrees end = start + sweep_;
+
+  // 1. start vector
+  // 2. end vector
+  // 3. optional center
+  // 4-7. optional quadrant extrema
+  Point extrema[7];
+  int count = 0;
+
+  extrema[count++] = Matrix::CosSin(start);
+  extrema[count++] = Matrix::CosSin(end);
+
+  if (include_center_) {
+    extrema[count++] = {0, 0};
+  }
+
+  if (start.degrees <= 90 && end.degrees >= 90) {
+    extrema[count++] = {0, 1};
+  }
+  if (start.degrees <= 180 && end.degrees >= 180) {
+    extrema[count++] = {-1, 0};
+  }
+  if (start.degrees <= 270 && end.degrees >= 270) {
+    extrema[count++] = {0, -1};
+  }
+  if (start.degrees <= 360 && end.degrees >= 360) {
+    extrema[count++] = {1, 0};
+  }
+
+  FML_DCHECK(count <= 7);
+
+  for (int i = 0; i < count; i++) {
+    extrema[i] = transform * (center + extrema[i] * size);
+  }
+  auto opt_rect = Rect::MakePointBounds(extrema, extrema + count);
+  if (opt_rect.has_value()) {
+    // Pretty much guaranteed because count >= 2...
+    opt_rect = opt_rect  //
+                   .value()
+                   .Expand(half_width)
+                   .TransformAndClipBounds(transform);
+  }
+  return opt_rect;
+}
+
+bool ArcGeometry::CoversArea(const Matrix& transform, const Rect& rect) const {
+  return false;
+}
+
+bool ArcGeometry::IsAxisAlignedRect() const {
+  return false;
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/entity/geometry/arc_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/arc_geometry.cc
@@ -121,7 +121,7 @@ std::optional<Rect> ArcGeometry::GetCoverage(const Matrix& transform) const {
   Size radii = oval_bounds_.GetSize() * 0.5f;
 
   for (int i = 0; i < count; i++) {
-    extrema[i] = transform * (center + extrema[i] * radii);
+    extrema[i] = center + extrema[i] * radii;
   }
   auto opt_rect = Rect::MakePointBounds(extrema, extrema + count);
   if (opt_rect.has_value()) {

--- a/engine/src/flutter/impeller/entity/geometry/arc_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/arc_geometry.h
@@ -1,0 +1,62 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_ENTITY_GEOMETRY_ARC_GEOMETRY_H_
+#define FLUTTER_IMPELLER_ENTITY_GEOMETRY_ARC_GEOMETRY_H_
+
+#include "impeller/entity/geometry/geometry.h"
+
+#include "impeller/geometry/stroke_parameters.h"
+
+namespace impeller {
+
+// Geometry class that can generate vertices (with or without texture
+// coordinates) for either filled or stroked circles
+class ArcGeometry final : public Geometry {
+ public:
+  explicit ArcGeometry(const Rect& oval_bounds,
+                       Degrees start,
+                       Degrees sweep,
+                       bool include_center);
+
+  explicit ArcGeometry(const Rect& oval_bounds,
+                       Degrees start,
+                       Degrees sweep,
+                       const StrokeParameters& stroke);
+
+  ~ArcGeometry() override;
+
+  // |Geometry|
+  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+
+  // |Geometry|
+  bool IsAxisAlignedRect() const override;
+
+  // |Geometry|
+  Scalar ComputeAlphaCoverage(const Matrix& transform) const override;
+
+ private:
+  // |Geometry|
+  GeometryResult GetPositionBuffer(const ContentContext& renderer,
+                                   const Entity& entity,
+                                   RenderPass& pass) const override;
+
+  // |Geometry|
+  std::optional<Rect> GetCoverage(const Matrix& transform) const override;
+
+  Rect oval_bounds_;
+  Degrees start_;
+  Degrees sweep_;
+  bool include_center_;
+  Scalar stroke_width_;
+  Cap cap_;
+
+  ArcGeometry(const ArcGeometry&) = delete;
+
+  ArcGeometry& operator=(const ArcGeometry&) = delete;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_ENTITY_GEOMETRY_ARC_GEOMETRY_H_

--- a/engine/src/flutter/impeller/entity/geometry/geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.cc
@@ -9,6 +9,7 @@
 
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/pipelines.h"
+#include "impeller/entity/geometry/arc_geometry.h"
 #include "impeller/entity/geometry/circle_geometry.h"
 #include "impeller/entity/geometry/cover_geometry.h"
 #include "impeller/entity/geometry/ellipse_geometry.h"
@@ -102,6 +103,22 @@ std::unique_ptr<Geometry> Geometry::MakeStrokedCircle(const Point& center,
                                                       Scalar radius,
                                                       Scalar stroke_width) {
   return std::make_unique<CircleGeometry>(center, radius, stroke_width);
+}
+
+std::unique_ptr<Geometry> Geometry::MakeFilledArc(const Rect& oval_bounds,
+                                                  Degrees start,
+                                                  Degrees sweep,
+                                                  bool include_center) {
+  return std::make_unique<ArcGeometry>(oval_bounds, start, sweep,
+                                       include_center);
+}
+
+std::unique_ptr<Geometry> Geometry::MakeStrokedArc(
+    const Rect& oval_bounds,
+    Degrees start,
+    Degrees sweep,
+    const StrokeParameters& stroke) {
+  return std::make_unique<ArcGeometry>(oval_bounds, start, sweep, stroke);
 }
 
 std::unique_ptr<Geometry> Geometry::MakeRoundRect(const Rect& rect,

--- a/engine/src/flutter/impeller/entity/geometry/geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/geometry.h
@@ -76,6 +76,17 @@ class Geometry {
                                                      Scalar radius,
                                                      Scalar stroke_width);
 
+  static std::unique_ptr<Geometry> MakeFilledArc(const Rect& oval_bounds,
+                                                 Degrees start,
+                                                 Degrees sweep,
+                                                 bool include_center);
+
+  static std::unique_ptr<Geometry> MakeStrokedArc(
+      const Rect& oval_bounds,
+      Degrees start,
+      Degrees sweep,
+      const StrokeParameters& stroke);
+
   static std::unique_ptr<Geometry> MakeRoundRect(const Rect& rect,
                                                  const Size& radii);
 

--- a/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
@@ -99,6 +99,9 @@ TEST(EntityGeometryTest, FillPathGeometryCoversAreaNoInnerRect) {
 
 TEST(EntityGeometryTest, FillArcGeometryCoverage) {
   Rect oval_bounds = Rect::MakeLTRB(100, 100, 200, 200);
+  Matrix transform45 = Matrix::MakeTranslation(oval_bounds.GetCenter()) *
+                       Matrix::MakeRotationZ(Degrees(45)) *
+                       Matrix::MakeTranslation(-oval_bounds.GetCenter());
 
   {  // Sweeps <=-360 or >=360
     for (int start = -720; start <= 720; start += 10) {
@@ -240,6 +243,24 @@ TEST(EntityGeometryTest, FillArcGeometryCoverage) {
       }
     }
   }
+  {  // 45 degree tilted full circle
+    auto geometry =
+        Geometry::MakeFilledArc(oval_bounds, Degrees(0), Degrees(360), false);
+    ASSERT_TRUE(oval_bounds.TransformBounds(transform45).Contains(oval_bounds));
+
+    EXPECT_TRUE(geometry->GetCoverage(transform45)
+                    .value_or(Rect())
+                    .Contains(oval_bounds));
+  }
+  {  // 45 degree tilted mostly full circle
+    auto geometry =
+        Geometry::MakeFilledArc(oval_bounds, Degrees(3), Degrees(359), false);
+    ASSERT_TRUE(oval_bounds.TransformBounds(transform45).Contains(oval_bounds));
+
+    EXPECT_TRUE(geometry->GetCoverage(transform45)
+                    .value_or(Rect())
+                    .Contains(oval_bounds));
+  }
 }
 
 TEST(EntityGeometryTest, StrokeArcGeometryCoverage) {
@@ -247,6 +268,9 @@ TEST(EntityGeometryTest, StrokeArcGeometryCoverage) {
   Rect expanded_bounds = Rect::MakeLTRB(95, 95, 205, 205);
   Rect squared_bounds = Rect::MakeLTRB(100 - 5 * kSqrt2, 100 - 5 * kSqrt2,
                                        200 + 5 * kSqrt2, 200 + 5 * kSqrt2);
+  Matrix transform45 = Matrix::MakeTranslation(oval_bounds.GetCenter()) *
+                       Matrix::MakeRotationZ(Degrees(45)) *
+                       Matrix::MakeTranslation(-oval_bounds.GetCenter());
 
   StrokeParameters butt_params = {
       .width = 10.0f,
@@ -397,6 +421,46 @@ TEST(EntityGeometryTest, StrokeArcGeometryCoverage) {
             << "start: " << start + 225;
       }
     }
+  }
+  {  // 45 degree tilted full circle, butt caps
+    auto geometry = Geometry::MakeStrokedArc(  //
+        oval_bounds, Degrees(0), Degrees(360), butt_params);
+    ASSERT_TRUE(
+        oval_bounds.TransformBounds(transform45).Contains(expanded_bounds));
+
+    EXPECT_TRUE(geometry->GetCoverage(transform45)
+                    .value_or(Rect())
+                    .Contains(expanded_bounds));
+  }
+  {  // 45 degree tilted full circle, square caps
+    auto geometry = Geometry::MakeStrokedArc(  //
+        oval_bounds, Degrees(0), Degrees(360), square_params);
+    ASSERT_TRUE(
+        oval_bounds.TransformBounds(transform45).Contains(expanded_bounds));
+
+    EXPECT_TRUE(geometry->GetCoverage(transform45)
+                    .value_or(Rect())
+                    .Contains(squared_bounds));
+  }
+  {  // 45 degree tilted mostly full circle, butt caps
+    auto geometry = Geometry::MakeStrokedArc(  //
+        oval_bounds, Degrees(3), Degrees(359), butt_params);
+    ASSERT_TRUE(
+        oval_bounds.TransformBounds(transform45).Contains(expanded_bounds));
+
+    EXPECT_TRUE(geometry->GetCoverage(transform45)
+                    .value_or(Rect())
+                    .Contains(expanded_bounds));
+  }
+  {  // 45 degree tilted mostly full circle, square caps
+    auto geometry = Geometry::MakeStrokedArc(  //
+        oval_bounds, Degrees(3), Degrees(359), square_params);
+    ASSERT_TRUE(
+        oval_bounds.TransformBounds(transform45).Contains(expanded_bounds));
+
+    EXPECT_TRUE(geometry->GetCoverage(transform45)
+                    .value_or(Rect())
+                    .Contains(squared_bounds));
   }
 }
 

--- a/engine/src/flutter/impeller/geometry/point.h
+++ b/engine/src/flutter/impeller/geometry/point.h
@@ -331,6 +331,14 @@ using UintPoint32 = TPoint<uint32_t>;
 using Vector2 = Point;
 using Quad = std::array<Point, 4>;
 
+[[maybe_unused]]
+static constexpr impeller::Vector2 kQuadrantAxes[4] = {
+    {1.0f, 0.0f},
+    {0.0f, 1.0f},
+    {-1.0f, 0.0f},
+    {0.0f, -1.0f},
+};
+
 #undef ONLY_ON_FLOAT
 #undef ONLY_ON_FLOAT_M
 

--- a/engine/src/flutter/impeller/geometry/scalar.h
+++ b/engine/src/flutter/impeller/geometry/scalar.h
@@ -59,6 +59,18 @@ struct Radians {
   constexpr Radians operator-(Radians r) {
     return Radians{radians - r.radians};
   }
+
+  constexpr bool operator>(Radians r) { return radians > r.radians; }
+
+  constexpr bool operator>=(Radians r) { return radians >= r.radians; }
+
+  constexpr bool operator==(Radians r) { return radians == r.radians; }
+
+  constexpr bool operator!=(Radians r) { return radians != r.radians; }
+
+  constexpr bool operator<=(Radians r) { return radians <= r.radians; }
+
+  constexpr bool operator<(Radians r) { return radians < r.radians; }
 };
 
 struct Degrees {
@@ -83,6 +95,18 @@ struct Degrees {
   constexpr Degrees operator-(Degrees d) const {
     return Degrees{degrees - d.degrees};
   }
+
+  constexpr bool operator>(Degrees d) { return degrees > d.degrees; }
+
+  constexpr bool operator>=(Degrees d) { return degrees >= d.degrees; }
+
+  constexpr bool operator==(Degrees d) { return degrees == d.degrees; }
+
+  constexpr bool operator!=(Degrees d) { return degrees != d.degrees; }
+
+  constexpr bool operator<=(Degrees d) { return degrees <= d.degrees; }
+
+  constexpr bool operator<(Degrees d) { return degrees < d.degrees; }
 
   constexpr Degrees GetPositive() const {
     Scalar deg = std::fmod(degrees, 360.0f);

--- a/engine/src/flutter/impeller/geometry/scalar.h
+++ b/engine/src/flutter/impeller/geometry/scalar.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_GEOMETRY_SCALAR_H_
 
 #include <cfloat>
+#include <ostream>
 #include <type_traits>
 #include <valarray>
 
@@ -46,6 +47,18 @@ struct Radians {
   constexpr Radians() = default;
 
   explicit constexpr Radians(Scalar p_radians) : radians(p_radians) {}
+
+  constexpr bool IsFinite() const { return std::isfinite(radians); }
+
+  constexpr Radians operator-() { return Radians{-radians}; }
+
+  constexpr Radians operator+(Radians r) {
+    return Radians{radians + r.radians};
+  }
+
+  constexpr Radians operator-(Radians r) {
+    return Radians{radians - r.radians};
+  }
 };
 
 struct Degrees {
@@ -58,10 +71,42 @@ struct Degrees {
   constexpr operator Radians() const {
     return Radians{degrees * kPi / 180.0f};
   };
+
+  constexpr bool IsFinite() const { return std::isfinite(degrees); }
+
+  constexpr Degrees operator-() const { return Degrees{-degrees}; }
+
+  constexpr Degrees operator+(Degrees d) const {
+    return Degrees{degrees + d.degrees};
+  }
+
+  constexpr Degrees operator-(Degrees d) const {
+    return Degrees{degrees - d.degrees};
+  }
+
+  constexpr Degrees GetPositive() const {
+    Scalar deg = std::fmod(degrees, 360.0f);
+    if (deg < 0.0f) {
+      deg += 360.0f;
+    }
+    return Degrees{deg};
+  }
 };
 
 // NOLINTEND(google-explicit-constructor)
 
 }  // namespace impeller
+
+namespace std {
+
+inline std::ostream& operator<<(std::ostream& out, const impeller::Degrees& d) {
+  return out << "Degrees(" << d.degrees << ")";
+}
+
+inline std::ostream& operator<<(std::ostream& out, const impeller::Radians& r) {
+  return out << "Radians(" << r.radians << ")";
+}
+
+}  // namespace std
 
 #endif  // FLUTTER_IMPELLER_GEOMETRY_SCALAR_H_

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -11,6 +11,7 @@
 
 namespace {
 static constexpr int kPrecomputedDivisionCount = 1024;
+
 static int kPrecomputedDivisions[kPrecomputedDivisionCount] = {
     // clang-format off
      1,  2,  3,  4,  4,  4,  5,  5,  5,  6,  6,  6,  7,  7,  7,  7,
@@ -288,6 +289,13 @@ class GLESPathVertexWriter : public impeller::PathTessellator::VertexWriter {
   std::vector<uint16_t>& indices_;
 };
 
+static constexpr impeller::Vector2 kQuadrantAxes[4] = {
+    {1.0f, 0.0f},
+    {0.0f, 1.0f},
+    {-1.0f, 0.0f},
+    {0.0f, -1.0f},
+};
+
 }  // namespace
 
 namespace impeller {
@@ -435,6 +443,7 @@ Tessellator::Trigs Tessellator::GetTrigsForDivisions(size_t divisions) {
 
 using TessellatedVertexProc = Tessellator::TessellatedVertexProc;
 using EllipticalVertexGenerator = Tessellator::EllipticalVertexGenerator;
+using ArcVertexGenerator = Tessellator::ArcVertexGenerator;
 
 EllipticalVertexGenerator::EllipticalVertexGenerator(
     EllipticalVertexGenerator::GeneratorProc& generator,
@@ -482,6 +491,106 @@ EllipticalVertexGenerator Tessellator::StrokedCircle(
   } else {
     return FilledCircle(view_transform, center, radius);
   }
+}
+
+ArcVertexGenerator::ArcVertexGenerator(const ArcIteration& iteration,
+                                       Trigs&& trigs,
+                                       const Rect& oval_bounds,
+                                       bool use_center,
+                                       bool supports_triangle_fans)
+    : iteration_(iteration),
+      trigs_(std::move(trigs)),
+      oval_bounds_(oval_bounds),
+      use_center_(use_center),
+      half_width_(-1.0f),
+      cap_(Cap::kButt),
+      supports_triangle_fans_(supports_triangle_fans) {}
+
+ArcVertexGenerator::ArcVertexGenerator(const ArcIteration& iteration,
+                                       Trigs&& trigs,
+                                       const Rect& oval_bounds,
+                                       Scalar half_width,
+                                       Cap cap)
+    : iteration_(iteration),
+      trigs_(std::move(trigs)),
+      oval_bounds_(oval_bounds),
+      use_center_(false),
+      half_width_(half_width),
+      cap_(cap),
+      supports_triangle_fans_(false) {}
+
+PrimitiveType ArcVertexGenerator::GetTriangleType() const {
+  return (half_width_ < 0 && supports_triangle_fans_)
+             ? PrimitiveType::kTriangleFan
+             : PrimitiveType::kTriangleStrip;
+}
+
+size_t ArcVertexGenerator::GetVertexCount() const {
+  size_t count = iteration_.GetPointCount();
+  if (half_width_ > 0) {
+    FML_DCHECK(!use_center_);
+    FML_DCHECK(cap_ != Cap::kRound);
+    count *= 2;
+    if (cap_ == Cap::kSquare) {
+      count += 4;
+    }
+  } else if (supports_triangle_fans_) {
+    if (use_center_) {
+      count++;
+    }
+  } else {
+    // corrugated triangle fan
+    count += (count + 1) / 2;
+  }
+  return count;
+}
+
+void ArcVertexGenerator::GenerateVertices(
+    const TessellatedVertexProc& proc) const {
+  if (half_width_ > 0) {
+    FML_DCHECK(!use_center_);
+    Tessellator::GenerateStrokedArc(trigs_, iteration_, oval_bounds_,
+                                    half_width_, cap_, proc);
+  } else if (supports_triangle_fans_) {
+    Tessellator::GenerateFilledArcFan(trigs_, iteration_, oval_bounds_,
+                                      use_center_, proc);
+  } else {
+    Tessellator::GenerateFilledArcStrip(trigs_, iteration_, oval_bounds_,
+                                        use_center_, proc);
+  }
+}
+
+ArcVertexGenerator Tessellator::FilledArc(const Matrix& view_transform,
+                                          const Rect& oval_bounds,
+                                          Degrees start,
+                                          Degrees sweep,
+                                          bool use_center,
+                                          bool supports_triangle_fans) {
+  size_t divisions =
+      ComputeQuadrantDivisions(view_transform.GetMaxBasisLengthXY() *
+                               oval_bounds.GetSize().MaxDimension());
+
+  return ArcVertexGenerator(
+      ComputeArcQuadrantIterations(divisions + 1, start, sweep),
+      GetTrigsForDivisions(divisions), oval_bounds, use_center,
+      supports_triangle_fans);
+};
+
+ArcVertexGenerator Tessellator::StrokedArc(const Matrix& view_transform,
+                                           const Rect& oval_bounds,
+                                           Degrees start,
+                                           Degrees sweep,
+                                           Cap cap,
+                                           Scalar half_width) {
+  FML_DCHECK(half_width > 0);
+  FML_DCHECK(oval_bounds.IsSquare());
+  size_t divisions = ComputeQuadrantDivisions(
+      view_transform.GetMaxBasisLengthXY() *
+      (oval_bounds.GetSize().MaxDimension() + half_width));
+
+  return ArcVertexGenerator(
+      ComputeArcQuadrantIterations(divisions + 1, start, sweep),
+      GetTrigsForDivisions(divisions), oval_bounds, half_width, cap);
 }
 
 EllipticalVertexGenerator Tessellator::RoundCapLine(
@@ -578,7 +687,7 @@ void Tessellator::GenerateFilledCircle(
   // we can instead iterate forward and swap the x/y values of the
   // offset as the angles should be symmetric and thus should generate
   // symmetrically reversed trig vectors.
-  // Quadrant 2 connecting with Quadrant 2:
+  // Quadrant 2 connecting with Quadrant 3:
   for (auto& trig : trigs) {
     auto offset = trig * radius;
     proc({center.x + offset.y, center.y + offset.x});
@@ -638,6 +747,98 @@ void Tessellator::GenerateStrokedCircle(
     auto inner = trig * inner_radius;
     proc({center.x - outer.y, center.y + outer.x});
     proc({center.x - inner.y, center.y + inner.x});
+  }
+}
+
+void Tessellator::GenerateFilledArcFan(const Trigs& trigs,
+                                       const ArcIteration& iteration,
+                                       const Rect& oval_bounds,
+                                       bool use_center,
+                                       const TessellatedVertexProc& proc) {
+  Point center = oval_bounds.GetCenter();
+  Size radii = oval_bounds.GetSize() * 0.5f;
+
+  if (use_center) {
+    proc(center);
+  }
+  proc(center + iteration.start * radii);
+  for (size_t i = 0; i < iteration.quadrant_count; i++) {
+    auto quadrant = iteration.quadrants[i];
+    for (size_t j = quadrant.start_index; j < quadrant.end_index; j++) {
+      proc(center + trigs[j] * quadrant.axis * radii);
+    }
+  }
+  proc(center + iteration.end * radii);
+}
+
+void Tessellator::GenerateFilledArcStrip(const Trigs& trigs,
+                                         const ArcIteration& iteration,
+                                         const Rect& oval_bounds,
+                                         bool use_center,
+                                         const TessellatedVertexProc& proc) {
+  Point center = oval_bounds.GetCenter();
+  Size radii = oval_bounds.GetSize() * 0.5f;
+
+  Point origin;
+  if (use_center) {
+    origin = center;
+  } else {
+    Point midpoint = (iteration.start + iteration.end) * 0.5f;
+    origin = center + midpoint * radii;
+  }
+
+  proc(origin);
+  proc(center + iteration.start * radii);
+  bool insert_origin = false;
+  for (size_t i = 0; i < iteration.quadrant_count; i++) {
+    auto quadrant = iteration.quadrants[i];
+    for (size_t j = quadrant.start_index; j < quadrant.end_index; j++) {
+      if (insert_origin) {
+        proc(origin);
+      }
+      insert_origin = !insert_origin;
+      proc(center + trigs[j] * quadrant.axis * radii);
+    }
+  }
+  if (insert_origin) {
+    proc(origin);
+  }
+  proc(center + iteration.end * radii);
+}
+
+void Tessellator::GenerateStrokedArc(const Trigs& trigs,
+                                     const ArcIteration& iteration,
+                                     const Rect& oval_bounds,
+                                     Scalar half_width,
+                                     Cap cap,
+                                     const TessellatedVertexProc& proc) {
+  Point center = oval_bounds.GetCenter();
+  Size base_radii = oval_bounds.GetSize() * 0.5f;
+  Size inner_radii = base_radii - Size(half_width, half_width);
+  Size outer_radii = base_radii + Size(half_width, half_width);
+
+  FML_DCHECK(cap != Cap::kRound);
+  if (cap == Cap::kSquare) {
+    Vector2 offset =
+        Vector2{iteration.start.y, -iteration.start.x} * half_width;
+    proc(center + iteration.start * inner_radii + offset);
+    proc(center + iteration.start * outer_radii + offset);
+  }
+  proc(center + iteration.start * inner_radii);
+  proc(center + iteration.start * outer_radii);
+  for (size_t i = 0; i < iteration.quadrant_count; i++) {
+    auto quadrant = iteration.quadrants[i];
+    for (size_t j = quadrant.start_index; j < quadrant.end_index; j++) {
+      proc(center + trigs[j] * quadrant.axis * inner_radii);
+      proc(center + trigs[j] * quadrant.axis * outer_radii);
+    }
+  }
+  proc(center + iteration.end * inner_radii);
+  proc(center + iteration.end * outer_radii);
+  if (cap == Cap::kSquare) {
+    Vector2 offset = Vector2{-iteration.end.y, iteration.end.x} * half_width;
+    proc(center + iteration.end * inner_radii + offset);
+    proc(center + iteration.end * outer_radii + offset);
   }
 }
 
@@ -732,6 +933,107 @@ void Tessellator::GenerateFilledRoundRect(
     proc({right + offset.x, bottom + offset.y});
     proc({right + offset.x, top - offset.y});
   }
+}
+
+const Tessellator::ArcIteration Tessellator::ComputeCircleArcIterations(
+    size_t count) {
+  return {
+      {1.0f, 0.0f},
+      {1.0f, 0.0f},
+      4u,
+      {
+          {kQuadrantAxes[0], 1u, count},
+          {kQuadrantAxes[1], 0u, count},
+          {kQuadrantAxes[2], 0u, count},
+          {kQuadrantAxes[3], 0u, count},
+          {{}, 0u, 0u},
+      },
+  };
+}
+
+Tessellator::ArcIteration Tessellator::ComputeArcQuadrantIterations(
+    size_t trig_size,
+    Degrees start,
+    Degrees sweep) {
+  if (sweep.degrees == 0 || !start.IsFinite() || !sweep.IsFinite()) {
+    return {};
+  }
+
+  if (sweep.degrees < 0) {
+    start = start + sweep;
+    sweep = -sweep;
+  }
+
+  size_t steps = trig_size - 1;
+
+  if (sweep.degrees >= 360) {
+    return ComputeCircleArcIterations(steps);
+  }
+
+  start = start.GetPositive();
+  Degrees end = start + sweep;
+  FML_DCHECK(start.degrees >= 0.0f &&  //
+             start.degrees < 360.0f);
+  FML_DCHECK(end.degrees >= start.degrees &&
+             end.degrees < start.degrees + 360.0f);
+
+  ArcIteration iterations;
+  iterations.start = impeller::Matrix::CosSin(start);
+  iterations.end = impeller::Matrix::CosSin(end);
+
+  // We nudge the start and stop by 1/10th of a step so we don't end
+  // up with degenerately small steps at the start and end of the
+  // arc.
+  Degrees nudge = Degrees((90.0f / steps) * 0.1f);
+
+  if ((start + nudge).degrees >= (end - nudge).degrees) {
+    iterations.quadrant_count = 0u;
+    return iterations;
+  }
+
+  int cur_quadrant =
+      static_cast<int>(std::floor((start + nudge).degrees / 90.0f));
+  int end_quadrant =
+      static_cast<int>(std::floor((end - nudge).degrees / 90.0f));
+  FML_DCHECK(cur_quadrant >= 0 &&  //
+             cur_quadrant <= 4);
+  FML_DCHECK(end_quadrant >= cur_quadrant &&  //
+             end_quadrant <= cur_quadrant + 4);
+  FML_DCHECK(cur_quadrant * 90 <= (start + nudge).degrees);
+  FML_DCHECK(end_quadrant * 90 + 90 >= (end - nudge).degrees);
+
+  auto next_step = [steps](Degrees angle, int quadrant) -> size_t {
+    Scalar quadrant_fract = angle.degrees / 90.0f - quadrant;
+    return static_cast<size_t>(std::ceil(quadrant_fract * steps));
+  };
+
+  int i = 0;
+  iterations.quadrants[i] = {
+      kQuadrantAxes[cur_quadrant % 4],
+      next_step(start + nudge, cur_quadrant),
+      steps,
+  };
+  if (iterations.quadrants[0].end_index > iterations.quadrants[0].start_index) {
+    i++;
+  }
+  while (cur_quadrant < end_quadrant) {
+    iterations.quadrants[i++] = {
+        kQuadrantAxes[(++cur_quadrant) % 4],
+        0u,
+        steps,
+    };
+  }
+  FML_DCHECK(i <= 5);
+  if (i > 0) {
+    iterations.quadrants[i - 1].end_index =
+        next_step(end - nudge, cur_quadrant);
+    if (iterations.quadrants[i - 1].end_index <=
+        iterations.quadrants[i - 1].start_index) {
+      i--;
+    }
+  }
+  iterations.quadrant_count = i;
+  return iterations;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -289,13 +289,6 @@ class GLESPathVertexWriter : public impeller::PathTessellator::VertexWriter {
   std::vector<uint16_t>& indices_;
 };
 
-static constexpr impeller::Vector2 kQuadrantAxes[4] = {
-    {1.0f, 0.0f},
-    {0.0f, 1.0f},
-    {-1.0f, 0.0f},
-    {0.0f, -1.0f},
-};
-
 }  // namespace
 
 namespace impeller {
@@ -972,10 +965,8 @@ Tessellator::ArcIteration Tessellator::ComputeArcQuadrantIterations(
 
   start = start.GetPositive();
   Degrees end = start + sweep;
-  FML_DCHECK(start.degrees >= 0.0f &&  //
-             start.degrees < 360.0f);
-  FML_DCHECK(end.degrees >= start.degrees &&
-             end.degrees < start.degrees + 360.0f);
+  FML_DCHECK(start.degrees >= 0.0f && start.degrees < 360.0f);
+  FML_DCHECK(end >= start && end.degrees < start.degrees + 360.0f);
 
   ArcIteration iterations;
   iterations.start = impeller::Matrix::CosSin(start);
@@ -986,7 +977,7 @@ Tessellator::ArcIteration Tessellator::ComputeArcQuadrantIterations(
   // arc.
   Degrees nudge = Degrees((90.0f / steps) * 0.1f);
 
-  if ((start + nudge).degrees >= (end - nudge).degrees) {
+  if ((start + nudge) >= (end - nudge)) {
     iterations.quadrant_count = 0u;
     return iterations;
   }
@@ -1009,7 +1000,7 @@ Tessellator::ArcIteration Tessellator::ComputeArcQuadrantIterations(
 
   int i = 0;
   iterations.quadrants[i] = {
-      kQuadrantAxes[cur_quadrant % 4],
+      kQuadrantAxes[cur_quadrant & 3],
       next_step(start + nudge, cur_quadrant),
       steps,
   };

--- a/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
@@ -526,5 +526,268 @@ TEST(TessellatorTest, EarlyReturnEmptyConvexShape) {
   EXPECT_TRUE(indices.empty());
 }
 
+namespace {
+
+// Tests the basic relationships of the angles iterated according to the
+// rules of the ArcIteration struct. Each step iterated should be just
+// about the same angular distance from the previous step, computed using
+// the Cross product of the adjacent vectors, which should be the same as
+// the sine of the angle between them when using unit vectors.
+//
+// Special support for shorter starting and ending steps to bridge the gap
+// from the true arc start and the true arc end and the first and last
+// angles iterated from the trigs.
+void TestArcIterator(const impeller::Tessellator::ArcIteration arc_iteration,
+                     const impeller::Tessellator::Trigs& trigs,
+                     Degrees start,
+                     Degrees sweep,
+                     const std::string& label) {
+  EXPECT_POINT_NEAR(arc_iteration.start, impeller::Matrix::CosSin(start))
+      << label;
+  EXPECT_POINT_NEAR(arc_iteration.end, impeller::Matrix::CosSin(start + sweep))
+      << label;
+  if (arc_iteration.quadrant_count == 0u) {
+    // There is just the begin and end angle and there are no constraints
+    // on how far apart they should be, but the end vector should be
+    // non-counterclockwise from the start vector.
+    EXPECT_GE(arc_iteration.start.Cross(arc_iteration.end), 0.0f);
+    return;
+  }
+
+  const size_t steps = trigs.size() - 1;
+  const Scalar step_angle = kPiOver2 / steps;
+
+  // The first and last steps are allowed to be from 0.1 to 1.1 in size
+  // as we don't want to iterate an extra step that is less than 0.1 steps
+  // from the begin/end angles. We use min/max values that are ever so
+  // slightly larger than that to avoid round-off errors.
+  const Scalar edge_min_cross = std::sin(step_angle * 0.099f);
+  const Scalar edge_max_cross = std::sin(step_angle * 1.101f);
+  const Scalar typical_min_cross = std::sin(step_angle * 0.999f);
+  const Scalar typical_max_cross = std::sin(step_angle * 1.001f);
+
+  Vector2 cur_vector;
+  auto trace = [&cur_vector](Vector2 vector, Scalar min_cross, Scalar max_cross,
+                             const std::string& label) -> void {
+    EXPECT_GT(cur_vector.Cross(vector), min_cross) << label;
+    EXPECT_LT(cur_vector.Cross(vector), max_cross) << label;
+    cur_vector = vector;
+  };
+
+  // The first edge encountered in the loop should be judged by the edge
+  // conditions. After that the steps derived from the Trigs should be
+  // judged by the typical min/max values.
+  Scalar min_cross = edge_min_cross;
+  Scalar max_cross = edge_max_cross;
+
+  cur_vector = arc_iteration.start;
+  for (size_t i = 0; i < arc_iteration.quadrant_count; i++) {
+    auto& quadrant = arc_iteration.quadrants[i];
+    EXPECT_LT(quadrant.start_index, quadrant.end_index)
+        << label << ", quadrant: " << i;
+    for (size_t j = quadrant.start_index; j < quadrant.end_index; j++) {
+      trace(trigs[j] * quadrant.axis, min_cross, max_cross,
+            label + ", quadrant: " + std::to_string(i) +
+                ", step: " + std::to_string(j));
+      // At this point we can guarantee that we've already used the initial
+      // min/max values, now replace them with the typical values.
+      min_cross = typical_min_cross;
+      max_cross = typical_max_cross;
+    }
+  }
+
+  // The jump to the end angle should be judged by the edge conditions.
+  trace(arc_iteration.end, edge_min_cross, edge_max_cross,
+        label + " step to end");
+}
+
+void TestFullCircleArc(Degrees start, Degrees sweep) {
+  auto label =
+      std::to_string(start.degrees) + " += " + std::to_string(sweep.degrees);
+
+  Tessellator tessellator;
+  const auto trigs = tessellator.GetTrigsForDeviceRadius(100);
+  size_t steps = trigs.size() - 1;
+  const auto& arc_iteration =
+      impeller::Tessellator::ComputeArcQuadrantIterations(trigs.size(), start,
+                                                          sweep);
+
+  EXPECT_EQ(arc_iteration.start, Vector2(1.0f, 0.0f)) << label;
+  EXPECT_EQ(arc_iteration.quadrant_count, 4u) << label;
+  EXPECT_EQ(arc_iteration.quadrants[0].axis, Vector2(1.0f, 0.0f)) << label;
+  EXPECT_EQ(arc_iteration.quadrants[0].start_index, 1u) << label;
+  EXPECT_EQ(arc_iteration.quadrants[0].end_index, steps) << label;
+  EXPECT_EQ(arc_iteration.quadrants[1].axis, Vector2(0.0f, 1.0f)) << label;
+  EXPECT_EQ(arc_iteration.quadrants[1].start_index, 0u) << label;
+  EXPECT_EQ(arc_iteration.quadrants[1].end_index, steps) << label;
+  EXPECT_EQ(arc_iteration.quadrants[2].axis, Vector2(-1.0f, 0.0f)) << label;
+  EXPECT_EQ(arc_iteration.quadrants[2].start_index, 0u) << label;
+  EXPECT_EQ(arc_iteration.quadrants[2].end_index, steps) << label;
+  EXPECT_EQ(arc_iteration.quadrants[3].axis, Vector2(0.0f, -1.0f)) << label;
+  EXPECT_EQ(arc_iteration.quadrants[3].start_index, 0u) << label;
+  EXPECT_EQ(arc_iteration.quadrants[3].end_index, steps) << label;
+  EXPECT_EQ(arc_iteration.end, Vector2(1.0f, 0.0f)) << label;
+
+  // For full circle arcs the original start and sweep are ignored and it
+  // returns an iterator that always goes from 0->360.
+  TestArcIterator(arc_iteration, trigs, Degrees(0), Degrees(360),
+                  "Full Circle(" + label + ")");
+}
+
+}  // namespace
+
+TEST(TessellatorTest, ArcIterationsFullCircle) {
+  // Anything with a sweep <=-360 or >=360 is a full circle regardless of
+  // starting angle
+  for (int start = -720; start < 720; start += 30) {
+    for (int sweep = 360; sweep < 1080; sweep += 45) {
+      TestFullCircleArc(Degrees(start), Degrees(sweep));
+      TestFullCircleArc(Degrees(start), Degrees(-sweep));
+    }
+  }
+}
+
+namespace {
+static void CheckOneQuadrant(Degrees start, Degrees sweep) {
+  Tessellator tessellator;
+  const auto trigs = tessellator.GetTrigsForDeviceRadius(100);
+  const auto& arc_iteration =
+      Tessellator::ComputeArcQuadrantIterations(trigs.size(), start, sweep);
+
+  EXPECT_POINT_NEAR(arc_iteration.start, Matrix::CosSin(start));
+  EXPECT_EQ(arc_iteration.quadrant_count, 1u);
+  EXPECT_POINT_NEAR(arc_iteration.end, Matrix::CosSin(start + sweep));
+
+  std::string label = "Quadrant(" + std::to_string(start.degrees) +
+                      " += " + std::to_string(sweep.degrees) + ")";
+  TestArcIterator(arc_iteration, trigs, start, sweep, label);
+}
+}  // namespace
+
+TEST(TessellatorTest, ArcIterationsVariousStartAnglesNearQuadrantAxis) {
+  Tessellator tessellator;
+  const auto trigs = tessellator.GetTrigsForDeviceRadius(100);
+  const Degrees sweep(45);
+
+  for (int start_i = -1000; start_i < 1000; start_i += 5) {
+    Scalar start_degrees = start_i * 0.01f;
+    for (int quadrant = -360; quadrant <= 360; quadrant += 90) {
+      const Degrees start(quadrant + start_degrees);
+      const auto& arc_iteration =
+          Tessellator::ComputeArcQuadrantIterations(trigs.size(), start, sweep);
+
+      TestArcIterator(arc_iteration, trigs, start, sweep,
+                      "Various angles(" + std::to_string(start.degrees) +
+                          " += " + std::to_string(sweep.degrees));
+    }
+  }
+}
+
+TEST(TessellatorTest, ArcIterationsVariousEndAnglesNearQuadrantAxis) {
+  Tessellator tessellator;
+  const auto trigs = tessellator.GetTrigsForDeviceRadius(100);
+
+  for (int sweep_i = 5; sweep_i < 20000; sweep_i += 5) {
+    const Degrees sweep(sweep_i * 0.01f);
+    for (int quadrant = -360; quadrant <= 360; quadrant += 90) {
+      const Degrees start(quadrant + 80);
+      const auto& arc_iteration =
+          Tessellator::ComputeArcQuadrantIterations(trigs.size(), start, sweep);
+
+      TestArcIterator(arc_iteration, trigs, start, sweep,
+                      "Various angles(" + std::to_string(start.degrees) +
+                          " += " + std::to_string(sweep.degrees));
+    }
+  }
+}
+
+TEST(TessellatorTest, ArcIterationsVariousTinyArcsNearQuadrantAxis) {
+  Tessellator tessellator;
+  const auto trigs = tessellator.GetTrigsForDeviceRadius(100);
+  const Degrees sweep(0.1f);
+
+  for (int start_i = -1000; start_i < 1000; start_i += 5) {
+    Scalar start_degrees = start_i * 0.01f;
+    for (int quadrant = -360; quadrant <= 360; quadrant += 90) {
+      const Degrees start(quadrant + start_degrees);
+      const auto& arc_iteration =
+          Tessellator::ComputeArcQuadrantIterations(trigs.size(), start, sweep);
+      ASSERT_EQ(arc_iteration.quadrant_count, 0u);
+
+      TestArcIterator(arc_iteration, trigs, start, sweep,
+                      "Various angles(" + std::to_string(start.degrees) +
+                          " += " + std::to_string(sweep.degrees));
+    }
+  }
+}
+
+TEST(TessellatorTest, ArcIterationsOnlyFirstQuadrant) {
+  CheckOneQuadrant(Degrees(90 * 0 + 30), Degrees(30));
+}
+
+TEST(TessellatorTest, ArcIterationsOnlySecondQuadrant) {
+  CheckOneQuadrant(Degrees(90 * 1 + 30), Degrees(30));
+}
+
+TEST(TessellatorTest, ArcIterationsOnlyThirdQuadrant) {
+  CheckOneQuadrant(Degrees(90 * 2 + 30), Degrees(30));
+}
+
+TEST(TessellatorTest, ArcIterationsOnlyFourthQuadrant) {
+  CheckOneQuadrant(Degrees(90 * 3 + 30), Degrees(30));
+}
+
+namespace {
+static void CheckFiveQuadrants(Degrees start, Degrees sweep) {
+  std::string label =
+      std::to_string(start.degrees) + " += " + std::to_string(sweep.degrees);
+
+  Tessellator tessellator;
+  const auto trigs = tessellator.GetTrigsForDeviceRadius(100);
+  const auto& arc_iteration =
+      Tessellator::ComputeArcQuadrantIterations(trigs.size(), start, sweep);
+  size_t steps = trigs.size() - 1;
+
+  EXPECT_POINT_NEAR(arc_iteration.start, Matrix::CosSin(start)) << label;
+  EXPECT_EQ(arc_iteration.quadrant_count, 5u) << label;
+
+  // quadrant 0 start index depends on angle
+  EXPECT_EQ(arc_iteration.quadrants[0].end_index, steps) << label;
+
+  EXPECT_EQ(arc_iteration.quadrants[1].start_index, 0u) << label;
+  EXPECT_EQ(arc_iteration.quadrants[1].end_index, steps) << label;
+
+  EXPECT_EQ(arc_iteration.quadrants[2].start_index, 0u) << label;
+  EXPECT_EQ(arc_iteration.quadrants[2].end_index, steps) << label;
+
+  EXPECT_EQ(arc_iteration.quadrants[3].start_index, 0u) << label;
+  EXPECT_EQ(arc_iteration.quadrants[3].end_index, steps) << label;
+
+  EXPECT_EQ(arc_iteration.quadrants[4].start_index, 0u) << label;
+  // quadrant 4 end index depends on angle
+
+  EXPECT_POINT_NEAR(arc_iteration.end, Matrix::CosSin(start + sweep)) << label;
+
+  TestArcIterator(arc_iteration, trigs, start, sweep,
+                  "Five quadrants(" + label + ")");
+}
+}  // namespace
+
+TEST(TessellatorTest, ArcIterationsAllQuadrantsFromFirst) {
+  CheckFiveQuadrants(Degrees(90 * 0 + 60), Degrees(330));
+}
+
+TEST(TessellatorTest, ArcIterationsAllQuadrantsFromSecond) {
+  CheckFiveQuadrants(Degrees(90 * 1 + 60), Degrees(330));
+}
+
+TEST(TessellatorTest, ArcIterationsAllQuadrantsFromThird) {
+  CheckFiveQuadrants(Degrees(90 * 2 + 60), Degrees(330));
+}
+
+TEST(TessellatorTest, ArcIterationsAllQuadrantsFromFourth) {
+  CheckFiveQuadrants(Degrees(90 * 3 + 60), Degrees(330));
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Currently arcs are rendered by creating/allocating a Path and using the path rendering code. We now directly tessellate most arcs (all filled arcs and any stroked arcs that avoid "use_center" and "round caps") using the most efficient mechanism to place the necessary vertices into the host buffers.