### PR TITLE
Fix whitespace issue in .ci.yaml.

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -60,7 +60,7 @@ targets:
     enabled_branches:
       - master
     recipe: engine_v2/engine_v2
-    bringup: true # LUCI failing KVM access https://github.com/flutter/flutter/issues/170529 
+    bringup: true # LUCI failing KVM access https://github.com/flutter/flutter/issues/170529
     properties:
       config_name: linux_android_emulator
       dependencies: >-


### PR DESCRIPTION
Getting failures in CI both presubmit and postsubmit that look like:

```
[2025-06-13 13:23:25.219514] ERROR: ERROR: Whitespace check failed. The following files have trailing spaces:

/b/s/w/ir/cache/builder/engine/src/flutter/.ci.yaml:62:    bringup: true # LUCI failing KVM access https://github.com/flutter/flutter/issues/170529
Checking C++/ObjC/Shader formatting...
```

This looks like it was introduced in https://github.com/flutter/flutter/pull/170607