### PR TITLE
feat(IconButton): add property to specify a states controller

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -208,6 +208,7 @@ class IconButton extends StatelessWidget {
     this.style,
     this.isSelected,
     this.selectedIcon,
+    this.statesController,
     required this.icon,
   }) : assert(splashRadius == null || splashRadius > 0),
        _variant = _IconButtonVariant.standard;
@@ -241,6 +242,7 @@ class IconButton extends StatelessWidget {
     this.style,
     this.isSelected,
     this.selectedIcon,
+    this.statesController,
     required this.icon,
   }) : assert(splashRadius == null || splashRadius > 0),
        _variant = _IconButtonVariant.filled;
@@ -276,6 +278,7 @@ class IconButton extends StatelessWidget {
     this.style,
     this.isSelected,
     this.selectedIcon,
+    this.statesController,
     required this.icon,
   }) : assert(splashRadius == null || splashRadius > 0),
        _variant = _IconButtonVariant.filledTonal;
@@ -310,6 +313,7 @@ class IconButton extends StatelessWidget {
     this.style,
     this.isSelected,
     this.selectedIcon,
+    this.statesController,
     required this.icon,
   }) : assert(splashRadius == null || splashRadius > 0),
        _variant = _IconButtonVariant.outlined;
@@ -594,6 +598,9 @@ class IconButton extends StatelessWidget {
   /// * [ImageIcon], for showing icons from [AssetImage]s or other [ImageProvider]s.
   final Widget? selectedIcon;
 
+  /// {@macro flutter.material.inkwell.statesController}
+  final MaterialStatesController? statesController;
+
   final _IconButtonVariant _variant;
 
   /// A static convenience method that constructs an icon button
@@ -754,6 +761,7 @@ class IconButton extends StatelessWidget {
         isSelected: isSelected,
         variant: _variant,
         tooltip: tooltip,
+        statesController: statesController,
         child: effectiveIcon,
       );
     }
