### PR TITLE
Remove stray (unused) `legacyFlutterPluginsWarning`.

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/plugins/PluginHandler.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/plugins/PluginHandler.kt
@@ -103,13 +103,6 @@ class PluginHandler(
          */
         private const val WEBSITE_DEPLOYMENT_ANDROID_BUILD_CONFIG = "https://flutter.dev/to/review-gradle-config"
 
-        @VisibleForTesting internal val legacyFlutterPluginsWarning =
-            """
-            Warning: This project is still reading the deprecated '.flutter-plugins. file.
-            In an upcoming stable release support for this file will be completely removed and your build will fail.
-            See https:/flutter.dev/to/flutter-plugins-configuration.
-            """.trimIndent()
-
         /**
          * Performs configuration related to the plugin's Gradle [Project], including
          * 1. Adding the plugin itself as a dependency to the main project.

--- a/packages/flutter_tools/gradle/src/main/kotlin/plugins/PluginHandler.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/plugins/PluginHandler.kt
@@ -4,7 +4,6 @@
 
 package com.flutter.gradle.plugins
 
-import androidx.annotation.VisibleForTesting
 import com.android.builder.model.BuildType
 import com.flutter.gradle.FlutterExtension
 import com.flutter.gradle.FlutterPluginUtils


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/pull/169894.