### PR TITLE
Fix: Update anchorRect for overlayBuilder when anchor moves

### DIFF
--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -781,21 +781,16 @@ class _RawMenuAnchorState extends State<RawMenuAnchor> with _RawMenuAnchorBaseMi
     }
   }
 
-  Widget _buildOverlay(BuildContext context) {
-    final BuildContext anchorContext = _anchorKey.currentContext!;
-    final RenderBox overlay =
-        Overlay.of(anchorContext, rootOverlay: useRootOverlay).context.findRenderObject()!
-            as RenderBox;
-    final RenderBox anchorBox = anchorContext.findRenderObject()! as RenderBox;
-    final ui.Offset upperLeft = anchorBox.localToGlobal(Offset.zero, ancestor: overlay);
-    final ui.Offset bottomRight = anchorBox.localToGlobal(
-      anchorBox.size.bottomRight(Offset.zero),
-      ancestor: overlay,
-    );
+  Widget _buildOverlay(BuildContext context, OverlayChildLayoutInfo layoutInfo) {
+    final Matrix4 transform = layoutInfo.childPaintTransform;
+    final Size anchorSize = layoutInfo.childSize;
+
+    // Transform the anchor rectangle using the full transform matrix.
+    final Rect anchorRect = MatrixUtils.transformRect(transform, Offset.zero & anchorSize);
 
     final RawMenuOverlayInfo info = RawMenuOverlayInfo(
-      anchorRect: Rect.fromPoints(upperLeft, bottomRight),
-      overlaySize: overlay.size,
+      anchorRect: anchorRect,
+      overlaySize: layoutInfo.overlaySize,
       position: _menuPosition,
       tapRegionGroupId: root.menuController,
     );
@@ -823,7 +818,7 @@ class _RawMenuAnchorState extends State<RawMenuAnchor> with _RawMenuAnchorBaseMi
       ),
     );
 
-    return OverlayPortal(
+    return OverlayPortal.overlayChildLayoutBuilder(
       controller: _overlayController,
       overlayChildBuilder: _buildOverlay,
       overlayLocation: useRootOverlay

--- a/packages/flutter/test/widgets/raw_menu_anchor_test.dart
+++ b/packages/flutter/test/widgets/raw_menu_anchor_test.dart
@@ -2902,6 +2902,50 @@ void main() {
     expect(customController.closeCallCount, equals(1));
     expect(find.text(Tag.a.text), findsNothing);
   });
+
+  testWidgets('RawMenuAnchor correctly updates anchorRect for overlayBuilder when anchor moves', (
+    WidgetTester tester,
+  ) async {
+    RawMenuOverlayInfo? overlayPosition;
+    late StateSetter setState;
+    bool showAdditionalWidget = true;
+
+    await tester.pumpWidget(
+      App(
+        StatefulBuilder(
+          builder: (BuildContext context, StateSetter setter) {
+            setState = setter;
+            return Column(
+              children: <Widget>[
+                if (showAdditionalWidget) const SizedBox(width: 100, height: 100),
+                RawMenuAnchor(
+                  overlayBuilder: (BuildContext context, RawMenuOverlayInfo position) {
+                    overlayPosition = position;
+                    return const SizedBox();
+                  },
+                  controller: controller,
+                  child: AnchorButton(Tag.anchor, onPressed: onPressed),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text(Tag.anchor.text));
+    await tester.pump();
+
+    expect(overlayPosition!.anchorRect, tester.getRect(find.byType(Button)));
+
+    setState(() {
+      showAdditionalWidget = false;
+    });
+
+    await tester.pumpAndSettle();
+
+    expect(overlayPosition!.anchorRect, tester.getRect(find.byType(Button)));
+  });
 }
 
 // Custom MenuController that extends the base MenuController


### PR DESCRIPTION
Fix: Update anchorRect for overlayBuilder when anchor moves
fixes: #169457 
part of https://github.com/flutter/flutter/issues/173440

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.