### PR TITLE
Posix: Use `aot-snapshot` if `FLUTTER_TOOLS_USE_AOT_SNAPSHOT=1`

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -201,9 +201,9 @@ GOTO :after_subroutine
       )
 
     IF "%FLUTTER_TOOL_ARGS%" == "" (
-      "%dart%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%" > NUL
+      "%dart%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="aot-snapshot" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%" > NUL
     ) else (
-      "%dart%" "%FLUTTER_TOOL_ARGS%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" "%script_path%" > NUL
+      "%dart%" "%FLUTTER_TOOL_ARGS%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="aot-snapshot" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" "%script_path%" > NUL
     )
     IF "%ERRORLEVEL%" NEQ "0" (
       ECHO Error: Unable to create dart snapshot for flutter tool. 1>&2

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -197,6 +197,10 @@ function upgrade_flutter () (
       rm -f "$SNAPSHOT_PATH_OLD"
     fi
   fi
+
+  # Even if pub did nothing, ensure the lockfile appears updated.
+  touch "$FLUTTER_TOOLS_DIR/pubspec.lock"
+
   # The exit here is extraneous since the function is run in a subshell, but
   # this serves as documentation that running the function in a subshell is
   # required to make sure any lock directory created by mkdir is cleaned up.

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -189,7 +189,7 @@ function upgrade_flutter () (
     else
       SNAPSHOT_KIND="jit-snapshot"
     fi
-    "$DART" compile $SNAPSHOT_KIND --verbosity=error $FLUTTER_TOOL_ARGS --output="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" "$SCRIPT_PATH" > /dev/null
+    "$DART" compile $SNAPSHOT_KIND --verbosity=error --output="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" "$SCRIPT_PATH" > /dev/null
     echo "$compilekey" > "$STAMP_PATH"
 
     # Delete any temporary snapshot path.
@@ -216,7 +216,7 @@ function shared::execute() {
   fi
 
   FLUTTER_TOOLS_DIR="$FLUTTER_ROOT/packages/flutter_tools"
-  
+
   SNAPSHOT_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.snapshot"
   if [[ "$FLUTTER_TOOLS_USE_AOT_SNAPSHOT" == "true" ]]; then
     SNAPSHOT_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.aot-snapshot"


### PR DESCRIPTION
I've added a flag, off by default, to use `aot-snapshot` when compiling/running `flutter`:
```sh
# On POSIX only, I have not done it for Windows (shared.bat) yet.
export FLUTTER_TOOLS_USE_AOT_SNAPSHOT=1
flutter --version
```

@jonahwilliams mentioned that the compile cost would be higher, and he's right:
```sh
$ time FLUTTER_TOOLS_USE_AOT_SNAPSHOT=0 flutter --version
Building flutter tool...
Resolving dependencies... (1.0s)
Downloading packages... 
Got dependencies.
Flutter 3.33.0-1.0.pre.465 • channel master • unknown source
Framework • revision ee089d09b2 (2 hours ago) • 2025-06-11 20:48:48 +0000
Engine • revision ee089d09b2 (2 hours ago) • 2025-06-11 20:48:48 +0000
Tools • Dart 3.9.0 (build 3.9.0-220.0.dev) • DevTools 2.48.0-dev.0
FLUTTER_TOOLS_USE_AOT_SNAPSHOT=0 flutter --version  0.35s user 0.22s system 3% cpu 14.477 total

$ time FLUTTER_TOOLS_USE_AOT_SNAPSHOT=1 flutter --version
Building flutter tool...
Resolving dependencies... 
Downloading packages... 
Got dependencies.
Flutter 3.33.0-1.0.pre.465 • channel master • unknown source
Framework • revision ee089d09b2 (2 hours ago) • 2025-06-11 20:48:48 +0000
Engine • revision ee089d09b2 (2 hours ago) • 2025-06-11 20:48:48 +0000
Tools • Dart 3.9.0 (build 3.9.0-220.0.dev) • DevTools 2.48.0-dev.0
FLUTTER_TOOLS_USE_AOT_SNAPSHOT=1 flutter --version  0.32s user 0.33s system 1% cpu 32.848 total
```

So, roughly twice as long to compile initially on my Macbook M1 Max laptop.

I'm considering letting others try it and give feedback, and if we like the behavior, we could do anything such as making it the default on `master`, or deciding it's not worth it and reverting the behavior entirely.