### PR TITLE
[engine] dont double free surface texture interop objects.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
@@ -233,6 +233,9 @@ HandleGLES ReactorGLES::CreateHandle(HandleType type, GLuint external_handle) {
 }
 
 void ReactorGLES::CollectHandle(HandleGLES handle) {
+  if (handle.IsDead()) {
+    return;
+  }
   if (handle.untracked_id_.has_value()) {
     LiveHandle live_handle(GLStorage{.integer = handle.untracked_id_.value()});
     live_handle.pending_collection = true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -16,6 +16,7 @@
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"
+#include "impeller/renderer/backend/gles/handle_gles.h"
 
 namespace impeller {
 
@@ -227,6 +228,10 @@ TextureGLES::~TextureGLES() {
   if (!cached_fbo_.IsDead()) {
     reactor_->CollectHandle(cached_fbo_);
   }
+}
+
+void TextureGLES::Leak() {
+  handle_ = HandleGLES::DeadHandle();
 }
 
 // |Texture|

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
@@ -102,6 +102,10 @@ class TextureGLES final : public Texture,
 
   bool IsWrapped() const;
 
+  /// @brief Reset the internal texture state so that the reactor will not free
+  ///        the associated handle.
+  void Leak();
+
   std::optional<GLuint> GetFBO() const;
 
   //----------------------------------------------------------------------------

--- a/engine/src/flutter/shell/platform/android/surface_texture_external_texture_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/surface_texture_external_texture_gl_impeller.cc
@@ -55,6 +55,8 @@ void SurfaceTextureExternalTextureGLImpeller::ProcessFrame(
 
 void SurfaceTextureExternalTextureGLImpeller::Detach() {
   SurfaceTextureExternalTexture::Detach();
+  // Detach will collect the texture handle.
+  // See also: https://github.com/flutter/flutter/issues/152459
   texture_->Leak();
   texture_.reset();
 }

--- a/engine/src/flutter/shell/platform/android/surface_texture_external_texture_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/surface_texture_external_texture_gl_impeller.cc
@@ -55,6 +55,7 @@ void SurfaceTextureExternalTextureGLImpeller::ProcessFrame(
 
 void SurfaceTextureExternalTextureGLImpeller::Detach() {
   SurfaceTextureExternalTexture::Detach();
+  texture_->Leak();
   texture_.reset();
 }
 

--- a/engine/src/flutter/shell/platform/android/surface_texture_external_texture_gl_skia.cc
+++ b/engine/src/flutter/shell/platform/android/surface_texture_external_texture_gl_skia.cc
@@ -52,10 +52,7 @@ void SurfaceTextureExternalTextureGLSkia::ProcessFrame(PaintContext& context,
 
 void SurfaceTextureExternalTextureGLSkia::Detach() {
   SurfaceTextureExternalTexture::Detach();
-  if (texture_name_ != 0) {
-    glDeleteTextures(1, &texture_name_);
-    texture_name_ = 0;
-  }
+  texture_name_ = 0;
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/surface_texture_external_texture_gl_skia.cc
+++ b/engine/src/flutter/shell/platform/android/surface_texture_external_texture_gl_skia.cc
@@ -52,6 +52,8 @@ void SurfaceTextureExternalTextureGLSkia::ProcessFrame(PaintContext& context,
 
 void SurfaceTextureExternalTextureGLSkia::Detach() {
   SurfaceTextureExternalTexture::Detach();
+  // Detach will collect the texture handle.
+  // See also: https://github.com/flutter/flutter/issues/152459
   texture_name_ = 0;
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/152459

I suspect the double free is related to https://github.com/flutter/flutter/issues/162147 .

With the Impeller backend, the second free is performed by the reactor and comes only after the application has returned to the foreground. This increaases the likelyhood that we nuke a handle that is in active use by another part of the system.

Since SurfaceTexture:: detachFromGLContext is documented as releasing the texture, we don't need to free it at all and can "leak" it on our side.
