### PR TITLE
[Impeller] let drawImage nine use porter duff optimization.

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -349,9 +349,7 @@ void Canvas::DrawPaint(const Paint& paint) {
 // Optimization: if the texture has a color filter that is a simple
 // porter-duff blend or matrix filter, then instead of performing a save layer
 // we should swap out the shader for the porter duff blend shader and avoid a
-// saveLayer. This can only be done for imageRects without a strict source
-// rect, as the porter duff shader does not support this feature. This
-// optimization is important for Flame.
+// saveLayer. This optimization is important for Flame.
 bool Canvas::AttemptColorFilterOptimization(
     const std::shared_ptr<Texture>& image,
     Rect source,

--- a/engine/src/flutter/impeller/entity/contents/atlas_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/atlas_contents.cc
@@ -23,13 +23,15 @@ DrawImageRectAtlasGeometry::DrawImageRectAtlasGeometry(
     const Rect& destination,
     const Color& color,
     BlendMode blend_mode,
-    const SamplerDescriptor& desc)
+    const SamplerDescriptor& desc,
+    bool use_strict_src_rect)
     : texture_(std::move(texture)),
       source_(source),
       destination_(destination),
       color_(color),
       blend_mode_(blend_mode),
-      desc_(desc) {}
+      desc_(desc),
+      use_strict_src_rect_(use_strict_src_rect) {}
 
 DrawImageRectAtlasGeometry::~DrawImageRectAtlasGeometry() = default;
 
@@ -121,6 +123,13 @@ BlendMode DrawImageRectAtlasGeometry::GetBlendMode() const {
 
 bool DrawImageRectAtlasGeometry::ShouldInvertBlendMode() const {
   return false;
+}
+
+std::optional<Rect> DrawImageRectAtlasGeometry::GetStrictSrcRect() const {
+  if (use_strict_src_rect_) {
+    return source_;
+  }
+  return std::nullopt;
 }
 
 ////
@@ -215,12 +224,16 @@ bool AtlasContents::Render(const ContentContext& renderer,
     frame_info.texture_sampler_y_coord_scale =
         geometry_->GetAtlas()->GetYCoordScale();
 
-    frag_info.output_alpha = alpha_;
-    frag_info.input_alpha = 1.0;
-
-    // These values are ignored on platforms that natively support decal.
-    frag_info.tmx = static_cast<int>(Entity::TileMode::kDecal);
-    frag_info.tmy = static_cast<int>(Entity::TileMode::kDecal);
+    frag_info.ai_ao_tmx_tmy =
+        Vector4(1.0, alpha_, static_cast<int>(Entity::TileMode::kDecal),
+                static_cast<int>(Entity::TileMode::kDecal));
+    if (auto rect = geometry_->GetStrictSrcRect(); rect.has_value()) {
+      Rect src_rect = rect.value();
+      frag_info.source_rect =
+          Vector4(src_rect.GetX(), src_rect.GetY(), src_rect.GetBottom(),
+                  src_rect.GetRight());
+      frag_info.use_strict_source_rect = 1.0;
+    }
 
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
 

--- a/engine/src/flutter/impeller/entity/contents/atlas_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/atlas_contents.cc
@@ -233,6 +233,8 @@ bool AtlasContents::Render(const ContentContext& renderer,
           Vector4(src_rect.GetX(), src_rect.GetY(), src_rect.GetBottom(),
                   src_rect.GetRight());
       frag_info.use_strict_source_rect = 1.0;
+    } else {
+      frag_info.use_strict_source_rect = 0.0;
     }
 
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));

--- a/engine/src/flutter/impeller/entity/contents/atlas_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/atlas_contents.cc
@@ -224,7 +224,7 @@ bool AtlasContents::Render(const ContentContext& renderer,
     frame_info.texture_sampler_y_coord_scale =
         geometry_->GetAtlas()->GetYCoordScale();
 
-    frag_info.ai_ao_tmx_tmy =
+    frag_info.input_alpha_output_alpha_tmx_tmy =
         Vector4(1.0, alpha_, static_cast<int>(Entity::TileMode::kDecal),
                 static_cast<int>(Entity::TileMode::kDecal));
     if (auto rect = geometry_->GetStrictSrcRect(); rect.has_value()) {

--- a/engine/src/flutter/impeller/entity/contents/atlas_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/atlas_contents.h
@@ -40,6 +40,10 @@ class AtlasGeometry {
 
   virtual bool ShouldInvertBlendMode() const { return true; }
 
+  /// @brief the source rect of the draw if a strict source rect should
+  ///        be applied, or nullopt.
+  ///
+  /// See also `Canvas::AttemptColorFilterOptimization`
   virtual std::optional<Rect> GetStrictSrcRect() const { return std::nullopt; }
 };
 

--- a/engine/src/flutter/impeller/entity/contents/atlas_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/atlas_contents.h
@@ -40,7 +40,7 @@ class AtlasGeometry {
 
   virtual bool ShouldInvertBlendMode() const { return true; }
 
-  /// @brief the source rect of the draw if a strict source rect should
+  /// @brief The source rect of the draw if a strict source rect should
   ///        be applied, or nullopt.
   ///
   /// See also `Canvas::AttemptColorFilterOptimization`

--- a/engine/src/flutter/impeller/entity/contents/atlas_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/atlas_contents.h
@@ -39,6 +39,8 @@ class AtlasGeometry {
   virtual BlendMode GetBlendMode() const = 0;
 
   virtual bool ShouldInvertBlendMode() const { return true; }
+
+  virtual std::optional<Rect> GetStrictSrcRect() const { return std::nullopt; }
 };
 
 /// @brief An atlas geometry that adapts for drawImageRect.
@@ -49,7 +51,8 @@ class DrawImageRectAtlasGeometry : public AtlasGeometry {
                              const Rect& destination,
                              const Color& color,
                              BlendMode blend_mode,
-                             const SamplerDescriptor& desc);
+                             const SamplerDescriptor& desc,
+                             bool use_strict_src_rect = false);
 
   ~DrawImageRectAtlasGeometry();
 
@@ -71,6 +74,8 @@ class DrawImageRectAtlasGeometry : public AtlasGeometry {
 
   bool ShouldInvertBlendMode() const override;
 
+  std::optional<Rect> GetStrictSrcRect() const override;
+
  private:
   const std::shared_ptr<Texture> texture_;
   const Rect source_;
@@ -78,6 +83,7 @@ class DrawImageRectAtlasGeometry : public AtlasGeometry {
   const Color color_;
   const BlendMode blend_mode_;
   const SamplerDescriptor desc_;
+  const bool use_strict_src_rect_;
 };
 
 class AtlasContents final : public Contents {

--- a/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -471,7 +471,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
     frame_info.texture_sampler_y_coord_scale =
         dst_snapshot->texture->GetYCoordScale();
 
-    frag_info.ai_ao_tmx_tmy =
+    frag_info.input_alpha_output_alpha_tmx_tmy =
         Vector4(absorb_opacity == ColorFilterContents::AbsorbOpacity::kYes
                     ? dst_snapshot->opacity * alpha.value_or(1.0)
                     : 1.0,

--- a/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -471,11 +471,11 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
     frame_info.texture_sampler_y_coord_scale =
         dst_snapshot->texture->GetYCoordScale();
 
-    frag_info.input_alpha =
-        absorb_opacity == ColorFilterContents::AbsorbOpacity::kYes
-            ? dst_snapshot->opacity * alpha.value_or(1.0)
-            : 1.0;
-    frag_info.output_alpha = 1.0;
+    frag_info.ai_ao_tmx_tmy =
+        Vector4(absorb_opacity == ColorFilterContents::AbsorbOpacity::kYes
+                    ? dst_snapshot->opacity * alpha.value_or(1.0)
+                    : 1.0,
+                1, 0, 0);
 
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
     VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));

--- a/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -476,6 +476,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
                     ? dst_snapshot->opacity * alpha.value_or(1.0)
                     : 1.0,
                 1, 0, 0);
+    frag_info.use_strict_source_rect = 0.0;
 
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
     VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));

--- a/engine/src/flutter/impeller/entity/contents/vertices_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/vertices_contents.cc
@@ -164,8 +164,9 @@ bool VerticesSimpleBlendContents::Render(const ContentContext& renderer,
     frame_info.texture_sampler_y_coord_scale = texture->GetYCoordScale();
     frame_info.mvp = geometry_result.transform;
 
-    frag_info.ai_ao_tmx_tmy = Vector4(1, alpha_, static_cast<int>(tile_mode_x_),
-                                      static_cast<int>(tile_mode_y_));
+    frag_info.input_alpha_output_alpha_tmx_tmy =
+        Vector4(1, alpha_, static_cast<int>(tile_mode_x_),
+                static_cast<int>(tile_mode_y_));
     frag_info.use_strict_source_rect = 0.0;
 
     auto& host_buffer = renderer.GetTransientsBuffer();

--- a/engine/src/flutter/impeller/entity/contents/vertices_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/vertices_contents.cc
@@ -164,12 +164,8 @@ bool VerticesSimpleBlendContents::Render(const ContentContext& renderer,
     frame_info.texture_sampler_y_coord_scale = texture->GetYCoordScale();
     frame_info.mvp = geometry_result.transform;
 
-    frag_info.output_alpha = alpha_;
-    frag_info.input_alpha = 1.0;
-
-    // These values are ignored if the platform supports native decal mode.
-    frag_info.tmx = static_cast<int>(tile_mode_x_);
-    frag_info.tmy = static_cast<int>(tile_mode_y_);
+    frag_info.ai_ao_tmx_tmy = Vector4(1, alpha_, static_cast<int>(tile_mode_x_),
+                                      static_cast<int>(tile_mode_y_));
 
     auto& host_buffer = renderer.GetTransientsBuffer();
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));

--- a/engine/src/flutter/impeller/entity/contents/vertices_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/vertices_contents.cc
@@ -166,6 +166,7 @@ bool VerticesSimpleBlendContents::Render(const ContentContext& renderer,
 
     frag_info.ai_ao_tmx_tmy = Vector4(1, alpha_, static_cast<int>(tile_mode_x_),
                                       static_cast<int>(tile_mode_y_));
+    frag_info.use_strict_source_rect = 0.0;
 
     auto& host_buffer = renderer.GetTransientsBuffer();
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));

