### PR TITLE
feat: experimental workflow for  Linux tool-tests-general

### DIFF
--- a/.github/workflows/tool-test-general.yml
+++ b/.github/workflows/tool-test-general.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   Linux_tool-tests-general:
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tool-test-general.yml
+++ b/.github/workflows/tool-test-general.yml
@@ -1,0 +1,53 @@
+name: Tool tests general - experiment
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'dev/**'
+      - 'packages/flutter_tools/**'
+      - 'bin/**'
+      - '.ci.yaml'
+      - 'engine/**'
+      - 'DEPS'
+  push:
+    branches: [main]
+
+jobs:
+  Linux_tool-tests-general:
+    runs-on: ubuntu-latest
+
+    steps:
+      # The following step is only run LOCALLY - Github runners have everything on them
+      - name: Set up our JDK environment
+        if: ${{ env.ACT }}
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # The following step is only run LOCALLY - Github runners have everything on them
+      - name: Setup Android SDK
+        if: ${{ env.ACT }}
+        uses: amyu/setup-android@v4
+        with:
+          sdk-version: 36
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Path Update
+        run: |
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+
+      - name: Flutter Doctor
+        run: |
+          flutter doctor
+
+      - name: Get packages
+        run: |
+          flutter update-packages
+
+      - name: Tool Test
+        run: |
+          SHARD=tool_tests SUBSHARD=general dart --enable-asserts dev/bots/test.dart

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -168,10 +168,7 @@ void foundError(List<String> messages) {
   assert(messages.isNotEmpty);
   // Make the error message easy to notice in the logs by
   // wrapping it in a red box.
-  final int width = math.max(
-    15,
-    (hasColor && stdout.hasTerminal ? stdout.terminalColumns : 80) - 1,
-  );
+  final int width = math.max(15, (hasColor ? stdout.terminalColumns : 80) - 1);
   final String title = 'ERROR #${_errorMessages.length + 1}';
   print('$red╔═╡$bold$title$reset$red╞═${"═" * (width - 4 - title.length)}');
   for (final String message in messages.expand((String line) => line.split('\n'))) {

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -168,7 +168,10 @@ void foundError(List<String> messages) {
   assert(messages.isNotEmpty);
   // Make the error message easy to notice in the logs by
   // wrapping it in a red box.
-  final int width = math.max(15, (hasColor ? stdout.terminalColumns : 80) - 1);
+  final int width = math.max(
+    15,
+    (hasColor && stdout.hasTerminal ? stdout.terminalColumns : 80) - 1,
+  );
   final String title = 'ERROR #${_errorMessages.length + 1}';
   print('$red╔═╡$bold$title$reset$red╞═${"═" * (width - 4 - title.length)}');
   for (final String message in messages.expand((String line) => line.split('\n'))) {


### PR DESCRIPTION
Demonstrates running Linux tool-tests-general running on workflows.

Can be run locally using ACT: `gh act --workflows ".github/workflows/tool-test-general.yml" --secret-file "" --var-file "" --input-file "" --eventpath ""` - except this works only in VSCode since tty isn't attached.