### PR TITLE
Enable support for dynamic view resizing

### DIFF
--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -1869,6 +1869,7 @@ class _ViewConfiguration {
     this.gestureSettings = const GestureSettings(),
     this.displayFeatures = const <DisplayFeature>[],
     this.displayId = 0,
+    // TODO: is this where we add the ViewConstraints?
   });
 
   /// The identifier for a display for this view, in

--- a/engine/src/flutter/lib/ui/window.dart
+++ b/engine/src/flutter/lib/ui/window.dart
@@ -166,7 +166,8 @@ class FlutterView {
   ///  * [physicalSize], which returns the current size of the view.
   // TODO(goderbauer): Wire this up so embedders can configure it. This will
   //   also require to message the size provided to the render call back to the
-  //   embedder.
+  //   embedder. Change this from ViewConstraints.tight to a lookup of the
+  //   stored view constraints on the FlutterView object.
   ViewConstraints get physicalConstraints => ViewConstraints.tight(physicalSize);
 
   /// The current dimensions of the rectangle as last reported by the platform

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -90,6 +90,9 @@ void PlatformConfiguration::DidCreateIsolate() {
 
 bool PlatformConfiguration::AddView(int64_t view_id,
                                     const ViewportMetrics& view_metrics) {
+  // TODO: This is calling "_addView" in hooks.dart with a bunch of params.
+  // _addView instantiates a new FlutterView via the FlutterView._()
+  // constructor. We need to pass the physicalConstraints view constraints.
   auto [view_iterator, insertion_happened] =
       metrics_.emplace(view_id, view_metrics);
   if (!insertion_happened) {

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -135,6 +135,8 @@ bool RuntimeController::FlushRuntimeStateToIsolate() {
 
   for (auto const& [view_id, viewport_metrics] :
        platform_data_.viewport_metrics_for_views) {
+    // TODO: this is a breadcrumb in the AddView call chain. Probably need to
+    // cache the physical constraints per view in the map.
     bool added = platform_configuration->AddView(view_id, viewport_metrics);
 
     // Callbacks will have been already invoked if the engine was restarted.
@@ -163,6 +165,8 @@ bool RuntimeController::FlushRuntimeStateToIsolate() {
 void RuntimeController::AddView(int64_t view_id,
                                 const ViewportMetrics& view_metrics,
                                 AddViewCallback callback) {
+  // TODO: this is a breadcrumb in the AddView call chain.
+
   // If the Dart isolate is not running, |FlushRuntimeStateToIsolate| will
   // add the view and invoke the callback when the isolate is started.
   auto* platform_configuration = GetPlatformConfigurationIfAvailable();

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -330,6 +330,7 @@ tonic::DartErrorHandleType Engine::GetUIIsolateLastError() {
 void Engine::AddView(int64_t view_id,
                      const ViewportMetrics& view_metrics,
                      std::function<void(bool added)> callback) {
+  // TODO: this is a breadcrumb in the AddView call chain.
   runtime_controller_->AddView(view_id, view_metrics, std::move(callback));
 }
 

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -90,6 +90,7 @@ void PlatformView::ScheduleFrame() {
 void PlatformView::AddView(int64_t view_id,
                            const ViewportMetrics& viewport_metrics,
                            AddViewCallback callback) {
+  // TODO: This is a breadcrumb in the AddView call chain.
   delegate_.OnPlatformViewAddView(view_id, viewport_metrics,
                                   std::move(callback));
 }

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -823,6 +823,8 @@ bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
   weak_platform_view_ = platform_view_->GetWeakPtr();
 
   // Add the implicit view with empty metrics.
+  // TODO: This is a breadcrumb in the AddView call chain. Default to tight
+  // constraints if we need to provide a default.
   engine_->AddView(kFlutterImplicitViewId, ViewportMetrics{}, [](bool added) {
     FML_DCHECK(added) << "Failed to add the implicit view";
   });
@@ -2117,6 +2119,7 @@ bool Shell::OnServiceProtocolReloadAssetFonts(
 void Shell::OnPlatformViewAddView(int64_t view_id,
                                   const ViewportMetrics& viewport_metrics,
                                   AddViewCallback callback) {
+  // TODO: This is a breadcrumb in the AddView call chain.
   TRACE_EVENT0("flutter", "Shell::AddView");
   FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());


### PR DESCRIPTION
Warning -- OUT-OF-DATE PR DESCRIPTION. This WIP patch replaces the previous resize patch.

This enables support for dynamic view resizing in non-web embedders. While this patch enables support and exposes API for dynamic view resizing in non-web embedders and in the embedder API, it does not *implement* support in any embedder.

This feature is restricted to embedders with merged UI and platform thread due to the need to inform the embedder of the updated view size synchronously with presenting the content. With some effort, we could implement synchronisation logic that supports non-thread-merged embedders. See ResizeSynchronizer in the macOS embedder for details of what's involved.

When Flutter applications call `FlutterView.render` with a non-null `size` parameter, the size will be compared to the existing view size (if any), and if different, a call to `PlatformView::ResizeView` will be triggered. Embedders can respond to this call by resizing the underlying platform-specific FlutterView to the appropriate size.

Extracts a resize_view_callback to the embedder API that custom embedders can register to receive the updated size from the engine, and adapt their views accordingly.

Related patches:
* `dart:ui`: https://github.com/flutter/engine/pull/48090
* framework: https://github.com/flutter/flutter/pull/138648
* framework reland: https://github.com/flutter/flutter/pull/140918
* Web: https://github.com/flutter/engine/pull/50271

Issue: https://github.com/flutter/flutter/issues/169147
Issue: https://github.com/flutter/flutter/issues/149033

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
