### PR TITLE
Use explicit FontConfig SkFontMgr factory

### DIFF
--- a/engine/src/flutter/txt/src/txt/platform_linux.cc
+++ b/engine/src/flutter/txt/src/txt/platform_linux.cc
@@ -6,6 +6,7 @@
 
 #if defined(SK_FONTMGR_FONTCONFIG_AVAILABLE)
 #include "third_party/skia/include/ports/SkFontMgr_fontconfig.h"
+#include "third_party/skia/include/ports/SkFontScanner_FreeType.h"
 #endif
 
 #if defined(SK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE)
@@ -24,7 +25,8 @@ std::vector<std::string> GetDefaultFontFamilies() {
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
 #if defined(SK_FONTMGR_FONTCONFIG_AVAILABLE)
-  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_FontConfig(nullptr);
+  static sk_sp<SkFontMgr> mgr =
+      SkFontMgr_New_FontConfig(nullptr, SkFontScanner_Make_FreeType());
 #elif defined(SK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE)
   static sk_sp<SkFontMgr> mgr =
       SkFontMgr_New_Custom_Directory("/usr/share/fonts/");


### PR DESCRIPTION
In http://review.skia.org/987597, Skia is deprecating the 1 argument version of `SkFontMgr_New_FontConfig`

This updates Flutter to explicitly use the FreeType version of SkFontScanner.

## Pre-launch Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ x ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
