### PR TITLE
Align persistent nav bar leading widget

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1844,6 +1844,8 @@ class _PersistentNavigationBar extends StatelessWidget {
         backLabel != null &&
         !CupertinoSheetRoute.hasParentSheet(context)) {
       leading = CupertinoNavigationBarBackButton._assemble(backChevron, backLabel);
+    } else {
+      leading = Align(widthFactor: 1.0, child: leading);
     }
 
     Widget paddedToolbar = NavigationToolbar(

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -1011,11 +1011,11 @@ void main() {
     expect(flying(tester, find.text('custom')), findsOneWidget);
 
     checkOpacity(tester, flying(tester, find.text('custom')), 0.8948725312948227);
-    expect(tester.getTopLeft(flying(tester, find.text('custom'))), const Offset(16.0, 0.0));
+    expect(tester.getTopLeft(flying(tester, find.text('custom'))), const Offset(16.0, 13.5));
 
     await tester.pump(const Duration(milliseconds: 150));
     checkOpacity(tester, flying(tester, find.text('custom')), 0.0);
-    expect(tester.getTopLeft(flying(tester, find.text('custom'))), const Offset(16.0, 0.0));
+    expect(tester.getTopLeft(flying(tester, find.text('custom'))), const Offset(16.0, 13.5));
   });
 
   testWidgets('Bottom trailing fades in place', (WidgetTester tester) async {


### PR DESCRIPTION
| Before | After | 
| --- | --- |
| <img width="381" alt="before leading" src="https://github.com/user-attachments/assets/ffd22324-75a4-4ff8-a06c-87f9148c198c" /> | <img width="381" alt="after leading" src="https://github.com/user-attachments/assets/36a1cd49-856b-462f-b321-6a016ffed382" /> |


Fixes [CupertinoNavigationBar leading is too high](https://github.com/flutter/flutter/issues/18536)