### PR TITLE
[Impeller] eliminate PathReceiver::PathEnd which is only used in one case

### DIFF
--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
@@ -19,19 +19,23 @@ namespace testing {
 
 class DlPathVerbCounter : public DlPathReceiver {
  public:
-  void MoveTo(const DlPoint& p2, bool will_be_closed) { verb_count_++; }
-  void LineTo(const DlPoint& p2) { verb_count_++; }
-  void QuadTo(const DlPoint& cp, const DlPoint& p2) { verb_count_++; }
-  bool ConicTo(const DlPoint& cp, const DlPoint& p2, DlScalar weight) {
+  void MoveTo(const DlPoint& p2, bool will_be_closed) override {
+    verb_count_++;
+  }
+  void LineTo(const DlPoint& p2) override { verb_count_++; }
+  void QuadTo(const DlPoint& cp, const DlPoint& p2) override { verb_count_++; }
+  bool ConicTo(const DlPoint& cp, const DlPoint& p2, DlScalar weight) override {
     verb_count_++;
     return false;
   }
-  void CubicTo(const DlPoint& cp1, const DlPoint& cp2, const DlPoint& p2) {
+  void CubicTo(const DlPoint& cp1,
+               const DlPoint& cp2,
+               const DlPoint& p2) override {
     verb_count_++;
   }
-  void Close() { verb_count_++; }
+  void Close() override { verb_count_++; }
 
-  uint32_t GetVerbCount() { return verb_count_; }
+  uint32_t GetVerbCount() const { return verb_count_; }
 
  private:
   uint32_t verb_count_ = 0u;

--- a/engine/src/flutter/display_list/benchmarking/dl_complexity_helper.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_complexity_helper.cc
@@ -13,18 +13,21 @@ using DlScalar = flutter::DlScalar;
 
 class DlComplexityPathReceiver : public flutter::DlPathReceiver {
  public:
-  void MoveTo(const DlPoint& p2, bool will_be_closed) {}
-  void LineTo(const DlPoint& p2) { line_verb_count++; }
-  void QuadTo(const DlPoint& cp, const DlPoint& p2) { quad_verb_count++; }
-  bool ConicTo(const DlPoint& cp, const DlPoint& p2, DlScalar weight) {
+  void MoveTo(const DlPoint& p2, bool will_be_closed) override {}
+  void LineTo(const DlPoint& p2) override { line_verb_count++; }
+  void QuadTo(const DlPoint& cp, const DlPoint& p2) override {
+    quad_verb_count++;
+  }
+  bool ConicTo(const DlPoint& cp, const DlPoint& p2, DlScalar weight) override {
     conic_verb_count++;
     return true;
   }
-  void CubicTo(const DlPoint& cp1, const DlPoint& cp2, const DlPoint& p2) {
+  void CubicTo(const DlPoint& cp1,
+               const DlPoint& cp2,
+               const DlPoint& p2) override {
     cubic_verb_count++;
   }
-  void Close() {}
-  void PathEnd() {}
+  void Close() override {}
 
   uint32_t line_verb_count;
   uint32_t quad_verb_count;

--- a/engine/src/flutter/display_list/geometry/dl_path.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path.cc
@@ -120,7 +120,6 @@ const SkPath& DlPath::GetSkPath() const {
 void DlPath::Dispatch(DlPathReceiver& receiver) const {
   const SkPath& path = data_->sk_path;
   if (path.isEmpty()) {
-    receiver.PathEnd();
     return;
   }
 
@@ -170,7 +169,6 @@ void DlPath::Dispatch(DlPathReceiver& receiver) const {
         break;
     }
   } while (verb != SkPath::Verb::kDone_Verb);
-  receiver.PathEnd();
 }
 
 void DlPath::WillRenderSkPath() const {

--- a/engine/src/flutter/display_list/geometry/dl_path_builder_unittests.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path_builder_unittests.cc
@@ -88,7 +88,6 @@ TEST(DisplayListPathBuilder, LineToInsertsMoveTo) {
 
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(0, 0), false));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 10)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -106,7 +105,6 @@ TEST(DisplayListPathBuilder, QuadToInsertsMoveTo) {
 
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(0, 0), false));
     EXPECT_CALL(mock_receiver, QuadTo(DlPoint(10, 10), DlPoint(10, 0)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -125,7 +123,6 @@ TEST(DisplayListPathBuilder, ConicToInsertsMoveTo) {
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(0, 0), false));
     EXPECT_CALL(mock_receiver, ConicTo(DlPoint(10, 10), DlPoint(10, 0), 0.5f))
         .WillOnce(Return(true));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -144,7 +141,6 @@ TEST(DisplayListPathBuilder, CubicToInsertsMoveTo) {
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(0, 0), false));
     EXPECT_CALL(mock_receiver,
                 CubicTo(DlPoint(10, 10), DlPoint(10, 0), DlPoint(0, 10)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -168,7 +164,6 @@ TEST(DisplayListPathBuilder, ConicWithNonPositiveWeightsInsertLineTo) {
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 20)));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 30)));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 40)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -187,7 +182,6 @@ TEST(DisplayListPathBuilder, ConicWithWeight1InsertsQuadTo) {
 
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(10, 10), false));
     EXPECT_CALL(mock_receiver, QuadTo(DlPoint(20, 10), DlPoint(10, 20)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -209,7 +203,6 @@ TEST(DisplayListPathBuilder, AddRect) {
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 20)));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 10)));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -236,7 +229,6 @@ TEST(DisplayListPathBuilder, AddOval) {
     EXPECT_CALL(mock_receiver, ConicTo(DlPoint(30, 10), DlPoint(30, 15), wt))
         .WillOnce(Return(true));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -263,7 +255,6 @@ TEST(DisplayListPathBuilder, AddCircle) {
     EXPECT_CALL(mock_receiver, ConicTo(DlPoint(20, 10), DlPoint(20, 15), wt))
         .WillOnce(Return(true));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -301,7 +292,6 @@ TEST(DisplayListPathBuilder, AddRoundRect) {
     EXPECT_CALL(mock_receiver, ConicTo(DlPoint(10, 100), DlPoint(10, 86), wt))
         .WillOnce(Return(true));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -376,7 +366,6 @@ TEST(DisplayListPathBuilder, AddRoundSuperellipse) {
                                        PointEq(DlPoint(46.0f, 10.0f))));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(46, 10)));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -397,7 +386,6 @@ TEST(DisplayListPathBuilder, AddArcNoCenter) {
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(20, 20), false));
     EXPECT_CALL(mock_receiver, ConicTo(DlPoint(10, 20), DlPoint(10, 15), wt))
         .WillOnce(Return(true));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -421,7 +409,6 @@ TEST(DisplayListPathBuilder, AddArcWithCenter) {
         .WillOnce(Return(true));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(20, 15)));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -449,7 +436,6 @@ TEST(DisplayListPathBuilder, SimpleUnclosedPath) {
         .WillOnce(Return(true));
     EXPECT_CALL(mock_receiver, CubicTo(DlPoint(300, 300), DlPoint(400, 400),
                                        DlPoint(500, 500)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -480,7 +466,6 @@ TEST(DisplayListPathBuilder, SimpleClosedPath) {
                                        DlPoint(500, 500)));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(0, 0)));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);

