### PR TITLE
feat: experimental tool tests workflow (attempt 2)

### DIFF
--- a/.github/workflows/tool-test-general.yml
+++ b/.github/workflows/tool-test-general.yml
@@ -1,0 +1,93 @@
+name: Tool tests general - experiment
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '.github/workflows/tool-test-general.yml'
+      - 'dev/**'
+      - 'packages/flutter_tools/**'
+      - 'bin/**'
+      - '.ci.yaml'
+      - 'engine/**'
+      - 'DEPS'
+  push:
+    branches: [master]
+
+jobs:
+  Linux_tool-tests-general:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Real checkout on github actions for pull requests
+      - name: Checkout code (non-act)
+        uses: actions/checkout@v4
+        if: github.event_name == 'pull_request' && !env.ACT
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          # Checkout the PR; not the merge commit - we need to describe tags
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      # Real checkout on github actions for post submit
+      - name: Checkout code (non-act)
+        uses: actions/checkout@v4
+        if: github.event_name == 'push' && !env.ACT
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          # Checkout the PR; not the merge commit - we need to describe tags
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      # Fake checkout if running locally
+      - name: Checkout code (act)
+        uses: actions/checkout@v4
+        if: env.ACT
+
+      # If this is a branch / pr NOT on fluter/flutter, set the remote upstream
+      # so the flutter tool can figure out the version
+      - name: Set upstream (if not flutter/flutter)
+        if: github.repository != 'flutter/flutter' && !env.ACT
+        run: |
+          git remote add upstream https://github.com/flutter/flutter.git
+          git fetch --all --tags
+
+      # If running locally; install the JDK - Github runners have everything on them
+      - name: Set up our JDK environment
+        if: env.ACT
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # If running locally; install Android SDK tools - Github runners have everything on them
+      - name: Setup Android SDK
+        if: env.ACT
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+        with:
+          cmdline-tools-version: 13114758
+
+      # If running locally; install Android SDK - Github runners have everything on them
+      - name: install android
+        if: env.ACT
+        run: |
+          sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Add `flutter` to the PATH
+        run: |
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+
+      - name: Flutter Doctor
+        run: |
+          flutter doctor
+
+      - name: update-packages
+        run: |
+          flutter update-packages
+
+      - name: Tool Test
+        run: |
+          SHARD=tool_tests SUBSHARD=general dart --enable-asserts dev/bots/test.dart

--- a/.github/workflows/tool-test-general.yml
+++ b/.github/workflows/tool-test-general.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       # Real checkout on github actions for pull requests
-      - name: Checkout code (non-act)
+      - name: Checkout code (non-act pull_request)
         uses: actions/checkout@v4
         if: github.event_name == 'pull_request' && !env.ACT
         with:
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       # Real checkout on github actions for post submit
-      - name: Checkout code (non-act)
+      - name: Checkout code (non-act push)
         uses: actions/checkout@v4
         if: github.event_name == 'push' && !env.ACT
         with:
@@ -43,7 +43,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       # Fake checkout if running locally
-      - name: Checkout code (act)
+      - name: Checkout code (act local)
         uses: actions/checkout@v4
         if: env.ACT
 

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -107,9 +107,17 @@ const int kCSIIntermediateRangeEnd = 0x2F;
 const int kCSIFinalRangeStart = 0x40;
 const int kCSIFinalRangeEnd = 0x7E;
 
+int get terminalColumns {
+  try {
+    return stdout.terminalColumns;
+  } catch (e) {
+    return 40;
+  }
+}
+
 String get redLine {
   if (hasColor) {
-    return '$red${'━' * stdout.terminalColumns}$reset';
+    return '$red${'━' * terminalColumns}$reset';
   }
   return '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━';
 }
@@ -168,7 +176,7 @@ void foundError(List<String> messages) {
   assert(messages.isNotEmpty);
   // Make the error message easy to notice in the logs by
   // wrapping it in a red box.
-  final int width = math.max(15, (hasColor ? stdout.terminalColumns : 80) - 1);
+  final int width = math.max(15, (hasColor ? terminalColumns : 80) - 1);
   final String title = 'ERROR #${_errorMessages.length + 1}';
   print('$red╔═╡$bold$title$reset$red╞═${"═" * (width - 4 - title.length)}');
   for (final String message in messages.expand((String line) => line.split('\n'))) {
@@ -258,7 +266,7 @@ void _printQuietly(Object? message) {
     final int start = line.lastIndexOf(_lineBreak) + 1;
     int index = start;
     int length = 0;
-    while (index < line.length && length < stdout.terminalColumns) {
+    while (index < line.length && length < terminalColumns) {
       if (line.codeUnitAt(index) == kESC) {
         // 0x1B
         index += 1;


### PR DESCRIPTION
 - remote repo: set upstream and get tags (flutter tool reqs)
 - pull request to flutter: checkout the PR, not the merge commit
 - local runs: update utils.dart to safely call terminal width

Now `act -W .github/workflows/tool-test-general.yml` works locally on the command line.

Future improvements:
- Offer another way to set the "version" rather than tags; this causes a longer checkout time.
- Multi-proc the tests and use as many cores as possible?
- Solve for packages downloading?

3.5 minutes isn't terrible.