--- a/engine/src/flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
+++ b/engine/src/flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
@@ -20,16 +20,18 @@ layout(constant_id = 5) const float dst_coeff_src_color = 1.0;
 uniform f16sampler2D texture_sampler_dst;
 
 uniform FragInfo {
-  vec4 ai_ao_tmx_tmy;
+  // packed input, output alpha and x/y tilemodes.
+  vec4 input_alpha_output_alpha_tmx_tmy;
   vec4 source_rect;
+  // When value is non-zero, uses texture coordinates clamped by `source_rect`.
   float use_strict_source_rect;
 }
 frag_info;
 
-float input_alpha = frag_info.ai_ao_tmx_tmy.x;
-float output_alpha = frag_info.ai_ao_tmx_tmy.y;
-float tmx = frag_info.ai_ao_tmx_tmy.z;
-float tmy = frag_info.ai_ao_tmx_tmy.w;
+float input_alpha = frag_info.input_alpha_output_alpha_tmx_tmy.x;
+float output_alpha = frag_info.input_alpha_output_alpha_tmx_tmy.y;
+float tmx = frag_info.input_alpha_output_alpha_tmx_tmy.z;
+float tmy = frag_info.input_alpha_output_alpha_tmx_tmy.w;
 
 in vec2 v_texture_coords;
 in f16vec4 v_color;

