### PR TITLE
[Windows] Use ANGLE blit extension on GLES 2.0

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -141,6 +141,10 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
     DiscardFramebufferEXT.Reset();
   }
 
+  if (!description_->HasExtension("ANGLE_framebuffer_blit")) {
+    BlitFramebufferANGLE.Reset();
+  }
+
   capabilities_ = std::make_shared<CapabilitiesGLES>(*this);
 
   is_valid_ = true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -141,7 +141,7 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
     DiscardFramebufferEXT.Reset();
   }
 
-  if (!description_->HasExtension("ANGLE_framebuffer_blit")) {
+  if (!description_->HasExtension("GL_ANGLE_framebuffer_blit")) {
     BlitFramebufferANGLE.Reset();
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -266,7 +266,8 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(GetQueryObjectui64vEXT);             \
   PROC(BeginQueryEXT);                      \
   PROC(EndQueryEXT);                        \
-  PROC(GetQueryObjectuivEXT);
+  PROC(GetQueryObjectuivEXT);               \
+  PROC(BlitFramebufferANGLE);
 
 enum class DebugResourceType {
   kTexture,

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl_unittests.cc
@@ -27,6 +27,14 @@ namespace {
 using ::testing::AnyNumber;
 using ::testing::Return;
 
+void MockGetIntegerv(GLenum name, int* value) {
+  if (name == GL_NUM_EXTENSIONS) {
+    *value = 1;
+  } else {
+    *value = 0;
+  }
+}
+
 const unsigned char* MockGetString(GLenum name) {
   switch (name) {
     case GL_VERSION:
@@ -37,8 +45,12 @@ const unsigned char* MockGetString(GLenum name) {
   }
 }
 
-void MockGetIntegerv(GLenum name, int* value) {
-  *value = 0;
+const unsigned char* MockGetStringi(GLenum name, int index) {
+  if (name == GL_EXTENSIONS) {
+    return reinterpret_cast<const unsigned char*>("ANGLE_framebuffer_blit");
+  } else {
+    return reinterpret_cast<const unsigned char*>("");
+  }
 }
 
 GLenum MockGetError() {
@@ -52,6 +64,8 @@ const impeller::ProcTableGLES::Resolver kMockResolver = [](const char* name) {
 
   if (function_name == "glGetString") {
     return reinterpret_cast<void*>(&MockGetString);
+  } else if (function_name == "glGetStringi") {
+    return reinterpret_cast<void*>(&MockGetStringi);
   } else if (function_name == "glGetIntegerv") {
     return reinterpret_cast<void*>(&MockGetIntegerv);
   } else if (function_name == "glGetError") {
@@ -163,6 +177,30 @@ TEST_F(CompositorOpenGLTest, InitializationFailure) {
   EXPECT_FALSE(compositor.CreateBackingStore(config, &backing_store));
 }
 
+TEST_F(CompositorOpenGLTest, InitializationRequiresBlit) {
+  UseHeadlessEngine();
+
+  const impeller::ProcTableGLES::Resolver resolver = [](const char* name) {
+    std::string function_name{name};
+
+    if (function_name == "glBlitFramebuffer" ||
+        function_name == "glBlitFramebufferANGLE") {
+      return (void*)nullptr;
+    }
+
+    return kMockResolver(name);
+  };
+
+  auto compositor =
+      CompositorOpenGL{engine(), resolver, /*enable_impeller=*/false};
+
+  FlutterBackingStoreConfig config = {};
+  FlutterBackingStore backing_store = {};
+
+  EXPECT_CALL(*render_context(), MakeCurrent).WillOnce(Return(true));
+  ASSERT_FALSE(compositor.CreateBackingStore(config, &backing_store));
+}
+
 TEST_F(CompositorOpenGLTest, Present) {
   UseEngineWithView();
 
@@ -221,6 +259,47 @@ TEST_F(CompositorOpenGLTest, NoSurfaceIgnored) {
   const FlutterLayer* layer_ptr = &layer;
 
   EXPECT_FALSE(compositor.Present(view(), &layer_ptr, 1));
+
+  ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
+}
+
+TEST_F(CompositorOpenGLTest, PresentUsingANGLEBlitExtension) {
+  UseEngineWithView();
+
+  bool resolved_ANGLE_blit = false;
+  const impeller::ProcTableGLES::Resolver resolver =
+      [&resolved_ANGLE_blit](const char* name) {
+        std::string function_name{name};
+
+        if (function_name == "glBlitFramebuffer") {
+          return (void*)nullptr;
+        } else if (function_name == "glBlitFramebufferANGLE") {
+          resolved_ANGLE_blit = true;
+          return reinterpret_cast<void*>(&DoNothing);
+        }
+
+        return kMockResolver(name);
+      };
+
+  auto compositor =
+      CompositorOpenGL{engine(), resolver, /*enable_impeller=*/false};
+
+  FlutterBackingStoreConfig config = {};
+  FlutterBackingStore backing_store = {};
+
+  EXPECT_CALL(*render_context(), MakeCurrent).WillOnce(Return(true));
+  ASSERT_TRUE(compositor.CreateBackingStore(config, &backing_store));
+
+  FlutterLayer layer = {};
+  layer.type = kFlutterLayerContentTypeBackingStore;
+  layer.backing_store = &backing_store;
+  const FlutterLayer* layer_ptr = &layer;
+
+  EXPECT_CALL(*surface(), IsValid).WillRepeatedly(Return(true));
+  EXPECT_CALL(*surface(), MakeCurrent).WillOnce(Return(true));
+  EXPECT_CALL(*surface(), SwapBuffers).WillOnce(Return(true));
+  EXPECT_TRUE(compositor.Present(view(), &layer_ptr, 1));
+  EXPECT_TRUE(resolved_ANGLE_blit);
 
   ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
 }

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl_unittests.cc
@@ -47,7 +47,7 @@ const unsigned char* MockGetString(GLenum name) {
 
 const unsigned char* MockGetStringi(GLenum name, int index) {
   if (name == GL_EXTENSIONS) {
-    return reinterpret_cast<const unsigned char*>("ANGLE_framebuffer_blit");
+    return reinterpret_cast<const unsigned char*>("GL_ANGLE_framebuffer_blit");
   } else {
     return reinterpret_cast<const unsigned char*>("");
   }


### PR DESCRIPTION
This updates Flutter Windows to fall back to [`glBlitFramebufferANGLE`](https://github.com/google/angle/blob/main/extensions/ANGLE_framebuffer_blit.txt) if `glBlitFramebuffer` is not available. This makes Flutter Windows work on devices where ANGLE supports only GLES 2.0.

Fixes: https://github.com/flutter/flutter/issues/169178

### Background

ANGLE only implements GLES 2.0 on some Windows 10+ machines ([1](https://github.com/flutter/flutter/issues/169178#issuecomment-2943735504), [2](https://github.com/flutter/flutter/issues/169178#issuecomment-2944096179)). 

Flutter Windows 3.27.4 and lower was using `glBlitFramebuffer` on GLES 2.0 devices, even though that requires GLES 3.0. This magically worked though, thanks to ANGLE.

However in 3.29.0, Impeller was updated to not resolve GLES 3.0 procs on GLES 2.0: https://github.com/flutter/engine/pull/56636. This caused Flutter Windows to crash on GLES 2.0 devices since it was calling `glBlitFramebuffer`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
