### PR TITLE
Reduce some CI timeouts

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -394,7 +394,7 @@ targets:
     bringup: true # https://github.com/flutter/flutter/issues/164591
     presubmit: false
     recipe: flutter/coverage
-    timeout: 120
+    timeout: 90
     enabled_branches:
       # Don't run this on release branches
       - master
@@ -617,7 +617,7 @@ targets:
 
   - name: Linux docs_test
     recipe: flutter/flutter_drone
-    timeout: 90 # https://github.com/flutter/flutter/issues/120901
+    timeout: 30
     properties:
       cores: "32"
       dependencies: >-


### PR DESCRIPTION
- `Linux docs_test`: Has been running consistently under 25m, while timeout was set at 90m.
- `Linux coverage`: Has been running consistently under 1.2h (~75m), while timeout was set at 120m.