### PR TITLE
`CupertinoDatePicker` and `CupertinoTimerPicker` new onChanged behavior

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -433,6 +433,8 @@ class CupertinoDatePicker extends StatefulWidget {
   /// Callback called when the selected date and/or time changes. If the new
   /// selected [DateTime] is not valid, or is not in the [minimumDate] through
   /// [maximumDate] range, this callback will not be called.
+  ///
+  /// The timing of this callback is controlled by [changeReportingBehavior].
   final ValueChanged<DateTime> onDateTimeChanged;
 
   /// Background color of date picker.
@@ -504,7 +506,7 @@ class CupertinoDatePicker extends StatefulWidget {
 
   /// The behavior of reporting the selected date.
   ///
-  /// This determines when the `onDateTimeChanged` callback is called.
+  /// This determines when the [onDateTimeChanged] callback is called.
   ///
   /// Native iOS 18 behavior is [ChangeReportingBehavior.onScrollEnd], which
   /// calls the callback only when the scrolling stops.
@@ -2189,6 +2191,8 @@ class CupertinoTimerPicker extends StatefulWidget {
   final int secondInterval;
 
   /// Callback called when the timer duration changes.
+  ///
+  /// The timing of this callback is controlled by [changeReportingBehavior].
   final ValueChanged<Duration> onTimerDurationChanged;
 
   /// Defines how the timer picker should be positioned within its parent.
@@ -2248,7 +2252,7 @@ class CupertinoTimerPicker extends StatefulWidget {
 
   /// The behavior of reporting the selected duration.
   ///
-  /// This determines when the `onTimerDurationChanged` callback is called.
+  /// This determines when the [onTimerDurationChanged] callback is called.
   ///
   /// Native iOS 18 behavior is [ChangeReportingBehavior.onScrollEnd], which
   /// calls the callback only when the scrolling stops.

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -308,6 +308,7 @@ class CupertinoDatePicker extends StatefulWidget {
     this.showTimeSeparator = false,
     this.itemExtent = _kItemExtent,
     this.selectionOverlayBuilder,
+    this.changeReportingBehavior = ChangeReportingBehavior.onScrollUpdate,
   }) : initialDateTime = initialDateTime ?? DateTime.now(),
        assert(itemExtent > 0, 'item extent should be greater than 0'),
        assert(
@@ -500,6 +501,16 @@ class CupertinoDatePicker extends StatefulWidget {
   /// ```
   /// {@end-tool}
   final SelectionOverlayBuilder? selectionOverlayBuilder;
+
+  /// The behavior of reporting the selected date.
+  ///
+  /// This determines when the `onDateTimeChanged` callback is called.
+  ///
+  /// Native iOS 18 behavior is [ChangeReportingBehavior.onScrollEnd], which
+  /// calls the callback only when the scrolling stops.
+  ///
+  /// Defaults to [ChangeReportingBehavior.onScrollUpdate].
+  final ChangeReportingBehavior changeReportingBehavior;
 
   @override
   State<StatefulWidget> createState() {
@@ -840,6 +851,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: (int index) {
           _onSelectedItemChange(index);
         },
@@ -919,6 +931,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: (int index) {
           final bool regionChanged = meridiemRegion != index ~/ 12;
           final bool debugIsFlipped = isHourRegionFlipped;
@@ -988,6 +1001,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: _onSelectedItemChange,
         looping: true,
         selectionOverlay: selectionOverlay,
@@ -1043,6 +1057,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: (int index) {
           selectedAmPm = index;
           assert(selectedAmPm == 0 || selectedAmPm == 1);
@@ -1399,6 +1414,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: (int index) {
           selectedDay = index + 1;
           if (_isCurrentDateValid) {
@@ -1456,6 +1472,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: (int index) {
           selectedMonth = index + 1;
           if (_isCurrentDateValid) {
@@ -1506,6 +1523,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: (int index) {
           selectedYear = index;
           if (_isCurrentDateValid) {
@@ -1820,6 +1838,7 @@ class _CupertinoDatePickerMonthYearState extends State<CupertinoDatePicker> {
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: (int index) {
           selectedMonth = index + 1;
           if (_isCurrentDateValid) {
@@ -1869,6 +1888,7 @@ class _CupertinoDatePickerMonthYearState extends State<CupertinoDatePicker> {
         useMagnifier: _kUseMagnifier,
         magnification: _kMagnification,
         backgroundColor: widget.backgroundColor,
+        changeReportingBehavior: widget.changeReportingBehavior,
         onSelectedItemChanged: (int index) {
           selectedYear = index;
           if (_isCurrentDateValid) {
@@ -2144,6 +2164,7 @@ class CupertinoTimerPicker extends StatefulWidget {
     this.backgroundColor,
     this.itemExtent = _kItemExtent,
     required this.onTimerDurationChanged,
+    this.changeReportingBehavior = ChangeReportingBehavior.onScrollUpdate,
     this.selectionOverlayBuilder,
   }) : assert(initialTimerDuration >= Duration.zero),
        assert(initialTimerDuration < const Duration(days: 1)),
@@ -2224,6 +2245,16 @@ class CupertinoTimerPicker extends StatefulWidget {
   /// ```
   /// {@end-tool}
   final SelectionOverlayBuilder? selectionOverlayBuilder;
+
+  /// The behavior of reporting the selected duration.
+  ///
+  /// This determines when the `onTimerDurationChanged` callback is called.
+  ///
+  /// Native iOS 18 behavior is [ChangeReportingBehavior.onScrollEnd], which
+  /// calls the callback only when the scrolling stops.
+  ///
+  /// Defaults to [ChangeReportingBehavior.onScrollUpdate].
+  final ChangeReportingBehavior changeReportingBehavior;
 
   @override
   State<StatefulWidget> createState() => _CupertinoTimerPickerState();
@@ -2449,6 +2480,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
       itemExtent: widget.itemExtent,
       backgroundColor: widget.backgroundColor,
       squeeze: _kSqueeze,
+      changeReportingBehavior: widget.changeReportingBehavior,
       onSelectedItemChanged: (int index) {
         setState(() {
           selectedHour = index;
@@ -2513,6 +2545,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
       backgroundColor: widget.backgroundColor,
       squeeze: _kSqueeze,
       looping: true,
+      changeReportingBehavior: widget.changeReportingBehavior,
       onSelectedItemChanged: (int index) {
         setState(() {
           selectedMinute = index * widget.minuteInterval;
@@ -2585,6 +2618,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
       backgroundColor: widget.backgroundColor,
       squeeze: _kSqueeze,
       looping: true,
+      changeReportingBehavior: widget.changeReportingBehavior,
       onSelectedItemChanged: (int index) {
         setState(() {
           selectedSecond = index * widget.secondInterval;

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -210,6 +210,41 @@ void main() {
         distance,
       );
     });
+
+    testWidgets('onScrollEnd behavior reports changes correctly', (WidgetTester tester) async {
+      final List<Duration> selectedDurations = <Duration>[];
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: SizedBox(
+              height: 400.0,
+              width: 400.0,
+              child: CupertinoTimerPicker(
+                initialTimerDuration: const Duration(hours: 1, minutes: 30, seconds: 15),
+                changeReportingBehavior: ChangeReportingBehavior.onScrollEnd,
+                onTimerDurationChanged: (Duration duration) => selectedDurations.add(duration),
+              ),
+            ),
+          ),
+        ),
+      );
+      final Offset initialOffset = tester.getTopLeft(find.text('30'));
+
+      final TestGesture scrollGesture = await tester.startGesture(initialOffset);
+      // Should not report changes until the gesture ends.
+      await scrollGesture.moveBy(const Offset(0.0, 32.0));
+      expect(selectedDurations, isEmpty);
+
+      await scrollGesture.moveBy(const Offset(0.0, 32.0));
+      expect(selectedDurations, isEmpty);
+
+      await scrollGesture.up();
+      await tester.pumpAndSettle();
+
+      // Only reports the last change.
+      expect(selectedDurations, hasLength(1));
+      expect(selectedDurations.first, const Duration(hours: 1, minutes: 28, seconds: 15));
+    });
   });
 
   testWidgets('showDayOfWeek is only supported in date mode', (WidgetTester tester) async {
@@ -1710,6 +1745,42 @@ void main() {
       final double hourLeft = tester.getTopLeft(find.text('4')).dx;
       final double minuteLeft = tester.getTopLeft(find.text('00')).dx;
       expect(hourLeft, lessThan(minuteLeft));
+    });
+
+    testWidgets('onScrollEnd behavior reports changes correctly', (WidgetTester tester) async {
+      final List<DateTime> selectedDateTime = <DateTime>[];
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: SizedBox(
+              height: 400.0,
+              width: 400.0,
+              child: CupertinoDatePicker(
+                mode: CupertinoDatePickerMode.date,
+                changeReportingBehavior: ChangeReportingBehavior.onScrollEnd,
+                onDateTimeChanged: (DateTime dateTime) => selectedDateTime.add(dateTime),
+                initialDateTime: DateTime(2025),
+              ),
+            ),
+          ),
+        ),
+      );
+      final Offset initialOffset = tester.getTopLeft(find.text('2025'));
+
+      final TestGesture scrollGesture = await tester.startGesture(initialOffset);
+      // Should not report changes until the gesture ends.
+      await scrollGesture.moveBy(const Offset(0.0, -32.0));
+      expect(selectedDateTime, isEmpty);
+
+      await scrollGesture.moveBy(const Offset(0.0, -32.0));
+      expect(selectedDateTime, isEmpty);
+
+      await scrollGesture.up();
+      await tester.pumpAndSettle();
+
+      // Only reports the last change.
+      expect(selectedDateTime, hasLength(1));
+      expect(selectedDateTime.first, DateTime(2027));
     });
   });
 


### PR DESCRIPTION
This PR adds the new `changeReportingBehavior` parameter to `CupertinoDatePicker` and `CupertinoTimerPicker`.

Continuation of https://github.com/flutter/flutter/pull/170202
Fixes https://github.com/flutter/flutter/issues/92644
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
