### PR TITLE
Release validation: Check `bin/internal/engine.version` in presubmit

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -95,6 +95,9 @@ Future<void> run(List<String> arguments) async {
     foundError(<String>['The analyze.dart script must be run with --enable-asserts.']);
   }
 
+  printProgress('Release branch validation');
+  await verifyReleaseBranchState(flutterRoot);
+
   printProgress('TargetPlatform tool/framework consistency');
   await verifyTargetPlatform(flutterRoot);
 
@@ -298,6 +301,15 @@ _Line _getLine(ParseStringResult parseResult, int offset) {
     parseResult.lineInfo.getOffsetOfLine(lineNumber) - 1,
   );
   return _Line(lineNumber, content);
+}
+
+Future<void> verifyReleaseBranchState(String workringDirerctory) async {
+  final ProcessResult result = await Process.run(dart, <String>[
+    'bin/check_engine_version.dart',
+  ], workingDirectory: path.join(workringDirerctory, 'dev', 'tools'));
+  if (result.exitCode != 0) {
+    foundError(<String>['${result.stderr}']);
+  }
 }
 
 Future<void> verifyTargetPlatform(String workingDirectory) async {

--- a/dev/tools/bin/check_engine_version.dart
+++ b/dev/tools/bin/check_engine_version.dart
@@ -1,0 +1,48 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:args/args.dart';
+import 'package:dev_tools/check_engine_version.dart';
+import 'package:path/path.dart' as p;
+
+final String _scriptSuffix = io.Platform.isWindows ? '.bat' : '.sh';
+final ArgParser _argParser =
+    ArgParser()
+      ..addOption(
+        'version',
+        abbr: 'v',
+        help: 'Path to the engine.version file',
+        defaultsTo: p.join('bin', 'internal', 'engine.version'),
+      )
+      ..addOption(
+        'script',
+        abbr: 'l',
+        help: 'Path to the last_engine_commit$_scriptSuffix script',
+        defaultsTo: p.join('bin', 'internal', 'last_engine_commit$_scriptSuffix'),
+      )
+      ..addFlag(
+        'skip-if-version-file-not-changed-from-head',
+        help: 'Skips the check, if the file was not changed compared to HEAD',
+        defaultsTo: true,
+      );
+
+/// Checks if `bin/internal/engine.version` was updated to the current SHA.
+void main(List<String> args) async {
+  final ArgResults argResults = _argParser.parse(args);
+
+  final String versionPath = argResults.option('version')!;
+  final String scriptPath = argResults.option('script')!;
+  final bool skipIfNotChanged = argResults.flag('skip-if-version-file-not-changed-from-head');
+
+  final bool result = await checkEngineVersion(
+    versionPath: versionPath,
+    scriptPath: scriptPath,
+    onlyIfVersionChanged: skipIfNotChanged,
+  );
+  if (!result) {
+    io.exitCode = 1;
+  }
+}

--- a/dev/tools/lib/check_engine_version.dart
+++ b/dev/tools/lib/check_engine_version.dart
@@ -72,36 +72,14 @@ Future<bool> checkEngineVersion({
 }
 
 Future<bool> _wasUpdated(String path, ProcessRunner runner, StringSink stderr) async {
-  ProcessRunnerResult mergeBaseResult = await runner.runProcess(<String>[
-    'git',
-    'merge-base',
-    '--fork-point',
-    'FETCH_HEAD',
-    'HEAD',
-  ], failOk: true);
-
-  // Fallback to the default merge-base instead.
-  if (mergeBaseResult.exitCode != 0) {
-    stderr.writeln('git merge-base --fork-point failed, using default merge-base');
-    mergeBaseResult = await runner.runProcess(<String>[
-      'git',
-      'merge-base',
-      'FETCH_HEAD',
-      'HEAD',
-    ], failOk: true);
-  }
-  if (mergeBaseResult.exitCode != 0) {
-    stderr.writeln('git merge-base failed: ${mergeBaseResult.stdout}');
-    return false;
-  }
-
-  final String mergeBase = mergeBaseResult.stdout.trim();
   final ProcessRunnerResult diffResult = await runner.runProcess(<String>[
     'git',
     'diff',
     '--name-only',
     '--relative',
-    mergeBase,
+    'master...HEAD',
+    '--',
+    path,
   ], failOk: true);
   if (diffResult.exitCode != 0) {
     stderr.writeln('git diff failed: ${diffResult.stdout}');

--- a/dev/tools/lib/check_engine_version.dart
+++ b/dev/tools/lib/check_engine_version.dart
@@ -1,0 +1,113 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:meta/meta.dart';
+import 'package:process_runner/process_runner.dart';
+
+/// Checks if the contents of [versionPath] are the same as the output of [scriptPath].
+///
+/// ```dart
+/// final bool success = await checkEngineVersion(
+///   versionPath: 'bin/internal/engine.version',
+///   scriptPath: 'bin/internal/last_engine_commit.sh',
+/// );
+/// ```
+///
+/// If the file described at [versionPath] does not exist, this check returns `true`.
+///
+/// If [onlyIfVersionChanged] is `true` (default), and the file described by [versionPath]
+/// has not changed at the current commit SHA compared to HEAD, `true` is immediately
+/// returned without any additional checks.
+@useResult
+Future<bool> checkEngineVersion({
+  required String versionPath,
+  required String scriptPath,
+  bool onlyIfVersionChanged = true,
+  @visibleForTesting FileSystem? fileSystem,
+  @visibleForTesting ProcessRunner? runner,
+  @visibleForTesting StringSink? stderr,
+}) async {
+  fileSystem ??= const LocalFileSystem();
+  runner ??= ProcessRunner();
+  stderr ??= io.stderr;
+
+  // If the file does not exist, immediately return true.
+  final File versionFile = fileSystem.file(versionPath);
+  if (!versionFile.existsSync()) {
+    stderr.writeln('$versionPath does not exist, skipping engine.version check');
+    return true;
+  }
+
+  // The file exists. Do we need to verify it was updated?
+  if (onlyIfVersionChanged && !await _wasUpdated(versionPath, runner, stderr)) {
+    stderr.writeln('$versionPath has not changed, skipping engine.version check');
+    return true;
+  }
+
+  // Get the expected value.
+  final ProcessRunnerResult expectedShaResult = await runner.runProcess(<String>[
+    scriptPath,
+  ], failOk: true);
+  if (expectedShaResult.exitCode != 0) {
+    stderr.writeln('$scriptPath failed: ${expectedShaResult.stdout}');
+    return false;
+  }
+  final String expectedSha = expectedShaResult.stdout.trim();
+
+  // Get the actual value.
+  final String actualSha = versionFile.readAsStringSync().trim();
+
+  // Compare
+  if (expectedSha != actualSha) {
+    stderr.writeln('$scriptPath output $expectedSha, but $versionPath is $actualSha');
+    return false;
+  }
+
+  return true;
+}
+
+Future<bool> _wasUpdated(String path, ProcessRunner runner, StringSink stderr) async {
+  ProcessRunnerResult mergeBaseResult = await runner.runProcess(<String>[
+    'git',
+    'merge-base',
+    '--fork-point',
+    'FETCH_HEAD',
+    'HEAD',
+  ], failOk: true);
+
+  // Fallback to the default merge-base instead.
+  if (mergeBaseResult.exitCode != 0) {
+    stderr.writeln('git merge-base --fork-point failed, using default merge-base');
+    mergeBaseResult = await runner.runProcess(<String>[
+      'git',
+      'merge-base',
+      'FETCH_HEAD',
+      'HEAD',
+    ], failOk: true);
+  }
+  if (mergeBaseResult.exitCode != 0) {
+    stderr.writeln('git merge-base failed: ${mergeBaseResult.stdout}');
+    return false;
+  }
+
+  final String mergeBase = mergeBaseResult.stdout.trim();
+  final ProcessRunnerResult diffResult = await runner.runProcess(<String>[
+    'git',
+    'diff',
+    '--name-only',
+    '--relative',
+    mergeBase,
+  ], failOk: true);
+  if (diffResult.exitCode != 0) {
+    stderr.writeln('git diff failed: ${diffResult.stdout}');
+    return false;
+  }
+
+  final String diffOutput = diffResult.stdout.trim();
+  return diffOutput.split('\n').contains(path);
+}

--- a/dev/tools/test/check_engine_version_test.dart
+++ b/dev/tools/test/check_engine_version_test.dart
@@ -1,0 +1,156 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:dev_tools/check_engine_version.dart' as lib;
+import 'package:file/memory.dart';
+import 'package:process_runner/process_runner.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late MemoryFileSystem fileSystem;
+  late StringBuffer stderr;
+  late String versionPath;
+  late String scriptPath;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    versionPath = fileSystem.path.join('bin', 'internal', 'engine.version');
+    scriptPath = fileSystem.path.join('bin', 'internal', 'last_engine_commit.sh');
+
+    stderr = StringBuffer();
+  });
+
+  tearDown(() {
+    printOnFailure('$stderr');
+  });
+
+  test('skips check, returning true, if the file is missing', () async {
+    final ProcessRunner noRuns = FakeProcessRunner(<String, ProcessRunnerResult>{});
+    await expectLater(
+      lib.checkEngineVersion(
+        versionPath: versionPath,
+        scriptPath: scriptPath,
+        fileSystem: fileSystem,
+        runner: noRuns,
+        stderr: stderr,
+      ),
+      completion(isTrue),
+    );
+
+    expect('$stderr', contains('does not exist, skipping engine.version check'));
+  });
+
+  test('skips check, returning true, if file was not changed', () async {
+    fileSystem
+        .directory('bin')
+        .childDirectory('internal')
+        .childFile('engine.version')
+        .createSync(recursive: true);
+
+    final ProcessRunner gitExec = FakeProcessRunner(<String, ProcessRunnerResult>{
+      'git merge-base --fork-point FETCH_HEAD HEAD': ProcessRunnerResult(
+        0,
+        utf8.encode('abc123'),
+        <int>[],
+        <int>[],
+      ),
+      'git diff --name-only --relative abc123': ProcessRunnerResult(
+        0,
+        utf8.encode('dev/another/file.txt\n'),
+        <int>[],
+        <int>[],
+      ),
+    });
+
+    await expectLater(
+      lib.checkEngineVersion(
+        versionPath: versionPath,
+        scriptPath: scriptPath,
+        fileSystem: fileSystem,
+        runner: gitExec,
+        stderr: stderr,
+      ),
+      completion(isTrue),
+    );
+
+    expect('$stderr', contains('has not changed, skipping engine.version check'));
+  });
+
+  test('fails if the SHAs are different', () async {
+    fileSystem.directory('bin').childDirectory('internal').childFile('engine.version')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('def456');
+
+    final ProcessRunner scriptExec = FakeProcessRunner(<String, ProcessRunnerResult>{
+      scriptPath: ProcessRunnerResult(0, utf8.encode('abc123'), <int>[], <int>[]),
+    });
+
+    await expectLater(
+      lib.checkEngineVersion(
+        versionPath: versionPath,
+        scriptPath: scriptPath,
+        fileSystem: fileSystem,
+        runner: scriptExec,
+        stderr: stderr,
+        onlyIfVersionChanged: false,
+      ),
+      completion(isFalse),
+    );
+
+    expect('$stderr', stringContainsInOrder(<String>['output abc123', 'is def456']));
+  });
+
+  test('succeeds if the SHAs are the same', () async {
+    fileSystem.directory('bin').childDirectory('internal').childFile('engine.version')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('abc123');
+
+    final ProcessRunner scriptExec = FakeProcessRunner(<String, ProcessRunnerResult>{
+      scriptPath: ProcessRunnerResult(0, utf8.encode('abc123'), <int>[], <int>[]),
+    });
+
+    await expectLater(
+      lib.checkEngineVersion(
+        versionPath: versionPath,
+        scriptPath: scriptPath,
+        fileSystem: fileSystem,
+        runner: scriptExec,
+        stderr: stderr,
+        onlyIfVersionChanged: false,
+      ),
+      completion(isTrue),
+    );
+
+    expect('$stderr', isEmpty);
+  });
+}
+
+final class FakeProcessRunner extends Fake implements ProcessRunner {
+  FakeProcessRunner(this._cannedResponses);
+  final Map<String, ProcessRunnerResult> _cannedResponses;
+
+  @override
+  Future<ProcessRunnerResult> runProcess(
+    List<String> commandLine, {
+    io.Directory? workingDirectory,
+    bool? printOutput,
+    bool failOk = false,
+    Stream<List<int>>? stdin,
+    bool runInShell = false,
+    io.ProcessStartMode startMode = io.ProcessStartMode.normal,
+  }) async {
+    final ProcessRunnerResult? command = _cannedResponses[commandLine.join(' ')];
+    if (command == null) {
+      fail('Unexpected process: ${commandLine.join(' ')}');
+    }
+    return command;
+  }
+}

--- a/dev/tools/test/check_engine_version_test.dart
+++ b/dev/tools/test/check_engine_version_test.dart
@@ -56,13 +56,7 @@ void main() {
         .createSync(recursive: true);
 
     final ProcessRunner gitExec = FakeProcessRunner(<String, ProcessRunnerResult>{
-      'git merge-base --fork-point FETCH_HEAD HEAD': ProcessRunnerResult(
-        0,
-        utf8.encode('abc123'),
-        <int>[],
-        <int>[],
-      ),
-      'git diff --name-only --relative abc123': ProcessRunnerResult(
+      'git diff --name-only --relative master...HEAD -- $versionPath': ProcessRunnerResult(
         0,
         utf8.encode('dev/another/file.txt\n'),
         <int>[],


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/170012.

Note that this won't immediately apply to 3.32, but only for future branches from `master`.