### PR TITLE
Allow empty initial time when using text input mode in showTimePicker…

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1629,6 +1629,7 @@ class _TimePickerInput extends StatefulWidget {
     required this.helpText,
     required this.autofocusHour,
     required this.autofocusMinute,
+    this.emptyInitialTime,
     this.restorationId,
   });
 
@@ -1658,6 +1659,13 @@ class _TimePickerInput extends StatefulWidget {
   /// The state of this widget is persisted in a [RestorationBucket] claimed
   /// from the surrounding [RestorationScope] using the provided restoration ID.
   final String? restorationId;
+
+  /// If true and [TimePickerEntryMode.input] is used, hour and minute fields
+  /// start empty instead of using [initialSelectedTime].
+  ///
+  /// Useful when users prefer manual input without clearing pre-filled values.
+  /// Ignored in dial mode.
+  final bool? emptyInitialTime;
 
   @override
   _TimePickerInputState createState() => _TimePickerInputState();
@@ -1845,6 +1853,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
                               onSavedSubmitted: _handleHourSavedSubmitted,
                               onChanged: _handleHourChanged,
                               hourLabelText: widget.hourLabelText,
+                              emptyInitialTime: widget.emptyInitialTime,
                             ),
                           ),
                           if (!hourHasError.value && !minuteHasError.value)
@@ -1876,6 +1885,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
                               validator: _validateMinute,
                               onSavedSubmitted: _handleMinuteSavedSubmitted,
                               minuteLabelText: widget.minuteLabelText,
+                              emptyInitialTime: widget.emptyInitialTime,
                             ),
                           ),
                           if (!hourHasError.value && !minuteHasError.value)
@@ -1926,6 +1936,7 @@ class _HourTextField extends StatelessWidget {
     required this.onSavedSubmitted,
     required this.onChanged,
     required this.hourLabelText,
+    this.emptyInitialTime,
     this.restorationId,
   });
 
@@ -1938,6 +1949,7 @@ class _HourTextField extends StatelessWidget {
   final ValueChanged<String> onChanged;
   final String? hourLabelText;
   final String? restorationId;
+  final bool? emptyInitialTime;
 
   @override
   Widget build(BuildContext context) {
@@ -1951,6 +1963,7 @@ class _HourTextField extends StatelessWidget {
       semanticHintText: hourLabelText ?? MaterialLocalizations.of(context).timePickerHourLabel,
       validator: validator,
       onSavedSubmitted: onSavedSubmitted,
+      emptyInitialTime: emptyInitialTime,
       onChanged: onChanged,
     );
   }
@@ -1965,6 +1978,7 @@ class _MinuteTextField extends StatelessWidget {
     required this.validator,
     required this.onSavedSubmitted,
     required this.minuteLabelText,
+    this.emptyInitialTime,
     this.restorationId,
   });
 
@@ -1976,6 +1990,7 @@ class _MinuteTextField extends StatelessWidget {
   final ValueChanged<String?> onSavedSubmitted;
   final String? minuteLabelText;
   final String? restorationId;
+  final bool? emptyInitialTime;
 
   @override
   Widget build(BuildContext context) {
@@ -1988,6 +2003,7 @@ class _MinuteTextField extends StatelessWidget {
       style: style,
       semanticHintText: minuteLabelText ?? MaterialLocalizations.of(context).timePickerMinuteLabel,
       validator: validator,
+      emptyInitialTime: emptyInitialTime,
       onSavedSubmitted: onSavedSubmitted,
     );
   }
@@ -2004,6 +2020,7 @@ class _HourMinuteTextField extends StatefulWidget {
     required this.validator,
     required this.onSavedSubmitted,
     this.restorationId,
+    this.emptyInitialTime,
     this.onChanged,
   });
 
@@ -2017,6 +2034,7 @@ class _HourMinuteTextField extends StatefulWidget {
   final ValueChanged<String?> onSavedSubmitted;
   final ValueChanged<String>? onChanged;
   final String? restorationId;
+  final bool? emptyInitialTime;
 
   @override
   _HourMinuteTextFieldState createState() => _HourMinuteTextFieldState();
@@ -2051,7 +2069,8 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
     // version yet.
     if (!controllerHasBeenSet.value) {
       controllerHasBeenSet.value = true;
-      controller.value.value = TextEditingValue(text: _formattedValue);
+      final String initialTextValue = (widget.emptyInitialTime ?? false) ? '' : _formattedValue;
+      controller.value.value = TextEditingValue(text: initialTextValue);
     }
   }
 
