### PR TITLE
[Impeller] Fix vertex allocation counts for flat curves

### DIFF
--- a/engine/src/flutter/impeller/tessellator/path_tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/path_tessellator.cc
@@ -196,19 +196,19 @@ class StorageCounter : public SegmentReceiver {
   void RecordQuad(Point p1, Point cp, Point p2) override {
     size_t count =  //
         std::ceilf(ComputeQuadradicSubdivisions(scale_, p1, cp, p2));
-    point_count_ += std::max(count, 1ul);
+    point_count_ += std::max<size_t>(count, 1);
   }
 
   void RecordConic(Point p1, Point cp, Point p2, Scalar weight) override {
     size_t count =  //
         std::ceilf(ComputeConicSubdivisions(scale_, p1, cp, p2, weight));
-    point_count_ += std::max(count, 1ul);
+    point_count_ += std::max<size_t>(count, 1);
   }
 
   void RecordCubic(Point p1, Point cp1, Point cp2, Point p2) override {
     size_t count =  //
         std::ceilf(ComputeCubicSubdivisions(scale_, p1, cp1, cp2, p2));
-    point_count_ += std::max(count, 1ul);
+    point_count_ += std::max<size_t>(count, 1);
   }
 
   void EndContour(Point origin, bool with_close) override {

--- a/engine/src/flutter/impeller/tessellator/path_tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/path_tessellator.cc
@@ -194,17 +194,21 @@ class StorageCounter : public SegmentReceiver {
   void RecordLine(Point p1, Point p2) override { point_count_++; }
 
   void RecordQuad(Point p1, Point cp, Point p2) override {
-    point_count_ += std::ceil(ComputeQuadradicSubdivisions(scale_, p1, cp, p2));
+    size_t count =  //
+        std::ceilf(ComputeQuadradicSubdivisions(scale_, p1, cp, p2));
+    point_count_ += std::max(count, 1ul);
   }
 
   void RecordConic(Point p1, Point cp, Point p2, Scalar weight) override {
-    point_count_ +=
-        std::ceil(ComputeConicSubdivisions(scale_, p1, cp, p2, weight));
+    size_t count =  //
+        std::ceilf(ComputeConicSubdivisions(scale_, p1, cp, p2, weight));
+    point_count_ += std::max(count, 1ul);
   }
 
   void RecordCubic(Point p1, Point cp1, Point cp2, Point p2) override {
-    point_count_ +=
-        std::ceil(ComputeCubicSubdivisions(scale_, p1, cp1, cp2, p2));
+    size_t count =  //
+        std::ceilf(ComputeCubicSubdivisions(scale_, p1, cp1, cp2, p2));
+    point_count_ += std::max(count, 1ul);
   }
 
   void EndContour(Point origin, bool with_close) override {

--- a/engine/src/flutter/impeller/tessellator/path_tessellator_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/path_tessellator_unittests.cc
@@ -544,5 +544,41 @@ TEST(PathTessellatorTest, ComplexPathTrailingMoveTo) {
   PathTessellator::PathToFilledVertices(path, mock_writer, 1.0f);
 }
 
+TEST(PathTessellatorTest, LinearQuadToPointCount) {
+  flutter::DlPathBuilder builder;
+  builder.MoveTo({316.3, 121.5});
+  builder.QuadraticCurveTo({316.4, 121.5}, {316.5, 121.5});
+  builder.Close();
+  auto path = builder.TakePath();
+
+  auto [points, contours] = PathTessellator::CountFillStorage(path, 2.0f);
+  EXPECT_EQ(points, 3u);
+  EXPECT_EQ(contours, 1u);
+}
+
+TEST(PathTessellatorTest, LinearConicToPointCount) {
+  flutter::DlPathBuilder builder;
+  builder.MoveTo({316.3, 121.5});
+  builder.ConicCurveTo({316.4, 121.5}, {316.5, 121.5}, 2.0f);
+  builder.Close();
+  auto path = builder.TakePath();
+
+  auto [points, contours] = PathTessellator::CountFillStorage(path, 2.0f);
+  EXPECT_EQ(points, 3u);
+  EXPECT_EQ(contours, 1u);
+}
+
+TEST(PathTessellatorTest, LinearCubicToPointCount) {
+  flutter::DlPathBuilder builder;
+  builder.MoveTo({316.3, 121.5});
+  builder.CubicCurveTo({316.4, 121.5}, {316.5, 121.5}, {316.6, 121.5});
+  builder.Close();
+  auto path = builder.TakePath();
+
+  auto [points, contours] = PathTessellator::CountFillStorage(path, 2.0f);
+  EXPECT_EQ(points, 3u);
+  EXPECT_EQ(contours, 1u);
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
The code that estimated the vertex counts for filling paths was not taking into account that the minimum number of points allocated for a curve segment is 1. The iteration estimates will return "don't bother to subdivide the curve" cases as "0 subdivisions" and we estimated no vertices would be generated. In fact, the rendering code would always emit the final point regardless of the subdivision estimate. Other cases that returned a value >0 were already accurate.