### PR TITLE
Update triage for new team-devexp

### DIFF
--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -83,7 +83,7 @@ In general the flow chart for team assignment is as follows, stopping as soon as
 - If it's about the Flutter engine, add `team-engine`.
 - If it's about the Flutter framework, add `team-framework`.
 - If it's about the Flutter tool, add `team-tool`.
-- If it's about developers tools, add `team-devexp`.
+- If it's about developer tools, add `team-devexp`.
 - If it's about a first-party package:
   - If it's about `go_router` or `go_router_builder`, add `team-go_router`.
   - If it's about `two_dimensional_scrollables`, add `team-framework`.

--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -83,6 +83,7 @@ In general the flow chart for team assignment is as follows, stopping as soon as
 - If it's about the Flutter engine, add `team-engine`.
 - If it's about the Flutter framework, add `team-framework`.
 - If it's about the Flutter tool, add `team-tool`.
+- If it's about developers tools, add `team-devexp`.
 - If it's about a first-party package:
   - If it's about `go_router` or `go_router_builder`, add `team-go_router`.
   - If it's about `two_dimensional_scrollables`, add `team-framework`.
@@ -92,7 +93,7 @@ In general the flow chart for team assignment is as follows, stopping as soon as
 
 _It is expected that some bugs will end up being re-assigned to a different team during secondary triage. If there are specific categories of issues where this always happens, the flow chart above should be updated accordingly, but having it happen occasionally is just the process working as expected; in some cases only the engineers working on an issue will know how the work is divided among teams._
 
-Bugs relating to the developer tools should be moved to the `flutter/devtools` repo, unless it looks like the first step is a change to the core parts of Flutter (in which case it should receive the `d: devtools` label as well as the pertinent labels for where the work should occur). Issues tagged with `d: devtools` or moved to the `flutter/devtools` repo will be triaged as described by [flutter/devtools/wiki/Triage](https://github.com/flutter/devtools/wiki/Triage).
+Bugs relating to the developer tools should be moved to the `flutter/devtools` repo, unless it looks like the first step is a change to the core parts of Flutter (in which case it should receive the `a: devtools` label as well as the pertinent labels for where the work should occur). Issues tagged with `team-devexp` and/or `a: devtools`, or moved to the `flutter/devtools` repo, will be triaged as described by [flutter/devtools/wiki/Triage](https://github.com/flutter/devtools/wiki/Triage).
 
 Bugs relating to the IntelliJ IDEs should be moved to the `flutter/flutter-intellij` repo, unless it looks like the first step is a change to the core parts of Flutter (in which case it should receive the `d: intellij` label as well as the pertinent labels for where the work should occur).
 Issues tagged with `d: intellij` will be reviewed by the Flutter IntelliJ team as described by [flutter/flutter-intellij/wiki/Triaging](https://github.com/flutter/flutter-intellij/wiki/Triaging).


### PR DESCRIPTION
Adds the new `team-devexp` to the flowchart, and updates references to `d: devtools` to reflect that it's now `a: devtools`.