### PR TITLE
[native assets] Switch device lab Android with Linux host to emulator

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3090,13 +3090,13 @@ targets:
         ["devicelab", "android", "linux", "mokey"]
       task_name: list_text_layout_impeller_perf__e2e_summary
 
-  - name: Linux_pixel_7pro native_assets_android
+  - name: Linux_android_emu native_assets_android
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true # LUCI failing KVM access https://github.com/flutter/flutter/issues/170529
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux", "pixel", "7pro"]
+        ["devicelab", "linux"]
       task_name: native_assets_android
 
   # linux mokey benchmark


### PR DESCRIPTION
Closes: https://github.com/flutter/flutter/issues/170682

We have emulators available on the Linux host, so switch the Android device lab tests for native assets over to the emulator.

We don't seem to have emulators on Windows or MacOS hosts. (If we do, they are not used in `ci.yaml`.)

We want at least one physical device test for Android with native assets. And we want to cover all host OSes (not everything works the same everywhere). So keep the physical device tests for the MacOS and Windows hosts.

Should we wait with landing this until https://github.com/flutter/flutter/issues/170529 is resolved?