### PR TITLE
[ Tool ] Fix failed VSCode version lookup on Linux

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -68,10 +68,11 @@ class VsCode {
     String extensionDirectory, {
     String? edition,
     required FileSystem fileSystem,
+    required Platform platform,
   }) {
     final String packageJsonPath = fileSystem.path.join(
       installPath,
-      'Resources',
+      platform.isLinux ? 'resources' : 'Resources',
       'app',
       'package.json',
     );
@@ -311,6 +312,7 @@ class VsCode {
             extensionDirectory,
             edition: searchLocation.edition,
             fileSystem: fileSystem,
+            platform: platform,
           ),
         );
       }

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -1428,6 +1428,7 @@ class VsCodeValidatorTestTargets extends VsCodeValidator {
            extensionDirectory,
            edition: edition,
            fileSystem: globals.fs,
+           platform: globals.platform,
          ),
        );
 

--- a/packages/flutter_tools/test/data/vscode/application/resources/app/package.json
+++ b/packages/flutter_tools/test/data/vscode/application/resources/app/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "fake-vs-code-install-for-tests",
+	"version": "1.2.3"
+}

--- a/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
+++ b/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
@@ -56,7 +56,12 @@ void main() {
       ..createSync(recursive: true)
       ..writeAsStringSync('{');
 
-    final VsCode vsCode = VsCode.fromDirectory('', '', fileSystem: fileSystem, platform: const LocalPlatform());
+    final VsCode vsCode = VsCode.fromDirectory(
+      '',
+      '',
+      fileSystem: fileSystem,
+      platform: const LocalPlatform(),
+    );
 
     expect(vsCode.version, null);
   });
@@ -70,7 +75,12 @@ void main() {
       ..createSync(recursive: true)
       ..writeAsStringSync('{"version":"1.2.3"}');
 
-    final VsCode vsCode = VsCode.fromDirectory('', '', fileSystem: fileSystem, platform: FakePlatform());
+    final VsCode vsCode = VsCode.fromDirectory(
+      '',
+      '',
+      fileSystem: fileSystem,
+      platform: FakePlatform(),
+    );
 
     expect(vsCode.version, Version(1, 2, 3));
   });

--- a/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
+++ b/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/vscode/vscode.dart';
 
 import '../../src/common.dart';
@@ -55,9 +56,23 @@ void main() {
       ..createSync(recursive: true)
       ..writeAsStringSync('{');
 
-    final VsCode vsCode = VsCode.fromDirectory('', '', fileSystem: fileSystem);
+    final VsCode vsCode = VsCode.fromDirectory('', '', fileSystem: fileSystem, platform: const LocalPlatform());
 
     expect(vsCode.version, null);
+  });
+
+  testWithoutContext('VsCode.fromDirectory finds packages.json on Linux', () {
+    // Regression test for https://github.com/flutter/flutter/issues/169812
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+    // Installations on Linux appear to use $VSCODE_INSTALL/resources/app/package.json rather than
+    // $VSCODE_INSTALL/Resources/app/package.json.
+    fileSystem.file(fileSystem.path.join('', 'resources', 'app', 'package.json'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"version":"1.2.3"}');
+
+    final VsCode vsCode = VsCode.fromDirectory('', '', fileSystem: fileSystem, platform: FakePlatform());
+
+    expect(vsCode.version, Version(1, 2, 3));
   });
 
   testWithoutContext('can locate VS Code installed via Snap', () {


### PR DESCRIPTION
VSCode installations on Linux appear to place the packages.json file at `$VSCODE_INSTALL/resources/app/package.json` rather than at the expected `$VSCODE_INSTALL/Resources/app/package.json`, causing the VSCode version to not be reported correctly on Linux.

Fixes https://github.com/flutter/flutter/issues/169812