### PR TITLE
Add `--profile-microtasks` switch

### DIFF
--- a/engine/src/flutter/common/settings.h
+++ b/engine/src/flutter/common/settings.h
@@ -160,6 +160,7 @@ struct Settings {
   bool enable_dart_profiling = false;
   bool disable_dart_asserts = false;
   bool enable_serial_gc = false;
+  bool profile_microtasks = false;
 
   // Whether embedder only allows secure connections.
   bool may_insecurely_connect_to_all_domains = true;

--- a/engine/src/flutter/runtime/dart_vm.cc
+++ b/engine/src/flutter/runtime/dart_vm.cc
@@ -86,17 +86,27 @@ static std::string DartFileRecorderArgs(const std::string& path) {
   return oss.str();
 }
 
+// "Microtask" is included in all argument strings below, but "Microtask" stream
+// events will only be recorded by the VM's timeline recorders when
+// |Switch::ProfileMicrotasks| is set.
+
 [[maybe_unused]]
 static const char* kDartDefaultTraceStreamsArgs[]{
-    "--timeline_streams=Dart,Embedder,GC",
+    "--timeline_streams=Dart,Embedder,GC,Microtask",
 };
 
 static const char* kDartStartupTraceStreamsArgs[]{
-    "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM,API",
+    "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,Microtask,"
+    "VM,API",
 };
 
 static const char* kDartSystraceTraceStreamsArgs[] = {
-    "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM,API",
+    "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,Microtask,"
+    "VM,API",
+};
+
+static const char* kDartProfileMicrotasksArgs[]{
+    "--profile_microtasks",
 };
 
 static std::string DartOldGenHeapSizeArgs(uint64_t heap_size) {
@@ -390,6 +400,11 @@ DartVM::DartVM(const std::shared_ptr<const DartVMData>& vm_data,
                 std::size(kDartDefaultTraceStreamsArgs));
   }
 #endif  // defined(OS_FUCHSIA)
+
+  if (settings_.profile_microtasks) {
+    PushBackAll(&args, kDartProfileMicrotasksArgs,
+                std::size(kDartProfileMicrotasksArgs));
+  }
 
   std::string old_gen_heap_size_args;
   if (settings_.old_gen_heap_size >= 0) {

--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -332,6 +332,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   command_line.GetOptionValue(FlagForSwitch(Switch::TraceToFile),
                               &settings.trace_to_file);
 
+  settings.profile_microtasks =
+      command_line.HasOption(FlagForSwitch(Switch::ProfileMicrotasks));
+
   settings.skia_deterministic_rendering_on_cpu =
       command_line.HasOption(FlagForSwitch(Switch::SkiaDeterministicRendering));
 

--- a/engine/src/flutter/shell/common/switches.h
+++ b/engine/src/flutter/shell/common/switches.h
@@ -175,6 +175,12 @@ DEF_SWITCH(TraceToFile,
            "Write the timeline trace to a file at the specified path. The file "
            "will be in Perfetto's proto format; it will be possible to load "
            "the file into Perfetto's trace viewer.")
+DEF_SWITCH(ProfileMicrotasks,
+           "profile-microtasks",
+           "Enable collection of information about each microtask. Information "
+           "about completed microtasks will be written to the \"Microtask\" "
+           "timeline stream. Information about queued microtasks will be "
+           "accessible from Dart / Flutter DevTools.")
 DEF_SWITCH(UseTestFonts,
            "use-test-fonts",
            "Running tests that layout and measure text will not yield "

--- a/engine/src/flutter/shell/common/switches_unittests.cc
+++ b/engine/src/flutter/shell/common/switches_unittests.cc
@@ -59,6 +59,23 @@ TEST(SwitchesTest, TraceToFile) {
   EXPECT_EQ(settings.trace_to_file, "trace.binpb");
 }
 
+TEST(SwitchesTest, ProfileMicrotasks) {
+  {
+    fml::CommandLine command_line = fml::CommandLineFromInitializerList(
+        {"command", "--profile-microtasks"});
+    EXPECT_TRUE(command_line.HasOption("profile-microtasks"));
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.profile_microtasks, true);
+  }
+  {
+    // default
+    fml::CommandLine command_line =
+        fml::CommandLineFromInitializerList({"command"});
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.profile_microtasks, false);
+  }
+}
+
 TEST(SwitchesTest, RouteParsedFlag) {
   fml::CommandLine command_line =
       fml::CommandLineFromInitializerList({"command", "--route=/animation"});

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
@@ -44,6 +44,8 @@ public class FlutterShellArgs {
   public static final String ARG_TRACE_SYSTRACE = "--trace-systrace";
   public static final String ARG_KEY_TRACE_TO_FILE = "trace-to-file";
   public static final String ARG_TRACE_TO_FILE = "--trace-to-file";
+  public static final String ARG_KEY_PROFILE_MICROTASKS = "profile-microtasks";
+  public static final String ARG_PROFILE_MICROTASKS = "--profile-microtasks";
   public static final String ARG_KEY_TOGGLE_IMPELLER = "enable-impeller";
   public static final String ARG_ENABLE_IMPELLER = "--enable-impeller=true";
   public static final String ARG_DISABLE_IMPELLER = "--enable-impeller=false";
@@ -111,6 +113,9 @@ public class FlutterShellArgs {
     }
     if (intent.hasExtra(ARG_KEY_TRACE_TO_FILE)) {
       args.add(ARG_TRACE_TO_FILE + "=" + intent.getStringExtra(ARG_KEY_TRACE_TO_FILE));
+    }
+    if (intent.hasExtra(ARG_KEY_PROFILE_MICROTASKS)) {
+      args.add(ARG_PROFILE_MICROTASKS);
     }
     if (intent.hasExtra(ARG_KEY_TOGGLE_IMPELLER)) {
       if (intent.getBooleanExtra(ARG_KEY_TOGGLE_IMPELLER, false)) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -183,6 +183,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
     settings.trace_systrace = enableTraceSystrace.boolValue;
   }
 
+  NSNumber* profileMicrotasks = [mainBundle objectForInfoDictionaryKey:@"FLTProfileMicrotasks"];
+  // Change the default only if the option is present.
+  if (profileMicrotasks != nil) {
+    settings.profile_microtasks = profileMicrotasks.boolValue;
+  }
+
   NSNumber* enableDartAsserts = [mainBundle objectForInfoDictionaryKey:@"FLTEnableDartAsserts"];
   if (enableDartAsserts != nil) {
     settings.dart_flags.push_back("--enable-asserts");


### PR DESCRIPTION
This PR adds a switch that can be used to set [the Dart VM's `profile_microtasks` flag](https://github.com/dart-lang/sdk/blob/c48dd51b90a4a97f43f98c29c038c005fe7863bf/runtime/vm/microtask_mirror_queues.cc#L18-L23).