--- a/engine/src/flutter/display_list/geometry/dl_path_unittests.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path_unittests.cc
@@ -501,7 +501,6 @@ static void TestPathDispatchOneOfEachVerb(const DlPath& path) {
     // Closing LineTo added implicitly to return to first point
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(100, 200)));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -551,7 +550,6 @@ static void TestPathDispatchConicToQuads(
                 QuadTo(PointEq(quad_points[0]), PointEq(quad_points[1])));
     EXPECT_CALL(mock_receiver,
                 QuadTo(PointEq(quad_points[2]), PointEq(quad_points[3])));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -658,7 +656,6 @@ static void TestPathDispatchUnclosedTriangle(const DlPath& path) {
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(10, 10), false));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(20, 10)));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 20)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -693,7 +690,6 @@ static void TestPathDispatchClosedTriangle(const DlPath& path) {
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 20)));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, 10)));
     EXPECT_CALL(mock_receiver, Close());
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -736,7 +732,6 @@ static void TestPathDispatchMixedCloseTriangles(const DlPath& path) {
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(210, 10), false));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(220, 10)));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(210, 20)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);
@@ -788,7 +783,6 @@ static void TestPathDispatchImplicitMoveAfterClose(const DlPath& path) {
     EXPECT_CALL(mock_receiver, MoveTo(DlPoint(10, 10), false));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(-20, 10)));
     EXPECT_CALL(mock_receiver, LineTo(DlPoint(10, -20)));
