### PR TITLE
Use "flutter pub get" to resolve packages when building the docs snippets tool

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -113,7 +113,7 @@ function build_snippets_tool() (
   echo "Building snippets tool executable."
   command cd "$snippets_dir"
   mkdir -p "$output_dir"
-  dart pub get
+  "$FLUTTER" pub get
   dart compile exe -o "$output_dir/snippets" bin/snippets.dart
 )
 


### PR DESCRIPTION
"flutter pub get" should be used instead of "dart pub get" for packages within the Flutter pub workspace.

This was causing issues for some runs of the docs_test builder on CI.

(example: https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20docs_test/68448/overview)