### PR TITLE
Remove legacy checks for `.flutter-plugins`, which no longer exists.

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -569,23 +569,5 @@ class CocoaPods {
         );
       }
     }
-    // Most of the pod and plugin parsing logic was moved from the Podfile
-    // into the tool's podhelper.rb script. If the Podfile still references
-    // the old parsed .flutter-plugins file, prompt the regeneration. Old line was:
-    // plugin_pods = parse_KV_file('../.flutter-plugins')
-    if (xcodeProject.podfile.existsSync() &&
-        xcodeProject.podfile.readAsStringSync().contains(".flutter-plugins'")) {
-      const String warning =
-          'Warning: Podfile is out of date\n'
-          '$outOfDatePluginsPodfileConsequence\n'
-          'To regenerate the Podfile, run:\n';
-      if (isIos) {
-        throwToolExit('$warning\n$podfileIosMigrationInstructions\n');
-      } else {
-        // The old macOS Podfile will work until `.flutter-plugins` is removed.
-        // Warn instead of exit.
-        _logger.printWarning('$warning\n$podfileMacOSMigrationInstructions\n', emphasis: true);
-      }
-    }
   }
 }

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -492,48 +492,6 @@ environement:
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
-    testUsingContext('exits if iOS Podfile parses .flutter-plugins', () async {
-      final FlutterProject projectUnderTest = setupProjectUnderTest();
-      fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
-        ..createSync()
-        ..writeAsStringSync("plugin_pods = parse_KV_file('../.flutter-plugins')");
-
-      await expectLater(
-        cocoaPodsUnderTest.processPods(
-          xcodeProject: projectUnderTest.ios,
-          buildMode: BuildMode.debug,
-        ),
-        throwsToolExit(message: 'Podfile is out of date'),
-      );
-      expect(fakeProcessManager, hasNoRemainingExpectations);
-    });
-
-    testUsingContext('prints warning if macOS Podfile parses .flutter-plugins', () async {
-      final FlutterProject projectUnderTest = setupProjectUnderTest();
-      pretendPodIsInstalled();
-      pretendPodVersionIs('100.0.0');
-      fakeProcessManager.addCommands(const <FakeCommand>[
-        FakeCommand(command: <String>['pod', 'install', '--verbose']),
-        FakeCommand(command: <String>['touch', 'project/macos/Podfile.lock']),
-      ]);
-
-      projectUnderTest.macos.podfile
-        ..createSync()
-        ..writeAsStringSync("plugin_pods = parse_KV_file('../.flutter-plugins')");
-      projectUnderTest.macos.podfileLock
-        ..createSync()
-        ..writeAsStringSync('Existing lock file.');
-
-      await cocoaPodsUnderTest.processPods(
-        xcodeProject: projectUnderTest.macos,
-        buildMode: BuildMode.debug,
-      );
-
-      expect(logger.warningText, contains('Warning: Podfile is out of date'));
-      expect(logger.warningText, contains('rm macos/Podfile'));
-      expect(fakeProcessManager, hasNoRemainingExpectations);
-    });
-
     testUsingContext('throws, if Podfile is missing.', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       await expectLater(


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/48918.

You could keep this longer, but this format hasn't been supported in iOS/MacOS plugins for years?