### PR TITLE
Make ImageFilter::equals a static method and fix the name in its FFI annotation

### DIFF
--- a/engine/src/flutter/lib/ui/dart_ui.cc
+++ b/engine/src/flutter/lib/ui/dart_ui.cc
@@ -84,6 +84,7 @@ typedef CanvasPath Path;
   /* Other */                                                      \
   V(FontCollection::LoadFontFromList)                              \
   V(ImageDescriptor::initEncoded)                                  \
+  V(ImageFilter::equals)                                           \
   V(ImmutableBuffer::init)                                         \
   V(ImmutableBuffer::initFromAsset)                                \
   V(ImmutableBuffer::initFromFile)                                 \
@@ -209,7 +210,6 @@ typedef CanvasPath Path;
   V(ImageFilter, initComposeFilter)              \
   V(ImageFilter, initShader)                     \
   V(ImageFilter, initMatrix)                     \
-  V(ImageFilter, equals)                         \
   V(ImageShader, dispose)                        \
   V(ImageShader, initWithImage)                  \
   V(ImmutableBuffer, dispose)                    \

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4501,7 +4501,7 @@ class _FragmentShaderImageFilter implements ImageFilter {
         _equals(nativeFilter, other.nativeFilter);
   }
 
-  @Native<Bool Function(Handle, Handle)>(symbol: 'ImageFilter::equal')
+  @Native<Bool Function(Handle, Handle)>(symbol: 'ImageFilter::equals')
   external static bool _equals(_ImageFilter a, _ImageFilter b);
 
   @override

--- a/engine/src/flutter/lib/ui/painting/image_filter.h
+++ b/engine/src/flutter/lib/ui/painting/image_filter.h
@@ -36,7 +36,7 @@ class ImageFilter : public RefCountedDartWrappable<ImageFilter> {
   void initColorFilter(ColorFilter* colorFilter);
   void initComposeFilter(ImageFilter* outer, ImageFilter* inner);
   void initShader(ReusableFragmentShader* shader);
-  bool equals(ImageFilter* a, ImageFilter* b);
+  static bool equals(ImageFilter* a, ImageFilter* b);
 
   const std::shared_ptr<DlImageFilter> filter(DlTileMode mode) const;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/169936