### PR TITLE
[native assets] Roll dependencies

### DIFF
--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -22,12 +22,12 @@ const Map<String, String> kManuallyPinnedDependencies = <String, String>{
   // Add pinned packages here. Please leave a comment explaining why.
   'archive': '3.6.1', // https://github.com/flutter/flutter/issues/115660
   'code_assets':
-      '0.19.3', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
+      '0.19.4', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
   'flutter_template_images': '5.0.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912
   'hooks':
-      '0.19.3', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
+      '0.19.5', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'hooks_runner':
       '0.21.0', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'material_color_utilities': '0.11.1', // Keep pinned to latest until 1.0.0.

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -57,8 +57,8 @@ dependencies:
 
   graphs: 2.3.2
   hooks_runner: 0.21.0
-  hooks: 0.19.3
-  code_assets: 0.19.3
+  hooks: 0.19.5
+  code_assets: 0.19.4
 
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading
@@ -126,4 +126,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: untvjo
+# PUBSPEC CHECKSUM: gpkldp

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -6,10 +6,10 @@ environment:
   sdk: {{dartSdkVersionBounds}}
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: ^0.19.4
+  hooks: ^0.19.5
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: ^0.16.3
 
 dev_dependencies:
   ffi: ^2.1.3

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,10 +126,10 @@ packages:
     dependency: "direct main"
     description:
       name: code_assets
-      sha256: d1bacf6f0c507acc817e053f8186b79a600eeed78dbd04edcb8c5a8a07a37e1f
+      sha256: dd7ed641b7f642092092969f2dcd5845ab31c9f3efead0c06ca437bf9ce8a8b2
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.3"
+    version: "0.19.4"
   collection:
     dependency: "direct main"
     description:
@@ -350,10 +350,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks
-      sha256: "6fa18c99c5fd6456c3edd99e3f857099c8748eb2062bb8374970f7896858512b"
+      sha256: "75363eae6c0c2db051c4f6b3b1fcdea8a09c4a596cc83bfff847661da6e80dfc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.3"
+    version: "0.19.5"
   html:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -91,7 +91,7 @@ dependencies:
   checked_yaml: 2.0.4
   cli_config: 0.2.0
   clock: 1.1.2
-  code_assets: 0.19.3
+  code_assets: 0.19.4
   collection: 1.19.1
   convert: 3.1.2
   coverage: 1.14.1
@@ -115,7 +115,7 @@ dependencies:
   google_mobile_ads: 5.1.0
   googleapis: 12.0.0
   googleapis_auth: 1.6.0
-  hooks: 0.19.3
+  hooks: 0.19.5
   html: 0.15.6
   http: 1.4.0
   http_multi_server: 3.2.2
@@ -213,4 +213,4 @@ dependencies:
   pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.2
-# PUBSPEC CHECKSUM: vsmjan
+# PUBSPEC CHECKSUM: kolr2k


### PR DESCRIPTION
Rolls the dependencies to the once published this week.

Covered by existing integration tests.