### PR TITLE
IOSSystemContextMenuItem.toString to Diagnosticable

### DIFF
--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -5,6 +5,7 @@
 /// @docImport 'package:flutter/material.dart';
 library;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
@@ -320,7 +321,7 @@ final class IOSSystemContextMenuItemSelectAll extends IOSSystemContextMenuItem {
 ///    context menu.
 ///  * [IOSSystemContextMenuItemDataLookUp], which specifies the data to be sent
 ///    to the platform for this same button.
-final class IOSSystemContextMenuItemLookUp extends IOSSystemContextMenuItem {
+final class IOSSystemContextMenuItemLookUp extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemLookUp].
   const IOSSystemContextMenuItemLookUp({this.title});
 
@@ -333,8 +334,9 @@ final class IOSSystemContextMenuItemLookUp extends IOSSystemContextMenuItem {
   }
 
   @override
-  String toString() {
-    return 'IOSSystemContextMenuItemLookUp(title: $title)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<String>('title', title));
   }
 }
 
@@ -355,7 +357,7 @@ final class IOSSystemContextMenuItemLookUp extends IOSSystemContextMenuItem {
 ///    context menu.
 ///  * [IOSSystemContextMenuItemDataSearchWeb], which specifies the data to be
 ///    sent to the platform for this same button.
-final class IOSSystemContextMenuItemSearchWeb extends IOSSystemContextMenuItem {
+final class IOSSystemContextMenuItemSearchWeb extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemSearchWeb].
   const IOSSystemContextMenuItemSearchWeb({this.title});
 
@@ -370,8 +372,9 @@ final class IOSSystemContextMenuItemSearchWeb extends IOSSystemContextMenuItem {
   }
 
   @override
-  String toString() {
-    return 'IOSSystemContextMenuItemSearchWeb(title: $title)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<String>('title', title));
   }
 }
 
@@ -392,7 +395,7 @@ final class IOSSystemContextMenuItemSearchWeb extends IOSSystemContextMenuItem {
 ///    context menu.
 ///  * [IOSSystemContextMenuItemDataShare], which specifies the data to be sent
 ///    to the platform for this same button.
-final class IOSSystemContextMenuItemShare extends IOSSystemContextMenuItem {
+final class IOSSystemContextMenuItemShare extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemShare].
   const IOSSystemContextMenuItemShare({this.title});
 
@@ -405,8 +408,9 @@ final class IOSSystemContextMenuItemShare extends IOSSystemContextMenuItem {
   }
 
   @override
-  String toString() {
-    return 'IOSSystemContextMenuItemShare(title: $title)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('title', title));
   }
 }
 

--- a/packages/flutter/test/widgets/system_context_menu_test.dart
+++ b/packages/flutter/test/widgets/system_context_menu_test.dart
@@ -698,4 +698,34 @@ void main() {
       );
     },
   );
+
+  // Regression test for https://github.com/flutter/flutter/issues/169696.
+  test('IOSSystemContextMenuItemLookUp debugFillProperties', () {
+    const String title = 'my title';
+    const IOSSystemContextMenuItemLookUp item = IOSSystemContextMenuItemLookUp(title: title);
+    final List<DiagnosticsNode> diagnosticsNodes = item.toDiagnosticsNode().getProperties();
+    expect(diagnosticsNodes, hasLength(1));
+    expect(diagnosticsNodes.first.name, 'title');
+    expect(diagnosticsNodes.first.value, title);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/169696.
+  test('IOSSystemContextMenuItemSearchWeb debugFillProperties', () {
+    const String title = 'my title';
+    const IOSSystemContextMenuItemSearchWeb item = IOSSystemContextMenuItemSearchWeb(title: title);
+    final List<DiagnosticsNode> diagnosticsNodes = item.toDiagnosticsNode().getProperties();
+    expect(diagnosticsNodes, hasLength(1));
+    expect(diagnosticsNodes.first.name, 'title');
+    expect(diagnosticsNodes.first.value, title);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/169696.
+  test('IOSSystemContextMenuItemShare debugFillProperties', () {
+    const String title = 'my title';
+    const IOSSystemContextMenuItemShare item = IOSSystemContextMenuItemShare(title: title);
+    final List<DiagnosticsNode> diagnosticsNodes = item.toDiagnosticsNode().getProperties();
+    expect(diagnosticsNodes, hasLength(1));
+    expect(diagnosticsNodes.first.name, 'title');
+    expect(diagnosticsNodes.first.value, title);
+  });
 }


### PR DESCRIPTION
The IOSSystemContextMenuItem should mixin Diagnosticable instead of overriding toString.

Fixes https://github.com/flutter/flutter/issues/169696