### PR TITLE
[engine] ensure engines spawned from an engine using dynamic rendering selection still use the dynamic surface.

### DIFF
--- a/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.h
+++ b/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.h
@@ -31,6 +31,9 @@ class AndroidContextDynamicImpeller : public AndroidContext {
   bool IsValid() const override { return true; }
 
   // |AndroidContext|
+  bool IsDynamicSelection() const override { return true; }
+
+  // |AndroidContext|
   AndroidRenderingAPI RenderingApi() const override;
 
   /// @brief Retrieve the GL Context if it was created, or nullptr.

--- a/engine/src/flutter/shell/platform/android/context/android_context.cc
+++ b/engine/src/flutter/shell/platform/android/context/android_context.cc
@@ -50,4 +50,8 @@ std::shared_ptr<impeller::Context> AndroidContext::GetImpellerContext() const {
   return impeller_context_;
 }
 
+bool AndroidContext::IsDynamicSelection() const {
+  return false;
+}
+
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/context/android_context.h
+++ b/engine/src/flutter/shell/platform/android/context/android_context.h
@@ -39,6 +39,8 @@ class AndroidContext {
 
   virtual AndroidRenderingAPI RenderingApi() const;
 
+  virtual bool IsDynamicSelection() const;
+
   virtual bool IsValid() const;
 
   //----------------------------------------------------------------------------

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -78,6 +78,11 @@ AndroidSurfaceFactoryImpl::AndroidSurfaceFactoryImpl(
 AndroidSurfaceFactoryImpl::~AndroidSurfaceFactoryImpl() = default;
 
 std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
+  if (android_context_->IsDynamicSelection()) {
+    auto cast_ptr = std::static_pointer_cast<AndroidContextDynamicImpeller>(
+        android_context_);
+    return std::make_unique<AndroidSurfaceDynamicImpeller>(cast_ptr);
+  }
   switch (android_context_->RenderingApi()) {
 #if !SLIMPELLER
     case AndroidRenderingAPI::kSoftware:


### PR DESCRIPTION
The fact that this landed and failed no tests originally likely indicates we have no tests using Engine.spawn APIs. Seems bad.


Fixes https://github.com/flutter/flutter/issues/170295