### PR TITLE
Add DropdownButtonFormField value param test

### DIFF
--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -619,7 +619,7 @@ void main() {
     expect(fieldKey.currentState!.value, 'one');
 
     // Open the dropdown menu.
-    await tester.tap(find.text('one'), warnIfMissed: false);
+    await tester.tap(find.text('one'));
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('three').last);

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -588,47 +588,53 @@ void main() {
     expect(value, equals('three'));
   });
 
-  testWidgets('Dropdown form field only uses value as initial', (WidgetTester tester) async {
-    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+  testWidgets('Dropdown form field only uses value parameter when first built and when reset', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey<FormFieldState<String>> fieldKey = GlobalKey<FormFieldState<String>>();
     await tester.pumpWidget(
       StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
           return MaterialApp(
             home: Material(
-              child: Form(
-                key: formKey,
-                child: DropdownButtonFormField<String>(
-                  value: 'one',
-                  hint: const Text('Select Value'),
-                  items:
-                      menuItems.map((String val) {
-                        return DropdownMenuItem<String>(value: val, child: Text(val));
-                      }).toList(),
-                  onChanged: (String? newValue) {
-                    setState(() {
-                      // Do nothing, just to trigger a rebuild.
-                    });
-                  },
-                ),
+              child: DropdownButtonFormField<String>(
+                key: fieldKey,
+                value: 'one',
+                hint: const Text('Select Value'),
+                items:
+                    menuItems.map((String val) {
+                      return DropdownMenuItem<String>(value: val, child: Text(val));
+                    }).toList(),
+                onChanged: (String? newValue) {
+                  setState(() {
+                    // Do nothing, just to trigger a rebuild.
+                  });
+                },
               ),
             ),
           );
         },
       ),
     );
+    expect(fieldKey.currentState!.value, 'one');
 
+    // Open the dropdown menu
     await tester.tap(find.text('one'), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('three').last);
     await tester.pumpAndSettle();
-    expect(find.text('three'), findsOneWidget);
 
-    final FormState form = formKey.currentState!;
-    form.reset();
+    // The value should update to selected, not the initial value
+    expect(find.text('three'), findsOneWidget);
+    expect(fieldKey.currentState!.value, 'three');
+
+    fieldKey.currentState!.reset();
     await tester.pumpAndSettle();
 
+    // After reset, the value is initial value 'one'
     expect(find.text('one'), findsOneWidget);
+    expect(fieldKey.currentState!.value, 'one');
   });
 
   testWidgets('Dropdown in ListView', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -588,6 +588,49 @@ void main() {
     expect(value, equals('three'));
   });
 
+  testWidgets('Dropdown form field only uses value as initial', (WidgetTester tester) async {
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return MaterialApp(
+            home: Material(
+              child: Form(
+                key: formKey,
+                child: DropdownButtonFormField<String>(
+                  value: 'one',
+                  hint: const Text('Select Value'),
+                  items:
+                      menuItems.map((String val) {
+                        return DropdownMenuItem<String>(value: val, child: Text(val));
+                      }).toList(),
+                  onChanged: (String? newValue) {
+                    setState(() {
+                      // Do nothing, just to trigger a rebuild.
+                    });
+                  },
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    await tester.tap(find.text('one'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('three').last);
+    await tester.pumpAndSettle();
+    expect(find.text('three'), findsOneWidget);
+
+    final FormState form = formKey.currentState!;
+    form.reset();
+    await tester.pumpAndSettle();
+
+    expect(find.text('one'), findsOneWidget);
+  });
+
   testWidgets('Dropdown in ListView', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/12053
     // Positions a DropdownButton at the left and right edges of the screen,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -618,21 +618,21 @@ void main() {
     );
     expect(fieldKey.currentState!.value, 'one');
 
-    // Open the dropdown menu
+    // Open the dropdown menu.
     await tester.tap(find.text('one'), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('three').last);
     await tester.pumpAndSettle();
 
-    // The value should update to selected, not the initial value
+    // The value should update to selected, not the initial value.
     expect(find.text('three'), findsOneWidget);
     expect(fieldKey.currentState!.value, 'three');
 
     fieldKey.currentState!.reset();
-    await tester.pumpAndSettle();
+    await tester.pump();
 
-    // After reset, the value is initial value 'one'
+    // Reset to the initial value.
     expect(find.text('one'), findsOneWidget);
     expect(fieldKey.currentState!.value, 'one');
   });


### PR DESCRIPTION
This PR adds a new test that verifies that the value param is only used on initial build and when resetting the field.

Test for https://github.com/flutter/flutter/pull/170050#issuecomment-2965486000

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

