### PR TITLE
License cpp jun16

### DIFF
--- a/engine/src/flutter/tools/licenses_cpp/data/licenses/google.txt
+++ b/engine/src/flutter/tools/licenses_cpp/data/licenses/google.txt
@@ -1,5 +1,5 @@
 google
-Copyright \(c\) \d+ Google Inc
+^Copyright \(c\) \d+ Google Inc
 Copyright \(c\) \d+ Google Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/engine/src/flutter/tools/licenses_cpp/data/licenses/google.txt
+++ b/engine/src/flutter/tools/licenses_cpp/data/licenses/google.txt
@@ -1,0 +1,31 @@
+google
+Copyright \(c\) \d+ Google Inc
+Copyright \(c\) \d+ Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  \* Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  \* Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  \* Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES \(INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION\) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+\(INCLUDING NEGLIGENCE OR OTHERWISE\) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/engine/src/flutter/tools/licenses_cpp/data/licenses/google_commented.txt
+++ b/engine/src/flutter/tools/licenses_cpp/data/licenses/google_commented.txt
@@ -1,0 +1,29 @@
+google commented
+^// Copyright \(c\) \d+ Google Inc
+// Copyright \(c\) \d+ Google Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    \* Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    \* Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    \* Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES \(INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION\) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// \(INCLUDING NEGLIGENCE OR OTHERWISE\) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog.cc
@@ -91,7 +91,8 @@ Catalog::Catalog(RE2::Set selector,
       matchers_(std::move(matchers)),
       names_(std::move(names)) {}
 
-absl::StatusOr<Catalog::Match> Catalog::FindMatch(std::string_view query) const {
+absl::StatusOr<Catalog::Match> Catalog::FindMatch(
+    std::string_view query) const {
   std::vector<int> selector_results;
   if (!selector_.Match(query, &selector_results)) {
     return absl::NotFoundError("Selector didn't match.");
@@ -111,10 +112,8 @@ absl::StatusOr<Catalog::Match> Catalog::FindMatch(std::string_view query) const 
       matcher->Match(query, 0, query.length(), RE2::Anchor::UNANCHORED,
                      &match_text,
                      /*nsubmatch=*/1)) {
-    return Match {
-      .matcher = names_[selector_results[0]],
-      .matched_text = match_text
-    };
+    return Match{.matcher = names_[selector_results[0]],
+                 .matched_text = match_text};
   } else {
     return absl::NotFoundError(absl::StrCat(
         "Selected matcher (", names_[selector_results[0]], ") didn't match."));

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog.cc
@@ -109,7 +109,8 @@ absl::StatusOr<std::string> Catalog::FindMatch(std::string_view query) const {
       RE2::PartialMatch(query, *matchers_[selector_results[0]])) {
     return names_[selector_results[0]];
   } else {
-    return absl::NotFoundError("Selected matcher didn't match.");
+    return absl::NotFoundError(absl::StrCat(
+        "Selected matcher (", names_[selector_results[0]], ") didn't match."));
   }
 }
 

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog.cc
@@ -42,7 +42,7 @@ Catalog::Catalog(RE2::Set selector,
       matchers_(std::move(matchers)),
       names_(std::move(names)) {}
 
-absl::StatusOr<std::string> Catalog::FindMatch(std::string_view query) {
+absl::StatusOr<std::string> Catalog::FindMatch(std::string_view query) const {
   std::vector<int> selector_results;
   if (!selector_.Match(query, &selector_results)) {
     return absl::NotFoundError("Selector didn't match.");
@@ -57,7 +57,7 @@ absl::StatusOr<std::string> Catalog::FindMatch(std::string_view query) {
   }
 
   if (selector_results.size() == 1 &&
-      RE2::FullMatch(query, *matchers_[selector_results[0]])) {
+      RE2::PartialMatch(query, *matchers_[selector_results[0]])) {
     return names_[selector_results[0]];
   } else {
     return absl::NotFoundError("Selection didn't match.");

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog.h
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog.h
@@ -32,7 +32,7 @@ class Catalog {
   /// absl::StatusCode::kNotFound when a match can't be found.
   /// absl::StatusCode::kInvalidArgument if more than one match comes up from
   /// the selector.
-  absl::StatusOr<std::string> FindMatch(std::string_view query);
+  absl::StatusOr<std::string> FindMatch(std::string_view query) const;
 
  private:
   explicit Catalog(RE2::Set selector,

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog.h
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog.h
@@ -10,6 +10,7 @@
 #include "flutter/third_party/re2/re2/re2.h"
 #include "flutter/third_party/re2/re2/set.h"
 
+#include <iosfwd>
 #include <optional>
 
 /// A storage of licenses that can be matched against.
@@ -19,6 +20,13 @@
 /// that. This approach was chosen to minimize the size of the RE2::Set.
 class Catalog {
  public:
+  /// VisibleForTesting
+  struct Entry {
+    std::string name;
+    std::string unique;
+    std::unique_ptr<RE2> matcher;
+  };
+
   static absl::StatusOr<Catalog> Open(std::string_view data_dir);
 
   /// Make a Catalog for testing.
@@ -33,6 +41,9 @@ class Catalog {
   /// absl::StatusCode::kInvalidArgument if more than one match comes up from
   /// the selector.
   absl::StatusOr<std::string> FindMatch(std::string_view query) const;
+
+  /// VisibleForTesting
+  static absl::StatusOr<Entry> ParseEntry(std::istream& is);
 
  private:
   explicit Catalog(RE2::Set selector,

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog.h
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog.h
@@ -27,17 +27,22 @@ class Catalog {
     std::string matcher;
   };
 
+  struct Match {
+    std::string_view matcher;
+    std::string_view matched_text;
+  };
+
   static absl::StatusOr<Catalog> Open(std::string_view data_dir);
 
   /// Make a Catalog for testing.
   static absl::StatusOr<Catalog> Make(const std::vector<Entry>& entries);
 
   /// @brief Tries to identify a match for the `query` across the `Catalog`.
-  /// @param query The text that will be matched against. @return
-  /// absl::StatusCode::kNotFound when a match can't be found.
+  /// @param query The text that will be matched against.
+  /// @return absl::StatusCode::kNotFound when a match can't be found.
   /// absl::StatusCode::kInvalidArgument if more than one match comes up from
   /// the selector.
-  absl::StatusOr<std::string> FindMatch(std::string_view query) const;
+  absl::StatusOr<Match> FindMatch(std::string_view query) const;
 
   /// VisibleForTesting
   static absl::StatusOr<Entry> ParseEntry(std::istream& is);

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog.h
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog.h
@@ -24,16 +24,13 @@ class Catalog {
   struct Entry {
     std::string name;
     std::string unique;
-    std::unique_ptr<RE2> matcher;
+    std::string matcher;
   };
 
   static absl::StatusOr<Catalog> Open(std::string_view data_dir);
 
   /// Make a Catalog for testing.
-  /// The format is [[<name>, <unique regex>, <full regex>]*] where the unique
-  /// regex should only match one license.
-  static absl::StatusOr<Catalog> Make(
-      const std::vector<std::vector<std::string_view>>& entries);
+  static absl::StatusOr<Catalog> Make(const std::vector<Entry>& entries);
 
   /// @brief Tries to identify a match for the `query` across the `Catalog`.
   /// @param query The text that will be matched against. @return

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog_unittests.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog_unittests.cc
@@ -4,6 +4,71 @@
 #include "flutter/tools/licenses_cpp/src/catalog.h"
 #include "gtest/gtest.h"
 
+static const char* kEntry = R"entry(google
+Copyright \(c\) \d+ Google Inc
+Copyright \(c\) \d+ Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  \* Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  \* Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  \* Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES \(INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION\) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+\(INCLUDING NEGLIGENCE OR OTHERWISE\) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+)entry";
+
+static const char* kSkiaLicense =
+    R"entry(Copyright (c) 2011 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+)entry";
+
 TEST(CatalogTest, Simple) {
   absl::StatusOr<Catalog> catalog =
       Catalog::Make({{"foobar", ".*foo.*", ".*foo.*"}});
@@ -57,6 +122,19 @@ matcher
   if (entry.ok()) {
     EXPECT_EQ(entry->name, "foobar");
     EXPECT_EQ(entry->unique, "unique");
-    EXPECT_TRUE(entry->matcher);
+    EXPECT_EQ(entry->matcher, R"match(Multiline
+matcher
+.*)match");
   }
+}
+
+TEST(CatalogTest, SkiaLicense) {
+  std::stringstream ss;
+  ss << kEntry;
+  absl::StatusOr<Catalog::Entry> entry = Catalog::ParseEntry(ss);
+  ASSERT_TRUE(entry.ok()) << entry.status();
+  absl::StatusOr<Catalog> catalog = Catalog::Make({*entry});
+  ASSERT_TRUE(catalog.ok());
+  absl::StatusOr<std::string> match = catalog->FindMatch(kSkiaLicense);
+  EXPECT_TRUE(match.ok()) << match.status();
 }

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog_unittests.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog_unittests.cc
@@ -73,16 +73,16 @@ TEST(CatalogTest, Simple) {
   absl::StatusOr<Catalog> catalog =
       Catalog::Make({{"foobar", ".*foo.*", ".*foo.*"}});
   ASSERT_TRUE(catalog.ok());
-  absl::StatusOr<std::string> match = catalog->FindMatch("foo");
+  absl::StatusOr<Catalog::Match> match = catalog->FindMatch("foo");
   ASSERT_TRUE(match.ok());
-  ASSERT_EQ(*match, "foobar");
+  ASSERT_EQ(match->matcher, "foobar");
 }
 
 TEST(CatalogTest, MultipleMatch) {
   absl::StatusOr<Catalog> catalog =
       Catalog::Make({{"foobar", ".*foo.*", ""}, {"oo", ".*oo.*", ""}});
   ASSERT_TRUE(catalog.ok()) << catalog.status();
-  absl::StatusOr<std::string> has_match = catalog->FindMatch("foo");
+  absl::StatusOr<Catalog::Match> has_match = catalog->FindMatch("foo");
   ASSERT_FALSE(has_match.ok());
   ASSERT_TRUE(RE2::PartialMatch(has_match.status().message(),
                                 "Multiple unique matches found"))
@@ -95,7 +95,7 @@ TEST(CatalogTest, NoSelectorMatch) {
   absl::StatusOr<Catalog> catalog =
       Catalog::Make({{"foobar", ".*bar.*", ".*foo.*"}});
   ASSERT_TRUE(catalog.ok());
-  absl::StatusOr<std::string> match = catalog->FindMatch("foo");
+  absl::StatusOr<Catalog::Match> match = catalog->FindMatch("foo");
   ASSERT_FALSE(match.ok());
   ASSERT_EQ(match.status().code(), absl::StatusCode::kNotFound);
 }
@@ -104,7 +104,7 @@ TEST(CatalogTest, NoSelectionMatch) {
   absl::StatusOr<Catalog> catalog =
       Catalog::Make({{"foobar", ".*foo.*", ".*bar.*"}});
   ASSERT_TRUE(catalog.ok());
-  absl::StatusOr<std::string> match = catalog->FindMatch("foo");
+  absl::StatusOr<Catalog::Match> match = catalog->FindMatch("foo");
   ASSERT_FALSE(match.ok());
   ASSERT_EQ(match.status().code(), absl::StatusCode::kNotFound);
 }
@@ -135,6 +135,6 @@ TEST(CatalogTest, SkiaLicense) {
   ASSERT_TRUE(entry.ok()) << entry.status();
   absl::StatusOr<Catalog> catalog = Catalog::Make({*entry});
   ASSERT_TRUE(catalog.ok());
-  absl::StatusOr<std::string> match = catalog->FindMatch(kSkiaLicense);
+  absl::StatusOr<Catalog::Match> match = catalog->FindMatch(kSkiaLicense);
   EXPECT_TRUE(match.ok()) << match.status();
 }

--- a/engine/src/flutter/tools/licenses_cpp/src/catalog_unittests.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/catalog_unittests.cc
@@ -43,3 +43,20 @@ TEST(CatalogTest, NoSelectionMatch) {
   ASSERT_FALSE(match.ok());
   ASSERT_EQ(match.status().code(), absl::StatusCode::kNotFound);
 }
+
+TEST(CatalogTest, SimpleParseEntry) {
+  std::stringstream ss;
+  ss << "foobar\n";
+  ss << "unique\n";
+  ss << R"match(Multiline
+matcher
+.*)match";
+
+  absl::StatusOr<Catalog::Entry> entry = Catalog::ParseEntry(ss);
+  EXPECT_TRUE(entry.ok()) << entry.status();
+  if (entry.ok()) {
+    EXPECT_EQ(entry->name, "foobar");
+    EXPECT_EQ(entry->unique, "unique");
+    EXPECT_TRUE(entry->matcher);
+  }
+}

--- a/engine/src/flutter/tools/licenses_cpp/src/data.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/data.cc
@@ -26,6 +26,14 @@ absl::StatusOr<Data> Data::Open(std::string_view data_dir) {
                                       exclude_path.string() + ": " +
                                       include_filter.status().ToString());
   }
+  absl::StatusOr<Catalog> catalog = Catalog::Open(data_dir);
+  if (!catalog.ok()) {
+    return absl::InvalidArgumentError("Can't open catalog at " +
+                                      exclude_path.string() + ": " +
+                                      catalog.status().ToString());
+  }
+
   return Data{.include_filter = std::move(*include_filter),
-              .exclude_filter = std::move(*exclude_filter)};
+              .exclude_filter = std::move(*exclude_filter),
+              .catalog = std::move(*catalog)};
 }

--- a/engine/src/flutter/tools/licenses_cpp/src/data.h
+++ b/engine/src/flutter/tools/licenses_cpp/src/data.h
@@ -6,8 +6,8 @@
 #define FLUTTER_TOOLS_LICENSES_CPP_SRC_DATA_H_
 
 #include "flutter/third_party/abseil-cpp/absl/status/statusor.h"
-#include "flutter/tools/licenses_cpp/src/filter.h"
 #include "flutter/tools/licenses_cpp/src/catalog.h"
+#include "flutter/tools/licenses_cpp/src/filter.h"
 
 /// In memory representation of the contents of the data directory
 ///

--- a/engine/src/flutter/tools/licenses_cpp/src/data.h
+++ b/engine/src/flutter/tools/licenses_cpp/src/data.h
@@ -7,6 +7,7 @@
 
 #include "flutter/third_party/abseil-cpp/absl/status/statusor.h"
 #include "flutter/tools/licenses_cpp/src/filter.h"
+#include "flutter/tools/licenses_cpp/src/catalog.h"
 
 /// In memory representation of the contents of the data directory
 ///
@@ -15,6 +16,7 @@ struct Data {
   static absl::StatusOr<Data> Open(std::string_view data_dir);
   Filter include_filter;
   Filter exclude_filter;
+  Catalog catalog;
 };
 
 #endif  // FLUTTER_TOOLS_LICENSES_CPP_SRC_DATA_H_

--- a/engine/src/flutter/tools/licenses_cpp/src/license_checker.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/license_checker.cc
@@ -193,7 +193,7 @@ absl::Status MatchLicenseFile(const fs::path& path,
   if (!license.ok()) {
     return license.status();
   } else {
-    absl::StatusOr<std::string> match = data.catalog.FindMatch(
+    absl::StatusOr<Catalog::Match> match = data.catalog.FindMatch(
         std::string_view(license->GetData(), license->GetSize()));
 
     if (match.ok()) {
@@ -202,7 +202,7 @@ absl::Status MatchLicenseFile(const fs::path& path,
       if (size >= 1 && data[size - 1] == '\n') {
         size -= 1;
       }
-      license_map->Add(package.name, std::string_view(data, size));
+      license_map->Add(package.name, match->matched_text);
     } else {
       return absl::NotFoundError(absl::StrCat("Unknown license in ",
                                               package.license_file->string(),
@@ -278,7 +278,7 @@ std::vector<absl::Status> LicenseChecker::Run(std::string_view working_dir,
               did_find_copyright = true;
               VLOG(1) << comment;
               if (!package.license_file.has_value()) {
-                absl::StatusOr<std::string> match =
+                absl::StatusOr<Catalog::Match> match =
                     data.catalog.FindMatch(comment);
                 if (match.ok()) {
                   license_map.Add(package.name, comment);

--- a/engine/src/flutter/tools/licenses_cpp/src/license_checker.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/license_checker.cc
@@ -281,7 +281,7 @@ std::vector<absl::Status> LicenseChecker::Run(std::string_view working_dir,
                 absl::StatusOr<Catalog::Match> match =
                     data.catalog.FindMatch(comment);
                 if (match.ok()) {
-                  license_map.Add(package.name, comment);
+                  license_map.Add(package.name, match->matched_text);
                 } else {
                   errors.emplace_back(absl::NotFoundError(
                       absl::StrCat("Unknown license in ", full_path.string(),

--- a/engine/src/flutter/tools/licenses_cpp/src/license_checker.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/license_checker.cc
@@ -204,8 +204,9 @@ absl::Status MatchLicenseFile(const fs::path& path,
       }
       license_map->Add(package.name, std::string_view(data, size));
     } else {
-      return absl::NotFoundError("Unknown license in " +
-                                 package.license_file->string());
+      return absl::NotFoundError(absl::StrCat("Unknown license in ",
+                                              package.license_file->string(),
+                                              " : ", match.status().message()));
     }
   }
   return absl::OkStatus();
@@ -283,7 +284,8 @@ std::vector<absl::Status> LicenseChecker::Run(std::string_view working_dir,
                   license_map.Add(package.name, comment);
                 } else {
                   errors.emplace_back(absl::NotFoundError(
-                      absl::StrCat("Unknown license in ", full_path.string())));
+                      absl::StrCat("Unknown license in ", full_path.string(),
+                                   " : ", match.status().message())));
                 }
               }
             }

--- a/engine/src/flutter/tools/licenses_cpp/src/license_checker.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/license_checker.cc
@@ -189,6 +189,9 @@ absl::Status MatchLicenseFile(const fs::path& path,
                               const Package& package,
                               const Data& data,
                               LicenseMap* license_map) {
+  if (!package.license_file.has_value()) {
+    return absl::InvalidArgumentError("No license file.");
+  }
   absl::StatusOr<MMapFile> license = MMapFile::Make(path.string());
   if (!license.ok()) {
     return license.status();
@@ -197,11 +200,6 @@ absl::Status MatchLicenseFile(const fs::path& path,
         std::string_view(license->GetData(), license->GetSize()));
 
     if (match.ok()) {
-      size_t size = license->GetSize();
-      const char* data = license->GetData();
-      if (size >= 1 && data[size - 1] == '\n') {
-        size -= 1;
-      }
       license_map->Add(package.name, match->matched_text);
     } else {
       return absl::NotFoundError(absl::StrCat("Unknown license in ",

--- a/engine/src/flutter/tools/licenses_cpp/src/license_checker_unittests.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/license_checker_unittests.cc
@@ -166,7 +166,7 @@ TEST_F(LicenseCheckerTest, SimplePass) {
   std::stringstream ss;
   std::vector<absl::Status> errors =
       LicenseChecker::Run(temp_path->string(), ss, *data);
-  EXPECT_EQ(errors.size(), 0u);
+  EXPECT_EQ(errors.size(), 0u) << errors[0];
 }
 
 TEST_F(LicenseCheckerTest, UnknownLicense) {

--- a/engine/src/flutter/tools/licenses_cpp/src/license_checker_unittests.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/license_checker_unittests.cc
@@ -208,9 +208,12 @@ TEST_F(LicenseCheckerTest, UnknownLicense) {
 
   fs::current_path(*temp_path);
   ASSERT_TRUE(WriteFile(kHeader, *temp_path / "main.cc").ok());
+  // Make sure the error is only reported once.
+  ASSERT_TRUE(WriteFile(kHeader, *temp_path / "foo.cc").ok());
   ASSERT_TRUE(WriteFile(kUnknownLicense, *temp_path / "LICENSE").ok());
   Repo repo;
   repo.Add(*temp_path / "main.cc");
+  repo.Add(*temp_path / "foo.cc");
   repo.Add(*temp_path / "LICENSE");
   ASSERT_TRUE(repo.Commit().ok());
 

--- a/engine/src/flutter/tools/licenses_cpp/src/license_checker_unittests.cc
+++ b/engine/src/flutter/tools/licenses_cpp/src/license_checker_unittests.cc
@@ -110,13 +110,13 @@ v\d\.\d)lic"},
   };
 }
 
-absl::Status WriteFile(const char* data, const fs::path& path) {
+absl::Status WriteFile(std::string_view data, const fs::path& path) {
   std::ofstream of;
   of.open(path.string(), std::ios::binary);
   if (!of.good()) {
     return absl::InternalError("can't open file");
   }
-  of.write(data, std::strlen(data));
+  of.write(data.data(), data.length());
   of.close();
   return absl::OkStatus();
 }
@@ -384,7 +384,7 @@ v2.0
 )output");
 }
 
-TEST_F(LicenseCheckerTest, ThirdyPartyDirectoryLicense) {
+TEST_F(LicenseCheckerTest, ThirdPartyDirectoryLicense) {
   absl::StatusOr<fs::path> temp_path = MakeTempDir();
   ASSERT_TRUE(temp_path.ok());
 
@@ -414,6 +414,35 @@ TEST_F(LicenseCheckerTest, ThirdyPartyDirectoryLicense) {
 
   EXPECT_EQ(ss.str(), R"output(engine
 foobar
+
+Test License
+v2.0
+)output");
+}
+
+TEST_F(LicenseCheckerTest, OnlyPrintMatch) {
+  absl::StatusOr<fs::path> temp_path = MakeTempDir();
+  ASSERT_TRUE(temp_path.ok());
+
+  absl::StatusOr<Data> data = MakeTestData();
+  ASSERT_TRUE(data.ok());
+
+  fs::current_path(*temp_path);
+  ASSERT_TRUE(WriteFile(kHeader, *temp_path / "main.cc").ok());
+  ASSERT_TRUE(WriteFile(absl::StrCat(kLicense, "\n----------------------\n"),
+                        *temp_path / "LICENSE")
+                  .ok());
+  Repo repo;
+  repo.Add(*temp_path / "main.cc");
+  repo.Add(*temp_path / "LICENSE");
+  ASSERT_TRUE(repo.Commit().ok());
+
+  std::stringstream ss;
+  std::vector<absl::Status> errors =
+      LicenseChecker::Run(temp_path->string(), ss, *data);
+  EXPECT_EQ(errors.size(), 0u) << errors[0];
+
+  EXPECT_EQ(ss.str(), R"output(engine
 
 Test License
 v2.0


### PR DESCRIPTION
The big additions here are:
1) Checking against the catalog of known licenses
1) Parsing of the known catalogs from disk
1) Nicer error messages

With this PR we are getting pretty close to feature parity.  The big changes left are updating the contents of of the data directory so we match what we want.  Execution across the directory is still around 35s.

Known extra work:
1) Propagate the `data` directory
1) Make sure the auditable output is looking as we want it
1) Make sure to treat the root directory different where we want to enforce the presence of the file copyright
1) Remove hardcoded name "engine" for the root directory (that means shifting all the integration tests to run in a `engine` directory.
1) Maybe cleanup the file format for the known licenses?

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
