### PR TITLE
Started bridging the scene delegate to the lifecycle delegate for shortcuts

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -261,6 +261,7 @@ if (enable_ios_unittests) {
       "framework/Source/FlutterPlatformViewsTest.mm",
       "framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm",
       "framework/Source/FlutterRestorationPluginTest.mm",
+      "framework/Source/FlutterSceneDelegateTest.m",
       "framework/Source/FlutterSharedApplicationTest.mm",
       "framework/Source/FlutterSpellCheckPluginTest.mm",
       "framework/Source/FlutterTextInputPluginTest.mm",

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -7,7 +7,6 @@
 #import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterLaunchEngine.h"
@@ -27,6 +26,7 @@ static NSString* const kRestorationStateAppModificationKey = @"mod-date";
   NSObject<FlutterPluginRegistrant>* _strongRegistrant;
 }
 @property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
+@property(nonatomic, strong) FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate;
 @property(nonatomic, strong) FlutterLaunchEngine* launchEngine;
 @end
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -7,6 +7,7 @@
 #import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterLaunchEngine.h"
@@ -26,7 +27,6 @@ static NSString* const kRestorationStateAppModificationKey = @"mod-date";
   NSObject<FlutterPluginRegistrant>* _strongRegistrant;
 }
 @property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
-@property(nonatomic, strong) FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate;
 @property(nonatomic, strong) FlutterLaunchEngine* launchEngine;
 @end
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h
@@ -7,11 +7,9 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
-#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 
 @interface FlutterAppDelegate ()
 
-@property(nonatomic, strong, nullable) FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate;
 - (nullable FlutterEngine*)takeLaunchEngine;
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h
@@ -7,9 +7,11 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 
 @interface FlutterAppDelegate ()
 
+@property(nonatomic, nullable, readonly) FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate;
 - (nullable FlutterEngine*)takeLaunchEngine;
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h
@@ -6,9 +6,12 @@
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERAPPDELEGATE_INTERNAL_H_
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 
 @interface FlutterAppDelegate ()
 
+@property(nonatomic, strong, nullable) FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate;
 - (nullable FlutterEngine*)takeLaunchEngine;
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegate.m
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegate.m
@@ -33,10 +33,9 @@ FLUTTER_ASSERT_ARC
 - (void)windowScene:(UIWindowScene*)windowScene
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler {
-  id appDelegate = FlutterSharedApplication.application.delegate;
-  if ([appDelegate respondsToSelector:@selector(lifeCycleDelegate)]) {
-    FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate = [appDelegate lifeCycleDelegate];
-    [lifeCycleDelegate application:FlutterSharedApplication.application
+  NSObject<UIApplicationDelegate>* appDelegate = FlutterSharedApplication.application.delegate;
+  if ([appDelegate isKindOfClass:[FlutterAppDelegate class]]) {
+    [appDelegate application:FlutterSharedApplication.application
         performActionForShortcutItem:shortcutItem
                    completionHandler:completionHandler];
   }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegate.m
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegate.m
@@ -5,6 +5,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterSceneDelegate.h"
 
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterSharedApplication.h"
 
 FLUTTER_ASSERT_ARC
@@ -26,6 +27,18 @@ FLUTTER_ASSERT_ARC
     self.window.rootViewController = appDelegate.window.rootViewController;
     appDelegate.window = self.window;
     [self.window makeKeyAndVisible];
+  }
+}
+
+- (void)windowScene:(UIWindowScene*)windowScene
+    performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
+               completionHandler:(void (^)(BOOL succeeded))completionHandler {
+  id appDelegate = FlutterSharedApplication.application.delegate;
+  if ([appDelegate respondsToSelector:@selector(lifeCycleDelegate)]) {
+    FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate = [appDelegate lifeCycleDelegate];
+    [lifeCycleDelegate application:FlutterSharedApplication.application
+        performActionForShortcutItem:shortcutItem
+                   completionHandler:completionHandler];
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegate.m
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegate.m
@@ -33,9 +33,10 @@ FLUTTER_ASSERT_ARC
 - (void)windowScene:(UIWindowScene*)windowScene
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler {
-  NSObject<UIApplicationDelegate>* appDelegate = FlutterSharedApplication.application.delegate;
-  if ([appDelegate isKindOfClass:[FlutterAppDelegate class]]) {
-    [appDelegate application:FlutterSharedApplication.application
+  id appDelegate = FlutterSharedApplication.application.delegate;
+  if ([appDelegate respondsToSelector:@selector(lifeCycleDelegate)]) {
+    FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate = [appDelegate lifeCycleDelegate];
+    [lifeCycleDelegate application:FlutterSharedApplication.application
         performActionForShortcutItem:shortcutItem
                    completionHandler:completionHandler];
   }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegateTest.m
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegateTest.m
@@ -7,7 +7,9 @@
 #import <XCTest/XCTest.h>
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterSceneDelegate.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Internal.h"
 
 @interface FlutterSceneDelegateTest : XCTestCase
 @end
@@ -23,8 +25,10 @@
 - (void)testBridgeShortcut {
   id mockApplication = OCMClassMock([UIApplication class]);
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
-  id<UIApplicationDelegate> mockAppDelegate = OCMClassMock([FlutterAppDelegate class]);
+  id mockAppDelegate = OCMClassMock([FlutterAppDelegate class]);
+  id mockLifecycleDelegate = OCMClassMock([FlutterPluginAppLifeCycleDelegate class]);
   OCMStub([mockApplication delegate]).andReturn(mockAppDelegate);
+  OCMStub([mockAppDelegate lifeCycleDelegate]).andReturn(mockLifecycleDelegate);
   id windowScene = OCMClassMock([UIWindowScene class]);
   id shortcut = OCMClassMock([UIApplicationShortcutItem class]);
 
@@ -34,8 +38,8 @@
                  completionHandler:^(BOOL succeeded){
                  }];
 
-  OCMVerify([mockAppDelegate application:[OCMArg any]
-            performActionForShortcutItem:[OCMArg any]
-                       completionHandler:[OCMArg any]]);
+  OCMVerify([(FlutterPluginAppLifeCycleDelegate*)mockLifecycleDelegate application:[OCMArg any]
+                                                      performActionForShortcutItem:[OCMArg any]
+                                                                 completionHandler:[OCMArg any]]);
 }
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegateTest.m
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneDelegateTest.m
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterSceneDelegate.h"
+
+@interface FlutterSceneDelegateTest : XCTestCase
+@end
+
+@implementation FlutterSceneDelegateTest
+
+- (void)setUp {
+}
+
+- (void)tearDown {
+}
+
+- (void)testBridgeShortcut {
+  id mockApplication = OCMClassMock([UIApplication class]);
+  OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
+  id<UIApplicationDelegate> mockAppDelegate = OCMClassMock([FlutterAppDelegate class]);
+  OCMStub([mockApplication delegate]).andReturn(mockAppDelegate);
+  id windowScene = OCMClassMock([UIWindowScene class]);
+  id shortcut = OCMClassMock([UIApplicationShortcutItem class]);
+
+  FlutterSceneDelegate* sceneDelegate = [[FlutterSceneDelegate alloc] init];
+  [sceneDelegate windowScene:windowScene
+      performActionForShortcutItem:shortcut
+                 completionHandler:^(BOOL succeeded){
+                 }];
+
+  OCMVerify([mockAppDelegate application:[OCMArg any]
+            performActionForShortcutItem:[OCMArg any]
+                       completionHandler:[OCMArg any]]);
+}
+@end


### PR DESCRIPTION
testing: There integration tests in the plugins repo.
fixes: https://github.com/flutter/flutter/issues/169928

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