--- a/engine/src/flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
+++ b/engine/src/flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
@@ -20,12 +20,16 @@ layout(constant_id = 5) const float dst_coeff_src_color = 1.0;
 uniform f16sampler2D texture_sampler_dst;
 
 uniform FragInfo {
-  float16_t input_alpha;
-  float16_t output_alpha;
-  float tmx;
-  float tmy;
+  vec4 ai_ao_tmx_tmy;
+  vec4 source_rect;
+  float use_strict_source_rect;
 }
 frag_info;
+
+float input_alpha = frag_info.ai_ao_tmx_tmy.x;
+float output_alpha = frag_info.ai_ao_tmx_tmy.y;
+float tmx = frag_info.ai_ao_tmx_tmy.z;
+float tmy = frag_info.ai_ao_tmx_tmy.w;
 
 in vec2 v_texture_coords;
 in f16vec4 v_color;
@@ -43,12 +47,19 @@ f16vec4 Sample(f16sampler2D texture_sampler,
 }
 
 void main() {
-  f16vec4 dst = Sample(texture_sampler_dst, v_texture_coords, frag_info.tmx,
-                       frag_info.tmy) *
-                frag_info.input_alpha;
+  vec2 texture_coords =
+      mix(v_texture_coords,
+          vec2(clamp(v_texture_coords.x, frag_info.source_rect.x,
+                     frag_info.source_rect.z),
+               clamp(v_texture_coords.y, frag_info.source_rect.y,
+                     frag_info.source_rect.w)),
+          frag_info.use_strict_source_rect);
+
+  f16vec4 dst =
+      Sample(texture_sampler_dst, v_texture_coords, tmx, tmy) * input_alpha;
   f16vec4 src = v_color;
   frag_color = f16vec4(src * (src_coeff + dst.a * src_coeff_dst_alpha) +
                        dst * (dst_coeff + src.a * dst_coeff_src_alpha +
                               src * dst_coeff_src_color));
-  frag_color *= frag_info.output_alpha;
+  frag_color *= output_alpha;
 }