-    EXPECT_CALL(mock_receiver, PathEnd());
   }
 
   path.Dispatch(mock_receiver);

--- a/engine/src/flutter/display_list/testing/dl_test_mock_path_receiver.h
+++ b/engine/src/flutter/display_list/testing/dl_test_mock_path_receiver.h
@@ -34,7 +34,6 @@ class DlPathReceiverMock : public DlPathReceiver {
               (const DlPoint& cp1, const DlPoint& cp2, const DlPoint& p2),
               (override));
   MOCK_METHOD(void, Close, (), (override));
-  MOCK_METHOD(void, PathEnd, (), (override));
 };
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/geometry/dashed_line_path_source.cc
+++ b/engine/src/flutter/impeller/geometry/dashed_line_path_source.cc
@@ -62,7 +62,6 @@ void DashedLinePathSource::Dispatch(PathReceiver& receiver) const {
     receiver.MoveTo(p0_, false);
     receiver.LineTo(p1_);
   }
-  receiver.PathEnd();
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/geometry/path_source.cc
+++ b/engine/src/flutter/impeller/geometry/path_source.cc
@@ -27,7 +27,6 @@ void RectPathSource::Dispatch(PathReceiver& receiver) const {
   receiver.LineTo(rect_.GetLeftBottom());
   receiver.LineTo(rect_.GetLeftTop());
   receiver.Close();
-  receiver.PathEnd();
 }
 
 EllipsePathSource::EllipsePathSource(const Rect& bounds) : bounds_(bounds) {}
