### PR TITLE
Skwasm direct rendering

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -803,6 +803,8 @@ extension type DomHTMLCanvasElement._(JSObject _) implements DomHTMLElement {
 
   DomImageBitmapRenderingContext get contextBitmapRenderer =>
       getContext('bitmaprenderer')! as DomImageBitmapRenderingContext;
+
+  external DomOffscreenCanvas transferControlToOffscreen();
 }
 
 @visibleForTesting

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/scene_painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/scene_painting.dart
@@ -43,3 +43,7 @@ abstract class ScenePath implements ui.Path {
   // string representation of them.
   String toSvgString();
 }
+
+abstract class SceneSurface {
+  Future<void> renderPicture(ScenePicture picture);
+}

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/scene_view.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/scene_view.dart
@@ -21,7 +21,6 @@ abstract class PictureRenderer {
   ScenePicture clipPicture(ScenePicture picture, ui.Rect clip);
 }
 
-
 typedef SurfaceFactory = SceneSurface Function(DomOffscreenCanvas canvas);
 
 class _SceneRender {
@@ -41,7 +40,11 @@ class _SceneRender {
 
 // This class builds a DOM tree that composites an `EngineScene`.
 class EngineSceneView {
-  factory EngineSceneView(PictureRenderer pictureRenderer, SurfaceFactory factory, EngineFlutterView flutterView) {
+  factory EngineSceneView(
+    PictureRenderer pictureRenderer,
+    SurfaceFactory factory,
+    EngineFlutterView flutterView,
+  ) {
     final DomElement sceneElement = createDomElement('flt-scene');
     return EngineSceneView._(pictureRenderer, factory, flutterView, sceneElement);
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_surface.dart
@@ -5,7 +5,9 @@
 @DefaultAsset('skwasm')
 library skwasm_impl;
 
+import 'dart:_wasm';
 import 'dart:ffi';
+import 'dart:js_interop';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
 final class RawSurface extends Opaque {}
@@ -18,8 +20,11 @@ typedef OnRenderCallbackHandle = Pointer<RawRenderCallback>;
 
 typedef CallbackId = int;
 
-@Native<SurfaceHandle Function()>(symbol: 'surface_create', isLeaf: true)
-external SurfaceHandle surfaceCreate();
+SurfaceHandle surfaceCreate(JSAny canvas) =>
+    SurfaceHandle.fromAddress(surfaceCreateImpl(externRefForJSAny(canvas)).toIntUnsigned());
+
+@pragma('wasm:import', 'skwasm.surface_create')
+external WasmI32 surfaceCreateImpl(WasmExternRef? canvas);
 
 @Native<UnsignedLong Function(SurfaceHandle)>(symbol: 'surface_getThreadId', isLeaf: true)
 external int surfaceGetThreadId(SurfaceHandle handle);
@@ -33,18 +38,34 @@ external void surfaceSetCallbackHandler(SurfaceHandle surface, OnRenderCallbackH
 @Native<Void Function(SurfaceHandle)>(symbol: 'surface_destroy', isLeaf: true)
 external void surfaceDestroy(SurfaceHandle surface);
 
-@Native<Int32 Function(SurfaceHandle, Pointer<PictureHandle>, Int)>(
+@Native<Void Function(SurfaceHandle, Pointer<PictureHandle>, Int, Int32)>(
   symbol: 'surface_renderPictures',
   isLeaf: true,
 )
-external CallbackId surfaceRenderPictures(
+external void surfaceRenderPictures(
   SurfaceHandle surface,
   Pointer<PictureHandle> picture,
   int count,
+  CallbackId callbackId,
 );
 
-@Native<Int32 Function(SurfaceHandle, ImageHandle, Int)>(
+@Native<Void Function(SurfaceHandle, PictureHandle, Int32)>(
+  symbol: 'surface_renderPictureDirect',
+  isLeaf: true,
+)
+external void surfaceRenderPictureDirect(
+  SurfaceHandle surface,
+  PictureHandle picture,
+  CallbackId callbackId,
+);
+
+@Native<Void Function(SurfaceHandle, ImageHandle, Int, Int32)>(
   symbol: 'surface_rasterizeImage',
   isLeaf: true,
 )
-external CallbackId surfaceRasterizeImage(SurfaceHandle handle, ImageHandle image, int format);
+external void surfaceRasterizeImage(
+  SurfaceHandle handle,
+  ImageHandle image,
+  int format,
+  CallbackId callbackId,
+);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -319,7 +319,8 @@ class SkwasmRenderer implements Renderer {
 
   @override
   FutureOr<void> initialize() {
-    surface = SkwasmSurface();
+    final DomOffscreenCanvas canvas = DomOffscreenCanvas(100, 100);
+    surface = SkwasmSurface(canvas);
   }
 
   @override
@@ -395,8 +396,9 @@ class SkwasmRenderer implements Renderer {
 
   @override
   Future<void> renderScene(ui.Scene scene, EngineFlutterView view) {
-    final FrameTimingRecorder? recorder =
-        FrameTimingRecorder.frameTimingsEnabled ? FrameTimingRecorder() : null;
+    final FrameTimingRecorder? recorder = FrameTimingRecorder.frameTimingsEnabled
+        ? FrameTimingRecorder()
+        : null;
     recorder?.recordBuildFinish();
 
     final EngineSceneView sceneView = _getSceneViewForView(view);
@@ -405,7 +407,11 @@ class SkwasmRenderer implements Renderer {
 
   EngineSceneView _getSceneViewForView(EngineFlutterView view) {
     return _sceneViews.putIfAbsent(view, () {
-      final EngineSceneView sceneView = EngineSceneView(SkwasmPictureRenderer(surface), view);
+      final EngineSceneView sceneView = EngineSceneView(
+        SkwasmPictureRenderer(surface),
+        (DomOffscreenCanvas canvas) => SkwasmSurface(canvas),
+        view,
+      );
       view.dom.setScene(sceneView.sceneElement);
       return sceneView;
     });
@@ -475,13 +481,12 @@ class SkwasmRenderer implements Renderer {
     required bool transferOwnership,
   }) async {
     if (!transferOwnership) {
-      textureSource =
-          (await createImageBitmap(textureSource, (
-            x: 0,
-            y: 0,
-            width: width,
-            height: height,
-          ))).toJSAnyShallow;
+      textureSource = (await createImageBitmap(textureSource, (
+        x: 0,
+        y: 0,
+        width: width,
+        height: height,
+      ))).toJSAnyShallow;
     }
     return SkwasmImage(
       imageCreateFromTextureSource(textureSource as JSObject, width, height, surface.handle),

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -396,9 +396,8 @@ class SkwasmRenderer implements Renderer {
 
   @override
   Future<void> renderScene(ui.Scene scene, EngineFlutterView view) {
-    final FrameTimingRecorder? recorder = FrameTimingRecorder.frameTimingsEnabled
-        ? FrameTimingRecorder()
-        : null;
+    final FrameTimingRecorder? recorder =
+        FrameTimingRecorder.frameTimingsEnabled ? FrameTimingRecorder() : null;
     recorder?.recordBuildFinish();
 
     final EngineSceneView sceneView = _getSceneViewForView(view);
@@ -481,12 +480,13 @@ class SkwasmRenderer implements Renderer {
     required bool transferOwnership,
   }) async {
     if (!transferOwnership) {
-      textureSource = (await createImageBitmap(textureSource, (
-        x: 0,
-        y: 0,
-        width: width,
-        height: height,
-      ))).toJSAnyShallow;
+      textureSource =
+          (await createImageBitmap(textureSource, (
+            x: 0,
+            y: 0,
+            width: width,
+            height: height,
+          ))).toJSAnyShallow;
     }
     return SkwasmImage(
       imageCreateFromTextureSource(textureSource as JSObject, width, height, surface.handle),

--- a/engine/src/flutter/lib/web_ui/skwasm/library_skwasm_support.js
+++ b/engine/src/flutter/lib/web_ui/skwasm/library_skwasm_support.js
@@ -99,6 +99,14 @@ mergeInto(LibraryManager.library, {
               data.callbackId,
               skwasm_getCurrentTimestamp());
             return;
+          case 'renderPictureDirect':
+            _surface_renderPictureDirectOnWorker(
+              data.surface,
+              data.picture,
+              data.callbackId,
+              skwasm_getCurrentTimestamp(),
+            );
+            return;
           case 'onRenderComplete':
             _surface_onRenderComplete(
               data.surface,
@@ -153,8 +161,15 @@ mergeInto(LibraryManager.library, {
         callbackId,
       }, [], threadId);
     };
-    _skwasm_createOffscreenCanvas = function(width, height) {
-      const canvas = new OffscreenCanvas(width, height);
+    _skwasm_dispatchRenderPictureDirect = function(threadId, surfaceHandle, picture, callbackId) {
+      skwasm_postMessage({
+        skwasmMessage: 'renderPictureDirect',
+        surface: surfaceHandle,
+        picture,
+        callbackId,
+      }, [], threadId);
+    };
+    _skwasm_createOffscreenCanvas = function(canvas) {
       var contextAttributes = {
         majorVersion: 2,
         alpha: true,
@@ -188,10 +203,10 @@ mergeInto(LibraryManager.library, {
         skwasmMessage: 'onRenderComplete',
         surface: surfaceHandle,
         callbackId,
-        imageBitmaps,
+        imageBitmaps: imageBitmaps ?? [],
         rasterStart,
         rasterEnd,
-      }, [...imageBitmaps]);
+      }, imageBitmaps ? [...imageBitmaps] : []);
     };
     _skwasm_createGlTextureFromTextureSource = function(textureSource, width, height) {
       const glCtx = GL.currentContext.GLctx;
@@ -256,6 +271,8 @@ mergeInto(LibraryManager.library, {
   skwasm_connectThread__deps: ['$skwasm_support_setup', '$skwasm_registerMessageListener', '$skwasm_getCurrentTimestamp'],
   skwasm_dispatchRenderPictures: function() {},
   skwasm_dispatchRenderPictures__deps: ['$skwasm_support_setup'],
+  skwasm_dispatchRenderPictureDirect: function() {},
+  skwasm_dispatchRenderPictureDirect__deps: ['$skwasm_support_setup'],
   skwasm_createOffscreenCanvas: function () {},
   skwasm_createOffscreenCanvas__deps: ['$skwasm_support_setup'],
   skwasm_resizeCanvas: function () {},

--- a/engine/src/flutter/lib/web_ui/skwasm/skwasm_support.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/skwasm_support.h
@@ -26,7 +26,11 @@ extern void skwasm_dispatchRenderPictures(unsigned long threadId,
                                           sk_sp<SkPicture>* pictures,
                                           int count,
                                           uint32_t callbackId);
-extern uint32_t skwasm_createOffscreenCanvas(int width, int height);
+extern void skwasm_dispatchRenderPictureDirect(unsigned long threadId,
+                                       Skwasm::Surface* surface,
+                                       SkPicture* picture,
+                                       uint32_t callbackId);
+extern uint32_t skwasm_createOffscreenCanvas(SkwasmObject canvas);
 extern void skwasm_resizeCanvas(uint32_t contextHandle, int width, int height);
 extern SkwasmObject skwasm_captureImageBitmap(uint32_t contextHandle,
                                               SkwasmObject imagePromises);

--- a/engine/src/flutter/lib/web_ui/skwasm/skwasm_support.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/skwasm_support.h
@@ -27,9 +27,9 @@ extern void skwasm_dispatchRenderPictures(unsigned long threadId,
                                           int count,
                                           uint32_t callbackId);
 extern void skwasm_dispatchRenderPictureDirect(unsigned long threadId,
-                                       Skwasm::Surface* surface,
-                                       SkPicture* picture,
-                                       uint32_t callbackId);
+                                               Skwasm::Surface* surface,
+                                               SkPicture* picture,
+                                               uint32_t callbackId);
 extern uint32_t skwasm_createOffscreenCanvas(SkwasmObject canvas);
 extern void skwasm_resizeCanvas(uint32_t contextHandle, int width, int height);
 extern SkwasmObject skwasm_captureImageBitmap(uint32_t contextHandle,

--- a/engine/src/flutter/lib/web_ui/skwasm/surface.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/surface.cpp
@@ -49,7 +49,9 @@ void Surface::dispose() {
 }
 
 // Main thread only
-void Surface::renderPictures(SkPicture** pictures, int count, uint32_t callbackId) {
+void Surface::renderPictures(SkPicture** pictures,
+                             int count,
+                             uint32_t callbackId) {
   assert(emscripten_is_main_browser_thread());
   std::unique_ptr<sk_sp<SkPicture>[]> picturePointers =
       std::make_unique<sk_sp<SkPicture>[]>(count);
@@ -69,7 +71,9 @@ void Surface::renderPictureDirect(SkPicture* picture, uint32_t callbackId) {
 }
 
 // Main thread only
-void Surface::rasterizeImage(SkImage* image, ImageByteFormat format, uint32_t callbackId) {
+void Surface::rasterizeImage(SkImage* image,
+                             ImageByteFormat format,
+                             uint32_t callbackId) {
   assert(emscripten_is_main_browser_thread());
   image->ref();
 

--- a/engine/src/flutter/lib/web_ui/skwasm/surface.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/surface.h
@@ -49,14 +49,15 @@ class Surface {
   using CallbackHandler = void(uint32_t, void*, SkwasmObject);
 
   // Main thread only
-  Surface();
+  Surface(SkwasmObject canvas);
 
   unsigned long getThreadId() { return _thread; }
 
   // Main thread only
   void dispose();
-  uint32_t renderPictures(SkPicture** picture, int count);
-  uint32_t rasterizeImage(SkImage* image, ImageByteFormat format);
+  void renderPictures(SkPicture** picture, int count, uint32_t callbackId);
+  void renderPictureDirect(SkPicture* picture, uint32_t callbackId);
+  void rasterizeImage(SkImage* image, ImageByteFormat format, uint32_t callbackId);
   void setCallbackHandler(CallbackHandler* callbackHandler);
   void onRenderComplete(uint32_t callbackId, SkwasmObject imageBitmap);
   void onRasterizeComplete(uint32_t callbackId, SkData* data);
@@ -70,6 +71,9 @@ class Surface {
                               int pictureCount,
                               uint32_t callbackId,
                               double rasterStart);
+  void renderPictureDirectOnWorker(sk_sp<SkPicture> picture,
+                                   uint32_t callbackId,
+                                   double rasterStart);
   void rasterizeImageOnWorker(SkImage* image,
                               ImageByteFormat format,
                               uint32_t callbackId);
@@ -80,7 +84,6 @@ class Surface {
   void _recreateSurface();
 
   CallbackHandler* _callbackHandler = nullptr;
-  uint32_t _currentCallbackId = 0;
 
   int _canvasWidth = 0;
   int _canvasHeight = 0;

--- a/engine/src/flutter/lib/web_ui/skwasm/surface.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/surface.h
@@ -57,7 +57,9 @@ class Surface {
   void dispose();
   void renderPictures(SkPicture** picture, int count, uint32_t callbackId);
   void renderPictureDirect(SkPicture* picture, uint32_t callbackId);
-  void rasterizeImage(SkImage* image, ImageByteFormat format, uint32_t callbackId);
+  void rasterizeImage(SkImage* image,
+                      ImageByteFormat format,
+                      uint32_t callbackId);
   void setCallbackHandler(CallbackHandler* callbackHandler);
   void onRenderComplete(uint32_t callbackId, SkwasmObject imageBitmap);
   void onRasterizeComplete(uint32_t callbackId, SkData* data);


### PR DESCRIPTION
This is a hacked together prototype of Skwasm doing direct rendering to multiple WebGL-canvases rather than using `transferFromImageBitmap`/`transferToImageBitmap`. This is not ready for prime time in any way, so please don't attempt to merge.