### PR TITLE
Add debugOverridePlatformViewRegistry to HtmlElementView test.

### DIFF
--- a/packages/flutter/lib/src/widgets/_html_element_view_web.dart
+++ b/packages/flutter/lib/src/widgets/_html_element_view_web.dart
@@ -78,7 +78,7 @@ PlatformViewCreatedCallback? _createPlatformViewCallbackForElementCallback(
     return null;
   }
   return (int id) {
-    onElementCreated(_platformViewsRegistry.getViewById(id));
+    onElementCreated(ui_web.platformViewRegistry.getViewById(id));
   };
 }
 
@@ -126,11 +126,3 @@ class _HtmlElementViewController extends PlatformViewController {
     }
   }
 }
-
-/// Overrides the [ui_web.PlatformViewRegistry] used by [HtmlElementView].
-///
-/// This is used for testing view factory registration.
-@visibleForTesting
-ui_web.PlatformViewRegistry? debugOverridePlatformViewRegistry;
-ui_web.PlatformViewRegistry get _platformViewsRegistry =>
-    debugOverridePlatformViewRegistry ?? ui_web.platformViewRegistry;

--- a/packages/flutter/test/widgets/html_element_view_test.dart
+++ b/packages/flutter/test/widgets/html_element_view_test.dart
@@ -10,8 +10,6 @@ import 'dart:ui_web' as ui_web;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/src/widgets/_html_element_view_web.dart'
-    show debugOverridePlatformViewRegistry;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:web/web.dart' as web;
@@ -269,11 +267,11 @@ void main() {
 
   group('HtmlElementView.fromTagName', () {
     setUp(() {
-      debugOverridePlatformViewRegistry = fakePlatformViewRegistry;
+      ui_web.debugOverridePlatformViewRegistry(fakePlatformViewRegistry);
     });
 
     tearDown(() {
-      debugOverridePlatformViewRegistry = null;
+      ui_web.debugOverridePlatformViewRegistry(null);
     });
 
     testWidgets('Create platform view from tagName', (WidgetTester tester) async {


### PR DESCRIPTION
### Description
- Adds `debugOverridePlatformViewRegistry` usage to `HtmlElementView` tests
- Removes private `debugOverridePlatformViewRegistry` from `_html_element_view_web.dart`

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
