### PR TITLE
Fix time picker period selector a11y touch targets

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -3021,10 +3021,22 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
                 ? localizations.timePickerDialHelpText
                 : localizations.timePickerDialHelpText.toUpperCase());
 
+        // The vertical adjustment used to make both AM/PM buttons accessible.
+        // Because the period selector height is increased based on this value,
+        // the dial padding has to be decreased of the same amount.
+        final double portraitMinInteractiveVerticalAdjustment = math.max(
+          0,
+          2 * kMinInteractiveDimension - defaultTheme.dayPeriodPortraitSize.height,
+        );
         final EdgeInsetsGeometry dialPadding = switch (orientation) {
-          Orientation.portrait => const EdgeInsets.only(left: 12, right: 12, top: 36),
+          Orientation.portrait => EdgeInsets.only(
+            left: 12,
+            right: 12,
+            top: 36 - portraitMinInteractiveVerticalAdjustment / 2,
+          ),
           Orientation.landscape => const EdgeInsetsDirectional.only(start: 64),
         };
+
         final Widget dial = Padding(
           padding: dialPadding,
           child: Semantics(

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -18,6 +18,7 @@ import 'package:flutter/widgets.dart';
 import 'button_style.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
+import 'constants.dart';
 import 'curves.dart';
 import 'debug.dart';
 import 'dialog.dart';
@@ -248,22 +249,29 @@ class _TimePickerHeader extends StatelessWidget {
       context,
     ).timeOfDayFormat(alwaysUse24HourFormat: _TimePickerModel.use24HourFormatOf(context));
 
+    final _TimePickerDefaults defaultTheme = _TimePickerModel.defaultThemeOf(context);
+    final Orientation orientation = _TimePickerModel.orientationOf(context);
+    final double dayPeriodHeight = orientation == Orientation.portrait
+        ? defaultTheme.dayPeriodPortraitSize.height
+        : defaultTheme.dayPeriodLandscapeSize.height;
+    final double minInteractiveVerticalPadding = orientation == Orientation.portrait
+        ? math.max(0, 2 * kMinInteractiveDimension - dayPeriodHeight)
+        : math.max(0, kMinInteractiveDimension - dayPeriodHeight);
+
     final _HourDialType hourDialType = _TimePickerModel.hourDialTypeOf(context);
-    final RenderObjectWidget orientationSpecificHeader = switch (_TimePickerModel.orientationOf(
-      context,
-    )) {
+    final RenderObjectWidget orientationSpecificHeader = switch (orientation) {
       Orientation.portrait => Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Padding(
             padding: EdgeInsetsDirectional.only(
-              bottom: _TimePickerModel.useMaterial3Of(context) ? 20 : 24,
+              bottom:
+                  (_TimePickerModel.useMaterial3Of(context) ? 20 : 24) -
+                  minInteractiveVerticalPadding / 2,
             ),
             child: Text(
               helpText,
-              style:
-                  _TimePickerModel.themeOf(context).helpTextStyle ??
-                  _TimePickerModel.defaultThemeOf(context).helpTextStyle,
+              style: _TimePickerModel.themeOf(context).helpTextStyle ?? defaultTheme.helpTextStyle,
             ),
           ),
           Row(
@@ -294,9 +302,7 @@ class _TimePickerHeader extends StatelessWidget {
           children: <Widget>[
             Text(
               helpText,
-              style:
-                  _TimePickerModel.themeOf(context).helpTextStyle ??
-                  _TimePickerModel.defaultThemeOf(context).helpTextStyle,
+              style: _TimePickerModel.themeOf(context).helpTextStyle ?? defaultTheme.helpTextStyle,
             ),
             Column(
               verticalDirection: timeOfDayFormat == TimeOfDayFormat.a_space_h_colon_mm
@@ -304,7 +310,7 @@ class _TimePickerHeader extends StatelessWidget {
                   : VerticalDirection.down,
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
-              spacing: 12,
+              spacing: math.max(0, 16 - minInteractiveVerticalPadding / 2),
               children: <Widget>[
                 Row(
                   // Hour/minutes should not change positions in RTL locales.
@@ -625,18 +631,6 @@ class _DayPeriodControl extends StatelessWidget {
           side: resolvedSide,
         );
 
-    final Widget amButton = _AmPmButton(
-      selected: amSelected,
-      onPressed: () => _setAm(context),
-      label: materialLocalizations.anteMeridiemAbbreviation,
-    );
-
-    final Widget pmButton = _AmPmButton(
-      selected: pmSelected,
-      onPressed: () => _setPm(context),
-      label: materialLocalizations.postMeridiemAbbreviation,
-    );
-
     Size dayPeriodSize;
     final Orientation orientation;
     switch (_TimePickerModel.entryModeOf(context)) {
@@ -654,50 +648,123 @@ class _DayPeriodControl extends StatelessWidget {
     }
 
     final Widget result;
+    OutlinedBorder amShape = resolvedShape;
+    OutlinedBorder pmShape = resolvedShape;
+    final bool hasRoundedBorder =
+        resolvedShape is RoundedRectangleBorder && resolvedShape.borderRadius is BorderRadius;
+
+    // In order to respect Material touch target guidelines, the Semantics for
+    // AM and PM buttons needs to expand out of the bounds of the buttons
+    // (Similarly to Google Agenda).
+    // To achieve this, instead of using a parent Material which clips
+    // the Semantics, each button should manage its own shape.
+    // The logic below "cuts" the given period selector shape in two parts,
+    // one for the AM button, the other for the PM button. Each sub-shape
+    // is obtained by removing some rounded corners from the original shape.
     switch (orientation) {
       case Orientation.portrait:
+        if (hasRoundedBorder) {
+          final BorderRadius borderRadius = resolvedShape.borderRadius as BorderRadius;
+          amShape = resolvedShape.copyWith(
+            borderRadius: BorderRadius.only(
+              topLeft: borderRadius.topLeft,
+              topRight: borderRadius.topRight,
+            ),
+          );
+          pmShape = resolvedShape.copyWith(
+            borderRadius: BorderRadius.only(
+              bottomLeft: borderRadius.bottomLeft,
+              bottomRight: borderRadius.bottomRight,
+            ),
+          );
+        }
+
+        final Size minInteractiveSize = Size(
+          dayPeriodSize.width,
+          math.max(dayPeriodSize.height, 2 * kMinInteractiveDimension),
+        );
+
+        final Widget amButton = _AmPmButton(
+          selected: amSelected,
+          onPressed: () => _setAm(context),
+          label: materialLocalizations.anteMeridiemAbbreviation,
+          padding: EdgeInsets.only(top: (minInteractiveSize.height - dayPeriodSize.height) / 2),
+          shape: amShape,
+        );
+
+        final Widget pmButton = _AmPmButton(
+          selected: pmSelected,
+          onPressed: () => _setPm(context),
+          label: materialLocalizations.postMeridiemAbbreviation,
+          padding: EdgeInsets.only(bottom: (minInteractiveSize.height - dayPeriodSize.height) / 2),
+          shape: pmShape,
+        );
+
         result = _DayPeriodInputPadding(
-          minSize: dayPeriodSize,
+          minSize: minInteractiveSize,
           orientation: orientation,
           child: SizedBox.fromSize(
-            size: dayPeriodSize,
-            child: Material(
-              clipBehavior: Clip.antiAlias,
-              color: Colors.transparent,
-              shape: resolvedShape,
-              child: Column(
-                children: <Widget>[
-                  Expanded(child: amButton),
-                  Container(
-                    decoration: BoxDecoration(border: Border(top: resolvedSide)),
-                    height: 1,
-                  ),
-                  Expanded(child: pmButton),
-                ],
-              ),
+            size: minInteractiveSize,
+            child: Column(
+              children: <Widget>[
+                Expanded(child: amButton),
+                Expanded(child: pmButton),
+              ],
             ),
           ),
         );
       case Orientation.landscape:
+        if (hasRoundedBorder) {
+          final BorderRadius borderRadius = resolvedShape.borderRadius as BorderRadius;
+          amShape = resolvedShape.copyWith(
+            borderRadius: BorderRadius.only(
+              topLeft: borderRadius.topLeft,
+              bottomLeft: borderRadius.bottomLeft,
+            ),
+          );
+          pmShape = resolvedShape.copyWith(
+            borderRadius: BorderRadius.only(
+              topRight: borderRadius.topRight,
+              bottomRight: borderRadius.bottomRight,
+            ),
+          );
+        }
+
+        final Size minInteractiveSize = Size(
+          dayPeriodSize.width,
+          math.max(dayPeriodSize.height, kMinInteractiveDimension),
+        );
+
+        final Widget amButton = _AmPmButton(
+          selected: amSelected,
+          onPressed: () => _setAm(context),
+          label: materialLocalizations.anteMeridiemAbbreviation,
+          padding: EdgeInsets.symmetric(
+            vertical: (minInteractiveSize.height - dayPeriodSize.height) / 2,
+          ),
+          shape: amShape,
+        );
+
+        final Widget pmButton = _AmPmButton(
+          selected: pmSelected,
+          onPressed: () => _setPm(context),
+          label: materialLocalizations.postMeridiemAbbreviation,
+          padding: EdgeInsets.symmetric(
+            vertical: (minInteractiveSize.height - dayPeriodSize.height) / 2,
+          ),
+          shape: pmShape,
+        );
+
         result = _DayPeriodInputPadding(
-          minSize: dayPeriodSize,
+          minSize: minInteractiveSize,
           orientation: orientation,
           child: SizedBox(
-            height: dayPeriodSize.height,
-            child: Material(
-              clipBehavior: Clip.antiAlias,
-              color: Colors.transparent,
-              shape: resolvedShape,
-              child: Row(
-                children: <Widget>[
-                  Expanded(child: amButton),
-                  Container(
-                    decoration: BoxDecoration(border: Border(left: resolvedSide)),
-                    width: 1,
-                  ),
-                  Expanded(child: pmButton),
-                ],
-              ),
+            height: minInteractiveSize.height,
+            child: Row(
+              children: <Widget>[
+                Expanded(child: amButton),
+                Expanded(child: pmButton),
+              ],
             ),
           ),
         );
@@ -707,11 +774,19 @@ class _DayPeriodControl extends StatelessWidget {
 }
 
 class _AmPmButton extends StatelessWidget {
-  const _AmPmButton({required this.onPressed, required this.selected, required this.label});
+  const _AmPmButton({
+    required this.onPressed,
+    required this.selected,
+    required this.label,
+    required this.padding,
+    required this.shape,
+  });
 
   final bool selected;
   final VoidCallback onPressed;
   final String label;
+  final EdgeInsets padding;
+  final OutlinedBorder shape;
 
   @override
   Widget build(BuildContext context) {
@@ -732,16 +807,21 @@ class _AmPmButton extends StatelessWidget {
     )?.copyWith(color: resolvedTextColor);
     final TextScaler buttonTextScaler = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 2.0);
 
-    return Material(
-      color: resolvedBackgroundColor,
-      child: InkWell(
-        onTap: onPressed,
-        child: Semantics(
-          checked: selected,
-          inMutuallyExclusiveGroup: true,
-          button: true,
-          child: Center(
-            child: Text(label, style: resolvedTextStyle, textScaler: buttonTextScaler),
+    return Semantics(
+      checked: selected,
+      inMutuallyExclusiveGroup: true,
+      button: true,
+      child: Padding(
+        padding: padding,
+        child: Material(
+          clipBehavior: Clip.antiAlias,
+          color: resolvedBackgroundColor,
+          shape: shape,
+          child: InkWell(
+            onTap: onPressed,
+            child: Center(
+              child: Text(label, style: resolvedTextStyle, textScaler: buttonTextScaler),
+            ),
           ),
         ),
       ),
@@ -1809,6 +1889,11 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     final TextStyle hourMinuteStyle =
         timePickerTheme.hourMinuteTextStyle ?? defaultTheme.hourMinuteTextStyle;
 
+    final double minInteractiveVerticalPadding = math.max(
+      0,
+      2 * kMinInteractiveDimension - defaultTheme.dayPeriodInputSize.height,
+    );
+
     return Padding(
       padding: _TimePickerModel.useMaterial3Of(context)
           ? EdgeInsets.zero
@@ -1818,7 +1903,9 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
         children: <Widget>[
           Padding(
             padding: EdgeInsetsDirectional.only(
-              bottom: _TimePickerModel.useMaterial3Of(context) ? 20 : 24,
+              bottom:
+                  (_TimePickerModel.useMaterial3Of(context) ? 20 : 24) -
+                  minInteractiveVerticalPadding / 2,
             ),
             child: Text(
               widget.helpText,
@@ -1838,79 +1925,79 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
                 ),
               ],
               Expanded(
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  // Hour/minutes should not change positions in RTL locales.
-                  textDirection: TextDirection.ltr,
-                  children: <Widget>[
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 10),
-                            child: _HourTextField(
-                              restorationId: 'hour_text_field',
-                              selectedTime: _selectedTime.value,
-                              style: hourMinuteStyle,
-                              autofocus: widget.autofocusHour,
-                              inputAction: TextInputAction.next,
-                              validator: _validateHour,
-                              onSavedSubmitted: _handleHourSavedSubmitted,
-                              onChanged: _handleHourChanged,
-                              hourLabelText: widget.hourLabelText,
-                              emptyInitialTime: widget.emptyInitialTime,
-                            ),
-                          ),
-                          if (!hourHasError.value && !minuteHasError.value)
-                            ExcludeSemantics(
-                              child: Text(
-                                widget.hourLabelText ??
-                                    MaterialLocalizations.of(context).timePickerHourLabel,
-                                style: theme.textTheme.bodySmall,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
+                child: Padding(
+                  padding: EdgeInsetsDirectional.only(top: minInteractiveVerticalPadding / 2),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    // Hour/minutes should not change positions in RTL locales.
+                    textDirection: TextDirection.ltr,
+                    children: <Widget>[
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Padding(
+                              padding: const EdgeInsets.only(bottom: 10),
+                              child: _HourTextField(
+                                restorationId: 'hour_text_field',
+                                selectedTime: _selectedTime.value,
+                                style: hourMinuteStyle,
+                                autofocus: widget.autofocusHour,
+                                inputAction: TextInputAction.next,
+                                validator: _validateHour,
+                                onSavedSubmitted: _handleHourSavedSubmitted,
+                                onChanged: _handleHourChanged,
+                                hourLabelText: widget.hourLabelText,
+                                emptyInitialTime: widget.emptyInitialTime,
                               ),
                             ),
-                        ],
+                            if (!hourHasError.value && !minuteHasError.value)
+                              ExcludeSemantics(
+                                child: Text(
+                                  widget.hourLabelText ??
+                                      MaterialLocalizations.of(context).timePickerHourLabel,
+                                  style: theme.textTheme.bodySmall,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                          ],
+                        ),
                       ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 10),
-                      child: _TimeSelectorSeparator(timeOfDayFormat: timeOfDayFormat),
-                    ),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 10),
-                            child: _MinuteTextField(
-                              restorationId: 'minute_text_field',
-                              selectedTime: _selectedTime.value,
-                              style: hourMinuteStyle,
-                              autofocus: widget.autofocusMinute,
-                              inputAction: TextInputAction.done,
-                              validator: _validateMinute,
-                              onSavedSubmitted: _handleMinuteSavedSubmitted,
-                              minuteLabelText: widget.minuteLabelText,
-                              emptyInitialTime: widget.emptyInitialTime,
-                            ),
-                          ),
-                          if (!hourHasError.value && !minuteHasError.value)
-                            ExcludeSemantics(
-                              child: Text(
-                                widget.minuteLabelText ??
-                                    MaterialLocalizations.of(context).timePickerMinuteLabel,
-                                style: theme.textTheme.bodySmall,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
+                      _TimeSelectorSeparator(timeOfDayFormat: timeOfDayFormat),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Padding(
+                              padding: const EdgeInsets.only(bottom: 10),
+                              child: _MinuteTextField(
+                                restorationId: 'minute_text_field',
+                                selectedTime: _selectedTime.value,
+                                style: hourMinuteStyle,
+                                autofocus: widget.autofocusMinute,
+                                inputAction: TextInputAction.done,
+                                validator: _validateMinute,
+                                onSavedSubmitted: _handleMinuteSavedSubmitted,
+                                minuteLabelText: widget.minuteLabelText,
+                                emptyInitialTime: widget.emptyInitialTime,
                               ),
                             ),
-                        ],
+                            if (!hourHasError.value && !minuteHasError.value)
+                              ExcludeSemantics(
+                                child: Text(
+                                  widget.minuteLabelText ??
+                                      MaterialLocalizations.of(context).timePickerMinuteLabel,
+                                  style: theme.textTheme.bodySmall,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
               if (!use24HourDials &&

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -647,7 +647,6 @@ class _DayPeriodControl extends StatelessWidget {
         dayPeriodSize = defaultTheme.dayPeriodInputSize;
     }
 
-    final Widget result;
     OutlinedBorder amShape = resolvedShape;
     OutlinedBorder pmShape = resolvedShape;
     final bool hasRoundedBorder =
@@ -700,7 +699,7 @@ class _DayPeriodControl extends StatelessWidget {
           shape: pmShape,
         );
 
-        result = _DayPeriodInputPadding(
+        return _DayPeriodInputPadding(
           minSize: minInteractiveSize,
           orientation: orientation,
           child: SizedBox.fromSize(
@@ -755,7 +754,7 @@ class _DayPeriodControl extends StatelessWidget {
           shape: pmShape,
         );
 
-        result = _DayPeriodInputPadding(
+        return _DayPeriodInputPadding(
           minSize: minInteractiveSize,
           orientation: orientation,
           child: SizedBox(
@@ -769,7 +768,6 @@ class _DayPeriodControl extends StatelessWidget {
           ),
         );
     }
-    return result;
   }
 }
 

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -1699,6 +1699,46 @@ void main() {
         expect(minuteSize.width, greaterThanOrEqualTo(48));
         expect(minuteSize.height, greaterThanOrEqualTo(48));
       });
+
+      testWidgets(
+        'Period selector touch target respects accessibility guidelines - Portrait mode',
+        (WidgetTester tester) async {
+          final SemanticsTester semantics = SemanticsTester(tester);
+          const Size minInteractiveSize = Size(kMinInteractiveDimension, kMinInteractiveDimension);
+
+          // Ensure picker is displayed in portrait mode.
+          tester.view.physicalSize = const Size(600, 1000);
+          addTearDown(tester.view.reset);
+
+          await mediaQueryBoilerplate(tester, materialType: materialType);
+
+          final SemanticsNode amButton = semantics.nodesWith(label: amString).single;
+          expect(amButton.rect.size >= minInteractiveSize, isTrue);
+
+          final SemanticsNode pmButton = semantics.nodesWith(label: pmString).single;
+          expect(pmButton.rect.size >= minInteractiveSize, isTrue);
+
+          semantics.dispose();
+        },
+      );
+
+      testWidgets(
+        'Period selector touch target respects accessibility guidelines - Landscape mode',
+        (WidgetTester tester) async {
+          final SemanticsTester semantics = SemanticsTester(tester);
+          const Size minInteractiveSize = Size(kMinInteractiveDimension, kMinInteractiveDimension);
+
+          await mediaQueryBoilerplate(tester, materialType: materialType);
+
+          final SemanticsNode amButton = semantics.nodesWith(label: amString).single;
+          expect(amButton.rect.size >= minInteractiveSize, isTrue);
+
+          final SemanticsNode pmButton = semantics.nodesWith(label: pmString).single;
+          expect(pmButton.rect.size >= minInteractiveSize, isTrue);
+
+          semantics.dispose();
+        },
+      );
     });
 
     group('Time picker - Input (${materialType.name})', () {
@@ -2490,8 +2530,9 @@ void main() {
     (WidgetTester tester) async {
       addTearDown(tester.view.reset);
 
-      final Finder dayPeriodControlFinder = find.byWidgetPredicate(
-        (Widget w) => '${w.runtimeType}' == '_DayPeriodControl',
+      final Finder amMaterialFinder = find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_AmPmButton').first,
+        matching: find.byType(Material),
       );
       final Finder timeControlFinder = find
           .ancestor(of: find.text('7'), matching: find.byType(Row))
@@ -2506,10 +2547,10 @@ void main() {
         locale: const Locale('ko', 'KR'),
       );
 
+      const double dayPeriodPortraitGap = 12.0; // From Material spec.
       expect(
-        tester.getBottomLeft(timeControlFinder).dx -
-            tester.getBottomRight(dayPeriodControlFinder).dx,
-        12,
+        tester.getBottomLeft(timeControlFinder).dx - tester.getBottomRight(amMaterialFinder).dx,
+        dayPeriodPortraitGap,
       );
 
       // Dismiss the dialog.
@@ -2528,9 +2569,10 @@ void main() {
         locale: const Locale('ko', 'KR'),
       );
 
+      const double dayPeriodLandscapeGap = 16.0; // From Material spec.
       expect(
-        tester.getTopLeft(timeControlFinder).dy - tester.getBottomLeft(dayPeriodControlFinder).dy,
-        12,
+        tester.getTopLeft(timeControlFinder).dy - tester.getBottomLeft(amMaterialFinder).dy,
+        dayPeriodLandscapeGap,
       );
     },
   );

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -258,21 +258,31 @@ void main() {
       defaultTheme.colorScheme.onSurface.withOpacity(0.38),
       defaultTheme.colorScheme.surface,
     );
-    final Material dayPeriodMaterial = _dayPeriodMaterial(tester);
-    expect(
-      dayPeriodMaterial.shape,
-      RoundedRectangleBorder(
-        borderRadius: const BorderRadius.all(Radius.circular(4.0)),
-        side: BorderSide(color: expectedBorderColor),
+
+    final RoundedRectangleBorder expectedAmShape = RoundedRectangleBorder(
+      side: BorderSide(color: expectedBorderColor),
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(4.0),
+        bottomLeft: Radius.circular(4.0),
       ),
     );
+    expect(amMaterial.shape, expectedAmShape);
 
-    final Container dayPeriodDivider = _dayPeriodDivider(tester);
-    expect(
-      dayPeriodDivider.decoration,
-      BoxDecoration(
-        border: Border(left: BorderSide(color: expectedBorderColor)),
+    final RoundedRectangleBorder expectedPmShape = RoundedRectangleBorder(
+      side: BorderSide(color: expectedBorderColor),
+      borderRadius: const BorderRadius.only(
+        topRight: Radius.circular(4.0),
+        bottomRight: Radius.circular(4.0),
       ),
+    );
+    expect(pmMaterial.shape, expectedPmShape);
+
+    expect(
+      find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodControl'),
+        matching: find.byType(Container),
+      ),
+      findsNothing,
     );
 
     final IconButton entryModeIconButton = _entryModeIconButton(tester);
@@ -416,21 +426,30 @@ void main() {
     final Material pmMaterial = _textMaterial(tester, 'PM');
     expect(pmMaterial.color, Colors.transparent);
 
-    final Material dayPeriodMaterial = _dayPeriodMaterial(tester);
-    expect(
-      dayPeriodMaterial.shape,
-      RoundedRectangleBorder(
-        borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-        side: BorderSide(color: defaultTheme.colorScheme.outline),
+    final RoundedRectangleBorder expectedAmShape = RoundedRectangleBorder(
+      side: BorderSide(color: defaultTheme.colorScheme.outline),
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(8.0),
+        bottomLeft: Radius.circular(8.0),
       ),
     );
+    expect(amMaterial.shape, expectedAmShape);
 
-    final Container dayPeriodDivider = _dayPeriodDivider(tester);
-    expect(
-      dayPeriodDivider.decoration,
-      BoxDecoration(
-        border: Border(left: BorderSide(color: defaultTheme.colorScheme.outline)),
+    final RoundedRectangleBorder expectedPmShape = RoundedRectangleBorder(
+      side: BorderSide(color: defaultTheme.colorScheme.outline),
+      borderRadius: const BorderRadius.only(
+        topRight: Radius.circular(8.0),
+        bottomRight: Radius.circular(8.0),
       ),
+    );
+    expect(pmMaterial.shape, expectedPmShape);
+
+    expect(
+      find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodControl'),
+        matching: find.byType(Container),
+      ),
+      findsNothing,
     );
 
     final IconButton entryModeIconButton = _entryModeIconButton(tester);
@@ -686,16 +705,34 @@ void main() {
     final Material pmMaterial = _textMaterial(tester, 'PM');
     expect(pmMaterial.color, _unselectedColor);
 
-    final Material dayPeriodMaterial = _dayPeriodMaterial(tester);
-    expect(
-      dayPeriodMaterial.shape,
-      timePickerTheme.dayPeriodShape!.copyWith(side: timePickerTheme.dayPeriodBorderSide),
-    );
+    final RoundedRectangleBorder dayPeriodShape =
+        timePickerTheme.dayPeriodShape! as RoundedRectangleBorder;
+    final BorderRadius borderRadius = dayPeriodShape.borderRadius as BorderRadius;
 
-    final Container dayPeriodDivider = _dayPeriodDivider(tester);
+    final RoundedRectangleBorder expectedAmShape = dayPeriodShape.copyWith(
+      side: timePickerTheme.dayPeriodBorderSide,
+      borderRadius: BorderRadius.only(
+        topLeft: borderRadius.topLeft,
+        bottomLeft: borderRadius.topRight,
+      ),
+    );
+    expect(amMaterial.shape, expectedAmShape);
+
+    final RoundedRectangleBorder expectedPmShape = dayPeriodShape.copyWith(
+      side: timePickerTheme.dayPeriodBorderSide,
+      borderRadius: BorderRadius.only(
+        topRight: borderRadius.topLeft,
+        bottomRight: borderRadius.topRight,
+      ),
+    );
+    expect(pmMaterial.shape, expectedPmShape);
+
     expect(
-      dayPeriodDivider.decoration,
-      BoxDecoration(border: Border(left: timePickerTheme.dayPeriodBorderSide!)),
+      find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodControl'),
+        matching: find.byType(Container),
+      ),
+      findsNothing,
     );
 
     final IconButton entryModeIconButton = _entryModeIconButton(tester);
@@ -818,16 +855,34 @@ void main() {
     final Material pmMaterial = _textMaterial(tester, 'PM');
     expect(pmMaterial.color, _unselectedColor);
 
-    final Material dayPeriodMaterial = _dayPeriodMaterial(tester);
-    expect(
-      dayPeriodMaterial.shape,
-      timePickerTheme.dayPeriodShape!.copyWith(side: timePickerTheme.dayPeriodBorderSide),
-    );
+    final RoundedRectangleBorder dayPeriodShape =
+        timePickerTheme.dayPeriodShape! as RoundedRectangleBorder;
+    final BorderRadius borderRadius = dayPeriodShape.borderRadius as BorderRadius;
 
-    final Container dayPeriodDivider = _dayPeriodDivider(tester);
+    final RoundedRectangleBorder expectedAmShape = dayPeriodShape.copyWith(
+      side: timePickerTheme.dayPeriodBorderSide,
+      borderRadius: BorderRadius.only(
+        topLeft: borderRadius.topLeft,
+        bottomLeft: borderRadius.topRight,
+      ),
+    );
+    expect(amMaterial.shape, expectedAmShape);
+
+    final RoundedRectangleBorder expectedPmShape = dayPeriodShape.copyWith(
+      side: timePickerTheme.dayPeriodBorderSide,
+      borderRadius: BorderRadius.only(
+        topRight: borderRadius.topLeft,
+        bottomRight: borderRadius.topRight,
+      ),
+    );
+    expect(pmMaterial.shape, expectedPmShape);
+
     expect(
-      dayPeriodDivider.decoration,
-      BoxDecoration(border: Border(left: timePickerTheme.dayPeriodBorderSide!)),
+      find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodControl'),
+        matching: find.byType(Container),
+      ),
+      findsNothing,
     );
 
     final IconButton entryModeIconButton = _entryModeIconButton(tester);
@@ -1107,28 +1162,6 @@ Material _textMaterial(WidgetTester tester, String text) {
 TextField _textField(WidgetTester tester, String text) {
   return tester.widget<TextField>(
     find.ancestor(of: find.text(text), matching: find.byType(TextField)).first,
-  );
-}
-
-Material _dayPeriodMaterial(WidgetTester tester) {
-  return tester.widget<Material>(
-    find
-        .descendant(
-          of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodControl'),
-          matching: find.byType(Material),
-        )
-        .first,
-  );
-}
-
-Container _dayPeriodDivider(WidgetTester tester) {
-  return tester.widget<Container>(
-    find
-        .descendant(
-          of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodControl'),
-          matching: find.byType(Container),
-        )
-        .at(0),
   );
 }
 


### PR DESCRIPTION
## Description

This PR fixes the TimePicker day period selector touch targets.

### Before

| Flutter | Google Agenda | Compose |
|--------|--------|--------|
| ![Image](https://github.com/user-attachments/assets/9395a032-0e5c-4255-8620-e2c499bfed44) | ![Image](https://github.com/user-attachments/assets/5a63b78c-45d2-4958-9088-5bc89c02c7fe) | ![Image](https://github.com/user-attachments/assets/0b2ac630-9b8d-44ed-936f-297bd2798981) ![Image](https://github.com/user-attachments/assets/f4750ded-fc4b-4d86-8825-f4e9b38b6231) | 

### After

| Flutter | Google Agenda | Compose |
|--------|--------|--------|
|![image](https://github.com/user-attachments/assets/fde7d655-6151-42d8-a162-fe410e2278da) | ![Image](https://github.com/user-attachments/assets/5a63b78c-45d2-4958-9088-5bc89c02c7fe) | ![Image](https://github.com/user-attachments/assets/0b2ac630-9b8d-44ed-936f-297bd2798981) ![Image](https://github.com/user-attachments/assets/f4750ded-fc4b-4d86-8825-f4e9b38b6231) | 

## Implementation choice

This PR implements two main changes:
- it expands the `_DayPeriodControl` bounds by reducing some existing spacing. Doing so the touch area of the AM/PM buttons can grow outside the day period container and respect the minimum interactive height.
- it changes the tree order to correctly sized the AM/PM buttons semantics. The solution here is somewhat tricky/hacky:
 
Because the semantics bounds are clipped by their ancestor, the PR changes the widget order:

Before, the order was `_DayPeriodControl` > `_DayPeriodInputPadding` > `Material` (with shape and clip) > `Row` (or Column depending on the orientation) > children [ `Semantics` > AM `InkWell`, `Semantics` > PM `InkWell` ]
(Which leads to the Semantics being clipped by the Material shape).

After, the order is `_DayPeriodControl` > `_DayPeriodInputPadding` > `Row` (or Column depending on the orientation) > children [ `Semantics` > `Material` (with shape and clip) > AM `InkWell`, `Semantics` > `Material` (with shape and clip) > PM `InkWell` ]

The difficulty here is that the `TimePickerThemeData.dayPeriodShape` is meant to be the shape for the whole day period container. In order to change the order, this PR has to set separetly the shapes of the AM and PM buttons. To do so it adds some logic to 'split' the shape in two parts. This is ok for the default shape but not possible for any shape, in that case the original shape will be use for both buttons which gives a different result than before this PR. This annoyance seems less a problem than having the default rendering not respecting a11y touch targets.


## Related Issue

Fixes [touch target size not up to a11y standards for DatePicker day period selector.](https://github.com/flutter/flutter/issues/168245)

## Tests

Adds 2 tests.
Updates 5 tests.