### PR TITLE
Add `CupertinoPicker` ticking sound

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -566,6 +566,7 @@ public class PlatformChannel {
   /** Types of sounds the Android OS can play on behalf of an application. */
   public enum SoundType {
     CLICK("SystemSoundType.click"),
+    TICK("SystemSoundType.tick"),
     ALERT("SystemSoundType.alert");
 
     @NonNull

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -23,6 +23,7 @@ namespace {
 
 constexpr char kTextPlainFormat[] = "text/plain";
 const UInt32 kKeyPressClickSoundId = 1306;
+const UInt32 kPickerTickSoundId = 1157;
 
 NSString* const kSearchURLPrefix = @"x-web-search://?";
 
@@ -243,6 +244,8 @@ static void SetStatusBarStyleForSharedApplication(UIStatusBarStyle style) {
     // All feedback types are specific to Android and are treated as equal on
     // iOS.
     AudioServicesPlaySystemSound(kKeyPressClickSoundId);
+  } else if ([soundType isEqualToString:@"SystemSoundType.tick"]) {
+    AudioServicesPlaySystemSound(kPickerTickSoundId);
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -22,8 +22,10 @@ FLUTTER_ASSERT_ARC
 namespace {
 
 constexpr char kTextPlainFormat[] = "text/plain";
+// Some of the official iOS system sounds. A full list can be found in many places online, such as:
+// https://github.com/p-x9/swift-system-sound/blob/cb4327b223d55d01e9156539c8442db16f4b1f85/SystemSoundTable.md
 const UInt32 kKeyPressClickSoundId = 1306;
-const UInt32 kPickerTickSoundId = 1157;
+const UInt32 kWheelsOfTimeSoundId = 1157;
 
 NSString* const kSearchURLPrefix = @"x-web-search://?";
 
@@ -245,7 +247,7 @@ static void SetStatusBarStyleForSharedApplication(UIStatusBarStyle style) {
     // iOS.
     AudioServicesPlaySystemSound(kKeyPressClickSoundId);
   } else if ([soundType isEqualToString:@"SystemSoundType.tick"]) {
-    AudioServicesPlaySystemSound(kPickerTickSoundId);
+    AudioServicesPlaySystemSound(kWheelsOfTimeSoundId);
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -22,6 +22,7 @@ FLUTTER_ASSERT_ARC
 - (void)searchWeb:(NSString*)searchTerm;
 - (void)showLookUpViewController:(NSString*)term;
 - (void)showShareViewController:(NSString*)content;
+- (void)playSystemSound:(NSString*)soundType;
 @end
 
 @interface UIViewController ()
@@ -287,6 +288,24 @@ FLUTTER_ASSERT_ARC
                                         arguments:nil];
   FlutterResult result = ^(id result) {
     OCMVerify([mockPlugin isLiveTextInputAvailable]);
+    [invokeExpectation fulfill];
+  };
+  [mockPlugin handleMethodCall:methodCall result:result];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testSystemSoundPlay {
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
+  XCTestExpectation* invokeExpectation =
+      [self expectationWithDescription:@"SystemSound.play invoked"];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
+
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"SystemSound.play"
+                                        arguments:@"SystemSoundType.click"];
+  FlutterResult result = ^(id result) {
+    OCMVerify([mockPlugin playSystemSound:@"SystemSoundType.click"]);
     [invokeExpectation fulfill];
   };
   [mockPlugin handleMethodCall:methodCall result:result];

--- a/engine/src/flutter/shell/platform/linux/fl_platform_handler.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_platform_handler.cc
@@ -18,6 +18,7 @@ static constexpr char kTextPlainFormat[] = "text/plain";
 
 static constexpr char kSoundTypeAlert[] = "SystemSoundType.alert";
 static constexpr char kSoundTypeClick[] = "SystemSoundType.click";
+static constexpr char kSoundTypeClick[] = "SystemSoundType.tick";
 
 struct _FlPlatformHandler {
   GObject parent_instance;
@@ -208,6 +209,8 @@ static void system_sound_play(const gchar* type, gpointer user_data) {
     }
   } else if (strcmp(type, kSoundTypeClick) == 0) {
     // We don't make sounds for keyboard on desktops.
+  } else if (strcmp(type, kSoundTypeTick) == 0) {
+    // We don't make ticking sounds on desktops.
   } else {
     g_warning("Ignoring unknown sound type %s in SystemSound.play.\n", type);
   }

--- a/engine/src/flutter/shell/platform/linux/fl_platform_handler.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_platform_handler.cc
@@ -18,7 +18,7 @@ static constexpr char kTextPlainFormat[] = "text/plain";
 
 static constexpr char kSoundTypeAlert[] = "SystemSoundType.alert";
 static constexpr char kSoundTypeClick[] = "SystemSoundType.click";
-static constexpr char kSoundTypeClick[] = "SystemSoundType.tick";
+static constexpr char kSoundTypeTick[] = "SystemSoundType.tick";
 
 struct _FlPlatformHandler {
   GObject parent_instance;

--- a/engine/src/flutter/shell/platform/windows/platform_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_handler.cc
@@ -368,6 +368,12 @@ void PlatformHandler::SystemSoundPlay(
   if (sound_type.compare(kSoundTypeAlert) == 0) {
     MessageBeep(MB_OK);
     result->Success();
+  } else if (sound_type.compare(kSoundTypeClick) == 0) {
+    // No-op, as there is no system sound for key presses.
+    result->Success();
+  } else if (sound_type.compare(kSoundTypeTick) == 0) {
+    // No-op, as there is no system sound for ticks.
+    result->Success();
   } else {
     result->NotImplemented();
   }

--- a/engine/src/flutter/shell/platform/windows/platform_handler.h
+++ b/engine/src/flutter/shell/platform/windows/platform_handler.h
@@ -104,6 +104,8 @@ class PlatformHandler {
   static constexpr char kClipboardError[] = "Clipboard error";
 
   static constexpr char kSoundTypeAlert[] = "SystemSoundType.alert";
+  static constexpr char kSoundTypeClick[] = "SystemSoundType.click";
+  static constexpr char kSoundTypeTick[] = "SystemSoundType.tick";
 
  private:
   // Called when a method is called on |channel_|;

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -279,6 +279,7 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
         if (index != _lastHapticIndex) {
           _lastHapticIndex = index;
           HapticFeedback.selectionClick();
+          SystemSound.play(SystemSoundType.tick);
         }
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -24,8 +24,12 @@ enum SystemSoundType {
   /// ignored on the web as well.
   alert,
 
-  // If you add new values here, you also need to update the `SoundType` Java
-  // enum in `PlatformChannel.java`.
+  // If you add new values here, you also need to update:
+  // - the `SoundType` Java enum in `PlatformChannel.java` (Android);
+  // - `FlutterPlatformPlugin.mm` (iOS);
+  // - `FlutterPlatformPlugin.mm` (macOS);
+  // - `fl_platform_handler.cc` (Linux);
+  // - `platform_handler.cc` (Windows);
 }
 
 /// Provides access to the library of short system specific sounds for common

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -11,6 +11,11 @@ enum SystemSoundType {
   /// A short indication that a button was pressed.
   click,
 
+  /// A short indication that a picker value was changed.
+  ///
+  /// This is ignored on all platforms except iOS.
+  tick,
+
   /// A short system alert sound indicating the need for user attention.
   ///
   /// Desktop platforms are the only platforms that support a system alert

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -398,7 +398,7 @@ void main() {
     });
 
     testWidgets(
-      'does not trigger haptics and sound when scrolling by tapping on the item',
+      'does not trigger haptics or sounds when scrolling by tapping on the item',
       (WidgetTester tester) async {
         final List<int> selectedItems = <int>[];
         final List<MethodCall> systemCalls = <MethodCall>[];
@@ -444,7 +444,7 @@ void main() {
     );
 
     testWidgets(
-      'do not trigger haptic and sound effects on non-iOS devices',
+      'do not trigger haptic or sounds on non-iOS devices',
       (WidgetTester tester) async {
         final List<int> selectedItems = <int>[];
         final List<MethodCall> systemCalls = <MethodCall>[];

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -313,10 +313,13 @@ void main() {
 
         // Let the scroll settle and end up in the middle of the item.
         await tester.pumpAndSettle();
+        expect(systemCalls, hasLength(2));
+        // Check that the haptic feedback and ticking sound were triggered.
         expect(
-          systemCalls.single,
+          systemCalls[0],
           isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.selectionClick'),
         );
+        expect(systemCalls[1], isMethodCall('SystemSound.play', arguments: 'SystemSoundType.tick'));
 
         // Overscroll a little to pass the middle of the item.
         await tester.drag(
@@ -325,11 +328,12 @@ void main() {
           warnIfMissed: false,
         ); // has an IgnorePointer
         expect(selectedItems, <int>[1, 0]);
-        expect(systemCalls, hasLength(2));
+        expect(systemCalls, hasLength(4));
         expect(
-          systemCalls.last,
+          systemCalls[2],
           isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.selectionClick'),
         );
+        expect(systemCalls[3], isMethodCall('SystemSound.play', arguments: 'SystemSoundType.tick'));
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );
@@ -394,7 +398,7 @@ void main() {
     });
 
     testWidgets(
-      'does not trigger haptics when scrolling by tapping on the item',
+      'does not trigger haptics and sound when scrolling by tapping on the item',
       (WidgetTester tester) async {
         final List<int> selectedItems = <int>[];
         final List<MethodCall> systemCalls = <MethodCall>[];
@@ -440,7 +444,7 @@ void main() {
     );
 
     testWidgets(
-      'do not trigger haptic effects on non-iOS devices',
+      'do not trigger haptic and sound effects on non-iOS devices',
       (WidgetTester tester) async {
         final List<int> selectedItems = <int>[];
         final List<MethodCall> systemCalls = <MethodCall>[];


### PR DESCRIPTION
This PR adds a ticking sound to the `CupertinoPicker` on iOS.

Fixes https://github.com/flutter/flutter/issues/37329

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

