### PR TITLE
Add a getter to get the recorder used by painting context

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -331,7 +331,6 @@ class PaintingContext extends ClipContext {
   ///
   /// It's fragile to hold a reference to the recorder
   /// returned by this getter as it can change at any time.
-  @override
   ui.PictureRecorder get recorder {
     if (_recorder == null) {
       _startRecording();

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -325,7 +325,6 @@ class PaintingContext extends ClipContext {
   ui.PictureRecorder? _recorder;
   Canvas? _canvas;
 
-
   /// The recorder that is being used by this [PaintingContext] 
   /// to record interactions with the [Canvas].
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -325,7 +325,7 @@ class PaintingContext extends ClipContext {
   ui.PictureRecorder? _recorder;
   Canvas? _canvas;
 
-  /// The recorder that is being used by this [PaintingContext] 
+  /// The recorder that is being used by this [PaintingContext]
   /// to record interactions with the [Canvas].
   ///
   /// It's fragile to hold a reference to the recorder

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -325,6 +325,21 @@ class PaintingContext extends ClipContext {
   ui.PictureRecorder? _recorder;
   Canvas? _canvas;
 
+
+  /// The recorder that is being used by this [PaintingContext] 
+  /// to record interactions with the [Canvas].
+  ///
+  /// It's fragile to hold a reference to the recorder
+  /// returned by this getter as it can change at any time.
+  @override
+  ui.PictureRecorder get recorder {
+    if (_recorder == null) {
+      _startRecording();
+    }
+    assert(_currentLayer != null);
+    return _recorder!;
+  }
+
   /// The canvas on which to paint.
   ///
   /// The current canvas can change whenever you paint a child using this

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -532,6 +532,11 @@ void main() {
       ),
     );
   });
+
+  test('PictureRecorder getter', () {
+    final PaintingContext context = PaintingContext(ContainerLayer(), Rect.zero);
+    expect(context.recorder.isRecording, isTrue);
+  });
 }
 
 class TestObservingRenderObject extends RenderBox {


### PR DESCRIPTION
Fixes #169990

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
