### PR TITLE
Add maxLines property to Wrap Widget for line limitation (#65331)

### DIFF
--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -453,13 +453,7 @@ class RenderWrap extends RenderBox
     }
   }
 
-  /// The maximum number of lines to display.
-  ///
-  /// If null, there is no limit on the number of lines.
-  /// If not null, the wrap will stop creating new lines after reaching this limit.
-  /// Children that would exceed this limit are not displayed or laid out.
-  ///
-  /// Defaults to null.
+  /// {@macro flutter.widgets.Wrap.maxLines}
   int? get maxLines => _maxLines;
   int? _maxLines;
   set maxLines(int? value) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6052,6 +6052,7 @@ class Wrap extends MultiChildRenderObjectWidget {
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
     this.clipBehavior = Clip.none,
+    this.maxLines,
     super.children,
   });
 
@@ -6192,6 +6193,15 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
+  /// The maximum number of lines to display before wrapping.
+  ///
+  /// If null, there is no limit on the number of lines.
+  /// If not null, the wrap will stop creating new lines after reaching this limit.
+  /// Children that would exceed this limit are not displayed.
+  ///
+  /// Defaults to null.
+  final int? maxLines;
+
   @override
   RenderWrap createRenderObject(BuildContext context) {
     return RenderWrap(
@@ -6204,6 +6214,7 @@ class Wrap extends MultiChildRenderObjectWidget {
       textDirection: textDirection ?? Directionality.maybeOf(context),
       verticalDirection: verticalDirection,
       clipBehavior: clipBehavior,
+      maxLines: maxLines,
     );
   }
 
@@ -6218,7 +6229,8 @@ class Wrap extends MultiChildRenderObjectWidget {
       ..crossAxisAlignment = crossAxisAlignment
       ..textDirection = textDirection ?? Directionality.maybeOf(context)
       ..verticalDirection = verticalDirection
-      ..clipBehavior = clipBehavior;
+      ..clipBehavior = clipBehavior
+      ..maxLines = maxLines;
   }
 
   @override
@@ -6238,6 +6250,7 @@ class Wrap extends MultiChildRenderObjectWidget {
         defaultValue: VerticalDirection.down,
       ),
     );
+    properties.add(IntProperty('maxLines', maxLines, ifNull: 'unlimited'));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6193,6 +6193,7 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
+  /// {@template flutter.widgets.Wrap.maxLines}
   /// The maximum number of lines to display before wrapping.
   ///
   /// If null, there is no limit on the number of lines.
@@ -6200,6 +6201,7 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// Children that would exceed this limit are not displayed.
   ///
   /// Defaults to null.
+  /// {@endtemplate}
   final int? maxLines;
 
   @override

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -1592,6 +1592,7 @@ void main() {
         contains('crossAxisAlignment: start'),
         contains('textDirection: ltr'),
         contains('verticalDirection: up'),
+        contains('maxLines: unlimited'),
       ]),
     );
   });

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -1039,4 +1039,253 @@ void main() {
     );
     verify(tester, <Offset>[const Offset(700.0, 0.0)]);
   });
