### PR TITLE
[Impeller] Remove use of simple Skia objects

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_playground.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_playground.cc
@@ -10,7 +10,6 @@
 #include "impeller/display_list/dl_dispatcher.h"
 #include "impeller/typographer/backends/skia/typographer_context_skia.h"
 #include "impeller/typographer/typographer_context.h"
-#include "include/core/SkRect.h"
 
 namespace impeller {
 
@@ -54,9 +53,9 @@ bool AiksPlayground::OpenPlaygroundHere(
             renderer.GetContentContext(),  //
             render_target,                 //
             callback(),                    //
-            SkIRect::MakeWH(render_target.GetRenderTargetSize().width,
-                            render_target.GetRenderTargetSize().height),  //
-            /*reset_host_buffer=*/true,                                   //
+            Rect::MakeWH(render_target.GetRenderTargetSize().width,
+                         render_target.GetRenderTargetSize().height),  //
+            /*reset_host_buffer=*/true,                                //
             /*is_onscreen=*/false);
       });
 }

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1293,13 +1293,11 @@ std::shared_ptr<Texture> DisplayListToTexture(
 bool RenderToTarget(ContentContext& context,
                     RenderTarget render_target,
                     const sk_sp<flutter::DisplayList>& display_list,
-                    SkIRect cull_rect,
+                    Rect cull_rect,
                     bool reset_host_buffer,
                     bool is_onscreen) {
-  Rect ip_cull_rect = Rect::MakeLTRB(cull_rect.left(), cull_rect.top(),
-                                     cull_rect.right(), cull_rect.bottom());
-  FirstPassDispatcher collector(context, impeller::Matrix(), ip_cull_rect);
-  display_list->Dispatch(collector, ip_cull_rect);
+  FirstPassDispatcher collector(context, impeller::Matrix(), cull_rect);
+  display_list->Dispatch(collector, cull_rect);
 
   impeller::CanvasDlDispatcher impeller_dispatcher(
       context,                                   //
@@ -1307,7 +1305,7 @@ bool RenderToTarget(ContentContext& context,
       /*is_onscreen=*/is_onscreen,               //
       display_list->root_has_backdrop_filter(),  //
       display_list->max_root_blend_mode(),       //
-      IRect::RoundOut(ip_cull_rect)              //
+      IRect::RoundOut(cull_rect)                 //
   );
   const auto& [data, count] = collector.TakeBackdropData();
   impeller_dispatcher.SetBackdropData(data, count);
@@ -1319,7 +1317,7 @@ bool RenderToTarget(ContentContext& context,
     context.GetTextShadowCache().MarkFrameEnd();
   });
 
-  display_list->Dispatch(impeller_dispatcher, ip_cull_rect);
+  display_list->Dispatch(impeller_dispatcher, cull_rect);
   impeller_dispatcher.FinishRecording();
   context.GetLazyGlyphAtlas()->ResetTextFrames();
 

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.h
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.h
@@ -412,7 +412,7 @@ std::shared_ptr<Texture> DisplayListToTexture(
 /// submitted via Context::SubmitOnscreen.
 bool RenderToTarget(ContentContext& context, RenderTarget render_target,
                          const sk_sp<flutter::DisplayList>& display_list,
-                         SkIRect cull_rect,
+                         Rect cull_rect,
                          bool reset_host_buffer,
                          bool is_onscreen = true);
 

--- a/engine/src/flutter/impeller/display_list/dl_playground.cc
+++ b/engine/src/flutter/impeller/display_list/dl_playground.cc
@@ -44,10 +44,10 @@ bool DlPlayground::OpenPlaygroundHere(DisplayListPlaygroundCallback callback) {
             context.GetContentContext(),  //
             render_target,                //
             callback(),                   //
-            SkIRect::MakeWH(render_target.GetRenderTargetSize().width,
-                            render_target.GetRenderTargetSize().height),  //
-            /*reset_host_buffer=*/true,                                   //
-            /*is_onscreen=*/false                                         //
+            Rect::MakeWH(render_target.GetRenderTargetSize().width,
+                         render_target.GetRenderTargetSize().height),  //
+            /*reset_host_buffer=*/true,                                //
+            /*is_onscreen=*/false                                      //
         );
       });
 }
