### PR TITLE
[impellerc] add GLES shader define.

### DIFF
--- a/engine/src/flutter/impeller/compiler/compiler.cc
+++ b/engine/src/flutter/impeller/compiler/compiler.cc
@@ -363,6 +363,11 @@ Compiler::Compiler(const std::shared_ptr<const fml::Mapping>& source_mapping,
 
       spirv_options.target = target;
       spirv_options.macro_definitions.push_back("IMPELLER_GRAPHICS_BACKEND");
+      if (source_options.target_platform == TargetPlatform::kRuntimeStageGLES ||
+          source_options.target_platform ==
+              TargetPlatform::kRuntimeStageGLES3) {
+        spirv_options.macro_definitions.push_back("IMPELLER_TARGET_OPENGLES");
+      }
     } break;
     case TargetPlatform::kSkSL: {
       SPIRVCompilerTargetEnv target;

--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -17,12 +17,16 @@ namespace testing {
 
 TEST(CompilerTest, Defines) {
   std::shared_ptr<const fml::Mapping> fixture =
-      flutter::testing::OpenFixtureAsMapping("sample.vert");
+      flutter::testing::OpenFixtureAsMapping("check_gles_definition.frag");
 
   SourceOptions options;
   options.source_language = SourceLanguage::kGLSL;
   options.target_platform = TargetPlatform::kRuntimeStageGLES;
+  options.entry_point_name = "main";
+  options.type = SourceType::kFragmentShader;
+
   Reflector::Options reflector_options;
+  reflector_options.target_platform = TargetPlatform::kRuntimeStageGLES;
   Compiler compiler = Compiler(fixture, options, reflector_options);
 
   // Should fail as the shader has a compilation error in it.
@@ -30,8 +34,9 @@ TEST(CompilerTest, Defines) {
 
   // Should succeed as the compilation error is ifdef'd out.
   options.target_platform = TargetPlatform::kRuntimeStageVulkan;
+  reflector_options.target_platform = TargetPlatform::kRuntimeStageVulkan;
   Compiler compiler_2 = Compiler(fixture, options, reflector_options);
-  EXPECT_NE(compiler.GetSPIRVAssembly(), nullptr);
+  EXPECT_NE(compiler_2.GetSPIRVAssembly(), nullptr);
 }
 
 TEST(CompilerTest, ShaderKindMatchingIsSuccessful) {

--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -15,6 +15,25 @@ namespace impeller {
 namespace compiler {
 namespace testing {
 
+TEST(CompilerTest, Defines) {
+  std::shared_ptr<const fml::Mapping> fixture =
+      flutter::testing::OpenFixtureAsMapping("sample.vert");
+
+  SourceOptions options;
+  options.source_language = SourceLanguage::kGLSL;
+  options.target_platform = TargetPlatform::kRuntimeStageGLES;
+  Reflector::Options reflector_options;
+  Compiler compiler = Compiler(fixture, options, reflector_options);
+
+  // Should fail as the shader has a compilation error in it.
+  EXPECT_EQ(compiler.GetSPIRVAssembly(), nullptr);
+
+  // Should succeed as the compilation error is ifdef'd out.
+  options.target_platform = TargetPlatform::kRuntimeStageVulkan;
+  Compiler compiler_2 = Compiler(fixture, options, reflector_options);
+  EXPECT_NE(compiler.GetSPIRVAssembly(), nullptr);
+}
+
 TEST(CompilerTest, ShaderKindMatchingIsSuccessful) {
   ASSERT_EQ(SourceTypeFromFileName("hello.vert"), SourceType::kVertexShader);
   ASSERT_EQ(SourceTypeFromFileName("hello.frag"), SourceType::kFragmentShader);

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -131,6 +131,7 @@ test_fixtures("file_fixtures") {
     "sample.comp",
     "sample.frag",
     "sample.vert",
+    "check_gles_definition.frag",
     "sample_with_binding.vert",
     "simple.vert.hlsl",
     "sa%m#ple.vert",

--- a/engine/src/flutter/impeller/fixtures/check_gles_definition.frag
+++ b/engine/src/flutter/impeller/fixtures/check_gles_definition.frag
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+out vec4 out_color;
+
+void main() {
+#ifdef IMPELLER_TARGET_OPENGLES
+    fail
+#else
+  out_color = vec4(1, 0, 0, 0);
+#endif
+}

--- a/engine/src/flutter/impeller/fixtures/check_gles_definition.frag
+++ b/engine/src/flutter/impeller/fixtures/check_gles_definition.frag
@@ -6,7 +6,7 @@ out vec4 out_color;
 
 void main() {
 #ifdef IMPELLER_TARGET_OPENGLES
-    fail
+  fail
 #else
   out_color = vec4(1, 0, 0, 0);
 #endif


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/169429

For ImageShader.filter we need a way to distinguish between the coordinate system of GL vs Metal/Vulkan. I documented in https://github.com/flutter/flutter/pull/169761 how to do it but neglected to wire up the define. This fixes that.