@@ -2204,6 +2223,7 @@ class TimePickerDialog extends StatefulWidget {
     this.onEntryModeChanged,
     this.switchToInputEntryModeIcon,
     this.switchToTimerEntryModeIcon,
+    this.emptyInitialTimeInInputMode,
   });
 
   /// The time initially selected when the dialog is shown.
@@ -2269,6 +2289,13 @@ class TimePickerDialog extends StatefulWidget {
 
   /// {@macro flutter.material.time_picker.switchToTimerEntryModeIcon}
   final Icon? switchToTimerEntryModeIcon;
+
+  /// If true and entry mode is [TimePickerEntryMode.input], the hour and minute
+  /// fields will be empty on start instead of pre-filled with [initialTime].
+  ///
+  /// Improves UX by removing the need to delete default values before typing.
+  /// Skipped in dial mode.
+  final bool? emptyInitialTimeInInputMode;
 
   @override
   State<TimePickerDialog> createState() => _TimePickerDialogState();
@@ -2608,6 +2635,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
                               onEntryModeChanged: _handleEntryModeChanged,
                               switchToInputEntryModeIcon: widget.switchToInputEntryModeIcon,
                               switchToTimerEntryModeIcon: widget.switchToTimerEntryModeIcon,
+                              emptyInitialTimeInInputMode: widget.emptyInitialTimeInInputMode,
                             ),
                           );
                           if (_entryMode.value != TimePickerEntryMode.input &&
@@ -2652,6 +2680,7 @@ class _TimePicker extends StatefulWidget {
     this.onEntryModeChanged,
     this.switchToInputEntryModeIcon,
     this.switchToTimerEntryModeIcon,
+    this.emptyInitialTimeInInputMode,
   });
 
   /// Optionally provide your own text for the help text at the top of the
@@ -2725,6 +2754,9 @@ class _TimePicker extends StatefulWidget {
 
   /// {@macro flutter.material.time_picker.switchToTimerEntryModeIcon}
   final Icon? switchToTimerEntryModeIcon;
+
+  /// If true, input fields start empty in input mode.
+  final bool? emptyInitialTimeInInputMode;
 
   @override
   State<_TimePicker> createState() => _TimePickerState();
@@ -2988,6 +3020,7 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
               autofocusHour: _autofocusHour.value,
               autofocusMinute: _autofocusMinute.value,
               restorationId: 'time_picker_input',
+              emptyInitialTime: widget.emptyInitialTimeInInputMode,
             ),
           ],
         );
@@ -3140,6 +3173,7 @@ Future<TimeOfDay?> showTimePicker({
   Orientation? orientation,
   Icon? switchToInputEntryModeIcon,
   Icon? switchToTimerEntryModeIcon,
+  bool? emptyInitialTimeInInputMode,
 }) async {
   assert(debugCheckHasMaterialLocalizations(context));
 
@@ -3156,6 +3190,7 @@ Future<TimeOfDay?> showTimePicker({
     onEntryModeChanged: onEntryModeChanged,
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToTimerEntryModeIcon: switchToTimerEntryModeIcon,
+    emptyInitialTimeInInputMode: emptyInitialTimeInInputMode,
   );
   return showDialog<TimeOfDay>(
     context: context,

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -2228,6 +2228,86 @@ void main() {
         expect(result, equals(const TimeOfDay(hour: 6, minute: 45)));
       });
     });
