### PR TITLE
Trigger `CupertinoPicker` haptics in the middle of the item

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -220,7 +220,7 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
   late int _lastHapticIndex = _effectiveController.initialItem;
   int? _lastMiddlePosition;
   FixedExtentScrollController? _controller;
-  bool _skipHapticFeedback = false;
+  bool _enableHapticFeedback = true;
 
   FixedExtentScrollController get _effectiveController => widget.scrollController ?? _controller!;
 
@@ -259,7 +259,7 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
   }
 
   void _handleHapticFeedback(int index) {
-    if (_skipHapticFeedback) {
+    if (!_enableHapticFeedback) {
       return;
     }
     switch (defaultTargetPlatform) {
@@ -300,13 +300,13 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
   }
 
   Future<void> _handleChildTap(int index) async {
-    _skipHapticFeedback = true;
+    _enableHapticFeedback = false;
     await _effectiveController.animateToItem(
       index,
       duration: _kCupertinoPickerTapToScrollDuration,
       curve: _kCupertinoPickerTapToScrollCurve,
     );
-    _skipHapticFeedback = false;
+    _enableHapticFeedback = true;
     _lastHapticIndex = _effectiveController.selectedItem;
   }
 

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -293,6 +293,9 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
     // scroll position is very close to the middle of the item,
     // but not exactly in the middle.
     if (currentPosition != _lastMiddlePosition || currentItemOffset.abs() <= 0.1) {
+      // Middle is checked with currentPosition, but we pass the real index
+      // to avoid multiple haptics for the same item and to avoid
+      // calling haptic feedback when overscrolling.
       _handleHapticFeedback(index);
     }
 

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -272,7 +272,7 @@ void main() {
 
   group('scroll', () {
     testWidgets(
-      'scrolling calls onSelectedItemChanged and triggers haptic feedback',
+      'scrolling calls onSelectedItemChanged and triggers haptic feedback when scroll passes middle of item',
       (WidgetTester tester) async {
         final List<int> selectedItems = <int>[];
         final List<MethodCall> systemCalls = <MethodCall>[];
@@ -300,21 +300,28 @@ void main() {
             ),
           ),
         );
-
+        // Drag to almost the middle of the next item.
         await tester.drag(
           find.text('0'),
-          const Offset(0.0, -100.0),
+          const Offset(0.0, -90.0),
           warnIfMissed: false,
         ); // has an IgnorePointer
+        // Expect that the item changed, but haptics were not triggered yet,
+        // since we are not in the middle of the item.
         expect(selectedItems, <int>[1]);
+        expect(systemCalls, isEmpty);
+
+        // Let the scroll settle and end up in the middle of the item.
+        await tester.pumpAndSettle();
         expect(
           systemCalls.single,
           isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.selectionClick'),
         );
 
+        // Overscroll a little to pass the middle of the item.
         await tester.drag(
           find.text('0'),
-          const Offset(0.0, 100.0),
+          const Offset(0.0, 110.0),
           warnIfMissed: false,
         ); // has an IgnorePointer
         expect(selectedItems, <int>[1, 0]);
@@ -362,6 +369,10 @@ void main() {
           const Offset(0.0, -100.0),
           warnIfMissed: false,
         ); // has an IgnorePointer
+
+        // Allow the scroll to settle in the middle of the item.
+        await tester.pumpAndSettle();
+
         expect(selectedItems, <int>[1]);
         expect(systemCalls, isEmpty);
       },


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/169606

This PR only fixes the haptic behaviour of `CupertinoPicker`, which now triggers only when passing the middle of the item. Haptic feedback is now also not trigger when tapping on an item to scroll to.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
