### PR TITLE
Relax RadioGroup semantics to allow non-radio children

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -239,6 +239,11 @@ sealed class _DebugSemanticsRoleChecks {
     bool hasCheckedChild = false;
     bool validateRadioGroupChildren(SemanticsNode node) {
       final SemanticsData data = node.getSemanticsData();
+      if (data.role == SemanticsRole.radioGroup) {
+        // Children under sub radio groups don't belong to this radio group.
+        return error == null;
+      }
+
       if (!data.flagsCollection.isInMutuallyExclusiveGroup) {
         node.visitChildren(validateRadioGroupChildren);
         return error == null;

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -239,16 +239,9 @@ sealed class _DebugSemanticsRoleChecks {
     bool hasCheckedChild = false;
     bool validateRadioGroupChildren(SemanticsNode node) {
       final SemanticsData data = node.getSemanticsData();
-      if (!data.flagsCollection.hasCheckedState) {
+      if (!data.flagsCollection.isInMutuallyExclusiveGroup) {
         node.visitChildren(validateRadioGroupChildren);
         return error == null;
-      }
-
-      if (!data.flagsCollection.isInMutuallyExclusiveGroup) {
-        error = FlutterError(
-          'Radio buttons in a radio group must be in a mutually exclusive group',
-        );
-        return false;
       }
 
       if (data.flagsCollection.isChecked) {

--- a/packages/flutter/lib/src/widgets/radio_group.dart
+++ b/packages/flutter/lib/src/widgets/radio_group.dart
@@ -177,6 +177,7 @@ class _RadioGroupState<T> extends State<RadioGroup<T>> implements RadioGroupRegi
   @override
   Widget build(BuildContext context) {
     return Semantics(
+      container: true,
       role: SemanticsRole.radioGroup,
       child: Shortcuts(
         shortcuts: _radioGroupShortcuts,

--- a/packages/flutter/test/widgets/radio_group_test.dart
+++ b/packages/flutter/test/widgets/radio_group_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -88,6 +89,29 @@ void main() {
       tester.getSemantics(find.byKey(key1)),
       containsSemantics(isInMutuallyExclusiveGroup: true, isChecked: false, isEnabled: true),
     );
+  });
+
+  testWidgets('Radio group will not merge up', (WidgetTester tester) async {
+    final UniqueKey key = UniqueKey();
+
+    await tester.pumpWidget(
+      Material(
+        child: Semantics(
+          container: true,
+          child: Column(
+            children: <Widget>[
+              Checkbox(value: true, onChanged: (bool? value) {}),
+              const TestRadioGroup<int>(
+                child: Column(children: <Widget>[Radio<int>(value: 0), Radio<int>(value: 1)]),
+              ),
+              Checkbox(value: true, onChanged: (bool? value) {}),
+            ],
+          ),
+        ),
+      ),
+    );
+    final SemanticsNode radioGroup = tester.getSemantics(find.byType(RadioGroup<int>));
+    expect(radioGroup.childrenCount, 2);
   });
 
   testWidgets('Radio group can use arrow key', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/radio_group_test.dart
+++ b/packages/flutter/test/widgets/radio_group_test.dart
@@ -92,8 +92,6 @@ void main() {
   });
 
   testWidgets('Radio group will not merge up', (WidgetTester tester) async {
-    final UniqueKey key = UniqueKey();
-
     await tester.pumpWidget(
       Material(
         child: Semantics(

--- a/packages/flutter/test/widgets/semantics_role_checks_test.dart
+++ b/packages/flutter/test/widgets/semantics_role_checks_test.dart
@@ -284,7 +284,32 @@ void main() {
           ),
         ),
       );
-      expect(find.byType(Checkbox), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('success case, radio group can nest', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Material(
+          child: Material(
+            child: RadioGroup<int>(
+              groupValue: 0,
+              onChanged: (int? value) {},
+              child: Column(
+                children: <Widget>[
+                  RadioGroup<String>(
+                    groupValue: 'string',
+                    onChanged: (String? value) {},
+                    child: const Radio<String>(value: 'string'),
+                  ),
+                  const Radio<int>(value: 0),
+                  const Radio<int>(value: 1),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
     });
   });
 

--- a/packages/flutter/test/widgets/semantics_role_checks_test.dart
+++ b/packages/flutter/test/widgets/semantics_role_checks_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -138,7 +139,7 @@ void main() {
   });
 
   group('radioGroup', () {
-    testWidgets('failure case, child is not mutually exclusive', (WidgetTester tester) async {
+    testWidgets('success case, child is not mutually exclusive', (WidgetTester tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -154,9 +155,7 @@ void main() {
         ),
       );
       final Object? exception = tester.takeException();
-      expect(exception, isFlutterError);
-      final FlutterError error = exception! as FlutterError;
-      expect(error.message, 'Radio buttons in a radio group must be in a mutually exclusive group');
+      expect(exception, isNull);
     });
 
     testWidgets('failure case, multiple checked children', (WidgetTester tester) async {
@@ -187,40 +186,6 @@ void main() {
       expect(exception, isFlutterError);
       final FlutterError error = exception! as FlutterError;
       expect(error.message, 'Radio groups must not have multiple checked children');
-    });
-
-    testWidgets('error case, reports first error', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: Semantics(
-            role: SemanticsRole.radioGroup,
-            explicitChildNodes: true,
-            child: Column(
-              children: <Widget>[
-                Semantics(
-                  label: 'Option A',
-                  child: Semantics(checked: true, child: const SizedBox.square(dimension: 1)),
-                ),
-                Semantics(
-                  label: 'Option B',
-                  child: Semantics(
-                    checked: true,
-                    inMutuallyExclusiveGroup: true,
-                    child: const SizedBox.square(dimension: 1),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-      // The widget tree has multiple errors. The validation walk should stop
-      // on the first error.
-      final Object? exception = tester.takeException();
-      expect(exception, isFlutterError);
-      final FlutterError error = exception! as FlutterError;
-      expect(error.message, 'Radio buttons in a radio group must be in a mutually exclusive group');
     });
 
     testWidgets('success case', (WidgetTester tester) async {
@@ -297,6 +262,29 @@ void main() {
         ),
       );
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('success case, radio group can have checkbox children', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        Material(
+          child: Material(
+            child: RadioGroup<int>(
+              groupValue: 0,
+              onChanged: (int? value) {},
+              child: Column(
+                children: <Widget>[
+                  Checkbox(value: false, onChanged: (bool? value) {}),
+                  const Radio<int>(value: 0),
+                  const Radio<int>(value: 1),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(Checkbox), findsOneWidget);
     });
   });
 

--- a/packages/flutter/test/widgets/semantics_role_checks_test.dart
+++ b/packages/flutter/test/widgets/semantics_role_checks_test.dart
@@ -5,7 +5,6 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

as title, also adjust radio group semantics to form a semantics node. This makes sure it won't merge up and end up taking other semantics node sibling as its children

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
