### PR TITLE
Make dev/customer_testing/ci.sh invoke `flutter pub get` instead of `dart pub get`

### DIFF
--- a/dev/customer_testing/ci.sh
+++ b/dev/customer_testing/ci.sh
@@ -29,7 +29,7 @@ cd "$(script_location)"
 # largely not needed to run the flutter/tests tests.
 #
 # However, we do need to update this directory.
-dart pub get
+flutter pub get
 
 # Run the cross-platform script.
 ../../bin/dart run ci.dart


### PR DESCRIPTION
`flutter-linux-customer-testing` builds on Dart CI are failing, and the logs indicate that this change should fix the failures.

example logs from https://ci.chromium.org/ui/p/dart/builders/ci.sandbox/flutter-linux-customer-testing/6490/overview:

```
RUNNING: cd dev/customer_testing; ../../ci.sh 
workingDirectory: /b/s/w/ir/cache/builder/flutter/dev/customer_testing, executable: ./ci.sh, arguments: []
Resolving dependencies in `/b/s/w/ir/cache/builder/flutter`...
Because flutter_api_samples requires the Flutter SDK, version solving failed.

Flutter users should use `flutter pub` instead of `dart pub`.
╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════
║ Command: ../../ci.sh 
║ Command exited with exit code 1 but expected zero exit code.
║ Working directory: /b/s/w/ir/cache/builder/flutter/dev/customer_testing
║ stdout and stderr output:
║ Resolving dependencies in `/b/s/w/ir/cache/builder/flutter`...
║ Because flutter_api_samples requires the Flutter SDK, version solving failed.
║ 
║ Flutter users should use `flutter pub` instead of `dart pub`.
╚═══════════════════════════════════════════════════════════════════════════════
▌05:31:35▐ Test failed.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```