### PR TITLE
Move the check for Git in the PATH into the top level Windows flutter.bat script

### DIFF
--- a/bin/dart.bat
+++ b/bin/dart.bat
@@ -15,6 +15,19 @@ SETLOCAL
 
 FOR %%i IN ("%~dp0..") DO SET FLUTTER_ROOT=%%~fi
 
+REM Detect which PowerShell executable is available on the host
+REM PowerShell version <= 5: PowerShell.exe
+REM PowerShell version >= 6: pwsh.exe
+WHERE /Q pwsh.exe && (
+    SET powershell_executable=pwsh.exe
+) || WHERE /Q PowerShell.exe && (
+    SET powershell_executable=PowerShell.exe
+) || (
+    ECHO Error: PowerShell executable not found.                        1>&2
+    ECHO        Either pwsh.exe or PowerShell.exe must be in your PATH. 1>&2
+    EXIT /B 1
+)
+
 REM Include shared scripts in shared.bat
 SET shared_bin=%FLUTTER_ROOT%/bin/internal/shared.bat
 CALL "%shared_bin%"

--- a/bin/flutter-dev.bat
+++ b/bin/flutter-dev.bat
@@ -27,7 +27,26 @@ REM If available, add location of bundled mingit to PATH
 SET mingit_path=%FLUTTER_ROOT%\bin\mingit\cmd
 IF EXIST "%mingit_path%" SET PATH=%PATH%;%mingit_path%
 
-REM We test if Git is available on the Host as we run git in shared.bat
+REM Test if Git is available on the host
+WHERE /Q git
+IF "%ERRORLEVEL%" NEQ "0" (
+  ECHO Error: Unable to find git in your PATH.
+  EXIT /B 1
+)
+
+REM Detect which PowerShell executable is available on the host
+REM PowerShell version <= 5: PowerShell.exe
+REM PowerShell version >= 6: pwsh.exe
+WHERE /Q pwsh.exe && (
+    SET powershell_executable=pwsh.exe
+) || WHERE /Q PowerShell.exe && (
+    SET powershell_executable=PowerShell.exe
+) || (
+    ECHO Error: PowerShell executable not found.                        1>&2
+    ECHO        Either pwsh.exe or PowerShell.exe must be in your PATH. 1>&2
+    EXIT /B 1
+)
+
 REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail
 IF NOT EXIST "%flutter_root%\.git" (
   ECHO Error: The Flutter directory is not a clone of the GitHub project.

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -29,6 +29,19 @@ IF "%ERRORLEVEL%" NEQ "0" (
   EXIT /B 1
 )
 
+REM Detect which PowerShell executable is available on the host
+REM PowerShell version <= 5: PowerShell.exe
+REM PowerShell version >= 6: pwsh.exe
+WHERE /Q pwsh.exe && (
+    SET powershell_executable=pwsh.exe
+) || WHERE /Q PowerShell.exe && (
+    SET powershell_executable=PowerShell.exe
+) || (
+    ECHO Error: PowerShell executable not found.                        1>&2
+    ECHO        Either pwsh.exe or PowerShell.exe must be in your PATH. 1>&2
+    EXIT /B 1
+)
+
 REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail
 IF NOT EXIST "%flutter_root%\.git" (
   ECHO Error: The Flutter directory is not a clone of the GitHub project.

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -22,7 +22,13 @@ REM If available, add location of bundled mingit to PATH
 SET mingit_path=%FLUTTER_ROOT%\bin\mingit\cmd
 IF EXIST "%mingit_path%" SET PATH=%PATH%;%mingit_path%
 
-REM We test if Git is available on the Host as we run git in shared.bat
+REM Test if Git is available on the host
+WHERE /Q git
+IF "%ERRORLEVEL%" NEQ "0" (
+  ECHO Error: Unable to find git in your PATH.
+  EXIT /B 1
+)
+
 REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail
 IF NOT EXIST "%flutter_root%\.git" (
   ECHO Error: The Flutter directory is not a clone of the GitHub project.

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -98,18 +98,6 @@ GOTO :after_subroutine
   EXIT /B
 
   :do_ensure_engine_version
-    REM Detect which PowerShell executable is available on the Host
-    REM PowerShell version <= 5: PowerShell.exe
-    REM PowerShell version >= 6: pwsh.exe
-    WHERE /Q pwsh.exe && (
-        SET powershell_executable=pwsh.exe
-    ) || WHERE /Q PowerShell.exe && (
-        SET powershell_executable=PowerShell.exe
-    ) || (
-        ECHO Error: PowerShell executable not found.                        1>&2
-        ECHO        Either pwsh.exe or PowerShell.exe must be in your PATH. 1>&2
-        EXIT 1
-    )
     SET update_engine_bin=%FLUTTER_ROOT%\bin\internal\update_engine_version.ps1
     REM Escape apostrophes from the executable path
     SET "update_engine_bin=%update_engine_bin:'=''%"
@@ -128,18 +116,6 @@ GOTO :after_subroutine
     EXIT /B
 
   :do_sdk_update_and_snapshot
-    REM Detect which PowerShell executable is available on the Host
-    REM PowerShell version <= 5: PowerShell.exe
-    REM PowerShell version >= 6: pwsh.exe
-    WHERE /Q pwsh.exe && (
-        SET powershell_executable=pwsh.exe
-    ) || WHERE /Q PowerShell.exe && (
-        SET powershell_executable=PowerShell.exe
-    ) || (
-        ECHO Error: PowerShell executable not found.                        1>&2
-        ECHO        Either pwsh.exe or PowerShell.exe must be in your PATH. 1>&2
-        EXIT 1
-    )
     SET /A dart_sdk_retries+=1
     ECHO Checking Dart SDK version... 1>&2
     SET update_dart_bin=%FLUTTER_ROOT%\bin\internal\update_dart_sdk.ps1

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -52,12 +52,7 @@ GOTO :after_subroutine
     CALL "%bootstrap_path%"
   )
 
-  REM Check that git exists and get the revision.
-  WHERE git >NUL 2>&1
-  IF "%ERRORLEVEL%" NEQ "0" (
-    REM Could not find git. Exit without /B to avoid retrying.
-    ECHO Error: Unable to find git in your PATH. && EXIT 1
-  )
+  REM Get the Git revision.
   2>NUL (
     REM 'FOR /f' spawns a new terminal instance to run the command. If an
     REM 'AutoRun' command is defined in the user's registry, that command could


### PR DESCRIPTION
The check for Git was originally in flutter.bat but was removed by https://github.com/flutter/flutter/commit/b84bfa35264385a897e6d85d039eae0ea6ba90ab in order to improve performance.

It was later brought back in https://github.com/flutter/flutter/commit/bc4fc5ffb98478340b53c097d83245582b776940. However, that change added it to a subroutine in shared.bat.  If Git is not found then shared.bat would exit the shell process to stop retries of the subroutine.

This PR moves the check back into flutter.bat and exits the script without quitting the shell.

Fixes https://github.com/flutter/flutter/issues/169784