### PR TITLE
Redirect the output of the "pub upgrade" command run by bin/flutter to stderr

### DIFF
--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -20,7 +20,7 @@ function pub_upgrade_with_retry {
   local total_tries="10"
   local remaining_tries=$((total_tries - 1))
   while [[ "$remaining_tries" -gt 0 ]]; do
-    (cd "$FLUTTER_TOOLS_DIR" && "$DART" pub upgrade --suppress-analytics) && break
+    (cd "$FLUTTER_TOOLS_DIR" && "$DART" pub upgrade --suppress-analytics >&2) && break
     >&2 echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
     remaining_tries=$((remaining_tries - 1))
     sleep 5


### PR DESCRIPTION
The dev/bots/analyze.dart script is now running "flutter pub deps --json" to query packages in the Flutter workspace (see https://github.com/flutter/flutter/pull/169556)

analyze.dart is capturing the stdout of that bin/flutter command and expecting the output to contain only JSON.  If the flutter_tools snapshot needs to be rebuilt, then the output of the pub command invoked by the rebuild should not show up in stdout.