### PR TITLE
fix: Skip native assets build test (flaky, takes 15m+)

### DIFF
--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_agp_version_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_agp_version_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@Skip('flutter/flutter/issues/170382')
+library;
+
 import 'dart:io';
 
 import 'package:file/file.dart';


### PR DESCRIPTION
fixes #170382, which is timing out at 6% flakey