### PR TITLE
CP: iOS tool dylibs do not need entitlements (#170448)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4704,6 +4704,34 @@ targets:
         ["framework", "hostonly", "shard", "mac"]
       shard: verify_binaries_codesigned
 
+  - name: Mac_x64 verify_binaries_pre_codesigned
+    # verify_binaries_codesigned, which verifies all binaries,
+    # runs on release branches, so this one does not need to.
+    enabled_branches:
+      - master
+    bringup: true
+    recipe: flutter/flutter_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["framework", "hostonly", "shard", "mac"]
+      shard: verify_binaries_pre_codesigned
+
+  - name: Mac_arm64 verify_binaries_pre_codesigned
+    # verify_binaries_codesigned, which verifies all binaries,
+    # runs on release branches, so this one does not need to.
+    enabled_branches:
+      - master
+    bringup: true
+    recipe: flutter/flutter_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["framework", "hostonly", "shard", "mac"]
+      shard: verify_binaries_pre_codesigned
+
   - name: Mac web_tool_tests
     recipe: flutter/flutter_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -354,6 +354,7 @@
 # android_java11_tool_integration_tests @gmackall @flutter/android
 # tool_tests @bkonyi @flutter/tool
 # verify_binaries_codesigned @cbracken @flutter/releases
+# verify_binaries_pre_codesigned @vashworth @flutter/releases
 # web_canvaskit_tests @yjbanov @flutter/web
 # web_integration_tests @yjbanov @flutter/web
 # web_long_running_tests @yjbanov @flutter/web

--- a/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
+++ b/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
@@ -25,6 +25,21 @@ Future<void> verifyCodesignedTestRunner() async {
   await verifySignatures(flutterRoot);
 }
 
+/// Some binaries should always be codesigned, even on master. Verify that they
+/// are codesigned and have the correct entitlements.
+Future<void> verifyPreCodesignedTestRunner() async {
+  printProgress('${green}Running binaries codesign verification$reset');
+  await runCommand('flutter', <String>[
+    'precache',
+    '--android',
+    '--ios',
+    '--macos',
+  ], workingDirectory: flutterRoot);
+
+  await verifyExist(flutterRoot);
+  await verifySignatures(flutterRoot, forRelease: false);
+}
+
 const List<String> expectedEntitlements = <String>[
   'com.apple.security.cs.allow-jit',
   'com.apple.security.cs.allow-unsigned-executable-memory',
@@ -39,40 +54,36 @@ const List<String> expectedEntitlements = <String>[
 /// This list should be kept in sync with the actual contents of Flutter's
 /// cache.
 List<String> binariesWithEntitlements(String flutterRoot) {
-  return <String>[
-    'artifacts/engine/android-arm-profile/darwin-x64/gen_snapshot',
-    'artifacts/engine/android-arm-release/darwin-x64/gen_snapshot',
-    'artifacts/engine/android-arm64-profile/darwin-x64/gen_snapshot',
-    'artifacts/engine/android-arm64-release/darwin-x64/gen_snapshot',
-    'artifacts/engine/android-x64-profile/darwin-x64/gen_snapshot',
-    'artifacts/engine/android-x64-release/darwin-x64/gen_snapshot',
-    'artifacts/engine/darwin-x64-profile/gen_snapshot',
-    'artifacts/engine/darwin-x64-profile/gen_snapshot_arm64',
-    'artifacts/engine/darwin-x64-profile/gen_snapshot_x64',
-    'artifacts/engine/darwin-x64-release/gen_snapshot',
-    'artifacts/engine/darwin-x64-release/gen_snapshot_arm64',
-    'artifacts/engine/darwin-x64-release/gen_snapshot_x64',
-    'artifacts/engine/darwin-x64/flutter_tester',
-    'artifacts/engine/darwin-x64/gen_snapshot',
-    'artifacts/engine/darwin-x64/gen_snapshot_arm64',
-    'artifacts/engine/darwin-x64/gen_snapshot_x64',
-    'artifacts/engine/ios-profile/gen_snapshot_arm64',
-    'artifacts/engine/ios-release/gen_snapshot_arm64',
-    'artifacts/engine/ios/gen_snapshot_arm64',
-    'artifacts/libimobiledevice/idevicescreenshot',
-    'artifacts/libimobiledevice/idevicesyslog',
-    'artifacts/libimobiledevice/libimobiledevice-1.0.6.dylib',
-    'artifacts/libimobiledeviceglue/libimobiledevice-glue-1.0.0.dylib',
-    'artifacts/libplist/libplist-2.0.4.dylib',
-    'artifacts/openssl/libcrypto.3.dylib',
-    'artifacts/openssl/libssl.3.dylib',
-    'artifacts/libusbmuxd/iproxy',
-    'artifacts/libusbmuxd/libusbmuxd-2.0.7.dylib',
-    'dart-sdk/bin/dart',
-    'dart-sdk/bin/dartaotruntime',
-    'dart-sdk/bin/utils/gen_snapshot',
-    'dart-sdk/bin/utils/wasm-opt',
-  ].map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
+  final List<String> binaries =
+      <String>[
+        'artifacts/engine/android-arm-profile/darwin-x64/gen_snapshot',
+        'artifacts/engine/android-arm-release/darwin-x64/gen_snapshot',
+        'artifacts/engine/android-arm64-profile/darwin-x64/gen_snapshot',
+        'artifacts/engine/android-arm64-release/darwin-x64/gen_snapshot',
+        'artifacts/engine/android-x64-profile/darwin-x64/gen_snapshot',
+        'artifacts/engine/android-x64-release/darwin-x64/gen_snapshot',
+        'artifacts/engine/darwin-x64-profile/gen_snapshot',
+        'artifacts/engine/darwin-x64-profile/gen_snapshot_arm64',
+        'artifacts/engine/darwin-x64-profile/gen_snapshot_x64',
+        'artifacts/engine/darwin-x64-release/gen_snapshot',
+        'artifacts/engine/darwin-x64-release/gen_snapshot_arm64',
+        'artifacts/engine/darwin-x64-release/gen_snapshot_x64',
+        'artifacts/engine/darwin-x64/flutter_tester',
+        'artifacts/engine/darwin-x64/gen_snapshot',
+        'artifacts/engine/darwin-x64/gen_snapshot_arm64',
+        'artifacts/engine/darwin-x64/gen_snapshot_x64',
+        'artifacts/engine/ios-profile/gen_snapshot_arm64',
+        'artifacts/engine/ios-release/gen_snapshot_arm64',
+        'artifacts/engine/ios/gen_snapshot_arm64',
+        'dart-sdk/bin/dart',
+        'dart-sdk/bin/dartaotruntime',
+        'dart-sdk/bin/utils/gen_snapshot',
+        'dart-sdk/bin/utils/wasm-opt',
+      ].map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
+
+  presignedBinariesWithEntitlements(flutterRoot).forEach(binaries.add);
+
+  return binaries;
 }
 
 /// Binaries that are only expected to be codesigned.
@@ -80,28 +91,32 @@ List<String> binariesWithEntitlements(String flutterRoot) {
 /// This list should be kept in sync with the actual contents of Flutter's
 /// cache.
 List<String> binariesWithoutEntitlements(String flutterRoot) {
-  return <String>[
-    'artifacts/engine/darwin-x64-profile/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
-    'artifacts/engine/darwin-x64-release/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
-    'artifacts/engine/darwin-x64/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
-    'artifacts/engine/darwin-x64/font-subset',
-    'artifacts/engine/darwin-x64/impellerc',
-    'artifacts/engine/darwin-x64/libpath_ops.dylib',
-    'artifacts/engine/darwin-x64/libtessellator.dylib',
-    'artifacts/engine/ios-profile/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-    'artifacts/engine/ios-profile/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-    'artifacts/engine/ios-profile/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-    'artifacts/engine/ios-profile/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-    'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-    'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-    'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-    'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-    'artifacts/engine/ios/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-    'artifacts/engine/ios/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-    'artifacts/engine/ios/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-    'artifacts/engine/ios/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-    'artifacts/ios-deploy/ios-deploy',
-  ].map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
+  final List<String> binaries =
+      <String>[
+        'artifacts/engine/darwin-x64-profile/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
+        'artifacts/engine/darwin-x64-release/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
+        'artifacts/engine/darwin-x64/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
+        'artifacts/engine/darwin-x64/font-subset',
+        'artifacts/engine/darwin-x64/impellerc',
+        'artifacts/engine/darwin-x64/libpath_ops.dylib',
+        'artifacts/engine/darwin-x64/libtessellator.dylib',
+        'artifacts/engine/ios-profile/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+        'artifacts/engine/ios-profile/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+        'artifacts/engine/ios-profile/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+        'artifacts/engine/ios-profile/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+        'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+        'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+        'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+        'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+        'artifacts/engine/ios/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+        'artifacts/engine/ios/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+        'artifacts/engine/ios/extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+        'artifacts/engine/ios/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      ].map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
+
+  presignedBinariesWithoutEntitlements(flutterRoot).forEach(binaries.add);
+
+  return binaries;
 }
 
 /// Binaries that are not expected to be codesigned.
@@ -114,6 +129,28 @@ List<String> unsignedBinaries(String flutterRoot) {
     'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
     'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
     'artifacts/engine/ios-release/extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+  ].map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
+}
+
+/// Binaries with entitlements that should always be signed, even on master.
+List<String> presignedBinariesWithEntitlements(String flutterRoot) {
+  return <String>[
+    'artifacts/libimobiledevice/idevicescreenshot',
+    'artifacts/libimobiledevice/idevicesyslog',
+    'artifacts/libusbmuxd/iproxy',
+  ].map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
+}
+
+/// Binaries without entitlements that should always be signed, even on master.
+List<String> presignedBinariesWithoutEntitlements(String flutterRoot) {
+  return <String>[
+    'artifacts/ios-deploy/ios-deploy',
+    'artifacts/libimobiledevice/libimobiledevice-1.0.6.dylib',
+    'artifacts/libimobiledeviceglue/libimobiledevice-glue-1.0.0.dylib',
+    'artifacts/libplist/libplist-2.0.4.dylib',
+    'artifacts/openssl/libcrypto.3.dylib',
+    'artifacts/openssl/libssl.3.dylib',
+    'artifacts/libusbmuxd/libusbmuxd-2.0.7.dylib',
   ].map((String relativePath) => path.join(flutterRoot, 'bin', 'cache', relativePath)).toList();
 }
 
@@ -180,10 +217,13 @@ Future<void> verifyExist(
   print('All expected binaries present.');
 }
 
-/// Verify code signatures and entitlements of all binaries in the cache.
+/// Verify code signatures and entitlements of binaries in the cache.
+///
+/// If [forRelease] is true, verify for all binaries. Otherwise, only verify for pre-signed binaries.
 Future<void> verifySignatures(
   String flutterRoot, {
   @visibleForTesting ProcessManager processManager = const LocalProcessManager(),
+  bool forRelease = true,
 }) async {
   final List<String> unsignedFiles = <String>[];
   final List<String> wrongEntitlementBinaries = <String>[];
@@ -194,21 +234,39 @@ Future<void> verifySignatures(
       (await findBinaryPaths(cacheDirectory, processManager: processManager)) +
       (await findXcframeworksPaths(cacheDirectory, processManager: processManager));
 
+  final List<String> binariesToVerifyEntitlements;
+  final List<String> binariesToVerifyWithoutEntitlements;
+  final List<String> xcframeworksToVerifyCodesigned;
+  if (forRelease) {
+    binariesToVerifyEntitlements = binariesWithEntitlements(flutterRoot);
+    binariesToVerifyWithoutEntitlements = binariesWithoutEntitlements(flutterRoot);
+    xcframeworksToVerifyCodesigned = signedXcframeworks(flutterRoot);
+  } else {
+    binariesToVerifyEntitlements = presignedBinariesWithEntitlements(flutterRoot);
+    binariesToVerifyWithoutEntitlements = presignedBinariesWithoutEntitlements(flutterRoot);
+    xcframeworksToVerifyCodesigned = <String>[];
+  }
+
   for (final String pathToCheck in binariesAndXcframeworks) {
     bool verifySignature = false;
     bool verifyEntitlements = false;
-    if (binariesWithEntitlements(flutterRoot).contains(pathToCheck)) {
+    if (binariesToVerifyEntitlements.contains(pathToCheck)) {
       verifySignature = true;
       verifyEntitlements = true;
     }
-    if (binariesWithoutEntitlements(flutterRoot).contains(pathToCheck)) {
+    if (binariesToVerifyWithoutEntitlements.contains(pathToCheck)) {
       verifySignature = true;
     }
-    if (signedXcframeworks(flutterRoot).contains(pathToCheck)) {
+    if (xcframeworksToVerifyCodesigned.contains(pathToCheck)) {
       verifySignature = true;
     }
     if (unsignedBinaries(flutterRoot).contains(pathToCheck)) {
       // Binary is expected to be unsigned. No need to check signature, entitlements.
+      continue;
+    }
+
+    // If not testing for release, skip path if not going to verify it's codesigned/entitlements.
+    if (!forRelease && !verifySignature && !verifyEntitlements) {
       continue;
     }
 

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -149,6 +149,7 @@ Future<void> main(List<String> args) async {
       'snippets': _runSnippetsTests,
       'docs': docsRunner,
       'verify_binaries_codesigned': verifyCodesignedTestRunner,
+      'verify_binaries_pre_codesigned': verifyPreCodesignedTestRunner,
       kTestHarnessShardName:
           testHarnessTestsRunner, // Used for testing this script; also run as part of SHARD=framework_tests, SUBSHARD=misc.
     });


### PR DESCRIPTION
Cherrypick 0cea36129ff405428dc39671ec0463f584b3f42f (https://github.com/flutter/flutter/pull/170448) to unblock the 3.34 release.

Manual cherrypick because 3.34 is not an active release branch at the moment.