### PR TITLE
fix: correct typo in analysis_options.yaml comment (disabeling -> disabling)

### DIFF
--- a/engine/src/flutter/analysis_options.yaml
+++ b/engine/src/flutter/analysis_options.yaml
@@ -24,5 +24,5 @@ linter:
     avoid_equals_and_hash_code_on_mutable_classes: false # cannot import the meta package here
     missing_whitespace_between_adjacent_strings: false # too many false positives
     public_member_api_docs: true # dart:ui is public API
-    type_annotate_public_apis: true # to compensate for disabeling always_specify_types, see https://github.com/flutter/flutter/blob/main/engine/src/flutter/CONTRIBUTING.md#dart
+    type_annotate_public_apis: true # to compensate for disabling always_specify_types, see https://github.com/flutter/flutter/blob/main/engine/src/flutter/CONTRIBUTING.md#dart
     use_string_in_part_of_directives: false # needs to be evaluated, dart:ui frequently uses non-strings


### PR DESCRIPTION
This PR fixes a typo in the comment of `analysis_options.yaml`, changing 'disabeling' to 'disabling'. This is a simple typo fix in a comment that improves code readability.

No issue is required as this is a trivial typo fix in a comment.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
