### PR TITLE
Fix DropdownMenu does not apply opacity to the selected value when disabled

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1025,7 +1025,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     );
 
     final TextStyle? baseTextStyle = widget.textStyle ?? theme.textStyle ?? defaults.textStyle;
-    final Color disabledColor = Theme.of(context).colorScheme.onSurface.withOpacity(0.38);
+    final Color? disabledColor = theme.disabledColor ?? defaults.disabledColor;
     final TextStyle? effectiveTextStyle =
         widget.enabled
             ? baseTextStyle
@@ -1504,7 +1504,8 @@ class _RenderDropdownMenuBody extends RenderBox
 
 // Hand coded defaults. These will be updated once we have tokens/spec.
 class _DropdownMenuDefaultsM3 extends DropdownMenuThemeData {
-  _DropdownMenuDefaultsM3(this.context);
+  _DropdownMenuDefaultsM3(this.context)
+    : super(disabledColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.38));
 
   final BuildContext context;
   late final ThemeData _theme = Theme.of(context);

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1024,7 +1024,12 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       useMaterial3: useMaterial3,
     );
 
-    final TextStyle? effectiveTextStyle = widget.textStyle ?? theme.textStyle ?? defaults.textStyle;
+    final TextStyle? baseTextStyle = widget.textStyle ?? theme.textStyle ?? defaults.textStyle;
+    final Color disabledColor = Theme.of(context).colorScheme.onSurface.withOpacity(0.38);
+    final TextStyle? effectiveTextStyle =
+        widget.enabled
+            ? baseTextStyle
+            : baseTextStyle?.copyWith(color: disabledColor) ?? TextStyle(color: disabledColor);
 
     MenuStyle? effectiveMenuStyle = widget.menuStyle ?? theme.menuStyle ?? defaults.menuStyle!;
 

--- a/packages/flutter/lib/src/material/dropdown_menu_theme.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_theme.dart
@@ -37,6 +37,7 @@ class DropdownMenuThemeData with Diagnosticable {
     // TODO(bleroux): Clean this up once `InputDecorationTheme` is fully normalized.
     Object? inputDecorationTheme,
     this.menuStyle,
+    this.disabledColor,
   }) : assert(
          inputDecorationTheme == null ||
              (inputDecorationTheme is InputDecorationTheme ||
@@ -68,6 +69,10 @@ class DropdownMenuThemeData with Diagnosticable {
   /// property.
   final MenuStyle? menuStyle;
 
+  /// The color used for disabled DropdownMenu.
+  /// This color is applied to the text of the selected item on TextField.
+  final Color? disabledColor;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   DropdownMenuThemeData copyWith({
@@ -75,11 +80,13 @@ class DropdownMenuThemeData with Diagnosticable {
     // TODO(bleroux): Clean this up once `InputDecorationTheme` is fully normalized.
     Object? inputDecorationTheme,
     MenuStyle? menuStyle,
+    Color? disabledColor,
   }) {
     return DropdownMenuThemeData(
       textStyle: textStyle ?? this.textStyle,
       inputDecorationTheme: inputDecorationTheme ?? this.inputDecorationTheme,
       menuStyle: menuStyle ?? this.menuStyle,
+      disabledColor: disabledColor ?? this.disabledColor,
     );
   }
 
@@ -92,11 +99,12 @@ class DropdownMenuThemeData with Diagnosticable {
       textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
       inputDecorationTheme: t < 0.5 ? a?.inputDecorationTheme : b?.inputDecorationTheme,
       menuStyle: MenuStyle.lerp(a?.menuStyle, b?.menuStyle, t),
+      disabledColor: Color.lerp(a?.disabledColor, b?.disabledColor, t),
     );
   }
 
   @override
-  int get hashCode => Object.hash(textStyle, inputDecorationTheme, menuStyle);
+  int get hashCode => Object.hash(textStyle, inputDecorationTheme, menuStyle, disabledColor);
 
   @override
   bool operator ==(Object other) {
@@ -109,7 +117,8 @@ class DropdownMenuThemeData with Diagnosticable {
     return other is DropdownMenuThemeData &&
         other.textStyle == textStyle &&
         other.inputDecorationTheme == inputDecorationTheme &&
-        other.menuStyle == menuStyle;
+        other.menuStyle == menuStyle &&
+        other.disabledColor == disabledColor;
   }
 
   @override
@@ -124,6 +133,7 @@ class DropdownMenuThemeData with Diagnosticable {
       ),
     );
     properties.add(DiagnosticsProperty<MenuStyle>('menuStyle', menuStyle, defaultValue: null));
+    properties.add(ColorProperty('disabledColor', disabledColor, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/material/dropdown_menu_theme_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_theme_test.dart
@@ -413,4 +413,34 @@ void main() {
     expect(material.shape, const RoundedRectangleBorder());
     expect(material.textStyle?.color, theme.colorScheme.onSurface);
   });
+
+  testWidgets(
+    'DropdownMenuThemeData.menuStyle.disabledColor is being applied when the menu is disabled',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            dropdownMenuTheme: const DropdownMenuThemeData(disabledColor: Colors.grey),
+          ),
+          home: const Scaffold(
+            body: Center(
+              child: DropdownMenu<int>(
+                enabled: false,
+                initialSelection: 0,
+                dropdownMenuEntries: <DropdownMenuEntry<int>>[
+                  DropdownMenuEntry<int>(value: 0, label: 'Item 0'),
+                  DropdownMenuEntry<int>(value: 1, label: 'Item 1'),
+                  DropdownMenuEntry<int>(value: 2, label: 'Item 2'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // make sure the displaying text has grey color
+      final EditableText editableText = tester.widget(find.byType(EditableText));
+      expect(editableText.style.color, Colors.grey);
+    },
+  );
 }


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/169942

### Description

The bug is about the [effectiveTextStyle](https://github.com/flutter/flutter/blob/b086fe7b79b80a9567f61660b1565efba773fdc3/packages/flutter/lib/src/material/dropdown_menu.dart#L979) being applied to the inner [TextField](https://github.com/flutter/flutter/blob/b086fe7b79b80a9567f61660b1565efba773fdc3/packages/flutter/lib/src/material/dropdown_menu.dart#L1049) inside DropdownMenu fails to reflect the disabled style based on the [enabled property](https://github.com/flutter/flutter/blob/b086fe7b79b80a9567f61660b1565efba773fdc3/packages/flutter/lib/src/material/dropdown_menu.dart#L209).
The fix for this is simply to check the `enabled` property and override the TextField's TextStyle.

### Demo of the fix

| before | after |
| --------------- | --------------- |
<video src="https://github.com/user-attachments/assets/0c56577b-301a-4369-bb1c-280643521cab"/> | <video src="https://github.com/user-attachments/assets/7e806fc7-4b90-49e5-b91b-8779454c8e60"/>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
