### PR TITLE
Add support for customizable Kotlin and Gradle versions in project cr…

### DIFF
--- a/packages/flutter_tools/lib/src/templates/module/android/constants.dart
+++ b/packages/flutter_tools/lib/src/templates/module/android/constants.dart
@@ -1,0 +1,4 @@
+/// Default version constants for Android module templates.
+const String defaultKotlinVersion = '1.9.0';
+const String defaultAndroidGradlePlugin = '8.2.2';
+const String defaultGradleWrapperVersion = '8.2';

--- a/packages/flutter_tools/templates/app/android.tmpl/gradle/wrapper/gradle-wrapper.properties.tmpl
+++ b/packages/flutter_tools/templates/app/android.tmpl/gradle/wrapper/gradle-wrapper.properties.tmpl
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-{{gradleVersion}}-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-{{gradle_wrapper}}-all.zip

--- a/packages/flutter_tools/templates/module/android/host_app_ephemeral/settings.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_ephemeral/settings.gradle.tmpl
@@ -20,8 +20,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.library" version "{{agpVersionForModule}}" apply false
-    id "org.jetbrains.kotlin.android" version "{{kotlinVersion}}" apply false
+    id "com.android.library" version "{{agp_version_for_module}}" apply false
+    id "org.jetbrains.kotlin.android" version "{{kotlin_version}}" apply false
 }
 
 include ':app'

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:{{agpVersion}}")
+        classpath("com.android.tools.build:gradle:{{agp_version}}")
     }
 }
 

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -2,14 +2,14 @@ group = "{{androidIdentifier}}"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "{{kotlinVersion}}"
+    ext.kotlin_version = "{{kotlin_version}}"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:{{agpVersion}}")
+        classpath("com.android.tools.build:gradle:{{agp_version}}")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }

--- a/packages/flutter_tools/templates/plugin_ffi/android.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/android.tmpl/build.gradle.tmpl
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         // The Android Gradle Plugin knows how to build native code with the NDK.
-        classpath("com.android.tools.build:gradle:{{agpVersion}}")
+        classpath("com.android.tools.build:gradle:{{agp_version}}")
     }
 }
 


### PR DESCRIPTION
This update introduces new command-line options for overriding the Kotlin plugin version, Android Gradle Plugin version, and Gradle wrapper version when creating Flutter projects. The changes include:

- Added `--kotlin-version`, `--agp-version`, and `--gradle-wrapper-version` options to the `create` command.
- Implemented logic to merge version settings from command-line arguments, `pubspec.yaml`, and built-in defaults.
- Updated Gradle template files to use the new variable names for Kotlin and AGP versions.

This enhancement allows for greater flexibility in project configuration, particularly for module projects.

This tries to fix #160922 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
