### PR TITLE
Added a warning to using the launch engine

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterLaunchEngine.m
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterLaunchEngine.m
@@ -22,6 +22,9 @@
 
 - (FlutterEngine*)engine {
   if (!_didTakeEngine && !_engine) {
+    NSLog(@"Using FlutterAppDelegate as a FlutterPluginRegistry is deprecated.\n"
+          @"Use `FlutterAppDelegate.pluginRegistrant` and `FlutterPluginRegistrant` instead.\n"
+          @"See https://docs.flutter.dev/release/breaking-changes/uiscenedelegate.");
     // `allowHeadlessExecution` is set to `YES` since that has always been the
     // default behavior. Technically, someone could have set it to `NO` in their
     // nib and it would be ignored here. There is no documented usage of this

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterLaunchEngine.m
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterLaunchEngine.m
@@ -4,6 +4,8 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterLaunchEngine.h"
 
+#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
+
 @interface FlutterLaunchEngine () {
   BOOL _didTakeEngine;
   FlutterEngine* _engine;
@@ -22,9 +24,11 @@
 
 - (FlutterEngine*)engine {
   if (!_didTakeEngine && !_engine) {
-    NSLog(@"Using FlutterAppDelegate as a FlutterPluginRegistry is deprecated.\n"
-          @"Use `FlutterAppDelegate.pluginRegistrant` and `FlutterPluginRegistrant` instead.\n"
-          @"See https://docs.flutter.dev/release/breaking-changes/uiscenedelegate.");
+    [FlutterLogger
+        logWarning:@"Using FlutterAppDelegate as a FlutterPluginRegistry is deprecated.\n"
+                   @"Falling back to using a `FlutterLaunchEngine`, use "
+                   @"`FlutterAppDelegate.pluginRegistrant` and `FlutterPluginRegistrant` instead.\n"
+                   @"See https://docs.flutter.dev/release/breaking-changes/uiscenedelegate."];
     // `allowHeadlessExecution` is set to `YES` since that has always been the
     // default behavior. Technically, someone could have set it to `NO` in their
     // nib and it would be ignored here. There is no documented usage of this


### PR DESCRIPTION
**do no land until https://github.com/flutter/flutter/pull/169998 lands**

fixes https://github.com/flutter/flutter/issues/169678

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
