### PR TITLE
Revert "[a11y] Semantics flag refactor step 2: embedder part"

### DIFF
--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.h
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.h
@@ -161,7 +161,7 @@ class AccessibilityBridge
   // See FlutterSemanticsNode in embedder.h
   typedef struct {
     int32_t id;
-    FlutterSemanticsFlags* flags;
+    FlutterSemanticsFlag flags;
     FlutterSemanticsAction actions;
     int32_t text_selection_base;
     int32_t text_selection_extent;

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -15,15 +15,13 @@ namespace testing {
 
 using ::testing::Contains;
 
-FlutterSemanticsFlags kEmptyFlags = FlutterSemanticsFlags{};
-
 FlutterSemanticsNode2 CreateSemanticsNode(
     int32_t id,
     const char* label,
     const std::vector<int32_t>* children = nullptr) {
   return {
       .id = id,
-      .flags__deprecated__ = static_cast<FlutterSemanticsFlag>(0),
+      .flags = static_cast<FlutterSemanticsFlag>(0),
       .actions = static_cast<FlutterSemanticsAction>(0),
       .text_selection_base = -1,
       .text_selection_extent = -1,
@@ -36,7 +34,6 @@ FlutterSemanticsNode2 CreateSemanticsNode(
       .children_in_traversal_order = children ? children->data() : nullptr,
       .custom_accessibility_actions_count = 0,
       .tooltip = "",
-      .flags2 = &kEmptyFlags,
   };
 }
 
@@ -212,12 +209,9 @@ TEST(AccessibilityBridgeTest, CanHandleSelectionChangeCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
-  auto flags = FlutterSemanticsFlags{
-      .is_text_field = true,
-      .is_focused = true,
-  };
-  root.flags2 = &flags;
-
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsFocused);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
@@ -247,12 +241,9 @@ TEST(AccessibilityBridgeTest, DoesNotAssignEditableRootToSelectableText) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
-  auto flags = FlutterSemanticsFlags{
-      .is_text_field = true,
-      .is_read_only = true,
-  };
-  root.flags2 = &flags;
-
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
@@ -266,14 +257,10 @@ TEST(AccessibilityBridgeTest, SwitchHasSwitchRole) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
-  auto flags = FlutterSemanticsFlags{
-
-      .has_enabled_state = true,
-      .is_enabled = true,
-      .has_toggled_state = true,
-  };
-
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasEnabledState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsEnabled);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
@@ -285,16 +272,11 @@ TEST(AccessibilityBridgeTest, SliderHasSliderRole) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
-  auto flags = FlutterSemanticsFlags{
-
-      .has_enabled_state = true,
-      .is_enabled = true,
-      .is_focusable = true,
-      .is_slider = true,
-  };
-
-  root.flags2 = &flags;
-
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsSlider |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasEnabledState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsEnabled |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsFocusable);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
@@ -311,13 +293,9 @@ TEST(AccessibilityBridgeTest, CanSetCheckboxChecked) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
-  auto flags = FlutterSemanticsFlags{
-
-      .has_checked_state = true,
-      .is_checked = true,
-  };
-
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 

--- a/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -19,17 +19,14 @@ TEST(FlutterPlatformNodeDelegateTest, NodeDelegateHasUniqueId) {
   // Add node 0: root.
   FlutterSemanticsNode2 node0{sizeof(FlutterSemanticsNode2), 0};
   std::vector<int32_t> node0_children{1};
-  FlutterSemanticsFlags emptyFlags = FlutterSemanticsFlags{};
   node0.child_count = node0_children.size();
   node0.children_in_traversal_order = node0_children.data();
   node0.children_in_hit_test_order = node0_children.data();
-  node0.flags2 = &emptyFlags;
 
   // Add node 1: text child of node 0.
   FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
   node1.label = "prefecture";
   node1.value = "Kyoto";
-  node1.flags2 = &emptyFlags;
 
   bridge->AddFlutterSemanticsNodeUpdate(node0);
   bridge->AddFlutterSemanticsNodeUpdate(node1);
@@ -45,9 +42,7 @@ TEST(FlutterPlatformNodeDelegateTest, canPerfomActions) {
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root;
   root.id = 0;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  flags.is_text_field = true;
-  root.flags2 = &flags;
+  root.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
@@ -92,9 +87,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetAXNode) {
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root;
   root.id = 0;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  flags.is_text_field = true;
-  root.flags2 = &flags;
+  root.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
@@ -117,7 +110,6 @@ TEST(FlutterPlatformNodeDelegateTest, canGetAXNode) {
 TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
@@ -127,7 +119,6 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   root.decreased_value = "";
   root.tooltip = "";
   root.child_count = 1;
-  root.flags2 = &flags;
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
@@ -144,7 +135,6 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   child1.decreased_value = "";
   child1.tooltip = "";
   child1.child_count = 0;
-  child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;
   child1.rect = {0, 0, 50, 50};  // LTRB
   child1.transform = {0.5, 0, 0, 0, 0.5, 0, 0, 0, 1};
@@ -166,7 +156,6 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
 TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
@@ -176,7 +165,6 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   root.decreased_value = "";
   root.tooltip = "";
   root.child_count = 1;
-  root.flags2 = &flags;
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
@@ -193,7 +181,6 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   child1.decreased_value = "";
   child1.tooltip = "";
   child1.child_count = 0;
-  child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;
   child1.rect = {90, 90, 100, 100};  // LTRB
   child1.transform = {2, 0, 0, 0, 2, 0, 0, 0, 1};
@@ -215,7 +202,6 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
 TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
@@ -225,7 +211,6 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   root.decreased_value = "";
   root.tooltip = "";
   root.child_count = 1;
-  root.flags2 = &flags;
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
@@ -242,7 +227,6 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   child1.decreased_value = "";
   child1.tooltip = "";
   child1.child_count = 0;
-  child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;
   child1.rect = {0, 0, 50, 50};  // LTRB
   child1.transform = {0.5, 0, 0, 0, 0.5, 0, 0, 0, 1};
@@ -265,7 +249,6 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
 TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
@@ -275,7 +258,6 @@ TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
   root.decreased_value = "";
   root.tooltip = "";
   root.child_count = 0;
-  root.flags2 = &flags;
   root.children_in_traversal_order = nullptr;
   root.custom_accessibility_actions_count = 0;
   bridge->AddFlutterSemanticsNodeUpdate(root);
@@ -289,7 +271,6 @@ TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
 TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
@@ -299,7 +280,6 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   root.decreased_value = "";
   root.tooltip = "";
   root.child_count = 1;
-  root.flags2 = &flags;
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
@@ -314,7 +294,6 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   child1.decreased_value = "";
   child1.tooltip = "";
   child1.child_count = 0;
-  child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;
   bridge->AddFlutterSemanticsNodeUpdate(child1);
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -99,9 +99,8 @@ TEST_F(AccessibilityBridgeMacWindowTest, SendsAccessibilityCreateNotificationFlu
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
@@ -158,10 +157,9 @@ TEST_F(AccessibilityBridgeMacWindowTest, NonZeroRootNodeId) {
       viewController.accessibilityBridge.lock());
 
   FlutterSemanticsNode2 node1;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   std::vector<int32_t> node1_children{2};
   node1.id = 1;
-  node1.flags2 = &flags;
+  node1.flags = static_cast<FlutterSemanticsFlag>(0);
   node1.actions = static_cast<FlutterSemanticsAction>(0);
   node1.text_selection_base = -1;
   node1.text_selection_extent = -1;
@@ -178,7 +176,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, NonZeroRootNodeId) {
 
   FlutterSemanticsNode2 node2;
   node2.id = 2;
-  node2.flags2 = &flags;
+  node2.flags = static_cast<FlutterSemanticsFlag>(0);
   node2.actions = static_cast<FlutterSemanticsAction>(0);
   node2.text_selection_base = -1;
   node2.text_selection_extent = -1;
@@ -222,9 +220,8 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
@@ -269,9 +266,8 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -319,10 +319,8 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   EXPECT_TRUE(enabled_called);
   // Send flutter semantics updates.
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{0};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
@@ -339,7 +337,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
-  child1.flags2 = &child_flags;
+  child1.flags = static_cast<FlutterSemanticsFlag>(0);
   child1.actions = static_cast<FlutterSemanticsAction>(0);
   child1.text_selection_base = -1;
   child1.text_selection_extent = -1;
@@ -411,10 +409,8 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
   EXPECT_TRUE(enabled_called);
   // Send flutter semantics updates.
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{0};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
@@ -431,7 +427,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
-  child1.flags2 = &child_flags;
+  child1.flags = static_cast<FlutterSemanticsFlag>(0);
   child1.actions = static_cast<FlutterSemanticsAction>(0);
   child1.text_selection_base = -1;
   child1.text_selection_extent = -1;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -36,9 +36,9 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
+  ;
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
@@ -72,9 +72,10 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{.is_text_field = true, .is_read_only = true};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags =
+      static_cast<FlutterSemanticsFlag>(FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
+                                        FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = 1;
   root.text_selection_extent = 3;
@@ -113,9 +114,10 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{.is_text_field = true, .is_read_only = true};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags =
+      static_cast<FlutterSemanticsFlag>(FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
+                                        FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
@@ -159,8 +161,6 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{};
-  root.flags2 = &flags;
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -175,8 +175,6 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode2 child1;
-  FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{};
-  child1.flags2 = &child_flags;
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";
@@ -238,10 +236,8 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode2 root;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{.is_text_field = true};
   root.id = 0;
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.label = "root";
   root.hint = "";
@@ -262,7 +258,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
-  child1.flags2 = &child_flags;
+  child1.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
   child1.actions = static_cast<FlutterSemanticsAction>(0);
   child1.label = "";
   child1.hint = "";
@@ -317,8 +313,7 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   // Initialize ax node data.
   FlutterSemanticsNode2 root;
   root.id = 0;
-  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.label = "root";
   root.hint = "";
@@ -338,9 +333,8 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   double transformFactor = 0.5;
 
   FlutterSemanticsNode2 child1;
-  FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{0};
-  child1.flags2 = &child_flags;
   child1.id = 1;
+  child1.flags = static_cast<FlutterSemanticsFlag>(0);
   child1.actions = static_cast<FlutterSemanticsAction>(0);
   child1.label = "";
   child1.hint = "";
@@ -364,17 +358,14 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   EXPECT_TRUE([[native_accessibility className] isEqualToString:@"AXPlatformNodeCocoa"]);
 
   // Converting child to text field should produce `FlutterTextField` native view accessible.
-
-  FlutterSemanticsFlags child_flags_updated_1 = FlutterSemanticsFlags{.is_text_field = true};
-  child1.flags2 = &child_flags_updated_1;
+  child1.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
   bridge->AddFlutterSemanticsNodeUpdate(child1);
   bridge->CommitUpdates();
 
   native_accessibility = child_platform_node_delegate->GetNativeViewAccessible();
   EXPECT_TRUE([native_accessibility isKindOfClass:[FlutterTextField class]]);
 
-  FlutterSemanticsFlags child_flags_updated_2 = FlutterSemanticsFlags{.is_text_field = false};
-  child1.flags2 = &child_flags_updated_2;
+  child1.flags = static_cast<FlutterSemanticsFlag>(0);
   bridge->AddFlutterSemanticsNodeUpdate(child1);
   bridge->CommitUpdates();
 

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -174,10 +174,6 @@ typedef enum {
 /// The set of properties that may be associated with a semantics node.
 ///
 /// Must match the `SemanticsFlag` enum in semantics.dart.
-///
-/// @deprecated     Use `FlutterSemanticsFlags` instead. No new flags will
-///                 be added to `FlutterSemanticsFlag`. New flags will
-///                 continue to be added to `FlutterSemanticsFlags`.
 typedef enum {
   /// The semantics node has the quality of either being "checked" or
   /// "unchecked".
@@ -263,94 +259,6 @@ typedef enum {
   /// Only applicable when kFlutterSemanticsFlagHasRequiredState flag is on.
   kFlutterSemanticsFlagIsRequired = 1 << 30,
 } FlutterSemanticsFlag;
-
-typedef struct {
-  /// The size of this struct. Must be sizeof(FlutterSemanticsFlags).
-  size_t struct_size;
-  /// The semantics node has the quality of either being "checked" or
-  /// "unchecked".
-  bool has_checked_state;
-  /// Whether a semantics node is checked.
-  bool is_checked;
-  /// Whether a semantics node is selected.
-  bool is_selected;
-  /// Whether the semantic node represents a button.
-  bool is_button;
-  /// Whether the semantic node represents a text field.
-  bool is_text_field;
-  /// Whether the semantic node currently holds the user's focus.
-  bool is_focused;
-  /// The semantics node has the quality of either being "enabled" or
-  /// "disabled".
-  bool has_enabled_state;
-  /// Whether a semantic node that hasEnabledState is currently enabled.
-  bool is_enabled;
-  /// Whether a semantic node is in a mutually exclusive group.
-  bool is_in_mutually_exclusive_group;
-  /// Whether a semantic node is a header that divides content into sections.
-  bool is_header;
-  /// Whether the value of the semantics node is obscured.
-  bool is_obscured;
-  /// Whether the semantics node is the root of a subtree for which a route name
-  /// should be announced.
-  bool scopes_route;
-  /// Whether the semantics node label is the name of a visually distinct route.
-  bool names_route;
-  /// Whether the semantics node is considered hidden.
-  bool is_hidden;
-  /// Whether the semantics node represents an image.
-  bool is_image;
-  /// Whether the semantics node is a live region.
-  bool is_live_region;
-  /// The semantics node has the quality of either being "on" or "off".
-  bool has_toggled_state;
-  /// If true, the semantics node is "on". If false, the semantics node is
-  /// "off".
-  bool is_toggled;
-  /// Whether the platform can scroll the semantics node when the user attempts
-  /// to move the accessibility focus to an offscreen child.
-  ///
-  /// For example, a `ListView` widget has implicit scrolling so that users can
-  /// easily move the accessibility focus to the next set of children. A
-  /// `PageView` widget does not have implicit scrolling, so that users don't
-  /// navigate to the next page when reaching the end of the current one.
-  bool has_implicit_scrolling;
-  /// Whether the value of the semantics node is coming from a multi-line text
-  /// field.
-  ///
-  /// This is used for text fields to distinguish single-line text fields from
-  /// multi-line ones.
-  bool is_multiline;
-  /// Whether the semantic node is read only.
-  ///
-  /// Only applicable when kFlutterSemanticsFlagIsTextField flag is on.
-  bool is_read_only;
-  /// Whether the semantic node can hold the user's focus.
-  bool is_focusable;
-  /// Whether the semantics node represents a link.
-  bool is_link;
-  /// Whether the semantics node represents a slider.
-  bool is_slider;
-  /// Whether the semantics node represents a keyboard key.
-  bool is_keyboard_key;
-  /// Whether the semantics node represents a tristate checkbox in mixed state.
-  bool is_check_state_mixed;
-  /// The semantics node has the quality of either being "expanded" or
-  /// "collapsed".
-  bool has_expanded_state;
-  /// Whether a semantic node that hasExpandedState is currently expanded.
-  bool is_expanded;
-  /// The semantics node has the quality of either being "selected" or
-  /// "not selected".
-  bool has_selected_state;
-  /// Whether a semantics node has the quality of being required.
-  bool has_required_state;
-  /// Whether user input is required on the semantics node before a form can be
-  /// submitted.
-  ///
-  /// Only applicable when kFlutterSemanticsFlagHasRequiredState flag is on.
-  bool is_required;
-} FlutterSemanticsFlags;
 
 typedef enum {
   /// Text has unknown text direction.
@@ -1604,11 +1512,7 @@ typedef struct {
   /// The unique identifier for this node.
   int32_t id;
   /// The set of semantics flags associated with this node.
-  ///
-  /// @deprecated     Use `flags2` instead. No new flags will
-  ///                 be added to `FlutterSemanticsFlag`. New flags will
-  ///                 continue to be added to `FlutterSemanticsFlags`.
-  FlutterSemanticsFlag flags__deprecated__;
+  FlutterSemanticsFlag flags;
   /// The set of semantics actions applicable to this node.
   FlutterSemanticsAction actions;
   /// The position at which the text selection originates.
@@ -1692,9 +1596,6 @@ typedef struct {
   // Array of string attributes associated with the `decreased_value`.
   // Has length `decreased_value_attribute_count`.
   const FlutterStringAttribute** decreased_value_attributes;
-  // The set of semantics flags associated with this node. Prefer to use this
-  // over `flags__deprecated__`.
-  FlutterSemanticsFlags* flags2;
 } FlutterSemanticsNode2;
 
 /// `FlutterSemanticsCustomAction` ID used as a sentinel to signal the end of a

--- a/engine/src/flutter/shell/platform/embedder/embedder_semantics_update.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_semantics_update.cc
@@ -4,45 +4,6 @@
 
 #include "flutter/shell/platform/embedder/embedder_semantics_update.h"
 
-namespace {
-std::unique_ptr<FlutterSemanticsFlags> ConvertToFlutterSemanticsFlags(
-    const flutter::SemanticsFlags& source) {
-  return std::make_unique<FlutterSemanticsFlags>(FlutterSemanticsFlags{
-      .has_checked_state = source.hasCheckedState,
-      .is_checked = source.isChecked,
-      .is_selected = source.isSelected,
-      .is_button = source.isButton,
-      .is_text_field = source.isTextField,
-      .is_focused = source.isFocused,
-      .has_enabled_state = source.hasEnabledState,
-      .is_enabled = source.isEnabled,
-      .is_in_mutually_exclusive_group = source.isInMutuallyExclusiveGroup,
-      .is_header = source.isHeader,
-      .is_obscured = source.isObscured,
-      .scopes_route = source.scopesRoute,
-      .names_route = source.namesRoute,
-      .is_hidden = source.isHidden,
-      .is_image = source.isImage,
-      .is_live_region = source.isLiveRegion,
-      .has_toggled_state = source.hasToggledState,
-      .is_toggled = source.isToggled,
-      .has_implicit_scrolling = source.hasImplicitScrolling,
-      .is_multiline = source.isMultiline,
-      .is_read_only = source.isReadOnly,
-      .is_focusable = source.isFocusable,
-      .is_link = source.isLink,
-      .is_slider = source.isSlider,
-      .is_keyboard_key = source.isKeyboardKey,
-      .is_check_state_mixed = source.isCheckStateMixed,
-      .has_expanded_state = source.hasExpandedState,
-      .is_expanded = source.isExpanded,
-      .has_selected_state = source.hasSelectedState,
-      .has_required_state = source.hasRequiredState,
-      .is_required = source.isRequired,
-  });
-}
-}  // namespace
-
 namespace flutter {
 
 EmbedderSemanticsUpdate::EmbedderSemanticsUpdate(
@@ -65,9 +26,6 @@ EmbedderSemanticsUpdate::EmbedderSemanticsUpdate(
   };
 }
 
-// This function is for backward compatibility and contains only a subset of
-// the flags. New flags will be added only to `FlutterSemanticsFlags`, not
-// `FlutterSemanticsFlag`.
 FlutterSemanticsFlag SemanticsFlagsToInt(const SemanticsFlags& flags) {
   int result = 0;
 
@@ -234,7 +192,6 @@ EmbedderSemanticsUpdate2::EmbedderSemanticsUpdate2(
     const SemanticsNodeUpdates& nodes,
     const CustomAccessibilityActionUpdates& actions) {
   nodes_.reserve(nodes.size());
-  flags_.reserve(nodes.size());
   node_pointers_.reserve(nodes.size());
   actions_.reserve(actions.size());
   action_pointers_.reserve(actions.size());
@@ -281,7 +238,6 @@ void EmbedderSemanticsUpdate2::AddNode(const SemanticsNode& node) {
       CreateStringAttributes(node.increasedValueAttributes);
   auto decreased_value_attributes =
       CreateStringAttributes(node.decreasedValueAttributes);
-  flags_.emplace_back(ConvertToFlutterSemanticsFlags(node.flags));
 
   nodes_.push_back({
       sizeof(FlutterSemanticsNode2),
@@ -323,7 +279,6 @@ void EmbedderSemanticsUpdate2::AddNode(const SemanticsNode& node) {
       increased_value_attributes.attributes,
       decreased_value_attributes.count,
       decreased_value_attributes.attributes,
-      flags_.back().get(),
   });
 }
 

--- a/engine/src/flutter/shell/platform/embedder/embedder_semantics_update.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_semantics_update.h
@@ -67,7 +67,6 @@ class EmbedderSemanticsUpdate2 {
   std::vector<FlutterSemanticsNode2*> node_pointers_;
   std::vector<FlutterSemanticsCustomAction2> actions_;
   std::vector<FlutterSemanticsCustomAction2*> action_pointers_;
-  std::vector<std::unique_ptr<FlutterSemanticsFlags>> flags_;
 
   std::vector<std::unique_ptr<std::vector<const FlutterStringAttribute*>>>
       node_string_attributes_;

--- a/engine/src/flutter/shell/platform/linux/fl_view_accessible.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_accessible.cc
@@ -33,7 +33,7 @@ static FlAccessibleNode* create_node(FlViewAccessible* self,
     return nullptr;
   }
 
-  if (semantics->flags__deprecated__ & kFlutterSemanticsFlagIsTextField) {
+  if (semantics->flags & kFlutterSemanticsFlagIsTextField) {
     return fl_accessible_text_field_new(engine, self->view_id, semantics->id);
   }
 
@@ -152,7 +152,7 @@ void fl_view_accessible_handle_update_semantics(
     FlutterSemanticsNode2* node = update->nodes[i];
     FlAccessibleNode* atk_node = get_node(self, node);
 
-    fl_accessible_node_set_flags(atk_node, node->flags__deprecated__);
+    fl_accessible_node_set_flags(atk_node, node->flags);
     fl_accessible_node_set_actions(atk_node, node->actions);
     fl_accessible_node_set_name(atk_node, node->label);
     fl_accessible_node_set_extents(

--- a/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -140,18 +140,15 @@ std::unique_ptr<FlutterWindowsEngine> GetTestEngine() {
 void PopulateAXTree(std::shared_ptr<AccessibilityBridge> bridge) {
   // Add node 0: root.
   FlutterSemanticsNode2 node0{sizeof(FlutterSemanticsNode2), 0};
-  auto empty_flags = FlutterSemanticsFlags{};
   std::vector<int32_t> node0_children{1, 2};
   node0.child_count = node0_children.size();
   node0.children_in_traversal_order = node0_children.data();
   node0.children_in_hit_test_order = node0_children.data();
-  node0.flags2 = &empty_flags;
 
   // Add node 1: text child of node 0.
   FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
   node1.label = "prefecture";
   node1.value = "Kyoto";
-  node1.flags2 = &empty_flags;
 
   // Add node 2: subtree child of node 0.
   FlutterSemanticsNode2 node2{sizeof(FlutterSemanticsNode2), 2};
@@ -159,17 +156,14 @@ void PopulateAXTree(std::shared_ptr<AccessibilityBridge> bridge) {
   node2.child_count = node2_children.size();
   node2.children_in_traversal_order = node2_children.data();
   node2.children_in_hit_test_order = node2_children.data();
-  node2.flags2 = &empty_flags;
 
   // Add node 3: text child of node 2.
   FlutterSemanticsNode2 node3{sizeof(FlutterSemanticsNode2), 3};
   node3.label = "city";
   node3.value = "Uji";
-  node3.flags2 = &empty_flags;
 
   // Add node 4: text child (with no text) of node 2.
   FlutterSemanticsNode2 node4{sizeof(FlutterSemanticsNode2), 4};
-  node4.flags2 = &empty_flags;
 
   bridge->AddFlutterSemanticsNodeUpdate(node0);
   bridge->AddFlutterSemanticsNodeUpdate(node1);

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -162,12 +162,9 @@ TEST(FlutterWindowsViewTest, SubMenuExpandedState) {
   root.decreased_value = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  auto flags = FlutterSemanticsFlags{
-      .has_expanded_state = true,
-      .is_expanded = true,
-  };
-  root.flags2 = &flags;
-
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsExpanded);
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -203,11 +200,8 @@ TEST(FlutterWindowsViewTest, SubMenuExpandedState) {
   }
 
   // Test collapsed too.
-  auto updated_flags = FlutterSemanticsFlags{
-      .has_expanded_state = true,
-  };
-  root.flags2 = &updated_flags;
-
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
@@ -387,8 +381,6 @@ TEST(FlutterWindowsViewTest, AddSemanticsNodeUpdate) {
   node.label = "name";
   node.value = "value";
   node.platform_view_id = -1;
-  auto flags = FlutterSemanticsFlags{};
-  node.flags2 = &flags;
   bridge->AddFlutterSemanticsNodeUpdate(node);
   bridge->CommitUpdates();
 
@@ -487,23 +479,18 @@ TEST(FlutterWindowsViewTest, AddSemanticsNodeUpdateWithChildren) {
   node0.child_count = node0_children.size();
   node0.children_in_traversal_order = node0_children.data();
   node0.children_in_hit_test_order = node0_children.data();
-  auto empty_flags = FlutterSemanticsFlags{};
-  node0.flags2 = &empty_flags;
 
   FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
   node1.label = "prefecture";
   node1.value = "Kyoto";
-  node1.flags2 = &empty_flags;
   FlutterSemanticsNode2 node2{sizeof(FlutterSemanticsNode2), 2};
   std::vector<int32_t> node2_children{3};
   node2.child_count = node2_children.size();
   node2.children_in_traversal_order = node2_children.data();
   node2.children_in_hit_test_order = node2_children.data();
-  node2.flags2 = &empty_flags;
   FlutterSemanticsNode2 node3{sizeof(FlutterSemanticsNode2), 3};
   node3.label = "city";
   node3.value = "Uji";
-  node3.flags2 = &empty_flags;
 
   bridge->AddFlutterSemanticsNodeUpdate(node0);
   bridge->AddFlutterSemanticsNodeUpdate(node1);
@@ -688,13 +675,11 @@ TEST(FlutterWindowsViewTest, NonZeroSemanticsRoot) {
   node1.child_count = node1_children.size();
   node1.children_in_traversal_order = node1_children.data();
   node1.children_in_hit_test_order = node1_children.data();
-  auto empty_flags = FlutterSemanticsFlags{};
-  node1.flags2 = &empty_flags;
 
   FlutterSemanticsNode2 node2{sizeof(FlutterSemanticsNode2), 2};
   node2.label = "prefecture";
   node2.value = "Kyoto";
-  node2.flags2 = &empty_flags;
+
   bridge->AddFlutterSemanticsNodeUpdate(node1);
   bridge->AddFlutterSemanticsNodeUpdate(node2);
   bridge->CommitUpdates();
@@ -816,14 +801,12 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
 
   // Add root node at origin. Size 500x500.
   FlutterSemanticsNode2 node0{sizeof(FlutterSemanticsNode2), 0};
-  auto empty_flags = FlutterSemanticsFlags{};
   std::vector<int32_t> node0_children{1, 2};
   node0.rect = {0, 0, 500, 500};
   node0.transform = kIdentityTransform;
   node0.child_count = node0_children.size();
   node0.children_in_traversal_order = node0_children.data();
   node0.children_in_hit_test_order = node0_children.data();
-  node0.flags2 = &empty_flags;
 
   // Add node 1 located at 0,0 relative to node 0. Size 250x500.
   FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
@@ -831,7 +814,6 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   node1.transform = kIdentityTransform;
   node1.label = "prefecture";
   node1.value = "Kyoto";
-  node1.flags2 = &empty_flags;
 
   // Add node 2 located at 250,0 relative to node 0. Size 250x500.
   FlutterSemanticsNode2 node2{sizeof(FlutterSemanticsNode2), 2};
@@ -841,7 +823,6 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   node2.child_count = node2_children.size();
   node2.children_in_traversal_order = node2_children.data();
   node2.children_in_hit_test_order = node2_children.data();
-  node2.flags2 = &empty_flags;
 
   // Add node 3 located at 0,250 relative to node 2. Size 250, 250.
   FlutterSemanticsNode2 node3{sizeof(FlutterSemanticsNode2), 3};
@@ -849,7 +830,6 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   node3.transform = {1, 0, 0, 0, 1, 250, 0, 0, 1};
   node3.label = "city";
   node3.value = "Uji";
-  node3.flags2 = &empty_flags;
 
   bridge->AddFlutterSemanticsNodeUpdate(node0);
   bridge->AddFlutterSemanticsNodeUpdate(node1);
@@ -1176,11 +1156,9 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   root.decreased_value = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  auto flags = FlutterSemanticsFlags{
-      .has_checked_state = true,
-      .is_checked = true,
-  };
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked);
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -1218,10 +1196,8 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   }
 
   // Test unchecked too.
-  auto updated_flags = FlutterSemanticsFlags{
-      .has_checked_state = true,
-  };
-  root.flags2 = &updated_flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
@@ -1258,11 +1234,9 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   }
 
   // Now check mixed state.
-  auto updated_mixe_flags = FlutterSemanticsFlags{
-      .has_checked_state = true,
-      .is_check_state_mixed = true,
-  };
-  root.flags2 = &updated_mixe_flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsCheckStateMixed);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
@@ -1326,12 +1300,9 @@ TEST(FlutterWindowsViewTest, SwitchNativeState) {
   root.decreased_value = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-
-  auto flags = FlutterSemanticsFlags{
-      .has_toggled_state = true,
-      .is_toggled = true,
-  };
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsToggled);
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
@@ -1380,11 +1351,8 @@ TEST(FlutterWindowsViewTest, SwitchNativeState) {
   }
 
   // Test unpressed too.
-  auto updated_flags = FlutterSemanticsFlags{
-      .has_toggled_state = true,
-  };
-  root.flags2 = &updated_flags;
-
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState);
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
@@ -1450,10 +1418,8 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
   root.tooltip = "tooltip";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  auto flags = FlutterSemanticsFlags{
-      .is_text_field = true,
-  };
-  root.flags2 = &flags;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField);
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();


### PR DESCRIPTION
Reverts flutter/flutter#167738

Reason: I want to make more changes on embedder so some semantics flags will be tristate.  To avoid introducing breaking changes, revert the former PR