+
+  group('Wrap maxLines', () {
+    testWidgets('maxLines limits the number of lines in horizontal direction', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const Wrap(
+          textDirection: TextDirection.ltr,
+          maxLines: 2,
+          children: <Widget>[
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+          ],
+        ),
+      );
+      final List<RenderBox> children = tester
+          .renderObjectList<RenderBox>(find.byType(SizedBox))
+          .toList();
+      final List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(4));
+    });
+
+    testWidgets('maxLines limits the number of lines in vertical direction', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const Wrap(
+          direction: Axis.vertical,
+          textDirection: TextDirection.ltr,
+          maxLines: 2,
+          children: <Widget>[
+            SizedBox(width: 100.0, height: 300.0),
+            SizedBox(width: 100.0, height: 300.0),
+            SizedBox(width: 100.0, height: 300.0),
+            SizedBox(width: 100.0, height: 300.0),
+            SizedBox(width: 100.0, height: 300.0),
+            SizedBox(width: 100.0, height: 300.0),
+          ],
+        ),
+      );
+      final List<RenderBox> children = tester
+          .renderObjectList<RenderBox>(find.byType(SizedBox))
+          .toList();
+      final List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(4));
+    });
+
+    testWidgets('maxLines 1 shows only first line', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Wrap(
+          textDirection: TextDirection.ltr,
+          maxLines: 1,
+          children: <Widget>[
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+          ],
+        ),
+      );
+      final List<RenderBox> children = tester
+          .renderObjectList<RenderBox>(find.byType(SizedBox))
+          .toList();
+      final List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(2));
+    });
+
+    testWidgets('maxLines works with spacing and runSpacing', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Wrap(
+          textDirection: TextDirection.ltr,
+          spacing: 10.0,
+          runSpacing: 10.0,
+          maxLines: 2,
+          children: <Widget>[
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+          ],
+        ),
+      );
+      final List<RenderBox> children = tester
+          .renderObjectList<RenderBox>(find.byType(SizedBox))
+          .toList();
+      final List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(4));
+    });
+
+    testWidgets('maxLines works with RTL text direction', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Wrap(
+          textDirection: TextDirection.rtl,
+          maxLines: 2,
+          children: <Widget>[
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+          ],
+        ),
+      );
+      final List<RenderBox> children = tester
+          .renderObjectList<RenderBox>(find.byType(SizedBox))
+          .toList();
+      final List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(4));
+    });
+
+    testWidgets('maxLines works with different alignments', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Wrap(
+          textDirection: TextDirection.ltr,
+          alignment: WrapAlignment.center,
+          maxLines: 2,
+          children: <Widget>[
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+          ],
+        ),
+      );
+      final List<RenderBox> children = tester
+          .renderObjectList<RenderBox>(find.byType(SizedBox))
+          .toList();
+      final List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(4));
+    });
+
+    testWidgets('maxLines can be updated dynamically', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Wrap(
+          textDirection: TextDirection.ltr,
+          maxLines: 1,
+          children: <Widget>[
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+          ],
+        ),
+      );
+      List<RenderBox> children = tester.renderObjectList<RenderBox>(find.byType(SizedBox)).toList();
+      List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(2));
+
+      // Update maxLines to 2
+      await tester.pumpWidget(
+        const Wrap(
+          textDirection: TextDirection.ltr,
+          maxLines: 2,
+          children: <Widget>[
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+            SizedBox(width: 300.0, height: 100.0),
+          ],
+        ),
+      );
+      children = tester.renderObjectList<RenderBox>(find.byType(SizedBox)).toList();
+      visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(4));
+    });
+
+    testWidgets('maxLines works with empty children list', (WidgetTester tester) async {
+      await tester.pumpWidget(const Wrap(textDirection: TextDirection.ltr, maxLines: 5));
+      final List<RenderBox> children = tester
+          .renderObjectList<RenderBox>(find.byType(SizedBox))
+          .toList();
+      final List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(0));
+    });
+
+    testWidgets('maxLines works with single child', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Wrap(
+          textDirection: TextDirection.ltr,
+          maxLines: 1,
+          children: <Widget>[SizedBox(width: 300.0, height: 100.0)],
+        ),
+      );
+      final List<RenderBox> children = tester
+          .renderObjectList<RenderBox>(find.byType(SizedBox))
+          .toList();
+      final List<RenderBox> visibleChildren = children.where((RenderBox child) {
+        final Offset offset = (child.parentData as dynamic).offset as Offset;
+        return child.size.width > 0 &&
+            child.size.height > 0 &&
+            (offset != Offset.zero || children.indexOf(child) == 0);
+      }).toList();
+      expect(visibleChildren.length, equals(1));
+    });
+  });
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR adds a `maxLines` property to the Wrap widget, allowing developers to limit the number of lines displayed. When `maxLines` is set, the Wrap widget will stop creating new lines after reaching the specified limit, and children that would exceed this limit are not displayed or laid out. This provides better control over layout in constrained spaces and prevents unwanted vertical overflow.

The implementation includes:
- Adding `maxLines` property to `RenderWrap` with proper getter/setter
- Updating `_computeRuns` method to respect the `maxLines` limit
- Modifying `performLayout` to size excluded children to zero
- Comprehensive test coverage for various scenarios

Fixes https://github.com/flutter/flutter/issues/65331

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