@@ -57,7 +57,7 @@ std::unique_ptr<testing::Screenshot> DlPlayground::MakeScreenshot(
   return nullptr;
 }
 
-SkFont DlPlayground::CreateTestFontOfSize(SkScalar scalar) {
+SkFont DlPlayground::CreateTestFontOfSize(Scalar scalar) {
   static constexpr const char* kTestFontFixture = "Roboto-Regular.ttf";
   auto mapping = flutter::testing::OpenFixtureAsSkData(kTestFontFixture);
   FML_CHECK(mapping);

--- a/engine/src/flutter/impeller/display_list/dl_playground.h
+++ b/engine/src/flutter/impeller/display_list/dl_playground.h
@@ -31,7 +31,7 @@ class DlPlayground : public PlaygroundTest {
   std::unique_ptr<testing::Screenshot> MakeScreenshot(
       const sk_sp<flutter::DisplayList>& list);
 
-  SkFont CreateTestFontOfSize(SkScalar scalar);
+  SkFont CreateTestFontOfSize(Scalar scalar);
 
   SkFont CreateTestFont();
 

--- a/engine/src/flutter/impeller/display_list/skia_conversions_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/skia_conversions_unittests.cc
@@ -10,8 +10,6 @@
 #include "impeller/display_list/skia_conversions.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/scalar.h"
-#include "include/core/SkMatrix.h"
-#include "include/core/SkRRect.h"
 
 namespace impeller {
 namespace testing {

--- a/engine/src/flutter/impeller/display_list/testing/render_text_in_canvas.h
+++ b/engine/src/flutter/impeller/display_list/testing/render_text_in_canvas.h
@@ -17,7 +17,7 @@ namespace testing {
 
 struct TextRenderOptions {
   bool stroke = false;
-  SkScalar font_size = 50;
+  DlScalar font_size = 50;
   DlColor color = DlColor::kYellow();
   std::shared_ptr<DlMaskFilter> mask_filter;
   bool is_subpixel = false;

--- a/engine/src/flutter/impeller/toolkit/interop/surface.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/surface.cc
@@ -32,12 +32,10 @@ bool Surface::DrawDisplayList(const DisplayList& dl) const {
   auto& content_context = context_->GetAiksContext().GetContentContext();
   auto render_target = surface_->GetRenderTarget();
 
-  const auto cull_rect = IRect::MakeSize(surface_->GetSize());
-  auto skia_cull_rect =
-      SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
+  const auto cull_rect = Rect::MakeSize(surface_->GetSize());
 
   auto result = RenderToTarget(content_context, render_target, display_list,
-                               skia_cull_rect, /*reset_host_buffer=*/true);
+                               cull_rect, /*reset_host_buffer=*/true);
   context_->GetContext()->ResetThreadLocalState();
   return result;
 }

--- a/engine/src/flutter/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_gl_impeller.cc
@@ -114,12 +114,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
       return false;
     }
 
-    auto cull_rect = render_target.GetRenderTargetSize();
-    SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.width, cull_rect.height);
+    auto cull_rect =
+        impeller::Rect::MakeSize(render_target.GetRenderTargetSize());
     return impeller::RenderToTarget(aiks_context->GetContentContext(),  //
                                     render_target,                      //
                                     display_list,                       //
-                                    sk_cull_rect,                       //
+                                    cull_rect,                          //
                                     /*reset_host_buffer=*/true          //
     );
     return true;

--- a/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller.mm
@@ -170,15 +170,14 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
           return true;
         }
 
-        impeller::IRect cull_rect = surface->coverage();
-        SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
+        impeller::Rect cull_rect = impeller::Rect::Make(surface->coverage());
         surface->SetFrameBoundary(surface_frame.submit_info().frame_boundary);
 
         const bool reset_host_buffer = surface_frame.submit_info().frame_boundary;
         auto render_result = impeller::RenderToTarget(aiks_context->GetContentContext(),       //
                                                       surface->GetRenderTarget(),              //
                                                       display_list,                            //
-                                                      sk_cull_rect,                            //
+                                                      cull_rect,                               //
                                                       /*reset_host_buffer=*/reset_host_buffer  //
         );
         if (!render_result) {
@@ -288,12 +287,11 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromMTLTextur
           return surface->Present();
         }
 
-        impeller::IRect cull_rect = surface->coverage();
-        SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
+        impeller::Rect cull_rect = impeller::Rect::Make(surface->coverage());
         auto render_result = impeller::RenderToTarget(aiks_context->GetContentContext(),  //
                                                       surface->GetRenderTarget(),         //
                                                       display_list,                       //
-                                                      sk_cull_rect,                       //
+                                                      cull_rect,                          //
                                                       /*reset_host_buffer=*/true          //
         );
         if (!render_result) {

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -97,7 +97,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     }
 
     impeller::RenderTarget render_target = surface->GetRenderTarget();
-    auto cull_rect = render_target.GetRenderTargetSize();
+    auto cull_rect =
+        impeller::Rect::MakeSize(render_target.GetRenderTargetSize());
 
     SurfaceFrame::EncodeCallback encode_callback = [aiks_context =
                                                         aiks_context_,  //
@@ -114,12 +115,11 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         return false;
       }
 
-      SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.width, cull_rect.height);
       return impeller::RenderToTarget(
           aiks_context->GetContentContext(),                                //
           render_target,                                                    //
           display_list,                                                     //
-          sk_cull_rect,                                                     //
+          cull_rect,                                                        //
           /*reset_host_buffer=*/surface_frame.submit_info().frame_boundary  //
       );
     };
@@ -195,7 +195,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     auto surface = impeller::SurfaceVK::WrapSwapchainImage(
         transients_, wrapped_onscreen, [&]() -> bool { return true; });
     impeller::RenderTarget render_target = surface->GetRenderTarget();
-    auto cull_rect = render_target.GetRenderTargetSize();
+    auto cull_rect =
+        impeller::Rect::MakeSize(render_target.GetRenderTargetSize());
 
     SurfaceFrame::EncodeCallback encode_callback = [aiks_context =
                                                         aiks_context_,  //
@@ -212,11 +213,10 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         return false;
       }
 
-      SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.width, cull_rect.height);
       return impeller::RenderToTarget(aiks_context->GetContentContext(),  //
                                       render_target,                      //
                                       display_list,                       //
-                                      sk_cull_rect,                       //
+                                      cull_rect,                          //
                                       /*reset_host_buffer=*/true          //
       );
     };

--- a/engine/src/flutter/shell/platform/embedder/embedder_external_view.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_view.cc
@@ -129,14 +129,12 @@ bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
     auto display_list = dl_builder.Build();
 
     auto cull_rect =
-        impeller::IRect::MakeSize(impeller_target->GetRenderTargetSize());
-    SkIRect sk_cull_rect =
-        SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
+        impeller::Rect::MakeSize(impeller_target->GetRenderTargetSize());
 
     return impeller::RenderToTarget(aiks_context->GetContentContext(),  //
                                     *impeller_target,                   //
                                     display_list,                       //
-                                    sk_cull_rect,                       //
+                                    cull_rect,                          //
                                     /*reset_host_buffer=*/true,         //
                                     /*is_onscreen=*/false               //
     );


### PR DESCRIPTION
Just a few remaining references to Skia types like SkScalar and SkSize/Rect. After this most of Impeller is Skia-free except for areas that deal with fonts, images, and the `toolkit/interop` and `typographer` directories.