### PR TITLE
Re-enable SelectableRegion web tests

### DIFF
--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';

--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -188,7 +188,7 @@ void main() {
     expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 4));
 
     await gesture.up();
-  }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+  });
 
   testWidgets('mouse can select multiple widgets on double-click drag - horizontal', (
     WidgetTester tester,
@@ -238,7 +238,7 @@ void main() {
     expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
 
     await gesture.up();
-  }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+  });
 
   testWidgets('mouse can select multiple widgets on triple-click drag', (
     WidgetTester tester,
@@ -310,7 +310,7 @@ void main() {
     expect(paragraph4.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
 
     await gesture.up();
-  }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+  });
 
   testWidgets('mouse can select multiple widgets on triple-click drag - horizontal', (
     WidgetTester tester,
@@ -372,7 +372,7 @@ void main() {
     expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
 
     await gesture.up();
-  }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+  });
 
   testWidgets('select to scroll forward', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -444,7 +444,6 @@ void main() {
         expect(pageController.page, 1.0);
       },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
     );
 
     testWidgets('mouse single-click selection collapses the selection', (
@@ -6261,7 +6260,7 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text('Copy'), findsNothing);
       },
-      skip: !kIsWeb, // [intended]
+      skip: !kIsWeb, // [intended] This test verifies web behavior.
     );
   });
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -443,7 +443,88 @@ void main() {
         expect(pageController.page, isNotNull);
         expect(pageController.page, 1.0);
       },
-      variant: TargetPlatformVariant.mobile(),
+      variant: const TargetPlatformVariant(<TargetPlatform>{
+        TargetPlatform.android,
+        TargetPlatform.fuchsia,
+      }),
+      // [intended] Web does not support double tap + drag gestures on the tested platforms.
+      skip: kIsWeb,
+    );
+
+    testWidgets(
+      'Vertical PageView beats SelectionArea child touch drag gestures on iOS',
+      (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/150897.
+        final PageController pageController = PageController();
+        const String testValue = 'abc def ghi jkl mno pqr stu vwx yz';
+        addTearDown(pageController.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: PageView(
+              scrollDirection: Axis.vertical,
+              controller: pageController,
+              children: <Widget>[
+                Center(
+                  child: SelectableRegion(
+                    selectionControls: materialTextSelectionControls,
+                    child: const Text(testValue),
+                  ),
+                ),
+                const SizedBox(height: 200.0, child: Center(child: Text('Page 2'))),
+              ],
+            ),
+          ),
+        );
+
+        final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+          find.descendant(of: find.text(testValue), matching: find.byType(RichText)),
+        );
+        final Offset gPos = textOffsetToPosition(paragraph, testValue.indexOf('g'));
+        final Offset pPos = textOffsetToPosition(paragraph, testValue.indexOf('p'));
+
+        // A double tap + drag should take precedence over parent drags.
+        final TestGesture gesture = await tester.startGesture(gPos);
+        addTearDown(gesture.removePointer);
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+        await gesture.down(gPos);
+        await tester.pumpAndSettle();
+        await gesture.moveTo(pPos);
+        await tester.pump();
+        await gesture.up();
+        await tester.pumpAndSettle();
+        expect(paragraph.selections, isNotEmpty);
+        expect(
+          paragraph.selections[0],
+          TextSelection(
+            baseOffset: testValue.indexOf('g'),
+            extentOffset: testValue.indexOf('p') + 3,
+          ),
+        );
+
+        expect(pageController.page, isNotNull);
+        expect(pageController.page, 0.0);
+        // A vertical drag directly on the SelectableRegion should move the page
+        // view to the next page.
+        final Rect selectableTextRect = tester.getRect(find.byType(SelectableRegion));
+        // Simulate a pan by drag vertically first.
+        await gesture.down(selectableTextRect.center);
+        await tester.pump();
+        await gesture.moveTo(selectableTextRect.center + const Offset(0.0, -200.0));
+        // Introduce horizontal movement.
+        await gesture.moveTo(selectableTextRect.center + const Offset(5.0, -300.0));
+        await gesture.moveTo(selectableTextRect.center + const Offset(-10.0, -400.0));
+        // Continue dragging vertically.
+        await gesture.moveTo(selectableTextRect.center + const Offset(0.0, -500.0));
+        await tester.pump();
+        await gesture.up();
+        await tester.pumpAndSettle();
+        expect(pageController.page, isNotNull);
+        expect(pageController.page, 1.0);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );
 
     testWidgets('mouse single-click selection collapses the selection', (


### PR DESCRIPTION
This change re-enables some `SelectableRegion` tests now that https://github.com/flutter/flutter/issues/125582 has been closed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.