### PR TITLE
Check to see if previous page is laid out before starting hero flight

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -679,14 +679,9 @@ class _HeroFlight {
         case HeroFlightDirection.pop:
           return initialManifest.isUserGestureTransition
               // During user gesture transitions, the animation controller isn't
-              // driving the reverse transition, but should have a starting value
-              // approaching 1.0. In cases where the toRoute begane offstage, there
-              // is a slight delay while the toRoute laysout before the hero's
-              // flight begins, so the animation may not begin completed.
-              ? initial.value == 1.0
-                  ? initial.status == AnimationStatus.completed
-                  : initial.status == AnimationStatus.forward
-              : initial.status == AnimationStatus.reverse;
+              // driving the reverse transition, so the status is not important.
+              ||
+              initial.status == AnimationStatus.reverse;
         case HeroFlightDirection.push:
           return initial.value == 0.0 && initial.status == AnimationStatus.forward;
       }
@@ -929,11 +924,13 @@ class HeroController extends NavigatorObserver {
     // maintainState = true, then the hero's final dimensions can be measured
     // immediately because their page's layout is still valid. Unless due to directly
     // adding routes to the pages stack causing the route to never get laid out.
-    final bool needsLayout = toRoute.subtreeContext?.findRenderObject()?.debugNeedsLayout ?? true;
+    final RenderBox? fromRouteRenderBox = toRoute.subtreeContext?.findRenderObject() as RenderBox?;
+    final bool hasLayout =
+        (fromRouteRenderBox?.hasSize ?? false) && fromRouteRenderBox!.size.isFinite;
     if (isUserGestureTransition &&
         flightType == HeroFlightDirection.pop &&
         toRoute.maintainState &&
-        !needsLayout) {
+        hasLayout) {
       _startHeroTransition(fromRoute, toRoute, flightType, isUserGestureTransition);
     } else {
       // Otherwise, delay measuring until the end of the next frame to allow

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -925,12 +925,12 @@ class HeroController extends NavigatorObserver {
     // immediately because their page's layout is still valid. Unless due to directly
     // adding routes to the pages stack causing the route to never get laid out.
     final RenderBox? fromRouteRenderBox = toRoute.subtreeContext?.findRenderObject() as RenderBox?;
-    final bool hasLayout =
+    final bool hasValidSize =
         (fromRouteRenderBox?.hasSize ?? false) && fromRouteRenderBox!.size.isFinite;
     if (isUserGestureTransition &&
         flightType == HeroFlightDirection.pop &&
         toRoute.maintainState &&
-        hasLayout) {
+        hasValidSize) {
       _startHeroTransition(fromRoute, toRoute, flightType, isUserGestureTransition);
     } else {
       // Otherwise, delay measuring until the end of the next frame to allow

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -928,7 +928,7 @@ class HeroController extends NavigatorObserver {
     // For pop transitions driven by a user gesture: if the "to" page has
     // maintainState = true, then the hero's final dimensions can be measured
     // immediately because their page's layout is still valid. Unless due to directly
-    // adding routes to the pages stack caused the route to never get laid out.
+    // adding routes to the pages stack causing the route to never get laid out.
     final bool needsLayout = toRoute.subtreeContext?.findRenderObject()?.debugNeedsLayout ?? true;
     if (isUserGestureTransition &&
         flightType == HeroFlightDirection.pop &&


### PR DESCRIPTION
Fixes #168267

When going back to a page that never rendered with a hero transition, the app was hanging. This adds a check to see if a page needs to layout before starting the hero flight, and if so, adding a frame delay.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
