### PR TITLE
Enable support for dynamic view resizing

### DIFF
--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -432,6 +432,10 @@ void RuntimeController::Render(int64_t view_id,
   if (view_metrics == nullptr) {
     return;
   }
+  if (width != view_metrics->physical_width ||
+      height != view_metrics->physical_height) {
+    client_.ResizeView(view_id, width, height);
+  }
   client_.Render(view_id, scene->takeLayerTree(width, height),
                  view_metrics->device_pixel_ratio);
   rendered_views_during_frame_.insert(view_id);

--- a/engine/src/flutter/runtime/runtime_delegate.h
+++ b/engine/src/flutter/runtime/runtime_delegate.h
@@ -32,6 +32,8 @@ class RuntimeDelegate {
                       std::unique_ptr<flutter::LayerTree> layer_tree,
                       float device_pixel_ratio) = 0;
 
+  virtual void ResizeView(int64_t view_id, double width, double height) = 0;
+
   virtual void UpdateSemantics(int64_t view_id,
                                SemanticsNodeUpdates update,
                                CustomAccessibilityActionUpdates actions) = 0;

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -525,6 +525,10 @@ void Engine::Render(int64_t view_id,
   animator_->Render(view_id, std::move(layer_tree), device_pixel_ratio);
 }
 
+void Engine::ResizeView(int64_t view_id, double width, double height) {
+  delegate_.OnEngineResizeView(view_id, width, height);
+}
+
 void Engine::UpdateSemantics(int64_t view_id,
                              SemanticsNodeUpdates update,
                              CustomAccessibilityActionUpdates actions) {

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -135,6 +135,32 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   ///
   class Delegate {
    public:
+    //----------------------------------------------------------------------------
+    /// @brief      This callback is invoked by the engine when the FlutterView
+    ///             has requested a change in platform-specific view dimensions,
+    ///             in physical pixels.
+    ///
+    ///             When a Flutter application calls `FlutterView.render` with a
+    ///             content size that differs from the existing view size, the
+    ///             new view size needs to be communicated to the underlying
+    ///             platform embedder so it can resize the Flutter view. The
+    ///             engine cannot access the underlying platform directly
+    ///             because of threading considerations.
+    ///
+    ///             Currently, this callback is only supported in embedders with
+    ///             a merged UI and Platform thread. View resizing is typically
+    ///             only safe to implement on the platform task runner.
+    ///
+    /// @see        `FlutterView.render`, `PlatformView::ResizeView`
+    ///
+    /// @param[in]  view_id  The ID of the view that this update is for
+    /// @param[in]  width    The requested view width in physical pixels.
+    /// @param[in]  height   The requested view height in physical pixels.
+    ///
+    virtual void OnEngineResizeView(int64_t view_id,
+                                    double width,
+                                    double height) = 0;
+
     //--------------------------------------------------------------------------
     /// @brief      When the accessibility tree has been updated by the Flutter
     ///             application, this new information needs to be conveyed to
@@ -1011,6 +1037,9 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   void Render(int64_t view_id,
               std::unique_ptr<flutter::LayerTree> layer_tree,
               float device_pixel_ratio) override;
+
+  // |RuntimeDelegate|
+  void ResizeView(int64_t view_id, double width, double height) override;
 
   // |RuntimeDelegate|
   void UpdateSemantics(int64_t view_id,

--- a/engine/src/flutter/shell/common/engine_animator_unittests.cc
+++ b/engine/src/flutter/shell/common/engine_animator_unittests.cc
@@ -53,6 +53,7 @@ std::vector<const LayerTreeTask*> Sorted(
 
 class MockDelegate : public Engine::Delegate {
  public:
+  MOCK_METHOD(void, OnEngineResizeView, (int64_t, double, double), (override));
   MOCK_METHOD(void,
               OnEngineUpdateSemantics,
               (int64_t, SemanticsNodeUpdates, CustomAccessibilityActionUpdates),

--- a/engine/src/flutter/shell/common/engine_unittests.cc
+++ b/engine/src/flutter/shell/common/engine_unittests.cc
@@ -60,6 +60,7 @@ class FontManifestAssetResolver : public AssetResolver {
 
 class MockDelegate : public Engine::Delegate {
  public:
+  MOCK_METHOD(void, OnEngineResizeView, (int64_t, double, double), (override));
   MOCK_METHOD(void,
               OnEngineUpdateSemantics,
               (int64_t, SemanticsNodeUpdates, CustomAccessibilityActionUpdates),
@@ -111,6 +112,7 @@ class MockRuntimeDelegate : public RuntimeDelegate {
               Render,
               (int64_t, std::unique_ptr<flutter::LayerTree>, float),
               (override));
+  MOCK_METHOD(void, ResizeView, (int64_t, double, double), (override));
   MOCK_METHOD(void,
               UpdateSemantics,
               (int64_t, SemanticsNodeUpdates, CustomAccessibilityActionUpdates),

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -124,6 +124,8 @@ fml::WeakPtr<PlatformView> PlatformView::GetWeakPtr() const {
   return weak_factory_.GetWeakPtr();
 }
 
+void PlatformView::ResizeView(int64_t view_id, double width, double height) {}
+
 void PlatformView::UpdateSemantics(
     int64_t view_id,
     SemanticsNodeUpdates update,  // NOLINT(performance-unnecessary-value-param)

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -497,6 +497,30 @@ class PlatformView {
   virtual void SetAccessibilityFeatures(int32_t flags);
 
   //----------------------------------------------------------------------------
+  /// @brief      This callback is invoked by the engine when the FlutterView
+  ///             has requested a change in platform-specific view dimensions,
+  ///             in physical pixels.
+  ///
+  ///             When a Flutter application calls `FlutterView.render` with a
+  ///             content size that differs from the existing view size, the
+  ///             new view size needs to be communicated to the underlying
+  ///             platform embedder so it can resize the Flutter view. The
+  ///             engine cannot access the underlying platform directly
+  ///             because of threading considerations.
+  ///
+  ///             Currently, this callback is only supported in embedders with
+  ///             a merged UI and Platform thread. View resizing is typically
+  ///             only safe to implement on the platform task runner.
+  ///
+  /// @see        `FlutterView.render`, `Engine::Delegate::OnEngineResizeView`
+  ///
+  /// @param[in]  view_id  The ID of the view that this update is for
+  /// @param[in]  width    The requested view width in physical pixels.
+  /// @param[in]  height   The requested view height in physical pixels.
+  ///
+  virtual void ResizeView(int64_t view_id, double width, double height);
+
+  //----------------------------------------------------------------------------
   /// @brief      Used by the framework to tell the embedder to apply the
   ///             specified semantics node updates. The default implementation
   ///             of this method does nothing.

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1379,6 +1379,22 @@ void Shell::OnAnimatorDrawLastLayerTrees(
 }
 
 // |Engine::Delegate|
+void Shell::OnEngineResizeView(int64_t view_id, double width, double height) {
+  FML_DCHECK(is_set_up_);
+
+  if (!task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread()) {
+    FML_LOG(INFO) << "Resize view is only supported when UI thread and "
+                     "platform thread are merged";
+    return;
+  }
+
+  fml::WeakPtr<PlatformView> view = platform_view_->GetWeakPtr();
+  if (view) {
+    view->ResizeView(view_id, width, height);
+  }
+}
+
+// |Engine::Delegate|
 void Shell::OnEngineUpdateSemantics(int64_t view_id,
                                     SemanticsNodeUpdates update,
                                     CustomAccessibilityActionUpdates actions) {

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -669,6 +669,11 @@ class Shell final : public PlatformView::Delegate,
       std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder) override;
 
   // |Engine::Delegate|
+  void OnEngineResizeView(int64_t view_id,
+                          double width,
+                          double height) override;
+
+  // |Engine::Delegate|
   void OnEngineUpdateSemantics(
       int64_t view_id,
       SemanticsNodeUpdates update,

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -313,6 +313,13 @@ void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
 }
 
 // |PlatformView|
+void PlatformViewAndroid::ResizeView(int64_t view_id,
+                                     double width,
+                                     double height) {
+  // TODO(mboetger): https://github.com/flutter/flutter/issues/149033
+}
+
+// |PlatformView|
 void PlatformViewAndroid::UpdateSemantics(
     int64_t view_id,
     flutter::SemanticsNodeUpdates update,

--- a/engine/src/flutter/shell/platform/android/platform_view_android.h
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.h
@@ -139,6 +139,9 @@ class PlatformViewAndroid final : public PlatformView {
   bool android_meets_hcpp_criteria_ = false;
 
   // |PlatformView|
+  void ResizeView(int64_t view_id, double width, double height) override;
+
+  // |PlatformView|
   void UpdateSemantics(
       int64_t view_id,
       flutter::SemanticsNodeUpdates update,

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -2118,6 +2118,15 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
     settings.log_tag = SAFE_ACCESS(args, log_tag, nullptr);
   }
 
+  flutter::PlatformViewEmbedder::ResizeViewCallback resize_view_callback =
+      nullptr;
+  if (SAFE_ACCESS(args, resize_view_callback, nullptr) != nullptr) {
+    resize_view_callback = [ptr = args->resize_view_callback, user_data](
+                               int64_t view_id, double width, double height) {
+      ptr(view_id, width, height, user_data);
+    };
+  }
+
   bool has_update_semantics_2_callback =
       SAFE_ACCESS(args, update_semantics_callback2, nullptr) != nullptr;
   bool has_update_semantics_callback =
@@ -2265,13 +2274,17 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
 
   flutter::PlatformViewEmbedder::PlatformDispatchTable platform_dispatch_table =
       {
-          update_semantics_callback,                  //
-          platform_message_response_callback,         //
-          vsync_callback,                             //
-          compute_platform_resolved_locale_callback,  //
-          on_pre_engine_restart_callback,             //
-          channel_update_callback,                    //
-          view_focus_change_request_callback,         //
+          .resize_view_callback = resize_view_callback,
+          .update_semantics_callback = update_semantics_callback,
+          .platform_message_response_callback =
+              platform_message_response_callback,
+          .vsync_callback = vsync_callback,
+          .compute_platform_resolved_locale_callback =
+              compute_platform_resolved_locale_callback,
+          .on_pre_engine_restart_callback = on_pre_engine_restart_callback,
+          .on_channel_update = channel_update_callback,
+          .view_focus_change_request_callback =
+              view_focus_change_request_callback,
       };
 
   auto on_create_platform_view = InferPlatformViewCreationCallback(

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -1725,6 +1725,11 @@ typedef void (*FlutterViewFocusChangeRequestCallback)(
     const FlutterViewFocusChangeRequest* /* request */,
     void* /* user data */);
 
+typedef void (*FlutterResizeViewCallback)(int64_t /* view ID */,
+                                          double /* physical_width */,
+                                          double /* physical_height */,
+                                          void* /* user_data */);
+
 typedef struct _FlutterTaskRunner* FlutterTaskRunner;
 
 typedef struct {
@@ -2645,6 +2650,22 @@ typedef struct {
   /// `PlatformDispatcher.instance.engineId`. Can be used in native code to
   /// retrieve the engine instance that is running the Dart code.
   int64_t engine_id;
+
+  /// Resize view callback.
+  ///
+  /// This callback is invoked by the engine when the FlutterView has requested
+  /// a change in platform-specific view dimensions, in physical pixels.
+  ///
+  /// When a Flutter application calls `FlutterView.render` with a content size
+  /// that differs from the existing view size, the new view size needs to be
+  /// communicated to the underlying platform embedder so it can resize the
+  /// Flutter view. The engine cannot access the underlying platform directly
+  /// because of threading considerations.
+  ///
+  /// Currently, this callback is only supported in embedders with a merged UI
+  /// and Platform thread. View resizing is typically only safe to implement on
+  /// the platform task runner.
+  FlutterResizeViewCallback resize_view_callback;
 } FlutterProjectArgs;
 
 typedef struct {

--- a/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/embedder/fixtures/main.dart
@@ -1322,6 +1322,23 @@ void custom_logger(List<String> args) {
 
 @pragma('vm:entry-point')
 // ignore: non_constant_identifier_names
+void resize_view_called(List<String> args) {
+  FlutterView implicitView = PlatformDispatcher.instance.implicitView!;
+  SceneBuilder builder = SceneBuilder();
+  Scene scene = builder.build();
+
+  // First call: new size; triggers a resize callback.
+  implicitView.render(scene, size: Size(100, 101));
+
+  // Second call: new size; triggers a resize callback.
+  implicitView.render(scene, size: Size(200, 201));
+
+  // Signal the C++ test that we're done.
+  signalNativeTest();
+}
+
+@pragma('vm:entry-point')
+// ignore: non_constant_identifier_names
 void dart_entrypoint_args(List<String> args) {
   nativeArgumentsCallback(args);
 }

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder.cc
@@ -112,6 +112,12 @@ PlatformViewEmbedder::PlatformViewEmbedder(
 
 PlatformViewEmbedder::~PlatformViewEmbedder() = default;
 
+void PlatformViewEmbedder::ResizeView(int64_t view_id,
+                                      double width,
+                                      double height) {
+  platform_dispatch_table_.resize_view_callback(view_id, width, height);
+}
+
 void PlatformViewEmbedder::UpdateSemantics(
     int64_t view_id,
     flutter::SemanticsNodeUpdates update,

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder.h
@@ -35,6 +35,8 @@ namespace flutter {
 
 class PlatformViewEmbedder final : public PlatformView {
  public:
+  using ResizeViewCallback =
+      std::function<void(int64_t view_id, double width, double height)>;
   using UpdateSemanticsCallback =
       std::function<void(int64_t view_id,
                          flutter::SemanticsNodeUpdates update,
@@ -50,6 +52,7 @@ class PlatformViewEmbedder final : public PlatformView {
       std::function<void(const ViewFocusChangeRequest&)>;
 
   struct PlatformDispatchTable {
+    ResizeViewCallback resize_view_callback;            // optional
     UpdateSemanticsCallback update_semantics_callback;  // optional
     PlatformMessageResponseCallback
         platform_message_response_callback;             // optional
@@ -102,6 +105,9 @@ class PlatformViewEmbedder final : public PlatformView {
 #endif
 
   ~PlatformViewEmbedder() override;
+
+  // |PlatformView|
+  void ResizeView(int64_t view_id, double width, double height) override;
 
   // |PlatformView|
   void UpdateSemantics(

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -38,6 +38,7 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
     SetLocalizationCallbackHooks();
     SetChannelUpdateCallbackHook();
     SetViewFocusChangeRequestHook();
+    SetResizeViewCallbackHook();
     AddCommandLineArgument("--disable-vm-service");
 
     if (preference == InitializationPreference::kSnapshotsInitialize ||
@@ -116,6 +117,10 @@ void EmbedderConfigBuilder::SetChannelUpdateCallbackHook() {
 void EmbedderConfigBuilder::SetViewFocusChangeRequestHook() {
   project_args_.view_focus_change_request_callback =
       context_.GetViewFocusChangeRequestCallbackHook();
+}
+
+void EmbedderConfigBuilder::SetResizeViewCallbackHook() {
+  project_args_.resize_view_callback = context_.GetResizeViewCallbackHook();
 }
 
 void EmbedderConfigBuilder::SetLogTag(std::string tag) {
@@ -203,6 +208,11 @@ void EmbedderConfigBuilder::SetPlatformMessageCallback(
 void EmbedderConfigBuilder::SetViewFocusChangeRequestCallback(
     const std::function<void(const FlutterViewFocusChangeRequest*)>& callback) {
   context_.SetViewFocusChangeRequestCallback(callback);
+}
+
+void EmbedderConfigBuilder::SetResizeViewCallback(
+    const std::function<void(int64_t, double, double)>& callback) {
+  context_.SetResizeViewCallback(callback);
 }
 
 void EmbedderConfigBuilder::SetCompositor(bool avoid_backing_store_cache,

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.h
@@ -61,6 +61,8 @@ class EmbedderConfigBuilder {
 
   void SetViewFocusChangeRequestHook();
 
+  void SetResizeViewCallbackHook();
+
   // Used to set a custom log tag.
   void SetLogTag(std::string tag);
 
@@ -86,6 +88,9 @@ class EmbedderConfigBuilder {
   void SetViewFocusChangeRequestCallback(
       const std::function<void(const FlutterViewFocusChangeRequest*)>&
           callback);
+
+  void SetResizeViewCallback(
+      const std::function<void(int64_t, double, double)>& callback);
 
   void SetCompositor(bool avoid_backing_store_cache = false,
                      bool use_present_layers_callback = false);

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_test_context.cc
@@ -161,6 +161,11 @@ void EmbedderTestContext::SetViewFocusChangeRequestCallback(
   view_focus_change_request_callback_ = callback;
 }
 
+void EmbedderTestContext::SetResizeViewCallback(
+    const ResizeViewCallback& callback) {
+  resize_view_callback_ = callback;
+}
+
 void EmbedderTestContext::PlatformMessageCallback(
     const FlutterPlatformMessage* message) {
   if (platform_message_callback_) {
@@ -266,6 +271,15 @@ EmbedderTestContext::GetViewFocusChangeRequestCallbackHook() {
     auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
     if (context->view_focus_change_request_callback_) {
       context->view_focus_change_request_callback_(request);
+    }
+  };
+}
+
+FlutterResizeViewCallback EmbedderTestContext::GetResizeViewCallbackHook() {
+  return [](int64_t view_id, double width, double height, void* user_data) {
+    auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
+    if (context->resize_view_callback_) {
+      context->resize_view_callback_(view_id, width, height);
     }
   };
 }

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_test_context.h
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_test_context.h
@@ -36,6 +36,8 @@ using LogMessageCallback =
 using ChannelUpdateCallback = std::function<void(const FlutterChannelUpdate*)>;
 using ViewFocusChangeRequestCallback =
     std::function<void(const FlutterViewFocusChangeRequest*)>;
+using ResizeViewCallback =
+    std::function<void(int64_t view_id, double width, double height)>;
 
 struct AOTDataDeleter {
   void operator()(FlutterEngineAOTData aot_data) {
@@ -99,6 +101,8 @@ class EmbedderTestContext {
   void SetViewFocusChangeRequestCallback(
       const ViewFocusChangeRequestCallback& callback);
 
+  void SetResizeViewCallback(const ResizeViewCallback& callback);
+
   std::future<sk_sp<SkImage>> GetNextSceneImage();
 
   EmbedderTestCompositor& GetCompositor();
@@ -139,6 +143,7 @@ class EmbedderTestContext {
   SemanticsActionCallback update_semantics_custom_action_callback_;
   ChannelUpdateCallback channel_update_callback_;
   ViewFocusChangeRequestCallback view_focus_change_request_callback_;
+  ResizeViewCallback resize_view_callback_;
   std::function<void(const FlutterPlatformMessage*)> platform_message_callback_;
   LogMessageCallback log_message_callback_;
   std::unique_ptr<EmbedderTestCompositor> compositor_;
@@ -165,6 +170,8 @@ class EmbedderTestContext {
   FlutterChannelUpdateCallback GetChannelUpdateCallbackHook();
 
   FlutterViewFocusChangeRequestCallback GetViewFocusChangeRequestCallbackHook();
+
+  FlutterResizeViewCallback GetResizeViewCallbackHook();
 
   void SetupAOTMappingsIfNecessary();
 

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc
@@ -43,7 +43,9 @@
 
 namespace {
 
-static uint64_t NanosFromEpoch(int millis_from_now) {
+constexpr int64_t kImplicitViewId = 0;
+
+uint64_t NanosFromEpoch(int millis_from_now) {
   const auto now = fml::TimePoint::Now();
   const auto delta = fml::TimeDelta::FromMilliseconds(millis_from_now);
   return (now + delta).ToEpochDelta().ToNanoseconds();
@@ -798,6 +800,137 @@ TEST_F(EmbedderTest, CanSetCustomLogTag) {
   auto engine = builder.LaunchEngine();
   ASSERT_TRUE(engine.is_valid());
   callback_latch.Wait();
+}
+
+//------------------------------------------------------------------------------
+/// Tests that resize_view_callback is called if FlutterView.render() is called
+/// with a new size.
+TEST_F(EmbedderTest, ResizeCallbackCalledOnSizeChange) {
+  bool resize_called = false;
+
+  struct Expectations {
+    int64_t view_id;
+    double width;
+    double height;
+  };
+  std::array<Expectations, 2> expectations{
+      Expectations{0, 100.0, 101.0},  // First call.
+      Expectations{0, 200.0, 201.0},  // Second call.
+  };
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+  context.AddNativeCallback("SignalNativeTest",
+                            CREATE_NATIVE_ENTRY([](Dart_NativeArguments args) {
+                              // Ignored: used by following test; uses same Dart
+                              // entry point.
+                            }));
+  context.SetResizeViewCallback([&resize_called, &expectations](int64_t view_id,
+                                                                double width,
+                                                                double height) {
+    static size_t i = 0;
+    EXPECT_EQ(view_id, expectations[i].view_id);
+    EXPECT_EQ(width, expectations[i].width);
+    EXPECT_EQ(height, expectations[i].height);
+    i++;
+    resize_called = true;
+  });
+
+  UniqueEngine engine;
+  auto task_runner = GetCurrentTaskRunner();
+  EmbedderTestTaskRunner merged_task_runner(task_runner, [&](FlutterTask task) {
+    if (!engine.is_valid()) {
+      return;
+    }
+    FlutterEngineRunTask(engine.get(), &task);
+  });
+  const auto merged_task_runner_description =
+      merged_task_runner.GetFlutterTaskRunnerDescription();
+
+  // Launch the test.
+  EmbedderConfigBuilder builder(context);
+  builder.SetDartEntrypoint("resize_view_called");
+  builder.SetSurface(SkISize::Make(1, 1));
+  builder.SetUITaskRunner(&merged_task_runner_description);
+  builder.SetPlatformTaskRunner(&merged_task_runner_description);
+  engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+
+  // Spin until resize-view callback triggered.
+  while (!resize_called) {
+    fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  }
+  resize_called = false;
+}
+
+//------------------------------------------------------------------------------
+// Tests that FlutterView.render() with updated size parameters does not cause
+// a crash if no resize callback is registered.
+TEST_F(EmbedderTest, ResizeCallbackDoesNotCrashOnSizeChangeIfNotInstalled) {
+  bool signal_called = false;
+
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+  context.AddNativeCallback(
+      "SignalNativeTest",
+      CREATE_NATIVE_ENTRY([&signal_called](Dart_NativeArguments args) {
+        signal_called = true;
+      }));
+
+  UniqueEngine engine;
+  auto task_runner = GetCurrentTaskRunner();
+  EmbedderTestTaskRunner merged_task_runner(task_runner, [&](FlutterTask task) {
+    if (!engine.is_valid()) {
+      return;
+    }
+    FlutterEngineRunTask(engine.get(), &task);
+  });
+  const auto merged_task_runner_description =
+      merged_task_runner.GetFlutterTaskRunnerDescription();
+
+  // Launch the test.
+  EmbedderConfigBuilder builder(context);
+  builder.SetDartEntrypoint("resize_view_called");
+  builder.SetSurface(SkISize::Make(1, 1));
+  builder.SetUITaskRunner(&merged_task_runner_description);
+  builder.SetPlatformTaskRunner(&merged_task_runner_description);
+  engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+
+  // Spin until resize-view callback triggered.
+  while (!signal_called) {
+    fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  }
+  // Test passes if no crash when callback is nullptr.
+}
+
+//------------------------------------------------------------------------------
+/// Tests that resize_view_callback is NOT called if FlutterView.render() is
+/// called in an embedder with non-merged Platform and UI threads.
+TEST_F(EmbedderTest, ResizeCallbackNotCalledIfUIAndPlatformThreadNotMerged) {
+  bool signal_called = false;
+  bool resize_called = false;
+
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+  context.AddNativeCallback(
+      "SignalNativeTest",
+      CREATE_NATIVE_ENTRY([&signal_called](Dart_NativeArguments args) {
+        signal_called = true;
+      }));
+  context.SetResizeViewCallback(
+      [&resize_called](int64_t view_id, double width, double height) {
+        resize_called = true;
+      });
+
+  // Launch the test.
+  EmbedderConfigBuilder builder(context);
+  builder.SetDartEntrypoint("resize_view_called");
+  builder.SetSurface(SkISize::Make(1, 1));
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+
+  // Spin until resize-view callback triggered.
+  while (!signal_called) {
+    fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  }
+  EXPECT_FALSE(resize_called);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This enables support for dynamic view resizing in non-web embedders. While this patch enables support and exposes API for dynamic view resizing in non-web embedders and in the embedder API, it does not *implement* support in any embedder.

This feature is restricted to embedders with merged UI and platform thread due to the need to inform the embedder of the updated view size synchronously with presenting the content. With some effort, we could implement synchronisation logic that supports non-thread-merged embedders. See ResizeSynchronizer in the macOS embedder for details of what's involved.

When Flutter applications call `FlutterView.render` with a non-null `size` parameter, the size will be compared to the existing view size (if any), and if different, a call to `PlatformView::ResizeView` will be triggered. Embedders can respond to this call by resizing the underlying platform-specific FlutterView to the appropriate size.

Extracts a resize_view_callback to the embedder API that custom embedders can register to receive the updated size from the engine, and adapt their views accordingly.

Related patches:
* `dart:ui`: https://github.com/flutter/engine/pull/48090
* framework: https://github.com/flutter/flutter/pull/138648
* framework reland: https://github.com/flutter/flutter/pull/140918
* Web: https://github.com/flutter/engine/pull/50271

Issue: https://github.com/flutter/flutter/issues/169147
Issue: https://github.com/flutter/flutter/issues/149033

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