--- a/engine/src/flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
+++ b/engine/src/flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
@@ -30,22 +30,20 @@ frag_info;
 
 float input_alpha = frag_info.input_alpha_output_alpha_tmx_tmy.x;
 float output_alpha = frag_info.input_alpha_output_alpha_tmx_tmy.y;
-float tmx = frag_info.input_alpha_output_alpha_tmx_tmy.z;
-float tmy = frag_info.input_alpha_output_alpha_tmx_tmy.w;
+float tile_mode_x = frag_info.input_alpha_output_alpha_tmx_tmy.z;
+float tile_mode_y = frag_info.input_alpha_output_alpha_tmx_tmy.w;
 
 in vec2 v_texture_coords;
 in f16vec4 v_color;
 
 out vec4 frag_color;
 
-f16vec4 Sample(f16sampler2D texture_sampler,
-               vec2 texture_coords,
-               float tmx,
-               float tmy) {
+f16vec4 Sample(f16sampler2D texture_sampler, vec2 texture_coords) {
   if (supports_decal > 0.0) {
     return texture(texture_sampler, texture_coords);
   }
-  return IPHalfSampleWithTileMode(texture_sampler, texture_coords, tmx, tmy);
+  return IPHalfSampleWithTileMode(texture_sampler, texture_coords, tile_mode_x,
+                                  tile_mode_y);
 }
 
 void main() {
@@ -57,8 +55,8 @@ void main() {
                      frag_info.source_rect.w)),
           frag_info.use_strict_source_rect);
 