@@ -60,7 +59,6 @@ void EllipsePathSource::Dispatch(PathReceiver& receiver) const {
   receiver.ConicTo(Point(left, bottom), Point(left, center.y), kSqrt2Over2);
 
   receiver.Close();
-  receiver.PathEnd();
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/geometry/path_source.h
+++ b/engine/src/flutter/impeller/geometry/path_source.h
@@ -50,7 +50,6 @@ class PathReceiver {
   }
   virtual void CubicTo(const Point& cp1, const Point& cp2, const Point& p2) = 0;
   virtual void Close() = 0;
-  virtual void PathEnd() {}
 };
 
 class PathSource {

--- a/engine/src/flutter/impeller/geometry/path_source_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/path_source_unittests.cc
@@ -37,7 +37,6 @@ TEST(PathSourceTest, RectSourceTest) {
     EXPECT_CALL(receiver, LineTo(Point(10, 30)));
     EXPECT_CALL(receiver, LineTo(Point(10, 15)));
     EXPECT_CALL(receiver, Close());
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);
@@ -62,7 +61,6 @@ TEST(PathSourceTest, EllipseSourceTest) {
     EXPECT_CALL(receiver, ConicTo(Point(20, 30), Point(15, 30), kSqrt2Over2));
     EXPECT_CALL(receiver, ConicTo(Point(10, 30), Point(10, 22.5), kSqrt2Over2));
     EXPECT_CALL(receiver, Close());
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);
@@ -98,7 +96,6 @@ TEST(PathSourceTest, RoundRectSourceTest) {
     EXPECT_CALL(receiver, LineTo(Point(10, 26)));
     EXPECT_CALL(receiver, ConicTo(Point(10, 15), Point(11, 15), kSqrt2Over2));
     EXPECT_CALL(receiver, Close());
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);
@@ -152,8 +149,6 @@ TEST(PathSourceTest, DiffRoundRectSourceTest) {
     EXPECT_CALL(receiver, ConicTo(Point(50, 60), Point(51, 60), kSqrt2Over2));
     // RetiresOnSaturation keeps identical calls from matching each other
     EXPECT_CALL(receiver, Close()).RetiresOnSaturation();
-
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);
@@ -175,7 +170,6 @@ TEST(PathSourceTest, DashedLinePathSource) {
     EXPECT_CALL(receiver, LineTo(Point(15, 10)));
     EXPECT_CALL(receiver, MoveTo(Point(20, 10), false));
     EXPECT_CALL(receiver, LineTo(Point(25, 10)));
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);
@@ -195,7 +189,6 @@ TEST(PathSourceTest, EmptyDashedLinePathSource) {
 
     EXPECT_CALL(receiver, MoveTo(Point(10, 10), false));
     EXPECT_CALL(receiver, LineTo(Point(10, 10)));
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);
@@ -215,7 +208,6 @@ TEST(PathSourceTest, DashedLinePathSourceZeroOffGaps) {
 
     EXPECT_CALL(receiver, MoveTo(Point(10, 10), false));
     EXPECT_CALL(receiver, LineTo(Point(30, 10)));
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);
@@ -235,7 +227,6 @@ TEST(PathSourceTest, DashedLinePathSourceInvalidOffGaps) {
 
     EXPECT_CALL(receiver, MoveTo(Point(10, 10), false));
     EXPECT_CALL(receiver, LineTo(Point(30, 10)));
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);
@@ -255,7 +246,6 @@ TEST(PathSourceTest, DashedLinePathSourceInvalidOnRegion) {
 
     EXPECT_CALL(receiver, MoveTo(Point(10, 10), false));
     EXPECT_CALL(receiver, LineTo(Point(30, 10)));
-    EXPECT_CALL(receiver, PathEnd());
   }
 
   source.Dispatch(receiver);

--- a/engine/src/flutter/impeller/geometry/round_rect.cc
+++ b/engine/src/flutter/impeller/geometry/round_rect.cc
@@ -87,7 +87,7 @@ static constexpr Point kLowerRightDirection(1.0f, 1.0f);
   return true;
 }
 
