### PR TITLE
[native assets] Add error message for #169475

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -41,6 +41,15 @@ abstract class DartBuild extends Target {
       final Uri projectUri = environment.projectDir.uri;
       final String? runPackageName =
           packageConfig.packages.where((Package p) => p.root == projectUri).firstOrNull?.name;
+      if (runPackageName == null) {
+        throw StateError(
+          'Could not determine run package name. '
+          'Project path "${projectUri.toFilePath()}" did not occur as package '
+          'root in package config "${environment.packageConfigPath}". '
+          'Please report a reproduction on '
+          'https://github.com/flutter/flutter/issues/169475.',
+        );
+      }
       final String pubspecPath = packageConfigFile.uri.resolve('../pubspec.yaml').toFilePath();
       final FlutterNativeAssetsBuildRunner buildRunner =
           _buildRunner ??
@@ -49,7 +58,7 @@ abstract class DartBuild extends Target {
             packageConfig,
             fileSystem,
             environment.logger,
-            runPackageName!,
+            runPackageName,
             pubspecPath,
           );
       result = await runFlutterSpecificDartBuild(
@@ -77,7 +86,7 @@ abstract class DartBuild extends Target {
     }
     environment.depFileService.writeToFile(depfile, outputDepfile);
     if (!await outputDepfile.exists()) {
-      throwToolExit("${outputDepfile.path} doesn't exist.");
+      throw StateError("${outputDepfile.path} doesn't exist.");
     }
   }
 


### PR DESCRIPTION
Bug:

* https://github.com/flutter/flutter/issues/169475

I don't want to skip building native assets and sweep the actual cause of this under the rug. If native assets would be used, the app build would succeed but accessing the assets would fail at runtime. It seems the project path should always occur as a package root in the package config json. So this is a state error.