### PR TITLE
Only reload each isolate group once in _reloadDeviceSources

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1354,13 +1354,17 @@ Future<List<Future<vm_service.ReloadReport>>> _reloadDeviceSources(
 }) async {
   final String deviceEntryUri = device.devFS!.baseUri!.resolve(entryPath).toString();
   final vm_service.VM vm = await device.vmService!.service.getVM();
+  // Once you have reloaded one isolate in an isolate group - you have reloaded
+  // all of them.
+  final Set<String> alreadyReloadedGroups = <String>{};
   return <Future<vm_service.ReloadReport>>[
     for (final vm_service.IsolateRef isolateRef in vm.isolates!)
-      device.vmService!.service.reloadSources(
-        isolateRef.id!,
-        pause: pause,
-        rootLibUri: deviceEntryUri,
-      ),
+      if (alreadyReloadedGroups.add(isolateRef.isolateGroupId!))
+        device.vmService!.service.reloadSources(
+          isolateRef.id!,
+          pause: pause,
+          rootLibUri: deviceEntryUri,
+        ),
   ];
 }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -158,7 +158,7 @@ class HotRunner extends ResidentRunner {
     }
   }
 
-  void _addBenchmarkData(String name, int value) {
+  void addBenchmarkData(String name, int value) {
     benchmarkData[name] ??= <int>[];
     benchmarkData[name]!.add(value);
   }
@@ -300,7 +300,7 @@ class HotRunner extends ResidentRunner {
 
     final Stopwatch initialUpdateDevFSsTimer = Stopwatch()..start();
     final UpdateFSReport devfsResult = await _updateDevFS(fullRestart: needsFullRestart);
-    _addBenchmarkData(
+    addBenchmarkData(
       'hotReloadInitialDevFSSyncMilliseconds',
       initialUpdateDevFSsTimer.elapsed.inMilliseconds,
     );
@@ -717,7 +717,7 @@ class HotRunner extends ResidentRunner {
     globals.printTrace(
       'Hot restart performed in ${getElapsedAsMilliseconds(restartTimer.elapsed)}.',
     );
-    _addBenchmarkData('hotRestartMillisecondsToFrame', restartTimer.elapsed.inMilliseconds);
+    addBenchmarkData('hotRestartMillisecondsToFrame', restartTimer.elapsed.inMilliseconds);
 
     // Send timing analytics.
     final Duration elapsedDuration = restartTimer.elapsed;
@@ -1027,7 +1027,7 @@ class HotRunner extends ResidentRunner {
     }
     // Record time it took to synchronize to DevFS.
     bool shouldReportReloadTime = true;
-    _addBenchmarkData('hotReloadDevFSSyncMilliseconds', devFSTimer.elapsed.inMilliseconds);
+    addBenchmarkData('hotReloadDevFSSyncMilliseconds', devFSTimer.elapsed.inMilliseconds);
     if (!updatedDevFS.success) {
       return OperationResult(1, 'DevFS synchronization failed');
     }
@@ -1057,7 +1057,7 @@ class HotRunner extends ResidentRunner {
       }
       reloadMessage = result.message;
     } else {
-      _addBenchmarkData('hotReloadVMReloadMilliseconds', 0);
+      addBenchmarkData('hotReloadVMReloadMilliseconds', 0);
     }
     reloadVMTimer.stop();
     extraTimings.add(OperationResultExtraTiming('reload', reloadVMTimer.elapsedMilliseconds));
@@ -1079,7 +1079,7 @@ class HotRunner extends ResidentRunner {
     }
     // Record time it took for Flutter to reassemble the application.
     reassembleTimer.stop();
-    _addBenchmarkData(
+    addBenchmarkData(
       'hotReloadFlutterReassembleMilliseconds',
       reassembleTimer.elapsed.inMilliseconds,
     );
@@ -1142,7 +1142,7 @@ class HotRunner extends ResidentRunner {
     if (shouldReportReloadTime) {
       globals.printTrace('Hot reload performed in ${getElapsedAsMilliseconds(reloadDuration)}.');
       // Record complete time it took for the reload.
-      _addBenchmarkData('hotReloadMillisecondsToFrame', reloadInMs);
+      addBenchmarkData('hotReloadMillisecondsToFrame', reloadInMs);
     }
     // Only report timings if we reloaded a single view without any errors.
     if ((reassembleResult.reassembleViews.length == 1) &&
@@ -1340,10 +1340,7 @@ Future<OperationResult> defaultReloadSourcesHelper(
   globals.printTrace('reloaded $loadedLibraryCount of $finalLibraryCount libraries');
   // reloadMessage = 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries';
   // Record time it took for the VM to reload the sources.
-  hotRunner._addBenchmarkData(
-    'hotReloadVMReloadMilliseconds',
-    vmReloadTimer.elapsed.inMilliseconds,
-  );
+  hotRunner.addBenchmarkData('hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
   return OperationResult(0, 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries');
 }
 

--- a/packages/flutter_tools/test/general.shard/run_hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/run_hot_test.dart
@@ -41,7 +41,7 @@ void main() {
       vmService: _FakeFlutterVmService(service: fakeService),
     );
 
-    fakeService._vm._isolates.addAll([
+    fakeService._vm._isolates.addAll(<_FakeIsolateRef>[
       _FakeIsolateRef(isolateGroupId: 'Group A', id: 'Isolate A.1'),
       _FakeIsolateRef(isolateGroupId: 'Group B', id: 'Isolate B.1'),
       _FakeIsolateRef(isolateGroupId: 'Group B', id: 'Isolate B.2'),
@@ -166,14 +166,14 @@ class _FakeDevFS extends Fake implements DevFS {
 }
 
 class _FakeFlutterDevice extends Fake implements FlutterDevice {
+  _FakeFlutterDevice({FlutterVmService? vmService})
+    : vmService = vmService ?? _FakeFlutterVmService();
+
   @override
   final DevFS? devFS = _FakeDevFS();
 
   @override
   final FlutterVmService? vmService;
-
-  _FakeFlutterDevice({FlutterVmService? vmService})
-    : vmService = vmService ?? _FakeFlutterVmService();
 
   @override
   Future<void> updateReloadStatus(bool wasReloadSuccessful) async {}
@@ -208,10 +208,9 @@ class _FakeHotCompatibleFlutterDevice extends Fake implements FlutterDevice {
 }
 
 class _FakeFlutterVmService extends Fake implements FlutterVmService {
+  _FakeFlutterVmService({vm_service.VmService? service}) : service = service ?? _FakeVmService();
   @override
   final vm_service.VmService service;
-
-  _FakeFlutterVmService({vm_service.VmService? service}) : service = service ?? _FakeVmService();
 }
 
 class _FakeVmService extends Fake implements vm_service.VmService {
@@ -245,10 +244,9 @@ class _FakeVm extends Fake implements vm_service.VM {
 }
 
 class _FakeIsolateRef extends Fake implements vm_service.IsolateRef {
+  _FakeIsolateRef({this.isolateGroupId, this.id});
   @override
   String? isolateGroupId;
   @override
   String? id;
-
-  _FakeIsolateRef({this.isolateGroupId, this.id});
 }

--- a/packages/flutter_tools/test/general.shard/run_hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/run_hot_test.dart
@@ -57,6 +57,7 @@ void main() {
       false,
       'test-reason',
       const NoOpAnalytics(),
+      addBenchmarkData: (String name, int value) {},
     );
 
     expect(fakeService._reloadedIsolates.length, equals(2));
@@ -149,10 +150,7 @@ class _FakeAnalytics extends Fake implements Analytics {
   void send(Event event) {}
 }
 
-class _FakeHotRunner extends Fake implements HotRunner {
-  @override
-  void addBenchmarkData(String name, int value) {}
-}
+class _FakeHotRunner extends Fake implements HotRunner {}
 
 class _FakeDevFS extends Fake implements DevFS {
   @override


### PR DESCRIPTION
Only reload each isolate group once in _reloadDeviceSources. Once you have reloaded one isolate - you have reloaded the whole group because group shares the underlying program.

Fixes https://github.com/flutter/flutter/issues/169437

