### PR TITLE
[Impeller] Maintain a global map of each context's currently active thread-local command pools

### DIFF
--- a/engine/src/flutter/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/engine/src/flutter/impeller/golden_tests/golden_playground_test_mac.cc
@@ -132,6 +132,11 @@ void GoldenPlaygroundTest::SetTypographerContext(
 
 void GoldenPlaygroundTest::TearDown() {
   ASSERT_FALSE(dlopen("/usr/local/lib/libMoltenVK.dylib", RTLD_NOLOAD));
+
+  auto context = GetContext();
+  if (context) {
+    context->DisposeThreadLocalCachedResources();
+  }
 }
 
 namespace {
@@ -280,6 +285,9 @@ RuntimeStage::Map GoldenPlaygroundTest::OpenAssetAsRuntimeStage(
 }
 
 std::shared_ptr<Context> GoldenPlaygroundTest::GetContext() const {
+  if (!pimpl_->screenshotter) {
+    return nullptr;
+  }
   return pimpl_->screenshotter->GetPlayground().GetContext();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -214,8 +214,8 @@ std::shared_ptr<CommandPoolVK> CommandPoolRecyclerVK::Get() {
 
   {
     Lock all_pools_lock(g_all_pools_map_mutex);
-    g_all_pools_map[strong_context->GetHash()].emplace(
-        std::this_thread::get_id(), resource);
+    g_all_pools_map[strong_context->GetHash()][std::this_thread::get_id()] =
+        resource;
   }
 
   return resource;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -214,8 +214,7 @@ std::shared_ptr<CommandPoolVK> CommandPoolRecyclerVK::Get() {
 
   {
     Lock all_pools_lock(g_all_pools_map_mutex);
-    g_all_pools_map[strong_context->GetHash()][std::this_thread::get_id()] =
-        resource;
+    g_all_pools_map[hash][std::this_thread::get_id()] = resource;
   }
 
   return resource;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -110,16 +110,13 @@ class CommandPoolRecyclerVK final
   };
 
   /// @brief      Clean up resources held by all per-thread command pools
-  ///             associated with the given context.
-  ///
-  /// @param[in]  context The context.
-  static void DestroyThreadLocalPools(const ContextVK& context);
+  ///             associated with the context.
+  void DestroyThreadLocalPools();
 
   /// @brief      Creates a recycler for the given |ContextVK|.
   ///
   /// @param[in]  context The context to create the recycler for.
-  explicit CommandPoolRecyclerVK(std::weak_ptr<ContextVK> context)
-      : context_(std::move(context)) {}
+  explicit CommandPoolRecyclerVK(const std::shared_ptr<ContextVK>& context);
 
   /// @brief      Gets a command pool for the current thread.
   ///
@@ -136,13 +133,14 @@ class CommandPoolRecyclerVK final
                bool should_trim = false);
 
   /// @brief      Clears this context's thread-local command pool.
-  void Dispose(const ContextVK& context);
+  void Dispose();
 
   // Visible for testing.
   static int GetGlobalPoolCount(const ContextVK& context);
 
  private:
   std::weak_ptr<ContextVK> context_;
+  uint64_t context_hash_;
 
   Mutex recycled_mutex_;
   std::vector<RecycledData> recycled_ IPLR_GUARDED_BY(recycled_mutex_);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -103,8 +103,6 @@ class CommandPoolVK final {
 class CommandPoolRecyclerVK final
     : public std::enable_shared_from_this<CommandPoolRecyclerVK> {
  public:
-  ~CommandPoolRecyclerVK();
-
   /// A unique command pool and zero or more recycled command buffers.
   struct RecycledData {
     vk::UniqueCommandPool pool;
@@ -115,7 +113,7 @@ class CommandPoolRecyclerVK final
   ///             associated with the given context.
   ///
   /// @param[in]  context The context.
-  static void DestroyThreadLocalPools(const ContextVK* context);
+  static void DestroyThreadLocalPools(const ContextVK& context);
 
   /// @brief      Creates a recycler for the given |ContextVK|.
   ///
@@ -137,8 +135,11 @@ class CommandPoolRecyclerVK final
                std::vector<vk::UniqueCommandBuffer>&& buffers,
                bool should_trim = false);
 
-  /// @brief      Clears all recycled command pools to let them be reclaimed.
-  void Dispose();
+  /// @brief      Clears this context's thread-local command pool.
+  void Dispose(const ContextVK& context);
+
+  // Visible for testing.
+  static int GetGlobalPoolCount(const ContextVK& context);
 
  private:
   std::weak_ptr<ContextVK> context_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
@@ -82,7 +82,7 @@ TEST(CommandPoolRecyclerVKTest, ReclaimMakesCommandPoolAvailable) {
     auto const pool = recycler->Get();
 
     // This normally is called at the end of a frame.
-    recycler->Dispose(*context);
+    recycler->Dispose();
   }
 
   // Add something to the resource manager and have it notify us when it's
@@ -124,7 +124,7 @@ TEST(CommandPoolRecyclerVKTest, CommandBuffersAreRecycled) {
     pool->CollectCommandBuffer(std::move(buffer));
 
     // This normally is called at the end of a frame.
-    recycler->Dispose(*context);
+    recycler->Dispose();
   }
 
   // Wait for the pool to be reclaimed.
@@ -148,7 +148,7 @@ TEST(CommandPoolRecyclerVKTest, CommandBuffersAreRecycled) {
     pool->CollectCommandBuffer(std::move(buffer));
 
     // This normally is called at the end of a frame.
-    recycler->Dispose(*context);
+    recycler->Dispose();
   }
 
   // Now check that we only ever created one pool and one command buffer.
@@ -177,7 +177,7 @@ TEST(CommandPoolRecyclerVKTest, ExtraCommandBufferAllocationsTriggerTrim) {
     }
 
     // This normally is called at the end of a frame.
-    recycler->Dispose(*context);
+    recycler->Dispose();
   }
 
   // Wait for the pool to be reclaimed.
@@ -203,7 +203,7 @@ TEST(CommandPoolRecyclerVKTest, ExtraCommandBufferAllocationsTriggerTrim) {
     auto pool = recycler->Get();
 
     // This normally is called at the end of a frame.
-    recycler->Dispose(*context);
+    recycler->Dispose();
   }
 
   // Wait for the pool to be reclaimed.
@@ -241,8 +241,10 @@ TEST(CommandPoolRecyclerVKTest, RecyclerGlobalPoolMapSize) {
 
   // Disposing this thread's pool should remove it from the global map.
   pool.reset();
-  recycler->Dispose(*context);
+  recycler->Dispose();
   EXPECT_EQ(CommandPoolRecyclerVK::GetGlobalPoolCount(*context), 0);
+
+  context->Shutdown();
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -134,7 +134,7 @@ ContextVK::~ContextVK() {
   if (device_holder_ && device_holder_->device) {
     [[maybe_unused]] auto result = device_holder_->device->waitIdle();
   }
-  CommandPoolRecyclerVK::DestroyThreadLocalPools(this);
+  CommandPoolRecyclerVK::DestroyThreadLocalPools(*this);
 }
 
 Context::BackendType ContextVK::GetBackendType() const {
@@ -720,7 +720,7 @@ void ContextVK::DisposeThreadLocalCachedResources() {
     Lock lock(desc_pool_mutex_);
     cached_descriptor_pool_.erase(std::this_thread::get_id());
   }
-  command_pool_recycler_->Dispose();
+  command_pool_recycler_->Dispose(*this);
 }
 
 const std::shared_ptr<YUVConversionLibraryVK>&

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -134,7 +134,9 @@ ContextVK::~ContextVK() {
   if (device_holder_ && device_holder_->device) {
     [[maybe_unused]] auto result = device_holder_->device->waitIdle();
   }
-  command_pool_recycler_->DestroyThreadLocalPools();
+  if (command_pool_recycler_) {
+    command_pool_recycler_->DestroyThreadLocalPools();
+  }
 }
 
 Context::BackendType ContextVK::GetBackendType() const {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -134,7 +134,7 @@ ContextVK::~ContextVK() {
   if (device_holder_ && device_holder_->device) {
     [[maybe_unused]] auto result = device_holder_->device->waitIdle();
   }
-  CommandPoolRecyclerVK::DestroyThreadLocalPools(*this);
+  command_pool_recycler_->DestroyThreadLocalPools();
 }
 
 Context::BackendType ContextVK::GetBackendType() const {
@@ -421,7 +421,7 @@ void ContextVK::Setup(Settings settings) {
   }
 
   auto command_pool_recycler =
-      std::make_shared<CommandPoolRecyclerVK>(weak_from_this());
+      std::make_shared<CommandPoolRecyclerVK>(shared_from_this());
   if (!command_pool_recycler) {
     VALIDATION_LOG << "Could not create command pool recycler.";
     return;
@@ -720,7 +720,7 @@ void ContextVK::DisposeThreadLocalCachedResources() {
     Lock lock(desc_pool_mutex_);
     cached_descriptor_pool_.erase(std::this_thread::get_id());
   }
-  command_pool_recycler_->Dispose(*this);
+  command_pool_recycler_->Dispose();
 }
 
 const std::shared_ptr<YUVConversionLibraryVK>&


### PR DESCRIPTION
The Impeller Vulkan back end creates a thread-local map of contexts to CommandPoolVK instances for each thread that uses Vulkan.  This allows a thread to obtain the CommandPoolVK that is currently in use for a given context.

When a context is shut down, the Vulkan resources used by each thread's local CommandPoolVK for that context must be freed.  To do this, CommandPoolVK maintains a global map of CommandPoolVK instances.

Prior to this PR Impeller was appending to the context's pool list in the global map each time a new CommandPoolVK was created.  In the original implementation this worked because Impeller was only creating one CommandPoolVK per thread for a given context.

However, CommandPoolVK later adopted a recycling scheme where each frame creates a new CommandPoolVK instance that acquires a Vulkan command pool from the CommandPoolRecyclerVK.  So inserting every CommandPoolVK into the global map will cause the global map to grow unbounded.

This PR changes the structure of the global map.  The global map will now associate each context with a map of thread IDs to the CommandPoolVK that is currently placed in the thread's local storage.  When a thread calls CommandPoolRecyclerVK::Dispose to clear its thread-local CommandPoolVK for a context, the corresponding entry is also removed from the global map.

Fixes https://github.com/flutter/flutter/issues/169208