### PR TITLE
Fix wrong path in 'archives' for release mode iOS DDM artifacts.

### DIFF
--- a/engine/src/flutter/ci/builders/mac_ios_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/mac_ios_engine_ddm.json
@@ -265,7 +265,7 @@
       "realm": "production"
     },
     {
-      "source": "out/debug_ddm/artifacts.zip",
+      "source": "out/release_ddm/artifacts.zip",
       "destination": "ios-release-ddm/artifacts.zip",
       "realm": "production"
     }


### PR DESCRIPTION
This is intended to fix a bug where DDM iOS builds were not working in release mode and failing at runtime with an error like:
```
Failed to find snapshot at /private/var/containers/Bundle/Application/CA6AA16E-2C5E-4C1F-A650-E48AC9AC68BD/my_app.app/Frameworks/ios.framework/ios.assets/kernel_blob.bin:
Error Domain=NSCocoaErrorDomain Code=260 "The file “kernel_blob.bin” couldn’t be opened because there is no such file."
UserInfo={NSURL=kernel_blob.bin -- 
file:///private/var/containers/Bundle/Application/CA6AA16E-2C5E-4C1F-A650-E48AC9AC68BD/my_app.app/Frameworks/ios.framework/ios.assets/, NSFilePath=/private/var/containers/Bundle/Application/CA6AA16E-2C5E-4C1F-A650-E48AC9AC68BD/my_app.app/Frameworks/ios.framework/ios.assets/kernel_blob.bin, NSUnderlyingError=0x302f3b480 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```

I think what was happening is the Google internal build infra was trying to create a release mode app with no kernel_blob.bin etc, but it actually contained a flutter.so built for debug mode which was expecting to find kernel_blob.bin.

See internal bug b/419694561 for full context.