### PR TITLE
Mark `Linux web_tool_tests` as `bringup` due to being 10%+ flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2246,6 +2246,7 @@ targets:
 
   - name: Linux web_tool_tests
     recipe: flutter/flutter_drone
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/169574
     timeout: 90 # https://github.com/flutter/flutter/issues/169634
     properties:
       dependencies: >-


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/169574.