### PR TITLE
[engine] Reland: ensure engines spawned from an engine using dynamic rendering selection still use the dynamic surface.

### DIFF
--- a/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.h
+++ b/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.h
@@ -31,6 +31,9 @@ class AndroidContextDynamicImpeller : public AndroidContext {
   bool IsValid() const override { return true; }
 
   // |AndroidContext|
+  bool IsDynamicSelection() const override { return true; }
+
+  // |AndroidContext|
   AndroidRenderingAPI RenderingApi() const override;
 
   /// @brief Retrieve the GL Context if it was created, or nullptr.

--- a/engine/src/flutter/shell/platform/android/context/android_context.cc
+++ b/engine/src/flutter/shell/platform/android/context/android_context.cc
@@ -50,4 +50,8 @@ std::shared_ptr<impeller::Context> AndroidContext::GetImpellerContext() const {
   return impeller_context_;
 }
 
+bool AndroidContext::IsDynamicSelection() const {
+  return false;
+}
+
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/context/android_context.h
+++ b/engine/src/flutter/shell/platform/android/context/android_context.h
@@ -39,6 +39,8 @@ class AndroidContext {
 
   virtual AndroidRenderingAPI RenderingApi() const;
 
+  virtual bool IsDynamicSelection() const;
+
   virtual bool IsValid() const;
 
   //----------------------------------------------------------------------------

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool.cc
@@ -49,6 +49,7 @@ std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
 
     FML_CHECK(java_metadata->window);
     android_surface->SetNativeWindow(java_metadata->window, jni_facade);
+    android_surface->SetupImpellerSurface();
 
     std::unique_ptr<Surface> surface =
         android_surface->CreateGPUSurface(gr_context);

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -78,6 +78,11 @@ AndroidSurfaceFactoryImpl::AndroidSurfaceFactoryImpl(
 AndroidSurfaceFactoryImpl::~AndroidSurfaceFactoryImpl() = default;
 
 std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
+  if (android_context_->IsDynamicSelection()) {
+    auto cast_ptr = std::static_pointer_cast<AndroidContextDynamicImpeller>(
+        android_context_);
+    return std::make_unique<AndroidSurfaceDynamicImpeller>(cast_ptr);
+  }
   switch (android_context_->RenderingApi()) {
 #if !SLIMPELLER
     case AndroidRenderingAPI::kSoftware:


### PR DESCRIPTION
Reland of https://github.com/flutter/flutter/pull/170313

We were missing a call to android_surface->SetupImpellerSurface(); which happened to just work before.