### PR TITLE
Reland "[native assets] Build dev dependencies in `flutter test integration_test`"

### DIFF
--- a/dev/devicelab/lib/tasks/native_assets_test.dart
+++ b/dev/devicelab/lib/tasks/native_assets_test.dart
@@ -209,7 +209,7 @@ Future<T> inTempDir<T>(Future<T> Function(Directory tempDirectory) fun) async {
 }
 
 void addIntegrationTest(Uri exampleDirectory, String packageName) {
-  final ProcessResult result = Process.runSync('flutter', <String>[
+  final ProcessResult result = Process.runSync(_flutterBin, <String>[
     'pub',
     'add',
     'dev:integration_test:{"sdk":"flutter"}',

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -51,6 +51,12 @@ abstract class DartBuild extends Target {
         );
       }
       final String pubspecPath = packageConfigFile.uri.resolve('../pubspec.yaml').toFilePath();
+      final String? buildModeEnvironment = environment.defines[kBuildMode];
+      if (buildModeEnvironment == null) {
+        throw MissingDefineException(kBuildMode, name);
+      }
+      final BuildMode buildMode = BuildMode.fromCliName(buildModeEnvironment);
+      final bool includeDevDependencies = !buildMode.isRelease;
       final FlutterNativeAssetsBuildRunner buildRunner =
           _buildRunner ??
           FlutterNativeAssetsBuildRunnerImpl(
@@ -59,7 +65,7 @@ abstract class DartBuild extends Target {
             fileSystem,
             environment.logger,
             runPackageName,
-            includeDevDependencies: false,
+            includeDevDependencies: includeDevDependencies,
             pubspecPath,
           );
       result = await runFlutterSpecificDartBuild(

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -471,7 +471,10 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       webUseWasm: useWasm,
     );
 
-    final Uri? nativeAssetsJson = await nativeAssetsBuilder?.build(buildInfo);
+    final Uri? nativeAssetsJson =
+        _isIntegrationTest
+            ? null // Don't build for host when running integration tests.
+            : await nativeAssetsBuilder?.build(buildInfo);
     String? testAssetPath;
     if (buildTestAssets) {
       await _buildTestAsset(

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -159,6 +159,29 @@ void main() {
     });
   });
 
+  for (final String device in devices) {
+    testWithoutContext('flutter test integration_test $device native assets', () async {
+      await inTempDir((Directory tempDirectory) async {
+        final Directory packageDirectory = await createTestProject(packageName, tempDirectory);
+
+        final Uri exampleDirectory = Uri.directory(packageDirectory.path).resolve('example/');
+        addIntegrationTest(exampleDirectory, packageName);
+
+        final ProcessTestResult result = await runFlutter(
+          <String>['test', 'integration_test', '-d', device],
+          exampleDirectory.toFilePath(),
+          <Transition>[Barrier(RegExp('.* All tests passed!'))],
+          logging: false,
+        );
+        if (result.exitCode != 0) {
+          throw Exception(
+            'flutter test integration_test failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
+          );
+        }
+      });
+    });
+  }
+
   for (final String buildSubcommand in buildSubcommands) {
     for (final String buildMode in buildModes) {
       testWithoutContext(
@@ -230,6 +253,43 @@ void main() {
       });
     });
   }
+}
+
+void addIntegrationTest(Uri exampleDirectory, String packageName) {
+  final ProcessResult result = processManager.runSync(<String>[
+    'flutter',
+    'pub',
+    'add',
+    'dev:integration_test:{"sdk":"flutter"}',
+  ], workingDirectory: exampleDirectory.toFilePath());
+  if (result.exitCode != 0) {
+    throw Exception(
+      'flutter pub add failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
+    );
+  }
+
+  final Uri integrationTestPath = exampleDirectory.resolve('integration_test/my_test.dart');
+  final File integrationTestFile = fileSystem.file(integrationTestPath);
+  integrationTestFile.createSync(recursive: true);
+  integrationTestFile.writeAsStringSync('''
+import 'package:flutter_test/flutter_test.dart';
+import 'package:${packageName}_example/main.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('end-to-end test', () {
+    testWidgets('invoke native code', (tester) async {
+      // Load app widget.
+      await tester.pumpWidget(const MyApp());
+
+      // Verify the native function was called.
+      expect(find.text('sum(1, 2) = 3'), findsOneWidget);
+    });
+  });
+}
+''');
 }
 
 void expectDylibIsCodeSignedMacOS(Directory appDirectory, String buildMode) {


### PR DESCRIPTION
Reland https://github.com/flutter/flutter/pull/170374

Original PR in first commit. Fixes in subsequent commits:

* `flutter` is not on the `PATH` in the device lab, use `_flutterBin` (consistent with the rest of the test).
   Fixes `flutter` not found.
* `flutter test integration_test` now does not build assets for the host anymore. `flutter test` builds assets for the host. The `TestCommand` is now special-case to check for `_isIntegrationTest`.
   Fixes `clang++` not found. (It's the compiler for Linux, but we are running integration tests on an Android device.)

Tests pass locally with:

```
$ cd /Users/dacoharkes/src/flutter/flutter/dev/devicelab && dart bin/test_runner.dart test -t native_assets_android
```

Note:

* The device lab tests are not run on presubmit until https://github.com/flutter/flutter/issues/170682 is addressed.
* The emulator tests are not run at all atm: https://github.com/flutter/flutter/issues/170529.