### PR TITLE
Clean up references to deprecated onPop method in docs

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator_pop_handler.dart
+++ b/packages/flutter/lib/src/widgets/navigator_pop_handler.dart
@@ -10,10 +10,10 @@ import 'pop_scope.dart';
 /// Enables the handling of system back gestures.
 ///
 /// Typically wraps a nested [Navigator] widget and allows it to handle system
-/// back gestures in the [onPop] callback.
+/// back gestures in the [onPopWithResult] callback.
 ///
 /// The type parameter `<T>` indicates the type of the [Route]'s return value,
-/// which is passed to [onPopWithResult.
+/// which is passed to [onPopWithResult].
 ///
 /// {@tool dartpad}
 /// This sample demonstrates how to use this widget to properly handle system
@@ -53,8 +53,8 @@ class NavigatorPopHandler<T> extends StatefulWidget {
 
   /// The widget to place below this in the widget tree.
   ///
-  /// Typically this is a [Navigator] that will handle the pop when [onPop] is
-  /// called.
+  /// Typically this is a [Navigator] that will handle the pop when
+  /// [onPopWithResult] is called.
   final Widget child;
 
   /// Whether this widget's ability to handle system back gestures is enabled or
@@ -87,7 +87,7 @@ class NavigatorPopHandler<T> extends StatefulWidget {
   ///
   /// For example, a pop is handleable when a [Navigator] in [child] has
   /// multiple routes on its stack. It's not handleable when it has only a
-  /// single route, and so [onPop] will not be called.
+  /// single route, and so [onPopWithResult] will not be called.
   ///
   /// Typically this is used to pop the [Navigator] in [child]. See the sample
   /// code on [NavigatorPopHandler] for a full example of this.


### PR DESCRIPTION
onPop is deprecated but was mentioned in the docs. I've put its replacement onPopWithResult in its place. Also, there was one unterminated square bracket that I've fixed.