### PR TITLE
Add connectedApps listener before we launch the browser

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -918,7 +918,9 @@ class WebDevFS implements DevFS {
 
   /// Connect and retrieve the [DebugConnection] for the current application.
   ///
-  /// Only calls [AppConnection.runMain] on the subsequent connections.
+  /// Only calls [AppConnection.runMain] on the subsequent connections. This
+  /// should be called before the browser is launched to make sure the listener
+  /// is registered early enough.
   Future<ConnectionResult?> connect(
     bool useDebugExtension, {
     @visibleForTesting VmServiceFactory vmServiceFactory = createVmServiceDelegate,

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -794,7 +794,8 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       _wipConnection = await chromeTab.connect();
     }
     Uri? websocketUri;
-    if (connectDebug != null) {
+    if (supportsServiceProtocol) {
+      assert(connectDebug != null);
       _connectionResult = await connectDebug;
       unawaited(_connectionResult!.debugConnection!.onDone.whenComplete(_cleanupAndExit));
 

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -367,7 +367,8 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
             device!.device is WebServerDevice && debuggingOptions.startPaused;
         // Listen for connected apps early and then await this `Future` later
         // when we attach.
-        final Future<ConnectionResult?> connectWebDevFS = webDevFS.connect(useDebugExtension);
+        final Future<ConnectionResult?>? connectDebug =
+            supportsServiceProtocol ? webDevFS.connect(useDebugExtension) : null;
         await device!.device!.startApp(
           package,
           mainPath: target,
@@ -377,7 +378,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
         return attach(
           connectionInfoCompleter: connectionInfoCompleter,
           appStartedCompleter: appStartedCompleter,
-          connectWebDevFS: connectWebDevFS,
+          connectDebug: connectDebug,
         );
       });
     } on WebSocketException catch (error, stackTrace) {
@@ -769,7 +770,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
   Future<int> attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
-    Future<ConnectionResult?>? connectWebDevFS,
+    Future<ConnectionResult?>? connectDebug,
     bool allowExistingDdsInstance = false,
     bool needsFullRestart = true,
   }) async {
@@ -793,8 +794,8 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       _wipConnection = await chromeTab.connect();
     }
     Uri? websocketUri;
-    if (supportsServiceProtocol) {
-      _connectionResult = await connectWebDevFS;
+    if (connectDebug != null) {
+      _connectionResult = await connectDebug;
       unawaited(_connectionResult!.debugConnection!.onDone.whenComplete(_cleanupAndExit));
 
       void onLogEvent(vmservice.Event event) {


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/issues/169574

There's a race condition where we currently might listen for the connected app after the stream has already sent the app. That would make the app wait forever. This avoids that by registering the listener before the browser even launches to make sure that the stream can't possibly send a connected app before we get to listen to it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