+
+    group('Time picker - emptyInitialTimeInInputMode (${materialType.name})', () {
+      testWidgets(
+        'Fields are empty and show correct hints when emptyInitialTimeInInputMode is true',
+        (WidgetTester tester) async {
+          await startPicker(
+            tester,
+            (_) {},
+            entryMode: TimePickerEntryMode.input,
+            materialType: materialType,
+            emptyInitialTimeInInputMode: true,
+          );
+          await tester.pump();
+
+          final List<TextField> textFields =
+              tester.widgetList<TextField>(find.byType(TextField)).toList();
+
+          expect(textFields[0].controller?.text, isEmpty); // hour
+          expect(textFields[1].controller?.text, isEmpty); // minute
+          expect(textFields[0].decoration?.hintText, '7');
+          expect(textFields[1].decoration?.hintText, '00');
+          await finishPicker(tester);
+        },
+      );
+
+      testWidgets('User sets hour/minute after initially empty fields', (
+        WidgetTester tester,
+      ) async {
+        late TimeOfDay result;
+        await startPicker(
+          tester,
+          (TimeOfDay? time) {
+            result = time!;
+          },
+          entryMode: TimePickerEntryMode.input,
+          materialType: materialType,
+          emptyInitialTimeInInputMode: true,
+        );
+
+        final List<TextField> textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+
+        expect(textFields[0].controller?.text, isEmpty); // hour
+        expect(textFields[1].controller?.text, isEmpty); // minute
+
+        await tester.enterText(find.byType(TextField).first, '11');
+        await tester.enterText(find.byType(TextField).last, '30');
+        await finishPicker(tester);
+
+        expect(result, equals(const TimeOfDay(hour: 11, minute: 30)));
+      });
+
+      testWidgets('User overrides default values when emptyInitialTimeInInputMode is false', (
+        WidgetTester tester,
+      ) async {
+        late TimeOfDay result;
+        await startPicker(
+          tester,
+          (TimeOfDay? time) {
+            result = time!;
+          },
+          entryMode: TimePickerEntryMode.input,
+          materialType: materialType,
+          emptyInitialTimeInInputMode: false,
+        );
+
+        final List<TextField> textFields =
+            tester.widgetList<TextField>(find.byType(TextField)).toList();
+
+        expect(textFields[0].controller?.text, '7'); // hour
+        expect(textFields[1].controller?.text, '00'); // minute
+
+        await tester.enterText(find.byType(TextField).first, '8');
+        await tester.enterText(find.byType(TextField).last, '15');
+        await tester.pump();
+        await finishPicker(tester);
+
+        expect(result, equals(const TimeOfDay(hour: 8, minute: 15)));
+      });
+    });
   }
 
   testWidgets('Material3 - Time selector separator default text style', (
@@ -2523,6 +2603,7 @@ class _TimePickerLauncher extends StatefulWidget {
     this.restorationId,
     this.cancelText,
     this.confirmText,
+    this.emptyInitialTimeInInputMode,
   });
 
   final ValueChanged<TimeOfDay?> onChanged;
@@ -2530,6 +2611,7 @@ class _TimePickerLauncher extends StatefulWidget {
   final String? restorationId;
   final String? cancelText;
   final String? confirmText;
+  final bool? emptyInitialTimeInInputMode;
 
   @override
   _TimePickerLauncherState createState() => _TimePickerLauncherState();
@@ -2569,6 +2651,7 @@ class _TimePickerLauncherState extends State<_TimePickerLauncher> with Restorati
     );
     final String? cancelText = args['cancel_text'] as String?;
     final String? confirmText = args['confirm_text'] as String?;
+    final bool? emptyInitialTimeInInputMode = args['emptyInitialTimeInInputMode'] as bool?;
     return DialogRoute<TimeOfDay>(
       context: context,
       builder: (BuildContext context) {
@@ -2578,6 +2661,7 @@ class _TimePickerLauncherState extends State<_TimePickerLauncher> with Restorati
           initialEntryMode: entryMode,
           cancelText: cancelText,
           confirmText: confirmText,
+          emptyInitialTimeInInputMode: emptyInitialTimeInInputMode,
         );
       },
     );
@@ -2607,6 +2691,7 @@ class _TimePickerLauncherState extends State<_TimePickerLauncher> with Restorati
                       context: context,
                       initialTime: const TimeOfDay(hour: 7, minute: 0),
                       initialEntryMode: widget.entryMode,
+                      emptyInitialTimeInInputMode: widget.emptyInitialTimeInInputMode,
                     ),
                   );
                 } else {
@@ -2636,6 +2721,7 @@ Future<Offset?> startPicker(
   MaterialType? materialType,
   String? cancelText,
   String? confirmText,
+  bool? emptyInitialTimeInInputMode,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -2648,6 +2734,7 @@ Future<Offset?> startPicker(
         restorationId: restorationId,
         cancelText: cancelText,
         confirmText: confirmText,
+        emptyInitialTimeInInputMode: emptyInitialTimeInInputMode,
       ),
     ),
   );


### PR DESCRIPTION
Added ability to allow empty initial time when using text input mode in showTimePicker dialog. #169131

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.