### PR TITLE
Fix `Semantics.identifier` on TextField not working on web

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -764,20 +764,19 @@ abstract class SemanticRole {
       updateValidationResult();
     }
 
+    final List<SemanticBehavior>? behaviors = _behaviors;
+    if (behaviors != null) {
+      for (final SemanticBehavior behavior in behaviors) {
+        behavior.update();
+      }
+    }
+
     if (semanticsObject.isIdentifierDirty) {
       _updateIdentifier();
     }
 
     if (semanticsObject.isControlsNodesDirty) {
       _updateControls();
-    }
-
-    final List<SemanticBehavior>? behaviors = _behaviors;
-    if (behaviors == null) {
-      return;
-    }
-    for (final SemanticBehavior behavior in behaviors) {
-      behavior.update();
     }
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -764,20 +764,20 @@ abstract class SemanticRole {
       updateValidationResult();
     }
 
-    final List<SemanticBehavior>? behaviors = _behaviors;
-    if (behaviors == null) {
-      return;
-    }
-    for (final SemanticBehavior behavior in behaviors) {
-      behavior.update();
-    }
-
     if (semanticsObject.isIdentifierDirty) {
       _updateIdentifier();
     }
 
     if (semanticsObject.isControlsNodesDirty) {
       _updateControls();
+    }
+
+    final List<SemanticBehavior>? behaviors = _behaviors;
+    if (behaviors == null) {
+      return;
+    }
+    for (final SemanticBehavior behavior in behaviors) {
+      behavior.update();
     }
   }
 

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -204,6 +204,76 @@ void _testSemanticRole() {
     <sem id="flt-semantic-node-612" flt-semantics-identifier="test-id-333"></sem>
 </sem>''');
   });
+
+  test(
+    'Sets id and flt-semantics-identifier on the element when SemanticRole has no behaviors',
+    () {
+      semantics()
+        ..debugOverrideTimestampFunction(() => _testTime)
+        ..semanticsEnabled = true;
+
+      final SemanticsTester tester = SemanticsTester(owner());
+      tester.updateNode(
+        id: 0,
+        children: <SemanticsNodeUpdate>[
+          tester.updateNode(
+            id: 372,
+            flags: const ui.SemanticsFlags(isTextField: true),
+          ), // SemanticTextField has no SemanticBehaviors.
+          tester.updateNode(id: 599),
+        ],
+      );
+      tester.apply();
+
+      tester.expectSemantics('''
+    <sem id="flt-semantic-node-0">
+        <sem id="flt-semantic-node-372">
+          <input />
+        </sem>
+        <sem id="flt-semantic-node-599"></sem>
+    </sem>''');
+
+      tester.updateNode(
+        id: 0,
+        children: <SemanticsNodeUpdate>[
+          tester.updateNode(
+            id: 372,
+            identifier: 'test-id-123',
+            flags: const ui.SemanticsFlags(isTextField: true),
+          ),
+          tester.updateNode(id: 599),
+        ],
+      );
+      tester.apply();
+
+      tester.expectSemantics('''
+    <sem id="flt-semantic-node-0">
+        <sem id="flt-semantic-node-372" flt-semantics-identifier="test-id-123">
+          <input />
+        </sem>
+        <sem id="flt-semantic-node-599"></sem>
+    </sem>''');
+
+      tester.updateNode(
+        id: 0,
+        children: <SemanticsNodeUpdate>[
+          tester.updateNode(id: 372, flags: const ui.SemanticsFlags(isTextField: true)),
+          tester.updateNode(id: 599, identifier: 'test-id-211'),
+          tester.updateNode(id: 612, identifier: 'test-id-333'),
+        ],
+      );
+      tester.apply();
+
+      tester.expectSemantics('''
+    <sem id="flt-semantic-node-0">
+        <sem id="flt-semantic-node-372">
+          <input />
+        </sem>
+        <sem id="flt-semantic-node-599" flt-semantics-identifier="test-id-211"></sem>
+        <sem id="flt-semantic-node-612" flt-semantics-identifier="test-id-333"></sem>
+    </sem>''');
+    },
+  );
 }
 
 void _testRoleLifecycle() {


### PR DESCRIPTION
Fixes #155323

Before this change the `identifier` would not be updated even if marked dirty for a `SemanticRole` that had no `SemanticBehavior`s. After this change an `identifier` marked dirty is now updated even if the `SemanticRole` has no `SemanticBehavior`s.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.