### PR TITLE
Roll-foward: "Remove legacy platforms in `.ci.yaml` with 0 usages"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -26,6 +26,7 @@ platform_properties:
       cores: "8"
       device_type: none
       ignore_flakiness: "true"
+
   linux:
     properties:
       dependencies: >-
@@ -35,6 +36,7 @@ platform_properties:
       os: Ubuntu
       cores: "8"
       device_type: none
+
   # The current android emulator config names can be found here:
   # https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/android/avd/proto
   # You may use those names for the android_virtual_device version. You may find the
@@ -58,6 +60,7 @@ platform_properties:
       cores: "8"
       device_type: none
       kvm: "1"
+
   # linux_android_emu_unstable is intended to be how flutter-android proves the stability
   # of new combinations of dependencies.
   linux_android_emu_unstable:
@@ -77,6 +80,7 @@ platform_properties:
       cores: "8"
       device_type: none
       kvm: "1"
+
   linux_build_test:
     properties:
       dependencies: >-
@@ -88,16 +92,6 @@ platform_properties:
       os: Ubuntu
       cores: "8"
       device_type: none
-  linux_android:
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v1"},
-          {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "curl", "version": "version:7.64.0"}
-        ]
-      os: Linux
-      device_type: "msm8952"
 
   linux_pixel_7pro:
     properties:
@@ -148,6 +142,7 @@ platform_properties:
         {
           "sdk_version": "16c5032a"
         }
+
   mac_arm64:
     properties:
       contexts: >-
@@ -165,6 +160,7 @@ platform_properties:
         {
           "sdk_version": "16c5032a"
         }
+
   mac_benchmark:
     properties:
       contexts: >-
@@ -184,6 +180,7 @@ platform_properties:
         {
           "sdk_version": "16c5032a"
         }
+
   mac_x64:
     properties:
       contexts: >-
@@ -201,6 +198,7 @@ platform_properties:
         {
           "sdk_version": "16c5032a"
         }
+
   mac_build_test:
     properties:
       contexts: >-
@@ -219,27 +217,6 @@ platform_properties:
         {
           "sdk_version": "16c5032a"
         }
-  mac_android:
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v1"},
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
-          {"dependency": "open_jdk", "version": "version:21"}
-        ]
-      os: Mac-14|Mac-15.5
-      cpu: x86
-      device_type: "msm8952"
-  mac_arm64_android:
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v1"},
-          {"dependency": "open_jdk", "version": "version:21"}
-        ]
-      os: Mac-14|Mac-15.5
-      cpu: arm64
-      device_type: "msm8952"
 
   mac_mokey:
     properties:
@@ -252,6 +229,7 @@ platform_properties:
       os: Mac-14|Mac-15.5
       cpu: x86
       device_type: "mokey"
+
   mac_arm64_mokey:
     properties:
       dependencies: >-
@@ -263,16 +241,6 @@ platform_properties:
       cpu: arm64
       device_type: "mokey"
 
-  mac_pixel_7pro:
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v1"},
-          {"dependency": "open_jdk", "version": "version:21"}
-        ]
-      os: Mac-14|Mac-15.5
-      cpu: x86
-      device_type: "Pixel 7 Pro"
   mac_ios:
     properties:
       contexts: >-
@@ -290,6 +258,7 @@ platform_properties:
         {
           "sdk_version": "16c5032a"
         }
+
   mac_x64_ios:
     properties:
       contexts: >-
@@ -308,6 +277,7 @@ platform_properties:
         {
           "sdk_version": "16c5032a"
         }
+
   mac_arm64_ios:
     properties:
       contexts: >-
@@ -326,26 +296,18 @@ platform_properties:
         {
           "sdk_version": "16c5032a"
         }
+
   windows:
     properties:
       os: Windows-10
       device_type: none
+
   windows_arm64:
     properties:
-      # The arch can be removed after https://github.com/flutter/flutter/issues/135722.
       arch: arm
       os: Windows
       cpu: arm64
-  windows_android:
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v1"},
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
-          {"dependency": "open_jdk", "version": "version:21"}
-        ]
-      os: Windows-10
-      device_type: "msm8952"
+
   windows_mokey:
     properties:
       dependencies: >-


### PR DESCRIPTION
This reverts commit 99f74987aa46022c56f2b6d4cf9ae364cc3dc667.

Infrastructure was updated in http://go/flutter-cl/66120 to avoid future failures.