### PR TITLE
Prevent --web-experimental-hot-reload on web-server

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -29,6 +29,7 @@ import '../project.dart';
 import '../reporting/reporting.dart';
 import '../reporting/unified_analytics.dart';
 import '../version.dart';
+import '../web/web_device.dart';
 import 'flutter_command_runner.dart';
 import 'target_devices.dart';
 
@@ -1333,7 +1334,11 @@ abstract class FlutterCommand extends Command<void> {
     // TODO(natebiggs): Delete this when new DDC module system is the default.
     final bool webEnableHotReload =
         argParser.options.containsKey(FlutterOptions.kWebExperimentalHotReload) &&
-        boolArg(FlutterOptions.kWebExperimentalHotReload);
+        boolArg(FlutterOptions.kWebExperimentalHotReload) &&
+        // TODO(nshahan): Enable on web-server when the app is started correctly
+        // https://github.com/dart-lang/sdk/issues/60289.
+        (globals.deviceManager == null ||
+            globals.deviceManager!.specifiedDeviceId != WebServerDevice.kWebServerDeviceId);
 
     String? codeSizeDirectory;
     if (argParser.options.containsKey(FlutterOptions.kAnalyzeSize) &&

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -370,6 +370,28 @@ void main() {
       },
     );
 
+    // TODO(nshahan): Delete when hot reload on web is always enabled
+    // https://github.com/flutter/flutter/issues/170685.
+    testUsingContext('web hot reload enabled by default', () async {
+      final DummyFlutterCommand dummyCommand =
+          DummyFlutterCommand()..usesWebOptions(verboseHelp: false);
+      final CommandRunner<void> runner = createTestCommandRunner(dummyCommand);
+      await runner.run(<String>['dummy']);
+      final BuildInfo buildInfo = await dummyCommand.getBuildInfo(forcedBuildMode: BuildMode.debug);
+      expect(buildInfo.webEnableHotReload, isTrue);
+    });
+
+    // TODO(nshahan): Delete when hot reload doesn't break on web-server
+    // https://github.com/dart-lang/sdk/issues/60289.
+    testUsingContext('web hot reload disabled when device is web-server', () async {
+      final DummyFlutterCommand dummyCommand =
+          DummyFlutterCommand()..usesWebOptions(verboseHelp: false);
+      final CommandRunner<void> runner = createTestCommandRunner(dummyCommand);
+      await runner.run(<String>['dummy', '-d', 'web-server']);
+      final BuildInfo buildInfo = await dummyCommand.getBuildInfo(forcedBuildMode: BuildMode.debug);
+      expect(buildInfo.webEnableHotReload, isFalse);
+    });
+
     group('signals tests', () {
       late FakeIoProcessSignal mockSignal;
       late ProcessSignal signalUnderTest;


### PR DESCRIPTION
When running on the web-server device hot reload option will default to disabled when `-d web-server` is also passed.
This is temporary until the app can start correctly with hot reload enabled.

Issue: https://github.com/dart-lang/sdk/issues/60289
