### PR TITLE
Revert "Add call to Dart_NotifyDestroyed when the flutter view is des…

### DIFF
--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -348,19 +348,6 @@ bool RuntimeController::NotifyIdle(fml::TimeDelta deadline) {
   return true;
 }
 
-bool RuntimeController::NotifyDestroyed() {
-  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
-  if (!root_isolate) {
-    return false;
-  }
-
-  tonic::DartState::Scope scope(root_isolate);
-
-  Dart_NotifyDestroyed();
-
-  return true;
-}
-
 bool RuntimeController::DispatchPlatformMessage(
     std::unique_ptr<PlatformMessage> message) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -445,17 +445,6 @@ class RuntimeController : public PlatformConfigurationClient,
   virtual bool NotifyIdle(fml::TimeDelta deadline);
 
   //----------------------------------------------------------------------------
-  /// @brief      Notify the Dart VM that the attached flutter view has been
-  ///             destroyed. This gives the Dart VM to perform some cleanup
-  ///             activities e.g: perform garbage collection to free up any
-  ///             unused memory.
-  ///
-  /// NotifyDestroyed is advisory. The VM may or may not perform any clean up
-  /// activities.
-  ///
-  virtual bool NotifyDestroyed();
-
-  //----------------------------------------------------------------------------
   /// @brief      Returns if the root isolate is running. The isolate must be
   ///             transitioned to the running phase manually. The isolate can
   ///             stop running if it terminates execution on its own.

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -303,11 +303,6 @@ void Engine::NotifyIdle(fml::TimeDelta deadline) {
   runtime_controller_->NotifyIdle(deadline);
 }
 
-void Engine::NotifyDestroyed() {
-  TRACE_EVENT0("flutter", "Engine::NotifyDestroyed");
-  runtime_controller_->NotifyDestroyed();
-}
-
 std::optional<uint32_t> Engine::GetUIIsolateReturnCode() {
   return runtime_controller_->GetRootIsolateReturnCode();
 }

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -599,13 +599,6 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   void NotifyIdle(fml::TimeDelta deadline);
 
   //----------------------------------------------------------------------------
-  /// @brief      Notifies the engine that the attached flutter view has been
-  ///             destroyed.
-  ///             This enables the engine to notify the Dart VM so it can do
-  ///             some cleanp activities.
-  void NotifyDestroyed();
-
-  //----------------------------------------------------------------------------
   /// @brief      Dart code cannot fully measure the time it takes for a
   ///             specific frame to be rendered. This is because Dart code only
   ///             runs on the UI task runner. That is only a small part of the

--- a/engine/src/flutter/shell/common/fixtures/shell_test.dart
+++ b/engine/src/flutter/shell/common/fixtures/shell_test.dart
@@ -215,11 +215,6 @@ void performanceModeImpactsNotifyIdle() {
   PlatformDispatcher.instance.requestDartPerformanceMode(DartPerformanceMode.balanced);
 }
 
-@pragma('vm:entry-point')
-void callNotifyDestroyed() {
-  notifyDestroyed();
-}
-
 @pragma('vm:external-name', 'NotifyMessage')
 external void notifyMessage(String string);
 
@@ -380,8 +375,6 @@ Future<void> runCallback(IsolateParam param) async {
 @pragma('vm:entry-point')
 @pragma('vm:external-name', 'NotifyNativeBool')
 external void notifyNativeBool(bool value);
-@pragma('vm:external-name', 'NotifyDestroyed')
-external void notifyDestroyed();
 
 @pragma('vm:entry-point')
 Future<void> testPluginUtilitiesCallbackHandle() async {

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -999,15 +999,6 @@ void Shell::OnPlatformViewDestroyed() {
   // This incorrect assumption can lead to deadlock.
   rasterizer_->DisableThreadMergerIfNeeded();
 
-  // Notify the Dart VM that the PlatformView has been destroyed and some
-  // cleanup activity can be done (e.g: garbage collect the Dart heap).
-  fml::TaskRunner::RunNowOrPostTask(task_runners_.GetUITaskRunner(),
-                                    [engine = engine_->GetWeakPtr()]() {
-                                      if (engine) {
-                                        engine->NotifyDestroyed();
-                                      }
-                                    });
-
   // Note:
   // This is a synchronous operation because certain platforms depend on
   // setup/suspension of all activities that may be interacting with the GPU in

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -4211,40 +4211,6 @@ TEST_F(ShellTest, NotifyIdleNotCalledInLatencyMode) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST_F(ShellTest, NotifyDestroyed) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  Settings settings = CreateSettingsForFixture();
-  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
-                         ThreadHost::Type::kPlatform | ThreadHost::kUi |
-                             ThreadHost::kIo | ThreadHost::kRaster);
-  auto platform_task_runner = thread_host.platform_thread->GetTaskRunner();
-  TaskRunners task_runners("test", thread_host.platform_thread->GetTaskRunner(),
-                           thread_host.raster_thread->GetTaskRunner(),
-                           thread_host.ui_thread->GetTaskRunner(),
-                           thread_host.io_thread->GetTaskRunner());
-  auto shell = CreateShell(settings, task_runners);
-  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  ASSERT_TRUE(ValidateShell(shell.get()));
-
-  fml::CountDownLatch latch(1);
-  AddNativeCallback("NotifyDestroyed", CREATE_NATIVE_ENTRY([&](auto args) {
-                      auto runtime_controller = const_cast<RuntimeController*>(
-                          shell->GetEngine()->GetRuntimeController());
-                      bool success = runtime_controller->NotifyDestroyed();
-                      EXPECT_TRUE(success);
-                      latch.CountDown();
-                    }));
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("callNotifyDestroyed");
-  RunEngine(shell.get(), std::move(configuration));
-
-  latch.Wait();
-
-  DestroyShell(std::move(shell), task_runners);
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
 TEST_F(ShellTest, PrintsErrorWhenPlatformMessageSentFromWrongThread) {
 #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_DEBUG || OS_FUCHSIA
   GTEST_SKIP() << "Test is for debug mode only on non-fuchsia targets.";


### PR DESCRIPTION
…troyed. (flutter/engine#37539)"

This reverts commit 7296b2b66dac82f04ebe9017320bde81a7b5f486.

In b/422322882, we have done a small experiment on addtoapp Android, with and without a patched engine where `Dart_NotifyDestroyed` is not called:

1. Add a Flutter view
2. Measure memory with `adb shell dumpsys meminfo`
3. Call detach
5. Measure memory again

"Call detach" refers to the following pseudocode:

```kt
    flutterViewContainer.removeView(flutterView)
    engine.activityControlSurface.detachFromActivity()
    engine.lifecycleChannel.appIsDetached()
    flutterView!!.detachFromFlutterEngine()
```

https://github.com/user-attachments/assets/420ebf72-aa21-41c3-b462-b2fe0990db1a

We observed that the memory recordings with and without the patched engine are mostly the same. @a-siva also mentioned that 7296b2b66dac82f04ebe9017320bde81a7b5f486 could be no longer needed today.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