-  f16vec4 dst = Sample(texture_sampler_dst, texture_coords, tmx, tmy) *
-                float16_t(input_alpha);
+  f16vec4 dst =
+      Sample(texture_sampler_dst, texture_coords) * float16_t(input_alpha);
   f16vec4 src = v_color;
   frag_color = f16vec4(src * (src_coeff + dst.a * src_coeff_dst_alpha) +
                        dst * (dst_coeff + src.a * dst_coeff_src_alpha +

--- a/engine/src/flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
+++ b/engine/src/flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
@@ -55,8 +55,8 @@ void main() {
                      frag_info.source_rect.w)),
           frag_info.use_strict_source_rect);
 
-  f16vec4 dst =
-      Sample(texture_sampler_dst, v_texture_coords, tmx, tmy) * input_alpha;
+  f16vec4 dst = Sample(texture_sampler_dst, texture_coords, tmx, tmy) *
+                float16_t(input_alpha);
   f16vec4 src = v_color;
   frag_color = f16vec4(src * (src_coeff + dst.a * src_coeff_dst_alpha) +
                        dst * (dst_coeff + src.a * dst_coeff_src_alpha +

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -5161,16 +5161,16 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 71,
+          "fp16_arithmetic": 60,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "varying"
             ],
             "longest_path_cycles": [
-              0.21875,
-              0.21875,
-              0.03125,
+              0.28125,
+              0.28125,
+              0.078125,
               0.0,
               0.0,
               0.5,
@@ -5189,9 +5189,9 @@
               "varying"
             ],
             "shortest_path_cycles": [
-              0.21875,
-              0.21875,
-              0.0,
+              0.28125,
+              0.28125,
+              0.046875,
               0.0,
               0.0,
               0.5,
@@ -5201,9 +5201,9 @@
               "varying"
             ],
             "total_cycles": [
-              0.21875,
-              0.21875,
-              0.03125,
+              0.28125,
+              0.28125,
+              0.078125,
               0.0,
               0.0,
               0.5,
@@ -5212,7 +5212,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
+          "uniform_registers_used": 6,
           "work_registers_used": 20
         }
       }
@@ -5230,7 +5230,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              1.3200000524520874,
+              2.309999942779541,
               1.0,
               1.0
             ],
@@ -5243,7 +5243,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              1.3200000524520874,
+              2.309999942779541,
               1.0,
               1.0
             ],
@@ -5251,7 +5251,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              1.6666666269302368,
+              2.6666667461395264,
               1.0,
               1.0
             ]
@@ -9014,16 +9014,16 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 100,
+          "fp16_arithmetic": 60,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "varying"
             ],
             "longest_path_cycles": [
-              0.1875,
-              0.1875,
-              0.0,
+              0.25,
+              0.25,
+              0.0625,
               0.0,
               0.0,
               0.5,
@@ -9042,9 +9042,9 @@
               "varying"
             ],
             "shortest_path_cycles": [
-              0.1875,
-              0.1875,
-              0.0,
+              0.25,
+              0.25,
+              0.0625,
               0.0,
               0.0,
               0.5,
@@ -9054,9 +9054,9 @@
               "varying"
             ],
             "total_cycles": [
-              0.1875,
-              0.1875,
-              0.0,
+              0.25,
+              0.25,
+              0.0625,
               0.0,
               0.0,
               0.5,
@@ -9065,8 +9065,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 6,
-          "work_registers_used": 8
+          "uniform_registers_used": 10,
+          "work_registers_used": 9
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/169492

Currently we apply a color filter nine times for the drawImageNine calls, which is very expensive. We can do the same porterduff optimization we did for flame for drawImage nine by allowing the porter duff shader to specify a strict src rect.

### Before

![flutter_04](https://github.com/user-attachments/assets/006c89ad-14a6-4387-9bfb-f6be357f43d6)

### After

![flutter_03](https://github.com/user-attachments/assets/e058d86e-7f1a-4708-bb40-8746bb9199e4)

