### PR TITLE
[iOS] Fix tapping on selection should toggle the toolbar with iOS System Context Menu

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1235,12 +1235,22 @@ mixin TextSelectionDelegate {
   ///   updating the text editing state.
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause);
 
+  /// Shows the text selection toolbar.
+  void showToolbar();
+
   /// Hides the text selection toolbar.
   ///
-  /// By default, hideHandles is true, and the toolbar is hidden along with its
-  /// handles. If hideHandles is set to false, then the toolbar will be hidden
+  /// By default, [hideHandles] is true, and the toolbar is hidden along with its
+  /// handles. If [hideHandles] is set to false, then the toolbar will be hidden
   /// but the handles will remain.
-  void hideToolbar([bool hideHandles = true]);
+  ///
+  /// When [toggleDebounceDuration] is non-null, a subsequent call to [toggleToolbar]
+  /// should not show the toolbar unless a duration threshold of [toggleDebounceDuration]
+  /// has been exceeded.
+  void hideToolbar([bool hideHandles = true, Duration? toggleDebounceDuration]);
+
+  /// Toggles the visibility of the toolbar.
+  void toggleToolbar();
 
   /// Brings the provided [TextPosition] into the visible area of the text
   /// input.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4981,7 +4981,7 @@ class EditableTextState extends State<EditableText>
 
   // The time when the last call to [hideSystemToolbar] was made.
   Duration? _hideSystemToolbarLastTimestamp;
-  static const Duration _systemToolbarToggleDebounceThreshold = Duration(milliseconds: 100);
+  static const Duration _kSystemToolbarToggleDebounceThreshold = Duration(milliseconds: 100);
 
   /// This is called by the [SystemContextMenu] when the platform dismisses the system
   /// context menu.
@@ -5012,7 +5012,7 @@ class EditableTextState extends State<EditableText>
       if (_hideSystemToolbarLastTimestamp != null &&
           (SchedulerBinding.instance.currentSystemFrameTimeStamp -
                   _hideSystemToolbarLastTimestamp!) <
-              _systemToolbarToggleDebounceThreshold) {
+              _kSystemToolbarToggleDebounceThreshold) {
         // Do not show the system toolbar if it was only just hidden. This is
         // needed to prevent the system toolbar from being shown again when tapping
         // the selection to toggle the toolbar on iOS.
@@ -5022,7 +5022,7 @@ class EditableTextState extends State<EditableText>
         // The framework implements a feature on iOS that toggles the toolbar whenever
         // the selection is tapped on. The system context menu on iOS dismisses itself
         // whenever a tap happens outside of it. In this scenario the framework first
-        // handles the dismiss event from the platform, as a result of the tap and hides
+        // handles the dismiss event from the platform as a result of the tap and hides
         // the toolbar. Then the framework handles the same tap and attempts to toggle
         // the toolbar. Since the toolbar is hidden at the time when the framework handles
         // the tap it attempts to show the toolbar again. The expected behavior would be

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5010,7 +5010,8 @@ class EditableTextState extends State<EditableText>
       hideToolbar(hideHandles);
     } else {
       if (_hideSystemToolbarLastTimestamp != null &&
-          (SchedulerBinding.instance.currentSystemFrameTimeStamp - _hideSystemToolbarLastTimestamp!) <
+          (SchedulerBinding.instance.currentSystemFrameTimeStamp -
+                  _hideSystemToolbarLastTimestamp!) <
               _systemToolbarToggleDebounceThreshold) {
         // Do not show the system toolbar if it was only just hidden. This is
         // needed to prevent the system toolbar from being shown again when tapping

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4980,13 +4980,13 @@ class EditableTextState extends State<EditableText>
   }
 
   // The time when the last call to [hideSystemToolbar] was made.
-  DateTime? _hideSystemToolbarLastTimestamp;
+  Duration? _hideSystemToolbarLastTimestamp;
   static const Duration _systemToolbarToggleDebounceThreshold = Duration(milliseconds: 100);
 
   /// This is called by the [SystemContextMenu] when the platform dismisses the system
   /// context menu.
   void hideSystemToolbar() {
-    _hideSystemToolbarLastTimestamp = DateTime.now();
+    _hideSystemToolbarLastTimestamp = SchedulerBinding.instance.currentSystemFrameTimeStamp;
     hideToolbar(false);
   }
 
@@ -5010,7 +5010,7 @@ class EditableTextState extends State<EditableText>
       hideToolbar(hideHandles);
     } else {
       if (_hideSystemToolbarLastTimestamp != null &&
-          _hideSystemToolbarLastTimestamp!.difference(DateTime.now()) <
+          (SchedulerBinding.instance.currentSystemFrameTimeStamp - _hideSystemToolbarLastTimestamp!) <
               _systemToolbarToggleDebounceThreshold) {
         // Do not show the system toolbar if it was only just hidden. This is
         // needed to prevent the system toolbar from being shown again when tapping

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -895,11 +895,11 @@ class SelectableRegionState extends State<SelectableRegion>
       case TargetPlatform.fuchsia:
         if (shouldShowSelectionOverlayOnMobile) {
           _showHandles();
-          _showToolbar();
+          showToolbar();
         }
       case TargetPlatform.iOS:
         if (shouldShowSelectionOverlayOnMobile) {
-          _showToolbar();
+          showToolbar();
         }
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
@@ -917,12 +917,7 @@ class SelectableRegionState extends State<SelectableRegion>
         _positionIsOnActiveSelection(globalPosition: details.globalPosition)) {
       // On iOS when the tap occurs on the previous selection, instead of
       // moving the selection, the context menu will be toggled.
-      final bool toolbarIsVisible = _selectionOverlay?.toolbarIsVisible ?? false;
-      if (toolbarIsVisible) {
-        hideToolbar(false);
-      } else {
-        _showToolbar();
-      }
+      toggleToolbar();
       return;
     }
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
@@ -948,7 +943,7 @@ class SelectableRegionState extends State<SelectableRegion>
               // On Android, a double tap will only show the selection overlay after
               // the following tap up when the pointer device kind is not precise.
               _showHandles();
-              _showToolbar();
+              showToolbar();
             }
           case TargetPlatform.iOS:
             if (!isPointerPrecise) {
@@ -958,7 +953,7 @@ class SelectableRegionState extends State<SelectableRegion>
               }
               // On iOS, a double tap will only show the selection toolbar after
               // the following tap up when the pointer device kind is not precise.
