### PR TITLE
[Impeller] Make GL version parsing less strict

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
@@ -17,6 +17,7 @@ impeller_component("gles_unittests") {
     "buffer_bindings_gles_unittests.cc",
     "device_buffer_gles_unittests.cc",
     "test/capabilities_unittests.cc",
+    "test/description_unittests.cc",
     "test/formats_gles_unittests.cc",
     "test/gpu_tracer_gles_unittests.cc",
     "test/mock_gles.cc",

--- a/engine/src/flutter/impeller/renderer/backend/gles/description_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/description_gles.cc
@@ -52,16 +52,20 @@ static std::optional<Version> DetermineVersion(std::string version) {
   // number><space><vendor-specific information>"
   //
   // The prefixes appear to be absent on Desktop GL.
+  std::optional<size_t> version_start;
+  for (size_t i = 0; i < version.size(); i++) {
+    if (std::isdigit(version[i])) {
+      version_start = i;
+      break;
+    }
+  }
 
-  version = StripPrefix(version, "OpenGL ES ");
-  version = StripPrefix(version, "GLSL ES ");
-
-  if (version.empty()) {
+  if (!version_start.has_value()) {
     return std::nullopt;
   }
 
   std::stringstream stream;
-  for (size_t i = 0; i < version.size(); i++) {
+  for (size_t i = version_start.value(); i < version.size(); i++) {
     const auto character = version[i];
     if (std::isdigit(character) || character == '.') {
       stream << character;

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/description_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/description_unittests.cc
@@ -1,0 +1,61 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+#include "impeller/renderer/backend/gles/test/mock_gles.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(DescriptionGLES, DeterminesOpenGLVersion) {
+  auto mock_gles = MockGLES::Init(std::nullopt, "OpenGL 4.0");
+  auto description = mock_gles->GetProcTable().GetDescription();
+  auto version = description->GetGlVersion();
+
+  EXPECT_FALSE(description->IsES());
+  EXPECT_EQ(version.major_version, size_t{4});
+  EXPECT_EQ(version.minor_version, size_t{0});
+  EXPECT_EQ(version.patch_version, size_t{0});
+}
+
+TEST(DescriptionGLES, DeterminesANGLEVersion) {
+  auto mock_gles = MockGLES::Init(
+      std::nullopt, "OpenGL ES 3.1.0 (ANGLE 1.2.3 git hash: abcdef)");
+  auto description = mock_gles->GetProcTable().GetDescription();
+  auto version = description->GetGlVersion();
+
+  EXPECT_TRUE(description->IsANGLE());
+  EXPECT_TRUE(description->IsES());
+  EXPECT_EQ(version.major_version, size_t{3});
+  EXPECT_EQ(version.minor_version, size_t{1});
+  EXPECT_EQ(version.patch_version, size_t{0});
+}
+
+TEST(DescriptionGLES, DeterminesUnprefixedVersion) {
+  auto mock_gles = MockGLES::Init(std::nullopt, "3.0.0");
+  auto description = mock_gles->GetProcTable().GetDescription();
+  auto version = description->GetGlVersion();
+
+  EXPECT_FALSE(description->IsANGLE());
+  EXPECT_FALSE(description->IsES());
+  EXPECT_EQ(version.major_version, size_t{3});
+  EXPECT_EQ(version.minor_version, size_t{0});
+  EXPECT_EQ(version.patch_version, size_t{0});
+}
+
+TEST(DescriptionGLES, DeterminesWeirdVersion) {
+  auto mock_gles = MockGLES::Init(std::nullopt, "Hi, I am version 1.2.3");
+  auto description = mock_gles->GetProcTable().GetDescription();
+  auto version = description->GetGlVersion();
+
+  EXPECT_FALSE(description->IsANGLE());
+  EXPECT_FALSE(description->IsES());
+  EXPECT_EQ(version.major_version, size_t{1});
+  EXPECT_EQ(version.minor_version, size_t{2});
+  EXPECT_EQ(version.patch_version, size_t{3});
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
Starting in 3.29.0, Flutter Windows started to crash on some machines because the `glBlitFrameBuffer` proc is not resolved.

In 3.29.0, we updated Impeller to only load GLES 3.0 procs if we detect version 3.0 or higher: https://github.com/flutter/engine/pull/56636. However, our [GL version detection logic](https://github.com/flutter/flutter/blob/11bf180af0bd2b03ccbec636249250dbd10384f9/engine/src/flutter/impeller/renderer/backend/gles/description_gles.cc#L48-L57) is strict and only parses GL versions strings if they have a known prefix.

This change makes Impeller's GL version parsing less strict. It now parses the version from the first `\d(\d|\.)*` match from the GL version string.

Speculative fix for: https://github.com/flutter/flutter/issues/169178

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
