### PR TITLE
Reland "[native assets] Build dev dependencies in `flutter test integration_test`"

### DIFF
--- a/dev/devicelab/lib/tasks/native_assets_test.dart
+++ b/dev/devicelab/lib/tasks/native_assets_test.dart
@@ -114,7 +114,6 @@ TaskFunction createNativeAssetsTest({
 
         if (buildMode == _buildModes.last) {
           // Only run integration tests once.
-          addIntegrationTest(exampleDirectory.uri, _packageName);
           done = false;
           final int integrationTestResult = await inDirectory<int>(exampleDirectory, () async {
             return runFlutter(
@@ -182,6 +181,8 @@ Future<Directory> createTestProject(String packageName, Directory tempDirectory)
   await _pinDependencies(File(path.join(packageDirectory.path, 'pubspec.yaml')));
   await _pinDependencies(File(path.join(packageDirectory.path, 'example', 'pubspec.yaml')));
 
+  await _addIntegrationTest(packageDirectory.uri.resolve('example/'), _packageName);
+
   await exec(_flutterBin, <String>['pub', 'get'], workingDirectory: packageDirectory.path);
 
   return packageDirectory;
@@ -208,17 +209,12 @@ Future<T> inTempDir<T>(Future<T> Function(Directory tempDirectory) fun) async {
   }
 }
 
-void addIntegrationTest(Uri exampleDirectory, String packageName) {
-  final ProcessResult result = Process.runSync(_flutterBin, <String>[
+Future<void> _addIntegrationTest(Uri exampleDirectory, String packageName) async {
+  await exec(_flutterBin, <String>[
     'pub',
     'add',
     'dev:integration_test:{"sdk":"flutter"}',
   ], workingDirectory: exampleDirectory.toFilePath());
-  if (result.exitCode != 0) {
-    throw Exception(
-      'flutter pub add failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
-    );
-  }
 
   final Uri integrationTestPath = exampleDirectory.resolve('integration_test/my_test.dart');
   final File integrationTestFile = File.fromUri(integrationTestPath);

--- a/dev/devicelab/lib/tasks/native_assets_test.dart
+++ b/dev/devicelab/lib/tasks/native_assets_test.dart
@@ -54,6 +54,7 @@ TaskFunction createNativeAssetsTest({
 
         await inDirectory<void>(exampleDirectory, () async {
           final int runFlutterResult = await runFlutter(
+            command: 'run',
             options: options,
             onLine: (String line, Process process) {
               error |= line.contains('EXCEPTION CAUGHT BY WIDGETS LIBRARY');
@@ -110,6 +111,27 @@ TaskFunction createNativeAssetsTest({
         if (error) {
           return TaskResult.failure('Error during hot reload or hot restart.');
         }
+
+        if (buildMode == _buildModes.last) {
+          // Only run integration tests once.
+          addIntegrationTest(exampleDirectory.uri, _packageName);
+          done = false;
+          final int integrationTestResult = await inDirectory<int>(exampleDirectory, () async {
+            return runFlutter(
+              command: 'test',
+              options: <String>['integration_test', '-d', deviceIdOverride!],
+              onLine: (String line, Process _) {
+                if (line.contains('All tests passed!')) {
+                  done = true;
+                }
+              },
+            );
+          });
+          if (!done && integrationTestResult != 0) {
+            return TaskResult.failure('flutter test integration test failed');
+          }
+        }
+
         return TaskResult.success(null);
       });
       if (buildModeResult.failed) {
@@ -121,10 +143,11 @@ TaskFunction createNativeAssetsTest({
 }
 
 Future<int> runFlutter({
+  required String command,
   required List<String> options,
   required void Function(String, Process) onLine,
 }) async {
-  final Process process = await startFlutter('run', options: options);
+  final Process process = await startFlutter(command, options: options);
 
   final Completer<void> stdoutDone = Completer<void>();
   final Completer<void> stderrDone = Completer<void>();
@@ -183,4 +206,41 @@ Future<T> inTempDir<T>(Future<T> Function(Directory tempDirectory) fun) async {
       // Ignore failures to delete a temporary directory.
     }
   }
+}
+
+void addIntegrationTest(Uri exampleDirectory, String packageName) {
+  final ProcessResult result = Process.runSync(_flutterBin, <String>[
+    'pub',
+    'add',
+    'dev:integration_test:{"sdk":"flutter"}',
+  ], workingDirectory: exampleDirectory.toFilePath());
+  if (result.exitCode != 0) {
+    throw Exception(
+      'flutter pub add failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
+    );
+  }
+
+  final Uri integrationTestPath = exampleDirectory.resolve('integration_test/my_test.dart');
+  final File integrationTestFile = File.fromUri(integrationTestPath);
+  integrationTestFile
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+import 'package:flutter_test/flutter_test.dart';
+import 'package:${packageName}_example/main.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('end-to-end test', () {
+    testWidgets('invoke native code', (tester) async {
+      // Load app widget.
+      await tester.pumpWidget(const MyApp());
+
+      // Verify the native function was called.
+      expect(find.text('sum(1, 2) = 3'), findsOneWidget);
+    });
+  });
+}
+''');
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -51,6 +51,12 @@ abstract class DartBuild extends Target {
         );
       }
       final String pubspecPath = packageConfigFile.uri.resolve('../pubspec.yaml').toFilePath();
+      final String? buildModeEnvironment = environment.defines[kBuildMode];
+      if (buildModeEnvironment == null) {
+        throw MissingDefineException(kBuildMode, name);
+      }
+      final BuildMode buildMode = BuildMode.fromCliName(buildModeEnvironment);
+      final bool includeDevDependencies = !buildMode.isRelease;
       final FlutterNativeAssetsBuildRunner buildRunner =
           _buildRunner ??
           FlutterNativeAssetsBuildRunnerImpl(
@@ -59,7 +65,7 @@ abstract class DartBuild extends Target {
             fileSystem,
             environment.logger,
             runPackageName,
-            includeDevDependencies: false,
+            includeDevDependencies: includeDevDependencies,
             pubspecPath,
           );
       result = await runFlutterSpecificDartBuild(

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -471,7 +471,10 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       webUseWasm: useWasm,
     );
 
-    final Uri? nativeAssetsJson = await nativeAssetsBuilder?.build(buildInfo);
+    final Uri? nativeAssetsJson =
+        _isIntegrationTest
+            ? null // Don't build for host when running integration tests.
+            : await nativeAssetsBuilder?.build(buildInfo);
     String? testAssetPath;
     if (buildTestAssets) {
       await _buildTestAsset(

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -159,6 +159,29 @@ void main() {
     });
   });
 
+  for (final String device in devices) {
+    testWithoutContext('flutter test integration_test $device native assets', () async {
+      await inTempDir((Directory tempDirectory) async {
+        final Directory packageDirectory = await createTestProject(packageName, tempDirectory);
+
+        final Uri exampleDirectory = Uri.directory(packageDirectory.path).resolve('example/');
+        addIntegrationTest(exampleDirectory, packageName);
+
+        final ProcessTestResult result = await runFlutter(
+          <String>['test', 'integration_test', '-d', device],
+          exampleDirectory.toFilePath(),
+          <Transition>[Barrier(RegExp('.* All tests passed!'))],
+          logging: false,
+        );
+        if (result.exitCode != 0) {
+          throw Exception(
+            'flutter test integration_test failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
+          );
+        }
+      });
+    });
+  }
+
   for (final String buildSubcommand in buildSubcommands) {
     for (final String buildMode in buildModes) {
       testWithoutContext(
@@ -230,6 +253,43 @@ void main() {
       });
     });
   }
+}
+
+void addIntegrationTest(Uri exampleDirectory, String packageName) {
+  final ProcessResult result = processManager.runSync(<String>[
+    'flutter',
+    'pub',
+    'add',
+    'dev:integration_test:{"sdk":"flutter"}',
+  ], workingDirectory: exampleDirectory.toFilePath());
+  if (result.exitCode != 0) {
+    throw Exception(
+      'flutter pub add failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
+    );
+  }
+
+  final Uri integrationTestPath = exampleDirectory.resolve('integration_test/my_test.dart');
+  final File integrationTestFile = fileSystem.file(integrationTestPath);
+  integrationTestFile.createSync(recursive: true);
+  integrationTestFile.writeAsStringSync('''
+import 'package:flutter_test/flutter_test.dart';
+import 'package:${packageName}_example/main.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('end-to-end test', () {
+    testWidgets('invoke native code', (tester) async {
+      // Load app widget.
+      await tester.pumpWidget(const MyApp());
+
+      // Verify the native function was called.
+      expect(find.text('sum(1, 2) = 3'), findsOneWidget);
+    });
+  });
+}
+''');
 }
 
 void expectDylibIsCodeSignedMacOS(Directory appDirectory, String buildMode) {


### PR DESCRIPTION
Reland https://github.com/flutter/flutter/pull/170686.

Closes: https://github.com/flutter/flutter/issues/168961.

Original PR in first commit. Fix in subsequent commit:

* Do process invocation of `flutter pub add` in a different way.
   Fixes: `ProcessException: %1 is not a valid Win32 application`

Reproduced locally by changing dev/devicelab/bin/tasks/native_assets_android.dart to `DeviceOperatingSystem.windows` and verified the `flutter pub add` call now succeeds.

(Also, moved the add integration test into the create test project to avoid having multiple `flutter pub get`s.)

Third time is the charm.