### PR TITLE
Update test_vulkan_context.cc to use Vulkan 1.1

### DIFF
--- a/engine/src/flutter/testing/test_vulkan_context.cc
+++ b/engine/src/flutter/testing/test_vulkan_context.cc
@@ -49,7 +49,7 @@ TestVulkanContext::TestVulkanContext() {
 
   application_ = std::make_unique<vulkan::VulkanApplication>(
       *vk_, "Flutter Unittests", std::vector<std::string>{},
-      VK_MAKE_VERSION(1, 0, 0), VK_MAKE_VERSION(1, 0, 0), true);
+      VK_MAKE_VERSION(1, 0, 0), VK_MAKE_VERSION(1, 1, 0), true);
   if (!application_->IsValid()) {
     FML_LOG(ERROR) << "Failed to initialize basic Vulkan state.";
     return;
@@ -85,7 +85,7 @@ TestVulkanContext::TestVulkanContext() {
 
   sk_sp<skgpu::VulkanMemoryAllocator> allocator =
       flutter::FlutterSkiaVulkanMemoryAllocator::Make(
-          VK_MAKE_VERSION(1, 0, 0), application_->GetInstance(),
+          VK_MAKE_VERSION(1, 1, 0), application_->GetInstance(),
           device_->GetPhysicalDeviceHandle(), device_->GetHandle(), vk_, true);
 
   skgpu::VulkanExtensions extensions;
@@ -96,7 +96,7 @@ TestVulkanContext::TestVulkanContext() {
   backend_context.fDevice = device_->GetHandle();
   backend_context.fQueue = device_->GetQueueHandle();
   backend_context.fGraphicsQueueIndex = device_->GetGraphicsQueueIndex();
-  backend_context.fMaxAPIVersion = VK_MAKE_VERSION(1, 0, 0);
+  backend_context.fMaxAPIVersion = VK_MAKE_VERSION(1, 1, 0);
   backend_context.fDeviceFeatures = &features;
   backend_context.fVkExtensions = &extensions;
   backend_context.fGetProc = get_proc;


### PR DESCRIPTION
Skia is moving to require 1.1 as its minimum supported version instead of 1.0.

This is part of an effort to clean up and consolidate Vulkan initialization logic, which gets much easier with some of the extensions that were promoted to 1.1.  This is for skbug.com/422204178 and required to roll https://skia-review.googlesource.com/c/skia/+/1002391 into Flutter.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