-void RoundRect::Dispatch(PathReceiver& receiver, bool include_end) const {
+void RoundRect::Dispatch(PathReceiver& receiver) const {
   Scalar left = bounds_.GetLeft();
   Scalar top = bounds_.GetTop();
   Scalar right = bounds_.GetRight();
@@ -119,9 +119,6 @@ void RoundRect::Dispatch(PathReceiver& receiver, bool include_end) const {
                    kSqrt2Over2);
 
   receiver.Close();
-  if (include_end) {
-    receiver.PathEnd();
-  }
 }
 
 RoundRectPathSource::RoundRectPathSource(const RoundRect& round_rect)
@@ -142,7 +139,7 @@ bool RoundRectPathSource::IsConvex() const {
 }
 
 void RoundRectPathSource::Dispatch(PathReceiver& receiver) const {
-  round_rect_.Dispatch(receiver, true);
+  round_rect_.Dispatch(receiver);
 }
 
 DiffRoundRectPathSource::DiffRoundRectPathSource(const RoundRect& outer,
@@ -164,8 +161,8 @@ bool DiffRoundRectPathSource::IsConvex() const {
 }
 
 void DiffRoundRectPathSource::Dispatch(PathReceiver& receiver) const {
-  outer_.Dispatch(receiver, false);
-  inner_.Dispatch(receiver, true);
+  outer_.Dispatch(receiver);
+  inner_.Dispatch(receiver);
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/geometry/round_rect.h
+++ b/engine/src/flutter/impeller/geometry/round_rect.h
@@ -140,7 +140,7 @@ struct RoundRect {
   RoundingRadii radii_;
 
   // Helps with RoundRectPathSource and DiffRoundRectPathSource
-  void Dispatch(PathReceiver& receiver, bool include_end = true) const;
+  void Dispatch(PathReceiver& receiver) const;
 
   friend class RoundRectPathSource;
   friend class DiffRoundRectPathSource;

--- a/engine/src/flutter/impeller/geometry/round_superellipse.cc
+++ b/engine/src/flutter/impeller/geometry/round_superellipse.cc
@@ -60,7 +60,6 @@ void RoundSuperellipsePathSource::Dispatch(PathReceiver& receiver) const {
   auto param = RoundSuperellipseParam::MakeBoundsRadii(
       round_superellipse_.GetBounds(), round_superellipse_.GetRadii());
   param.Dispatch(receiver);
-  receiver.PathEnd();
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/tessellator/path_tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/path_tessellator.cc
@@ -149,7 +149,7 @@ class PathPruner : public impeller::PathReceiver {
     // See SegmentEncountered()
   }
 
-  void PathEnd() override {
+  void PathEnd() {
     if (!is_stroking_ && current_point_ != contour_origin_) {
       FML_DCHECK(contour_has_segments_);
       FML_DCHECK(contour_has_points_);
@@ -284,12 +284,14 @@ void PathTessellator::PathToFilledSegments(const PathSource& source,
                                            SegmentReceiver& receiver) {
   PathPruner pruner(receiver, false);
   source.Dispatch(pruner);
+  pruner.PathEnd();
 }
 
 void PathTessellator::PathToStrokedSegments(const PathSource& source,
                                             SegmentReceiver& receiver) {
   PathPruner pruner(receiver, true);
   source.Dispatch(pruner);
+  pruner.PathEnd();
 }
 
 std::pair<size_t, size_t> PathTessellator::CountFillStorage(
@@ -298,6 +300,7 @@ std::pair<size_t, size_t> PathTessellator::CountFillStorage(
   StorageCounter counter(scale);
   PathPruner pruner(counter, false);
   source.Dispatch(pruner);
+  pruner.PathEnd();
   return {counter.GetPointCount(), counter.GetContourCount()};
 }
 
@@ -307,6 +310,7 @@ void PathTessellator::PathToFilledVertices(const PathSource& source,
   PathFillWriter path_writer(writer, scale);
   PathPruner pruner(path_writer, false);
   source.Dispatch(pruner);
+  pruner.PathEnd();
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -2130,7 +2130,7 @@ class AndroidPathReceiver final : public DlPathReceiver {
     env_->CallVoidMethod(android_path_, path_close_method);
   }
 
-  jobject TakePath() { return android_path_; }
+  jobject TakePath() const { return android_path_; }
 
  private:
   JNIEnv* env_;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -64,7 +64,7 @@ class CGPathReceiver final : public flutter::DlPathReceiver {
   }
   void Close() override { CGPathCloseSubpath(path_ref_); }
 
-  CGMutablePathRef TakePath() { return path_ref_; }
+  CGMutablePathRef TakePath() const { return path_ref_; }
 
  private:
   CGMutablePathRef path_ref_ = CGPathCreateMutable();

--- a/engine/src/flutter/testing/display_list_testing.h
+++ b/engine/src/flutter/testing/display_list_testing.h
@@ -238,12 +238,16 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
     explicit DlPathStreamer(DisplayListStreamDispatcher& dispatcher)
         : dispatcher_(dispatcher) {}
 
-    void MoveTo(const DlPoint& p2, bool will_be_closed);
-    void LineTo(const DlPoint& p2);
-    void QuadTo(const DlPoint& cp, const DlPoint& p2);
-    bool ConicTo(const DlPoint& cp, const DlPoint& p2, DlScalar weight);
-    void CubicTo(const DlPoint& cp1, const DlPoint& cp2, const DlPoint& p2);
-    void Close();
+    void MoveTo(const DlPoint& p2, bool will_be_closed) override;
+    void LineTo(const DlPoint& p2) override;
+    void QuadTo(const DlPoint& cp, const DlPoint& p2) override;
+    bool ConicTo(const DlPoint& cp,
+                 const DlPoint& p2,
+                 DlScalar weight) override;
+    void CubicTo(const DlPoint& cp1,
+                 const DlPoint& cp2,
+                 const DlPoint& p2) override;
+    void Close() override;
 
    private:
     DisplayListStreamDispatcher& dispatcher_;


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/169719