-              _showToolbar();
+              showToolbar();
             }
           case TargetPlatform.macOS:
           case TargetPlatform.linux:
@@ -1007,7 +1002,7 @@ class SelectableRegionState extends State<SelectableRegion>
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
     _finalizeSelectableRegionStatus();
-    _showToolbar();
+    showToolbar();
     if (defaultTargetPlatform == TargetPlatform.android) {
       _showHandles();
     }
@@ -1043,7 +1038,7 @@ class SelectableRegionState extends State<SelectableRegion>
           // accesses contextMenuAnchors.
           _lastSecondaryTapDownPosition = details.globalPosition;
           _showHandles();
-          _showToolbar(location: _lastSecondaryTapDownPosition);
+          showToolbar(location: _lastSecondaryTapDownPosition);
           _updateSelectedContentIfNeeded();
           return;
         }
@@ -1076,7 +1071,7 @@ class SelectableRegionState extends State<SelectableRegion>
     // accesses contextMenuAnchors.
     _lastSecondaryTapDownPosition = details.globalPosition;
     _showHandles();
-    _showToolbar(location: _lastSecondaryTapDownPosition);
+    showToolbar(location: _lastSecondaryTapDownPosition);
     _updateSelectedContentIfNeeded();
   }
 
@@ -1347,7 +1342,8 @@ class SelectableRegionState extends State<SelectableRegion>
   /// [Overlay].
   ///
   /// Returns true if the toolbar is shown, false if the toolbar can't be shown.
-  bool _showToolbar({Offset? location}) {
+  @override
+  bool showToolbar({Offset? location}) {
     if (!_hasSelectionOverlayGeometry && _selectionOverlay == null) {
       return false;
     }
@@ -1380,6 +1376,16 @@ class SelectableRegionState extends State<SelectableRegion>
       },
     );
     return true;
+  }
+
+  @override
+  void toggleToolbar() {
+    final bool toolbarIsVisible = _selectionOverlay?.toolbarIsVisible ?? false;
+    if (toolbarIsVisible) {
+      hideToolbar(false);
+    } else {
+      showToolbar();
+    }
   }
 
   /// Sets or updates selection end edge to the `offset` location.
@@ -1821,7 +1827,7 @@ class SelectableRegionState extends State<SelectableRegion>
   bool get pasteEnabled => false;
 
   @override
-  void hideToolbar([bool hideHandles = true]) {
+  void hideToolbar([bool hideHandles = true, Duration? toggleDebounceDuration]) {
     _selectionOverlay?.hideToolbar();
     if (hideHandles) {
       _selectionOverlay?.hideHandles();
@@ -1833,7 +1839,7 @@ class SelectableRegionState extends State<SelectableRegion>
     clearSelection();
     _selectable?.dispatchSelectionEvent(const SelectAllSelectionEvent());
     if (cause == SelectionChangedCause.toolbar) {
-      _showToolbar();
+      showToolbar();
       _showHandles();
     }
     _updateSelectedContentIfNeeded();

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -84,9 +84,12 @@ class SystemContextMenu extends StatefulWidget {
         ),
       ),
       items: items ?? getDefaultItems(editableTextState),
-      onSystemHide: editableTextState.hideSystemToolbar,
+      onSystemHide: () =>
+          editableTextState.hideToolbar(false, _kSystemToolbarToggleDebounceThreshold),
     );
   }
