### PR TITLE
`CupertinoPicker` new onChanged behaviour

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -192,6 +192,10 @@ class CupertinoPicker extends StatefulWidget {
   /// The behavior of reporting the selected item index.
   ///
   /// This determines when the `onSelectedItemChanged` callback is called.
+  ///
+  /// Native iOS 18 behavior is [ChangeReportingBehavior.onScrollEnd], which
+  /// calls the callback only when the scrolling stops.
+  ///
   /// Defaults to [ChangeReportingBehavior.onScrollUpdate].
   final ChangeReportingBehavior changeReportingBehavior;
 

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -89,7 +89,7 @@ class CupertinoPicker extends StatefulWidget {
     this.magnification = 1.0,
     this.scrollController,
     this.squeeze = _kSqueeze,
-    this.legacyChangeReportingBehavior = true,
+    this.changeReportingBehavior = ChangeReportingBehavior.onScrollUpdate,
     required this.itemExtent,
     required this.onSelectedItemChanged,
     required List<Widget> children,
@@ -130,7 +130,7 @@ class CupertinoPicker extends StatefulWidget {
     this.magnification = 1.0,
     this.scrollController,
     this.squeeze = _kSqueeze,
-    this.legacyChangeReportingBehavior = true,
+    this.changeReportingBehavior = ChangeReportingBehavior.onScrollUpdate,
     required this.itemExtent,
     required this.onSelectedItemChanged,
     required NullableIndexedWidgetBuilder itemBuilder,
@@ -189,13 +189,11 @@ class CupertinoPicker extends StatefulWidget {
   /// Defaults to `1.45` to visually mimic iOS.
   final double squeeze;
 
-  /// Whether to use the legacy change reporting behavior.
+  /// The behavior of reporting the selected item index.
   ///
-  /// If `true`, the picker will report changes to the selected item
-  /// immediately as the user scrolls.
-  /// If `false`, the picker will report changes to the selected item
-  /// only when the scroll ends.
-  final bool legacyChangeReportingBehavior;
+  /// This determines when the `onSelectedItemChanged` callback is called.
+  /// Defaults to [ChangeReportingBehavior.onScrollUpdate].
+  final ChangeReportingBehavior changeReportingBehavior;
 
   /// An option callback when the currently centered item changes.
   ///
@@ -367,10 +365,7 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
                 squeeze: widget.squeeze,
                 onSelectedItemChanged: widget.onSelectedItemChanged,
                 dragStartBehavior: DragStartBehavior.down,
-                changeReportingBehavior:
-                    widget.legacyChangeReportingBehavior
-                        ? ListWheelChangeReportingBehavior.onScrollUpdate
-                        : ListWheelChangeReportingBehavior.onScrollEnd,
+                changeReportingBehavior: widget.changeReportingBehavior,
                 childDelegate: _CupertinoPickerListWheelChildDelegateWrapper(
                   widget.childDelegate,
                   onTappedChild: _handleChildTap,

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -89,6 +89,7 @@ class CupertinoPicker extends StatefulWidget {
     this.magnification = 1.0,
     this.scrollController,
     this.squeeze = _kSqueeze,
+    this.legacyChangeReportingBehavior = true,
     required this.itemExtent,
     required this.onSelectedItemChanged,
     required List<Widget> children,
@@ -129,6 +130,7 @@ class CupertinoPicker extends StatefulWidget {
     this.magnification = 1.0,
     this.scrollController,
     this.squeeze = _kSqueeze,
+    this.legacyChangeReportingBehavior = true,
     required this.itemExtent,
     required this.onSelectedItemChanged,
     required NullableIndexedWidgetBuilder itemBuilder,
@@ -186,6 +188,14 @@ class CupertinoPicker extends StatefulWidget {
   ///
   /// Defaults to `1.45` to visually mimic iOS.
   final double squeeze;
+
+  /// Whether to use the legacy change reporting behavior.
+  ///
+  /// If `true`, the picker will report changes to the selected item
+  /// immediately as the user scrolls.
+  /// If `false`, the picker will report changes to the selected item
+  /// only when the scroll ends.
+  final bool legacyChangeReportingBehavior;
 
   /// An option callback when the currently centered item changes.
   ///
@@ -357,6 +367,10 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
                 squeeze: widget.squeeze,
                 onSelectedItemChanged: widget.onSelectedItemChanged,
                 dragStartBehavior: DragStartBehavior.down,
+                changeReportingBehavior:
+                    widget.legacyChangeReportingBehavior
+                        ? ListWheelChangeReportingBehavior.onScrollUpdate
+                        : ListWheelChangeReportingBehavior.onScrollEnd,
                 childDelegate: _CupertinoPickerListWheelChildDelegateWrapper(
                   widget.childDelegate,
                   onTappedChild: _handleChildTap,

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -31,7 +31,7 @@ import 'scrollable.dart';
 /// The behavior of reporting the selected item index in a [ListWheelScrollView].
 ///
 /// This determines when the `onSelectedItemChanged` callback is called.
-enum ListWheelChangeReportingBehavior {
+enum ChangeReportingBehavior {
   /// Report the selected item index only when the scroll view stops scrolling.
   onScrollEnd,
 
@@ -596,7 +596,7 @@ class ListWheelScrollView extends StatefulWidget {
     this.restorationId,
     this.scrollBehavior,
     this.dragStartBehavior = DragStartBehavior.start,
-    this.changeReportingBehavior = ListWheelChangeReportingBehavior.onScrollUpdate,
+    this.changeReportingBehavior = ChangeReportingBehavior.onScrollUpdate,
     required List<Widget> children,
   }) : assert(diameterRatio > 0.0, RenderListWheelViewport.diameterRatioZeroMessage),
        assert(perspective > 0),
@@ -632,7 +632,7 @@ class ListWheelScrollView extends StatefulWidget {
     this.restorationId,
     this.scrollBehavior,
     this.dragStartBehavior = DragStartBehavior.start,
-    this.changeReportingBehavior = ListWheelChangeReportingBehavior.onScrollUpdate,
+    this.changeReportingBehavior = ChangeReportingBehavior.onScrollUpdate,
     required this.childDelegate,
   }) : assert(diameterRatio > 0.0, RenderListWheelViewport.diameterRatioZeroMessage),
        assert(perspective > 0),
@@ -737,8 +737,8 @@ class ListWheelScrollView extends StatefulWidget {
   /// The behavior of reporting the selected item index.
   ///
   /// This determines when the [onSelectedItemChanged] callback is called.
-  /// Defaults to [ListWheelChangeReportingBehavior.onScrollUpdate].
-  final ListWheelChangeReportingBehavior changeReportingBehavior;
+  /// Defaults to [ChangeReportingBehavior.onScrollUpdate].
+  final ChangeReportingBehavior changeReportingBehavior;
 
   @override
   State<ListWheelScrollView> createState() => _ListWheelScrollViewState();
@@ -784,7 +784,7 @@ class _ListWheelScrollViewState extends State<ListWheelScrollView> {
       return false;
     }
 
-    if (widget.changeReportingBehavior == ListWheelChangeReportingBehavior.onScrollEnd) {
+    if (widget.changeReportingBehavior == ChangeReportingBehavior.onScrollEnd) {
       if (notification is ScrollEndNotification) {
         _reportSelectedItemChanged(notification);
       }

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -784,14 +784,15 @@ class _ListWheelScrollViewState extends State<ListWheelScrollView> {
       return false;
     }
 
-    if (widget.changeReportingBehavior == ChangeReportingBehavior.onScrollEnd) {
-      if (notification is ScrollEndNotification) {
-        _reportSelectedItemChanged(notification);
-      }
-    } else {
-      if (notification is ScrollUpdateNotification) {
-        _reportSelectedItemChanged(notification);
-      }
+    switch (widget.changeReportingBehavior) {
+      case ChangeReportingBehavior.onScrollEnd:
+        if (notification is ScrollEndNotification) {
+          _reportSelectedItemChanged(notification);
+        }
+      case ChangeReportingBehavior.onScrollUpdate:
+        if (notification is ScrollUpdateNotification) {
+          _reportSelectedItemChanged(notification);
+        }
     }
     return false;
   }

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -28,6 +28,17 @@ import 'scroll_position.dart';
 import 'scroll_position_with_single_context.dart';
 import 'scrollable.dart';
 
+/// The behavior of reporting the selected item index in a [ListWheelScrollView].
+///
+/// This determines when the `onSelectedItemChanged` callback is called.
+enum ListWheelChangeReportingBehavior {
+  /// Report the selected item index only when the scroll view stops scrolling.
+  onScrollEnd,
+
+  /// Report the selected item index on every scroll update.
+  onScrollUpdate,
+}
+
 /// A delegate that supplies children for [ListWheelScrollView].
 ///
 /// [ListWheelScrollView] lazily constructs its children during layout to avoid
@@ -548,17 +559,6 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
       toleranceFor(position).velocity * velocity.sign,
     );
   }
-}
-
-/// The behavior of reporting the selected item index in a [ListWheelScrollView].
-///
-/// This determines when the [onSelectedItemChanged] callback is called.
-enum ListWheelChangeReportingBehavior {
-  /// Report the selected item index only when the scroll view stops scrolling.
-  onScrollEnd,
-
-  /// Report the selected item index on every scroll update.
-  onScrollUpdate,
 }
 
 /// A box in which children on a wheel can be scrolled.

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -334,6 +334,65 @@ void main() {
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );
 
+    testWidgets('scrolling with new behavior calls onSelectedItemChanged only when scroll ends', (
+      WidgetTester tester,
+    ) async {
+      final List<int> selectedItems = <int>[];
+      final List<MethodCall> systemCalls = <MethodCall>[];
+
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+        MethodCall methodCall,
+      ) async {
+        systemCalls.add(methodCall);
+        return null;
+      });
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: CupertinoPicker(
+            itemExtent: 100.0,
+            legacyChangeReportingBehavior: false,
+            onSelectedItemChanged: (int index) {
+              selectedItems.add(index);
+            },
+            children: List<Widget>.generate(100, (int index) {
+              return Center(
+                child: SizedBox(width: 400.0, height: 100.0, child: Text(index.toString())),
+              );
+            }),
+          ),
+        ),
+      );
+
+      final Offset initialOffset = tester.getTopLeft(find.text('0'));
+      // Drag to almost the middle of the next item.
+      final TestGesture scrollGesture = await tester.startGesture(initialOffset);
+      // Item 0 is still closest to the center. No updates.
+      await scrollGesture.moveBy(const Offset(0.0, -49.0));
+      expect(selectedItems.isEmpty, true);
+
+      // Now item 1 is closest to the center.
+      await scrollGesture.moveBy(const Offset(0.0, -1.0));
+      expect(selectedItems, <int>[]);
+
+      // Now item 1 is still closest to the center for another full itemExtent (100px).
+      await scrollGesture.moveBy(const Offset(0.0, -99.0));
+      expect(selectedItems, <int>[]);
+
+      await scrollGesture.moveBy(const Offset(0.0, -1.0));
+      await scrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(selectedItems, <int>[2]);
+
+      await scrollGesture.down(initialOffset);
+      await scrollGesture.moveBy(const Offset(0.0, 100.0));
+      expect(selectedItems, <int>[2]);
+
+      await scrollGesture.up();
+      expect(selectedItems, <int>[2, 1]);
+    });
+
     testWidgets(
       'does not trigger haptics when scrolling by tapping on the item',
       (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -352,7 +352,7 @@ void main() {
           textDirection: TextDirection.ltr,
           child: CupertinoPicker(
             itemExtent: 100.0,
-            legacyChangeReportingBehavior: false,
+            changeReportingBehavior: ChangeReportingBehavior.onScrollEnd,
             onSelectedItemChanged: (int index) {
               selectedItems.add(index);
             },

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -1227,6 +1227,52 @@ void main() {
       expect(selectedItems, <int>[1, 2, 1]);
     });
 
+    testWidgets('onSelectedItemChanged with new change reporting behavior', (
+      WidgetTester tester,
+    ) async {
+      final List<int> selectedItems = <int>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListWheelScrollView(
+            itemExtent: 100.0,
+            onSelectedItemChanged: (int index) {
+              selectedItems.add(index);
+            },
+            changeReportingBehavior: ListWheelChangeReportingBehavior.onScrollEnd,
+            children: List<Widget>.generate(10, (int index) {
+              return const Placeholder();
+            }),
+          ),
+        ),
+      );
+
+      final TestGesture scrollGesture = await tester.startGesture(const Offset(10.0, 10.0));
+      // Item 0 is still closest to the center. No updates.
+      await scrollGesture.moveBy(const Offset(0.0, -49.0));
+      expect(selectedItems.isEmpty, true);
+
+      // Now item 1 is closest to the center.
+      await scrollGesture.moveBy(const Offset(0.0, -1.0));
+      expect(selectedItems, <int>[]);
+
+      // Now item 1 is still closest to the center for another full itemExtent (100px).
+      await scrollGesture.moveBy(const Offset(0.0, -99.0));
+      expect(selectedItems, <int>[]);
+
+      await scrollGesture.moveBy(const Offset(0.0, -1.0));
+      await scrollGesture.up();
+      expect(selectedItems, <int>[2]);
+
+      await scrollGesture.down(const Offset(10.0, 10.0));
+      await scrollGesture.moveBy(const Offset(0.0, 100.0));
+      expect(selectedItems, <int>[2]);
+
+      await scrollGesture.up();
+      expect(selectedItems, <int>[2, 1]);
+    });
+
     testWidgets('onSelectedItemChanged reports only in valid range', (WidgetTester tester) async {
       final List<int> selectedItems = <int>[];
 

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -1240,7 +1240,7 @@ void main() {
             onSelectedItemChanged: (int index) {
               selectedItems.add(index);
             },
-            changeReportingBehavior: ListWheelChangeReportingBehavior.onScrollEnd,
+            changeReportingBehavior: ChangeReportingBehavior.onScrollEnd,
             children: List<Widget>.generate(10, (int index) {
               return const Placeholder();
             }),


### PR DESCRIPTION
This PR adds a new behaviour to `ListWheelScrollView` that allows to switch between reporting changes on scroll update or only on scroll end. 
`CupertinoPicker` now has a `changeReportingBehavior` param that forwards to `ListWheelScrollView`.

New behaviour is a breaking change if set as default, so I have added the `changeReportingBehavior` param to opt-in. My idea is that it can be marked as `Deprecated` immediately and then removed from `CupertinoPicker` later or we can just leave the param there and make it more customizable.

I am open to other ideas on how to land this without breaking clients.

Fixes https://github.com/flutter/flutter/issues/170201

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.