### PR TITLE
[Impeller] fix mask filter application to Vertices.

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_vertices_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_vertices_unittests.cc
@@ -5,6 +5,7 @@
 #include "display_list/dl_sampling_options.h"
 #include "display_list/dl_tile_mode.h"
 #include "display_list/dl_vertices.h"
+#include "display_list/effects/dl_mask_filter.h"
 #include "flutter/impeller/display_list/aiks_unittests.h"
 
 #include "flutter/display_list/dl_blend_mode.h"
@@ -547,6 +548,24 @@ TEST_P(AiksTest,
   builder.DrawRect(DlRect::MakeLTRB(200, 200, 250, 250), rect_paint);
   builder.DrawVertices(vertices, flutter::DlBlendMode::kSrcOver, paint);
 
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
+// Regression test for https://github.com/flutter/flutter/issues/170480 .
+TEST_P(AiksTest, VerticesGeometryWithMaskFilter) {
+  DisplayListBuilder builder;
+  DlPaint paint;
+  paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 10));
+
+  std::vector<DlPoint> vertex_coordinates = {
+      DlPoint(0, 0),
+      DlPoint(400, 0),
+      DlPoint(0, 400),
+  };
+  auto vertices = MakeVertices(DlVertexMode::kTriangleStrip, vertex_coordinates,
+                               {0, 1, 2}, {}, {});
+
+  builder.DrawVertices(vertices, DlBlendMode::kSrcOver, paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -14,7 +14,6 @@
 #include "display_list/effects/dl_color_filter.h"
 #include "display_list/effects/dl_color_source.h"
 #include "display_list/effects/dl_image_filter.h"
-#include "display_list/geometry/dl_path_builder.h"
 #include "display_list/image/dl_image.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"

--- a/engine/src/flutter/impeller/display_list/dl_vertices_geometry.cc
+++ b/engine/src/flutter/impeller/display_list/dl_vertices_geometry.cc
@@ -221,4 +221,8 @@ bool DlVerticesGeometry::MaybePerformIndexNormalization(
   return false;
 }
 
+bool DlVerticesGeometry::CanApplyMaskFilter() const {
+  return false;
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/display_list/dl_vertices_geometry.h
+++ b/engine/src/flutter/impeller/display_list/dl_vertices_geometry.h
@@ -37,6 +37,9 @@ class DlVerticesGeometry final : public VerticesGeometry {
 
   bool HasTextureCoordinates() const override;
 
+  // |Geometry|
+  bool CanApplyMaskFilter() const override;
+
   std::optional<Rect> GetTextureCoordinateCoverage() const override;
 
  private:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/170480

Vertices should ignore mask filter. One particular code path in draw vertices with no per-vertex colors was applying it though.
