### PR TITLE
Fix the path to `packages_autoroller`.

### DIFF
--- a/dev/packages_autoroller/run
+++ b/dev/packages_autoroller/run
@@ -37,7 +37,7 @@ function follow_links() (
 
 PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
 BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
-REPO_DIR="$BIN_DIR/../../.."
+REPO_DIR="$BIN_DIR/../.."
 DART_BIN="$REPO_DIR/bin/dart"
 FLUTTER_BIN="$REPO_DIR/bin/flutter"
 


### PR DESCRIPTION
Recipe already was updated, it will be easier to just make this shell script location correct.