@@ -856,6 +864,7 @@ class _SelectableIconButton extends StatefulWidget {
     this.focusNode,
     this.onLongPress,
     this.onHover,
+    this.statesController,
     required this.variant,
     required this.autofocus,
     required this.onPressed,
@@ -873,38 +882,54 @@ class _SelectableIconButton extends StatefulWidget {
   final Widget child;
   final VoidCallback? onLongPress;
   final ValueChanged<bool>? onHover;
+  final MaterialStatesController? statesController;
 
   @override
   State<_SelectableIconButton> createState() => _SelectableIconButtonState();
 }
 
 class _SelectableIconButtonState extends State<_SelectableIconButton> {
-  late final MaterialStatesController statesController;
+  MaterialStatesController? _internalStatesController;
+
+  MaterialStatesController get statesController =>
+      widget.statesController ?? _internalStatesController!;
+
+  bool get _isSelected => widget.isSelected ?? false;
 
   @override
   void initState() {
     super.initState();
-    if (widget.isSelected == null) {
-      statesController = MaterialStatesController();
-    } else {
-      statesController = MaterialStatesController(<MaterialState>{
-        if (widget.isSelected!) MaterialState.selected,
-      });
+
+    if (widget.statesController == null) {
+      _internalStatesController = MaterialStatesController();
     }
+
+    statesController.update(MaterialState.selected, _isSelected);
   }
 
   @override
   void didUpdateWidget(_SelectableIconButton oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.isSelected == null) {
-      if (statesController.value.contains(MaterialState.selected)) {
-        statesController.update(MaterialState.selected, false);
+
+    if (widget.statesController != oldWidget.statesController) {
+      if (widget.statesController != null) {
+        _internalStatesController?.dispose();
+        _internalStatesController = null;
       }
-      return;
+      _initStatesController();
     }
+
     if (widget.isSelected != oldWidget.isSelected) {
-      statesController.update(MaterialState.selected, widget.isSelected!);
+      statesController.update(MaterialState.selected, _isSelected);
     }
+  }
+
+  void _initStatesController() {
+    if (widget.statesController == null) {
+      _internalStatesController = MaterialStatesController();
+    }
+
+    statesController.update(MaterialState.selected, _isSelected);
   }
 
   @override
@@ -928,7 +953,7 @@ class _SelectableIconButtonState extends State<_SelectableIconButton> {
 
   @override
   void dispose() {
-    statesController.dispose();
+    _internalStatesController?.dispose();
     super.dispose();
   }
 }

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -3421,6 +3421,110 @@ void main() {
 
     await expectLater(find.byType(IconButton), matchesGoldenFile('icon_button.badge.outline.png'));
   });
+
+  Future<void> testStatesController(WidgetTester tester, IconButton iconButton) async {
+    int count = 0;
+    void valueChanged() {
+      count += 1;
+    }
+
+    final MaterialStatesController controller = iconButton.statesController!;
+    addTearDown(controller.dispose);
+    controller.addListener(valueChanged);
+
+    await tester.pumpWidget(MaterialApp(home: Center(child: iconButton)));
+
+    expect(controller.value, <MaterialState>{});
+    expect(count, 0);
+
+    final Offset center = tester.getCenter(find.byType(Icon));
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+
+    expect(controller.value, <MaterialState>{MaterialState.hovered});
+    expect(count, 1);
+
+    await gesture.moveTo(Offset.zero);
+    await tester.pumpAndSettle();
+
+    expect(controller.value, <MaterialState>{});
+    expect(count, 2);
+
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+
+    expect(controller.value, <MaterialState>{MaterialState.hovered});
+    expect(count, 3);
+
+    await gesture.down(center);
+    await tester.pumpAndSettle();
+
+    expect(controller.value, <MaterialState>{MaterialState.hovered, MaterialState.pressed});
+    expect(count, 4);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(controller.value, <MaterialState>{MaterialState.hovered});
+    expect(count, 5);
+
+    await gesture.moveTo(Offset.zero);
+    await tester.pumpAndSettle();
+
+    expect(controller.value, <MaterialState>{});
+    expect(count, 6);
+
+    await gesture.down(center);
+    await tester.pumpAndSettle();
+    expect(controller.value, <MaterialState>{MaterialState.hovered, MaterialState.pressed});
+    expect(count, 8); // adds hovered and pressed - two changes
+  }
+
+  testWidgets('IconButton statesController', (WidgetTester tester) async {
+    await testStatesController(
+      tester,
+      IconButton(
+        icon: const Icon(Icons.add),
+        onPressed: () {},
+        statesController: MaterialStatesController(),
+      ),
+    );
+  });
+
+  testWidgets('IconButton.filled statesController', (WidgetTester tester) async {
+    await testStatesController(
+      tester,
+      IconButton.filled(
+        onPressed: () {},
+        icon: const Icon(Icons.add),
+        statesController: MaterialStatesController(),
+      ),
+    );
+  });
+
+  testWidgets('IconButton.filledTonal statesController', (WidgetTester tester) async {
+    await testStatesController(
+      tester,
+      IconButton.filledTonal(
+        onPressed: () {},
+        icon: const Icon(Icons.add),
+        statesController: MaterialStatesController(),
+      ),
+    );
+  });
+
+  testWidgets('IconButton.outlined statesController', (WidgetTester tester) async {
+    await testStatesController(
+      tester,
+      IconButton.outlined(
+        onPressed: () {},
+        icon: const Icon(Icons.add),
+        statesController: MaterialStatesController(),
+      ),
+    );
+  });
 }
 
 Widget buildAllVariants({


### PR DESCRIPTION
## Description

Enable specifying a custom statesController to the IconButton widget. This increase consistency since other widgets expose this property as well.

## Related Issues

- Closes https://github.com/flutter/flutter/issues/139372

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.