### PR TITLE
synchronously flush semantics when semantics is enabled

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -261,9 +261,6 @@ mixin RendererBinding
     'This feature was deprecated after v3.10.0-12.0.pre.',
   )
   late final PipelineOwner pipelineOwner = PipelineOwner(
-    onSemanticsOwnerCreated: () {
-      (pipelineOwner.rootNode as RenderView?)?.scheduleInitialSemantics();
-    },
     onSemanticsUpdate: (ui.SemanticsUpdate update) {
       (pipelineOwner.rootNode as RenderView?)?.updateSemantics(update);
     },

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -23,8 +23,10 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
 
 import 'binding.dart';
+import 'box.dart';
 import 'debug.dart';
 import 'layer.dart';
+import 'view.dart';
 
 export 'package:flutter/foundation.dart'
     show
@@ -1401,6 +1403,19 @@ base class PipelineOwner with DiagnosticableTreeMixin {
           'Attempted to enable semantics without configuring an onSemanticsUpdate callback.',
         );
         _semanticsOwner = SemanticsOwner(onSemanticsUpdate: onSemanticsUpdate!);
+        final RenderObject? root = rootNode;
+        if (root != null) {
+          root.scheduleInitialSemantics();
+          // Synchronously flush semantics if possible. This should send the
+          // update to platform synchronously if UI and platform threads are
+          // merged.
+          //
+          // Doing this let OS to read the semantics tree synchronously even if
+          // semantics has not been built before.
+          if (root is RenderObjectWithChildMixin<RenderBox> && (root.child?.hasSize ?? false)) {
+            _flushSemanticsWithin();
+          }
+        }
         onSemanticsOwnerCreated?.call();
       }
     } else if (_semanticsOwner != null) {
@@ -1449,6 +1464,13 @@ base class PipelineOwner with DiagnosticableTreeMixin {
   // See [_RenderObjectSemantics]'s documentation for detailed explanations on
   // what this method does.
   void flushSemantics() {
+    _flushSemanticsWithin();
+    for (final PipelineOwner child in _children) {
+      child.flushSemantics();
+    }
+  }
+
+  void _flushSemanticsWithin() {
     if (_semanticsOwner == null) {
       return;
     }
@@ -1638,9 +1660,6 @@ base class PipelineOwner with DiagnosticableTreeMixin {
       }
 
       _semanticsOwner!.sendSemanticsUpdate();
-      for (final PipelineOwner child in _children) {
-        child.flushSemantics();
-      }
       assert(
         _nodesNeedingSemanticsUpdate.isEmpty,
         'Child PipelineOwners must not dirty nodes in their parent.',
@@ -5977,7 +5996,6 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       effectiveChildParentData = childParentData;
     }
     for (final _RenderObjectSemantics childSemantics in _getNonBlockedChildren()) {
-      assert(!childSemantics.renderObject._needsLayout);
       childSemantics._didUpdateParentData(effectiveChildParentData);
       for (final _SemanticsFragment fragment in childSemantics.mergeUp) {
         if (hasChildConfigurationsDelegate && fragment.configToMergeUp != null) {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3951,6 +3951,8 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   /// Subclasses can override this method to add additional [SemanticsNode]s
   /// to the tree. If new [SemanticsNode]s are instantiated in this method
   /// they must be disposed in [clearSemantics].
+  ///
+  /// This callback can be called during idle phase or during draw frame.
   void assembleSemanticsNode(
     SemanticsNode node,
     SemanticsConfiguration config,

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -81,9 +81,6 @@ class TestRenderingFlutterBinding extends BindingBase
   @override
   PipelineOwner createRootPipelineOwner() {
     return PipelineOwner(
-      onSemanticsOwnerCreated: () {
-        renderView.scheduleInitialSemantics();
-      },
       onSemanticsUpdate: (SemanticsUpdate update) {
         renderView.updateSemantics(update);
       },

--- a/packages/flutter/test/semantics/flush_semantics_test.dart
+++ b/packages/flutter/test/semantics/flush_semantics_test.dart
@@ -1,0 +1,69 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'semantics_update_tester.dart';
+
+void main() {
+  SemanticsUpdateTestBinding();
+
+  testWidgets('Flush semantics synchronously', (WidgetTester tester) async {
+    addTearDown(SemanticsUpdateBuilderSpy.observations.clear);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('appbar')),
+          body: ElevatedButton(onPressed: () {}, child: const Text('button')),
+        ),
+      ),
+    );
+
+    expect(tester.binding.semanticsEnabled, isFalse);
+    expect(SemanticsUpdateBuilderSpy.observations.length, 0);
+
+    // EnsureSemantics should send update to engine synchronously.
+    final SemanticsHandle handle = tester.binding.ensureSemantics();
+    expect(SemanticsUpdateBuilderSpy.observations.length, 7);
+    handle.dispose();
+  }, semanticsEnabled: false);
+
+  testWidgets('Flush semantics when tree is dirty', (WidgetTester tester) async {
+    addTearDown(SemanticsUpdateBuilderSpy.observations.clear);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('appbar')),
+          body: ElevatedButton(onPressed: () {}, child: const Text('button')),
+        ),
+      ),
+    );
+
+    RenderObject? root;
+    void getRootNode(PipelineOwner child) {
+      root ??= child.rootNode;
+      if (root == null) {
+        child.visitChildren(getRootNode);
+      }
+    }
+
+    tester.binding.rootPipelineOwner.visitChildren(getRootNode);
+
+    void markLayoutDirty(RenderObject object) {
+      object.markNeedsLayout();
+      object.visitChildren(markLayoutDirty);
+    }
+
+    root!.visitChildren(markLayoutDirty);
+    expect(tester.binding.semanticsEnabled, isFalse);
+    expect(SemanticsUpdateBuilderSpy.observations.length, 0);
+
+    // EnsureSemantics should send update to engine synchronously.
+    final SemanticsHandle handle = tester.binding.ensureSemantics();
+    expect(SemanticsUpdateBuilderSpy.observations.length, 7);
+    handle.dispose();
+  }, semanticsEnabled: false);
+}

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -2,23 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui;
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-typedef SemanticsNodeUpdateObservation = ({
-  String label,
-  List<StringAttribute>? labelAttributes,
-  String value,
-  List<StringAttribute>? valueAttributes,
-  String hint,
-  List<StringAttribute>? hintAttributes,
-  Int32List childrenInTraversalOrder,
-  Float64List transform,
-});
+import 'semantics_update_tester.dart';
 
 void main() {
   SemanticsUpdateTestBinding();
@@ -26,6 +14,7 @@ void main() {
   testWidgets('Semantics update does not send update for merged nodes.', (
     WidgetTester tester,
   ) async {
+    addTearDown(SemanticsUpdateBuilderSpy.observations.clear);
     final SemanticsHandle handle = tester.ensureSemantics();
     // Pumps a placeholder to trigger the warm up frame.
     await tester.pumpWidget(
@@ -36,7 +25,6 @@ void main() {
     // The warm up frame will send update for an empty semantics tree. We
     // ignore this one time update.
     SemanticsUpdateBuilderSpy.observations.clear();
-
     // Builds the real widget tree.
     await tester.pumpWidget(
       Directionality(
@@ -85,11 +73,11 @@ void main() {
     expect(SemanticsUpdateBuilderSpy.observations[1]!.childrenInTraversalOrder.length, 0);
     expect(SemanticsUpdateBuilderSpy.observations[1]!.label, 'outer\ninner-updated\ntext');
 
-    SemanticsUpdateBuilderSpy.observations.clear();
     handle.dispose();
   });
 
   testWidgets('Semantics update receives attributed text', (WidgetTester tester) async {
+    addTearDown(SemanticsUpdateBuilderSpy.observations.clear);
     final SemanticsHandle handle = tester.ensureSemantics();
     // Pumps a placeholder to trigger the warm up frame.
     await tester.pumpWidget(
@@ -183,8 +171,6 @@ void main() {
       'attributedHint: "hint" [SpellOutStringAttribute(TextRange(start: 1, end: 2))]' // ignore: missing_whitespace_between_adjacent_strings
       ')',
     );
-
-    SemanticsUpdateBuilderSpy.observations.clear();
     handle.dispose();
   });
 
@@ -264,85 +250,4 @@ void main() {
     SemanticsUpdateBuilderSpy.observations.clear();
     handle.dispose();
   }, skip: kIsWeb); // intended: the web engine handles the transform calculation itself.
-}
-
-class SemanticsUpdateTestBinding extends AutomatedTestWidgetsFlutterBinding {
-  @override
-  ui.SemanticsUpdateBuilder createSemanticsUpdateBuilder() {
-    return SemanticsUpdateBuilderSpy();
-  }
-}
-
-class SemanticsUpdateBuilderSpy extends Fake implements ui.SemanticsUpdateBuilder {
-  final SemanticsUpdateBuilder _builder = ui.SemanticsUpdateBuilder();
-
-  static Map<int, SemanticsNodeUpdateObservation> observations =
-      <int, SemanticsNodeUpdateObservation>{};
-
-  @override
-  void updateNode({
-    required int id,
-    required SemanticsFlags flags,
-    required int actions,
-    required int maxValueLength,
-    required int currentValueLength,
-    required int textSelectionBase,
-    required int textSelectionExtent,
-    required int platformViewId,
-    required int scrollChildren,
-    required int scrollIndex,
-    required int? traversalParent,
-    required double scrollPosition,
-    required double scrollExtentMax,
-    required double scrollExtentMin,
-    required Rect rect,
-    required String identifier,
-    required String label,
-    List<StringAttribute>? labelAttributes,
-    required String value,
-    List<StringAttribute>? valueAttributes,
-    required String increasedValue,
-    List<StringAttribute>? increasedValueAttributes,
-    required String decreasedValue,
-    List<StringAttribute>? decreasedValueAttributes,
-    required String hint,
-    List<StringAttribute>? hintAttributes,
-    String? tooltip,
-    TextDirection? textDirection,
-    required Float64List transform,
-    required Float64List hitTestTransform,
-    required Int32List childrenInTraversalOrder,
-    required Int32List childrenInHitTestOrder,
-    required Int32List additionalActions,
-    int headingLevel = 0,
-    String? linkUrl,
-    SemanticsRole role = SemanticsRole.none,
-    required List<String>? controlsNodes,
-    SemanticsValidationResult validationResult = SemanticsValidationResult.none,
-    ui.SemanticsHitTestBehavior hitTestBehavior = ui.SemanticsHitTestBehavior.defer,
-    required ui.SemanticsInputType inputType,
-    required ui.Locale? locale,
-    required String minValue,
-    required String maxValue,
-  }) {
-    // Makes sure we don't send the same id twice.
-    assert(!observations.containsKey(id));
-    observations[id] = (
-      label: label,
-      labelAttributes: labelAttributes,
-      hint: hint,
-      hintAttributes: hintAttributes,
-      value: value,
-      valueAttributes: valueAttributes,
-      childrenInTraversalOrder: childrenInTraversalOrder,
-      transform: transform,
-    );
-  }
-
-  @override
-  void updateCustomAction({required int id, String? label, String? hint, int overrideId = -1}) =>
-      _builder.updateCustomAction(id: id, label: label, hint: hint, overrideId: overrideId);
-
-  @override
-  ui.SemanticsUpdate build() => _builder.build();
 }

--- a/packages/flutter/test/semantics/semantics_update_tester.dart
+++ b/packages/flutter/test/semantics/semantics_update_tester.dart
@@ -1,0 +1,110 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class SemanticsUpdateBuilderSpy extends Fake implements ui.SemanticsUpdateBuilder {
+  final SemanticsUpdateBuilder _builder = ui.SemanticsUpdateBuilder();
+
+  static Map<int, SemanticsNodeUpdateObservation> observations =
+      <int, SemanticsNodeUpdateObservation>{};
+
+  @override
+  void updateNode({
+    required int id,
+    required SemanticsFlags flags,
+    required int actions,
+    required int maxValueLength,
+    required int currentValueLength,
+    required int textSelectionBase,
+    required int textSelectionExtent,
+    required int platformViewId,
+    required int scrollChildren,
+    required int scrollIndex,
+    required int? traversalParent,
+    required double scrollPosition,
+    required double scrollExtentMax,
+    required double scrollExtentMin,
+    required Rect rect,
+    required String identifier,
+    required String label,
+    List<StringAttribute>? labelAttributes,
+    required String value,
+    List<StringAttribute>? valueAttributes,
+    required String increasedValue,
+    List<StringAttribute>? increasedValueAttributes,
+    required String decreasedValue,
+    List<StringAttribute>? decreasedValueAttributes,
+    required String hint,
+    List<StringAttribute>? hintAttributes,
+    String? tooltip,
+    TextDirection? textDirection,
+    required Float64List transform,
+    required Float64List hitTestTransform,
+    required Int32List childrenInTraversalOrder,
+    required Int32List childrenInHitTestOrder,
+    required Int32List additionalActions,
+    int headingLevel = 0,
+    String? linkUrl,
+    SemanticsRole role = SemanticsRole.none,
+    required List<String>? controlsNodes,
+    SemanticsValidationResult validationResult = SemanticsValidationResult.none,
+    ui.SemanticsHitTestBehavior hitTestBehavior = ui.SemanticsHitTestBehavior.defer,
+    required ui.SemanticsInputType inputType,
+    required ui.Locale? locale,
+    required String minValue,
+    required String maxValue,
+  }) {
+    observations[id] = SemanticsNodeUpdateObservation(
+      label: label,
+      labelAttributes: labelAttributes,
+      hint: hint,
+      hintAttributes: hintAttributes,
+      value: value,
+      valueAttributes: valueAttributes,
+      childrenInTraversalOrder: childrenInTraversalOrder,
+      transform: transform,
+    );
+  }
+
+  @override
+  void updateCustomAction({required int id, String? label, String? hint, int overrideId = -1}) =>
+      _builder.updateCustomAction(id: id, label: label, hint: hint, overrideId: overrideId);
+
+  @override
+  ui.SemanticsUpdate build() => _builder.build();
+}
+
+class SemanticsNodeUpdateObservation {
+  const SemanticsNodeUpdateObservation({
+    required this.label,
+    this.labelAttributes,
+    required this.value,
+    this.valueAttributes,
+    required this.hint,
+    this.hintAttributes,
+    required this.childrenInTraversalOrder,
+    required this.transform,
+  });
+
+  final String label;
+  final List<StringAttribute>? labelAttributes;
+  final String value;
+  final List<StringAttribute>? valueAttributes;
+  final String hint;
+  final List<StringAttribute>? hintAttributes;
+  final Int32List childrenInTraversalOrder;
+  final Float64List transform;
+}
+
+class SemanticsUpdateTestBinding extends AutomatedTestWidgetsFlutterBinding {
+  @override
+  ui.SemanticsUpdateBuilder createSemanticsUpdateBuilder() {
+    return SemanticsUpdateBuilderSpy();
+  }
+}


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This is an attempt to reduce initial data delay when android or iOS tries to query semantics tree.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
