### PR TITLE
🐛 Use consist slashes when generating dep files

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -96,7 +96,8 @@ class DepfileService {
         // The tool doesn't write duplicates to these lists. This call is an attempt to
         // be resilient to the outputs of other tools which write or user edits to depfiles.
         .toSet()
-        .map(_fileSystem.file)
+        // Normalize the path before creating a file object.
+        .map((String path) => _fileSystem.file(_fileSystem.path.normalize(path)))
         .toList();
   }
 }

--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -68,16 +68,14 @@ class DepfileService {
   void _writeFilesToBuffer(List<File> files, StringBuffer buffer) {
     final bool backslash = _fileSystem.path.style.separator == r'\';
     for (final File outputFile in files) {
-      // Escape spaces.
-      String path = _fileSystem.path.normalize(outputFile.path).replaceAll(r' ', r'\ ');
+      String path = _fileSystem.path.normalize(outputFile.path);
       if (backslash) {
         // Convert all path separators to backslashes.
         // Backslashes in a depfile have to be escaped if the platform separator is a backslash.
-        path = path.replaceAll(RegExp(r'[/\\]'), r'\\');
-      } else {
-        // Convert all path separators to forward slashes.
-        path = path.replaceAll(r'\', r'/');
+        path = path.replaceAll(r'\', r'\\');
       }
+      // Escape spaces.
+      path = path.replaceAll(r' ', r'\ ');
       buffer.write(' $path');
     }
   }

--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -70,9 +70,11 @@ class DepfileService {
     for (final File outputFile in files) {
       String path = _fileSystem.path.normalize(outputFile.path);
       if (backslash) {
-        // Convert all path separators to backslashes.
         // Backslashes in a depfile have to be escaped if the platform separator is a backslash.
         path = path.replaceAll(r'\', r'\\');
+      } else {
+        // Convert all path separators to forward slashes.
+        path = path.replaceAll(r'\', r'/');
       }
       // Escape spaces.
       path = path.replaceAll(r' ', r'\ ');

--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -66,16 +66,19 @@ class DepfileService {
   }
 
   void _writeFilesToBuffer(List<File> files, StringBuffer buffer) {
+    final bool backslash = _fileSystem.path.style.separator == r'\';
     for (final File outputFile in files) {
-      if (_fileSystem.path.style.separator == r'\') {
-        // backslashes and spaces in a depfile have to be escaped if the
-        // platform separator is a backslash.
-        final String path = outputFile.path.replaceAll(r'\', r'\\').replaceAll(r' ', r'\ ');
-        buffer.write(' $path');
+      // Escape spaces.
+      String path = _fileSystem.path.normalize(outputFile.path).replaceAll(r' ', r'\ ');
+      if (backslash) {
+        // Convert all path separators to backslashes.
+        // Backslashes in a depfile have to be escaped if the platform separator is a backslash.
+        path = path.replaceAll(RegExp(r'[/\\]'), r'\\');
       } else {
-        final String path = outputFile.path.replaceAll(r' ', r'\ ');
-        buffer.write(' $path');
+        // Convert all path separators to forward slashes.
+        path = path.replaceAll(r'\', r'/');
       }
+      buffer.write(' $path');
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
@@ -17,6 +17,7 @@ void main() {
     fileSystem = MemoryFileSystem.test();
     depfileService = DepfileService(logger: BufferLogger.test(), fileSystem: fileSystem);
   });
+
   testWithoutContext('Can parse depfile from file', () {
     final File depfileSource = fileSystem.file('example.d')..writeAsStringSync('''
 a.txt: b.txt
@@ -48,8 +49,11 @@ a.txt c.txt d.txt: b.txt
   });
 
   testWithoutContext('Can parse depfile with windows file paths', () {
-    fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
-    depfileService = DepfileService(logger: BufferLogger.test(), fileSystem: fileSystem);
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    final DepfileService depfileService = DepfileService(
+      logger: BufferLogger.test(),
+      fileSystem: fileSystem,
+    );
     final File depfileSource = fileSystem.file('example.d')..writeAsStringSync(r'''
 C:\\a1.txt C:\\a2/a3.txt: C:\\b1.txt C:\\b2/b3.txt
 ''');
@@ -57,19 +61,22 @@ C:\\a1.txt C:\\a2/a3.txt: C:\\b1.txt C:\\b2/b3.txt
 
     expect(depfile.inputs.map((File e) => e.path).toList(), <String>[
       r'C:\b1.txt',
-      r'C:\b2/b3.txt',
+      r'C:\b2\b3.txt',
     ]);
     expect(depfile.outputs.map((File e) => e.path).toList(), <String>[
       r'C:\a1.txt',
-      r'C:\a2/a3.txt',
+      r'C:\a2\a3.txt',
     ]);
   });
 
   testWithoutContext(
     'Can escape depfile with windows file paths and spaces in directory names',
     () {
-      fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
-      depfileService = DepfileService(logger: BufferLogger.test(), fileSystem: fileSystem);
+      final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+      final DepfileService depfileService = DepfileService(
+        logger: BufferLogger.test(),
+        fileSystem: fileSystem,
+      );
       final File inputFile =
           fileSystem.directory(r'Hello Flutter').childFile('a.txt').absolute
             ..createSync(recursive: true);


### PR DESCRIPTION
Continue with https://github.com/flutter/flutter/pull/169467. I've noticed that paths in the depfile on Windows are generated with non-normalized paths. This PR normalizes every single file path before putting them into the output.

This might also fix https://github.com/flutter/flutter/issues/163591 as a root cause and can be easily cherry-picked.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
