### PR TITLE
Fix RawGestureDetector semantics

### DIFF
--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1704,10 +1704,9 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
     return Rect.fromLTWH(0, 0, size.width, size.height);
   }
 
-  static Rect _getGlobalRectFromRenderObject(RenderObject renderObject) {
-    final Rect localRect = _getLocalRectFromRenderObject(renderObject);
-    final Matrix4 transform = renderObject.getTransformTo(null);
-    return MatrixUtils.transformRect(transform, localRect);
+  static Offset _transformOffsetToGlobal(RenderObject object, Offset local) {
+    final Matrix4 transform = object.getTransformTo(null);
+    return MatrixUtils.transformPoint(transform, local);
   }
 
   @override
@@ -1732,7 +1731,7 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
 
     return () {
       final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
-      final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+      final Offset globalCenter = _transformOffsetToGlobal(renderObject, localCenter);
       tap.onTapDown?.call(
         TapDownDetails(
           globalPosition: globalCenter,
@@ -1763,7 +1762,7 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
 
     return () {
       final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
-      final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+      final Offset globalCenter = _transformOffsetToGlobal(renderObject, localCenter);
 
       longPress.onLongPressDown?.call(
         LongPressDownDetails(localPosition: localCenter, globalPosition: globalCenter),
@@ -1792,9 +1791,9 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
             ? null
             : (DragUpdateDetails details) {
               final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
-              final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+              final Offset globalCenter = _transformOffsetToGlobal(renderObject, localCenter);
               final Offset newLocalOffset = localCenter + details.delta;
-              final Offset newGlobalOffset = globalCenter + details.delta;
+              final Offset newGlobalOffset = _transformOffsetToGlobal(renderObject, newLocalOffset);
               horizontal.onDown?.call(
                 DragDownDetails(localPosition: localCenter, globalPosition: globalCenter),
               );
@@ -1816,9 +1815,9 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
             ? null
             : (DragUpdateDetails details) {
               final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
-              final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+              final Offset globalCenter = _transformOffsetToGlobal(renderObject, localCenter);
               final Offset newLocalOffset = localCenter + details.delta;
-              final Offset newGlobalOffset = globalCenter + details.delta;
+              final Offset newGlobalOffset = _transformOffsetToGlobal(renderObject, newLocalOffset);
 
               pan.onDown?.call(
                 DragDownDetails(localPosition: localCenter, globalPosition: globalCenter),
@@ -1854,9 +1853,9 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
             ? null
             : (DragUpdateDetails details) {
               final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
-              final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+              final Offset globalCenter = _transformOffsetToGlobal(renderObject, localCenter);
               final Offset newLocalOffset = localCenter + details.delta;
-              final Offset newGlobalOffset = globalCenter + details.delta;
+              final Offset newGlobalOffset = _transformOffsetToGlobal(renderObject, newLocalOffset);
               vertical.onDown?.call(
                 DragDownDetails(localPosition: localCenter, globalPosition: globalCenter),
               );
@@ -1878,9 +1877,9 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
             ? null
             : (DragUpdateDetails details) {
               final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
-              final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+              final Offset globalCenter = _transformOffsetToGlobal(renderObject, localCenter);
               final Offset newLocalOffset = localCenter + details.delta;
-              final Offset newGlobalOffset = globalCenter + details.delta;
+              final Offset newGlobalOffset = _transformOffsetToGlobal(renderObject, newLocalOffset);
               pan.onDown?.call(
                 DragDownDetails(localPosition: localCenter, globalPosition: globalCenter),
               );

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1695,31 +1695,66 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
 
   final RawGestureDetectorState detectorState;
 
+  static Rect _getLocalRectFromRenderObject(RenderObject renderObject) {
+    if (renderObject is! RenderBox) {
+      return Rect.zero;
+    }
+
+    final Size size = renderObject.size;
+    return Rect.fromLTWH(0, 0, size.width, size.height);
+  }
+
+  static Rect _getGlobalRectFromRenderObject(RenderObject renderObject) {
+    final Rect localRect = _getLocalRectFromRenderObject(renderObject);
+    final Matrix4 transform = renderObject.getTransformTo(null);
+    return MatrixUtils.transformRect(transform, localRect);
+  }
+
   @override
   void assignSemantics(RenderSemanticsGestureHandler renderObject) {
     assert(!detectorState.widget.excludeFromSemantics);
     final Map<Type, GestureRecognizer> recognizers = detectorState._recognizers!;
     renderObject
-      ..onTap = _getTapHandler(recognizers)
-      ..onLongPress = _getLongPressHandler(recognizers)
-      ..onHorizontalDragUpdate = _getHorizontalDragUpdateHandler(recognizers)
-      ..onVerticalDragUpdate = _getVerticalDragUpdateHandler(recognizers);
+      ..onTap = _getTapHandler(renderObject, recognizers)
+      ..onLongPress = _getLongPressHandler(renderObject, recognizers)
+      ..onHorizontalDragUpdate = _getHorizontalDragUpdateHandler(renderObject, recognizers)
+      ..onVerticalDragUpdate = _getVerticalDragUpdateHandler(renderObject, recognizers);
   }
 
-  GestureTapCallback? _getTapHandler(Map<Type, GestureRecognizer> recognizers) {
+  GestureTapCallback? _getTapHandler(
+    RenderObject renderObject,
+    Map<Type, GestureRecognizer> recognizers,
+  ) {
     final TapGestureRecognizer? tap = recognizers[TapGestureRecognizer] as TapGestureRecognizer?;
     if (tap == null) {
       return null;
     }
 
     return () {
-      tap.onTapDown?.call(TapDownDetails());
-      tap.onTapUp?.call(TapUpDetails(kind: PointerDeviceKind.unknown));
+      final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
+      final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+      tap.onTapDown?.call(
+        TapDownDetails(
+          globalPosition: globalCenter,
+          localPosition: localCenter,
+          kind: PointerDeviceKind.unknown,
+        ),
+      );
+      tap.onTapUp?.call(
+        TapUpDetails(
+          globalPosition: globalCenter,
+          localPosition: localCenter,
+          kind: PointerDeviceKind.unknown,
+        ),
+      );
       tap.onTap?.call();
     };
   }
 
-  GestureLongPressCallback? _getLongPressHandler(Map<Type, GestureRecognizer> recognizers) {
+  GestureLongPressCallback? _getLongPressHandler(
+    RenderObject renderObject,
+    Map<Type, GestureRecognizer> recognizers,
+  ) {
     final LongPressGestureRecognizer? longPress =
         recognizers[LongPressGestureRecognizer] as LongPressGestureRecognizer?;
     if (longPress == null) {
@@ -1727,15 +1762,25 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
     }
 
     return () {
-      longPress.onLongPressDown?.call(const LongPressDownDetails());
-      longPress.onLongPressStart?.call(const LongPressStartDetails());
+      final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
+      final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+
+      longPress.onLongPressDown?.call(
+        LongPressDownDetails(localPosition: localCenter, globalPosition: globalCenter),
+      );
+      longPress.onLongPressStart?.call(
+        LongPressStartDetails(localPosition: localCenter, globalPosition: globalCenter),
+      );
       longPress.onLongPress?.call();
-      longPress.onLongPressEnd?.call(const LongPressEndDetails());
+      longPress.onLongPressEnd?.call(
+        LongPressEndDetails(localPosition: localCenter, globalPosition: globalCenter),
+      );
       longPress.onLongPressUp?.call();
     };
   }
 
   GestureDragUpdateCallback? _getHorizontalDragUpdateHandler(
+    RenderObject renderObject,
     Map<Type, GestureRecognizer> recognizers,
   ) {
     final HorizontalDragGestureRecognizer? horizontal =
@@ -1746,20 +1791,45 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
         horizontal == null
             ? null
             : (DragUpdateDetails details) {
-              horizontal.onDown?.call(DragDownDetails());
-              horizontal.onStart?.call(DragStartDetails());
+              final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
+              final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+              final Offset newLocalOffset = localCenter + details.delta;
+              final Offset newGlobalOffset = globalCenter + details.delta;
+              horizontal.onDown?.call(
+                DragDownDetails(localPosition: localCenter, globalPosition: globalCenter),
+              );
+              horizontal.onStart?.call(
+                DragStartDetails(localPosition: localCenter, globalPosition: globalCenter),
+              );
               horizontal.onUpdate?.call(details);
-              horizontal.onEnd?.call(DragEndDetails(primaryVelocity: 0.0));
+              horizontal.onEnd?.call(
+                DragEndDetails(
+                  primaryVelocity: 0.0,
+                  localPosition: newLocalOffset,
+                  globalPosition: newGlobalOffset,
+                ),
+              );
             };
 
     final GestureDragUpdateCallback? panHandler =
         pan == null
             ? null
             : (DragUpdateDetails details) {
-              pan.onDown?.call(DragDownDetails());
-              pan.onStart?.call(DragStartDetails());
+              final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
+              final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+              final Offset newLocalOffset = localCenter + details.delta;
+              final Offset newGlobalOffset = globalCenter + details.delta;
+
+              pan.onDown?.call(
+                DragDownDetails(localPosition: localCenter, globalPosition: globalCenter),
+              );
+              pan.onStart?.call(
+                DragStartDetails(localPosition: localCenter, globalPosition: globalCenter),
+              );
               pan.onUpdate?.call(details);
-              pan.onEnd?.call(DragEndDetails());
+              pan.onEnd?.call(
+                DragEndDetails(localPosition: newLocalOffset, globalPosition: newGlobalOffset),
+              );
             };
 
     if (horizontalHandler == null && panHandler == null) {
@@ -1772,6 +1842,7 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
   }
 
   GestureDragUpdateCallback? _getVerticalDragUpdateHandler(
+    RenderObject renderObject,
     Map<Type, GestureRecognizer> recognizers,
   ) {
     final VerticalDragGestureRecognizer? vertical =
@@ -1782,20 +1853,44 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
         vertical == null
             ? null
             : (DragUpdateDetails details) {
-              vertical.onDown?.call(DragDownDetails());
-              vertical.onStart?.call(DragStartDetails());
+              final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
+              final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+              final Offset newLocalOffset = localCenter + details.delta;
+              final Offset newGlobalOffset = globalCenter + details.delta;
+              vertical.onDown?.call(
+                DragDownDetails(localPosition: localCenter, globalPosition: globalCenter),
+              );
+              vertical.onStart?.call(
+                DragStartDetails(localPosition: localCenter, globalPosition: globalCenter),
+              );
               vertical.onUpdate?.call(details);
-              vertical.onEnd?.call(DragEndDetails(primaryVelocity: 0.0));
+              vertical.onEnd?.call(
+                DragEndDetails(
+                  primaryVelocity: 0.0,
+                  localPosition: newLocalOffset,
+                  globalPosition: newGlobalOffset,
+                ),
+              );
             };
 
     final GestureDragUpdateCallback? panHandler =
         pan == null
             ? null
             : (DragUpdateDetails details) {
-              pan.onDown?.call(DragDownDetails());
-              pan.onStart?.call(DragStartDetails());
+              final Offset localCenter = _getLocalRectFromRenderObject(renderObject).center;
+              final Offset globalCenter = _getGlobalRectFromRenderObject(renderObject).center;
+              final Offset newLocalOffset = localCenter + details.delta;
+              final Offset newGlobalOffset = globalCenter + details.delta;
+              pan.onDown?.call(
+                DragDownDetails(localPosition: localCenter, globalPosition: globalCenter),
+              );
+              pan.onStart?.call(
+                DragStartDetails(localPosition: localCenter, globalPosition: globalCenter),
+              );
               pan.onUpdate?.call(details);
-              pan.onEnd?.call(DragEndDetails());
+              pan.onEnd?.call(
+                DragEndDetails(localPosition: newLocalOffset, globalPosition: newGlobalOffset),
+              );
             };
 
     if (verticalHandler == null && panHandler == null) {

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -820,6 +820,301 @@ void main() {
     expect(forcePressStart, 0);
   });
 
+  group('default semantics', () {
+    testWidgets('tap', (WidgetTester tester) async {
+      TapDownDetails? receivedTapDownDetails;
+      TapUpDetails? receivedTapUpDetails;
+      bool tapped = false;
+      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+      final UniqueKey key = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: RawGestureDetector(
+                key: key,
+                gestures: <Type, GestureRecognizerFactory>{
+                  TapGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+                    () => TapGestureRecognizer(postAcceptSlopTolerance: null),
+                    (TapGestureRecognizer instance) {
+                      instance.onTapDown = (TapDownDetails details) {
+                        receivedTapDownDetails = details;
+                      };
+                      instance.onTapUp = (TapUpDetails details) {
+                        receivedTapUpDetails = details;
+                      };
+                      instance.onTap = () {
+                        tapped = true;
+                      };
+                    },
+                  ),
+                },
+                child: const SizedBox(width: 20, height: 20),
+              ),
+            ),
+          ),
+        ),
+      );
+      final SemanticsNode node = tester.semantics.find(find.byKey(key));
+      expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
+
+      semanticsOwner.performAction(node.id, SemanticsAction.tap);
+      await tester.pump();
+      expect(receivedTapDownDetails!.localPosition, const Offset(10, 10));
+      expect(receivedTapDownDetails!.globalPosition, const Offset(400, 300));
+      expect(receivedTapUpDetails!.localPosition, const Offset(10, 10));
+      expect(receivedTapUpDetails!.globalPosition, const Offset(400, 300));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('long press', (WidgetTester tester) async {
+      LongPressDownDetails? receivedLongPressDownDetails;
+      LongPressStartDetails? receivedLongPressStartDetails;
+      LongPressEndDetails? receivedLongPressEndDetails;
+      bool pressed = false;
+      bool upped = false;
+      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+      final UniqueKey key = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: RawGestureDetector(
+                key: key,
+                gestures: <Type, GestureRecognizerFactory>{
+                  LongPressGestureRecognizer:
+                      GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+                        () => LongPressGestureRecognizer(),
+                        (LongPressGestureRecognizer instance) {
+                          instance.onLongPressDown = (LongPressDownDetails details) {
+                            receivedLongPressDownDetails = details;
+                          };
+                          instance.onLongPressStart = (LongPressStartDetails details) {
+                            receivedLongPressStartDetails = details;
+                          };
+                          instance.onLongPressEnd = (LongPressEndDetails details) {
+                            receivedLongPressEndDetails = details;
+                          };
+                          instance.onLongPressUp = () {
+                            upped = true;
+                          };
+                          instance.onLongPress = () {
+                            pressed = true;
+                          };
+                        },
+                      ),
+                },
+                child: const SizedBox(width: 20, height: 20),
+              ),
+            ),
+          ),
+        ),
+      );
+      final SemanticsNode node = tester.semantics.find(find.byKey(key));
+      expect(node.getSemanticsData().hasAction(SemanticsAction.longPress), isTrue);
+
+      semanticsOwner.performAction(node.id, SemanticsAction.longPress);
+      await tester.pump();
+      expect(receivedLongPressDownDetails!.localPosition, const Offset(10, 10));
+      expect(receivedLongPressDownDetails!.globalPosition, const Offset(400, 300));
+      expect(receivedLongPressStartDetails!.localPosition, const Offset(10, 10));
+      expect(receivedLongPressStartDetails!.globalPosition, const Offset(400, 300));
+      expect(receivedLongPressEndDetails!.localPosition, const Offset(10, 10));
+      expect(receivedLongPressEndDetails!.globalPosition, const Offset(400, 300));
+      expect(pressed, isTrue);
+      expect(upped, isTrue);
+    });
+
+    testWidgets('horizontal drag', (WidgetTester tester) async {
+      DragDownDetails? receivedDragDownDetails;
+      DragStartDetails? receivedDragStartDetails;
+      DragUpdateDetails? receivedDragUpdateDetails;
+      DragEndDetails? receivedDragEndDetails;
+      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+      final UniqueKey key = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: RawGestureDetector(
+                key: key,
+                gestures: <Type, GestureRecognizerFactory>{
+                  HorizontalDragGestureRecognizer:
+                      GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
+                        () => HorizontalDragGestureRecognizer(),
+                        (HorizontalDragGestureRecognizer instance) {
+                          instance.onDown = (DragDownDetails details) {
+                            receivedDragDownDetails = details;
+                          };
+                          instance.onStart = (DragStartDetails details) {
+                            receivedDragStartDetails = details;
+                          };
+                          instance.onUpdate = (DragUpdateDetails details) {
+                            receivedDragUpdateDetails = details;
+                          };
+                          instance.onEnd = (DragEndDetails details) {
+                            receivedDragEndDetails = details;
+                          };
+                        },
+                      ),
+                },
+                child: const SizedBox(width: 20, height: 20),
+              ),
+            ),
+          ),
+        ),
+      );
+      final SemanticsNode node = tester.semantics.find(find.byKey(key));
+      expect(node.getSemanticsData().hasAction(SemanticsAction.scrollRight), isTrue);
+
+      semanticsOwner.performAction(node.id, SemanticsAction.scrollRight);
+      await tester.pump();
+      expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
+      expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
+      expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
+      expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
+      final Offset delta = receivedDragUpdateDetails!.delta;
+      final Offset local = const Offset(10, 10) + delta;
+      final RenderObject object = tester.renderObject(find.byKey(key));
+      final Matrix4 transform = object.getTransformTo(null);
+      final Offset global = MatrixUtils.transformPoint(transform, local);
+      expect(receivedDragEndDetails!.localPosition, local);
+      expect(receivedDragEndDetails!.globalPosition, global);
+    });
+
+    testWidgets('vertical drag', (WidgetTester tester) async {
+      DragDownDetails? receivedDragDownDetails;
+      DragStartDetails? receivedDragStartDetails;
+      DragUpdateDetails? receivedDragUpdateDetails;
+      DragEndDetails? receivedDragEndDetails;
+      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+      final UniqueKey key = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: RawGestureDetector(
+                key: key,
+                gestures: <Type, GestureRecognizerFactory>{
+                  VerticalDragGestureRecognizer:
+                      GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
+                        () => VerticalDragGestureRecognizer(),
+                        (VerticalDragGestureRecognizer instance) {
+                          instance.onDown = (DragDownDetails details) {
+                            receivedDragDownDetails = details;
+                          };
+                          instance.onStart = (DragStartDetails details) {
+                            receivedDragStartDetails = details;
+                          };
+                          instance.onUpdate = (DragUpdateDetails details) {
+                            receivedDragUpdateDetails = details;
+                          };
+                          instance.onEnd = (DragEndDetails details) {
+                            receivedDragEndDetails = details;
+                          };
+                        },
+                      ),
+                },
+                child: const SizedBox(width: 20, height: 20),
+              ),
+            ),
+          ),
+        ),
+      );
+      final SemanticsNode node = tester.semantics.find(find.byKey(key));
+      expect(node.getSemanticsData().hasAction(SemanticsAction.scrollUp), isTrue);
+
+      semanticsOwner.performAction(node.id, SemanticsAction.scrollUp);
+      await tester.pump();
+      expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
+      expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
+      expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
+      expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
+      final Offset delta = receivedDragUpdateDetails!.delta;
+      final Offset local = const Offset(10, 10) + delta;
+      final RenderObject object = tester.renderObject(find.byKey(key));
+      final Matrix4 transform = object.getTransformTo(null);
+      final Offset global = MatrixUtils.transformPoint(transform, local);
+      expect(receivedDragEndDetails!.localPosition, local);
+      expect(receivedDragEndDetails!.globalPosition, global);
+    });
+
+    testWidgets('pan', (WidgetTester tester) async {
+      DragDownDetails? receivedDragDownDetails;
+      DragStartDetails? receivedDragStartDetails;
+      DragUpdateDetails? receivedDragUpdateDetails;
+      DragEndDetails? receivedDragEndDetails;
+      final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+      final UniqueKey key = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: RawGestureDetector(
+                key: key,
+                gestures: <Type, GestureRecognizerFactory>{
+                  PanGestureRecognizer: GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
+                    () => PanGestureRecognizer(),
+                    (PanGestureRecognizer instance) {
+                      instance.onDown = (DragDownDetails details) {
+                        receivedDragDownDetails = details;
+                      };
+                      instance.onStart = (DragStartDetails details) {
+                        receivedDragStartDetails = details;
+                      };
+                      instance.onUpdate = (DragUpdateDetails details) {
+                        receivedDragUpdateDetails = details;
+                      };
+                      instance.onEnd = (DragEndDetails details) {
+                        receivedDragEndDetails = details;
+                      };
+                    },
+                  ),
+                },
+                child: const SizedBox(width: 20, height: 20),
+              ),
+            ),
+          ),
+        ),
+      );
+      final SemanticsNode node = tester.semantics.find(find.byKey(key));
+      expect(node.getSemanticsData().hasAction(SemanticsAction.scrollRight), isTrue);
+
+      semanticsOwner.performAction(node.id, SemanticsAction.scrollRight);
+      await tester.pump();
+      expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
+      expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
+      expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
+      expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
+      Offset delta = receivedDragUpdateDetails!.delta;
+
+      expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
+      expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
+
+      // scroll vertically
+      receivedDragDownDetails = null;
+      receivedDragStartDetails = null;
+      receivedDragUpdateDetails = null;
+      receivedDragEndDetails = null;
+
+      expect(node.getSemanticsData().hasAction(SemanticsAction.scrollUp), isTrue);
+
+      semanticsOwner.performAction(node.id, SemanticsAction.scrollUp);
+      await tester.pump();
+      expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
+      expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
+      expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
+      expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
+      delta = receivedDragUpdateDetails!.delta;
+      final Offset local = const Offset(10, 10) + delta;
+      final RenderObject object = tester.renderObject(find.byKey(key));
+      final Matrix4 transform = object.getTransformTo(null);
+      final Offset global = MatrixUtils.transformPoint(transform, local);
+      expect(receivedDragEndDetails!.localPosition, local);
+      expect(receivedDragEndDetails!.globalPosition, global);
+    });
+  });
+
   group("RawGestureDetectorState's debugFillProperties", () {
     testWidgets('when default', (WidgetTester tester) async {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
@@ -899,294 +1194,6 @@ void main() {
               .toList();
 
       expect(description, <String>['gestures: <none>', 'excludeFromSemantics: true']);
-    });
-
-    group('default semantics', () {
-      testWidgets('tap', (WidgetTester tester) async {
-        TapDownDetails? receivedTapDownDetails;
-        TapUpDetails? receivedTapUpDetails;
-        bool tapped = false;
-        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-        final UniqueKey key = UniqueKey();
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Center(
-                child: RawGestureDetector(
-                  key: key,
-                  gestures: <Type, GestureRecognizerFactory>{
-                    TapGestureRecognizer:
-                        GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
-                          () => TapGestureRecognizer(postAcceptSlopTolerance: null),
-                          (TapGestureRecognizer instance) {
-                            instance.onTapDown = (TapDownDetails details) {
-                              receivedTapDownDetails = details;
-                            };
-                            instance.onTapUp = (TapUpDetails details) {
-                              receivedTapUpDetails = details;
-                            };
-                            instance.onTap = () {
-                              tapped = true;
-                            };
-                          },
-                        ),
-                  },
-                  child: const SizedBox(width: 20, height: 20),
-                ),
-              ),
-            ),
-          ),
-        );
-        final SemanticsNode node = tester.semantics.find(find.byKey(key));
-        expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
-
-        semanticsOwner.performAction(node.id, SemanticsAction.tap);
-        await tester.pump();
-        expect(receivedTapDownDetails!.localPosition, const Offset(10, 10));
-        expect(receivedTapDownDetails!.globalPosition, const Offset(400, 300));
-        expect(receivedTapUpDetails!.localPosition, const Offset(10, 10));
-        expect(receivedTapUpDetails!.globalPosition, const Offset(400, 300));
-        expect(tapped, isTrue);
-      });
-
-      testWidgets('long press', (WidgetTester tester) async {
-        LongPressDownDetails? receivedLongPressDownDetails;
-        LongPressStartDetails? receivedLongPressStartDetails;
-        LongPressEndDetails? receivedLongPressEndDetails;
-        bool pressed = false;
-        bool upped = false;
-        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-        final UniqueKey key = UniqueKey();
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Center(
-                child: RawGestureDetector(
-                  key: key,
-                  gestures: <Type, GestureRecognizerFactory>{
-                    LongPressGestureRecognizer:
-                        GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
-                          () => LongPressGestureRecognizer(),
-                          (LongPressGestureRecognizer instance) {
-                            instance.onLongPressDown = (LongPressDownDetails details) {
-                              receivedLongPressDownDetails = details;
-                            };
-                            instance.onLongPressStart = (LongPressStartDetails details) {
-                              receivedLongPressStartDetails = details;
-                            };
-                            instance.onLongPressEnd = (LongPressEndDetails details) {
-                              receivedLongPressEndDetails = details;
-                            };
-                            instance.onLongPressUp = () {
-                              upped = true;
-                            };
-                            instance.onLongPress = () {
-                              pressed = true;
-                            };
-                          },
-                        ),
-                  },
-                  child: const SizedBox(width: 20, height: 20),
-                ),
-              ),
-            ),
-          ),
-        );
-        final SemanticsNode node = tester.semantics.find(find.byKey(key));
-        expect(node.getSemanticsData().hasAction(SemanticsAction.longPress), isTrue);
-
-        semanticsOwner.performAction(node.id, SemanticsAction.longPress);
-        await tester.pump();
-        expect(receivedLongPressDownDetails!.localPosition, const Offset(10, 10));
-        expect(receivedLongPressDownDetails!.globalPosition, const Offset(400, 300));
-        expect(receivedLongPressStartDetails!.localPosition, const Offset(10, 10));
-        expect(receivedLongPressStartDetails!.globalPosition, const Offset(400, 300));
-        expect(receivedLongPressEndDetails!.localPosition, const Offset(10, 10));
-        expect(receivedLongPressEndDetails!.globalPosition, const Offset(400, 300));
-        expect(pressed, isTrue);
-        expect(upped, isTrue);
-      });
-
-      testWidgets('horizontal drag', (WidgetTester tester) async {
-        DragDownDetails? receivedDragDownDetails;
-        DragStartDetails? receivedDragStartDetails;
-        DragUpdateDetails? receivedDragUpdateDetails;
-        DragEndDetails? receivedDragEndDetails;
-        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-        final UniqueKey key = UniqueKey();
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Center(
-                child: RawGestureDetector(
-                  key: key,
-                  gestures: <Type, GestureRecognizerFactory>{
-                    HorizontalDragGestureRecognizer:
-                        GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
-                          () => HorizontalDragGestureRecognizer(),
-                          (HorizontalDragGestureRecognizer instance) {
-                            instance.onDown = (DragDownDetails details) {
-                              receivedDragDownDetails = details;
-                            };
-                            instance.onStart = (DragStartDetails details) {
-                              receivedDragStartDetails = details;
-                            };
-                            instance.onUpdate = (DragUpdateDetails details) {
-                              receivedDragUpdateDetails = details;
-                            };
-                            instance.onEnd = (DragEndDetails details) {
-                              receivedDragEndDetails = details;
-                            };
-                          },
-                        ),
-                  },
-                  child: const SizedBox(width: 20, height: 20),
-                ),
-              ),
-            ),
-          ),
-        );
-        final SemanticsNode node = tester.semantics.find(find.byKey(key));
-        expect(node.getSemanticsData().hasAction(SemanticsAction.scrollRight), isTrue);
-
-        semanticsOwner.performAction(node.id, SemanticsAction.scrollRight);
-        await tester.pump();
-        expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
-        expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
-        expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
-        expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
-        final Offset delta = receivedDragUpdateDetails!.delta;
-
-        expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
-        expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
-      });
-
-      testWidgets('vertical drag', (WidgetTester tester) async {
-        DragDownDetails? receivedDragDownDetails;
-        DragStartDetails? receivedDragStartDetails;
-        DragUpdateDetails? receivedDragUpdateDetails;
-        DragEndDetails? receivedDragEndDetails;
-        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-        final UniqueKey key = UniqueKey();
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Center(
-                child: RawGestureDetector(
-                  key: key,
-                  gestures: <Type, GestureRecognizerFactory>{
-                    VerticalDragGestureRecognizer:
-                        GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
-                          () => VerticalDragGestureRecognizer(),
-                          (VerticalDragGestureRecognizer instance) {
-                            instance.onDown = (DragDownDetails details) {
-                              receivedDragDownDetails = details;
-                            };
-                            instance.onStart = (DragStartDetails details) {
-                              receivedDragStartDetails = details;
-                            };
-                            instance.onUpdate = (DragUpdateDetails details) {
-                              receivedDragUpdateDetails = details;
-                            };
-                            instance.onEnd = (DragEndDetails details) {
-                              receivedDragEndDetails = details;
-                            };
-                          },
-                        ),
-                  },
-                  child: const SizedBox(width: 20, height: 20),
-                ),
-              ),
-            ),
-          ),
-        );
-        final SemanticsNode node = tester.semantics.find(find.byKey(key));
-        expect(node.getSemanticsData().hasAction(SemanticsAction.scrollUp), isTrue);
-
-        semanticsOwner.performAction(node.id, SemanticsAction.scrollUp);
-        await tester.pump();
-        expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
-        expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
-        expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
-        expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
-        final Offset delta = receivedDragUpdateDetails!.delta;
-
-        expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
-        expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
-      });
-
-      testWidgets('pan', (WidgetTester tester) async {
-        DragDownDetails? receivedDragDownDetails;
-        DragStartDetails? receivedDragStartDetails;
-        DragUpdateDetails? receivedDragUpdateDetails;
-        DragEndDetails? receivedDragEndDetails;
-        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
-        final UniqueKey key = UniqueKey();
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Center(
-                child: RawGestureDetector(
-                  key: key,
-                  gestures: <Type, GestureRecognizerFactory>{
-                    PanGestureRecognizer:
-                        GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
-                          () => PanGestureRecognizer(),
-                          (PanGestureRecognizer instance) {
-                            instance.onDown = (DragDownDetails details) {
-                              receivedDragDownDetails = details;
-                            };
-                            instance.onStart = (DragStartDetails details) {
-                              receivedDragStartDetails = details;
-                            };
-                            instance.onUpdate = (DragUpdateDetails details) {
-                              receivedDragUpdateDetails = details;
-                            };
-                            instance.onEnd = (DragEndDetails details) {
-                              receivedDragEndDetails = details;
-                            };
-                          },
-                        ),
-                  },
-                  child: const SizedBox(width: 20, height: 20),
-                ),
-              ),
-            ),
-          ),
-        );
-        final SemanticsNode node = tester.semantics.find(find.byKey(key));
-        expect(node.getSemanticsData().hasAction(SemanticsAction.scrollRight), isTrue);
-
-        semanticsOwner.performAction(node.id, SemanticsAction.scrollRight);
-        await tester.pump();
-        expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
-        expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
-        expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
-        expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
-        Offset delta = receivedDragUpdateDetails!.delta;
-
-        expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
-        expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
-
-        // scroll vertically
-        receivedDragDownDetails = null;
-        receivedDragStartDetails = null;
-        receivedDragUpdateDetails = null;
-        receivedDragEndDetails = null;
-
-        expect(node.getSemanticsData().hasAction(SemanticsAction.scrollUp), isTrue);
-
-        semanticsOwner.performAction(node.id, SemanticsAction.scrollUp);
-        await tester.pump();
-        expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
-        expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
-        expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
-        expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
-        delta = receivedDragUpdateDetails!.delta;
-
-        expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
-        expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
-      });
     });
 
     group('error control test', () {

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -899,6 +900,294 @@ void main() {
               .toList();
 
       expect(description, <String>['gestures: <none>', 'excludeFromSemantics: true']);
+    });
+
+    group('default semantics', () {
+      testWidgets('tap', (WidgetTester tester) async {
+        TapDownDetails? receivedTapDownDetails;
+        TapUpDetails? receivedTapUpDetails;
+        bool tapped = false;
+        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+        final UniqueKey key = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: RawGestureDetector(
+                  key: key,
+                  gestures: <Type, GestureRecognizerFactory>{
+                    TapGestureRecognizer:
+                        GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+                          () => TapGestureRecognizer(postAcceptSlopTolerance: null),
+                          (TapGestureRecognizer instance) {
+                            instance.onTapDown = (TapDownDetails details) {
+                              receivedTapDownDetails = details;
+                            };
+                            instance.onTapUp = (TapUpDetails details) {
+                              receivedTapUpDetails = details;
+                            };
+                            instance.onTap = () {
+                              tapped = true;
+                            };
+                          },
+                        ),
+                  },
+                  child: const SizedBox(width: 20, height: 20),
+                ),
+              ),
+            ),
+          ),
+        );
+        final SemanticsNode node = tester.semantics.find(find.byKey(key));
+        expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
+
+        semanticsOwner.performAction(node.id, SemanticsAction.tap);
+        await tester.pump();
+        expect(receivedTapDownDetails!.localPosition, const Offset(10, 10));
+        expect(receivedTapDownDetails!.globalPosition, const Offset(400, 300));
+        expect(receivedTapUpDetails!.localPosition, const Offset(10, 10));
+        expect(receivedTapUpDetails!.globalPosition, const Offset(400, 300));
+        expect(tapped, isTrue);
+      });
+
+      testWidgets('long press', (WidgetTester tester) async {
+        LongPressDownDetails? receivedLongPressDownDetails;
+        LongPressStartDetails? receivedLongPressStartDetails;
+        LongPressEndDetails? receivedLongPressEndDetails;
+        bool pressed = false;
+        bool upped = false;
+        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+        final UniqueKey key = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: RawGestureDetector(
+                  key: key,
+                  gestures: <Type, GestureRecognizerFactory>{
+                    LongPressGestureRecognizer:
+                        GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+                          () => LongPressGestureRecognizer(),
+                          (LongPressGestureRecognizer instance) {
+                            instance.onLongPressDown = (LongPressDownDetails details) {
+                              receivedLongPressDownDetails = details;
+                            };
+                            instance.onLongPressStart = (LongPressStartDetails details) {
+                              receivedLongPressStartDetails = details;
+                            };
+                            instance.onLongPressEnd = (LongPressEndDetails details) {
+                              receivedLongPressEndDetails = details;
+                            };
+                            instance.onLongPressUp = () {
+                              upped = true;
+                            };
+                            instance.onLongPress = () {
+                              pressed = true;
+                            };
+                          },
+                        ),
+                  },
+                  child: const SizedBox(width: 20, height: 20),
+                ),
+              ),
+            ),
+          ),
+        );
+        final SemanticsNode node = tester.semantics.find(find.byKey(key));
+        expect(node.getSemanticsData().hasAction(SemanticsAction.longPress), isTrue);
+
+        semanticsOwner.performAction(node.id, SemanticsAction.longPress);
+        await tester.pump();
+        expect(receivedLongPressDownDetails!.localPosition, const Offset(10, 10));
+        expect(receivedLongPressDownDetails!.globalPosition, const Offset(400, 300));
+        expect(receivedLongPressStartDetails!.localPosition, const Offset(10, 10));
+        expect(receivedLongPressStartDetails!.globalPosition, const Offset(400, 300));
+        expect(receivedLongPressEndDetails!.localPosition, const Offset(10, 10));
+        expect(receivedLongPressEndDetails!.globalPosition, const Offset(400, 300));
+        expect(pressed, isTrue);
+        expect(upped, isTrue);
+      });
+
+      testWidgets('horizontal drag', (WidgetTester tester) async {
+        DragDownDetails? receivedDragDownDetails;
+        DragStartDetails? receivedDragStartDetails;
+        DragUpdateDetails? receivedDragUpdateDetails;
+        DragEndDetails? receivedDragEndDetails;
+        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+        final UniqueKey key = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: RawGestureDetector(
+                  key: key,
+                  gestures: <Type, GestureRecognizerFactory>{
+                    HorizontalDragGestureRecognizer:
+                        GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
+                          () => HorizontalDragGestureRecognizer(),
+                          (HorizontalDragGestureRecognizer instance) {
+                            instance.onDown = (DragDownDetails details) {
+                              receivedDragDownDetails = details;
+                            };
+                            instance.onStart = (DragStartDetails details) {
+                              receivedDragStartDetails = details;
+                            };
+                            instance.onUpdate = (DragUpdateDetails details) {
+                              receivedDragUpdateDetails = details;
+                            };
+                            instance.onEnd = (DragEndDetails details) {
+                              receivedDragEndDetails = details;
+                            };
+                          },
+                        ),
+                  },
+                  child: const SizedBox(width: 20, height: 20),
+                ),
+              ),
+            ),
+          ),
+        );
+        final SemanticsNode node = tester.semantics.find(find.byKey(key));
+        expect(node.getSemanticsData().hasAction(SemanticsAction.scrollRight), isTrue);
+
+        semanticsOwner.performAction(node.id, SemanticsAction.scrollRight);
+        await tester.pump();
+        expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
+        expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
+        expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
+        expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
+        final Offset delta = receivedDragUpdateDetails!.delta;
+
+        expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
+        expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
+      });
+
+      testWidgets('vertical drag', (WidgetTester tester) async {
+        DragDownDetails? receivedDragDownDetails;
+        DragStartDetails? receivedDragStartDetails;
+        DragUpdateDetails? receivedDragUpdateDetails;
+        DragEndDetails? receivedDragEndDetails;
+        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+        final UniqueKey key = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: RawGestureDetector(
+                  key: key,
+                  gestures: <Type, GestureRecognizerFactory>{
+                    VerticalDragGestureRecognizer:
+                        GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
+                          () => VerticalDragGestureRecognizer(),
+                          (VerticalDragGestureRecognizer instance) {
+                            instance.onDown = (DragDownDetails details) {
+                              receivedDragDownDetails = details;
+                            };
+                            instance.onStart = (DragStartDetails details) {
+                              receivedDragStartDetails = details;
+                            };
+                            instance.onUpdate = (DragUpdateDetails details) {
+                              receivedDragUpdateDetails = details;
+                            };
+                            instance.onEnd = (DragEndDetails details) {
+                              receivedDragEndDetails = details;
+                            };
+                          },
+                        ),
+                  },
+                  child: const SizedBox(width: 20, height: 20),
+                ),
+              ),
+            ),
+          ),
+        );
+        final SemanticsNode node = tester.semantics.find(find.byKey(key));
+        expect(node.getSemanticsData().hasAction(SemanticsAction.scrollUp), isTrue);
+
+        semanticsOwner.performAction(node.id, SemanticsAction.scrollUp);
+        await tester.pump();
+        expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
+        expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
+        expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
+        expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
+        final Offset delta = receivedDragUpdateDetails!.delta;
+
+        expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
+        expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
+      });
+
+      testWidgets('pan', (WidgetTester tester) async {
+        DragDownDetails? receivedDragDownDetails;
+        DragStartDetails? receivedDragStartDetails;
+        DragUpdateDetails? receivedDragUpdateDetails;
+        DragEndDetails? receivedDragEndDetails;
+        final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
+        final UniqueKey key = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: RawGestureDetector(
+                  key: key,
+                  gestures: <Type, GestureRecognizerFactory>{
+                    PanGestureRecognizer:
+                        GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
+                          () => PanGestureRecognizer(),
+                          (PanGestureRecognizer instance) {
+                            instance.onDown = (DragDownDetails details) {
+                              receivedDragDownDetails = details;
+                            };
+                            instance.onStart = (DragStartDetails details) {
+                              receivedDragStartDetails = details;
+                            };
+                            instance.onUpdate = (DragUpdateDetails details) {
+                              receivedDragUpdateDetails = details;
+                            };
+                            instance.onEnd = (DragEndDetails details) {
+                              receivedDragEndDetails = details;
+                            };
+                          },
+                        ),
+                  },
+                  child: const SizedBox(width: 20, height: 20),
+                ),
+              ),
+            ),
+          ),
+        );
+        final SemanticsNode node = tester.semantics.find(find.byKey(key));
+        expect(node.getSemanticsData().hasAction(SemanticsAction.scrollRight), isTrue);
+
+        semanticsOwner.performAction(node.id, SemanticsAction.scrollRight);
+        await tester.pump();
+        expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
+        expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
+        expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
+        expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
+        Offset delta = receivedDragUpdateDetails!.delta;
+
+        expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
+        expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
+
+        // scroll vertically
+        receivedDragDownDetails = null;
+        receivedDragStartDetails = null;
+        receivedDragUpdateDetails = null;
+        receivedDragEndDetails = null;
+
+        expect(node.getSemanticsData().hasAction(SemanticsAction.scrollUp), isTrue);
+
+        semanticsOwner.performAction(node.id, SemanticsAction.scrollUp);
+        await tester.pump();
+        expect(receivedDragDownDetails!.localPosition, const Offset(10, 10));
+        expect(receivedDragDownDetails!.globalPosition, const Offset(400, 300));
+        expect(receivedDragStartDetails!.localPosition, const Offset(10, 10));
+        expect(receivedDragStartDetails!.globalPosition, const Offset(400, 300));
+        delta = receivedDragUpdateDetails!.delta;
+
+        expect(receivedDragEndDetails!.localPosition, const Offset(10, 10) + delta);
+        expect(receivedDragEndDetails!.globalPosition, const Offset(400, 300) + delta);
+      });
     });
 
     group('error control test', () {

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/170348

The root cause is the RawGestureDetector doesn't call individual ontap method with correct position. A previous refactor to cupertinoButton remove the onTap, but instead using the individual tap method to register the click and surfaced this issue

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
