### PR TITLE
Update deprecated vector_math calls

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1742,7 +1742,7 @@ class _RenderLargeTitle extends RenderShiftedBox {
 
     super.applyPaintTransform(child, transform);
 
-    transform.scale(_scale, _scale);
+    transform.scaledByDouble(_scale, _scale, _scale, 1);
   }
 
   @override
@@ -1776,8 +1776,8 @@ class _RenderLargeTitle extends RenderShiftedBox {
 
     final Matrix4 transform =
         Matrix4.identity()
-          ..scale(1.0 / _scale, 1.0 / _scale, 1.0)
-          ..translate(-childOffset.dx, -childOffset.dy);
+          ..scaleByDouble(1.0 / _scale, 1.0 / _scale, 1.0, 1)
+          ..translateByDouble(-childOffset.dx, -childOffset.dy, 0, 1);
 
     return result.addWithRawTransform(
       transform: transform,
@@ -2357,7 +2357,7 @@ class _BackChevron extends StatelessWidget {
     switch (textDirection) {
       case TextDirection.rtl:
         iconWidget = Transform(
-          transform: Matrix4.identity()..scale(-1.0, 1.0, 1.0),
+          transform: Matrix4.identity()..scaleByDouble(-1.0, 1.0, 1.0, 1),
           alignment: Alignment.center,
           transformHitTests: false,
           child: iconWidget,

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1742,7 +1742,7 @@ class _RenderLargeTitle extends RenderShiftedBox {
 
     super.applyPaintTransform(child, transform);
 
-    transform.scaledByDouble(_scale, _scale, _scale, 1);
+    transform.scaleByDouble(_scale, _scale, _scale, 1);
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -141,9 +141,9 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
         return Transform(
           transform:
               Matrix4.identity()
-                ..translate(desiredSize.width / 2, desiredSize.height / 2)
+                ..translateByDouble(desiredSize.width / 2, desiredSize.height / 2, 0, 1)
                 ..rotateZ(math.pi)
-                ..translate(-desiredSize.width / 2, -desiredSize.height / 2),
+                ..translateByDouble(-desiredSize.width / 2, -desiredSize.height / 2, 0, 1),
           child: handle,
         );
       // iOS should draw an invisible box so the handle can still receive gestures

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -103,7 +103,7 @@ class _OffsetTransformPart extends _TransformPart {
 
   @override
   Matrix4 multiply(Matrix4 rhs) {
-    return rhs.clone()..leftTranslate(offset.dx, offset.dy);
+    return rhs.clone()..leftTranslateByDouble(offset.dx, offset.dy, 0, 1);
   }
 }
 

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -333,7 +333,8 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
               begin: widget.expandedTitleScale,
               end: 1.0,
             ).transform(t);
-            final Matrix4 scaleTransform = Matrix4.identity()..scale(scaleValue, scaleValue, 1.0);
+            final Matrix4 scaleTransform =
+                Matrix4.identity()..scaleByDouble(scaleValue, scaleValue, 1.0, 1);
             final Alignment titleAlignment = _getTitleAlignment(effectiveCenterTitle);
             children.add(
               Padding(

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1604,8 +1604,8 @@ class _RenderDecoration extends RenderBox
       final double dy = lerpDouble(0.0, floatingY - labelOffset.dy, t)!;
       _labelTransform =
           Matrix4.identity()
-            ..translate(dx, labelOffset.dy + dy)
-            ..scale(scale);
+            ..translateByDouble(dx, labelOffset.dy + dy,0,1)
+            ..scaleByDouble(scale, scale, scale, 1);
       layer = context.pushTransform(
         needsCompositing,
         offset,
@@ -1636,7 +1636,7 @@ class _RenderDecoration extends RenderBox
       final Offset labelOffset = _boxParentData(label!).offset;
       transform
         ..multiply(_labelTransform!)
-        ..translate(-labelOffset.dx, -labelOffset.dy);
+        ..translateByDouble(-labelOffset.dx, -labelOffset.dy, 0, 1);
     }
     super.applyPaintTransform(child, transform);
   }

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1604,7 +1604,7 @@ class _RenderDecoration extends RenderBox
       final double dy = lerpDouble(0.0, floatingY - labelOffset.dy, t)!;
       _labelTransform =
           Matrix4.identity()
-            ..translateByDouble(dx, labelOffset.dy + dy,0,1)
+            ..translateByDouble(dx, labelOffset.dy + dy, 0, 1)
             ..scaleByDouble(scale, scale, scale, 1);
       layer = context.pushTransform(
         needsCompositing,

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -1261,10 +1261,10 @@ void _updateScaledTransform(Matrix4 transform, double scale, Size size) {
   if (scale == 1.0) {
     return;
   }
-  transform.scale(scale, scale);
+  transform.scaleByDouble(scale, scale, scale, 1);
   final double dx = ((size.width * scale) - size.width) / 2;
   final double dy = ((size.height * scale) - size.height) / 2;
-  transform.translate(-dx, -dy);
+  transform.translateByDouble(-dx, -dy, 0, 1);
 }
 
 mixin _ZoomTransitionBase<S extends StatefulWidget> on State<S> {

--- a/packages/flutter/lib/src/material/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar.dart
@@ -370,7 +370,7 @@ class _TextSelectionToolbarTrailingEdgeAlignRenderBox extends RenderProxyBox {
   @override
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     final ToolbarItemsParentData childParentData = child.parentData! as ToolbarItemsParentData;
-    transform.translate(childParentData.offset.dx, childParentData.offset.dy);
+    transform.translateByDouble(childParentData.offset.dx, childParentData.offset.dy, 0, 1);
     super.applyPaintTransform(child, transform);
   }
 }

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -12,10 +12,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui show Gradient, lerpDouble;
 
 import 'package:flutter/foundation.dart';
-import 'package:vector_math/vector_math_64.dart';
-
-import 'alignment.dart';
-import 'basic_types.dart';
+import 'package:flutter/rendering.dart';
 
 class _ColorsAndStops {
   _ColorsAndStops(this.colors, this.stops);
@@ -121,7 +118,7 @@ class GradientRotation extends GradientTransform {
     final double originY = -sinRadians * center.dx + oneMinusCosRadians * center.dy;
 
     return Matrix4.identity()
-      ..translate(originX, originY)
+      ..translateByDouble(originX, originY, 0, 1)
       ..rotateZ(radians);
   }
 

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -12,7 +12,10 @@ import 'dart:math' as math;
 import 'dart:ui' as ui show Gradient, lerpDouble;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/rendering.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'alignment.dart';
+import 'basic_types.dart';
 
 class _ColorsAndStops {
   _ColorsAndStops(this.colors, this.stops);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -17,8 +17,7 @@ import 'dart:ui' as ui show ViewConstraints, lerpDouble;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-
-import 'package:vector_math/vector_math_64.dart';
+import 'package:vector_math/vector_math_64.dart' show Matrix4, Vector3;
 
 import 'debug.dart';
 import 'object.dart';
@@ -3037,7 +3036,7 @@ abstract class RenderBox extends RenderObject {
     }());
     final BoxParentData childParentData = child.parentData! as BoxParentData;
     final Offset offset = childParentData.offset;
-    transform.translate(offset.dx, offset.dy);
+    transform.translateByDouble(offset.dx, offset.dy, 0, 1);
   }
 
   /// Convert the given point from the global coordinate system in logical pixels

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -18,7 +18,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:vector_math/vector_math_64.dart';
+import 'package:vector_math/vector_math_64.dart' show Vector4;
 
 import 'debug.dart';
 
@@ -1491,7 +1491,7 @@ class OffsetLayer extends ContainerLayer {
   @override
   void applyTransform(Layer? child, Matrix4 transform) {
     assert(child != null);
-    transform.translate(offset.dx, offset.dy);
+    transform.translateByDouble(offset.dx, offset.dy, 0, 1);
   }
 
   @override
@@ -1519,7 +1519,7 @@ class OffsetLayer extends ContainerLayer {
   ui.Scene _createSceneForImage(Rect bounds, {double pixelRatio = 1.0}) {
     final ui.SceneBuilder builder = ui.SceneBuilder();
     final Matrix4 transform = Matrix4.diagonal3Values(pixelRatio, pixelRatio, 1);
-    transform.translate(-(bounds.left + offset.dx), -(bounds.top + offset.dy));
+    transform.translateByDouble(-(bounds.left + offset.dx), -(bounds.top + offset.dy), 0, 1);
     builder.pushTransform(transform.storage);
     return buildScene(builder);
   }
@@ -2578,7 +2578,7 @@ class LeaderLayer extends ContainerLayer {
   @override
   void applyTransform(Layer? child, Matrix4 transform) {
     if (offset != Offset.zero) {
-      transform.translate(offset.dx, offset.dy);
+      transform.translateByDouble(offset.dx, offset.dy, 0, 1);
     }
   }
 
@@ -2826,7 +2826,7 @@ class FollowerLayer extends ContainerLayer {
     // of the leader layer, to account for the leader's additional paint offset
     // and layer offset (LeaderLayer.offset).
     leader.applyTransform(null, forwardTransform);
-    forwardTransform.translate(linkedOffset!.dx, linkedOffset!.dy);
+    forwardTransform.translateByDouble(linkedOffset!.dx, linkedOffset!.dy, 0, 1);
 
     final Matrix4 inverseTransform = _collectTransformForLayerChain(inverseLayers);
 

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1020,7 +1020,7 @@ class RenderListWheelViewport extends RenderBox
     final ListWheelParentData childParentData = child.parentData! as ListWheelParentData;
     // Save the final transform that accounts both for the offset and cylindrical transform.
     final Matrix4 transform = _centerOriginTransform(cylindricalTransform)
-      ..translate(paintOriginOffset.dx, paintOriginOffset.dy);
+      ..translateByDouble(paintOriginOffset.dx, paintOriginOffset.dy, 0, 1);
     childParentData.transform = transform;
   }
 
@@ -1028,9 +1028,9 @@ class RenderListWheelViewport extends RenderBox
   /// magnified area.
   Matrix4 _magnifyTransform() {
     final Matrix4 magnify = Matrix4.identity();
-    magnify.translate(size.width * (-_offAxisFraction + 0.5), size.height / 2);
-    magnify.scale(_magnification, _magnification, _magnification);
-    magnify.translate(-size.width * (-_offAxisFraction + 0.5), -size.height / 2);
+    magnify.translateByDouble(size.width * (-_offAxisFraction + 0.5), size.height / 2, 0, 1);
+    magnify.scaledByDouble(_magnification, _magnification, _magnification, 1.0);
+    magnify.translateByDouble(-size.width * (-_offAxisFraction + 0.5), -size.height / 2, 0, 1);
     return magnify;
   }
 
@@ -1039,14 +1039,18 @@ class RenderListWheelViewport extends RenderBox
   Matrix4 _centerOriginTransform(Matrix4 originalMatrix) {
     final Matrix4 result = Matrix4.identity();
     final Offset centerOriginTranslation = Alignment.center.alongSize(size);
-    result.translate(
+    result.translateByDouble(
       centerOriginTranslation.dx * (-_offAxisFraction * 2 + 1),
       centerOriginTranslation.dy,
+      0,
+      1,
     );
     result.multiply(originalMatrix);
-    result.translate(
+    result.translateByDouble(
       -centerOriginTranslation.dx * (-_offAxisFraction * 2 + 1),
       -centerOriginTranslation.dy,
+      0,
+      1,
     );
     return result;
   }

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1027,11 +1027,10 @@ class RenderListWheelViewport extends RenderBox
   /// Return the Matrix4 transformation that would zoom in content in the
   /// magnified area.
   Matrix4 _magnifyTransform() {
-    final Matrix4 magnify = Matrix4.identity();
-    magnify.translateByDouble(size.width * (-_offAxisFraction + 0.5), size.height / 2, 0, 1);
-    magnify.scaledByDouble(_magnification, _magnification, _magnification, 1.0);
-    magnify.translateByDouble(-size.width * (-_offAxisFraction + 0.5), -size.height / 2, 0, 1);
-    return magnify;
+    return Matrix4.identity()
+      ..translateByDouble(size.width * (-_offAxisFraction + 0.5), size.height / 2, 0, 1)
+      ..scaleByDouble(_magnification, _magnification, _magnification, 1.0)
+      ..translateByDouble(-size.width * (-_offAxisFraction + 0.5), -size.height / 2, 0, 1);
   }
 
   /// Apply incoming transformation with the transformation's origin at the

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -780,7 +780,7 @@ class PaintingContext extends ClipContext {
     final Matrix4 effectiveTransform =
         Matrix4.translationValues(offset.dx, offset.dy, 0.0)
           ..multiply(transform)
-          ..translate(-offset.dx, -offset.dy);
+          ..translateByDouble(-offset.dx, -offset.dy, 0, 1);
     if (needsCompositing) {
       final TransformLayer layer = oldLayer ?? TransformLayer();
       layer.transform = effectiveTransform;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -248,7 +248,7 @@ mixin RenderInlineChildrenContainerDefaults
     if (offset == null) {
       transform.setZero();
     } else {
-      transform.translate(offset.dx, offset.dy);
+      transform.translateByDouble(offset.dx, offset.dy, 0, 1);
     }
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2606,14 +2606,14 @@ class RenderTransform extends RenderProxyBox {
 
   /// Concatenates a translation by (x, y, z) into the transform.
   void translate(double x, [double y = 0.0, double z = 0.0]) {
-    _transform!.translate(x, y, z);
+    _transform!.translateByDouble(x, y, z, 1);
     markNeedsPaint();
     markNeedsSemanticsUpdate();
   }
 
   /// Concatenates a scale into the transform.
   void scale(double x, [double? y, double? z]) {
-    _transform!.scale(x, y, z);
+    _transform!.scaledByDouble(x, y ?? x, z ?? x, 1);
     markNeedsPaint();
     markNeedsSemanticsUpdate();
   }
@@ -2625,19 +2625,19 @@ class RenderTransform extends RenderProxyBox {
     }
     final Matrix4 result = Matrix4.identity();
     if (_origin != null) {
-      result.translate(_origin!.dx, _origin!.dy);
+      result.translateByDouble(_origin!.dx, _origin!.dy, 0, 1);
     }
     Offset? translation;
     if (resolvedAlignment != null) {
       translation = resolvedAlignment.alongSize(size);
-      result.translate(translation.dx, translation.dy);
+      result.translateByDouble(translation.dx, translation.dy, 0, 1);
     }
     result.multiply(_transform!);
     if (resolvedAlignment != null) {
-      result.translate(-translation!.dx, -translation.dy);
+      result.translateByDouble(-translation!.dx, -translation.dy, 0, 1);
     }
     if (_origin != null) {
-      result.translate(-_origin!.dx, -_origin!.dy);
+      result.translateByDouble(-_origin!.dx, -_origin!.dy, 0, 1);
     }
     return result;
   }
@@ -2692,7 +2692,7 @@ class RenderTransform extends RenderProxyBox {
         final Matrix4 effectiveTransform =
             Matrix4.translationValues(offset.dx, offset.dy, 0.0)
               ..multiply(transform)
-              ..translate(-offset.dx, -offset.dy);
+              ..translateByDouble(-offset.dx, -offset.dy, 0, 1);
         final ui.ImageFilter filter = ui.ImageFilter.matrix(
           effectiveTransform.storage,
           filterQuality: filterQuality!,
@@ -2911,8 +2911,8 @@ class RenderFittedBox extends RenderProxyBox {
       assert(scaleX.isFinite && scaleY.isFinite);
       _transform =
           Matrix4.translationValues(destinationRect.left, destinationRect.top, 0.0)
-            ..scale(scaleX, scaleY, 1.0)
-            ..translate(-sourceRect.left, -sourceRect.top);
+            ..scaleByDouble(scaleX, scaleY, 1.0, 1)
+            ..translateByDouble(-sourceRect.left, -sourceRect.top, 0, 1);
       assert(_transform!.storage.every((double value) => value.isFinite));
     }
   }
@@ -3072,7 +3072,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
 
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
-    transform.translate(translation.dx * size.width, translation.dy * size.height);
+    transform.translateByDouble(translation.dx * size.width, translation.dy * size.height, 0, 1);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2613,7 +2613,7 @@ class RenderTransform extends RenderProxyBox {
 
   /// Concatenates a scale into the transform.
   void scale(double x, [double? y, double? z]) {
-    _transform!.scaledByDouble(x, y ?? x, z ?? x, 1);
+    _transform!.scaleByDouble(x, y ?? x, z ?? x, 1);
     markNeedsPaint();
     markNeedsSemanticsUpdate();
   }

--- a/packages/flutter/lib/src/rendering/rotated_box.dart
+++ b/packages/flutter/lib/src/rendering/rotated_box.dart
@@ -8,7 +8,7 @@ library;
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:vector_math/vector_math_64.dart';
+import 'package:vector_math/vector_math_64.dart' show Matrix4;
 
 import 'box.dart';
 import 'layer.dart';
@@ -92,9 +92,9 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
       size = _isVertical ? Size(child!.size.height, child!.size.width) : child!.size;
       _paintTransform =
           Matrix4.identity()
-            ..translate(size.width / 2.0, size.height / 2.0)
+            ..translateByDouble(size.width / 2.0, size.height / 2.0, 0, 1)
             ..rotateZ(_kQuarterTurnsInRadians * (quarterTurns % 4))
-            ..translate(-child!.size.width / 2.0, -child!.size.height / 2.0);
+            ..translateByDouble(-child!.size.width / 2.0, -child!.size.height / 2.0, 0, 1);
     } else {
       size = constraints.smallest;
     }

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1135,7 +1135,7 @@ class SliverPhysicalParentData extends ParentData {
   /// [SliverPhysicalParentData].
   void applyPaintTransform(Matrix4 transform) {
     // Hit test logic relies on this always providing an invertible matrix.
-    transform.translate(paintOffset.dx, paintOffset.dy);
+    transform.translateByDouble(paintOffset.dx, paintOffset.dy, 0, 1);
   }
 
   @override
@@ -1913,12 +1913,12 @@ mixin RenderSliverHelpers implements RenderSliver {
         if (!rightWayUp) {
           delta = geometry!.paintExtent - child.size.width - delta;
         }
-        transform.translate(delta, crossAxisDelta);
+        transform.translateByDouble(delta, crossAxisDelta, 0, 1);
       case Axis.vertical:
         if (!rightWayUp) {
           delta = geometry!.paintExtent - child.size.height - delta;
         }
-        transform.translate(crossAxisDelta, delta);
+        transform.translateByDouble(crossAxisDelta, delta, 0, 1);
     }
   }
 }

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -2087,7 +2087,7 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     // Hit test logic relies on this always providing an invertible matrix.
     final Offset offset = paintOffsetOf(child as RenderSliver);
-    transform.translate(offset.dx, offset.dy);
+    transform.translateByDouble(offset.dx, offset.dy, 0, 1);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -542,7 +542,8 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       OptionsViewOpenDirection.down => overlayRectInField.bottom - optionsViewBoundingBox.height,
     };
 
-    final Matrix4 transform = layoutInfo.childPaintTransform.clone()..translate(0.0, originY);
+    final Matrix4 transform =
+        layoutInfo.childPaintTransform.clone()..translateByDouble(0.0, originY, 0, 1);
     final Widget child = Builder(
       builder: (BuildContext context) => widget.optionsViewBuilder(context, _select, _options),
     );

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -334,7 +334,7 @@ class Icon extends StatelessWidget {
       switch (textDirection) {
         case TextDirection.rtl:
           iconWidget = Transform(
-            transform: Matrix4.identity()..scale(-1.0, 1.0, 1.0),
+            transform: Matrix4.identity()..scaleByDouble(-1.0, 1.0, 1.0, 1),
             alignment: Alignment.center,
             transformHitTests: false,
             child: iconWidget,

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -12,7 +12,8 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
-import 'package:vector_math/vector_math_64.dart' show Matrix4, Quad, Vector3;
+import 'package:flutter/rendering.dart';
+import 'package:vector_math/vector_math_64.dart' show Quad, Vector3;
 
 import 'basic.dart';
 import 'framework.dart';
@@ -565,7 +566,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     }
 
     final Matrix4 nextMatrix =
-        matrix.clone()..translate(alignedTranslation.dx, alignedTranslation.dy);
+        matrix.clone()..translateByDouble(alignedTranslation.dx, alignedTranslation.dy, 0, 1);
 
     // Transform the viewport to determine where its four corners will be after
     // the child has been transformed.
@@ -658,7 +659,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     );
     final double clampedTotalScale = clampDouble(totalScale, widget.minScale, widget.maxScale);
     final double clampedScale = clampedTotalScale / currentScale;
-    return matrix.clone()..scale(clampedScale);
+    return matrix.clone()..scaleByDouble(clampedScale, clampedScale, clampedScale, 1);
   }
 
   // Return a new matrix representing the given matrix after applying the given
@@ -669,9 +670,9 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     }
     final Offset focalPointScene = _transformer.toScene(focalPoint);
     return matrix.clone()
-      ..translate(focalPointScene.dx, focalPointScene.dy)
+      ..translateByDouble(focalPointScene.dx, focalPointScene.dy, 0, 1)
       ..rotateZ(-rotation)
-      ..translate(-focalPointScene.dx, -focalPointScene.dy);
+      ..translateByDouble(-focalPointScene.dx, -focalPointScene.dy, 0, 1);
   }
 
   // Returns true iff the given _GestureType is enabled.
@@ -1236,9 +1237,9 @@ Quad _transformViewport(Matrix4 matrix, Rect viewport) {
 Quad _getAxisAlignedBoundingBoxWithRotation(Rect rect, double rotation) {
   final Matrix4 rotationMatrix =
       Matrix4.identity()
-        ..translate(rect.size.width / 2, rect.size.height / 2)
+        ..translateByDouble(rect.size.width / 2, rect.size.height / 2, 0, 1)
         ..rotateZ(rotation)
-        ..translate(-rect.size.width / 2, -rect.size.height / 2);
+        ..translateByDouble(-rect.size.width / 2, -rect.size.height / 2, 0, 1);
   final Quad boundariesRotated = Quad.points(
     rotationMatrix.transform3(Vector3(rect.left, rect.top, 0.0)),
     rotationMatrix.transform3(Vector3(rect.right, rect.top, 0.0)),

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -631,11 +631,13 @@ class _RenderMagnification extends RenderProxyBox {
     final Offset thisCenter = Alignment.center.alongSize(size) + offset;
     final Matrix4 matrix =
         Matrix4.identity()
-          ..translate(
+          ..translateByDouble(
             magnificationScale * ((focalPointOffset.dx * -1) - thisCenter.dx) + thisCenter.dx,
             magnificationScale * ((focalPointOffset.dy * -1) - thisCenter.dy) + thisCenter.dy,
+            0,
+            1,
           )
-          ..scale(magnificationScale);
+          ..scaleByDouble(magnificationScale, magnificationScale, magnificationScale, 1);
     final ImageFilter filter = ImageFilter.matrix(
       matrix.storage,
       filterQuality: FilterQuality.high,

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -2547,7 +2547,7 @@ final class _RenderDeferredLayoutBox extends RenderProxyBox
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
     final BoxParentData childParentData = child.parentData! as BoxParentData;
     final Offset offset = childParentData.offset;
-    transform.translate(offset.dx, offset.dy);
+    transform.translateByDouble(offset.dx, offset.dy, 0, 1);
   }
 }
 
@@ -2663,7 +2663,7 @@ class _RenderLayoutBuilder extends RenderProxyBox
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
     final BoxParentData childParentData = child.parentData! as BoxParentData;
     final Offset offset = childParentData.offset;
-    transform.translate(offset.dx, offset.dy);
+    transform.translateByDouble(offset.dx, offset.dy, 0, 1);
   }
 
   @protected

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -576,7 +576,7 @@ class _RenderSingleChildViewport extends RenderBox
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
     final Offset paintOffset = _paintOffset;
-    transform.translateByDouble(paintOffset.dx, paintOffset.dy,0,1);
+    transform.translateByDouble(paintOffset.dx, paintOffset.dy, 0, 1);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -576,7 +576,7 @@ class _RenderSingleChildViewport extends RenderBox
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
     final Offset paintOffset = _paintOffset;
-    transform.translate(paintOffset.dx, paintOffset.dy);
+    transform.translateByDouble(paintOffset.dx, paintOffset.dy,0,1);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -420,7 +420,7 @@ class _RenderScaledInlineWidget extends RenderBox with RenderObjectWithChildMixi
 
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
-    transform.scale(scale, scale);
+    transform.scaleByDouble(scale, scale, scale, 1);
   }
 
   @override


### PR DESCRIPTION
We updated pkg:vector_math to eliminate MANY dynamic calls.

This PR updates the API calls to the soundly typed variants.

Should be ZERO behavior changes, so no tests changes included.