+
+  static const Duration _kSystemToolbarToggleDebounceThreshold = Duration(milliseconds: 100);
 
   /// The [Rect] that the context menu should point to.
   final Rect anchor;

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -84,7 +84,7 @@ class SystemContextMenu extends StatefulWidget {
         ),
       ),
       items: items ?? getDefaultItems(editableTextState),
-      onSystemHide: () => editableTextState.hideSystemToolbar,
+      onSystemHide: editableTextState.hideSystemToolbar,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -84,7 +84,7 @@ class SystemContextMenu extends StatefulWidget {
         ),
       ),
       items: items ?? getDefaultItems(editableTextState),
-      onSystemHide: () => editableTextState.hideToolbar(false),
+      onSystemHide: () => editableTextState.hideSystemToolbar,
     );
   }
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -9448,8 +9448,6 @@ void main() {
 
         expect(find.byType(SystemContextMenu), findsOneWidget);
 
-        // Tap the selection to toggle the toolbar (hide).
-        await tester.tapAt(textOffsetToPosition(tester, 1));
         // Simulate system hiding the menu as a result of tapping outside of it.
         final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
           'method': 'ContextMenu.onDismissSystemContextMenu',
@@ -9464,6 +9462,8 @@ void main() {
         } catch (e) {
           error = e;
         }
+        // Tap the selection to toggle the toolbar (hide).
+        await tester.tapAt(textOffsetToPosition(tester, 1));
         await tester.pumpAndSettle();
 
         expect(error, isNull);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -9448,7 +9448,7 @@ void main() {
 
         expect(find.byType(SystemContextMenu), findsOneWidget);
 
-        // Tap the selection to toggle the toolbar.
+        // Tap the selection to toggle the toolbar (hide).
         await tester.tapAt(textOffsetToPosition(tester, 1));
         // Simulate system hiding the menu as a result of tapping outside of it.
         final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
@@ -9469,6 +9469,7 @@ void main() {
         expect(error, isNull);
         expect(find.byType(SystemContextMenu), findsNothing);
 
+        // Tap again to show the context menu.
         await tester.pumpAndSettle(kDoubleTapTimeout);
         await tester.tapAt(textOffsetToPosition(tester, 1));
         await tester.pumpAndSettle();

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -9414,6 +9414,69 @@ void main() {
       skip: kIsWeb, // [intended] on web the browser handles the context menu.
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );
+
+    testWidgets(
+      'iOS system context menu, tapping the selection toggles the toolbar',
+      (WidgetTester tester) async {
+        tester.platformDispatcher.supportsShowingSystemContextMenu = true;
+        addTearDown(() {
+          tester.platformDispatcher.resetSupportsShowingSystemContextMenu();
+          tester.view.reset();
+        });
+
+        final TextEditingController controller = TextEditingController(text: 'one two three');
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          // Don't wrap with the global View so that the change to
+          // platformDispatcher is read.
+          wrapWithView: false,
+          View(
+            view: tester.view,
+            child: CupertinoApp(home: CupertinoTextField(controller: controller)),
+          ),
+        );
+
+        // No context menu shown.
+        expect(find.byType(SystemContextMenu), findsNothing);
+
+        // Double tap to select the first word and show the menu.
+        await tester.tapAt(textOffsetToPosition(tester, 1));
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.tapAt(textOffsetToPosition(tester, 1));
+        await tester.pumpAndSettle(kDoubleTapTimeout);
+
+        expect(find.byType(SystemContextMenu), findsOneWidget);
+
+        // Tap the selection to toggle the toolbar.
+        await tester.tapAt(textOffsetToPosition(tester, 1));
+        // Simulate system hiding the menu as a result of tapping outside of it.
+        final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+          'method': 'ContextMenu.onDismissSystemContextMenu',
+        });
+        Object? error;
+        try {
+          await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+            'flutter/platform',
+            messageBytes,
+            (ByteData? data) {},
+          );
+        } catch (e) {
+          error = e;
+        }
+        await tester.pumpAndSettle();
+
+        expect(error, isNull);
+        expect(find.byType(SystemContextMenu), findsNothing);
+
+        await tester.pumpAndSettle(kDoubleTapTimeout);
+        await tester.tapAt(textOffsetToPosition(tester, 1));
+        await tester.pumpAndSettle();
+        expect(find.byType(SystemContextMenu), findsOneWidget);
+      },
+      skip: kIsWeb, // [intended] on web the browser handles the context menu.
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
   });
 
   group('magnifier', () {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -17117,7 +17117,7 @@ void main() {
 
         expect(find.byType(SystemContextMenu), findsOneWidget);
 
-        // Tap the selection to toggle the toolbar.
+        // Tap the selection to toggle the toolbar (hide).
         await tester.tapAt(textOffsetToPosition(tester, 1));
         // Simulate system hiding the menu as a result of tapping outside of it.
         final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
@@ -17138,6 +17138,7 @@ void main() {
         expect(error, isNull);
         expect(find.byType(SystemContextMenu), findsNothing);
 
+        // Tap again to show the context menu.
         await tester.pumpAndSettle(kDoubleTapTimeout);
         await tester.tapAt(textOffsetToPosition(tester, 1));
         await tester.pumpAndSettle();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -17118,7 +17118,6 @@ void main() {
         expect(find.byType(SystemContextMenu), findsOneWidget);
 
         // Tap the selection to toggle the toolbar (hide).
-        await tester.tapAt(textOffsetToPosition(tester, 1));
         // Simulate system hiding the menu as a result of tapping outside of it.
         final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
           'method': 'ContextMenu.onDismissSystemContextMenu',
@@ -17133,6 +17132,7 @@ void main() {
         } catch (e) {
           error = e;
         }
+        await tester.tapAt(textOffsetToPosition(tester, 1));
         await tester.pumpAndSettle();
 
         expect(error, isNull);

--- a/packages/flutter/test/rendering/editable_intrinsics_test.dart
+++ b/packages/flutter/test/rendering/editable_intrinsics_test.dart
@@ -111,7 +111,13 @@ class _FakeEditableTextState with TextSelectionDelegate {
   TextSelection? selection;
 
   @override
-  void hideToolbar([bool hideHandles = true]) {}
+  void showToolbar() {}
+
+  @override
+  void hideToolbar([bool hideHandles = true, Duration? toggleDebouceDuration]) {}
+
+  @override
+  void toggleToolbar() {}
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -44,7 +44,13 @@ class _FakeEditableTextState with TextSelectionDelegate {
   TextSelection? selection;
 
   @override
-  void hideToolbar([bool hideHandles = true]) {}
+  void showToolbar() {}
+
+  @override
+  void toggleToolbar() {}
+
+  @override
+  void hideToolbar([bool hideHandles = true, Duration? toggleDebounceDuration]) {}
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) {

--- a/packages/flutter/test/widgets/text_scaler_backward_compatibility_test.dart
+++ b/packages/flutter/test/widgets/text_scaler_backward_compatibility_test.dart
@@ -239,13 +239,13 @@ class _FakeEditableTextState with TextSelectionDelegate {
   TextSelection? selection;
 
   @override
-  void showToolbar(){}
+  void showToolbar() {}
 
   @override
   void hideToolbar([bool hideHandles = true, Duration? toggleDebounceDuration]) {}
 
   @override
-  void toggleToolbar(){}
+  void toggleToolbar() {}
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) {

--- a/packages/flutter/test/widgets/text_scaler_backward_compatibility_test.dart
+++ b/packages/flutter/test/widgets/text_scaler_backward_compatibility_test.dart
@@ -239,7 +239,13 @@ class _FakeEditableTextState with TextSelectionDelegate {
   TextSelection? selection;
 
   @override
-  void hideToolbar([bool hideHandles = true]) {}
+  void showToolbar(){}
+
+  @override
+  void hideToolbar([bool hideHandles = true, Duration? toggleDebounceDuration]) {}
+
+  @override
+  void toggleToolbar(){}
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) {


### PR DESCRIPTION
Fixes an issue with tapping the selection to toggle the toolbar on iOS when using the system context menu. 

Cause: On the framework side we have implemented toggling the selection toolbar when tapping on the current selection. This does not work with the system context menu as seen in the video in the actual results of this issue, tapping the selection hides the toolbar but immediately shows it again after. This happens because first the system dismisses the platform context menu when the tap happens outside the context menu (tap on the selection), the framework then responds to this by hiding the context menu. The framework also then responds to the tap on the selection and tries to toggle the toolbar, this ends up bringing up the toolbar again. The expected behavior would have been for the tap on the selection to hide the toolbar and not reshow it until a subsequent tap.

Fix: Add a toggle debounce that prevents the toolbar from being shown when calling `EditableTextState.toggleToolbar` if it has only just been hidden (within 100ms).

Fixes #168743

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.